### PR TITLE
debate: normalize absolute paths in repo grounding

### DIFF
--- a/aragora/debate/repo_grounding.py
+++ b/aragora/debate/repo_grounding.py
@@ -74,6 +74,28 @@ def _normalize_repo_path(candidate: str) -> str | None:
     return value
 
 
+def _resolve_path_against_repo(candidate: str, repo_root: Path) -> tuple[str, Path]:
+    """Resolve extracted path against repo root, handling stripped absolute paths."""
+    raw = candidate.strip()
+    root = repo_root.resolve()
+    root_prefix = str(root).lstrip("/")
+
+    # Absolute paths are normalized by _normalize_repo_path() via lstrip("/"),
+    # so remap `<root>/...` back to a repo-relative path when possible.
+    if root_prefix and (raw == root_prefix or raw.startswith(f"{root_prefix}/")):
+        rel = "." if raw == root_prefix else raw[len(root_prefix) + 1 :]
+        return rel, root / rel
+
+    abs_candidate = Path("/" + raw)
+    try:
+        rel = str(abs_candidate.relative_to(root))
+        return rel, abs_candidate
+    except ValueError:
+        pass
+
+    return raw, root / raw
+
+
 def extract_repo_paths(text: str) -> list[str]:
     """Extract normalized candidate repository paths from text."""
     if not text:
@@ -180,15 +202,22 @@ def assess_repo_grounding(
 
     owner_text = _find_section_content(sections, _normalize_heading("Owner module / file paths"))
     path_source = owner_text or text
-    mentioned_paths = extract_repo_paths(path_source)
+    extracted_paths = extract_repo_paths(path_source)
 
     root = Path(repo_root or os.getcwd())
+    mentioned_paths: list[str] = []
+    _seen_mentioned: set[str] = set()
     existing_paths: list[str] = []
     missing_paths: list[str] = []
     new_paths: list[str] = []
     _NEW_FILE_EXTENSIONS = {".py", ".ts", ".tsx", ".js", ".json", ".yaml", ".yml", ".md"}
-    for rel_path in mentioned_paths:
-        full = root / rel_path
+    for extracted in extracted_paths:
+        rel_path, full = _resolve_path_against_repo(extracted, root)
+        if rel_path in _seen_mentioned:
+            continue
+        _seen_mentioned.add(rel_path)
+        mentioned_paths.append(rel_path)
+
         if full.exists():
             existing_paths.append(rel_path)
         elif full.suffix in _NEW_FILE_EXTENSIONS:

--- a/tests/debate/test_repo_grounding.py
+++ b/tests/debate/test_repo_grounding.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from aragora.debate.repo_grounding import assess_repo_grounding
 
 
@@ -44,3 +46,27 @@ def test_assess_repo_grounding_penalizes_placeholders_and_missing_paths():
     assert "new_marker" in report.placeholder_hits
     assert report.placeholder_rate > 0.0
     assert report.practicality_score_10 < 5.0
+
+
+def test_assess_repo_grounding_handles_absolute_paths_under_repo():
+    repo_root = Path(__file__).resolve().parents[2]
+    absolute = repo_root / "aragora/debate/orchestrator.py"
+    answer = f"""
+## Owner module / file paths
+- {absolute}
+"""
+    report = assess_repo_grounding(answer, repo_root=str(repo_root))
+    assert report.path_existence_rate == 1.0
+    assert "aragora/debate/orchestrator.py" in report.existing_paths
+    assert all(not p.startswith("Users/") for p in report.mentioned_paths)
+
+
+def test_assess_repo_grounding_handles_markdown_link_absolute_paths():
+    repo_root = Path(__file__).resolve().parents[2]
+    absolute = repo_root / "aragora/debate/orchestrator.py"
+    answer = f"""
+## Owner module / file paths
+- [orchestrator.py]({absolute})
+"""
+    report = assess_repo_grounding(answer, repo_root=str(repo_root))
+    assert "aragora/debate/orchestrator.py" in report.existing_paths


### PR DESCRIPTION
## Summary\n- normalize extracted absolute paths so repo grounding treats paths under repo root as repo-relative\n- dedupe mentioned paths after normalization\n- add tests for plain absolute path and markdown-link absolute path handling\n\n## Validation\n- python -m pytest -q tests/debate/test_repo_grounding.py\n- python -m ruff format --check aragora/debate/repo_grounding.py tests/debate/test_repo_grounding.py