### PR TITLE
ci(deploy): gate staging rollback warning and enforce SHA guard

### DIFF
--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -491,10 +491,36 @@ jobs:
           echo "::warning::External health check via Cloudflare failed"
           echo "external_ok=false" >> $GITHUB_OUTPUT
 
-      - name: Rollback on failure
-        if: always() && steps.deploy.conclusion != 'skipped' && (steps.deploy.outputs.deploy_success != 'true' || steps.health.outputs.health_ok == 'false')
+      - name: Determine rollback requirement
+        id: rollback_gate
+        if: always() && steps.deploy.conclusion != 'skipped'
         run: |
-          echo "::warning::Deployment failed - initiating rollback"
+          DEPLOY_SUCCESS="${{ steps.deploy.outputs.deploy_success }}"
+          HEALTH_OK="${{ steps.health.outputs.health_ok }}"
+          SHOULD_ROLLBACK="false"
+          ROLLBACK_REASON=""
+
+          if [[ "$DEPLOY_SUCCESS" != "true" ]]; then
+            SHOULD_ROLLBACK="true"
+            ROLLBACK_REASON="deploy step did not report success (deploy_success=${DEPLOY_SUCCESS:-unset})"
+          elif [[ "$HEALTH_OK" == "false" ]]; then
+            SHOULD_ROLLBACK="true"
+            ROLLBACK_REASON="post-deploy health/SHA verification failed"
+          fi
+
+          echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"
+          echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"
+
+          if [[ "$SHOULD_ROLLBACK" == "true" ]]; then
+            echo "Rollback required: $ROLLBACK_REASON"
+          else
+            echo "::notice::Staging deployment succeeded; rollback not required"
+          fi
+
+      - name: Rollback on failure
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::warning::Deployment failed - initiating rollback (${{ steps.rollback_gate.outputs.rollback_reason }})"
           IFS=',' read -ra IDS <<< "${{ steps.get-instance.outputs.instance_ids }}"
 
           aws ssm send-command \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Enforce branch mutation policy
         run: python scripts/check_branch_mutation_policy.py
 
+      - name: Enforce deploy SHA verification guard
+        run: python scripts/check_deploy_secure_sha_guard.py
+
       - name: Run ruff format check (all Python files)
         run: ruff format --check aragora/ tests/ scripts/
         shell: bash

