### PR TITLE
ci(release-readiness): install optional deps for gate tests

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -38,6 +38,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+          # The handlers/openclaw gate patches redis/google-auth symbols directly.
+          # Install these optional deps so patch targets are importable in CI.
+          pip install redis google-auth
 
       - name: Run release-readiness gate
         run: bash scripts/ci_release_readiness.sh


### PR DESCRIPTION
## Summary
- install `redis` and `google-auth` in the Release Readiness Gate job
- align CI environment with handlers/openclaw tests that patch those modules

## Why
Release Readiness currently fails on main with `ModuleNotFoundError` for `redis` and `google` in the handlers/openclaw section.

## Scope
CI workflow only; no runtime or product code changes.
