### PR TITLE
feat(landing): unify "> ARAGORA" wordmark + collapsible sidebar with logo mark

### DIFF
--- a/aragora/live/src/components/landing/Header.tsx
+++ b/aragora/live/src/components/landing/Header.tsx
@@ -20,15 +20,15 @@ export function Header() {
         {/* Wordmark */}
         <Link href="/landing" className="flex items-center">
           <span
-            className="font-bold tracking-wider"
+            className="font-bold"
             style={{
               color: 'var(--accent)',
-              fontSize: theme === 'dark' ? '14px' : '16px',
-              fontFamily: theme === 'dark' ? "'JetBrains Mono', monospace" : "'Inter', system-ui, sans-serif",
-              letterSpacing: theme === 'dark' ? '0.15em' : '0.08em',
+              fontSize: '14px',
+              fontFamily: "'JetBrains Mono', monospace",
+              letterSpacing: '0.15em',
             }}
           >
-            {theme === 'dark' ? '> ARAGORA' : 'Aragora'}
+            {'> ARAGORA'}
           </span>
         </Link>
 

--- a/aragora/live/src/components/landing/LandingPage.tsx
+++ b/aragora/live/src/components/landing/LandingPage.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useTheme } from '@/context/ThemeContext';
+import { useLayout } from '@/context/LayoutContext';
+import { Logo } from '@/components/Logo';
+import { LeftSidebar } from '@/components/layout/LeftSidebar';
 import { Header } from './Header';
 import { HeroSection } from './HeroSection';
 import { HowItWorksSection } from './HowItWorksSection';
@@ -13,6 +17,19 @@ import { Footer } from './Footer';
 
 export function LandingPage() {
   const { theme } = useTheme();
+  const { leftSidebarOpen, leftSidebarWidth, toggleLeftSidebar, closeLeftSidebar, isMobile } =
+    useLayout();
+
+  // Sidebar starts closed on the landing page.
+  // LayoutProvider auto-opens it on desktop; setTimeout ensures our close
+  // runs after the provider's initialization effect.
+  const closedOnMountRef = useRef(false);
+  useEffect(() => {
+    if (!closedOnMountRef.current) {
+      closedOnMountRef.current = true;
+      setTimeout(closeLeftSidebar, 0);
+    }
+  }, [closeLeftSidebar]);
 
   return (
     <div
@@ -24,15 +41,29 @@ export function LandingPage() {
       }}
       data-landing-theme={theme}
     >
-      <Header />
-      <HeroSection />
-      <HowItWorksSection />
-      <ProblemSection />
-      <FeatureShowcase />
-      <IntegrationsGrid />
-      <LiveDemoSection />
-      <PricingSection />
-      <Footer />
+      {/* Logo mark — fixed upper-left, toggles sidebar */}
+      <div className="fixed top-3 left-3 z-[60]">
+        <Logo size="lg" pixelSize={32} onClick={toggleLeftSidebar} />
+      </div>
+
+      {/* Collapsible sidebar — self-hides when closed */}
+      <LeftSidebar />
+
+      {/* Main content — shifts right when sidebar is open on desktop */}
+      <div
+        className="transition-all duration-200"
+        style={{ marginLeft: !isMobile && leftSidebarOpen ? leftSidebarWidth : 0 }}
+      >
+        <Header />
+        <HeroSection />
+        <HowItWorksSection />
+        <ProblemSection />
+        <FeatureShowcase />
+        <IntegrationsGrid />
+        <LiveDemoSection />
+        <PricingSection />
+        <Footer />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- **Unified wordmark**: All three themes (warm, dark, professional) now show `> ARAGORA` in JetBrains Mono 14px with 0.15em letter spacing. Color uses `var(--accent)` so each theme keeps its own green.
- **Collapsible sidebar**: Logo mark (32px) fixed in upper-left corner of landing page. Clicking it opens the existing `LeftSidebar`. Sidebar starts closed by default. Content shifts right when open (desktop); overlay drawer on mobile.

## Implementation
- `Header.tsx`: Removed theme-conditional wordmark branching (5 lines → 1 style)
- `LandingPage.tsx`: Added `Logo`, `LeftSidebar`, `useLayout` integration with mount-time sidebar close

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx next build` succeeds
- [ ] Visual check: all 3 themes show "> ARAGORA" in monospace
- [ ] Visual check: logo mark in upper-left, clicking opens sidebar
- [ ] Visual check: sidebar closed by default on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)