### PR TITLE
ci: add draft fast-path and tighten required-check queue policy

### DIFF
--- a/.github/workflows/aragora-gauntlet.yml
+++ b/.github/workflows/aragora-gauntlet.yml
@@ -2,7 +2,7 @@ name: Aragora Gauntlet Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
@@ -11,10 +11,15 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE/**'
 
+concurrency:
+  group: aragora-gauntlet-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gauntlet:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -3,6 +3,7 @@ name: Autopilot Worktree E2E
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -16,6 +17,7 @@ jobs:
   scope:
     name: Autopilot Scope
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     outputs:
       run_autopilot: ${{ steps.filter.outputs.run_autopilot }}
 
@@ -52,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: scope
-    if: github.event_name != 'pull_request' || needs.scope.outputs.run_autopilot == 'true'
+    if: github.event_name != 'pull_request' || (!github.event.pull_request.draft && needs.scope.outputs.run_autopilot == 'true')
 
     steps:
       - name: Checkout

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -3,6 +3,7 @@ name: Build Documentation (PR Check)
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'docs/**'
       - 'docs-site/**'
@@ -28,9 +29,14 @@ on:
 env:
   NODE_VERSION: '20'
 
+concurrency:
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout

--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -7,6 +7,7 @@ name: "Integration Gate"
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'aragora/**'
       - 'tests/**'
@@ -33,6 +34,7 @@ jobs:
     name: Smoke Test Harness
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -73,6 +75,7 @@ jobs:
     name: API Contract Sync
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -103,7 +106,7 @@ jobs:
     name: Frontend Build
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    if: github.event_name != 'workflow_call'
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && github.event_name != 'workflow_call'
 
     steps:
       - name: Checkout
@@ -137,7 +140,10 @@ jobs:
           python-version: "3.11"
 
       - name: Install parity test deps
-        run: pip install pytest pytest-timeout
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest pytest-timeout
 
       - name: "BLOCKING: SDK contract parity"
         run: |
@@ -149,6 +155,7 @@ jobs:
     name: Status Doc Validation
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -217,7 +224,7 @@ jobs:
     name: Integration Gate Summary
     runs-on: ubuntu-latest
     needs: [smoke-tests, api-contract-sync, status-doc-validation, frontend-build]
-    if: always()
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && always()
     timeout-minutes: 2
 
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,6 +16,7 @@ on:
       - 'setup.py'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'aragora/**'
       - 'tests/**'
@@ -47,6 +48,7 @@ jobs:
     name: Self-Hosted Compose Readiness
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -102,6 +104,7 @@ jobs:
     name: E2E Harness Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     services:
       redis:
@@ -208,6 +211,7 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     services:
       redis:
@@ -350,6 +354,7 @@ jobs:
     name: Control Plane Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     services:
       redis:
@@ -444,7 +449,7 @@ jobs:
     name: Integration Summary
     runs-on: ubuntu-latest
     needs: [e2e-harness, integration-tests, control-plane-tests]
-    if: always()
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && always()
 
     steps:
       - name: Check results

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,7 @@ on:
       - 'aragora-operator/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'aragora/**'
       - 'tests/**'
@@ -33,6 +34,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -128,6 +130,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -24,11 +24,12 @@ on:
       - 'sdk/typescript/src/namespaces/**'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:
   group: openapi-sync-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   scope:
@@ -49,6 +50,11 @@ jobs:
           set -euo pipefail
           if [[ "${{ github.event_name }}" != "pull_request" ]]; then
             echo "run_openapi=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "${{ github.event.pull_request.draft }}" == "true" ]]; then
+            echo "run_openapi=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/.github/workflows/pr-debate.yml
+++ b/.github/workflows/pr-debate.yml
@@ -8,12 +8,16 @@ name: Aragora PR Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
     inputs:
       pr_number:
         description: 'PR number to review'
         required: true
+
+concurrency:
+  group: pr-debate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -24,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     # Skip if PR is from a fork (no access to secrets)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft)
 
     steps:
       # SECURITY: Checkout the BASE branch (trusted code), NOT the PR branch.

--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -6,7 +6,7 @@ on:
 
 concurrency:
   group: required-check-priority-${{ github.event.pull_request.number }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 permissions:
   actions: write
@@ -31,6 +31,7 @@ jobs:
             const headSha = pr.head.sha;
             const headBranch = pr.head.ref;
             const baseBranch = pr.base.ref;
+            const isDraft = Boolean(pr.draft);
             const selfRunId = Number(process.env.GITHUB_RUN_ID);
 
             const sweeps = 4;
@@ -44,9 +45,6 @@ jobs:
               '.github/workflows/sdk-test.yml',
               '.github/workflows/openapi.yml',
               '.github/workflows/required-check-priority.yml',
-              '.github/workflows/autopilot-worktree-e2e.yml',
-              '.github/workflows/aragora-gauntlet.yml',
-              '.github/workflows/pr-debate.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
               'Required Check Priority',
@@ -54,9 +52,6 @@ jobs:
               'SDK Parity Check',
               'SDK Tests',
               'OpenAPI Spec',
-              'Autopilot Worktree E2E',
-              'Aragora Gauntlet Review',
-              'Aragora PR Review',
             ]);
 
             const requiredContexts = new Set();
@@ -79,6 +74,7 @@ jobs:
                   `(continuing with static required-workflow keep-list): ${error.message}`
               );
             }
+            core.info(`Draft fast-path mode: ${isDraft ? 'enabled' : 'disabled'}`);
             const requiredContextsNormalized = new Set(
               Array.from(requiredContexts).map((value) => String(value || '').trim())
             );
@@ -170,17 +166,19 @@ jobs:
 
                 const workflowPath = (run.path || '').split('@')[0];
                 const workflowName = String(run.name || '').trim();
-                if (
-                  alwaysKeepWorkflowPaths.has(workflowPath) ||
-                  alwaysKeepWorkflowNames.has(workflowName)
-                ) {
-                  continue;
-                }
+                if (!isDraft) {
+                  if (
+                    alwaysKeepWorkflowPaths.has(workflowPath) ||
+                    alwaysKeepWorkflowNames.has(workflowName)
+                  ) {
+                    continue;
+                  }
 
-                // Defensive check: if a non-allowlisted workflow run currently owns
-                // a required status context, keep it.
-                const hasRequiredContext = await runHasRequiredContext(run);
-                if (hasRequiredContext) continue;
+                  // Defensive check: if a non-allowlisted workflow run currently owns
+                  // a required status context, keep it.
+                  const hasRequiredContext = await runHasRequiredContext(run);
+                  if (hasRequiredContext) continue;
+                }
 
                 try {
                   await github.rest.actions.cancelWorkflowRun({

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +16,7 @@ jobs:
   sdk-parity:
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -10,6 +10,7 @@ on:
       - '.github/workflows/sdk-test.yml'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -21,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: SDK Change Detection
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     outputs:
       run_python: ${{ steps.filter.outputs.python_sdk }}
 
@@ -39,7 +41,7 @@ jobs:
 
   python-sdk:
     needs: changes
-    if: needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Python SDK Tests
@@ -74,6 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: TypeScript SDK Type Check
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -101,7 +104,7 @@ jobs:
 
   sdk-integration:
     needs: changes
-    if: needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: SDK Integration Tests

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -6,6 +6,7 @@ name: "Security Gate"
 on:
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'aragora/**'
       - 'pyproject.toml'
@@ -31,6 +32,7 @@ jobs:
     name: Python Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -91,6 +93,7 @@ jobs:
     name: npm Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -162,7 +165,7 @@ jobs:
     name: Security Gate Summary
     runs-on: ubuntu-latest
     needs: [python-security, npm-security]
-    if: always()
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && always()
     timeout-minutes: 2
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,7 @@ on:
       - '.github/workflows/test.yml'
   pull_request:
     branches: [main]
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - 'aragora/**'
       - 'aragora-debate/**'
@@ -70,6 +71,7 @@ jobs:
     name: Version Alignment
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -232,6 +234,7 @@ jobs:
     name: Skip Marker Audit
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -280,6 +283,7 @@ jobs:
     name: Status Doc Reconciliation
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -1104,6 +1108,7 @@ jobs:
     name: Frontend E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -1165,7 +1170,7 @@ jobs:
     name: Frontend TypeScript Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -1205,6 +1210,7 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -1237,6 +1243,7 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     steps:
       - name: Checkout
@@ -1268,6 +1275,7 @@ jobs:
     name: Database Migrations
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
 
     services:
       postgres:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -32,6 +32,7 @@ Operational runbooks for responding to Aragora alerts and incidents.
 | Redis Failover | [redis-failover.md](./redis-failover.md) | Redis HA and recovery procedures |
 | Multi-Region | [RUNBOOK_MULTI_REGION_SETUP.md](./RUNBOOK_MULTI_REGION_SETUP.md) | Multi-region deployment and failover |
 | Fleet Coordination | [RUNBOOK_FLEET_COORDINATION.md](./RUNBOOK_FLEET_COORDINATION.md) | Multi-agent worktree ownership and merge queue policy |
+| CI Lane Discipline | [RUNBOOK_CI_LANE_DISCIPLINE.md](./RUNBOOK_CI_LANE_DISCIPLINE.md) | Draft-vs-integrator lane policy for high-throughput agent collaboration |
 
 ## Incident Severity Levels
 

--- a/docs/runbooks/RUNBOOK_CI_LANE_DISCIPLINE.md
+++ b/docs/runbooks/RUNBOOK_CI_LANE_DISCIPLINE.md
@@ -1,0 +1,62 @@
+# CI Lane Discipline Runbook
+
+This runbook keeps agent throughput high while preventing merge queue collapse.
+
+## Goal
+
+Run many agent sessions in parallel for ideation and implementation, but serialize merge integration so CI stays responsive.
+
+## Lane Model
+
+- `R&D lane`:
+  - Multiple branches/worktrees are allowed.
+  - PRs stay in `draft`.
+  - Expensive workflows are skipped for draft PRs.
+  - Iterate with local checks (`ruff`, targeted `pytest`).
+- `Integrator lane`:
+  - Exactly one non-draft PR at a time.
+  - Auto-merge enabled on that PR.
+  - Required checks must pass on the current head SHA.
+
+## Required Checks (main branch protection)
+
+Keep required contexts minimal and stable:
+
+- `lint`
+- `typecheck`
+- `sdk-parity`
+- `Generate & Validate`
+- `TypeScript SDK Type Check`
+
+If this set changes in GitHub branch protection, update:
+
+- `.github/workflows/required-check-priority.yml`
+- `scripts/check_required_check_priority_policy.py`
+
+## Fast-Path Rules Implemented
+
+- Draft PR fast-path:
+  - Heavy workflows/jobs skip when `pull_request.draft == true`.
+- Queue trimming:
+  - `Required Check Priority` cancels non-required runs for non-draft PRs.
+  - For draft PRs, it cancels all other PR runs on that head.
+- Concurrency:
+  - Workflows use per-ref concurrency with cancel-in-progress enabled for non-main refs.
+
+## Operator Procedure
+
+1. Choose integrator PR and keep all others in draft.
+2. Ensure integrator PR has auto-merge enabled.
+3. Let required checks run; ignore stale failures from superseded heads.
+4. On first required-check failure, patch only that failure and push.
+5. After merge, promote the next draft PR.
+
+## One-Shot Queue Cleanup (optional)
+
+```bash
+gh run list --limit 200 --json databaseId,headBranch,status \
+| jq -r '.[] | select((.status=="queued" or .status=="in_progress") and .headBranch!="main" and .headBranch!="<integrator-branch>") | .databaseId' \
+| xargs -n1 -I{} gh run cancel {}
+```
+
+Use one-shot commands only. Avoid long-lived `gh run watch` loops.


### PR DESCRIPTION
## Summary
- add draft PR fast-path gating to heavy workflows so draft branches avoid full-matrix CI load
- tighten `Required Check Priority` to keep only required-check workflows on ready PRs and aggressively cancel non-required runs
- add concurrency controls to review workflows to prevent duplicate long-running jobs
- harden integration-gate parity setup by installing project deps before parity tests
- document the operating model in `docs/runbooks/RUNBOOK_CI_LANE_DISCIPLINE.md`

## Validation
- `python scripts/check_required_check_priority_policy.py`
- `pytest -q tests/scripts/test_check_required_check_priority_policy.py`
- YAML parse check for all modified workflow files
