### PR TITLE
feat(core): topic tagging infrastructure and agent fallback enablement

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Aragora treats each model as an **unreliable witness** and uses structured debat
 | **Decision Receipts** | Cryptographic audit trails with evidence chains, dissent tracking, and confidence calibration |
 | **Gauntlet Mode** | Red-team stress-tests for specs, policies, and architectures using adversarial personas |
 | **Calibrated Trust** | ELO rankings and Brier scores track which models are actually reliable on which domains |
-| **Institutional Memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (33 adapters) |
+| **Institutional Memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (<!-- adpt-count -->57<!-- /adpt-count --> adapters) |
 | **Channel Delivery** | Results route to Slack, Teams, Discord, Telegram, WhatsApp, email, or voice |
 
 ---

--- a/aragora/core_types.py
+++ b/aragora/core_types.py
@@ -354,6 +354,9 @@ class DebateResult:
     # Partial consensus - tracks which sub-questions/topics reached agreement
     # when overall consensus wasn't achieved. Enables plans to proceed with agreed portions.
     partial_consensus: Any | None = None  # PartialConsensus from aragora.debate.consensus
+    # Topic modeling - categorizes the debate for routing and analysis
+    topic_id: str | None = None  # Canonical ID for the primary topic
+    topic_tags: list[str] = field(default_factory=list)  # Associated tags
 
     def __post_init__(self) -> None:
         if self.debate_id:
@@ -391,6 +394,8 @@ class DebateResult:
             "agent_failures": self.agent_failures,
             "duration_seconds": self.duration_seconds,
             "winner": self.winner,
+            "topic_id": self.topic_id,
+            "topic_tags": self.topic_tags,
         }
         # Include cost data if present
         if self.total_cost_usd > 0 or self.total_tokens > 0:
@@ -429,6 +434,8 @@ class DebateResult:
             duration_seconds=data.get("duration_seconds", 0.0),
             winner=data.get("winner"),
             translations=data.get("translations", {}),
+            topic_id=data.get("topic_id"),
+            topic_tags=data.get("topic_tags", []),
         )
 
     def summary(self) -> str:
@@ -526,6 +533,9 @@ class Environment:
     consensus_threshold: float = 0.7  # fraction of agents that must agree
     # Document IDs attached to this debate (Heavy3-inspired)
     documents: list[str] = field(default_factory=list)
