### PR TITLE
live: make debate route dynamicParams export-aware

### DIFF
--- a/aragora/live/src/app/(app)/debates/[id]/page.tsx
+++ b/aragora/live/src/app/(app)/debates/[id]/page.tsx
@@ -1,8 +1,8 @@
 import DebateDetailClient from './DebateDetailClient';
 
-// Allow runtime debate IDs in standalone/server mode.
-// Static export still uses the fallback static param below.
-export const dynamicParams = true;
+// Static export requires dynamicParams=false.
+// Runtime/standalone mode can enable dynamic IDs.
+export const dynamicParams = process.env.NEXT_OUTPUT === 'export' ? false : true;
 
 export async function generateStaticParams() {
   return [{ id: '_' }];

--- a/aragora/live/src/app/(standalone)/debate/[[...id]]/page.tsx
+++ b/aragora/live/src/app/(standalone)/debate/[[...id]]/page.tsx
@@ -1,9 +1,9 @@
 import { Metadata } from 'next';
 import { DebateViewerWrapper } from './DebateViewerWrapper';
 
-// Allow runtime debate IDs in standalone/server mode.
-// Static export still uses the base route param below.
-export const dynamicParams = true;
+// Static export requires dynamicParams=false.
+// Runtime/standalone mode can enable dynamic IDs.
+export const dynamicParams = process.env.NEXT_OUTPUT === 'export' ? false : true;
 
 export async function generateStaticParams() {
   // Only generate the base route - client handles the rest


### PR DESCRIPTION
## Summary\n- make dynamic route params conditional on NEXT_OUTPUT\n- preserve static export behavior while allowing runtime IDs\n\n## Validation\n- npx eslint src/app/(app)/debates/[id]/page.tsx src/app/(standalone)/debate/[[...id]]/page.tsx\n- npx tsc --noEmit --pretty false\n