### PR TITLE
ci: route all workflows to 32-core aragora runner

### DIFF
--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -17,7 +17,7 @@ jobs:
   scope:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Autopilot Scope
-    runs-on: ubuntu-latest
+    runs-on: aragora
     outputs:
       run_autopilot: ${{ steps.filter.outputs.run_autopilot }}
 

--- a/.github/workflows/backup-verification.yml
+++ b/.github/workflows/backup-verification.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   backup-tests:
     name: Backup System Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   dr-drill-tests:
     name: DR Drill Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 45
     needs: backup-tests
 
@@ -100,7 +100,7 @@ jobs:
 
   backup-handler-tests:
     name: Backup Handler Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     needs: backup-tests
 
@@ -126,7 +126,7 @@ jobs:
 
   summary:
     name: Generate Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [backup-tests, dr-drill-tests, backup-handler-tests]
     if: always()
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
   benchmark:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Performance Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     steps:
@@ -118,7 +118,7 @@ jobs:
     # REQUIRED STATUS CHECK: This job must pass on all PRs.
     # Validates that fast-first routing reduces critique latency by >=25%.
     name: Orchestration Speed Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
 
@@ -146,7 +146,7 @@ jobs:
     # REQUIRED STATUS CHECK: This job must pass on all PRs.
     # Fails if any benchmark regresses by >20% vs main branch.
     name: Performance Regression Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request')
 
@@ -218,7 +218,7 @@ jobs:
 
   latency-tests:
     name: Latency Distribution
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
 
@@ -257,7 +257,7 @@ jobs:
 
   baseline-comparison:
     name: Baseline Comparison
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.ref == 'refs/heads/main' || github.event_name == 'pull_request')
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ jobs:
   regression-gate:
     if: github.event_name == 'merge_group' || github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Regression Gate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     steps:

--- a/.github/workflows/branch-discipline.yml
+++ b/.github/workflows/branch-discipline.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   enforce-main-pr-policy:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
     permissions:
       contents: read
@@ -124,7 +124,7 @@ jobs:
   security-scan:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/capability-gap.yml
+++ b/.github/workflows/capability-gap.yml
@@ -44,7 +44,7 @@ jobs:
   report:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Generate Capability Gap Report
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/connector-registry.yml
+++ b/.github/workflows/connector-registry.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   governance:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   coverage:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     steps:
@@ -145,7 +145,7 @@ jobs:
             }
 
   coverage-diff:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request')
     needs: coverage

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -58,7 +58,7 @@ env:
 
 jobs:
   pre-flight:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     outputs:
       canary_instance_id: ${{ steps.instances.outputs.canary_id }}
@@ -155,7 +155,7 @@ jobs:
 
   deploy-canary:
     needs: pre-flight
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -253,7 +253,7 @@ jobs:
 
   shift-traffic:
     needs: [pre-flight, deploy-canary]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -299,7 +299,7 @@ jobs:
 
   bake-and-observe:
     needs: [pre-flight, shift-traffic]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 35
 
     outputs:
@@ -406,7 +406,7 @@ jobs:
   promote:
     needs: [pre-flight, bake-and-observe]
     if: needs.bake-and-observe.outputs.canary_healthy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     environment:
       name: ${{ inputs.auto_promote == 'true' && 'canary-auto' || 'production' }}
@@ -509,7 +509,7 @@ jobs:
   rollback:
     needs: [pre-flight, bake-and-observe]
     if: always() && needs.bake-and-observe.outputs.canary_healthy == 'false'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -570,7 +570,7 @@ jobs:
   summary:
     needs: [pre-flight, deploy-canary, shift-traffic, bake-and-observe, promote, rollback]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     defaults:
       run:
         working-directory: docs-site
@@ -55,7 +55,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -37,7 +37,7 @@ jobs:
   build-standalone:
     name: Build Frontend (Standalone)
     if: github.event.inputs.target == 'docker'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -84,7 +84,7 @@ jobs:
   deploy-vercel:
     name: Deploy to Vercel
     if: github.event.inputs.target == 'vercel' || github.event.inputs.target == '' || github.event_name == 'push' || github.event_name == 'schedule'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     steps:
