### PR TITLE
fix(playground): use registry agent names for live debates

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -1832,7 +1832,7 @@ class PlaygroundHandler(BaseHandler):
 _LIVE_TIMEOUT = 60  # seconds
 _LIVE_BUDGET_CAP = 0.05  # USD
 _LIVE_MAX_CONCURRENT = 2
-_LIVE_DEFAULT_AGENTS = ["anthropic", "openai"]
+_LIVE_DEFAULT_AGENTS = ["anthropic-api", "openai-api"]
 _LIVE_FALLBACK_AGENTS = ["openrouter"]
 
 _live_semaphore = asyncio.Semaphore(_LIVE_MAX_CONCURRENT)
@@ -1849,13 +1849,13 @@ def _get_available_live_agents(count: int) -> list[str]:
 
     candidates: list[str] = []
     if _get_api_key("ANTHROPIC_API_KEY"):
-        candidates.append("anthropic")
+        candidates.append("anthropic-api")
     if _get_api_key("OPENAI_API_KEY") or has_openrouter:
-        candidates.append("openai")
+        candidates.append("openai-api")
     if has_openrouter:
         candidates.append("openrouter")
     if _get_api_key("MISTRAL_API_KEY") or has_openrouter:
-        candidates.append("mistral")
+        candidates.append("mistral-api")
 
     # De-duplicate while preserving order
     seen: set[str] = set()

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -1090,7 +1090,7 @@ class TestGetAvailableLiveAgents:
             side_effect=fake_key,
         ):
             agents = _get_available_live_agents(3)
-            assert "anthropic" in agents
+            assert "anthropic-api" in agents
 
     def test_pads_to_requested_count(self):
         def fake_key(name):
@@ -1110,8 +1110,8 @@ class TestGetAvailableLiveAgents:
         ):
             agents = _get_available_live_agents(4)
             assert len(agents) == 4
-            assert "anthropic" in agents
-            assert "openai" in agents
+            assert "anthropic-api" in agents
+            assert "openai-api" in agents
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Fixed `_get_available_live_agents()` using shorthand names (`anthropic`, `openai`) that don't exist in `AgentRegistry`, causing `ValueError` on live debate creation
- Updated to correct registry names: `anthropic-api`, `openai-api`, `mistral-api`
- Fallback-aware agent selection: providers with OpenRouter fallback are included even when their primary API key is missing

## Test plan
- [x] 107 playground handler tests pass
- [x] Dogfood debate completed successfully (2 agents, consensus=True, 142s)
- [x] Verified fallback routing: bad OpenAI key → OpenRouter fallback fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)