### PR TITLE
fix(ci): add merge_group trigger to required-check workflows

### DIFF
--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -17,6 +17,7 @@ on:
       - 'docs/STATUS.md'
       - 'pyproject.toml'
       - '.github/workflows/integration-gate.yml'
+  merge_group:
   workflow_call:
     # Allow release.yml to call this workflow as a reusable gate
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ on:
       - '.github/workflows/**'
       - 'deploy/**'
       - 'aragora-operator/**'
+  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `merge_group` trigger to `lint.yml` and `integration-gate.yml`
- Required status checks (`lint`, `typecheck`, `Smoke Test Harness`) now run on merge queue branches

## Why
The merge queue was stuck in `AWAITING_CHECKS` because required checks only ran on `pull_request` events, not `merge_group` events. When a PR enters the merge queue, GitHub creates a temporary merge branch and runs checks against it — but only workflows with `merge_group` triggers fire.

## What changed
- `lint.yml`: Added `merge_group:` trigger (covers `lint` and `typecheck` required checks)
- `integration-gate.yml`: Added `merge_group:` trigger (covers `Smoke Test Harness` required check)

## Test plan
- [x] Both YAML files parse cleanly
- [ ] Merge queue should no longer get stuck on AWAITING_CHECKS
- Supersedes #424 (which only added merge_group to lint.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)