### PR TITLE
feat(fleet): add session visibility, claims, and merge queue APIs

### DIFF
--- a/aragora/server/handlers/control_plane/__init__.py
+++ b/aragora/server/handlers/control_plane/__init__.py
@@ -331,6 +331,22 @@ class ControlPlaneHandler(
         if path == "/api/v1/coordination/executions":
             return self._handle_list_executions(query_params)
 
+        # /api/v1/coordination/fleet/status
+        if path == "/api/v1/coordination/fleet/status":
+            return self._handle_fleet_status(query_params)
+
+        # /api/v1/coordination/fleet/logs
+        if path == "/api/v1/coordination/fleet/logs":
+            return self._handle_fleet_logs(query_params)
+
+        # /api/v1/coordination/fleet/claims
+        if path == "/api/v1/coordination/fleet/claims":
+            return self._handle_fleet_claims(query_params)
+
+        # /api/v1/coordination/fleet/merge-queue
+        if path == "/api/v1/coordination/fleet/merge-queue":
+            return self._handle_fleet_merge_queue(query_params)
+
         # /api/v1/coordination/consent
         if path == "/api/v1/coordination/consent":
             return self._handle_list_consents(query_params)
@@ -459,6 +475,27 @@ class ControlPlaneHandler(
             if err:
                 return err
             return self._handle_grant_consent(body)
+
+        # /api/v1/coordination/fleet/claims
+        if path == "/api/v1/coordination/fleet/claims":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_fleet_claim(body)
+
+        # /api/v1/coordination/fleet/claims/release
+        if path == "/api/v1/coordination/fleet/claims/release":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_fleet_release(body)
+
+        # /api/v1/coordination/fleet/merge-queue
+        if path == "/api/v1/coordination/fleet/merge-queue":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_fleet_merge_enqueue(body)
 
         # /api/v1/coordination/approve/:id
         if path.startswith("/api/v1/coordination/approve/"):

--- a/aragora/worktree/__init__.py
+++ b/aragora/worktree/__init__.py
@@ -13,6 +13,11 @@ from aragora.worktree.lifecycle import (
     WorktreeLifecycleService,
     WorktreeOperationResult,
 )
+from aragora.worktree.fleet import (
+    FleetCoordinationStore,
+    build_fleet_rows,
+    infer_orchestration_pattern,
+)
 
 __all__ = [
     "AUTOPILOT_ACTIONS",
@@ -24,4 +29,7 @@ __all__ = [
     "ManagedWorktreeSession",
     "WorktreeLifecycleService",
     "WorktreeOperationResult",
+    "FleetCoordinationStore",
+    "build_fleet_rows",
+    "infer_orchestration_pattern",
 ]

--- a/aragora/worktree/fleet.py
+++ b/aragora/worktree/fleet.py
@@ -1,0 +1,457 @@
+"""Shared fleet status and coordination primitives for worktree sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from collections import deque
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import uuid
+
+ACTIVE_QUEUE_STATUSES = {"queued", "in_progress"}
+SUPPORTED_ORCHESTRATORS = {
+    "gastown",
+    "langchain",
+    "crewai",
+    "langgraph",
+    "autogen",
+    "openclaw",
+    "nomic",
+    "generic",
+}
+
+
+def resolve_repo_root(path_hint: Path) -> Path:
+    """Resolve git repo root from any path inside a repository."""
+    proc = subprocess.run(
+        ["git", "-C", str(path_hint), "rev-parse", "--show-toplevel"],  # noqa: S607 -- fixed command
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode == 0 and proc.stdout.strip():
+        return Path(proc.stdout.strip()).resolve()
+    return path_hint.resolve()
+
+
+def _list_git_worktrees(repo_root: Path) -> list[dict[str, str | bool | None]]:
+    proc = subprocess.run(
+        ["git", "worktree", "list", "--porcelain"],  # noqa: S607 -- fixed command
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+
+    rows: list[dict[str, str | bool | None]] = []
+    current: dict[str, str | bool | None] | None = None
+    for raw in proc.stdout.splitlines():
+        line = raw.strip()
+        if not line:
+            if current:
+                rows.append(current)
+            current = None
+            continue
+        if line.startswith("worktree "):
+            if current:
+                rows.append(current)
+            current = {"path": line[len("worktree ") :], "branch": None, "detached": False}
+            continue
+        if current is None:
+            continue
+        if line.startswith("branch refs/heads/"):
+            current["branch"] = line[len("branch refs/heads/") :]
+            continue
+        if line == "detached":
+            current["detached"] = True
+
+    if current:
+        rows.append(current)
+    return rows
+
+
+def _parse_lock_file(lock_path: Path) -> dict[str, str]:
+    if not lock_path.exists():
+        return {}
+    parsed: dict[str, str] = {}
+    try:
+        for raw in lock_path.read_text(encoding="utf-8").splitlines():
+            if "=" not in raw:
+                continue
+            key, value = raw.split("=", 1)
+            parsed[key.strip()] = value.strip()
+    except OSError:
+        return {}
+    return parsed
+
+
+def _tail_file(path: Path, line_count: int) -> list[str]:
+    if line_count <= 0 or not path.exists():
+        return []
+    ring: deque[str] = deque(maxlen=line_count)
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                ring.append(line.rstrip("\n"))
+    except OSError:
+        return []
+    return list(ring)
+
+
+def _pid_alive(raw_pid: str | None) -> bool:
+    if not raw_pid:
+        return False
+    try:
+        pid = int(raw_pid)
+    except (TypeError, ValueError):
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _count_dirty(worktree_path: Path) -> int:
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],  # noqa: S607 -- fixed command
+        cwd=worktree_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return 0
+    return len([line for line in proc.stdout.splitlines() if line.strip()])
+
+
+def _ahead_behind(worktree_path: Path, base_branch: str) -> tuple[int | None, int | None]:
+    for target in (f"origin/{base_branch}", base_branch):
+        proc = subprocess.run(
+            ["git", "rev-list", "--left-right", "--count", f"{target}...HEAD"],  # noqa: S607 -- fixed command
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            continue
+        parts = proc.stdout.strip().split()
+        if len(parts) != 2:
+            continue
+        try:
+            behind = int(parts[0])
+            ahead = int(parts[1])
+            return ahead, behind
+        except ValueError:
+            continue
+    return None, None
+
+
+def _latest_activity_iso(paths: list[Path]) -> str | None:
+    latest: float | None = None
+    for path in paths:
+        if not path.exists():
+            continue
+        try:
+            ts = path.stat().st_mtime
+        except OSError:
+            continue
+        latest = ts if latest is None or ts > latest else latest
+    if latest is None:
+        return None
+    return datetime.fromtimestamp(latest, tz=timezone.utc).isoformat()
+
+
+def infer_orchestration_pattern(meta: dict[str, Any]) -> str:
+    """Infer orchestration flavor used by a session from command/meta fields."""
+    if not meta:
+        return "generic"
+
+    direct = str(meta.get("orchestrator", "")).strip().lower()
+    if direct in SUPPORTED_ORCHESTRATORS:
+        return direct
+
+    framework = str(meta.get("framework", "")).strip().lower()
+    if framework in SUPPORTED_ORCHESTRATORS:
+        return framework
+
+    command = str(meta.get("command", "")).lower()
+    args = meta.get("args") or []
+    args_text = " ".join(str(x).lower() for x in args if x is not None)
+    haystack = f"{command} {args_text}"
+
+    markers: list[tuple[str, tuple[str, ...]]] = [
+        ("gastown", ("gastown", "bead", "molecule", "handoff")),
+        ("langgraph", ("langgraph",)),
+        ("langchain", ("langchain", "lc-")),
+        ("crewai", ("crewai", "crew-ai")),
+        ("autogen", ("autogen",)),
+        ("openclaw", ("openclaw",)),
+        ("nomic", ("nomic", "fractal", "sprint_coordinator")),
+    ]
+    for label, needles in markers:
+        if any(needle in haystack for needle in needles):
+            return label
+
+    return "generic"
+
+
+def build_fleet_rows(repo_root: Path, *, base_branch: str, tail: int) -> list[dict[str, Any]]:
+    """Build fleet status rows for all git worktrees."""
+    rows: list[dict[str, Any]] = []
+    for wt in _list_git_worktrees(repo_root):
+        path_text = str(wt.get("path") or "")
+        if not path_text:
+            continue
+        worktree_path = Path(path_text)
+        lock_path = worktree_path / ".codex_session_active"
+        meta_path = worktree_path / ".codex_session_meta.json"
+        log_path = worktree_path / ".codex_session.log"
+        lock = _parse_lock_file(lock_path)
+
+        meta: dict[str, Any] = {}
+        if meta_path.exists():
+            try:
+                loaded = json.loads(meta_path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    meta = loaded
+            except (OSError, json.JSONDecodeError):
+                meta = {}
+
+        pid_raw = lock.get("pid")
+        ahead, behind = _ahead_behind(worktree_path, base_branch)
+        session_id = str(meta.get("session_id") or worktree_path.name)
+        rows.append(
+            {
+                "session_id": session_id,
+                "path": str(worktree_path),
+                "branch": str(wt.get("branch") or "(detached)"),
+                "detached": bool(wt.get("detached")),
+                "has_lock": lock_path.exists(),
+                "pid": int(pid_raw) if pid_raw and pid_raw.isdigit() else None,
+                "pid_alive": _pid_alive(pid_raw),
+                "agent": str(meta.get("agent") or lock.get("agent") or ""),
+                "mode": str(meta.get("mode") or lock.get("mode") or ""),
+                "dirty_files": _count_dirty(worktree_path),
+                "ahead": ahead,
+                "behind": behind,
+                "meta_path": str(meta_path) if meta_path.exists() else None,
+                "log_path": str(log_path) if log_path.exists() else None,
+                "last_activity": _latest_activity_iso([log_path, lock_path, meta_path]),
+                "log_tail": _tail_file(log_path, tail),
+                "orchestration_pattern": infer_orchestration_pattern(meta),
+                "meta": meta,
+            }
+        )
+    rows.sort(key=lambda row: str(row.get("path", "")))
+    return rows
+
+
+class FleetCoordinationStore:
+    """Persistent ownership + merge-queue state for fleet sessions."""
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = resolve_repo_root(repo_root)
+        self.path = self.repo_root / ".aragora" / "fleet_coordination.json"
+
+    @staticmethod
+    def _default_state() -> dict[str, Any]:
+        return {"claims": [], "merge_queue": []}
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return self._default_state()
+        try:
+            loaded = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return self._default_state()
+        if not isinstance(loaded, dict):
+            return self._default_state()
+        claims = loaded.get("claims")
+        queue = loaded.get("merge_queue")
+        if not isinstance(claims, list) or not isinstance(queue, list):
+            return self._default_state()
+        return {"claims": claims, "merge_queue": queue}
+
+    def _save(self, state: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = self.path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+        tmp_path.replace(self.path)
+
+    def _normalize_claim_path(self, path_text: str) -> str:
+        raw = path_text.strip()
+        if not raw:
+            return ""
+        candidate = Path(raw)
+        if candidate.is_absolute():
+            try:
+                return candidate.resolve().relative_to(self.repo_root).as_posix()
+            except ValueError:
+                return candidate.resolve().as_posix()
+        return candidate.as_posix().lstrip("./")
+
+    def list_claims(self) -> list[dict[str, Any]]:
+        state = self._load()
+        claims = [c for c in state["claims"] if isinstance(c, dict)]
+        return sorted(
+            claims,
+            key=lambda row: (
+                str(row.get("path", "")),
+                str(row.get("session_id", "")),
+            ),
+        )
+
+    def claim_paths(
+        self,
+        *,
+        session_id: str,
+        paths: list[str],
+        branch: str | None = None,
+        mode: str = "exclusive",
+    ) -> dict[str, Any]:
+        if mode not in {"exclusive", "shared"}:
+            raise ValueError("mode must be one of: exclusive, shared")
+
+        state = self._load()
+        claims = [c for c in state["claims"] if isinstance(c, dict)]
+        now = datetime.now(timezone.utc).isoformat()
+        normalized = [self._normalize_claim_path(path) for path in paths]
+        normalized = sorted({item for item in normalized if item})
+
+        conflicts: list[dict[str, str]] = []
+        claimed: list[str] = []
+        for path in normalized:
+            conflict_rows = [
+                c
+                for c in claims
+                if str(c.get("path", "")) == path
+                and str(c.get("session_id", "")) != session_id
+                and ("exclusive" in {str(c.get("mode", "exclusive")), mode})
+            ]
+            if conflict_rows:
+                for row in conflict_rows:
+                    conflicts.append(
+                        {
+                            "path": path,
+                            "session_id": str(row.get("session_id", "")),
+                            "branch": str(row.get("branch", "")),
+                        }
+                    )
+                continue
+
+            existing = next(
+                (
+                    c
+                    for c in claims
+                    if str(c.get("path", "")) == path and str(c.get("session_id", "")) == session_id
+                ),
+                None,
+            )
+            if existing is not None:
+                existing["updated_at"] = now
+                existing["mode"] = mode
+                if branch:
+                    existing["branch"] = branch
+            else:
+                claims.append(
+                    {
+                        "session_id": session_id,
+                        "path": path,
+                        "branch": branch or "",
+                        "mode": mode,
+                        "claimed_at": now,
+                        "updated_at": now,
+                    }
+                )
+            claimed.append(path)
+
+        state["claims"] = claims
+        self._save(state)
+        return {"session_id": session_id, "mode": mode, "claimed": claimed, "conflicts": conflicts}
+
+    def release_paths(self, *, session_id: str, paths: list[str] | None = None) -> dict[str, Any]:
+        state = self._load()
+        claims = [c for c in state["claims"] if isinstance(c, dict)]
+        path_filter: set[str] | None = None
+        if paths:
+            normalized = [self._normalize_claim_path(path) for path in paths]
+            path_filter = {item for item in normalized if item}
+
+        kept: list[dict[str, Any]] = []
+        released = 0
+        for claim in claims:
+            owner = str(claim.get("session_id", ""))
+            path = str(claim.get("path", ""))
+            should_release = owner == session_id and (path_filter is None or path in path_filter)
+            if should_release:
+                released += 1
+                continue
+            kept.append(claim)
+
+        state["claims"] = kept
+        self._save(state)
+        return {"session_id": session_id, "released": released}
+
+    def enqueue_merge(
+        self,
+        *,
+        session_id: str,
+        branch: str,
+        priority: int = 50,
+        title: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if not branch.strip():
+            raise ValueError("branch is required")
+        state = self._load()
+        queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
+        normalized_branch = branch.strip()
+
+        for item in queue:
+            if (
+                str(item.get("branch", "")) == normalized_branch
+                and str(item.get("status", "queued")) in ACTIVE_QUEUE_STATUSES
+            ):
+                return {"queued": False, "item": item, "duplicate": True}
+
+        now = datetime.now(timezone.utc).isoformat()
+        row = {
+            "id": f"mq-{uuid.uuid4().hex[:12]}",
+            "session_id": session_id,
+            "branch": normalized_branch,
+            "priority": max(0, min(int(priority), 100)),
+            "title": title.strip(),
+            "status": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "metadata": metadata or {},
+        }
+        queue.append(row)
+        state["merge_queue"] = queue
+        self._save(state)
+        return {"queued": True, "item": row, "duplicate": False}
+
+    def list_merge_queue(self, status: str | None = None) -> list[dict[str, Any]]:
+        state = self._load()
+        queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
+        if status:
+            queue = [q for q in queue if str(q.get("status", "")) == status]
+        queue.sort(
+            key=lambda row: (
+                0 if str(row.get("status", "queued")) == "queued" else 1,
+                -int(row.get("priority", 0)),
+                str(row.get("created_at", "")),
+            )
+        )
+        return queue

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -31,6 +31,7 @@ Operational runbooks for responding to Aragora alerts and incidents.
 | Backup Automation | [RUNBOOK_BACKUP_AUTOMATION.md](./RUNBOOK_BACKUP_AUTOMATION.md) | Automated backup scheduling and validation |
 | Redis Failover | [redis-failover.md](./redis-failover.md) | Redis HA and recovery procedures |
 | Multi-Region | [RUNBOOK_MULTI_REGION_SETUP.md](./RUNBOOK_MULTI_REGION_SETUP.md) | Multi-region deployment and failover |
+| Fleet Coordination | [RUNBOOK_FLEET_COORDINATION.md](./RUNBOOK_FLEET_COORDINATION.md) | Multi-agent worktree ownership and merge queue policy |
 
 ## Incident Severity Levels
 

--- a/docs/runbooks/RUNBOOK_FLEET_COORDINATION.md
+++ b/docs/runbooks/RUNBOOK_FLEET_COORDINATION.md
@@ -1,0 +1,78 @@
+# Fleet Coordination Runbook
+
+## Purpose
+
+Coordinate many concurrent Codex/Claude worktree sessions without collisions:
+
+- Session visibility (`fleet-status`)
+- File ownership claims (`fleet-claim`, `fleet-release`)
+- Merge queue ordering (`fleet-queue-add`, `fleet-queue-list`)
+
+This data is also available over control-plane API for dashboard automation.
+
+## CLI Commands
+
+```bash
+# 1) View all sessions + tails + inferred orchestration pattern
+python -m aragora.cli.main worktree fleet-status --tail 200
+
+# 2) Claim files for one session (exclusive by default)
+python -m aragora.cli.main worktree fleet-claim \
+  --session-id <session_id> \
+  --paths aragora/server/handlers/control_plane/coordination.py tests/handlers/control_plane/test_coordination.py
+
+# 3) Release claims
+python -m aragora.cli.main worktree fleet-release --session-id <session_id>
+
+# 4) Queue merge
+python -m aragora.cli.main worktree fleet-queue-add \
+  --session-id <session_id> \
+  --branch codex/my-branch \
+  --priority 70 \
+  --title "control-plane fleet claim API"
+
+# 5) Inspect merge queue
+python -m aragora.cli.main worktree fleet-queue-list
+```
+
+## API Endpoints
+
+- `GET /api/v1/coordination/fleet/status`
+- `GET /api/v1/coordination/fleet/logs?session_id=<id>`
+- `GET /api/v1/coordination/fleet/claims`
+- `POST /api/v1/coordination/fleet/claims`
+- `POST /api/v1/coordination/fleet/claims/release`
+- `GET /api/v1/coordination/fleet/merge-queue`
+- `POST /api/v1/coordination/fleet/merge-queue`
+
+## Orchestrator Extension Pattern
+
+`fleet-status` now emits `orchestration_pattern` inferred from session metadata/command. Current labels:
+
+- `gastown`
+- `langchain`
+- `crewai`
+- `langgraph`
+- `autogen`
+- `openclaw`
+- `nomic`
+- `generic`
+
+### How to extend to a new orchestrator
+
+1. Update `aragora/worktree/fleet.py` in `infer_orchestration_pattern()` with new markers.
+2. If launching via `scripts/codex_session.sh`, pass `--orchestrator <label>` or add marker detection.
+3. Add/adjust tests in `tests/worktree/test_fleet.py`.
+4. If needed, add routing or policy logic in control-plane based on `orchestration_pattern`.
+
+## Recommended Operating Policy
+
+1. All sessions claim files before edits.
+2. Claims are exclusive for code paths, shared only for docs/analysis.
+3. Every branch enters merge queue before PR merge.
+4. Merge queue item priority:
+   - `80-100`: hotfix / release blocker
+   - `60-79`: CI or security unblock
+   - `40-59`: normal feature work
+   - `0-39`: backlog/refactor
+

--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./scripts/codex_session.sh
 #   ./scripts/codex_session.sh --agent codex-qa
+#   ./scripts/codex_session.sh --orchestrator crewai
 #   ./scripts/codex_session.sh --agent codex-qa --base main -- python -m pytest tests/debate -q
 #   ./scripts/codex_session.sh --managed-dir .worktrees/codex-auto-qa --no-maintain --no-reconcile
 
@@ -16,6 +17,7 @@ RECONCILE=true
 MAINTAIN=true
 TTL_HOURS="${CODEX_WORKTREE_TTL_HOURS:-24}"
 MANAGED_DIR="${CODEX_WORKTREE_MANAGED_DIR:-.worktrees/codex-auto}"
+ORCHESTRATOR="${CODEX_ORCHESTRATOR:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -41,6 +43,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --managed-dir)
             MANAGED_DIR="${2:-.worktrees/codex-auto}"
+            shift 2
+            ;;
+        --orchestrator)
+            ORCHESTRATOR="${2:-}"
             shift 2
             ;;
         --help|-h)
@@ -85,15 +91,161 @@ cd "${WORKTREE_PATH}"
 echo "Codex worktree: ${WORKTREE_PATH}"
 
 LOCK_FILE="${WORKTREE_PATH}/.codex_session_active"
-printf 'pid=%s\nagent=%s\nstarted_at=%s\n' "$$" "${AGENT}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "${LOCK_FILE}"
+META_FILE="${WORKTREE_PATH}/.codex_session_meta.json"
+LOG_FILE="${WORKTREE_PATH}/.codex_session.log"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo detached)"
+SESSION_ID="$(basename "${WORKTREE_PATH}")"
+
+if [[ $# -eq 0 ]]; then
+    SESSION_MODE="codex"
+    SESSION_COMMAND="codex"
+    SESSION_ARGS_JSON='["codex"]'
+else
+    SESSION_MODE="command"
+    SESSION_COMMAND="$*"
+    SESSION_ARGS_JSON="$(python3 - "$@" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1:]))
+PY
+)"
+fi
+
+if [[ -z "${ORCHESTRATOR}" ]]; then
+    cmd_lc="${SESSION_COMMAND,,}"
+    case "${cmd_lc}" in
+        *gastown*|*bead*|*molecule*)
+            ORCHESTRATOR="gastown"
+            ;;
+        *langchain*)
+            ORCHESTRATOR="langchain"
+            ;;
+        *crewai*|*"crew ai"*)
+            ORCHESTRATOR="crewai"
+            ;;
+        *langgraph*)
+            ORCHESTRATOR="langgraph"
+            ;;
+        *autogen*)
+            ORCHESTRATOR="autogen"
+            ;;
+        *openclaw*)
+            ORCHESTRATOR="openclaw"
+            ;;
+        *nomic*)
+            ORCHESTRATOR="nomic"
+            ;;
+        *)
+            ORCHESTRATOR="generic"
+            ;;
+    esac
+fi
+
+printf \
+    'pid=%s\nsession_id=%s\nagent=%s\nbranch=%s\nworktree_path=%s\nlog_path=%s\nmeta_path=%s\nmode=%s\norchestrator=%s\nstarted_at=%s\n' \
+    "$$" \
+    "${SESSION_ID}" \
+    "${AGENT}" \
+    "${BRANCH_NAME}" \
+    "${WORKTREE_PATH}" \
+    "${LOG_FILE}" \
+    "${META_FILE}" \
+    "${SESSION_MODE}" \
+    "${ORCHESTRATOR}" \
+    "${STARTED_AT}" \
+    > "${LOCK_FILE}"
+
+META_FILE="${META_FILE}" \
+WORKTREE_PATH="${WORKTREE_PATH}" \
+BRANCH_NAME="${BRANCH_NAME}" \
+AGENT="${AGENT}" \
+SHELL_PID="$$" \
+SESSION_ID="${SESSION_ID}" \
+LOG_FILE="${LOG_FILE}" \
+SESSION_MODE="${SESSION_MODE}" \
+ORCHESTRATOR="${ORCHESTRATOR}" \
+SESSION_COMMAND="${SESSION_COMMAND}" \
+SESSION_ARGS_JSON="${SESSION_ARGS_JSON}" \
+STARTED_AT="${STARTED_AT}" \
+python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+meta = {
+    "pid": int(os.environ["SHELL_PID"]),
+    "session_id": os.environ["SESSION_ID"],
+    "agent": os.environ["AGENT"],
+    "branch": os.environ["BRANCH_NAME"],
+    "worktree_path": os.environ["WORKTREE_PATH"],
+    "log_path": os.environ["LOG_FILE"],
+    "mode": os.environ["SESSION_MODE"],
+    "orchestrator": os.environ["ORCHESTRATOR"],
+    "command": os.environ["SESSION_COMMAND"],
+    "args": json.loads(os.environ["SESSION_ARGS_JSON"]),
+    "started_at": os.environ["STARTED_AT"],
+}
+Path(os.environ["META_FILE"]).write_text(json.dumps(meta, indent=2) + "\n", encoding="utf-8")
+PY
+
+{
+    echo "=== session_start ==="
+    echo "started_at=${STARTED_AT}"
+    echo "pid=$$"
+    echo "agent=${AGENT}"
+    echo "branch=${BRANCH_NAME}"
+    echo "mode=${SESSION_MODE}"
+    echo "orchestrator=${ORCHESTRATOR}"
+    echo "command=${SESSION_COMMAND}"
+} >> "${LOG_FILE}"
+
 cleanup_lock() {
+    local exit_code=$?
+    local ended_at
+    ended_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+    {
+        echo "=== session_end ==="
+        echo "ended_at=${ended_at}"
+        echo "exit_code=${exit_code}"
+    } >> "${LOG_FILE}" 2>/dev/null || true
+
+    META_FILE="${META_FILE}" \
+    ENDED_AT="${ended_at}" \
+    EXIT_CODE="${exit_code}" \
+    python3 - <<'PY' >/dev/null 2>&1
+import json
+import os
+from pathlib import Path
+
+meta_path = Path(os.environ["META_FILE"])
+if not meta_path.exists():
+    raise SystemExit(0)
+data = json.loads(meta_path.read_text(encoding="utf-8"))
+data["ended_at"] = os.environ["ENDED_AT"]
+data["exit_code"] = int(os.environ["EXIT_CODE"])
+meta_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+PY
+
     rm -f "${LOCK_FILE}" 2>/dev/null || true
 }
 trap cleanup_lock EXIT INT TERM
 
-if [[ $# -eq 0 ]]; then
-    codex
+if command -v script >/dev/null 2>&1; then
+    if [[ $# -eq 0 ]]; then
+        script -q "${LOG_FILE}" codex
+    else
+        script -q "${LOG_FILE}" "$@"
+    fi
     exit $?
 fi
 
-"$@"
+# Fallback when script(1) is unavailable.
+if [[ $# -eq 0 ]]; then
+    codex 2>&1 | tee -a "${LOG_FILE}"
+    exit ${PIPESTATUS[0]}
+fi
+
+"$@" 2>&1 | tee -a "${LOG_FILE}"
+exit ${PIPESTATUS[0]}

--- a/tests/worktree/test_fleet.py
+++ b/tests/worktree/test_fleet.py
@@ -1,0 +1,58 @@
+"""Tests for shared fleet coordination utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.worktree.fleet import (
+    FleetCoordinationStore,
+    infer_orchestration_pattern,
+)
+
+
+def test_infer_orchestration_pattern_from_framework() -> None:
+    pattern = infer_orchestration_pattern({"framework": "CrewAI"})
+    assert pattern == "crewai"
+
+
+def test_infer_orchestration_pattern_from_command() -> None:
+    pattern = infer_orchestration_pattern({"command": "python scripts/gastown_migrate_state.py"})
+    assert pattern == "gastown"
+
+
+def test_claim_paths_detects_conflicts(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    first = store.claim_paths(
+        session_id="session-a",
+        paths=["aragora/server/handlers/a.py"],
+        mode="exclusive",
+    )
+    assert first["conflicts"] == []
+
+    second = store.claim_paths(
+        session_id="session-b",
+        paths=["aragora/server/handlers/a.py"],
+        mode="exclusive",
+    )
+    assert len(second["conflicts"]) == 1
+    assert second["conflicts"][0]["session_id"] == "session-a"
+
+
+def test_release_paths_by_subset(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.claim_paths(session_id="session-a", paths=["a.py", "b.py"])
+    result = store.release_paths(session_id="session-a", paths=["a.py"])
+    assert result["released"] == 1
+    claims = store.list_claims()
+    assert len(claims) == 1
+    assert claims[0]["path"] == "b.py"
+
+
+def test_enqueue_merge_deduplicates_active_branch(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    first = store.enqueue_merge(session_id="session-a", branch="codex/session-a", priority=70)
+    assert first["queued"] is True
+    second = store.enqueue_merge(session_id="session-b", branch="codex/session-a", priority=80)
+    assert second["duplicate"] is True
+    queue = store.list_merge_queue()
+    assert len(queue) == 1


### PR DESCRIPTION
## Summary
- add shared fleet coordination primitives for worktree sessions
- add CLI commands for fleet status/log tails, file claims, and merge queue operations
- add control-plane endpoints for fleet status/logs/claims/merge-queue
- persist ownership + merge queue state in .aragora/fleet_coordination.json
- infer orchestration pattern labels (gastown, langchain, crewai, langgraph, autogen, openclaw, nomic, generic)
- add runbook and tests for CLI/worktree/control-plane behavior

## Validation
- ruff check on changed python files
- python3 -m py_compile on changed python files
- bash -n scripts/codex_session.sh
- pytest -q tests/worktree/test_fleet.py tests/cli/test_worktree_command.py tests/handlers/control_plane/test_coordination.py