--- a/scripts/check_deploy_secure_sha_guard.py
+++ b/scripts/check_deploy_secure_sha_guard.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Guard deploy-secure SHA verification hardening against workflow regressions."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    message: str
+
+
+WORKFLOW_PATH = Path(".github/workflows/deploy-secure.yml")
+SHA_STEP_NAME = "- name: Post-deploy SHA verification"
+
+REQUIRED_MARKERS: dict[str, str] = {
+    "ec2_user_command": "sudo -u ec2-user git -C /home/ec2-user/aragora rev-parse HEAD",
+    "safe_directory_fallback": "git -C /home/ec2-user/aragora -c safe.directory=/home/ec2-user/aragora rev-parse HEAD",
+    "ssm_timeout": "--timeout-seconds 60",
+    "stdout_diagnostics": "::warning::SHA stdout for $INST_ID:",
+    "stderr_diagnostics": "::warning::SHA stderr for $INST_ID:",
+}
+
+
+def _extract_sha_step_block(workflow_text: str) -> str | None:
+    lines = workflow_text.splitlines()
+    start_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == SHA_STEP_NAME:
+            start_idx = i
+            break
+
+    if start_idx is None:
+        return None
+
+    block_lines: list[str] = []
+    for line in lines[start_idx + 1 :]:
+        if re.match(r"^  [A-Za-z0-9_-]+:\s*$", line):
+            break
+        block_lines.append(line)
+    return "\n".join(block_lines)
+
+
+def find_sha_verification_violations(workflow_text: str) -> list[str]:
+    violations: list[str] = []
+    block = _extract_sha_step_block(workflow_text)
+    if block is None:
+        return ["missing `Post-deploy SHA verification` step"]
+
+    for name, marker in REQUIRED_MARKERS.items():
+        if marker not in block:
+            violations.append(f"missing required marker `{name}`: {marker}")
+    return violations
+
+
+def check_repo(repo_root: Path) -> list[Violation]:
+    workflow_file = repo_root / WORKFLOW_PATH
+    if not workflow_file.exists():
+        return [Violation(path=str(WORKFLOW_PATH), message="missing workflow file")]
+
+    text = workflow_file.read_text(encoding="utf-8")
+    return [
+        Violation(path=str(WORKFLOW_PATH), message=message)
+        for message in find_sha_verification_violations(text)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce post-deploy SHA verification hardening in deploy-secure workflow."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Repository root to check",
+    )
+    args = parser.parse_args()
+
+    violations = check_repo(Path(args.repo_root).resolve())
+    if not violations:
+        print("Deploy secure SHA guard check passed")
+        return 0
+
+    print("Deploy secure SHA guard violations detected:")
+    for v in violations:
+        print(f"- {v.path}: {v.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_check_deploy_secure_sha_guard.py
+++ b/tests/scripts/test_check_deploy_secure_sha_guard.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_deploy_secure_sha_guard import (
+    check_repo,
+    find_sha_verification_violations,
+)
+
+
+def _valid_workflow_text() -> str:
+    return """
+jobs:
+  deploy-ec2-production:
+    steps:
+      - name: Post-deploy SHA verification
+        run: |
+          SHA_CMD_ID=$(aws ssm send-command \\
+            --instance-ids "${IDS[@]}" \\
+            --document-name "AWS-RunShellScript" \\
+            --parameters 'commands=[
+              "set -e",
+              "sudo -u ec2-user git -C /home/ec2-user/aragora rev-parse HEAD || git -C /home/ec2-user/aragora -c safe.directory=/home/ec2-user/aragora rev-parse HEAD"
+            ]' \\
+            --timeout-seconds 60 \\
+            --query 'Command.CommandId' \\
+            --output text)
+          echo "::warning::SHA stdout for $INST_ID: $STDOUT"
+          echo "::warning::SHA stderr for $INST_ID: $STDERR"
+  notify:
+    steps:
+      - name: done
+        run: echo done
+"""
+
+
+def test_sha_guard_accepts_valid_step() -> None:
+    violations = find_sha_verification_violations(_valid_workflow_text())
+    assert violations == []
+
+
+def test_sha_guard_requires_step() -> None:
+    violations = find_sha_verification_violations(
+        "jobs:\n  deploy-ec2-production:\n    steps: []\n"
+    )
+    assert violations
+    assert "missing `Post-deploy SHA verification` step" in violations[0]
+
+
+def test_sha_guard_requires_hardened_command_markers() -> None:
+    text = _valid_workflow_text().replace("sudo -u ec2-user ", "")
+    violations = find_sha_verification_violations(text)
+    assert violations
+    assert any("ec2_user_command" in message for message in violations)
+
+
+def test_repo_sha_guard_passes_for_current_tree() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = check_repo(repo_root)
+    assert violations == []


### PR DESCRIPTION
## Summary
- gate staging rollback messaging behind explicit failure signals so warning text only appears when rollback is truly required
- preserve rollback behavior while adding a clear rollback reason output
- add `scripts/check_deploy_secure_sha_guard.py` and tests to guard post-deploy SHA verification hardening
- wire the new guard into required `Lint` workflow

## Validation
- `python3 scripts/check_deploy_secure_sha_guard.py`
- `pytest -q tests/scripts/test_check_deploy_secure_sha_guard.py tests/scripts/test_check_branch_mutation_policy.py`
- YAML parse check for `.github/workflows/deploy-secure.yml`
- `ruff check scripts/check_deploy_secure_sha_guard.py tests/scripts/test_check_deploy_secure_sha_guard.py`
- `ruff format --check scripts/check_deploy_secure_sha_guard.py tests/scripts/test_check_deploy_secure_sha_guard.py`
