### PR TITLE
hardening: enforce ff-only worktree defaults and branch mutation policy

### DIFF
--- a/.github/workflows/branch-discipline.yml
+++ b/.github/workflows/branch-discipline.yml
@@ -1,10 +1,8 @@
 name: Branch Discipline
 
 on:
-  # Disabled during rapid parallel development phase.
-  # Re-enable push trigger when adopting PR-based workflow.
-  # push:
-  #   branches: [main]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,6 +51,9 @@ jobs:
           pip install ruff==0.14.14
           pip install -e .
 
+      - name: Enforce branch mutation policy
+        run: python scripts/check_branch_mutation_policy.py
+
       - name: Run ruff format check (all Python files)
         run: ruff format --check aragora/ tests/ scripts/
         shell: bash

--- a/aragora/worktree/autopilot.py
+++ b/aragora/worktree/autopilot.py
@@ -21,7 +21,7 @@ class AutopilotRequest:
     agent: str = "codex"
     session_id: str | None = None
     force_new: bool = False
-    strategy: str = "merge"
+    strategy: str = "ff-only"
     reconcile: bool = False
     reconcile_all: bool = False
     path: str | None = None

--- a/aragora/worktree/lifecycle.py
+++ b/aragora/worktree/lifecycle.py
@@ -166,7 +166,7 @@ class WorktreeLifecycleService:
         session_id: str | None = None,
         force_new: bool = False,
         reconcile: bool = True,
