### PR TITLE
feat: five pipeline improvements for self-improvement dogfooding

### DIFF
--- a/aragora/debate/output_quality.py
+++ b/aragora/debate/output_quality.py
@@ -289,7 +289,18 @@ def derive_output_contract_from_task(task: str) -> OutputContract | None:
             sections = sorted(present, key=lambda name: task_norm.find(name.lower()))
 
     if not sections:
-        return None
+        # Default fallback: derive a minimal contract for any task so
+        # quality assessment always runs. Callers who truly want no
+        # contract should pass --no-post-consensus-quality instead.
+        return OutputContract(
+            required_sections=[],
+            require_json_payload=False,
+            require_gate_thresholds=False,
+            require_rollback_triggers=False,
+            require_owner_paths=False,
+            require_repo_path_existence=False,
+            require_practicality_checks=True,
+        )
 
     normalized = {_normalize_heading(section) for section in sections}
     return OutputContract(

--- a/tests/debate/test_quality_pipeline.py
+++ b/tests/debate/test_quality_pipeline.py
@@ -151,12 +151,15 @@ class TestApplyPostConsensusQuality:
         assert result.passes_gate is False
         assert result.repaired is False
 
-    def test_no_contract_derivable_returns_original(self):
+    def test_no_contract_derivable_uses_default_contract(self):
         cfg = QualityPipelineConfig()
         result = apply_post_consensus_quality("some answer", "hello world", cfg)
-        # "hello world" has no section hints, so no contract -> passthrough
+        # "hello world" has no section hints, so a minimal default contract is
+        # used (practicality checks only, no required sections).
         assert result.answer == "some answer"
-        assert result.contract_dict is None
+        assert result.contract_dict is not None
+        assert result.contract_dict["required_sections"] == []
+        assert result.contract_dict["require_practicality_checks"] is True
 
     def test_good_answer_passes_gate(self):
         cfg = QualityPipelineConfig(

--- a/tests/debate/test_repo_grounding.py
+++ b/tests/debate/test_repo_grounding.py
@@ -36,7 +36,11 @@ def test_assess_repo_grounding_penalizes_placeholders_and_missing_paths():
 - aragora/not_real/missing_file.py
 """
     report = assess_repo_grounding(answer)
-    assert report.path_existence_rate == 0.0
+    # aragora/not_real/missing_file.py is a plausible new file proposal
+    # (grandparent aragora/ exists), so it counts as half-grounded
+    assert report.path_existence_rate == 0.5
+    assert "aragora/not_real/missing_file.py" in report.new_paths
+    assert report.missing_paths == []
     assert "new_marker" in report.placeholder_hits
     assert report.placeholder_rate > 0.0
     assert report.practicality_score_10 < 5.0


### PR DESCRIPTION
## Summary
- Default-on quality gate — every debate gets basic quality assessment instead of skipping when no explicit contract provided
- `nomic_staged.py --task/--context` flags — debates can now use canonical goals doc as input
- Dynamic codebase grounding in task decomposer — replaces hardcoded structure with live filesystem scan
- Practicality scoring fix — new file proposals count as half-grounded, not missing
- Resource leak cleanup — shared HTTP connector closed after debate completion

## Test plan
- [x] 39 quality/grounding/pipeline tests pass
- [ ] Re-run dogfood benchmark to verify improved quality scores
- [ ] Verify `nomic_staged.py debate --task "..." --context "..."` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)