### PR TITLE
fix(pipeline): restore router variable to unblock Next.js build

### DIFF
--- a/aragora/live/src/app/(app)/pipeline/page.tsx
+++ b/aragora/live/src/app/(app)/pipeline/page.tsx
@@ -314,7 +314,7 @@ function PipelinePageContent() {
   const [executeStatus, setExecuteStatus] = useState<'idle' | 'success' | 'failed'>('idle');
 
   // Self-improve integration state
-  const _router = useRouter();
+  const router = useRouter();
   const [showSelfImproveConfig, setShowSelfImproveConfig] = useState(false);
   const [siDryRun, setSiDryRun] = useState(false);
   const [siBudget, setSiBudget] = useState(10);


### PR DESCRIPTION
## Summary
- `useRouter()` was assigned to `_router` but referenced as `router` at line 894
- One-line fix: rename `_router` → `router`
- Build verified locally with `npx next build`

## Test plan
- [x] `npx next build` succeeds
- [x] TypeScript type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)