### PR TITLE
ci: add autopilot e2e lane and response telemetry

### DIFF
--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -1,0 +1,50 @@
+name: Autopilot Worktree E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'aragora/server/handlers/self_improve.py'
+      - 'aragora/worktree/**'
+      - 'scripts/codex_worktree_autopilot.py'
+      - 'tests/handlers/test_self_improve_api.py'
+      - '.github/workflows/autopilot-worktree-e2e.yml'
+      - 'pyproject.toml'
+  workflow_dispatch:
+
+concurrency:
+  group: autopilot-worktree-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  autopilot-api-e2e:
+    name: Autopilot API E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,test]"
+          pip install pytest-timeout
+
+      - name: Run autopilot API end-to-end test
+        env:
+          PYTHONPATH: .
+        run: |
+          pytest -q tests/handlers/test_self_improve_api.py::TestAutopilotWorktreesE2E::test_ensure_reconcile_maintain_flow \
+            --timeout=180 --tb=short

--- a/tests/handlers/test_self_improve.py
+++ b/tests/handlers/test_self_improve.py
@@ -1707,12 +1707,14 @@ class TestWorktrees:
         assert body["action"] == "status"
         assert body["ok"] is True
         assert body["result"]["sessions"] == []
+        assert body["telemetry"]["sessions_total"] == 0
+        assert body["telemetry"]["sessions_active"] == 0
 
     @pytest.mark.asyncio
     async def test_autopilot_ensure(self, handler):
         mock_proc = MagicMock(
             returncode=0,
-            stdout='{"ok": true, "session": {"branch": "codex/test"}}',
+            stdout='{"ok": true, "created": true, "session": {"session_id": "s1", "agent": "codex-ci", "branch": "codex/test", "path": "/tmp/codex/test"}}',
             stderr="",
         )
         mock_service = MagicMock()
@@ -1730,6 +1732,9 @@ class TestWorktrees:
         assert body["action"] == "ensure"
         assert body["ok"] is True
         assert body["result"]["session"]["branch"] == "codex/test"
+        assert body["telemetry"]["allocation"]["session_id"] == "s1"
+        assert body["telemetry"]["allocation"]["created"] is True
+        assert body["telemetry"]["allocation"]["path"] == "/tmp/codex/test"
 
     @pytest.mark.asyncio
     async def test_autopilot_failure_returns_503(self, handler):
@@ -1749,6 +1754,7 @@ class TestWorktrees:
         body = _body(result)
         assert body["ok"] is False
         assert "stderr" in body
+        assert body["telemetry"]["action"] == "reconcile"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- add dedicated GitHub Actions workflow for autopilot API end-to-end coverage
- expose structured `telemetry` in `/api/self-improve/worktrees/autopilot/*` responses
- extend handler tests to assert telemetry in mocked and real e2e flows

## Step 1 (stale branch cleanup)
- verified stale branch `codex/worktree-lifecycle-20260224-180834` is no longer present on `origin` (no remote heads match); no delete action required

## Validation
- ruff check aragora/server/handlers/self_improve.py tests/handlers/test_self_improve.py tests/handlers/test_self_improve_api.py
- pytest -q tests/handlers/test_self_improve.py -k autopilot
- pytest -q tests/handlers/test_self_improve_api.py -k AutopilotWorktrees
