### PR TITLE
ci(deploy): harden production post-deploy SHA verification

### DIFF
--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -762,9 +762,10 @@ jobs:
             --document-name "AWS-RunShellScript" \
             --comment "SHA verification from GitHub Actions run ${{ github.run_id }}" \
             --parameters 'commands=[
-              "cd /home/ec2-user/aragora && git rev-parse HEAD"
+              "set -e",
+              "sudo -u ec2-user git -C /home/ec2-user/aragora rev-parse HEAD || git -C /home/ec2-user/aragora -c safe.directory=/home/ec2-user/aragora rev-parse HEAD"
             ]' \
-            --timeout-seconds 30 \
+            --timeout-seconds 60 \
             --query 'Command.CommandId' \
             --output text)
 
@@ -801,6 +802,22 @@ jobs:
 
             if [[ "$STATUS" != "Success" ]]; then
               echo "::error::Failed to retrieve deployed SHA from $INST_ID (status: $STATUS)"
+              STDOUT=$(aws ssm get-command-invocation \
+                --command-id "$SHA_CMD_ID" \
+                --instance-id "$INST_ID" \
+                --query 'StandardOutputContent' \
+                --output text 2>/dev/null || echo "")
+              STDERR=$(aws ssm get-command-invocation \
+                --command-id "$SHA_CMD_ID" \
+                --instance-id "$INST_ID" \
+                --query 'StandardErrorContent' \
+                --output text 2>/dev/null || echo "")
+              if [[ -n "$STDOUT" ]]; then
+                echo "::warning::SHA stdout for $INST_ID: $STDOUT"
+              fi
+              if [[ -n "$STDERR" ]]; then
+                echo "::warning::SHA stderr for $INST_ID: $STDERR"
+              fi
               SHA_MISMATCH=true
               continue
             fi


### PR DESCRIPTION
## Summary
- harden `Deploy (Secure)` post-deploy SHA verification to run `git rev-parse HEAD` as `ec2-user`
- add fallback command with explicit `safe.directory` for root-owned SSM contexts
- increase SHA verification SSM timeout from 30s to 60s
- log stdout/stderr when SHA retrieval fails for faster diagnosis

## Why
Recent `main` deploy runs repeatedly failed in `deploy-ec2-production` at **Post-deploy SHA verification** even though the deploy command itself succeeded. This patch reduces false failures caused by ownership/safe-directory shell context differences in SSM commands.

## Validation
- YAML parse check: `python -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-secure.yml'))"`
