### PR TITLE
cli(worktree): accept --base after autopilot and document both forms

### DIFF
--- a/aragora/cli/commands/worktree.py
+++ b/aragora/cli/commands/worktree.py
@@ -106,6 +106,12 @@ Workflow:
         default=".worktrees/codex-auto",
         help="Managed worktree directory (relative to repo)",
     )
+    auto_p.add_argument(
+        "--base",
+        dest="auto_base",
+        default=None,
+        help="Base branch override for autopilot actions",
+    )
     auto_p.add_argument("--agent", default="codex", help="Agent name for ensure")
     auto_p.add_argument("--session-id", default=None, help="Optional session id for ensure")
     auto_p.add_argument("--force-new", action="store_true", help="Force new session on ensure")
@@ -156,6 +162,7 @@ def cmd_worktree(args: argparse.Namespace) -> None:
     base_branch = args.base
 
     if action == "autopilot":
+        base_branch = getattr(args, "auto_base", None) or base_branch
         _cmd_worktree_autopilot(args, repo_path=repo_root, base_branch=base_branch)
         return
 

--- a/docs/guides/CODEX_WORKTREE_AUTOPILOT.md
+++ b/docs/guides/CODEX_WORKTREE_AUTOPILOT.md
@@ -24,6 +24,10 @@ python -m aragora.cli.main worktree autopilot reconcile --all --base main --stra
 python -m aragora.cli.main worktree autopilot maintain --base main --strategy merge --ttl-hours 24 --no-delete-branches
 ```
 
+`--base` is accepted in both forms:
+- `aragora worktree --base main autopilot ...`
+- `aragora worktree autopilot ... --base main`
+
 Use this path when you want one canonical command surface (`aragora worktree ...`) instead of mixing CLI and raw scripts.
 
 ## Core Commands


### PR DESCRIPTION
## Summary
- add `--base` override directly on `aragora worktree autopilot ...`
- preserve top-level `aragora worktree --base ... autopilot ...` behavior
- update docs to show both accepted forms
- add parser + dispatch tests for `auto_base` override

## Validation
- `ruff check aragora/cli/commands/worktree.py tests/cli/test_worktree_command.py`
- `pytest -q tests/cli/test_worktree_command.py`
