### PR TITLE
fix(e2e): isolate tests from real services and guard golden paths

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -126,6 +126,9 @@ def _isolate_e2e_databases(tmp_path, monkeypatch):
     monkeypatch.setenv("ARAGORA_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("ARAGORA_CONVERGENCE_BACKEND", "jaccard")
     monkeypatch.setenv("ARAGORA_SIMILARITY_BACKEND", "jaccard")
+    monkeypatch.setenv("ARAGORA_OFFLINE", "1")
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/e2e/test_golden_paths.py
+++ b/tests/e2e/test_golden_paths.py
@@ -8,8 +8,8 @@ import pytest
 
 
 @pytest.mark.skipif(
-    not os.environ.get("ANTHROPIC_API_KEY") and not os.environ.get("OPENAI_API_KEY"),
-    reason="golden_paths script requires real API keys (ANTHROPIC_API_KEY or OPENAI_API_KEY)",
+    not os.environ.get("ARAGORA_RUN_GOLDEN_PATHS"),
+    reason="golden_paths script requires ARAGORA_RUN_GOLDEN_PATHS=1 (long-running, makes real API calls)",
 )
 def test_golden_paths_script(tmp_path: Path) -> None:
     output_dir = tmp_path / "golden_paths"


### PR DESCRIPTION
## Summary
- Set `ARAGORA_OFFLINE=1` in e2e conftest to prevent tests from making real service calls
- Remove `SLACK_BOT_TOKEN`/`SLACK_WEBHOOK_URL` from e2e environment
- Gate `test_golden_paths` behind explicit `ARAGORA_RUN_GOLDEN_PATHS=1` instead of auto-running when API keys are present

## Test plan
- [ ] E2E tests run without triggering real API calls
- [ ] Golden paths test skips unless explicitly opted in

🤖 Generated with [Claude Code](https://claude.com/claude-code)