### PR TITLE
fix(live-tests): align hook mocks with current store and SWR behavior

### DIFF
--- a/aragora/live/src/__tests__/hooks/useControlPlane.test.ts
+++ b/aragora/live/src/__tests__/hooks/useControlPlane.test.ts
@@ -2,7 +2,7 @@
  * Tests for useControlPlane hook
  */
 
-import { renderHook, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { useControlPlane } from '@/hooks/useControlPlane';
 
 // Mock the store selectors
@@ -28,6 +28,12 @@ const mockSetHealthLoading = jest.fn();
 const mockSetStatsLoading = jest.fn();
 const mockSetAgentsError = jest.fn();
 const mockSetTasksError = jest.fn();
+const mockUpdateAgent = jest.fn();
+const mockUpdateTask = jest.fn();
+const mockSetIsConnected = jest.fn();
+const mockSetLastUpdate = jest.fn();
+const mockSetSelectedAgentId = jest.fn();
+const mockSetSelectedTaskId = jest.fn();
 
 jest.mock('@/store/controlPlaneStore', () => ({
   useControlPlaneStore: jest.fn((selector) => {
@@ -55,6 +61,12 @@ jest.mock('@/store/controlPlaneStore', () => ({
       setStatsLoading: mockSetStatsLoading,
       setAgentsError: mockSetAgentsError,
       setTasksError: mockSetTasksError,
+      updateAgent: mockUpdateAgent,
+      updateTask: mockUpdateTask,
+      setIsConnected: mockSetIsConnected,
+      setLastUpdate: mockSetLastUpdate,
+      setSelectedAgentId: mockSetSelectedAgentId,
+      setSelectedTaskId: mockSetSelectedTaskId,
       setTaskFilters: mockSetTaskFilters,
       setSearchQuery: mockSetSearchQuery,
     };
@@ -101,6 +113,8 @@ jest.mock('@/hooks/useAragoraClient', () => ({
 jest.mock('@/hooks/useControlPlaneWebSocket', () => ({
   useControlPlaneWebSocket: jest.fn(() => ({
     isConnected: true,
+    agents: new Map(),
+    tasks: new Map(),
     lastMessage: null,
   })),
 }));

--- a/aragora/live/src/__tests__/hooks/useCosts.test.ts
+++ b/aragora/live/src/__tests__/hooks/useCosts.test.ts
@@ -45,11 +45,19 @@ import { useSWRFetch, invalidateCache } from '@/hooks/useSWRFetch';
 
 const mockUseSWRFetch = useSWRFetch as jest.Mock;
 
-describe('useCostSummary', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSWRFetch.mockReset();
+  mockUseSWRFetch.mockImplementation(() => ({
+    data: null,
+    error: null,
+    isLoading: false,
+    isValidating: false,
+    mutate: mockMutate,
+  }));
+});
 
+describe('useCostSummary', () => {
   it('returns null summary when no data', () => {
     const { result } = renderHook(() => useCostSummary());
     expect(result.current.summary).toBeNull();
@@ -94,10 +102,6 @@ describe('useCostSummary', () => {
 });
 
 describe('useCostsBreakdown', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null breakdown when no data', () => {
     const { result } = renderHook(() => useCostsBreakdown());
     expect(result.current.breakdown).toBeNull();
@@ -113,10 +117,6 @@ describe('useCostsBreakdown', () => {
 });
 
 describe('useCostTimeline', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null timeline when no data', () => {
     const { result } = renderHook(() => useCostTimeline());
     expect(result.current.timeline).toBeNull();
@@ -132,10 +132,6 @@ describe('useCostTimeline', () => {
 });
 
 describe('useCostAlerts', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns empty alerts array when no data', () => {
     const { result } = renderHook(() => useCostAlerts());
     expect(result.current.alerts).toEqual([]);
@@ -173,10 +169,6 @@ describe('useCostAlerts', () => {
 });
 
 describe('useCostRecommendations', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns empty recommendations when no data', () => {
     const { result } = renderHook(() => useCostRecommendations());
     expect(result.current.recommendations).toEqual([]);
@@ -192,10 +184,6 @@ describe('useCostRecommendations', () => {
 });
 
 describe('useCostEfficiency', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null efficiency when no data', () => {
     const { result } = renderHook(() => useCostEfficiency());
     expect(result.current.efficiency).toBeNull();
@@ -211,10 +199,6 @@ describe('useCostEfficiency', () => {
 });
 
 describe('useCostForecast', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null forecast when no data', () => {
     const { result } = renderHook(() => useCostForecast());
     expect(result.current.forecast).toBeNull();
@@ -230,10 +214,6 @@ describe('useCostForecast', () => {
 });
 
 describe('useSpendTrend', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null trend when no data', () => {
     const { result } = renderHook(() => useSpendTrend());
     expect(result.current.trend).toBeNull();
@@ -249,10 +229,6 @@ describe('useSpendTrend', () => {
 });
 
 describe('useAgentCostBreakdown', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null agent breakdown when no data', () => {
     const { result } = renderHook(() => useAgentCostBreakdown());
     expect(result.current.agentBreakdown).toBeNull();
@@ -268,10 +244,6 @@ describe('useAgentCostBreakdown', () => {
 });
 
 describe('useModelCostBreakdown', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null model breakdown when no data', () => {
     const { result } = renderHook(() => useModelCostBreakdown());
     expect(result.current.modelBreakdown).toBeNull();
@@ -279,10 +251,6 @@ describe('useModelCostBreakdown', () => {
 });
 
 describe('useDebateCostBreakdown', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null debate breakdown when no data', () => {
     const { result } = renderHook(() => useDebateCostBreakdown());
     expect(result.current.debateBreakdown).toBeNull();
@@ -298,10 +266,6 @@ describe('useDebateCostBreakdown', () => {
 });
 
 describe('useBudgetUtilization', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
   it('returns null utilization when no data', () => {
     const { result } = renderHook(() => useBudgetUtilization());
     expect(result.current.utilization).toBeNull();
@@ -317,16 +281,6 @@ describe('useBudgetUtilization', () => {
 });
 
 describe('useCosts (unified)', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseSWRFetch.mockReturnValue({
-      data: null,
-      error: null,
-      isLoading: false,
-      mutate: mockMutate,
-    });
-  });
-
   it('returns null costData when no summary', () => {
     const { result } = renderHook(() => useCosts());
     expect(result.current.costData).toBeNull();


### PR DESCRIPTION
## Summary
- align useControlPlane hook tests with current store action contract (setIsConnected, update/select actions, websocket maps)
- reset and default useSWRFetch mocks per test to avoid cross-test contamination in useCosts hook tests

## Validation
- npm test -- src/__tests__/hooks/useControlPlane.test.ts src/__tests__/hooks/useCosts.test.ts --runInBand
- pytest -q tests/rlm/test_true_rlm_priority.py