-        strategy: str = "merge",
+        strategy: str = "ff-only",
     ) -> ManagedWorktreeSession:
         """Ensure a managed worktree session exists and return its typed details."""
         request = AutopilotRequest(
@@ -217,7 +217,7 @@ class WorktreeLifecycleService:
         *,
         base_branch: str = "main",
         ttl_hours: int = 24,
-        strategy: str = "merge",
+        strategy: str = "ff-only",
         managed_dirs: list[str] | None = None,
         include_active: bool = False,
         reconcile_only: bool = False,

--- a/aragora/worktree/maintainer.py
+++ b/aragora/worktree/maintainer.py
@@ -24,7 +24,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--strategy",
         choices=("merge", "rebase", "ff-only", "none"),
-        default="merge",
+        default="ff-only",
         help="Integration strategy",
     )
     parser.add_argument(

--- a/scripts/check_branch_mutation_policy.py
+++ b/scripts/check_branch_mutation_policy.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Guard against CI/session defaults that silently mutate active PR branches.
+
+This script enforces two policies:
+1) Worktree/autopilot defaults must use non-mutating `ff-only` integration.
+2) Workflow files that run `git push` must be explicitly allowlisted and constrained.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    message: str
+
+
+# path -> list[regex patterns that must match]
+STRATEGY_REQUIRED_PATTERNS: dict[str, list[str]] = {
+    "scripts/codex_session.sh": [r"--reconcile --strategy ff-only"],
+    "scripts/install_worktree_maintainer_launchd.sh": [
+        r'^STRATEGY="ff-only"$',
+        r"Integration strategy \(default: ff-only\)",
+    ],
+    "aragora/worktree/autopilot.py": [r'strategy:\s*str\s*=\s*"ff-only"'],
+    "aragora/worktree/maintainer.py": [r'default="ff-only"'],
+    # ensure_managed_worktree + maintain_managed_dirs defaults
+    "aragora/worktree/lifecycle.py": [r'strategy:\s*str\s*=\s*"ff-only"'],
+    # ensure + reconcile + maintain parser defaults
+    "scripts/codex_worktree_autopilot.py": [r'default="ff-only"'],
+}
+
+REQUIRED_MATCH_COUNTS: dict[str, int] = {
+    "aragora/worktree/lifecycle.py": 2,
+    "scripts/codex_worktree_autopilot.py": 3,
+}
+
+WORKFLOW_MUTATION_ALLOWLIST = {
+    "openapi.yml",
+    "release-notes.yml",
+    "testfixer-auto.yml",
+}
+
+
+def find_strategy_default_violations(files: dict[str, str]) -> list[Violation]:
+    violations: list[Violation] = []
+    for path, patterns in STRATEGY_REQUIRED_PATTERNS.items():
+        text = files.get(path)
+        if text is None:
+            violations.append(Violation(path=path, message="missing required file"))
+            continue
+
+        total_matches = 0
+        for pattern in patterns:
+            matches = re.findall(pattern, text, flags=re.MULTILINE)
+            if not matches:
+                violations.append(
+                    Violation(path=path, message=f"missing required pattern: {pattern}")
+                )
+            total_matches += len(matches)
+
+        min_count = REQUIRED_MATCH_COUNTS.get(path, len(patterns))
+        if total_matches < min_count:
+            violations.append(
+                Violation(
+                    path=path,
+                    message=(
+                        f"expected at least {min_count} ff-only default markers, "
+                        f"found {total_matches}"
+                    ),
+                )
+            )
+    return violations
+
+
+def find_mutating_workflow_violations(workflows: dict[str, str]) -> list[Violation]:
+    violations: list[Violation] = []
+    for name, text in workflows.items():
+        if "git push" not in text:
+            continue
+
+        if name not in WORKFLOW_MUTATION_ALLOWLIST:
+            violations.append(
+                Violation(
+                    path=f".github/workflows/{name}",
+                    message=(
+                        "contains `git push` but is not in mutation allowlist "
+                        f"{sorted(WORKFLOW_MUTATION_ALLOWLIST)}"
+                    ),
+                )
+            )
+            continue
+
+        if name == "openapi.yml":
+            if "if: github.event_name == 'push' && github.ref == 'refs/heads/main'" not in text:
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must gate git push behind push-to-main condition",
+                    )
+                )
+
+        if name == "release-notes.yml":
+            if re.search(r"^\s*pull_request(_target)?\s*:", text, flags=re.MULTILINE):
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must not be triggered by pull_request/pull_request_target",
+                    )
+                )
+
+        if name == "testfixer-auto.yml":
+            if not re.search(r'branch="testfixer/', text):
+                violations.append(
+                    Violation(
+                        path=f".github/workflows/{name}",
+                        message="must push only to testfixer/* branch namespace",
+                    )
+                )
+    return violations
+
+
+def _load_repo_files(repo_root: Path) -> tuple[dict[str, str], dict[str, str]]:
+    strategy_files: dict[str, str] = {}
+    for rel in STRATEGY_REQUIRED_PATTERNS:
+        path = repo_root / rel
+        if path.exists():
+            strategy_files[rel] = path.read_text(encoding="utf-8")
+
+    workflows: dict[str, str] = {}
+    workflows_dir = repo_root / ".github" / "workflows"
+    if workflows_dir.exists():
+        for wf in sorted(workflows_dir.glob("*.yml")):
+            workflows[wf.name] = wf.read_text(encoding="utf-8")
+    return strategy_files, workflows
+
+
+def check_repo(repo_root: Path) -> list[Violation]:
+    strategy_files, workflows = _load_repo_files(repo_root)
+    violations = []
+    violations.extend(find_strategy_default_violations(strategy_files))
+    violations.extend(find_mutating_workflow_violations(workflows))
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Enforce branch mutation safety defaults.")
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Repository root to check",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    violations = check_repo(repo_root)
+    if not violations:
+        print("Branch mutation policy check passed")
+        return 0
+
+    print("Branch mutation policy violations detected:")
+    for v in violations:
+        print(f"- {v.path}: {v.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -59,7 +59,7 @@ done
 
 ENSURE_ARGS=(ensure --agent "${AGENT}" --base "${BASE_BRANCH}" --print-path)
 if ${RECONCILE}; then
-    ENSURE_ARGS+=(--reconcile --strategy merge)
+    ENSURE_ARGS+=(--reconcile --strategy ff-only)
 fi
 
 if ${MAINTAIN}; then

--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -688,7 +688,7 @@ def _build_parser() -> argparse.ArgumentParser:
     ensure.add_argument(
         "--strategy",
         choices=("merge", "rebase", "ff-only", "none"),
-        default="merge",
+        default="ff-only",
         help="Upstream integration strategy when --reconcile is enabled",
     )
     ensure.add_argument("--print-path", action="store_true")
@@ -700,7 +700,7 @@ def _build_parser() -> argparse.ArgumentParser:
     reconcile.add_argument(
         "--strategy",
         choices=("merge", "rebase", "ff-only", "none"),
-        default="rebase",
+        default="ff-only",
         help="Upstream integration strategy",
     )
     reconcile.add_argument("--all", action="store_true")
@@ -731,7 +731,7 @@ def _build_parser() -> argparse.ArgumentParser:
     maintain.add_argument(
         "--strategy",
         choices=("merge", "rebase", "ff-only", "none"),
-        default="merge",
+        default="ff-only",
         help="Upstream integration strategy for the reconcile phase",
     )
     maintain.add_argument("--ttl-hours", type=int, default=24)

--- a/scripts/install_worktree_maintainer_launchd.sh
+++ b/scripts/install_worktree_maintainer_launchd.sh
@@ -8,7 +8,7 @@ LABEL="com.aragora.codex-worktree-maintainer"
 INTERVAL_SECONDS=300
 BASE_BRANCH="main"
 TTL_HOURS="${CODEX_WORKTREE_TTL_HOURS:-24}"
-STRATEGY="merge"
+STRATEGY="ff-only"
 LOG_PATH="${REPO_ROOT}/.worktrees/codex-maintainer.log"
 KEEP_BRANCHES=true
 
@@ -21,7 +21,7 @@ Options:
   --base <branch>               Base branch to integrate from (default: main)
   --ttl-hours <n>               Stale-session TTL in hours (default: 24)
   --strategy <merge|rebase|ff-only|none>
-                                Integration strategy (default: merge)
+                                Integration strategy (default: ff-only)
   --delete-branches             Allow cleanup to delete local codex/* branches
   --log-path <file>             Log file path (default: .worktrees/codex-maintainer.log)
   --help                        Show this help
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --strategy)
-            STRATEGY="${2:-merge}"
+            STRATEGY="${2:-ff-only}"
             shift 2
             ;;
         --delete-branches)

--- a/tests/scripts/test_check_branch_mutation_policy.py
+++ b/tests/scripts/test_check_branch_mutation_policy.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_branch_mutation_policy import (
+    check_repo,
+    find_mutating_workflow_violations,
+    find_strategy_default_violations,
+)
+
+
+def test_find_strategy_default_violations_detects_missing_patterns() -> None:
+    files = {
+        "scripts/codex_session.sh": "ENSURE_ARGS+=(--reconcile --strategy merge)",
+    }
+    violations = find_strategy_default_violations(files)
+    assert violations
+    assert any(v.path == "scripts/codex_session.sh" for v in violations)
+
+
+def test_find_mutating_workflow_violations_rejects_unallowlisted_push() -> None:
+    workflows = {
+        "rogue.yml": "on:\n  workflow_dispatch:\njobs:\n  x:\n    steps:\n      - run: git push origin main",
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations
+    assert "not in mutation allowlist" in violations[0].message
+
+
+def test_find_mutating_workflow_violations_requires_testfixer_prefix() -> None:
+    workflows = {
+        "testfixer-auto.yml": (
+            "on:\n  workflow_run:\n    workflows: [Test]\n"
+            'jobs:\n  x:\n    steps:\n      - run: |\n          branch="autofix/tmp"\n          git push origin "$branch"'
+        ),
+    }
+    violations = find_mutating_workflow_violations(workflows)
+    assert violations
+    assert "testfixer/*" in violations[0].message
+
+
+def test_repo_branch_mutation_policy_passes_for_current_tree() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = check_repo(repo_root)
+    assert violations == []

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -126,20 +126,20 @@ def test_cleanup_parser_defaults_to_delete_branches():
     assert args.delete_branches is True
 
 
-def test_ensure_parser_defaults_to_merge_strategy():
+def test_ensure_parser_defaults_to_ff_only_strategy():
     import codex_worktree_autopilot as mod
 
     parser = mod._build_parser()
     args = parser.parse_args(["ensure"])
-    assert args.strategy == "merge"
+    assert args.strategy == "ff-only"
 
 
-def test_reconcile_parser_defaults_to_rebase_strategy():
+def test_reconcile_parser_defaults_to_ff_only_strategy():
     import codex_worktree_autopilot as mod
 
     parser = mod._build_parser()
     args = parser.parse_args(["reconcile"])
-    assert args.strategy == "rebase"
+    assert args.strategy == "ff-only"
 
 
 def test_cleanup_parser_allows_no_delete_branches_toggle():
@@ -158,12 +158,12 @@ def test_maintain_parser_allows_no_delete_branches_toggle():
     assert args.delete_branches is False
 
 
-def test_maintain_parser_defaults_to_merge_strategy():
+def test_maintain_parser_defaults_to_ff_only_strategy():
     import codex_worktree_autopilot as mod
 
     parser = mod._build_parser()
     args = parser.parse_args(["maintain"])
-    assert args.strategy == "merge"
+    assert args.strategy == "ff-only"
 
 
 def test_parse_ts_normalizes_naive_timestamp_to_utc():

--- a/tests/worktree/test_lifecycle.py
+++ b/tests/worktree/test_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -170,3 +171,11 @@ def test_ensure_managed_worktree_missing_session_payload_raises(tmp_path: Path) 
 
     with pytest.raises(RuntimeError, match="missing session payload"):
         service.ensure_managed_worktree(managed_dir=".worktrees/codex-auto")
+
+
+def test_worktree_lifecycle_defaults_to_ff_only_strategy(tmp_path: Path) -> None:
+    service = WorktreeLifecycleService(repo_root=tmp_path)
+    ensure_sig = inspect.signature(service.ensure_managed_worktree)
+    maintain_sig = inspect.signature(service.maintain_managed_dirs)
+    assert ensure_sig.parameters["strategy"].default == "ff-only"
+    assert maintain_sig.parameters["strategy"].default == "ff-only"

--- a/tests/worktree/test_maintainer.py
+++ b/tests/worktree/test_maintainer.py
@@ -58,3 +58,9 @@ def test_main_failure_exit_code(mock_service_cls, capsys) -> None:
     assert exit_code == 1
     out = capsys.readouterr().out
     assert "failures=1" in out
+
+
+def test_build_parser_defaults_to_ff_only_strategy() -> None:
+    parser = maintainer.build_parser()
+    args = parser.parse_args([])
+    assert args.strategy == "ff-only"


### PR DESCRIPTION
## Summary\n- switch worktree/autopilot integration defaults to  across lifecycle, maintainer, and helper scripts\n- add  to enforce non-mutating defaults and restrict mutating workflows\n- run the new mutation-policy guard in lint CI\n- add/adjust tests for parser defaults and policy enforcement\n\n## Validation\n- Branch mutation policy check passed\n- ........................................................................ [ 37%]
........................................................................ [ 75%]
...............................................                          [100%]
191 passed in 6.01s\n- All checks passed!