@@ -192,7 +192,7 @@ jobs:
     name: Build & Push Frontend Docker Image
     needs: build-standalone
     if: github.event.inputs.target == 'docker'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   test:
     if: ${{ github.event.inputs.skip_tests != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -44,7 +44,7 @@ jobs:
   deploy:
     needs: test
     if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     steps:
       - name: Deploy via SSH

--- a/.github/workflows/deploy-multi-region.yml
+++ b/.github/workflows/deploy-multi-region.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   check-credentials:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     outputs:
       has_credentials: ${{ steps.check.outputs.has_credentials }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   build:
     needs: check-credentials
     if: needs.check-credentials.outputs.has_credentials == 'true'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     outputs:
       image_tag: ${{ steps.build.outputs.image_tag }}
 
@@ -79,7 +79,7 @@ jobs:
 
   deploy-us-east-2:
     needs: [check-credentials, build]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: needs.check-credentials.outputs.has_credentials == 'true' && (contains(github.event.inputs.regions, 'us-east-2') || github.event.inputs.regions == 'all' || github.event_name == 'push')
     environment: production-us-east-2
 
@@ -119,7 +119,7 @@ jobs:
 
   deploy-eu-west-1:
     needs: [check-credentials, build, deploy-us-east-2]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: needs.check-credentials.outputs.has_credentials == 'true' && (contains(github.event.inputs.regions, 'eu-west-1') || github.event.inputs.regions == 'all' || github.event_name == 'push')
     environment: production-eu-west-1
 
@@ -158,7 +158,7 @@ jobs:
 
   deploy-ap-south-1:
     needs: [check-credentials, build, deploy-us-east-2]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: needs.check-credentials.outputs.has_credentials == 'true' && (contains(github.event.inputs.regions, 'ap-south-1') || github.event.inputs.regions == 'all' || github.event_name == 'push')
     environment: production-ap-south-1
 
@@ -197,7 +197,7 @@ jobs:
 
   post-deploy:
     needs: [deploy-us-east-2, deploy-eu-west-1, deploy-ap-south-1]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: always()
 
     steps:

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -51,7 +51,7 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
   deploy-vercel:
     needs: test
     if: github.event.inputs.environment == 'all' || github.event.inputs.environment == 'vercel' || github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     steps:
@@ -160,7 +160,7 @@ jobs:
   deploy-ec2-staging:
     needs: test
     if: github.event.inputs.environment == 'all' || github.event.inputs.environment == 'ec2-staging' || github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     environment: staging
 
@@ -534,7 +534,7 @@ jobs:
         (github.event.inputs.environment == 'ec2-production') ||
         (needs.deploy-ec2-staging.result == 'success' && (github.event.inputs.environment == 'all' || github.event_name == 'push'))
       )
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     environment:
       name: production
@@ -912,7 +912,7 @@ jobs:
   notify:
     needs: [deploy-vercel, deploy-ec2-staging, deploy-ec2-production]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ env:
 jobs:
   build-backend:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     permissions:
       contents: read
       packages: write
@@ -119,7 +119,7 @@ jobs:
 
   build-frontend:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     permissions:
       contents: read
       packages: write
@@ -196,7 +196,7 @@ jobs:
 
   build-operator:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     permissions:
       contents: read
       packages: write
@@ -273,7 +273,7 @@ jobs:
 
   integration-test:
     needs: [build-backend, build-frontend]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: github.event_name == 'pull_request' && !github.event.pull_request.draft
 
     steps:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   build:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
   e2e:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Playwright E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     services:
@@ -183,7 +183,7 @@ jobs:
   python-e2e:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Python E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     services:
@@ -232,7 +232,7 @@ jobs:
 
   visual-regression:
     name: Visual Regression Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: e2e
     if: (github.event_name != 'pull_request' || github.event.pull_request.draft == false) && (github.event_name == 'pull_request')

--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -34,7 +34,7 @@ jobs:
   smoke-tests:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Smoke Test Harness
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -75,7 +75,7 @@ jobs:
   api-contract-sync:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: API Contract Sync
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   frontend-build:
     name: Frontend Build
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 12
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name != 'workflow_call')
 
@@ -152,7 +152,7 @@ jobs:
   status-doc-validation:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Status Doc Validation
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -220,7 +220,7 @@ jobs:
 
   integration-summary:
     name: Integration Gate Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [smoke-tests, api-contract-sync, status-doc-validation, frontend-build]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
     timeout-minutes: 2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -447,7 +447,7 @@ jobs:
 
   summary:
     name: Integration Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [e2e-harness, integration-tests, control-plane-tests]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -29,7 +29,7 @@ jobs:
   lighthouse:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Lighthouse Performance Audit
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     steps:
@@ -211,7 +211,7 @@ jobs:
   accessibility-audit:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Accessibility Audit
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -290,7 +290,7 @@ jobs:
   mobile-responsiveness:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Mobile Responsiveness Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 3
     outputs:
       python: ${{ steps.filter.outputs.python }}
@@ -87,7 +87,7 @@ jobs:
   lint:
     needs: [changes, lint-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate lint result
@@ -99,7 +99,7 @@ jobs:
           echo "Lint passed (or skipped — no Python-relevant changes)"
 
   connector-exception-hygiene:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: Connector Exception Hygiene
     # PR fast path: this job is non-required and runs on push/workflow_dispatch.
@@ -123,7 +123,7 @@ jobs:
           echo "Reproduce locally: python scripts/check_connector_exception_handling.py --path aragora/connectors aragora/runtime"
 
   agent-registry-sync:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: Agent Registry Sync
     if: github.event_name != 'pull_request'
@@ -184,7 +184,7 @@ jobs:
   typecheck:
     needs: [changes, typecheck-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate typecheck result
@@ -196,7 +196,7 @@ jobs:
           echo "Type check passed (or skipped — no Python-relevant changes)"
 
   typecheck-core:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     name: Core Module Type Safety
     if: github.event_name != 'pull_request'
@@ -276,7 +276,7 @@ jobs:
           echo "Core modules type check passed!"
 
   frontend-lint:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     if: github.event_name != 'pull_request'
 
@@ -307,7 +307,7 @@ jobs:
         run: npm run check:types
 
   security:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     if: github.event_name != 'pull_request'
 
@@ -340,7 +340,7 @@ jobs:
           safety check --full-report --ignore 70612
 
   secrets:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: Secret Scanning
     if: github.event_name != 'pull_request'
@@ -358,7 +358,7 @@ jobs:
           GITLEAKS_ENABLE_COMMENTS: false
 
   helm-lint:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: Helm Chart Validation
     if: github.event_name != 'pull_request'
@@ -448,7 +448,7 @@ jobs:
           echo "All charts passed Kubernetes schema validation!"
 
   todo-audit:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     name: TODO/FIXME Enforcement
     if: github.event_name != 'pull_request'
@@ -486,7 +486,7 @@ jobs:
           fi
 
   docs-sync:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     if: github.event_name != 'pull_request'
 

--- a/.github/workflows/live-deploy-mode-gate.yml
+++ b/.github/workflows/live-deploy-mode-gate.yml
@@ -28,7 +28,7 @@ jobs:
   gate:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Validate Live Deploy Mode
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
     env:
       NODE_VERSION: '20'

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -46,7 +46,7 @@ jobs:
   load-test:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Load Test Suite
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     services:
@@ -410,7 +410,7 @@ jobs:
   memory-stress:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Memory Stress Test
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: load-test
 

--- a/.github/workflows/merge-group-frontend-typecheck.yml
+++ b/.github/workflows/merge-group-frontend-typecheck.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   frontend-typecheck:
     name: Frontend TypeScript Type Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -36,7 +36,7 @@ jobs:
   migration-tests:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Migration Tests (SQLite)
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   health-check:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     env:
       LIVE_FRONTEND_BASE_URL: ${{ vars.LIVE_FRONTEND_BASE_URL }}
@@ -84,7 +84,7 @@ jobs:
   notify-on-failure:
     needs: health-check
     if: failure()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     permissions:
       issues: write

--- a/.github/workflows/new-features.yml
+++ b/.github/workflows/new-features.yml
@@ -31,7 +31,7 @@ jobs:
   test-migrations:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test Migrations
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -75,7 +75,7 @@ jobs:
   test-workers:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test Background Workers
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -111,7 +111,7 @@ jobs:
   test-api-endpoints:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test API Endpoints
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -137,7 +137,7 @@ jobs:
   test-metrics:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Test Metrics Integration
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -193,7 +193,7 @@ jobs:
   validate-openapi:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Validate OpenAPI Spec
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -223,7 +223,7 @@ jobs:
   summary:
     name: Summary
     needs: [test-migrations, test-workers, test-api-endpoints, test-metrics, validate-openapi]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
 
     steps:

--- a/.github/workflows/nightly-full-matrix.yml
+++ b/.github/workflows/nightly-full-matrix.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   pre-release-gates:
     name: Pre-release Gates
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
 
     steps:
@@ -52,7 +52,7 @@ jobs:
 
   regression-matrix:
     name: Regression Matrix (${{ matrix.shard.name }})
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -99,7 +99,7 @@ jobs:
 
   frontend-build:
     name: Frontend Build
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
 
     steps:
@@ -127,7 +127,7 @@ jobs:
 
   summary:
     name: Nightly Matrix Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [pre-release-gates, regression-matrix, frontend-build]
     if: always()
 

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   live-debate:
     name: Live Debate E2E
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     if: github.repository == 'an0mium/aragora'
 
@@ -61,7 +61,7 @@ jobs:
 
   pypi-check:
     name: PyPI Build Verification
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/nomic-ci.yml
+++ b/.github/workflows/nomic-ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   targeted-tests:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -372,7 +372,7 @@ jobs:
 
   sync:
     name: Sync Spec (main only)
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: generate-run
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
@@ -442,7 +442,7 @@ jobs:
     name: Generate & Validate
     needs: [scope, generate-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate OpenAPI result

--- a/.github/workflows/pr-debate.yml
+++ b/.github/workflows/pr-debate.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     # Skip if PR is from a fork (no access to secrets), or if PR is a draft
     if: (github.event_name != 'pull_request_target' || !github.event.pull_request.draft) && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch')

--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   production-health:
     name: Production Health Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -68,7 +68,7 @@ jobs:
 
   production-auth:
     name: Production Auth Flow
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: production-health
 
@@ -125,7 +125,7 @@ jobs:
 
   production-full:
     name: Full Production Suite
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 30
     needs: production-auth
     if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     steps:
       - name: Check backend health

--- a/.github/workflows/publish-aragora-debate.yml
+++ b/.github/workflows/publish-aragora-debate.yml
@@ -33,7 +33,7 @@ jobs:
   # Resolve the version from either the tag or manual input
   # -------------------------------------------------------------------
   resolve-version:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     outputs:
       version: ${{ steps.version.outputs.version }}
       is_tag: ${{ steps.version.outputs.is_tag }}
@@ -62,7 +62,7 @@ jobs:
   # Run the full test suite before publishing
   # -------------------------------------------------------------------
   test:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
@@ -89,7 +89,7 @@ jobs:
   # -------------------------------------------------------------------
   publish:
     needs: [resolve-version, test]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     # For manual dispatch, require PUBLISH confirmation.
     # For tag pushes, always proceed.
     if: >-

--- a/.github/workflows/publish-aragora.yml
+++ b/.github/workflows/publish-aragora.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     steps:
       - uses: actions/checkout@v4
 
@@ -38,7 +38,7 @@ jobs:
 
   publish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: github.event.inputs.confirm == 'PUBLISH'
     environment: pypi
 

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -29,7 +29,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     name: Test Python SDK (Python ${{ matrix.python-version }})
     strategy:
@@ -66,7 +66,7 @@ jobs:
 
   build-and-publish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     environment: ${{ (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true') && '' || 'pypi' }}
 

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     name: Test TypeScript SDK (Node ${{ matrix.node-version }})
     strategy:
@@ -67,7 +67,7 @@ jobs:
 
   build-and-publish:
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     defaults:

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     defaults:
       run:
         working-directory: ide/vscode-aragora

--- a/.github/workflows/quality-smoke.yml
+++ b/.github/workflows/quality-smoke.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 3
     outputs:
       quality: ${{ steps.filter.outputs.quality }}
@@ -45,7 +45,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.quality == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.draft)
     name: Quality Pipeline Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -95,7 +95,7 @@ jobs:
   quality-smoke:
     needs: [changes, quality-smoke-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate quality smoke result

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -25,7 +25,7 @@ jobs:
   generate-release-notes:
     if: false  # Disabled: superseded by release.yml
     name: Generate Release Notes
-    runs-on: ubuntu-latest
+    runs-on: aragora
 
     steps:
       - name: Checkout

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -36,7 +36,7 @@ jobs:
   release-readiness:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Release Readiness
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 35
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     outputs:
       version: ${{ steps.get-version.outputs.version }}
@@ -50,7 +50,7 @@ jobs:
 
   docs-sync:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -78,7 +78,7 @@ jobs:
 
   test:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -120,7 +120,7 @@ jobs:
   # ---------------------------------------------------------------------------
   sdk-parity-gate:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -180,7 +180,7 @@ jobs:
   # ---------------------------------------------------------------------------
   security-gate:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -245,7 +245,7 @@ jobs:
   # ---------------------------------------------------------------------------
   frontend-build:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -277,7 +277,7 @@ jobs:
   # ---------------------------------------------------------------------------
   release-checks:
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -359,7 +359,7 @@ jobs:
   # ---------------------------------------------------------------------------
   integration-smoke:
     needs: [validate, test]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -420,7 +420,7 @@ jobs:
   # ---------------------------------------------------------------------------
   build:
     needs: [validate, test, docs-sync, sdk-parity-gate, security-gate, integration-smoke, frontend-build, release-checks]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -456,7 +456,7 @@ jobs:
 
   publish-pypi:
     needs: [validate, build]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     environment: pypi
 
@@ -476,7 +476,7 @@ jobs:
 
   release:
     needs: [validate, build]
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     permissions:
       contents: write

--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   prioritize-required-checks:
     name: Prioritize Required Checks
-    runs-on: ubuntu-latest
+    runs-on: aragora
     if: github.event.pull_request.head.repo.full_name == github.repository && !github.event.pull_request.draft
     timeout-minutes: 10
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   generate-python-sbom:
     name: Generate Python SBOM
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -61,7 +61,7 @@ jobs:
 
   generate-node-sbom:
     name: Generate Node.js SBOM
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     strategy:
@@ -109,7 +109,7 @@ jobs:
 
   generate-container-sbom:
     name: Generate Container SBOM
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     if: github.event_name == 'release'
 
@@ -151,7 +151,7 @@ jobs:
 
   vulnerability-scan:
     name: SBOM Vulnerability Scan
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [generate-python-sbom, generate-node-sbom]
     timeout-minutes: 15
 

--- a/.github/workflows/sdk-generate.yml
+++ b/.github/workflows/sdk-generate.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   generate-typescript-types:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     permissions:
       contents: write
@@ -96,7 +96,7 @@ jobs:
   validate-typescript:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     needs: generate-typescript-types
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -134,7 +134,7 @@ jobs:
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
       (github.event_name == 'pull_request' ||
       (github.event_name == 'push' && !contains(github.event.head_commit.modified, 'docs/api/openapi')))
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 3
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
@@ -102,7 +102,7 @@ jobs:
   sdk-parity:
     needs: [changes, sdk-parity-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate sdk-parity result

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     name: SDK Change Detection
     outputs:
@@ -47,7 +47,7 @@ jobs:
   python-sdk:
     needs: changes
     if: needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: Python SDK Tests
 
@@ -111,7 +111,7 @@ jobs:
   sdk-integration:
     needs: changes
     if: needs.changes.outputs.run_python == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     name: SDK Integration Tests
 
@@ -139,7 +139,7 @@ jobs:
     name: TypeScript SDK Type Check
     needs: [changes, typescript-sdk-run]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
     steps:
       - name: Evaluate TypeScript SDK result

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -31,7 +31,7 @@ jobs:
   python-security:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Python Security Scan
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -92,7 +92,7 @@ jobs:
   npm-security:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: npm Security Scan
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -163,7 +163,7 @@ jobs:
 
   security-summary:
     name: Security Gate Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     needs: [python-security, npm-security]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
     timeout-minutes: 2

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,7 @@ jobs:
   codeql:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: CodeQL Analysis
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 60
 
     strategy:
@@ -71,7 +71,7 @@ jobs:
   bandit:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Bandit Security Scan
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -103,7 +103,7 @@ jobs:
   aragora-security-scan:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Aragora Security Scanner
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -133,7 +133,7 @@ jobs:
   dependency-check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Dependency Vulnerability Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -230,7 +230,7 @@ jobs:
   pentest-findings:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: "Security: Pentest Findings Gate"
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -248,7 +248,7 @@ jobs:
   rbac-coverage:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: RBAC Coverage Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -266,7 +266,7 @@ jobs:
   secret-scanning:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Secret Scanning
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/smoke-offline.yml
+++ b/.github/workflows/smoke-offline.yml
@@ -25,7 +25,7 @@ jobs:
   offline-demo:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Offline Demo Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,7 +25,7 @@ jobs:
   smoke:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Smoke Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -64,7 +64,7 @@ jobs:
   offline-golden-path:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Offline Golden Path
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -94,7 +94,7 @@ jobs:
   server-smoke:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Server Smoke Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -133,7 +133,7 @@ jobs:
   decision-action-smoke:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Decision-to-Action Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   validate:
     name: Validate Configuration
-    runs-on: ubuntu-latest
+    runs-on: aragora
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,7 +90,7 @@ jobs:
     name: Deploy to Staging
     needs: validate
     if: github.event.inputs.environment == 'staging' || github.ref != 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     environment: staging
     steps:
       - name: Checkout
@@ -105,7 +105,7 @@ jobs:
     name: Deploy to Production
     needs: validate
     if: github.event.inputs.environment == 'production' || github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     environment: production
     outputs:
       deployed: ${{ steps.deploy_secrets.outputs.deploy_ready }}
@@ -229,7 +229,7 @@ jobs:
     name: Provision Monitors
     needs: deploy-production
     if: needs.deploy-production.outputs.deployed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     environment: production
     steps:
       - name: Checkout

--- a/.github/workflows/templates/aragora-gauntlet-template.yml
+++ b/.github/workflows/templates/aragora-gauntlet-template.yml
@@ -63,7 +63,7 @@ env:
 jobs:
   gauntlet-audit:
     name: Gauntlet Security Audit
-    runs-on: ubuntu-latest
+    runs-on: aragora
 
     # Skip forks
     if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request'

--- a/.github/workflows/templates/aragora-review-template.yml
+++ b/.github/workflows/templates/aragora-review-template.yml
@@ -32,7 +32,7 @@ env:
 jobs:
   ai-review:
     name: AI Red Team Review
-    runs-on: ubuntu-latest
+    runs-on: aragora
 
     # Skip forks (no access to secrets) and bot PRs
     if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,7 @@ jobs:
   version-check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Version Alignment
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 2
 
     steps:
@@ -168,7 +168,7 @@ jobs:
   sdk-typescript-compile-gate:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: SDK TypeScript Compile Gate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 8
     needs: version-check
 
@@ -208,7 +208,7 @@ jobs:
   baseline-determinism:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Baseline Determinism
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 12
     needs: version-check
 
@@ -235,7 +235,7 @@ jobs:
   skip-audit:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Skip Marker Audit
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -284,7 +284,7 @@ jobs:
   status-reconciliation:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Status Doc Reconciliation
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
 
     steps:
@@ -321,7 +321,7 @@ jobs:
   zero-coverage-check:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Zero Coverage Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: baseline-determinism
 
@@ -385,7 +385,7 @@ jobs:
   # Fast parallel tests by category (Ubuntu only, primary Python)
   test-fast:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: baseline-determinism
     strategy:
@@ -439,7 +439,7 @@ jobs:
   epistemic-settlement-gate:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Epistemic Hygiene + Settlement Gate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 12
     needs: baseline-determinism
 
@@ -489,7 +489,7 @@ jobs:
 
   v1-scope-lock-gate:
     name: V1 Scope Lock Gate
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     needs: baseline-determinism
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request')
@@ -515,7 +515,7 @@ jobs:
   integration-minimal:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Integration Minimal
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: baseline-determinism
 
@@ -548,7 +548,7 @@ jobs:
   # Integration smoke lane for high-risk paths (PR only)
   integration-smoke:
     name: Integration Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
     needs: baseline-determinism
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request')
@@ -604,7 +604,7 @@ jobs:
   test-pollution-randomized:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Randomized Order Pollution Guard
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 20
     needs: test-fast
     strategy:
@@ -664,7 +664,7 @@ jobs:
   golden-paths:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Golden Path Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 5
     needs: version-check
 
@@ -691,7 +691,7 @@ jobs:
   aragora-debate-tests:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Standalone Debate Package
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: test-fast
 
@@ -828,7 +828,7 @@ jobs:
   # Summary job: merge coverage from shards and enforce gates
   test-summary:
     name: Test Summary
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: [test]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
@@ -1010,7 +1010,7 @@ jobs:
   smoke:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: CLI Smoke
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: baseline-determinism
 
@@ -1081,7 +1081,7 @@ jobs:
 
   nightly-slow:
     name: Nightly Slow Tier
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 60
     needs: baseline-determinism
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
@@ -1118,7 +1118,7 @@ jobs:
   frontend:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Frontend E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -1179,7 +1179,7 @@ jobs:
   # Lightweight frontend type checking (PR-only, path-filtered)
   frontend-typecheck:
     name: Frontend TypeScript Type Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (github.event_name == 'pull_request')
 
@@ -1220,7 +1220,7 @@ jobs:
   security:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     steps:
@@ -1253,7 +1253,7 @@ jobs:
   typecheck:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 15
 
     steps:
@@ -1285,7 +1285,7 @@ jobs:
   migration-test:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Database Migrations
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
 
     services:
@@ -1365,7 +1365,7 @@ jobs:
 
   nightly-optional:
     name: Optional Deps (Full)
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 45
     needs: baseline-determinism
     # Run on schedule, push to main, or workflow_dispatch
@@ -1438,7 +1438,7 @@ jobs:
   quality-gates:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Quality Gates
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: [test-fast, test-summary, epistemic-settlement-gate, v1-scope-lock-gate]
 
@@ -1466,7 +1466,7 @@ jobs:
 
   test-analytics:
     name: Test Analytics
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     needs: [test-fast]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always() && github.event_name == 'pull_request')

--- a/.github/workflows/testfixer-auto.yml
+++ b/.github/workflows/testfixer-auto.yml
@@ -32,7 +32,7 @@ jobs:
     # Disabled: auto-fix loop causes CI thrash (push→cancel→restart cycle).
     # Re-enable via workflow_dispatch when needed for targeted fix runs.
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 45
     env:
       DEFAULT_TEST_COMMAND: >-

--- a/.github/workflows/weekly-epistemic-kpis.yml
+++ b/.github/workflows/weekly-epistemic-kpis.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   extract-runtime-kpis:
-    runs-on: ubuntu-latest
+    runs-on: aragora
     timeout-minutes: 10
     permissions:
       contents: read
@@ -77,4 +77,3 @@ jobs:
           name: weekly-epistemic-kpis
           path: artifacts/weekly-epistemic-kpis.*
           if-no-files-found: warn
-


### PR DESCRIPTION
## Summary
- Switches all 60 workflow files from `ubuntu-latest` to `aragora` (32-core, 128GB RAM, 1TB)
- Runner verified working on PR #481: `lint-run` and `typecheck-run` both completed successfully on `aragora-1000005001` and `aragora-1000005002`

## Test plan
- [x] Verified runner picks up jobs (PR #481)
- [ ] CI on this PR runs entirely on aragora runner
- [ ] Merge queue processes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)