### PR TITLE
ci(lint): support merge_queue merge_group checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ on:
       - '.github/workflows/**'
       - 'deploy/**'
       - 'aragora-operator/**'
+  merge_group:
   workflow_dispatch:
 
 concurrency:
@@ -73,7 +74,7 @@ jobs:
     timeout-minutes: 10
     name: Connector Exception Hygiene
     # PR fast path: this job is non-required and runs on push/workflow_dispatch.
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -96,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Agent Registry Sync
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -153,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     name: Core Module Type Safety
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -232,7 +233,7 @@ jobs:
   frontend-lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     defaults:
       run:
@@ -263,7 +264,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -297,7 +298,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Secret Scanning
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -315,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Helm Chart Validation
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -405,7 +406,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     name: TODO/FIXME Enforcement
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout
@@ -442,7 +443,7 @@ jobs:
   docs-sync:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: github.event_name != 'pull_request'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- add `merge_group` trigger to `.github/workflows/lint.yml` so required checks run for merge queue branches
- keep non-required lint workflow jobs limited to `push` and `workflow_dispatch` to avoid merge queue capacity churn

## Why
- merge queue was stuck in `AWAITING_CHECKS` because required context checks did not run on merge-group refs

## Validation
- YAML parse check for `.github/workflows/lint.yml`
