### PR TITLE
fix(ci): run Vercel CLI from repo root

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -146,8 +146,8 @@ jobs:
       - name: Deploy to Vercel
         if: steps.skip-check.outputs.skip != 'true'
         id: vercel-deploy
-        working-directory: aragora/live
         run: |
+          # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
           DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -116,8 +116,8 @@ jobs:
 
       - name: Deploy to Vercel
         id: vercel-deploy
-        working-directory: aragora/live
         run: |
+          # Run from repo root; Vercel project rootDirectory is configured server-side.
           npx vercel pull --yes --environment=production --token="${{ secrets.VERCEL_TOKEN }}"
           DEPLOY_URL=$(npx vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}")
           echo "deploy_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- run `vercel pull` and `vercel deploy` from repo root in deploy workflows
- preserve project-level `rootDirectory` behavior in Vercel settings

## Root cause
Vercel project has `rootDirectory=aragora/live`; executing CLI inside `aragora/live` produced a doubled path (`aragora/live/aragora/live`) and failed deploy.

## Validation
- workflow YAML parse passed for modified files
- failure reproduced and verified from Actions logs
