### PR TITLE
fix(types): resolve 4 remaining mypy errors

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -158,8 +158,9 @@ def _run_self_improve_handoff(
         print(f"Improvement score: {result.improvement_score:.3f}")
         print(f"Cost: ${result.total_cost_usd:.4f}")
         print(f"Duration: {result.duration_seconds:.1f}s")
-        if result.error:
-            print(f"Error: {result.error}")
+        _err = getattr(result, "error", None)
+        if _err:
+            print(f"Error: {_err}")
         print()
 
 

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -6,6 +6,9 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
+from pathlib import Path
+
+from aragora.harnesses.base import AnalysisType
 from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
@@ -193,8 +196,8 @@ class SwarmReporter:
             )
 
             llm_result = await harness.analyze_repository(
-                repo_path=".",
-                analysis_type="general",
+                repo_path=Path("."),
+                analysis_type=AnalysisType.GENERAL,
                 prompt=prompt,
             )
             raw = llm_result.raw_output if hasattr(llm_result, "raw_output") else str(llm_result)


### PR DESCRIPTION
## Summary
- **reporter.py**: Use `Path(".")` and `AnalysisType.GENERAL` instead of string literals for `analyze_repository()` call
- **pipeline.py**: Use `getattr(result, "error", None)` since `SelfImproveResult` doesn't have an `error` field

## Test plan
- [x] `mypy aragora/swarm/reporter.py aragora/cli/commands/pipeline.py` passes with zero errors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)