### PR TITLE
feat: complete Wave 3C - orphaned component wiring

### DIFF
--- a/aragora/live/src/app/(app)/pipeline/page.tsx
+++ b/aragora/live/src/app/(app)/pipeline/page.tsx
@@ -12,6 +12,7 @@ import { FeedbackLoopPanel } from '@/components/pipeline-canvas/FeedbackLoopPane
 import { AutoTransitionSuggestion } from '@/components/pipeline-canvas/AutoTransitionSuggestion';
 import type { TransitionSuggestion } from '@/components/pipeline-canvas/AutoTransitionSuggestion';
 import type { PipelineStageType, PipelineResultResponse, ExecutionStatus } from '@/components/pipeline-canvas/types';
+import { UseCaseWizard } from '@/components/wizards/UseCaseWizard';
 
 const PipelineCanvas = dynamic(
   () => import('@/components/pipeline-canvas/PipelineCanvas').then((m) => m.PipelineCanvas),
@@ -96,6 +97,7 @@ function PipelinePageContent() {
   const [showIdeaInput, setShowIdeaInput] = useState(false);
   const [showDebateInput, setShowDebateInput] = useState(false);
   const [showBrainDump, setShowBrainDump] = useState(false);
+  const [showWizard, setShowWizard] = useState(false);
   const [ideaText, setIdeaText] = useState('');
   const [brainDumpText, setBrainDumpText] = useState('');
   const [debateJson, setDebateJson] = useState('');
@@ -871,12 +873,30 @@ function PipelinePageContent() {
                       From Debate
                     </button>
                     <button
+                      onClick={() => setShowWizard(true)}
+                      className="px-6 py-3 bg-amber-600 text-white font-mono text-sm rounded hover:bg-amber-500 transition-colors"
+                    >
+                      Use Template
+                    </button>
+                    <button
                       onClick={handleDemo}
                       className="px-6 py-3 bg-emerald-600 text-white font-mono text-sm rounded hover:bg-emerald-500 transition-colors"
                     >
                       Try Demo
                     </button>
                   </div>
+
+                  {showWizard && (
+                    <div className="mt-8 max-w-2xl mx-auto">
+                      <UseCaseWizard
+                        onComplete={(id) => {
+                          setShowWizard(false);
+                          router.push(`/debate/${id}`);
+                        }}
+                        onCancel={() => setShowWizard(false)}
+                      />
+                    </div>
+                  )}
                 </div>
               )}
             </div>

--- a/aragora/live/src/components/graph-debate/NodeDetailPanel.tsx
+++ b/aragora/live/src/components/graph-debate/NodeDetailPanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { getAgentColors } from '@/utils/agentColors';
 import type { DebateNode } from './types';
 import { getBranchColor } from './utils';
@@ -75,6 +76,22 @@ export function NodeDetailPanel({ node, onClose }: NodeDetailPanelProps) {
             <span className="text-text-muted">Children: </span>
             <span className="text-text">{node.child_ids.length}</span>
           </div>
+        </div>
+
+        {/* Actions */}
+        <div className="pt-2 border-t border-border flex gap-2">
+          <Link
+            href={`/arena?task=${encodeURIComponent(node.content.slice(0, 500))}`}
+            className="flex-1 px-3 py-1.5 bg-acid-green/10 border border-acid-green/30 text-acid-green text-xs font-mono text-center hover:bg-acid-green/20 transition-colors"
+          >
+            [DEBATE THIS]
+          </Link>
+          <Link
+            href={`/pipeline?from=graph-debate&content=${encodeURIComponent(node.content.slice(0, 500))}`}
+            className="flex-1 px-3 py-1.5 bg-acid-cyan/10 border border-acid-cyan/30 text-acid-cyan text-xs font-mono text-center hover:bg-acid-cyan/20 transition-colors"
+          >
+            [TO PIPELINE]
+          </Link>
         </div>
 
         {/* Hash */}


### PR DESCRIPTION
## Summary
- Add [DEBATE THIS] and [TO PIPELINE] action buttons to graph-debate NodeDetailPanel for forward navigation from debate graph nodes
- Wire UseCaseWizard into pipeline empty state as "Use Template" onboarding option
- Completes all 3 waves of the Unified DAG Idea-to-Execution Platform plan

## Plan Status (zazzy-fluttering-lovelace)
| Wave | Tasks | Status |
|------|-------|--------|
| Wave 1 | 1A-1F (6 tasks) | All complete (prior work) |
| Wave 2 | 2A-2D (4 tasks) | All complete (prior work) |
| Wave 3 | 3A-3C (3 tasks) | All complete (this PR fills final gaps) |

## What was missing (now fixed)
- `NodeDetailPanel` had no forward navigation - users could view graph debate nodes but couldn't act on them
- Pipeline empty state had no template-based onboarding - `UseCaseWizard` existed but wasn't accessible from the pipeline page

## Test plan
- [ ] Open graph-debate view, click a node -> verify [DEBATE THIS] and [TO PIPELINE] buttons appear
- [ ] Click [DEBATE THIS] -> navigates to `/arena` with node content pre-filled
- [ ] Click [TO PIPELINE] -> navigates to `/pipeline` with graph-debate source
- [ ] Open `/pipeline` with no active pipeline -> verify "Use Template" button visible
- [ ] Click "Use Template" -> UseCaseWizard renders inline with template selection
- [ ] `npx tsc --noEmit` passes (only pre-existing jest/node type def warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)