### PR TITLE
fix(sdk-ts): restore cross-SDK parity for SME workflow detail route

### DIFF
--- a/sdk/typescript/src/namespaces/sme.ts
+++ b/sdk/typescript/src/namespaces/sme.ts
@@ -462,9 +462,11 @@ export class SMEAPI {
    * @route GET /api/v1/sme/workflows/{workflow_id}
    */
   async getWorkflow(workflowId: string): Promise<Record<string, unknown>> {
-    return this.invoke<Record<string, unknown>>(
-      'getSMEWorkflow',
-      [workflowId],
+    const legacy = (this.client as CompatClient).getSMEWorkflow;
+    if (typeof legacy === 'function') {
+      return (legacy as LegacyMethod).apply(this.client, [workflowId]) as Promise<Record<string, unknown>>;
+    }
+    return this.request<Record<string, unknown>>(
       'GET',
       `/api/v1/sme/workflows/${encodeURIComponent(workflowId)}`
     );


### PR DESCRIPTION
## Summary
- update `SMEAPI.getWorkflow()` in TS namespace to perform direct `request(...)` fallback when legacy client method is absent
- preserve legacy compatibility while exposing `/api/v1/sme/workflows/{workflow_id}` to cross-SDK parity extraction

## Why
- strict cross-SDK parity gate regressed on latest `main` with:
  - `NEW PY-ONLY: /api/sme/workflows/{param}`
- root cause: parity extractor only scans direct request invocations in `sdk/typescript/src/namespaces/*.ts`; previous `invoke(...)` path hid this endpoint.

## Validation
- `python scripts/check_cross_sdk_parity.py --strict --baseline scripts/baselines/cross_sdk_parity.json`
- `python scripts/check_sdk_parity.py --strict --baseline scripts/baselines/check_sdk_parity.json --budget scripts/baselines/check_sdk_parity_budget.json`
- `npm --prefix sdk/typescript run typecheck`
- `npm --prefix sdk/typescript test -- src/__tests__/namespaces.test.ts`
