### PR TITLE
test(canvas-e2e): bound start_debate action with timeout

### DIFF
--- a/tests/e2e/test_canvas_e2e.py
+++ b/tests/e2e/test_canvas_e2e.py
@@ -704,7 +704,11 @@ class TestCanvasActionExecutionE2E:
         result = await manager.execute_action(
             canvas_id=canvas.id,
             action="start_debate",
-            params={"question": "Should we use microservices?", "rounds": 3},
+            params={
+                "question": "Should we use microservices?",
+                "rounds": 3,
+                "timeout_seconds": 10,
+            },
         )
 
         # Should succeed (node created, even if execution not available)


### PR DESCRIPTION
## Summary
- add explicit `timeout_seconds` to the E2E canvas start_debate action test
- prevent indefinite blocking when a real debate execution path is available

## Validation
- `pytest -q tests/canvas/test_manager.py tests/config/test_validator.py tests/handlers/utils/test_rate_limit.py tests/integration/test_billing_flow.py tests/server/stream/test_ws_message_validation.py`
- `pytest -q tests/e2e/test_canvas_e2e.py::TestCanvasActionExecutionE2E::test_start_debate_action_creates_node`
- `pytest -q tests/e2e/test_canvas_e2e.py`
