### PR TITLE
Harden deploy rollback parity and required-check policy guards

### DIFF
--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -625,6 +625,7 @@ jobs:
           echo "All instances healthy"
 
       - name: Deploy via SSM
+        id: deploy
         run: |
           # Deploy to ALL production instances
           IFS=',' read -ra IDS <<< "${{ steps.get-instance.outputs.instance_ids }}"
@@ -778,6 +779,8 @@ jobs:
           echo "Production deploy completed successfully on all instances"
 
       - name: Post-deploy SHA verification
+        id: sha_verify
+        if: steps.deploy.conclusion == 'success'
         run: |
           EXPECTED_SHA="${{ github.sha }}"
           echo "Expected deployed SHA: $EXPECTED_SHA"
@@ -866,6 +869,63 @@ jobs:
           fi
 
           echo "SHA verification passed on all instances"
+
+      - name: Determine rollback requirement
+        id: rollback_gate
+        if: always() && steps.deploy.conclusion != 'skipped'
+        run: |
+          DEPLOY_CONCLUSION="${{ steps.deploy.conclusion }}"
+          SHA_CONCLUSION="${{ steps.sha_verify.conclusion }}"
+          SHOULD_ROLLBACK="false"
+          ROLLBACK_REASON=""
+
+          if [[ "$DEPLOY_CONCLUSION" != "success" ]]; then
+            SHOULD_ROLLBACK="true"
+            ROLLBACK_REASON="production deploy step conclusion=${DEPLOY_CONCLUSION}"
+          elif [[ "$SHA_CONCLUSION" != "success" && "$SHA_CONCLUSION" != "skipped" ]]; then
+            SHOULD_ROLLBACK="true"
+            ROLLBACK_REASON="post-deploy SHA verification conclusion=${SHA_CONCLUSION}"
+          fi
+
+          echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"
+          echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"
+
+          if [[ "$SHOULD_ROLLBACK" == "true" ]]; then
+            echo "Rollback required: $ROLLBACK_REASON"
+          else
+            echo "::notice::Production deployment succeeded; rollback not required"
+          fi
+
+      - name: Rollback on failure
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::warning::Production deployment failed - initiating rollback (${{ steps.rollback_gate.outputs.rollback_reason }})"
+          IFS=',' read -ra IDS <<< "${{ steps.get-instance.outputs.instance_ids }}"
+
+          aws ssm send-command \
+            --instance-ids "${IDS[@]}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Rollback aragora production from GitHub Actions run ${{ github.run_id }}" \
+            --parameters 'commands=[
+              "set -e",
+              "export HOME=/root",
+              "cd /home/ec2-user/aragora",
+              "git config --global safe.directory /home/ec2-user/aragora",
+              "if [ -f /tmp/aragora_deploy_state ]; then source /tmp/aragora_deploy_state; fi",
+              "if [ -n \"$PREVIOUS_COMMIT\" ]; then sudo -u ec2-user git checkout $PREVIOUS_COMMIT; fi",
+              "source venv/bin/activate",
+              "pip install -e . --quiet --no-cache-dir",
+              "sudo systemctl restart aragora",
+              "rm -f /tmp/aragora_deploy_state",
+              "echo \"Rollback complete\""
+            ]' \
+            --timeout-seconds 120
+
+      - name: Fail production deployment after rollback
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::error::Production deployment failed (${{ steps.rollback_gate.outputs.rollback_reason }}). Rollback command dispatched."
+          exit 1
 
   notify:
     needs: [deploy-cloudflare, deploy-ec2-staging, deploy-ec2-production]

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Enforce deploy SHA verification guard
         run: python scripts/check_deploy_secure_sha_guard.py
 
+      - name: Enforce required-check-priority keep-list policy
+        run: python scripts/check_required_check_priority_policy.py
+
       - name: Run ruff format check (all Python files)
         run: ruff format --check aragora/ tests/ scripts/
         shell: bash

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -9,6 +9,9 @@ on:
       - "pyproject.toml"
       - "requirements.txt"
       - "scripts/ci_release_readiness.sh"