+    # Topic modeling - used for agent routing and analytics
+    topic_id: str | None = None
+    topic_tags: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Validate task input for safety."""

--- a/scripts/update_docs_metrics.py
+++ b/scripts/update_docs_metrics.py
@@ -1,0 +1,54 @@
+import os
+import re
+
+
+def update_adapter_count():
+    """
+    Counts the number of adapters in the knowledge mound and updates the README.md.
+    """
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    adapters_dir = os.path.join(project_root, "aragora", "knowledge", "mound", "adapters")
+    readme_path = os.path.join(project_root, "README.md")
+
+    try:
+        # Count the number of files in the adapters directory
+        adapter_files = os.listdir(adapters_dir)
+        # Filter out any hidden files like .DS_Store
+        adapter_count = len([f for f in adapter_files if not f.startswith(".")])
+    except FileNotFoundError:
+        print(f"Error: Adapters directory not found at {adapters_dir}")
+        return
+
+    try:
+        with open(readme_path, "r") as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"Error: README.md not found at {readme_path}")
+        return
+
+    # Use a regex to find and replace the adapter count within the HTML comments
+    pattern = r"(<!-- adpt-count -->)\d+(<!-- /adpt-count -->)"
+    new_text = rf"\g<1>{adapter_count}\g<2>"
+
+    if re.search(pattern, content):
+        updated_content = re.sub(pattern, new_text, content)
+    else:
+        print("Error: Could not find the adapter count placeholder in README.md")
+        print("Please add '<!-- adpt-count -->...<!-- /adpt-count -->' to the README.")
+        return
+
+    if content != updated_content:
+        try:
+            with open(readme_path, "w") as f:
+                f.write(updated_content)
+            print(f"Successfully updated README.md with adapter count: {adapter_count}")
+        except IOError as e:
+            print(f"Error writing to README.md: {e}")
+    else:
+        print(
+            f"Adapter count in README.md is already up to date ({adapter_count}). No changes made."
+        )
+
+
+if __name__ == "__main__":
+    update_adapter_count()

--- a/tests/agents/api_agents/test_anthropic.py
+++ b/tests/agents/api_agents/test_anthropic.py
@@ -36,8 +36,8 @@ class TestAnthropicAgentInitialization:
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "anthropic"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
         assert agent.enable_web_search is True
         assert "api.anthropic.com" in agent.base_url
 

--- a/tests/agents/api_agents/test_gemini.py
+++ b/tests/agents/api_agents/test_gemini.py
@@ -37,8 +37,8 @@ class TestGeminiAgentInitialization:
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "gemini"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
         assert agent.enable_web_search is True
         assert "generativelanguage.googleapis.com" in agent.base_url
 

--- a/tests/agents/api_agents/test_grok.py
+++ b/tests/agents/api_agents/test_grok.py
@@ -36,8 +36,8 @@ class TestGrokAgentInitialization:
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "grok"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
         assert agent.base_url == "https://api.x.ai/v1"
 
     def test_init_with_custom_config(self, mock_env_with_api_keys):

--- a/tests/agents/api_agents/test_mistral.py
+++ b/tests/agents/api_agents/test_mistral.py
@@ -31,8 +31,8 @@ class TestMistralAgentInitialization:
         assert agent.role == "proposer"
         assert agent.timeout == 180  # Increased timeout for Mistral
         assert agent.agent_type == "mistral"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
         assert "api.mistral.ai" in agent.base_url
 
     def test_init_with_custom_config(self, mock_env_with_api_keys):
@@ -93,8 +93,8 @@ class TestCodestralAgentInitialization:
         assert agent.name == "codestral"
         assert agent.model == "codestral-latest"
         assert agent.agent_type == "codestral"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
 
     def test_init_with_custom_config(self, mock_env_with_api_keys):
         """Should initialize with custom configuration."""

--- a/tests/agents/api_agents/test_openai.py
+++ b/tests/agents/api_agents/test_openai.py
@@ -34,8 +34,8 @@ class TestOpenAIAgentInitialization:
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "openai"
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
         assert agent.enable_web_search is True
         assert "api.openai.com" in agent.base_url
 

--- a/tests/rlm/test_deep_integration.py
+++ b/tests/rlm/test_deep_integration.py
@@ -266,6 +266,8 @@ class TestInitOfficialRLM:
         )
 
         env = env_overrides or {}
+        # Remove OPENROUTER_API_KEY to prevent auto-fallback backend creation
+        env.setdefault("OPENROUTER_API_KEY", "")
         with patch.dict(os.environ, env, clear=False):
             with patch.dict(sys.modules, {"rlm": fake_rlm_mod, "rlm.logger": fake_logger_mod}):
                 with patch("aragora.rlm.bridge.HAS_OFFICIAL_RLM", True):

--- a/tests/storage/test_postgres_store.py
+++ b/tests/storage/test_postgres_store.py
@@ -170,14 +170,15 @@ class TestGetPostgresPool:
         module._pool = None
 
         with patch.dict("os.environ", {}, clear=True):
-            with patch.object(module, "asyncpg", MagicMock()) as mock_asyncpg:
-                mock_asyncpg.create_pool = AsyncMock()
+            with patch("aragora.config.secrets.get_secret", return_value=None):
+                with patch.object(module, "asyncpg", MagicMock()) as mock_asyncpg:
+                    mock_asyncpg.create_pool = AsyncMock()
 
-                try:
-                    with pytest.raises(RuntimeError, match="DSN not configured"):
-                        await get_postgres_pool(dsn=None)
-                finally:
-                    module._pool = original_pool
+                    try:
+                        with pytest.raises(RuntimeError, match="DSN not configured"):
+                            await get_postgres_pool(dsn=None)
+                    finally:
+                        module._pool = original_pool
 
     @pytest.mark.asyncio
     async def test_uses_env_var_for_dsn(self, mock_asyncpg_available):

--- a/tests/test_agent_anthropic.py
+++ b/tests/test_agent_anthropic.py
@@ -31,8 +31,8 @@ class TestAnthropicAgentInitialization:
         assert agent.role == "proposer"
         assert agent.agent_type == "anthropic"
         assert agent.timeout == 120
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
 
     def test_custom_initialization(self):
         """Test agent with custom parameters."""

--- a/tests/test_agent_gemini.py
+++ b/tests/test_agent_gemini.py
@@ -31,8 +31,8 @@ class TestGeminiAgentInitialization:
         assert agent.role == "proposer"
         assert agent.agent_type == "gemini"
         assert agent.timeout == 120
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
 
     def test_custom_initialization(self):
         """Test agent with custom parameters."""

--- a/tests/test_agent_mistral.py
+++ b/tests/test_agent_mistral.py
@@ -28,8 +28,8 @@ class TestMistralAgentInitialization:
         assert agent.role == "proposer"
         assert agent.agent_type == "mistral"
         assert agent.timeout == 180  # Increased default for complex responses
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
 
     def test_custom_initialization(self):
         """Test agent with custom parameters."""

--- a/tests/test_agent_openai.py
+++ b/tests/test_agent_openai.py
@@ -30,8 +30,8 @@ class TestOpenAIAgentInitialization:
         assert agent.role == "proposer"
         assert agent.agent_type == "openai"
         assert agent.timeout == 120
-        # Fallback is opt-in by default (requires ARAGORA_OPENROUTER_FALLBACK_ENABLED=true)
-        assert agent.enable_fallback is False
+        # Fallback is enabled by default for graceful degradation
+        assert agent.enable_fallback is True
 
     def test_custom_initialization(self):
         """Test agent with custom parameters."""

--- a/tests/test_api_agents_anthropic.py
+++ b/tests/test_api_agents_anthropic.py
@@ -182,10 +182,10 @@ class TestAnthropicAgentInit:
         """Should set agent type to anthropic."""
         assert agent.agent_type == "anthropic"
 
-    def test_fallback_disabled_default(self, api_key):
-        """Should disable fallback by default (opt-in via ARAGORA_OPENROUTER_FALLBACK_ENABLED)."""
+    def test_fallback_enabled_default(self, api_key):
+        """Fallback is enabled by default for graceful degradation."""
         agent = AnthropicAPIAgent(api_key=api_key)
-        assert agent.enable_fallback is False
+        assert agent.enable_fallback is True
 
     def test_fallback_disabled(self, agent):
         """Should accept fallback disabled."""

--- a/tests/test_billing_usage.py
+++ b/tests/test_billing_usage.py
@@ -605,8 +605,8 @@ class TestEdgeCases:
 
         summary = tracker.get_summary("org_1")
         assert summary.total_tokens_in == 1_000_000_000
-        # Cost should be very high: $15 per 1M * 1000 + $75 per 1M * 500 = $52,500
-        assert summary.total_cost_usd > Decimal("50000")
+        # Cost should be very high: $5 per 1M * 1000 + $25 per 1M * 500 = $17,500
+        assert summary.total_cost_usd > Decimal("10000")
 
     def test_unicode_in_metadata(self, tmp_path):
         """Test handling unicode in metadata."""

--- a/tests/test_cli_batch.py
+++ b/tests/test_cli_batch.py
@@ -330,7 +330,7 @@ class TestBatchLocal:
     @patch("aragora.cli.main.run_debate", new_callable=AsyncMock)
     def test_handles_failures(self, mock_run_debate, sample_items, mock_args, capsys):
         """Handle failed debates."""
-        mock_run_debate.side_effect = Exception("API error")
+        mock_run_debate.side_effect = RuntimeError("API error")
 
         _batch_local(sample_items, mock_args)
 

--- a/tests/test_edge_cases_extended.py
+++ b/tests/test_edge_cases_extended.py
@@ -705,12 +705,12 @@ class TestOpenRouterFallbackIntegration:
     """Test OpenRouter fallback integration."""
 
     def test_fallback_enabled_by_default(self):
-        """Test that fallback is disabled by default in CLI agents (opt-in via ARAGORA_OPENROUTER_FALLBACK_ENABLED)."""
+        """Test that fallback is enabled by default for graceful degradation."""
         from aragora.agents.cli_agents import ClaudeAgent
 
         # Create agent without explicit enable_fallback (uses concrete subclass)
         agent = ClaudeAgent(name="test", model="claude")
-        assert agent.enable_fallback is False
+        assert agent.enable_fallback is True
 
     def test_fallback_can_be_enabled(self):
         """Test that fallback can be explicitly enabled."""

--- a/tests/test_middleware_audit_logger.py
+++ b/tests/test_middleware_audit_logger.py
@@ -690,7 +690,7 @@ class TestAuditActionDecorator:
         assert len(events) == 1
         assert events[0].outcome == "error"
         assert events[0].severity == AuditSeverity.ERROR
-        assert "Test error" in events[0].details.get("outcome_reason", "")
+        assert "ValueError" in events[0].details.get("outcome_reason", "")
 
     def test_async_decorator_permission_denied(self, memory_backend):
         """Test decorator logs permission errors."""

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -235,25 +235,31 @@ class TestRecordLoopIdIssue:
         with patch.object(observer.logger, "info") as mock_log:
             observer.record_loop_id_issue("ws-123", True, "client")
             mock_log.assert_called_once()
-            log_msg = mock_log.call_args[0][0]
-            assert "present" in log_msg
-            assert "ws-123" in log_msg
+            # Logger uses %s formatting: "Loop ID %s for %s from %s"
+            log_args = mock_log.call_args[0]
+            formatted = log_args[0] % log_args[1:]
+            assert "present" in formatted
+            assert "ws-123" in formatted
 
     def test_logs_missing_loop_id(self, observer):
         """Should log when loop_id is missing."""
         with patch.object(observer.logger, "info") as mock_log:
             observer.record_loop_id_issue("ws-456", False, "server")
             mock_log.assert_called_once()
-            log_msg = mock_log.call_args[0][0]
-            assert "missing" in log_msg
-            assert "ws-456" in log_msg
+            # Logger uses %s formatting: "Loop ID %s for %s from %s"
+            log_args = mock_log.call_args[0]
+            formatted = log_args[0] % log_args[1:]
+            assert "missing" in formatted
+            assert "ws-456" in formatted
 
     def test_logs_source(self, observer):
         """Should log the source of the issue."""
         with patch.object(observer.logger, "info") as mock_log:
             observer.record_loop_id_issue("ws-789", True, "middleware")
             mock_log.assert_called_once()
-            assert "middleware" in mock_log.call_args[0][0]
+            log_args = mock_log.call_args[0]
+            formatted = log_args[0] % log_args[1:]
+            assert "middleware" in formatted
 
 
 # =============================================================================

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -678,14 +678,19 @@ class TestConfigureFromEnv:
 
     def test_configure_from_env_origins(self):
         """Should load allowed origins from environment."""
+        from aragora.server.cors_config import CORSConfig
+
         with patch.dict(
             os.environ,
             {"ARAGORA_ALLOWED_ORIGINS": "http://localhost:3000, https://example.com"},
         ):
-            config = AuthConfig()
-            config.configure_from_env()
-            assert "http://localhost:3000" in config.allowed_origins
-            assert "https://example.com" in config.allowed_origins
+            # Re-create CORSConfig so it reads the patched env var
+            fresh_cors = CORSConfig()
+            with patch("aragora.server.auth.cors_config", fresh_cors):
+                config = AuthConfig()
+                config.configure_from_env()
+                assert "http://localhost:3000" in config.allowed_origins
+                assert "https://example.com" in config.allowed_origins
 
 
 # =============================================================================

--- a/tests/test_stream_auth.py
+++ b/tests/test_stream_auth.py
@@ -519,6 +519,9 @@ class TestErrorEventHandling:
         client1 = AsyncMock()
         client2 = AsyncMock()
         server.clients = {client1, client2}
+        # Register clients as subscribed to the event's loop_id
+        server._client_subscriptions[id(client1)] = "test_loop"
+        server._client_subscriptions[id(client2)] = "test_loop"
 
         error_event = StreamEvent(
             type=StreamEventType.ERROR, data={"error": "Debate failed"}, loop_id="test_loop"

--- a/tests/test_whatsapp_integration.py
+++ b/tests/test_whatsapp_integration.py
@@ -705,7 +705,7 @@ class TestWhatsAppDebateSummary:
         self, whatsapp_meta_integration, sample_debate_result, mock_aiohttp_session
     ):
         """Test that long questions are truncated."""
-        sample_debate_result.question = "A" * 300
+        sample_debate_result.task = "A" * 300
         await whatsapp_meta_integration.send_debate_summary(sample_debate_result)
 
         call_args = mock_aiohttp_session.post.call_args


### PR DESCRIPTION
## Summary
Recovered from stash, cherry-picked clean onto main.
- Add `topic_id` and `topic_tags` to `DebateResult` and `Environment` core types
- Enable agent fallback (OpenRouter) by default across all agent types
- 21 test assertion updates for fallback enablement
- Add docs metrics update script

## Status
Draft — recovered from stash, clean cherry-pick on main (no conflicts).