### PR TITLE
ci(workflows): always emit required autopilot/openapi check statuses

### DIFF
--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -3,13 +3,6 @@ name: Autopilot Worktree E2E
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'aragora/server/handlers/self_improve.py'
-      - 'aragora/worktree/**'
-      - 'scripts/codex_worktree_autopilot.py'
-      - 'tests/handlers/test_self_improve_api.py'
-      - '.github/workflows/autopilot-worktree-e2e.yml'
-      - 'pyproject.toml'
   workflow_dispatch:
 
 concurrency:
@@ -20,10 +13,40 @@ permissions:
   contents: read
 
 jobs:
+  scope:
+    name: Autopilot Scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_autopilot: ${{ steps.filter.outputs.run_autopilot }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect autopilot-relevant changes
+        id: filter
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run_autopilot=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          CHANGED="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"
+
+          if printf '%s\n' "$CHANGED" | grep -Eq '^(aragora/server/handlers/self_improve.py|aragora/worktree/.*|scripts/codex_worktree_autopilot.py|tests/handlers/test_self_improve_api.py|\\.github/workflows/autopilot-worktree-e2e.yml|pyproject.toml)$'; then
+            echo "run_autopilot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_autopilot=false" >> "$GITHUB_OUTPUT"
+          fi
+
   autopilot-api-e2e:
     name: Autopilot API E2E
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: scope
+    if: github.event_name != 'pull_request' || needs.scope.outputs.run_autopilot == 'true'
 
     steps:
       - name: Checkout

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -24,23 +24,6 @@ on:
       - 'sdk/typescript/src/namespaces/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'aragora/server/handlers/**'
-      - 'aragora/server/openapi/**'
-      - 'aragora/server/openapi_impl.py'
-      - 'scripts/export_openapi.py'
-      - 'scripts/generate_openapi.py'
-      - 'scripts/verify_sdk_contracts.py'
-      - 'scripts/validate_openapi_routes.py'
-      - 'scripts/check_sdk_namespace_parity.py'
-      - 'scripts/contract_drift_report.py'
-      - 'scripts/generate_contract_drift_backlog.py'
-      - 'scripts/baselines/verify_sdk_contracts.json'
-      - 'scripts/baselines/validate_openapi_routes.json'
-      - 'scripts/baselines/check_sdk_namespace_parity.json'
-      - 'scripts/baselines/internal_route_prefixes.json'
-      - 'sdk/python/aragora/namespaces/**'
-      - 'sdk/typescript/src/namespaces/**'
   workflow_dispatch:
 
 concurrency:
@@ -48,10 +31,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  scope:
+    name: OpenAPI Scope
+    runs-on: ubuntu-latest
+    outputs:
+      run_openapi: ${{ steps.filter.outputs.run_openapi }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect OpenAPI-relevant changes
+        id: filter
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run_openapi=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"
+          CHANGED="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")"
+
+          if printf '%s\n' "$CHANGED" | grep -Eq '^(aragora/server/handlers/.*|aragora/server/openapi/.*|aragora/server/openapi_impl.py|scripts/export_openapi.py|scripts/generate_openapi.py|scripts/verify_sdk_contracts.py|scripts/validate_openapi_routes.py|scripts/check_sdk_namespace_parity.py|scripts/contract_drift_report.py|scripts/generate_contract_drift_backlog.py|scripts/baselines/verify_sdk_contracts.json|scripts/baselines/validate_openapi_routes.json|scripts/baselines/check_sdk_namespace_parity.json|scripts/baselines/internal_route_prefixes.json|sdk/python/aragora/namespaces/.*|sdk/typescript/src/namespaces/.*|docs/api/openapi.*\\.json|docs/api/openapi.*\\.yaml|\\.github/workflows/openapi.yml)$'; then
+            echo "run_openapi=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_openapi=false" >> "$GITHUB_OUTPUT"
+          fi
+
   generate:
     name: Generate & Validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: scope
+    if: github.event_name != 'pull_request' || needs.scope.outputs.run_openapi == 'true'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- remove PR-level `paths` filters from:
  - `.github/workflows/autopilot-worktree-e2e.yml`
  - `.github/workflows/openapi.yml`
- add lightweight `scope` jobs in both workflows to detect whether changed files are relevant
- gate heavy jobs using scope outputs:
  - `Autopilot API E2E` runs only when autopilot-related files changed (otherwise check is skipped)
  - `Generate & Validate` runs only when OpenAPI-related files changed (otherwise check is skipped)

## Why
`main` branch protection now requires `Autopilot API E2E` and `Generate & Validate`. With workflow `paths` filters, those checks were absent on unrelated PRs and could block merges with “expected status” gaps.

This change guarantees required checks always report a status on PRs while keeping compute costs low by skipping heavy jobs when irrelevant.

## Validation
- YAML parse sanity:
  - `python -c "import yaml; yaml.safe_load(open('.github/workflows/autopilot-worktree-e2e.yml'))"`
  - `python -c "import yaml; yaml.safe_load(open('.github/workflows/openapi.yml'))"`
- regex smoke check against representative changed paths