+      - "scripts/check_branch_mutation_policy.py"
+      - "scripts/check_deploy_secure_sha_guard.py"
+      - "scripts/check_required_check_priority_policy.py"
       - ".github/workflows/release-readiness.yml"
   workflow_dispatch:
 

--- a/aragora/server/handlers/debates/crud.py
+++ b/aragora/server/handlers/debates/crud.py
@@ -229,7 +229,16 @@ class CrudOperationsMixin:
             active_debates = _active_debates
 
         if slug in active_debates:
-            active = active_debates[slug]
+            active_raw = active_debates[slug]
+            if not isinstance(active_raw, dict):
+                logger.warning(
+                    "Malformed active debate state for %s: expected dict, got %s",
+                    slug,
+                    type(active_raw).__name__,
+                )
+                return error_response(f"Debate not found: {slug}", 404)
+
+            active = active_raw
             active_result = active.get("result") if isinstance(active, dict) else None
             mode = active.get("mode")
             settlement = active.get("settlement")

--- a/docs/status/WEEKLY_STATUS_2026-02-26.md
+++ b/docs/status/WEEKLY_STATUS_2026-02-26.md
@@ -29,3 +29,28 @@ Scope: Epistemic hygiene + settlement reliability lane (runtime KPI automation).
 
 1. Workflow supports manual `strict=true` runs that fail on KPI threshold breaches.
 2. Scheduled runs always publish artifacts and summary for weekly review.
+
+## Execution Update (2026-02-26, auto-worktree branch)
+
+1. CI signal quality hardening:
+   - Added `scripts/check_required_check_priority_policy.py`.
+   - Added `tests/scripts/test_check_required_check_priority_policy.py`.
+   - Wired lint gate: `.github/workflows/lint.yml` now enforces required-check-priority keep-list policy.
+2. Deploy rollback guard hardening:
+   - Extended `scripts/check_deploy_secure_sha_guard.py` to validate rollback-gate and rollback-step invariants in `deploy-secure.yml` in addition to SHA verification markers.
+   - Expanded unit tests in `tests/scripts/test_check_deploy_secure_sha_guard.py`.
+3. Auto-worktree cleanup reliability:
+   - Hardened `scripts/codex_worktree_autopilot.py` cleanup flow to keep state when active worktree removal fails and emit explicit failure counters.
+   - Added coverage in `tests/scripts/test_codex_worktree_autopilot.py`.
+4. Settlement/debate retrieval reliability:
+   - Hardened active-debate lookup in `aragora/server/handlers/debates/crud.py` to fail safe on malformed in-memory state.
+   - Added integration coverage in `tests/server/handlers/debates/test_handler_integration.py`.
+5. Release-readiness discipline:
+   - `scripts/ci_release_readiness.sh` now executes branch mutation, deploy SHA/rollback, and required-check-priority policy guards.
+   - `.github/workflows/release-readiness.yml` path filters now include those guard scripts.
+6. Production deploy rollback parity:
+   - `.github/workflows/deploy-secure.yml` production lane now mirrors staging rollback behavior via `rollback_gate`, `Rollback on failure`, and explicit post-rollback failure signaling.
+   - `scripts/check_deploy_secure_sha_guard.py` now enforces rollback parity markers for staging+production and validates production gate use of `steps.sha_verify.conclusion`.
+7. Required-context mapping validation:
+   - `scripts/check_required_check_priority_policy.py` now validates required branch-protection contexts against mapped workflow paths (`lint`, `typecheck`, `sdk-parity`, `Generate & Validate`, `TypeScript SDK Type Check`).
+   - Added mapping regression coverage in `tests/scripts/test_check_required_check_priority_policy.py`.

--- a/scripts/check_deploy_secure_sha_guard.py
+++ b/scripts/check_deploy_secure_sha_guard.py
@@ -16,7 +16,9 @@ class Violation:
 
 
 WORKFLOW_PATH = Path(".github/workflows/deploy-secure.yml")
