### PR TITLE
fix(ci): eliminate required-check deadlock on path-filtered PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,18 +15,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths:
-      - 'aragora/**'
-      - 'tests/**'
-      - 'scripts/**'
-      - 'AGENTS.md'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/**'
-      - 'deploy/**'
-      - 'aragora-operator/**'
   merge_group:
   workflow_dispatch:
 
@@ -35,7 +23,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  lint:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'aragora/**'
+              - 'tests/**'
+              - 'scripts/**'
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - '.github/workflows/**'
+              - 'deploy/**'
+              - 'aragora-operator/**'
+
+  lint-run:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: aragora
     timeout-minutes: 10
 
@@ -72,6 +83,20 @@ jobs:
       - name: Run ruff lint check (all Python files)
         run: ruff check aragora/ tests/ scripts/
         shell: bash
+
+  lint:
+    needs: [changes, lint-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate lint result
+        run: |
+          if [[ "${{ needs.lint-run.result }}" == "failure" ]]; then
+            echo "::error::Lint checks failed"
+            exit 1
+          fi
+          echo "Lint passed (or skipped — no Python-relevant changes)"
 
   connector-exception-hygiene:
     runs-on: ubuntu-latest
@@ -130,7 +155,9 @@ jobs:
           echo "  python scripts/check_agent_registry_sync.py"
           echo "  python scripts/check_agent_registry_drift.py"
 
-  typecheck:
+  typecheck-run:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: aragora
     timeout-minutes: 15
 
@@ -153,6 +180,20 @@ jobs:
         run: bash scripts/test_tiers.sh typecheck
         shell: bash
         # Phase 5: mypy now REQUIRED (43→0 errors fixed Jan 2026)
+
+  typecheck:
+    needs: [changes, typecheck-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate typecheck result
+        run: |
+          if [[ "${{ needs.typecheck-run.result }}" == "failure" ]]; then
+            echo "::error::Type check failed"
+            exit 1
+          fi
+          echo "Type check passed (or skipped — no Python-relevant changes)"
 
   typecheck-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -25,19 +25,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths:
-      - 'aragora/server/handlers/**'
-      - 'aragora/server/unified_server.py'
-      - 'aragora/server/openapi/**'
-      - 'aragora/server/openapi_impl.py'
-      - 'openapi/**'
-      - 'sdk/**'
-      - 'scripts/export_openapi.py'
-      - 'scripts/generate_openapi.py'
-      - 'scripts/verify_sdk_contracts.py'
-      - 'scripts/validate_openapi_routes.py'
-      - '.github/workflows/openapi.yml'
-      - 'pyproject.toml'
   workflow_dispatch:
 
 concurrency:
@@ -79,12 +66,12 @@ jobs:
             echo "run_openapi=false" >> "$GITHUB_OUTPUT"
           fi
 
-  generate:
-    name: Generate & Validate
+  generate-run:
+    name: OpenAPI Generate & Validate
     runs-on: aragora
     timeout-minutes: 10
     needs: scope
-    if: github.event_name != 'pull_request' || needs.scope.result == 'success'
+    if: needs.scope.outputs.run_openapi == 'true'
     permissions:
       contents: read
       issues: write
@@ -386,7 +373,7 @@ jobs:
   sync:
     name: Sync Spec (main only)
     runs-on: ubuntu-latest
-    needs: generate
+    needs: generate-run
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
@@ -450,3 +437,18 @@ jobs:
           else
             echo "::warning::Could not auto-push spec update (branch protection). The generated spec is available as a workflow artifact."
           fi
+
+  generate:
+    name: Generate & Validate
+    needs: [scope, generate-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate OpenAPI result
+        run: |
+          if [[ "${{ needs.generate-run.result }}" == "failure" ]]; then
+            echo "::error::OpenAPI generate & validate failed"
+            exit 1
+          fi
+          echo "OpenAPI passed (or skipped — no relevant changes)"

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -6,18 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths:
-      - 'aragora/server/handlers/**'
-      - 'sdk/**'
-      - 'aragora/server/unified_server.py'
-      - 'openapi/**'
-      - 'scripts/sdk_parity*'
-      - 'scripts/check_sdk_parity*'
-      - 'scripts/check_version_alignment*'
-      - '.github/workflows/sdk-parity.yml'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - 'package.json'
   workflow_dispatch:
 
 concurrency:
@@ -25,7 +13,33 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  sdk-parity:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'aragora/server/handlers/**'
+              - 'aragora/server/unified_server.py'
+              - 'sdk/**'
+              - 'openapi/**'
+              - 'scripts/sdk_parity*'
+              - 'scripts/check_sdk_parity*'
+              - 'scripts/check_version_alignment*'
+              - '.github/workflows/sdk-parity.yml'
+              - 'pyproject.toml'
+              - 'requirements*.txt'
+              - 'package.json'
+
+  sdk-parity-run:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
     runs-on: aragora
     timeout-minutes: 12
 
@@ -84,3 +98,17 @@ jobs:
             contract-drift-summary.json
             contract-drift-summary.md
           retention-days: 30
+
+  sdk-parity:
+    needs: [changes, sdk-parity-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate sdk-parity result
+        run: |
+          if [[ "${{ needs.sdk-parity-run.result }}" == "failure" ]]; then
+            echo "::error::SDK parity check failed"
+            exit 1
+          fi
+          echo "SDK parity passed (or skipped — no relevant changes)"

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -11,15 +11,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
-    paths:
-      - 'sdk/**'
-      - 'tests/sdk/**'
-      - 'openapi/**'
-      - '.github/workflows/sdk-test.yml'
-      - 'pyproject.toml'
-      - 'requirements*.txt'
-      - 'package.json'
-      - 'package-lock.json'
   workflow_dispatch:
 
 concurrency:
@@ -33,12 +24,13 @@ jobs:
     name: SDK Change Detection
     outputs:
       run_python: ${{ steps.filter.outputs.python_sdk }}
+      run_typescript: ${{ steps.filter.outputs.typescript_sdk }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Detect Python SDK relevant changes
+      - name: Detect SDK relevant changes
         id: filter
         uses: dorny/paths-filter@v3
         with:
@@ -46,6 +38,11 @@ jobs:
             python_sdk:
               - 'sdk/python/**'
               - 'tests/sdk/**'
+            typescript_sdk:
+              - 'sdk/typescript/**'
+              - 'openapi/**'
+              - 'package.json'
+              - 'package-lock.json'
 
   python-sdk:
     needs: changes
@@ -80,10 +77,12 @@ jobs:
         run: |
           cd sdk/python && python -m ruff check aragora_sdk/ tests/
 
-  typescript-sdk:
+  typescript-sdk-run:
+    needs: changes
+    if: needs.changes.outputs.run_typescript == 'true'
     runs-on: aragora
     timeout-minutes: 10
-    name: TypeScript SDK Type Check
+    name: TypeScript SDK Build
 
     steps:
       - name: Checkout
@@ -135,3 +134,18 @@ jobs:
       - name: Run SDK integration tests
         run: |
           python -m pytest tests/sdk/ -v --tb=short --timeout=60
+
+  typescript-sdk:
+    name: TypeScript SDK Type Check
+    needs: [changes, typescript-sdk-run]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate TypeScript SDK result
+        run: |
+          if [[ "${{ needs.typescript-sdk-run.result }}" == "failure" ]]; then
+            echo "::error::TypeScript SDK type check failed"
+            exit 1
+          fi
+          echo "TypeScript SDK passed (or skipped — no relevant changes)"


### PR DESCRIPTION
## Summary
- **Problem**: Required checks (lint, typecheck, sdk-parity, Generate & Validate, TypeScript SDK Type Check) were permanently pending on PRs that didn't touch their path filters. TypeScript-only dependabot PRs (#469, #454) were blocked forever because lint/typecheck never triggered.
- **Root cause**: Workflow-level `paths:` filters on `pull_request:` prevent the workflow from running at all. GitHub reports no check status → required check stays "pending" → PR blocked.
- **Fix**: Gate pattern — remove path filters from PR triggers, add `dorny/paths-filter` change detection, rename work jobs to `*-run` with conditional execution, add always-run gate jobs matching required check names.

### Pattern applied to all 4 required-check workflows:
```
changes → detect relevant file changes (ubuntu-latest, ~10s)
*-run   → actual work (conditional on changes, self-hosted runner)
*       → required check gate (always runs, evaluates *-run result)
```

### Verification
- All 5 required check names preserved exactly: `lint`, `typecheck`, `sdk-parity`, `Generate & Validate`, `TypeScript SDK Type Check`
- YAML validated for all 4 files
- `check_required_check_priority_policy.py` passes
- Push path filters retained for main branch optimization

## Test plan
- [ ] Verify this PR's own required checks all report (lint.yml changes trigger the workflow)
- [ ] After merge, verify dependabot PRs #469 and #454 get all 5 required checks reported
- [ ] Verify a TS-only PR gets lint/typecheck as "passed" (skipped via gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)