### PR TITLE
feat: increase Nomic design-phase timeout to 300s and strengthen gate criteria contract

### DIFF
--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -526,7 +526,14 @@ Required sections:
 3. Owner module / file paths — reference existing repo paths
 4. Test Plan — specific test commands and assertions
 5. Rollback Plan — MUST include trigger condition (e.g. "if tests fail") AND action (e.g. "revert commit")
-6. Gate Criteria — MUST include at least 2 numeric thresholds (e.g. "coverage >= 80%", "zero lint errors", "p95 < 250ms")
+6. Gate Criteria — MUST include at least 2 numeric thresholds with explicit comparison operators.
+   Example (yours MUST be similar — use numbers, not just words):
+   - coverage >= 80% on modified files
+   - p95 latency <= 250ms
+   - zero new lint errors (0 errors)
+   - all 7 required section headers present
+   - error rate < 1.0%
+   Do NOT write qualitative-only criteria like "tests should pass" — always include a number.
 7. JSON Payload — machine-readable summary"""
 
     @staticmethod

--- a/scripts/nomic_staged.py
+++ b/scripts/nomic_staged.py
@@ -219,13 +219,13 @@ Be specific enough that an engineer could implement it.""",
             name="architect",
             model="claude-opus-4-6",
             role="proposer",
-            timeout=120,
+            timeout=300,
         ),
         AnthropicAPIAgent(
             name="reviewer",
             model="claude-opus-4-6",
             role="synthesizer",
-            timeout=120,
+            timeout=300,
         ),
     ]
 
@@ -234,10 +234,27 @@ Be specific enough that an engineer could implement it.""",
     arena = Arena(env, agents, protocol)
     result = await arena.run()
 
+    # Filter ChaosTheater noise from design output
+    _CHAOS_MARKERS = (
+        "[System:",
+        "wild bug appeared",
+        "cognitive hiccup",
+        "FATAL EXCEPTION",
+        "brain.exe",
+        "is a teapot",
+        "thinking credits",
+        "QUOTA POLICE",
+        "NaN stares back",
+    )
+    design_text = result.final_answer or ""
+    if any(marker in design_text for marker in _CHAOS_MARKERS) or len(design_text) < 80:
+        print("[WARN] Design output appears to be ChaosTheater noise — filtering.")
+        design_text = ""
+
     data = {
         "timestamp": datetime.now().isoformat(),
         "improvement": improvement,
-        "design": result.final_answer,
+        "design": design_text,
         "consensus_reached": result.consensus_reached,
     }
 


### PR DESCRIPTION
## Summary
- Increased architect/reviewer agent timeout from 120s to 300s in the Nomic staged design phase to prevent design-phase failures during proof runs
- Added ChaosTheater output filtering to the design phase to prevent noise from corrupting design output
- Strengthened the synthesis contract with explicit numeric exemplars for the Gate Criteria section, improving quantitative threshold detection from ~40% to target 80%+ pass rate

## Test plan
- [x] `python -m pytest tests/debate/test_output_quality.py -v --timeout=30` — all 32 tests pass
- [x] `python -c "import ast; ast.parse(open('scripts/nomic_staged.py').read())"` — syntax OK
- [x] `python -c "import ast; ast.parse(open('aragora/debate/phases/synthesis_generator.py').read())"` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)