### PR TITLE
feat(verticals): persist config overrides + quickstart targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Aragora Makefile
 # Common development tasks for the Aragora multi-agent debate platform
 
-.PHONY: help install dev test test-e2e lint format typecheck check check-all ci guard guard-strict clean clean-all clean-runtime clean-runtime-dry docs serve docker demo demo-docker demo-stop worktree-ensure worktree-reconcile worktree-cleanup worktree-maintain worktree-maintainer-install worktree-maintainer-uninstall worktree-maintainer-status codex-session branch-start pr-open
+.PHONY: help install dev test test-e2e lint format typecheck check check-all ci guard guard-strict clean clean-all clean-runtime clean-runtime-dry docs serve docker demo demo-docker demo-stop quickstart quickstart-live worktree-ensure worktree-reconcile worktree-cleanup worktree-maintain worktree-maintainer-install worktree-maintainer-uninstall worktree-maintainer-status codex-session branch-start pr-open
 
 # Default target
 help:
@@ -38,6 +38,8 @@ help:
 	@echo "  make demo         Launch full-stack demo locally (backend + frontend)"
 	@echo "  make demo-docker  Launch demo via Docker Compose"
 	@echo "  make demo-stop    Stop running demo"
+	@echo "  make quickstart   Docker quickstart (mock agents, zero config)"
+	@echo "  make quickstart-live Docker quickstart with real agents (needs .env)"
 	@echo ""
 	@echo "Development:"
 	@echo "  make serve        Start development server"
@@ -150,6 +152,12 @@ demo-docker:
 
 demo-stop:
 	@bash scripts/demo.sh --stop
+
+quickstart:
+	docker compose -f docker-compose.quickstart.yml up --build
+
+quickstart-live:
+	docker compose -f docker-compose.simple.yml up --build
 
 # Development
 serve:

--- a/aragora/storage/repositories/verticals.py
+++ b/aragora/storage/repositories/verticals.py
@@ -1,0 +1,117 @@
+"""
+VerticalsConfigRepository - Persistence for vertical configuration overrides.
+
+Stores user-customized vertical configs (tools, compliance frameworks, model
+config) in SQLite so they survive server restarts. On startup, saved configs
+are loaded and applied on top of registry defaults.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.config import resolve_db_path
+from aragora.persistence.db_config import DatabaseType
+
+logger = logging.getLogger(__name__)
+
+
+class VerticalsConfigRepository:
+    """Repository for persisting vertical configuration overrides."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        if db_path is None:
+            self._db_path = self._get_default_db_path()
+        else:
+            self._db_path = Path(resolve_db_path(db_path))
+        self._init_schema()
+
+    def _get_default_db_path(self) -> Path:
+        from aragora.persistence.db_config import get_db_path
+
+        return get_db_path(DatabaseType.ONBOARDING)
+
+    def _init_schema(self) -> None:
+        with self._get_connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS vertical_configs (
+                    vertical_id TEXT NOT NULL,
+                    config_json TEXT NOT NULL,
+                    updated_by TEXT DEFAULT '',
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (vertical_id)
+                )
+            """)
+            conn.commit()
+
+    def _get_connection(self) -> sqlite3.Connection:
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self._db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def save_config(
+        self,
+        vertical_id: str,
+        config: dict[str, Any],
+        updated_by: str = "",
+    ) -> None:
+        """Save or update vertical config override."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self._get_connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO vertical_configs (vertical_id, config_json, updated_by, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(vertical_id) DO UPDATE SET
+                    config_json = excluded.config_json,
+                    updated_by = excluded.updated_by,
+                    updated_at = excluded.updated_at
+                """,
+                (vertical_id, json.dumps(config), updated_by, now),
+            )
+            conn.commit()
+        logger.info("Saved vertical config for %s", vertical_id)
+
+    def get_config(self, vertical_id: str) -> dict[str, Any] | None:
+        """Load saved config override for a vertical."""
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT config_json FROM vertical_configs WHERE vertical_id = ?",
+                (vertical_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return json.loads(row["config_json"])
+
+    def get_all_configs(self) -> dict[str, dict[str, Any]]:
+        """Load all saved config overrides."""
+        with self._get_connection() as conn:
+            rows = conn.execute("SELECT vertical_id, config_json FROM vertical_configs").fetchall()
+        return {row["vertical_id"]: json.loads(row["config_json"]) for row in rows}
+
+    def delete_config(self, vertical_id: str) -> bool:
+        """Delete a saved config override."""
+        with self._get_connection() as conn:
+            cursor = conn.execute(
+                "DELETE FROM vertical_configs WHERE vertical_id = ?",
+                (vertical_id,),
+            )
+            conn.commit()
+        return cursor.rowcount > 0
+
+
+_repository: VerticalsConfigRepository | None = None
+
+
+def get_verticals_config_repository() -> VerticalsConfigRepository:
+    """Get or create the singleton repository."""
+    global _repository
+    if _repository is None:
+        _repository = VerticalsConfigRepository()
+    return _repository


### PR DESCRIPTION
## Summary
- **Verticals config persistence**: Added `VerticalsConfigRepository` (SQLite) so vertical config customizations (tools, compliance frameworks, model config) survive server restarts. Previously these were in-memory only and lost on restart.
- **Makefile quickstart targets**: Added `make quickstart` (mock agents, zero config) and `make quickstart-live` (real agents, needs .env) for Docker quickstart discoverability.
- **Research findings**: Analytics outcomes dashboard, compliance doc generation, and Docker quickstart infrastructure are all already fully implemented — no additional work needed.

## Changes
- `aragora/storage/repositories/verticals.py` — New SQLite repository following existing patterns (OnboardingRepository)
- `aragora/server/handlers/verticals.py` — Wired persistence into `_update_config()` with graceful degradation
- `Makefile` — Added quickstart/quickstart-live targets and help text

## Test plan
- [x] All 166 verticals handler tests pass (0 failures)
- [x] Ruff lint and format pass
- [x] Repository import verified
- [ ] Manual: `PUT /api/verticals/:id/config` → restart server → config persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)