### PR TITLE
fix: isolate tests from external services

### DIFF
--- a/aragora/mcp/tools_module/control_plane.py
+++ b/aragora/mcp/tools_module/control_plane.py
@@ -263,11 +263,8 @@ async def submit_task_tool(
     if not task_type:
         return {"error": "task_type is required"}
 
-    coordinator = await _get_coordinator()
-    if not coordinator:
-        return {"error": "Control plane not available"}
-
-    # Parse payload with type validation
+    # Validate payload before checking coordinator availability so input
+    # errors are reported even when the control plane is offline.
     import json
 
     try:
@@ -276,6 +273,10 @@ async def submit_task_tool(
             return {"error": f"Payload must be a JSON object, not {type(payload_dict).__name__}"}
     except json.JSONDecodeError as e:
         return {"error": f"Invalid JSON payload: {e}"}
+
+    coordinator = await _get_coordinator()
+    if not coordinator:
+        return {"error": "Control plane not available"}
 
     # Parse capabilities
     cap_list = (

--- a/tests/debate/conftest.py
+++ b/tests/debate/conftest.py
@@ -64,6 +64,9 @@ def _isolate_debate_databases(tmp_path, monkeypatch):
     # (QuestionClassifier.classify() creates an AsyncAnthropic client that
     # opens TCP connections which keep the event loop alive).
     monkeypatch.setenv("ARAGORA_OFFLINE", "1")
+    # Prevent real Slack API calls from notification providers
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gauntlet/conftest.py
+++ b/tests/gauntlet/conftest.py
@@ -60,3 +60,9 @@ def _mock_gauntlet_runner_external_calls(monkeypatch):
     monkeypatch.setattr(GauntletRunner, "_run_red_team", _mock_run_red_team)
     monkeypatch.setattr(GauntletRunner, "_run_probes", _mock_run_probes)
     monkeypatch.setattr(GauntletRunner, "_run_scenarios", _mock_run_scenarios)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_signing_key(monkeypatch):
+    """Remove real signing key to prevent bytes.fromhex() failures."""
+    monkeypatch.delenv("ARAGORA_RECEIPT_SIGNING_KEY", raising=False)

--- a/tests/governance/conftest.py
+++ b/tests/governance/conftest.py
@@ -1,0 +1,10 @@
+"""Governance test fixtures — isolate external services."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_notification_tokens(monkeypatch):
+    """Remove real Slack tokens to prevent external API calls."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,3 +1,46 @@
-"""Skip MCP tests when optional dependency is missing."""
+"""MCP test fixtures — isolate external services."""
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_control_plane_coordinator(monkeypatch):
+    """Prevent MCP control-plane tools from connecting to Redis."""
+    try:
+        import aragora.mcp.tools_module.control_plane as cp_mod
+
+        async def _mock_get_coordinator():
+            return None
+
+        monkeypatch.setattr(cp_mod, "_get_coordinator", _mock_get_coordinator)
+        monkeypatch.setattr(cp_mod, "_coordinator", None)
+    except (ImportError, AttributeError):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _mock_knowledge_mound(monkeypatch):
+    """Prevent MCP knowledge tools from requiring a live KnowledgeMound."""
+    try:
+        import aragora.mcp.tools_module.knowledge as km_mod
+
+        mock_mound = MagicMock()
+        mock_mound.query = AsyncMock(return_value=[])
+        mock_mound.ingest = AsyncMock(return_value=None)
+        mock_mound.search = AsyncMock(return_value=[])
+
+        async def _mock_get_mound():
+            return mock_mound
+
+        monkeypatch.setattr(km_mod, "_get_mound", _mock_get_mound)
+    except (ImportError, AttributeError):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _isolate_notification_tokens(monkeypatch):
+    """Remove real Slack tokens to prevent external API calls."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)


### PR DESCRIPTION
## Summary
- **MCP tests**: Mock coordinator, knowledge mound, and remove Slack tokens to prevent real API/Redis calls
- **Debate/governance tests**: Remove Slack env vars to prevent real notification API calls
- **Gauntlet tests**: Remove signing key env var to prevent hex decode failures
- **control_plane.py**: Validate JSON payload before checking coordinator availability (input errors reported even when control plane is offline)
- **email_reply_loop.py**: Use centralized `REDIS_CONNECTION_ERRORS` constant instead of inline tuple

## Test plan
- [x] MCP tests: 550 passed
- [x] Gauntlet tests: 1313 passed
- [x] Marketplace tests: 203 passed
- [x] Debate tests: 409 passed (1 pre-existing checkpoint failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)