-SHA_STEP_NAME = "- name: Post-deploy SHA verification"
+SHA_STEP_NAME = "Post-deploy SHA verification"
+ROLLBACK_GATE_STEP_NAME = "Determine rollback requirement"
+ROLLBACK_STEP_NAME = "Rollback on failure"
 
 REQUIRED_MARKERS: dict[str, str] = {
     "ec2_user_command": "sudo -u ec2-user git -C /home/ec2-user/aragora rev-parse HEAD",
@@ -27,34 +29,94 @@ REQUIRED_MARKERS: dict[str, str] = {
 }
 
 
-def _extract_sha_step_block(workflow_text: str) -> str | None:
+ROLLBACK_GATE_REQUIRED_MARKERS: dict[str, str] = {
+    "rollback_gate_id": "id: rollback_gate",
+    "rollback_gate_condition": "if: always() && steps.deploy.conclusion != 'skipped'",
+    "rollback_should_output": 'echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"',
+    "rollback_reason_output": 'echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"',
+}
+
+
+ROLLBACK_STEP_REQUIRED_MARKERS: dict[str, str] = {
+    "rollback_condition": "if: steps.rollback_gate.outputs.should_rollback == 'true'",
+    "rollback_reason_reference": "steps.rollback_gate.outputs.rollback_reason",
+    "rollback_state_file": "/tmp/aragora_deploy_state",
+    "rollback_previous_commit": "git checkout $PREVIOUS_COMMIT",
+}
+
+
+def _extract_step_blocks(workflow_text: str, step_name: str) -> list[str]:
     lines = workflow_text.splitlines()
-    start_idx = None
-    for i, line in enumerate(lines):
-        if line.strip() == SHA_STEP_NAME:
-            start_idx = i
-            break
-
-    if start_idx is None:
-        return None
-
-    block_lines: list[str] = []
-    for line in lines[start_idx + 1 :]:
-        if re.match(r"^  [A-Za-z0-9_-]+:\s*$", line):
-            break
-        block_lines.append(line)
-    return "\n".join(block_lines)
+    blocks: list[str] = []
+    step_marker = f"- name: {step_name}"
+    for start_idx, line in enumerate(lines):
+        if line.strip() == step_marker:
+            start_indent = len(line) - len(line.lstrip())
+            block_lines: list[str] = []
+            for inner in lines[start_idx + 1 :]:
+                stripped = inner.lstrip()
+                indent = len(inner) - len(stripped)
+                if stripped.startswith("- name:") and indent == start_indent:
+                    break
+                if indent <= max(start_indent - 2, 0) and re.match(
+                    r"^[A-Za-z0-9_-]+:\s*$", stripped
+                ):
+                    break
+                block_lines.append(inner)
+            blocks.append("\n".join(block_lines))
+    return blocks
 
 
 def find_sha_verification_violations(workflow_text: str) -> list[str]:
     violations: list[str] = []
-    block = _extract_sha_step_block(workflow_text)
-    if block is None:
+    blocks = _extract_step_blocks(workflow_text, SHA_STEP_NAME)
+    if not blocks:
         return ["missing `Post-deploy SHA verification` step"]
+    block = blocks[-1]
 
     for name, marker in REQUIRED_MARKERS.items():
         if marker not in block:
             violations.append(f"missing required marker `{name}`: {marker}")
+    return violations
+
+
+def find_rollback_guard_violations(workflow_text: str) -> list[str]:
+    violations: list[str] = []
+
+    gate_blocks = _extract_step_blocks(workflow_text, ROLLBACK_GATE_STEP_NAME)
+    if not gate_blocks:
+        violations.append("missing `Determine rollback requirement` step")
+    else:
+        if len(gate_blocks) < 2:
+            violations.append(
+                "expected rollback gate parity for staging+production (>=2 `Determine rollback requirement` steps)"
+            )
+        for index, gate_block in enumerate(gate_blocks, start=1):
+            for name, marker in ROLLBACK_GATE_REQUIRED_MARKERS.items():
+                if marker not in gate_block:
+                    violations.append(
+                        f"gate step #{index} missing required marker `{name}`: {marker}"
+                    )
+        if not any("steps.sha_verify.conclusion" in block for block in gate_blocks):
+            violations.append(
+                "missing production rollback-gate marker `steps.sha_verify.conclusion`"
+            )
+
+    rollback_blocks = _extract_step_blocks(workflow_text, ROLLBACK_STEP_NAME)
+    if not rollback_blocks:
+        violations.append("missing `Rollback on failure` step")
+    else:
+        if len(rollback_blocks) < 2:
+            violations.append(
+                "expected rollback step parity for staging+production (>=2 `Rollback on failure` steps)"
+            )
+        for index, rollback_block in enumerate(rollback_blocks, start=1):
+            for name, marker in ROLLBACK_STEP_REQUIRED_MARKERS.items():
+                if marker not in rollback_block:
+                    violations.append(
+                        f"rollback step #{index} missing required marker `{name}`: {marker}"
+                    )
+
     return violations
 
 
@@ -64,10 +126,9 @@ def check_repo(repo_root: Path) -> list[Violation]:
         return [Violation(path=str(WORKFLOW_PATH), message="missing workflow file")]
 
     text = workflow_file.read_text(encoding="utf-8")
-    return [
-        Violation(path=str(WORKFLOW_PATH), message=message)
-        for message in find_sha_verification_violations(text)
-    ]
+    messages = find_sha_verification_violations(text)
+    messages.extend(find_rollback_guard_violations(text))
+    return [Violation(path=str(WORKFLOW_PATH), message=message) for message in messages]
 
 
 def main() -> int:

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Guard required-check-priority keep-lists against drift."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    message: str
+
+
+WORKFLOW_PATH = Path(".github/workflows/required-check-priority.yml")
+
+REQUIRED_KEEP_WORKFLOW_PATHS = {
+    ".github/workflows/lint.yml",
+    ".github/workflows/sdk-parity.yml",
+    ".github/workflows/sdk-test.yml",
+    ".github/workflows/openapi.yml",
+    ".github/workflows/required-check-priority.yml",
+}
+
+REQUIRED_KEEP_WORKFLOW_NAMES = {
+    "Required Check Priority",
+    "Lint",
+    "SDK Parity Check",
+    "SDK Tests",
+    "OpenAPI Spec",
+}
+
+REQUIRED_CONTEXT_TO_WORKFLOW_PATH = {
+    "lint": ".github/workflows/lint.yml",
+    "typecheck": ".github/workflows/lint.yml",
+    "sdk-parity": ".github/workflows/sdk-parity.yml",
+    "Generate & Validate": ".github/workflows/openapi.yml",
+    "TypeScript SDK Type Check": ".github/workflows/sdk-test.yml",
+}
+
+
+def _extract_js_set_items(workflow_text: str, set_name: str) -> list[str] | None:
+    pattern = r"const\s+" + re.escape(set_name) + r"\s*=\s*new Set\(\[(?P<body>.*?)\]\);"
+    match = re.search(pattern, workflow_text, flags=re.DOTALL)
+    if not match:
+        return None
+    body = match.group("body")
+    return re.findall(r"""["']([^"']+)["']""", body)
+
+
+def find_required_check_priority_violations(
+    workflow_text: str,
+    *,
+    repo_root: Path | None = None,
+) -> list[str]:
+    violations: list[str] = []
+
+    path_items = _extract_js_set_items(workflow_text, "alwaysKeepWorkflowPaths")
+    if path_items is None:
+        return ["missing `alwaysKeepWorkflowPaths` set definition"]
+
+    name_items = _extract_js_set_items(workflow_text, "alwaysKeepWorkflowNames")
+    if name_items is None:
+        return ["missing `alwaysKeepWorkflowNames` set definition"]
+
+    if len(path_items) != len(set(path_items)):
+        violations.append("duplicate entries found in alwaysKeepWorkflowPaths")
+    if len(name_items) != len(set(name_items)):
+        violations.append("duplicate entries found in alwaysKeepWorkflowNames")
+
+    path_set = set(path_items)
+    missing_required_paths = sorted(REQUIRED_KEEP_WORKFLOW_PATHS - path_set)
+    for path in missing_required_paths:
+        violations.append(f"missing required keep workflow path: {path}")
+
+    for context, mapped_path in sorted(REQUIRED_CONTEXT_TO_WORKFLOW_PATH.items()):
+        if mapped_path not in path_set:
+            violations.append(
+                f"required context `{context}` maps to workflow path not in keep-list: {mapped_path}"
+            )
+
+    name_set = set(name_items)
+    missing_required_names = sorted(REQUIRED_KEEP_WORKFLOW_NAMES - name_set)
+    for name in missing_required_names:
+        violations.append(f"missing required keep workflow name: {name}")
+
+    if repo_root is not None:
+        for rel in sorted(path_set):
+            wf_path = (repo_root / rel).resolve()
+            if not wf_path.exists():
+                violations.append(f"keep workflow path does not exist: {rel}")
+        for context, rel in sorted(REQUIRED_CONTEXT_TO_WORKFLOW_PATH.items()):
+            wf_path = (repo_root / rel).resolve()
+            if not wf_path.exists():
+                continue
+            text = wf_path.read_text(encoding="utf-8")
+            if context not in text:
+                violations.append(
+                    f"required context marker `{context}` not found in mapped workflow: {rel}"
+                )
+
+    return violations
+
+
+def check_repo(repo_root: Path) -> list[Violation]:
+    workflow_file = repo_root / WORKFLOW_PATH
+    if not workflow_file.exists():
+        return [Violation(path=str(WORKFLOW_PATH), message="missing workflow file")]
+
+    text = workflow_file.read_text(encoding="utf-8")
+    return [
+        Violation(path=str(WORKFLOW_PATH), message=message)
+        for message in find_required_check_priority_violations(text, repo_root=repo_root)
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce required-check-priority workflow keep-list policy."
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Repository root to check",
+    )
+    args = parser.parse_args()
+
+    violations = check_repo(Path(args.repo_root).resolve())
+    if not violations:
+        print("Required check priority policy check passed")
+        return 0
+
+    print("Required check priority policy violations detected:")
+    for v in violations:
+        print(f"- {v.path}: {v.message}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_release_readiness.sh
+++ b/scripts/ci_release_readiness.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 # Post-merge release-readiness gate for critical surfaces that have regressed
 # recently: debate orchestration, handler/openclaw, observability, and SDK parity.
 
+echo "[release-readiness] workflow guardrails"
+python3 scripts/check_branch_mutation_policy.py
+python3 scripts/check_deploy_secure_sha_guard.py
+python3 scripts/check_required_check_priority_policy.py
+
 echo "[release-readiness] debate/workflow"
 pytest -q \
   tests/debate/test_orchestrator_comprehensive.py \

--- a/tests/scripts/test_check_deploy_secure_sha_guard.py
+++ b/tests/scripts/test_check_deploy_secure_sha_guard.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from scripts.check_deploy_secure_sha_guard import (
     check_repo,
+    find_rollback_guard_violations,
     find_sha_verification_violations,
 )
 
@@ -11,6 +12,20 @@ from scripts.check_deploy_secure_sha_guard import (
 def _valid_workflow_text() -> str:
     return """
 jobs:
+  deploy-ec2-staging:
+    steps:
+      - name: Determine rollback requirement
+        id: rollback_gate
+        if: always() && steps.deploy.conclusion != 'skipped'
+        run: |
+          echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"
+          echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"
+      - name: Rollback on failure
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::warning::Deployment failed - initiating rollback (${{ steps.rollback_gate.outputs.rollback_reason }})"
+          if [ -f /tmp/aragora_deploy_state ]; then source /tmp/aragora_deploy_state; fi
+          if [ -n "$PREVIOUS_COMMIT" ]; then sudo -u ec2-user git checkout $PREVIOUS_COMMIT; fi
   deploy-ec2-production:
     steps:
       - name: Post-deploy SHA verification
@@ -27,6 +42,19 @@ jobs:
             --output text)
           echo "::warning::SHA stdout for $INST_ID: $STDOUT"
           echo "::warning::SHA stderr for $INST_ID: $STDERR"
+      - name: Determine rollback requirement
+        id: rollback_gate
+        if: always() && steps.deploy.conclusion != 'skipped'
+        run: |
+          SHA_CONCLUSION="${{ steps.sha_verify.conclusion }}"
+          echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"
+          echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"
+      - name: Rollback on failure
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::warning::Production deployment failed - initiating rollback (${{ steps.rollback_gate.outputs.rollback_reason }})"
+          if [ -f /tmp/aragora_deploy_state ]; then source /tmp/aragora_deploy_state; fi
+          if [ -n "$PREVIOUS_COMMIT" ]; then sudo -u ec2-user git checkout $PREVIOUS_COMMIT; fi
   notify:
     steps:
       - name: done
@@ -52,6 +80,50 @@ def test_sha_guard_requires_hardened_command_markers() -> None:
     violations = find_sha_verification_violations(text)
     assert violations
     assert any("ec2_user_command" in message for message in violations)
+
+
+def test_rollback_guard_accepts_valid_steps() -> None:
+    violations = find_rollback_guard_violations(_valid_workflow_text())
+    assert violations == []
+
+
+def test_rollback_guard_requires_gate_step() -> None:
+    violations = find_rollback_guard_violations(
+        "jobs:\n  deploy-ec2-staging:\n    steps:\n      - name: Rollback on failure\n"
+    )
+    assert violations
+    assert any("Determine rollback requirement" in message for message in violations)
+
+
+def test_rollback_guard_requires_hardened_markers() -> None:
+    text = _valid_workflow_text().replace("git checkout $PREVIOUS_COMMIT", "echo noop")
+    violations = find_rollback_guard_violations(text)
+    assert violations
+    assert any("rollback_previous_commit" in message for message in violations)
+
+
+def test_rollback_guard_requires_staging_production_parity() -> None:
+    text = _valid_workflow_text().replace(
+        """
+      - name: Determine rollback requirement
+        id: rollback_gate
+        if: always() && steps.deploy.conclusion != 'skipped'
+        run: |
+          SHA_CONCLUSION="${{ steps.sha_verify.conclusion }}"
+          echo "should_rollback=$SHOULD_ROLLBACK" >> "$GITHUB_OUTPUT"
+          echo "rollback_reason=$ROLLBACK_REASON" >> "$GITHUB_OUTPUT"
+      - name: Rollback on failure
+        if: steps.rollback_gate.outputs.should_rollback == 'true'
+        run: |
+          echo "::warning::Production deployment failed - initiating rollback (${{ steps.rollback_gate.outputs.rollback_reason }})"
+          if [ -f /tmp/aragora_deploy_state ]; then source /tmp/aragora_deploy_state; fi
+          if [ -n "$PREVIOUS_COMMIT" ]; then sudo -u ec2-user git checkout $PREVIOUS_COMMIT; fi
+""",
+        "",
+    )
+    violations = find_rollback_guard_violations(text)
+    assert violations
+    assert any("parity for staging+production" in message for message in violations)
 
 
 def test_repo_sha_guard_passes_for_current_tree() -> None:

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.check_required_check_priority_policy import (
+    check_repo,
+    find_required_check_priority_violations,
+)
+
+
+def _valid_workflow_text() -> str:
+    return """
+jobs:
+  prioritize-required-checks:
+    steps:
+      - name: Cancel non-required workflow runs for this PR head
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const alwaysKeepWorkflowPaths = new Set([
+              '.github/workflows/lint.yml',
+              '.github/workflows/sdk-parity.yml',
+              '.github/workflows/sdk-test.yml',
+              '.github/workflows/openapi.yml',
+              '.github/workflows/required-check-priority.yml',
+              '.github/workflows/autopilot-worktree-e2e.yml',
+            ]);
+            const alwaysKeepWorkflowNames = new Set([
+              'Required Check Priority',
+              'Lint',
+              'SDK Parity Check',
+              'SDK Tests',
+              'OpenAPI Spec',
+              'Autopilot Worktree E2E',
+            ]);
+"""
+
+
+def test_policy_accepts_required_keep_entries() -> None:
+    violations = find_required_check_priority_violations(_valid_workflow_text())
+    assert violations == []
+
+
+def test_policy_requires_required_keep_workflow_path() -> None:
+    text = _valid_workflow_text().replace(
+        ".github/workflows/openapi.yml", ".github/workflows/other.yml"
+    )
+    violations = find_required_check_priority_violations(text)
+    assert violations
+    assert any(
+        "missing required keep workflow path: .github/workflows/openapi.yml" == v
+        for v in violations
+    )
+
+
+def test_policy_requires_context_mapped_workflow_path_in_keep_list() -> None:
+    text = _valid_workflow_text().replace(
+        ".github/workflows/lint.yml", ".github/workflows/lint-alt.yml"
+    )
+    violations = find_required_check_priority_violations(text)
+    assert violations
+    assert any(
+        "required context `lint` maps to workflow path not in keep-list: .github/workflows/lint.yml"
+        == v
+        for v in violations
+    )
+
+
+def test_policy_requires_required_keep_workflow_name() -> None:
+    text = _valid_workflow_text().replace("SDK Tests", "SDK Smoke")
+    violations = find_required_check_priority_violations(text)
+    assert violations
+    assert any("missing required keep workflow name: SDK Tests" == v for v in violations)
+
+
+def test_policy_detects_stale_workflow_paths() -> None:
+    text = _valid_workflow_text().replace(
+        ".github/workflows/autopilot-worktree-e2e.yml",
+        ".github/workflows/does-not-exist.yml",
+    )
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = find_required_check_priority_violations(text, repo_root=repo_root)
+    assert violations
+    assert any("does not exist" in v for v in violations)
+
+
+def test_policy_detects_missing_context_marker_in_mapped_workflow(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    wf_dir = repo_root / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+
+    (wf_dir / "lint.yml").write_text(
+        "name: Lint\njobs:\n  lint:\n    runs-on: ubuntu-latest\n", encoding="utf-8"
+    )
+    (wf_dir / "sdk-parity.yml").write_text(
+        "name: SDK Parity Check\njobs:\n  sdk-parity:\n    runs-on: ubuntu-latest\n",
+        encoding="utf-8",
+    )
+    (wf_dir / "sdk-test.yml").write_text(
+        "name: SDK Tests\njobs:\n  typescript-sdk:\n    name: TypeScript SDK Type Check\n",
+        encoding="utf-8",
+    )
+    (wf_dir / "openapi.yml").write_text(
+        "name: OpenAPI Spec\njobs:\n  generate:\n    name: Generate & Validate\n",
+        encoding="utf-8",
+    )
+    (wf_dir / "required-check-priority.yml").write_text(
+        "name: Required Check Priority\n", encoding="utf-8"
+    )
+
+    text = """
+jobs:
+  prioritize-required-checks:
+    steps:
+      - name: Cancel non-required workflow runs for this PR head
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const alwaysKeepWorkflowPaths = new Set([
+              '.github/workflows/lint.yml',
+              '.github/workflows/sdk-parity.yml',
+              '.github/workflows/sdk-test.yml',
+              '.github/workflows/openapi.yml',
+              '.github/workflows/required-check-priority.yml',
+            ]);
+            const alwaysKeepWorkflowNames = new Set([
+              'Required Check Priority',
+              'Lint',
+              'SDK Parity Check',
+              'SDK Tests',
+              'OpenAPI Spec',
+            ]);
+"""
+    violations = find_required_check_priority_violations(text, repo_root=repo_root)
+    assert violations
+    assert any(
+        "required context marker `typecheck` not found in mapped workflow: .github/workflows/lint.yml"
+        == v
+        for v in violations
+    )
+
+
+def test_repo_required_check_priority_policy_passes_for_current_tree() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    violations = check_repo(repo_root)
+    assert violations == []

--- a/tests/server/handlers/debates/test_handler_integration.py
+++ b/tests/server/handlers/debates/test_handler_integration.py
@@ -174,6 +174,22 @@ class TestGetDebateBySlug:
             assert body["settlement"]["status"] == "pending_human_adjudication"
             assert body["settlement"]["sla_state"] == "pending"
 
+    def test_get_debate_malformed_in_progress_payload_returns_not_found(self, handler_with_storage):
+        """Malformed in-memory active debates should fail safe without raising."""
+        storage = handler_with_storage.get_storage()
+        storage.get_debate = MagicMock(return_value=None)
+
+        active_debates = {"in-progress-debate": "unexpected-non-dict-state"}
+        with patch(
+            "aragora.server.handlers.debates.handler._active_debates",
+            active_debates,
+        ):
+            mock_handler = MagicMock()
+            result = handler_with_storage._get_debate_by_slug(mock_handler, "in-progress-debate")
+
+            assert result is not None
+            assert result.status_code == 404
+
 
 class TestGetDebateMessages:
     """Integration tests for _get_debate_messages method."""


### PR DESCRIPTION
## Summary
This PR hardens CI/deploy/worktree reliability guardrails and closes the production rollback parity gap.

### Implemented
- Added required-check keep-list policy guard:
  - `scripts/check_required_check_priority_policy.py`
  - `tests/scripts/test_check_required_check_priority_policy.py`
  - Enforced in lint: `.github/workflows/lint.yml`
- Expanded deploy guard to enforce rollback invariants (not only SHA verification):
  - `scripts/check_deploy_secure_sha_guard.py`
  - `tests/scripts/test_check_deploy_secure_sha_guard.py`
- Added production rollback parity in secure deploy workflow:
  - `.github/workflows/deploy-secure.yml`
  - Added production `rollback_gate`, `Rollback on failure`, and explicit post-rollback failure step
- Hardened auto-worktree cleanup state consistency and telemetry:
  - `scripts/codex_worktree_autopilot.py`
  - `tests/scripts/test_codex_worktree_autopilot.py`
- Hardened debate active-state read path to fail safe on malformed in-memory entries:
  - `aragora/server/handlers/debates/crud.py`
  - `tests/server/handlers/debates/test_handler_integration.py`
- Strengthened release-readiness discipline:
  - `scripts/ci_release_readiness.sh`
  - `.github/workflows/release-readiness.yml`

## Validation
- Targeted guard tests:
  - `pytest -q tests/scripts/test_check_deploy_secure_sha_guard.py tests/scripts/test_check_required_check_priority_policy.py tests/scripts/test_codex_worktree_autopilot.py`
- Targeted debate/worktree regression tests:
  - `pytest -q tests/scripts/test_codex_worktree_autopilot.py tests/server/handlers/debates/test_handler_integration.py -k "cmd_cleanup or malformed_in_progress or get_debate_in_progress"`
- Guard scripts:
  - `python3 scripts/check_deploy_secure_sha_guard.py`
  - `python3 scripts/check_required_check_priority_policy.py`
- Release-readiness suite:
  - `bash scripts/ci_release_readiness.sh`
  - Passed locally (workflow guardrails + debate/workflow + handlers/openclaw + observability/logging + sdk parity/contracts)

## Status Evidence
- `docs/status/WEEKLY_STATUS_2026-02-26.md` (Execution Update section)
