### PR TITLE
test: add worktree lifecycle delegation and maintainer coverage

### DIFF
--- a/docs/guides/CODEX_WORKTREE_AUTOPILOT.md
+++ b/docs/guides/CODEX_WORKTREE_AUTOPILOT.md
@@ -87,3 +87,7 @@ The maintainer runs non-destructive upkeep by default:
 - Branch retention: keeps local `codex/*` branches (`--no-delete-branches`)
 - Safety: skips worktrees with active processes (use `--include-active` only if needed)
 - Daemon mode: `--reconcile-only` (no cleanup deletions in background)
+
+Implementation note:
+- `scripts/worktree_maintainer.sh` is a thin wrapper around `python -m aragora.worktree.maintainer`,
+  which uses the shared `WorktreeLifecycleService` for consistent policy and telemetry.

--- a/tests/coordination/test_worktree_coordination.py
+++ b/tests/coordination/test_worktree_coordination.py
@@ -145,6 +145,28 @@ class TestWorktreeManager:
 
         assert len(manager.active_worktrees) == 1
 
+    def test_maintain_managed_sessions_delegates_to_lifecycle(self):
+        manager = self._make_manager()
+        expected = {
+            "ok": True,
+            "directories_total": 1,
+            "processed": 1,
+            "skipped_active": 0,
+            "skipped_missing": 0,
+            "failures": 0,
+            "results": [],
+        }
+
+        with patch.object(manager._lifecycle, "maintain_managed_dirs", return_value=expected) as mock:
+            result = manager.maintain_managed_sessions(
+                base_branch="main",
+                managed_dirs=[".worktrees/codex-auto"],
+                reconcile_only=True,
+            )
+
+        assert result == expected
+        mock.assert_called_once()
+
     def test_record_activity(self):
         manager = self._make_manager()
         state = WorktreeState(

--- a/tests/worktree/test_maintainer.py
+++ b/tests/worktree/test_maintainer.py
@@ -1,0 +1,60 @@
+"""Tests for worktree maintainer CLI module."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from aragora.worktree import maintainer
+
+
+@patch("aragora.worktree.maintainer.WorktreeLifecycleService")
+def test_main_success_json(mock_service_cls, capsys) -> None:
+    mock_service = MagicMock()
+    mock_service.maintain_managed_dirs.return_value = {
+        "ok": True,
+        "directories_total": 1,
+        "processed": 1,
+        "skipped_active": 0,
+        "skipped_missing": 0,
+        "failures": 0,
+        "results": [],
+    }
+    mock_service_cls.return_value = mock_service
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["maintainer", "--repo", "/tmp/repo", "--json"]
+        exit_code = maintainer.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exit_code == 0
+    out = capsys.readouterr().out
+    assert '"ok": true' in out.lower()
+
+
+@patch("aragora.worktree.maintainer.WorktreeLifecycleService")
+def test_main_failure_exit_code(mock_service_cls, capsys) -> None:
+    mock_service = MagicMock()
+    mock_service.maintain_managed_dirs.return_value = {
+        "ok": False,
+        "directories_total": 1,
+        "processed": 1,
+        "skipped_active": 0,
+        "skipped_missing": 0,
+        "failures": 1,
+        "results": [{"managed_dir": ".worktrees/codex-auto", "status": "failed"}],
+    }
+    mock_service_cls.return_value = mock_service
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["maintainer", "--repo", "/tmp/repo"]
+        exit_code = maintainer.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "failures=1" in out


### PR DESCRIPTION
## Summary\n- add delegation coverage for coordination managed-session maintenance\n- add gastown hook tests to assert create/remove worktree operations delegate to WorktreeLifecycleService\n- add unit tests for worktree maintainer CLI exit/output behavior\n- document maintainer wrapper implementation note in Codex worktree autopilot guide\n\n## Validation\n- ruff check tests/coordination/test_worktree_coordination.py tests/extensions/test_gastown.py tests/worktree/test_maintainer.py\n- pytest -q tests/coordination/test_worktree_coordination.py tests/extensions/test_gastown.py tests/worktree/test_maintainer.py