### PR TITLE
fix(lint): remove unused import in output quality module

### DIFF
--- a/aragora/debate/output_quality.py
+++ b/aragora/debate/output_quality.py
@@ -11,7 +11,6 @@ This module provides:
 from __future__ import annotations
 
 import json
-import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path


### PR DESCRIPTION
## Summary
- remove unused os import from `aragora/debate/output_quality.py`

## Validation
- python -m ruff check aragora/debate/output_quality.py
