### PR TITLE
WIP: isolate dirty main changes (SDK agents + v2 route migrations)

### DIFF
--- a/aragora/server/fastapi/routes/marketplace.py
+++ b/aragora/server/fastapi/routes/marketplace.py
@@ -1,0 +1,681 @@
+"""
+Marketplace Endpoints (FastAPI v2).
+
+Migrated from: aragora/server/handlers/marketplace.py (aiohttp handler)
+
+Provides async marketplace template endpoints:
+- GET    /api/v2/marketplace/templates              - List/search templates
+- GET    /api/v2/marketplace/templates/{template_id} - Get template details
+- POST   /api/v2/marketplace/templates              - Create a template
+- DELETE /api/v2/marketplace/templates/{template_id} - Delete a template
+- POST   /api/v2/marketplace/templates/{template_id}/ratings - Rate a template
+- GET    /api/v2/marketplace/templates/{template_id}/ratings - Get template ratings
+- POST   /api/v2/marketplace/templates/{template_id}/star    - Star a template
+- GET    /api/v2/marketplace/categories             - List categories
+- GET    /api/v2/marketplace/templates/{template_id}/export  - Export template
+- POST   /api/v2/marketplace/templates/import       - Import a template
+- GET    /api/v2/marketplace/status                 - Health and circuit breaker status
+
+Migration Notes:
+    This module replaces the legacy MarketplaceHandler class with native FastAPI
+    routes. Key improvements:
+    - Pydantic request/response models with automatic validation
+    - FastAPI dependency injection for auth and storage
+    - Proper HTTP status codes (422 for validation, 404 for not found)
+    - OpenAPI schema auto-generation
+    - Circuit breaker pattern preserved for registry access resilience
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel, Field
+
+from aragora.rbac.models import AuthorizationContext
+
+from ..dependencies.auth import require_permission
+from ..middleware.error_handling import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/marketplace", tags=["Marketplace"])
+
+
+# =============================================================================
+# Constants for Input Validation
+# =============================================================================
+
+SAFE_ID_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,127}$")
+
+MAX_TEMPLATE_ID_LENGTH = 128
+MAX_QUERY_LENGTH = 500
+MAX_TAGS_LENGTH = 1000
+MAX_REVIEW_LENGTH = 2000
+MIN_RATING = 1
+MAX_RATING = 5
+DEFAULT_LIMIT = 50
+MIN_LIMIT = 1
+MAX_LIMIT = 200
+MAX_OFFSET = 10000
+
+
+# =============================================================================
+# Pydantic Models
+# =============================================================================
+
+
+class TemplateSummary(BaseModel):
+    """Summary of a marketplace template."""
+
+    id: str = ""
+    name: str = ""
+    description: str = ""
+    category: str = ""
+    template_type: str = ""
+    tags: list[str] = Field(default_factory=list)
+    downloads: int = 0
+    stars: int = 0
+    average_rating: float = 0.0
+
+    model_config = {"extra": "allow"}
+
+
+class TemplateListResponse(BaseModel):
+    """Response for template listing."""
+
+    templates: list[dict[str, Any]]
+    count: int
+    limit: int
+    offset: int
+
+
+class TemplateDetailResponse(BaseModel):
+    """Full template details."""
+
+    model_config = {"extra": "allow"}
+
+
+class CreateTemplateRequest(BaseModel):
+    """Request body for POST /templates."""
+
+    id: str | None = Field(None, max_length=128, description="Template ID")
+    name: str = Field(..., min_length=1, max_length=200, description="Template name")
+    description: str = Field("", max_length=2000, description="Template description")
+    category: str = Field("", description="Template category")
+    template_type: str = Field("", description="Template type")
+    tags: list[str] = Field(default_factory=list, description="Template tags")
+    config: dict[str, Any] = Field(default_factory=dict, description="Template configuration")
+
+    model_config = {"extra": "allow"}
+
+
+class CreateTemplateResponse(BaseModel):
+    """Response for POST /templates."""
+
+    id: str
+    success: bool
+
+
+class DeleteTemplateResponse(BaseModel):
+    """Response for DELETE /templates/{id}."""
+
+    success: bool
+    deleted: str
+
+
+class RateTemplateRequest(BaseModel):
+    """Request body for POST /templates/{id}/ratings."""
+
+    score: int = Field(..., ge=MIN_RATING, le=MAX_RATING, description="Rating score (1-5)")
+    review: str | None = Field(None, max_length=MAX_REVIEW_LENGTH, description="Optional review text")
+
+
+class RateTemplateResponse(BaseModel):
+    """Response for POST /templates/{id}/ratings."""
+
+    success: bool
+    average_rating: float
+
+
+class RatingEntry(BaseModel):
+    """A single rating entry."""
+
+    user_id: str = ""
+    score: int = 0
+    review: str | None = None
+    created_at: str = ""
+
+    model_config = {"extra": "allow"}
+
+
+class RatingsResponse(BaseModel):
+    """Response for GET /templates/{id}/ratings."""
+
+    ratings: list[RatingEntry]
+    average: float
+    count: int
+
+
+class StarTemplateResponse(BaseModel):
+    """Response for POST /templates/{id}/star."""
+
+    success: bool
+    stars: int
+
+
+class CategoriesResponse(BaseModel):
+    """Response for GET /categories."""
+
+    categories: list[str]
+
+
+class MarketplaceStatusResponse(BaseModel):
+    """Response for GET /status."""
+
+    status: str
+    circuit_breaker: dict[str, Any]
+
+
+# =============================================================================
+# Circuit Breaker
+# =============================================================================
+
+_circuit_breaker_instance: Any = None
+_circuit_breaker_lock = threading.Lock()
+
+
+def _get_circuit_breaker() -> Any:
+    """Get or create the marketplace circuit breaker."""
+    global _circuit_breaker_instance
+    with _circuit_breaker_lock:
+        if _circuit_breaker_instance is None:
+            try:
+                from aragora.resilience.simple_circuit_breaker import (
+                    SimpleCircuitBreaker,
+                )
+
+                _circuit_breaker_instance = SimpleCircuitBreaker()
+            except (ImportError, RuntimeError, ValueError) as e:
+                logger.warning("Circuit breaker not available: %s", e)
+                return None
+        return _circuit_breaker_instance
+
+
+def _check_circuit_breaker() -> None:
+    """Raise 503 if the circuit breaker is open."""
+    cb = _get_circuit_breaker()
+    if cb and not cb.can_proceed():
+        raise HTTPException(
+            status_code=503,
+            detail="Marketplace temporarily unavailable. Please try again later.",
+        )
+
+
+def _record_success() -> None:
+    """Record a successful operation on the circuit breaker."""
+    cb = _get_circuit_breaker()
+    if cb:
+        cb.record_success()
+
+
+def _record_failure() -> None:
+    """Record a failed operation on the circuit breaker."""
+    cb = _get_circuit_breaker()
+    if cb:
+        cb.record_failure()
+
+
+# =============================================================================
+# Dependencies
+# =============================================================================
+
+
+async def get_registry(request: Request) -> Any:
+    """Dependency to get the TemplateRegistry from app state or create one."""
+    ctx = getattr(request.app.state, "context", None)
+    if ctx and "marketplace_registry" in ctx:
+        return ctx.get("marketplace_registry")
+
+    # Fall back to creating a new registry
+    try:
+        from aragora.marketplace import TemplateRegistry
+
+        return TemplateRegistry()
+    except (ImportError, RuntimeError, ValueError) as e:
+        logger.warning("Marketplace registry not available: %s", e)
+        return None
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _validate_template_id(template_id: str) -> None:
+    """Validate a template ID string; raises HTTPException on failure."""
+    if not template_id or not isinstance(template_id, str):
+        raise HTTPException(status_code=400, detail="Template ID is required")
+    if len(template_id) > MAX_TEMPLATE_ID_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Template ID must be at most {MAX_TEMPLATE_ID_LENGTH} characters",
+        )
+    if not SAFE_ID_PATTERN.match(template_id):
+        raise HTTPException(
+            status_code=400,
+            detail="Template ID contains invalid characters",
+        )
+
+
+def _require_registry(registry: Any) -> Any:
+    """Ensure the registry is available; raises 503 if not."""
+    if registry is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Marketplace registry is not available",
+        )
+    return registry
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.get("/templates", response_model=TemplateListResponse)
+async def list_templates(
+    request: Request,
+    q: str | None = Query(None, max_length=MAX_QUERY_LENGTH, description="Search query"),
+    category: str | None = Query(None, description="Filter by category"),
+    type: str | None = Query(None, description="Filter by template type"),
+    tags: str | None = Query(None, max_length=MAX_TAGS_LENGTH, description="Comma-separated tags"),
+    limit: int = Query(DEFAULT_LIMIT, ge=MIN_LIMIT, le=MAX_LIMIT, description="Max results"),
+    offset: int = Query(0, ge=0, le=MAX_OFFSET, description="Pagination offset"),
+    registry=Depends(get_registry),
+) -> TemplateListResponse:
+    """
+    List or search marketplace templates.
+
+    Returns a paginated list of templates with optional filtering by query,
+    category, type, and tags.
+    """
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        # Parse category enum if provided
+        category_enum = None
+        if category:
+            try:
+                from aragora.marketplace import TemplateCategory
+
+                category_enum = TemplateCategory(category)
+            except (ValueError, ImportError):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Invalid category: {category}",
+                )
+
+        # Parse tags
+        parsed_tags: list[str] | None = None
+        if tags:
+            parsed_tags = [t.strip() for t in tags.split(",") if t.strip()]
+
+        templates = registry.search(
+            query=q if q else None,
+            category=category_enum,
+            template_type=type,
+            tags=parsed_tags,
+            limit=limit,
+            offset=offset,
+        )
+
+        _record_success()
+
+        return TemplateListResponse(
+            templates=[t.to_dict() for t in templates],
+            count=len(templates),
+            limit=limit,
+            offset=offset,
+        )
+
+    except HTTPException:
+        raise
+    except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error listing templates: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to list templates")
+
+
+@router.get("/categories", response_model=CategoriesResponse)
+async def list_categories(
+    request: Request,
+    registry=Depends(get_registry),
+) -> CategoriesResponse:
+    """
+    List available template categories.
+
+    Returns all marketplace category names.
+    """
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        categories = registry.list_categories()
+        _record_success()
+        return CategoriesResponse(categories=categories)
+
+    except (KeyError, ValueError, TypeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error listing categories: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to list categories")
+
+
+@router.get("/status", response_model=MarketplaceStatusResponse)
+async def get_marketplace_status(
+    request: Request,
+) -> MarketplaceStatusResponse:
+    """
+    Get marketplace health and circuit breaker status.
+
+    Returns the overall health status and circuit breaker state.
+    """
+    cb = _get_circuit_breaker()
+    if cb:
+        cb_status = cb.get_status()
+    else:
+        cb_status = {"state": "unknown", "message": "Circuit breaker not available"}
+
+    status = "healthy" if cb_status.get("state") == "closed" else "degraded"
+    return MarketplaceStatusResponse(status=status, circuit_breaker=cb_status)
+
+
+@router.post("/templates/import", response_model=CreateTemplateResponse, status_code=201)
+async def import_template(
+    request: Request,
+    body: CreateTemplateRequest,
+    auth: AuthorizationContext = Depends(require_permission("marketplace:write")),
+    registry=Depends(get_registry),
+) -> CreateTemplateResponse:
+    """
+    Import a template.
+
+    Alias for template creation. Accepts the same body format.
+    """
+    return await create_template(request=request, body=body, auth=auth, registry=registry)
+
+
+@router.get("/templates/{template_id}/ratings", response_model=RatingsResponse)
+async def get_template_ratings(
+    template_id: str,
+    request: Request,
+    registry=Depends(get_registry),
+) -> RatingsResponse:
+    """
+    Get ratings for a template.
+
+    Returns all ratings and the average score for the specified template.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        ratings = registry.get_ratings(template_id)
+        avg = registry.get_average_rating(template_id)
+
+        _record_success()
+
+        return RatingsResponse(
+            ratings=[
+                RatingEntry(
+                    user_id=r.user_id,
+                    score=r.score,
+                    review=r.review,
+                    created_at=r.created_at.isoformat() if hasattr(r.created_at, "isoformat") else str(r.created_at),
+                )
+                for r in ratings
+            ],
+            average=avg,
+            count=len(ratings),
+        )
+
+    except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error getting ratings for %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to get template ratings")
+
+
+@router.get("/templates/{template_id}/export")
+async def export_template(
+    template_id: str,
+    request: Request,
+    registry=Depends(get_registry),
+) -> Response:
+    """
+    Export a template as a JSON file download.
+
+    Returns the template data as an application/json attachment.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        json_str = registry.export_template(template_id)
+
+        if json_str is None:
+            raise NotFoundError(f"Template not found: {template_id}")
+
+        _record_success()
+
+        return Response(
+            content=json_str.encode("utf-8"),
+            media_type="application/json",
+            headers={"Content-Disposition": f'attachment; filename="{template_id}.json"'},
+        )
+
+    except NotFoundError:
+        raise
+    except (KeyError, ValueError, TypeError, OSError, UnicodeEncodeError) as e:
+        _record_failure()
+        logger.exception("Error exporting template %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to export template")
+
+
+@router.get("/templates/{template_id}", response_model=TemplateSummary)
+async def get_template(
+    template_id: str,
+    request: Request,
+    registry=Depends(get_registry),
+) -> dict[str, Any]:
+    """
+    Get template details by ID.
+
+    Returns detailed information about a specific template. Also increments
+    the download counter.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        template = registry.get(template_id)
+
+        if template is None:
+            raise NotFoundError(f"Template not found: {template_id}")
+
+        # Increment download count
+        registry.increment_downloads(template_id)
+
+        _record_success()
+
+        return template.to_dict()
+
+    except NotFoundError:
+        raise
+    except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error getting template %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to get template")
+
+
+@router.post("/templates", response_model=CreateTemplateResponse, status_code=201)
+async def create_template(
+    request: Request,
+    body: CreateTemplateRequest,
+    auth: AuthorizationContext = Depends(require_permission("marketplace:write")),
+    registry=Depends(get_registry),
+) -> CreateTemplateResponse:
+    """
+    Create a new marketplace template.
+
+    Requires `marketplace:write` permission. Validates the template ID if
+    provided, then imports the template into the registry.
+    """
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        # Validate template ID if explicitly provided
+        if body.id:
+            _validate_template_id(body.id)
+
+        template_data = body.model_dump(exclude_none=True)
+        template_id = registry.import_template(json.dumps(template_data))
+
+        _record_success()
+
+        return CreateTemplateResponse(id=template_id, success=True)
+
+    except HTTPException:
+        raise
+    except ValueError as e:
+        logger.warning("Invalid template data: %s", e)
+        raise HTTPException(status_code=400, detail="Invalid template data")
+    except (KeyError, TypeError, OSError, json.JSONDecodeError) as e:
+        _record_failure()
+        logger.exception("Error creating template: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to create template")
+
+
+@router.delete("/templates/{template_id}", response_model=DeleteTemplateResponse)
+async def delete_template(
+    template_id: str,
+    auth: AuthorizationContext = Depends(require_permission("marketplace:delete")),
+    registry=Depends(get_registry),
+) -> DeleteTemplateResponse:
+    """
+    Delete a marketplace template.
+
+    Requires `marketplace:delete` permission. Built-in templates cannot be
+    deleted and will return 403.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        result = registry.delete(template_id)
+
+        if not result:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Cannot delete template: {template_id} (may be built-in)",
+            )
+
+        _record_success()
+
+        return DeleteTemplateResponse(success=True, deleted=template_id)
+
+    except HTTPException:
+        raise
+    except (KeyError, ValueError, TypeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error deleting template %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to delete template")
+
+
+@router.post("/templates/{template_id}/ratings", response_model=RateTemplateResponse)
+async def rate_template(
+    template_id: str,
+    body: RateTemplateRequest,
+    auth: AuthorizationContext = Depends(require_permission("marketplace:write")),
+    registry=Depends(get_registry),
+) -> RateTemplateResponse:
+    """
+    Rate a marketplace template.
+
+    Requires `marketplace:write` permission. Accepts a score (1-5) and an
+    optional review text.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        from aragora.marketplace import TemplateRating
+
+        rating = TemplateRating(
+            user_id=auth.user_id,
+            template_id=template_id,
+            score=body.score,
+            review=body.review,
+        )
+        registry.rate(rating)
+
+        _record_success()
+
+        return RateTemplateResponse(
+            success=True,
+            average_rating=registry.get_average_rating(template_id),
+        )
+
+    except (ImportError, RuntimeError) as e:
+        logger.warning("Marketplace rating infrastructure not available: %s", e)
+        raise HTTPException(status_code=503, detail="Marketplace rating not available")
+    except ValueError as e:
+        logger.warning("Invalid rating data for template %s: %s", template_id, e)
+        raise HTTPException(status_code=400, detail="Invalid rating data")
+    except (KeyError, TypeError, AttributeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error rating template %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to rate template")
+
+
+@router.post("/templates/{template_id}/star", response_model=StarTemplateResponse)
+async def star_template(
+    template_id: str,
+    auth: AuthorizationContext = Depends(require_permission("marketplace:write")),
+    registry=Depends(get_registry),
+) -> StarTemplateResponse:
+    """
+    Star a marketplace template.
+
+    Requires `marketplace:write` permission. Increments the star count
+    and returns the new total.
+    """
+    _validate_template_id(template_id)
+    _check_circuit_breaker()
+    registry = _require_registry(registry)
+
+    try:
+        registry.star(template_id)
+
+        template = registry.get(template_id)
+        stars = template.metadata.stars if template else 0
+
+        _record_success()
+
+        return StarTemplateResponse(success=True, stars=stars)
+
+    except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
+        _record_failure()
+        logger.exception("Error starring template %s: %s", template_id, e)
+        raise HTTPException(status_code=500, detail="Failed to star template")

--- a/aragora/server/fastapi/routes/orchestration.py
+++ b/aragora/server/fastapi/routes/orchestration.py
@@ -1,0 +1,661 @@
+"""
+Orchestration Endpoints (FastAPI v2).
+
+Migrated from: aragora/server/handlers/orchestration/ (aiohttp handler)
+
+Surfaces the unified orchestration control plane as REST endpoints:
+- POST   /api/v2/orchestration/deliberate       - Start async deliberation
+- POST   /api/v2/orchestration/deliberate/sync   - Start sync deliberation
+- GET    /api/v2/orchestration/status/{request_id} - Get deliberation status
+- GET    /api/v2/orchestration/templates         - List deliberation templates
+
+Migration Notes:
+    This module replaces OrchestrationHandler in the legacy handler with
+    native FastAPI routes. Key improvements:
+    - Pydantic request/response models with automatic validation
+    - FastAPI dependency injection for auth and storage
+    - Proper HTTP status codes (422 for validation, 404 for not found)
+    - OpenAPI schema auto-generation
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
+from aragora.rbac.models import AuthorizationContext
+
+from ..dependencies.auth import require_permission
+from ..middleware.error_handling import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2", tags=["Orchestration"])
+
+# =============================================================================
+# Pydantic Models
+# =============================================================================
+
+
+class KnowledgeSourceItem(BaseModel):
+    """A knowledge context source for deliberation."""
+
+    type: str = Field(..., description="Source type (slack, confluence, github, jira, document)")
+    id: str = Field(..., description="Source identifier (channel ID, page ID, PR number, etc.)")
+    lookback_minutes: int = Field(60, ge=1, le=10080, description="Lookback window in minutes")
+    max_items: int = Field(50, ge=1, le=500, description="Maximum items to fetch")
+
+
+class OutputChannelItem(BaseModel):
+    """An output channel for routing deliberation results."""
+
+    type: str = Field(..., description="Channel type (slack, teams, discord, telegram, email, webhook)")
+    id: str = Field(..., description="Channel identifier (channel ID, email, webhook URL)")
+    thread_id: str | None = Field(None, description="Optional thread/conversation ID")
+
+
+class DeliberateRequest(BaseModel):
+    """Request body for POST /orchestration/deliberate.
+
+    Unified deliberation endpoint that accepts knowledge context sources,
+    agent configuration, and output channels.
+    """
+
+    question: str = Field(
+        ..., min_length=1, max_length=5000, description="Question or topic for deliberation"
+    )
+    knowledge_sources: list[KnowledgeSourceItem] = Field(
+        default_factory=list, description="Knowledge context sources"
+    )
+    workspaces: list[str] = Field(
+        default_factory=list, description="Workspace IDs for knowledge context"
+    )
+    team_strategy: str = Field(
+        "best_for_domain",
+        description="Agent team selection strategy (specified, best_for_domain, diverse, fast, random)",
+    )
+    agents: list[str] = Field(
+        default_factory=list, description="Explicit agent list (used with 'specified' strategy)"
+    )
+    output_channels: list[OutputChannelItem] = Field(
+        default_factory=list, description="Channels to route results to"
+    )
+    output_format: str = Field(
+        "standard",
+        description="Output format (standard, decision_receipt, summary, github_review, slack_message)",
+    )
+    require_consensus: bool = Field(True, description="Whether consensus is required")
+    priority: str = Field("normal", description="Request priority (low, normal, high, critical)")
+    max_rounds: int = Field(5, ge=1, le=20, description="Maximum debate rounds")
+    timeout_seconds: float = Field(300.0, ge=10, le=3600, description="Timeout in seconds")
+    template: str | None = Field(None, description="Deliberation template name")
+    notify: bool = Field(True, description="Auto-notify on completion")
+    dry_run: bool = Field(False, description="Return cost estimate only without executing")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata")
+
+
+class DeliberateAsyncResponse(BaseModel):
+    """Response for async POST /orchestration/deliberate."""
+
+    request_id: str
+    status: str
+    message: str | None = None
+    estimated_cost_usd: float | None = None
+
+    model_config = {"extra": "allow"}
+
+
+class DryRunResponse(BaseModel):
+    """Response for dry_run deliberation requests."""
+
+    request_id: str
+    dry_run: bool = True
+    estimated_cost: dict[str, Any] | None = None
+    agents: list[str]
+    max_rounds: int
+    message: str = "Dry run -- no debate executed"
+
+
+class OrchestrationResultResponse(BaseModel):
+    """Full orchestration result."""
+
+    request_id: str
+    success: bool
+    consensus_reached: bool = False
+    final_answer: str | None = None
+    confidence: float | None = None
+    agents_participated: list[str] = Field(default_factory=list)
+    rounds_completed: int = 0
+    duration_seconds: float = 0.0
+    knowledge_context_used: list[str] = Field(default_factory=list)
+    channels_notified: list[str] = Field(default_factory=list)
+    receipt_id: str | None = None
+    error: str | None = None
+    created_at: str | None = None
+    estimated_cost_usd: float | None = None
+
+    model_config = {"extra": "allow"}
+
+
+class StatusResponse(BaseModel):
+    """Response for GET /orchestration/status/{request_id}."""
+
+    request_id: str
+    status: str  # completed, failed, in_progress
+    result: OrchestrationResultResponse | None = None
+
+
+class TemplateItem(BaseModel):
+    """A deliberation template."""
+
+    name: str
+    description: str
+    default_agents: list[str] = Field(default_factory=list)
+    default_knowledge_sources: list[str] = Field(default_factory=list)
+    output_format: str = "standard"
+    consensus_threshold: float = 0.7
+    max_rounds: int = 5
+    personas: list[str] = Field(default_factory=list)
+
+    model_config = {"extra": "allow"}
+
+
+class TemplateListResponse(BaseModel):
+    """Response for GET /orchestration/templates."""
+
+    templates: list[TemplateItem]
+    count: int
+
+
+# =============================================================================
+# Dependencies
+# =============================================================================
+
+
+def _get_orchestration_handler() -> Any:
+    """Lazily import and return the legacy OrchestrationHandler singleton.
+
+    Returns None if the handler module is unavailable, allowing
+    graceful degradation with a 503 response.
+    """
+    try:
+        from aragora.server.handlers.orchestration.handler import handler
+
+        return handler
+    except (ImportError, AttributeError, RuntimeError) as e:
+        logger.debug("Orchestration handler not available: %s", e)
+        return None
+
+
+def _get_orchestration_stores() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Get the in-memory orchestration request and result stores."""
+    try:
+        from aragora.server.handlers.orchestration.handler import (
+            _orchestration_requests,
+            _orchestration_results,
+        )
+
+        return _orchestration_requests, _orchestration_results
+    except (ImportError, AttributeError) as e:
+        logger.debug("Orchestration stores not available: %s", e)
+        return {}, {}
+
+
+async def get_orch_handler(request: Request) -> Any:
+    """Dependency to get the orchestration handler from app state or module."""
+    ctx = getattr(request.app.state, "context", None)
+    if ctx:
+        handler = ctx.get("orchestration_handler")
+        if handler is not None:
+            return handler
+
+    handler = _get_orchestration_handler()
+    if handler is None:
+        raise HTTPException(status_code=503, detail="Orchestration service not available")
+    return handler
+
+
+# =============================================================================
+# Helper: Build legacy request dict from Pydantic model
+# =============================================================================
+
+
+def _build_legacy_request_dict(body: DeliberateRequest) -> dict[str, Any]:
+    """Convert a DeliberateRequest Pydantic model to the legacy dict format
+    expected by OrchestrationRequest.from_dict().
+    """
+    data: dict[str, Any] = {
+        "question": body.question,
+        "team_strategy": body.team_strategy,
+        "agents": body.agents,
+        "output_format": body.output_format,
+        "require_consensus": body.require_consensus,
+        "priority": body.priority,
+        "max_rounds": body.max_rounds,
+        "timeout_seconds": body.timeout_seconds,
+        "template": body.template,
+        "notify": body.notify,
+        "dry_run": body.dry_run,
+        "metadata": body.metadata,
+        "workspaces": body.workspaces,
+    }
+
+    # Convert knowledge sources
+    if body.knowledge_sources:
+        data["knowledge_sources"] = [
+            {
+                "type": ks.type,
+                "id": ks.id,
+                "lookback_minutes": ks.lookback_minutes,
+                "max_items": ks.max_items,
+            }
+            for ks in body.knowledge_sources
+        ]
+
+    # Convert output channels
+    if body.output_channels:
+        data["output_channels"] = [
+            {
+                "type": ch.type,
+                "id": ch.id,
+                "thread_id": ch.thread_id,
+            }
+            for ch in body.output_channels
+        ]
+
+    return data
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.post("/orchestration/deliberate", status_code=202)
+async def start_deliberation(
+    body: DeliberateRequest,
+    request: Request,
+    auth: AuthorizationContext = Depends(require_permission("orchestration:execute")),
+    orch_handler: Any = Depends(get_orch_handler),
+) -> DeliberateAsyncResponse | DryRunResponse | OrchestrationResultResponse:
+    """
+    Start an asynchronous deliberation.
+
+    Queues a deliberation request and returns immediately with a request_id.
+    Poll GET /orchestration/status/{request_id} for results.
+
+    Requires `orchestration:execute` permission.
+    """
+    try:
+        data = _build_legacy_request_dict(body)
+
+        # Delegate to legacy handler's _handle_deliberate (which does
+        # full RBAC validation on sources/channels, cost estimation, etc.)
+        try:
+            from aragora.server.handlers.orchestration.models import (
+                OrchestrationRequest,
+                OrchestrationResult,
+            )
+            from aragora.server.handlers.orchestration.templates import TEMPLATES
+        except ImportError:
+            raise HTTPException(
+                status_code=503, detail="Orchestration models not available"
+            )
+
+        # Parse the request using the legacy model
+        orch_request = OrchestrationRequest.from_dict(data)
+
+        # Apply template if specified
+        if orch_request.template and orch_request.template in TEMPLATES:
+            template = TEMPLATES[orch_request.template]
+            if not orch_request.agents:
+                orch_request.agents = template.default_agents
+            if not orch_request.knowledge_sources:
+                from aragora.server.handlers.orchestration.models import KnowledgeContextSource
+
+                for src in template.default_knowledge_sources:
+                    orch_request.knowledge_sources.append(
+                        KnowledgeContextSource.from_string(src)
+                    )
+            orch_request.max_rounds = template.max_rounds
+
+        # Validate question
+        if not orch_request.question:
+            raise HTTPException(status_code=400, detail="Question is required")
+
+        # Cost estimation (non-blocking)
+        cost_estimate = None
+        estimated_cost_usd = None
+        try:
+            from aragora.server.handlers.debates.cost_estimation import estimate_debate_cost
+
+            cost_estimate = estimate_debate_cost(
+                num_agents=len(orch_request.agents) or 3,
+                num_rounds=orch_request.max_rounds,
+                model_types=orch_request.agents if orch_request.agents else None,
+            )
+            if cost_estimate and "total_estimated_cost_usd" in cost_estimate:
+                estimated_cost_usd = float(cost_estimate["total_estimated_cost_usd"])
+        except (ImportError, ValueError, TypeError, KeyError, AttributeError) as exc:
+            logger.warning("Cost estimation failed (non-blocking): %s", exc)
+
+        # Handle dry_run
+        if orch_request.dry_run:
+            return DryRunResponse(
+                request_id=orch_request.request_id,
+                estimated_cost=cost_estimate,
+                agents=orch_request.agents,
+                max_rounds=orch_request.max_rounds,
+            )
+
+        # Store request
+        requests_store, results_store = _get_orchestration_stores()
+        requests_store[orch_request.request_id] = orch_request
+
+        # Queue async execution
+        async def _execute_and_store() -> None:
+            try:
+                result = await orch_handler._execute_deliberation(orch_request)
+                results_store[orch_request.request_id] = result
+            except (
+                ValueError, TypeError, KeyError, AttributeError,
+                RuntimeError, OSError,
+            ) as e:
+                logger.exception("Async deliberation failed: %s", e)
+                results_store[orch_request.request_id] = OrchestrationResult(
+                    request_id=orch_request.request_id,
+                    success=False,
+                    error="Orchestration failed",
+                )
+            finally:
+                requests_store.pop(orch_request.request_id, None)
+
+        task = asyncio.create_task(_execute_and_store())
+        task.add_done_callback(
+            lambda t: logger.error("Async deliberation task failed: %s", t.exception())
+            if not t.cancelled() and t.exception()
+            else None
+        )
+
+        return DeliberateAsyncResponse(
+            request_id=orch_request.request_id,
+            status="queued",
+            message=(
+                "Deliberation queued. Check status at "
+                f"/api/v2/orchestration/status/{orch_request.request_id}"
+            ),
+            estimated_cost_usd=estimated_cost_usd,
+        )
+
+    except HTTPException:
+        raise
+    except NotFoundError:
+        raise
+    except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error starting deliberation: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to start deliberation")
+
+
+@router.post("/orchestration/deliberate/sync")
+async def start_deliberation_sync(
+    body: DeliberateRequest,
+    request: Request,
+    auth: AuthorizationContext = Depends(require_permission("orchestration:execute")),
+    orch_handler: Any = Depends(get_orch_handler),
+) -> OrchestrationResultResponse | DryRunResponse:
+    """
+    Start a synchronous deliberation.
+
+    Blocks until the deliberation is complete and returns the full result.
+    For long-running deliberations, prefer the async endpoint.
+
+    Requires `orchestration:execute` permission.
+    """
+    try:
+        data = _build_legacy_request_dict(body)
+
+        try:
+            from aragora.server.handlers.orchestration.models import (
+                OrchestrationRequest,
+            )
+            from aragora.server.handlers.orchestration.templates import TEMPLATES
+        except ImportError:
+            raise HTTPException(
+                status_code=503, detail="Orchestration models not available"
+            )
+
+        orch_request = OrchestrationRequest.from_dict(data)
+
+        # Apply template if specified
+        if orch_request.template and orch_request.template in TEMPLATES:
+            template = TEMPLATES[orch_request.template]
+            if not orch_request.agents:
+                orch_request.agents = template.default_agents
+            if not orch_request.knowledge_sources:
+                from aragora.server.handlers.orchestration.models import KnowledgeContextSource
+
+                for src in template.default_knowledge_sources:
+                    orch_request.knowledge_sources.append(
+                        KnowledgeContextSource.from_string(src)
+                    )
+            orch_request.max_rounds = template.max_rounds
+
+        if not orch_request.question:
+            raise HTTPException(status_code=400, detail="Question is required")
+
+        # Cost estimation
+        cost_estimate = None
+        estimated_cost_usd = None
+        try:
+            from aragora.server.handlers.debates.cost_estimation import estimate_debate_cost
+
+            cost_estimate = estimate_debate_cost(
+                num_agents=len(orch_request.agents) or 3,
+                num_rounds=orch_request.max_rounds,
+                model_types=orch_request.agents if orch_request.agents else None,
+            )
+            if cost_estimate and "total_estimated_cost_usd" in cost_estimate:
+                estimated_cost_usd = float(cost_estimate["total_estimated_cost_usd"])
+        except (ImportError, ValueError, TypeError, KeyError, AttributeError) as exc:
+            logger.warning("Cost estimation failed (non-blocking): %s", exc)
+
+        # Handle dry_run
+        if orch_request.dry_run:
+            return DryRunResponse(
+                request_id=orch_request.request_id,
+                estimated_cost=cost_estimate,
+                agents=orch_request.agents,
+                max_rounds=orch_request.max_rounds,
+            )
+
+        # Synchronous execution
+        requests_store, results_store = _get_orchestration_stores()
+        requests_store[orch_request.request_id] = orch_request
+
+        try:
+            result = await orch_handler._execute_deliberation(orch_request)
+            results_store[orch_request.request_id] = result
+        finally:
+            requests_store.pop(orch_request.request_id, None)
+
+        result_dict = result.to_dict()
+
+        return OrchestrationResultResponse(
+            request_id=result_dict.get("request_id", orch_request.request_id),
+            success=result_dict.get("success", False),
+            consensus_reached=result_dict.get("consensus_reached", False),
+            final_answer=result_dict.get("final_answer"),
+            confidence=result_dict.get("confidence"),
+            agents_participated=result_dict.get("agents_participated", []),
+            rounds_completed=result_dict.get("rounds_completed", 0),
+            duration_seconds=result_dict.get("duration_seconds", 0.0),
+            knowledge_context_used=result_dict.get("knowledge_context_used", []),
+            channels_notified=result_dict.get("channels_notified", []),
+            receipt_id=result_dict.get("receipt_id"),
+            error=result_dict.get("error"),
+            created_at=result_dict.get("created_at"),
+            estimated_cost_usd=estimated_cost_usd,
+        )
+
+    except HTTPException:
+        raise
+    except NotFoundError:
+        raise
+    except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error in synchronous deliberation: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to execute deliberation")
+
+
+@router.get("/orchestration/status/{request_id}", response_model=StatusResponse)
+async def get_deliberation_status(
+    request_id: str,
+    auth: AuthorizationContext = Depends(require_permission("orchestration:read")),
+) -> StatusResponse:
+    """
+    Get the status of a deliberation request.
+
+    Returns status (completed, failed, in_progress) and, if completed,
+    the full result.
+
+    Requires `orchestration:read` permission.
+    """
+    try:
+        requests_store, results_store = _get_orchestration_stores()
+
+        # Check if result is available
+        if request_id in results_store:
+            result = results_store[request_id]
+            result_dict = result.to_dict() if hasattr(result, "to_dict") else {}
+
+            return StatusResponse(
+                request_id=request_id,
+                status="completed" if result_dict.get("success") else "failed",
+                result=OrchestrationResultResponse(
+                    request_id=result_dict.get("request_id", request_id),
+                    success=result_dict.get("success", False),
+                    consensus_reached=result_dict.get("consensus_reached", False),
+                    final_answer=result_dict.get("final_answer"),
+                    confidence=result_dict.get("confidence"),
+                    agents_participated=result_dict.get("agents_participated", []),
+                    rounds_completed=result_dict.get("rounds_completed", 0),
+                    duration_seconds=result_dict.get("duration_seconds", 0.0),
+                    knowledge_context_used=result_dict.get("knowledge_context_used", []),
+                    channels_notified=result_dict.get("channels_notified", []),
+                    receipt_id=result_dict.get("receipt_id"),
+                    error=result_dict.get("error"),
+                    created_at=result_dict.get("created_at"),
+                ),
+            )
+
+        # Check if request is still in progress
+        if request_id in requests_store:
+            return StatusResponse(
+                request_id=request_id,
+                status="in_progress",
+                result=None,
+            )
+
+        raise NotFoundError(f"Orchestration request {request_id} not found")
+
+    except NotFoundError:
+        raise
+    except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error getting deliberation status %s: %s", request_id, e)
+        raise HTTPException(status_code=500, detail="Failed to get deliberation status")
+
+
+@router.get("/orchestration/templates", response_model=TemplateListResponse)
+async def list_templates(
+    request: Request,
+    category: str | None = Query(None, description="Filter by category"),
+    search: str | None = Query(None, description="Text search in name and description"),
+    tags: str | None = Query(None, description="Comma-separated tag filter"),
+    limit: int = Query(50, ge=1, le=500, description="Max results to return"),
+    offset: int = Query(0, ge=0, description="Pagination offset"),
+    auth: AuthorizationContext = Depends(require_permission("orchestration:read")),
+) -> TemplateListResponse:
+    """
+    List available deliberation templates.
+
+    Returns templates that define pre-built deliberation patterns with
+    default agent configurations, knowledge sources, and output formats.
+
+    Supports filtering by category, text search, and tags.
+    Requires `orchestration:read` permission.
+    """
+    try:
+        try:
+            from aragora.server.handlers.orchestration.templates import (
+                _list_templates,
+                TEMPLATES,
+            )
+        except ImportError:
+            raise HTTPException(
+                status_code=503, detail="Orchestration templates not available"
+            )
+
+        parsed_tags = None
+        if tags:
+            parsed_tags = [t.strip() for t in tags.split(",") if t.strip()]
+
+        if _list_templates is not None:
+            templates_raw = _list_templates(
+                category=category,
+                search=search,
+                tags=parsed_tags,
+                limit=limit,
+                offset=offset,
+            )
+            template_dicts = [
+                t.to_dict() if hasattr(t, "to_dict") else t for t in templates_raw
+            ]
+        else:
+            # Fallback: unfiltered from TEMPLATES dict
+            template_dicts = [
+                t.to_dict() if hasattr(t, "to_dict") else t
+                for t in TEMPLATES.values()
+            ]
+
+        templates = []
+        for td in template_dicts:
+            if isinstance(td, dict):
+                templates.append(
+                    TemplateItem(
+                        name=td.get("name", ""),
+                        description=td.get("description", ""),
+                        default_agents=td.get("default_agents", []),
+                        default_knowledge_sources=td.get("default_knowledge_sources", []),
+                        output_format=td.get("output_format", "standard"),
+                        consensus_threshold=td.get("consensus_threshold", 0.7),
+                        max_rounds=td.get("max_rounds", 5),
+                        personas=td.get("personas", []),
+                    )
+                )
+            else:
+                templates.append(
+                    TemplateItem(
+                        name=getattr(td, "name", ""),
+                        description=getattr(td, "description", ""),
+                        default_agents=getattr(td, "default_agents", []),
+                        default_knowledge_sources=getattr(td, "default_knowledge_sources", []),
+                        output_format=str(getattr(td, "output_format", "standard")),
+                        consensus_threshold=getattr(td, "consensus_threshold", 0.7),
+                        max_rounds=getattr(td, "max_rounds", 5),
+                        personas=getattr(td, "personas", []),
+                    )
+                )
+
+        return TemplateListResponse(
+            templates=templates,
+            count=len(templates),
+        )
+
+    except HTTPException:
+        raise
+    except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error listing orchestration templates: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to list templates")

--- a/sdk/python/aragora_sdk/namespaces/agents.py
+++ b/sdk/python/aragora_sdk/namespaces/agents.py
@@ -386,6 +386,110 @@ class AgentsAPI:
         """
         return self._client.request("GET", f"/api/agents/{agent_id}/feedback/domains")
 
+    # =========================================================================
+    # Agent Statistics
+    # =========================================================================
+
+    def get_stats(self) -> dict[str, Any]:
+        """
+        Get aggregate agent statistics.
+
+        Returns:
+            Dict with overall agent statistics (counts, averages, etc.)
+        """
+        return self._client.request("GET", "/api/v1/agents/stats")
+
+    # =========================================================================
+    # Agent Lifecycle
+    # =========================================================================
+
+    def enable(self, name: str) -> dict[str, Any]:
+        """
+        Enable an agent.
+
+        Args:
+            name: Agent name or identifier.
+
+        Returns:
+            Dict confirming the agent has been enabled.
+        """
+        return self._client.request("POST", f"/api/v1/agents/{name}/enable")
+
+    def disable(self, name: str, reason: str | None = None) -> dict[str, Any]:
+        """
+        Disable an agent.
+
+        Args:
+            name: Agent name or identifier.
+            reason: Optional reason for disabling.
+
+        Returns:
+            Dict confirming the agent has been disabled.
+        """
+        body: dict[str, Any] = {}
+        if reason:
+            body["reason"] = reason
+        return self._client.request("POST", f"/api/v1/agents/{name}/disable", json=body or None)
+
+    def register(
+        self,
+        agent_id: str,
+        capabilities: list[str] | None = None,
+        model: str | None = None,
+        provider: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Register a new agent.
+
+        Args:
+            agent_id: Unique agent identifier.
+            capabilities: List of agent capabilities.
+            model: Model name.
+            provider: Model provider.
+            metadata: Additional metadata.
+
+        Returns:
+            Dict with registration confirmation.
+        """
+        body: dict[str, Any] = {"agent_id": agent_id}
+        if capabilities:
+            body["capabilities"] = capabilities
+        if model:
+            body["model"] = model
+        if provider:
+            body["provider"] = provider
+        if metadata is not None:
+            body["metadata"] = metadata
+        return self._client.request("POST", "/api/v1/control-plane/agents", json=body)
+
+    def unregister(self, agent_id: str) -> dict[str, Any]:
+        """
+        Unregister an agent.
+
+        Args:
+            agent_id: Agent identifier.
+
+        Returns:
+            Dict confirming unregistration.
+        """
+        return self._client.request("DELETE", f"/api/v1/control-plane/agents/{agent_id}")
+
+    def heartbeat(self, agent_id: str, status: str) -> dict[str, Any]:
+        """
+        Send a heartbeat for an agent.
+
+        Args:
+            agent_id: Agent identifier.
+            status: Current agent status.
+
+        Returns:
+            Dict confirming heartbeat received.
+        """
+        return self._client.request(
+            "POST", f"/api/v1/control-plane/agents/{agent_id}/heartbeat", json={"status": status}
+        )
+
 
 class AsyncAgentsAPI:
     """
@@ -687,3 +791,60 @@ class AsyncAgentsAPI:
     async def get_feedback_domains(self, agent_id: str) -> dict[str, Any]:
         """Get feedback domain breakdown for a specific agent."""
         return await self._client.request("GET", f"/api/agents/{agent_id}/feedback/domains")
+
+    # =========================================================================
+    # Agent Statistics
+    # =========================================================================
+
+    async def get_stats(self) -> dict[str, Any]:
+        """Get aggregate agent statistics."""
+        return await self._client.request("GET", "/api/v1/agents/stats")
+
+    # =========================================================================
+    # Agent Lifecycle
+    # =========================================================================
+
+    async def enable(self, name: str) -> dict[str, Any]:
+        """Enable an agent."""
+        return await self._client.request("POST", f"/api/v1/agents/{name}/enable")
+
+    async def disable(self, name: str, reason: str | None = None) -> dict[str, Any]:
+        """Disable an agent with optional reason."""
+        body: dict[str, Any] = {}
+        if reason:
+            body["reason"] = reason
+        return await self._client.request(
+            "POST", f"/api/v1/agents/{name}/disable", json=body or None
+        )
+
+    async def register(
+        self,
+        agent_id: str,
+        capabilities: list[str] | None = None,
+        model: str | None = None,
+        provider: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Register a new agent."""
+        body: dict[str, Any] = {"agent_id": agent_id}
+        if capabilities:
+            body["capabilities"] = capabilities
+        if model:
+            body["model"] = model
+        if provider:
+            body["provider"] = provider
+        if metadata is not None:
+            body["metadata"] = metadata
+        return await self._client.request("POST", "/api/v1/control-plane/agents", json=body)
+
+    async def unregister(self, agent_id: str) -> dict[str, Any]:
+        """Unregister an agent."""
+        return await self._client.request("DELETE", f"/api/v1/control-plane/agents/{agent_id}")
+
+    async def heartbeat(self, agent_id: str, status: str) -> dict[str, Any]:
+        """Send a heartbeat for an agent."""
+        return await self._client.request(
+            "POST",
+            f"/api/v1/control-plane/agents/{agent_id}/heartbeat",
+            json={"status": status},
+        )


### PR DESCRIPTION
## Summary
- isolates in-progress local changes that were sitting on `main` into a dedicated branch
- adds new FastAPI v2 route modules for marketplace and orchestration migration work
- adds additional agent lifecycle/statistics helpers to the Python SDK `AgentsAPI`

## Validation
- `ruff check sdk/python/aragora_sdk/namespaces/agents.py aragora/server/fastapi/routes/marketplace.py aragora/server/fastapi/routes/orchestration.py`
- `python scripts/validate_openapi_routes.py`
- `pytest -q tests/sdk/test_openapi_sync.py::TestTypeScriptSDKDrift::test_no_new_ts_drift --timeout=60 --tb=short`

## Notes
- route modules are currently added as isolated migration artifacts and are not yet wired into `aragora/server/fastapi/factory.py`
- follow-up PR should decide registration strategy and any API contract/test updates before merge
