### PR TITLE
ci: harden self-hosted checkout integrity for deploy + offline smoke

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -44,6 +44,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate checkout integrity
+        run: |
+          git sparse-checkout disable || true
+          if [ ! -f aragora/live/package-lock.json ]; then
+            echo "::error::Missing aragora/live/package-lock.json after checkout"
+            echo "pwd: $(pwd)"
+            echo "Top-level files:"
+            ls -la
+            echo "aragora/live listing:"
+            ls -la aragora/live || true
+            exit 1
+          fi
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -90,6 +103,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate checkout integrity
+        run: |
+          git sparse-checkout disable || true
+          if [ ! -f aragora/live/package-lock.json ]; then
+            echo "::error::Missing aragora/live/package-lock.json after checkout"
+            echo "pwd: $(pwd)"
+            echo "Top-level files:"
+            ls -la
+            echo "aragora/live listing:"
+            ls -la aragora/live || true
+            exit 1
+          fi
 
       - name: Skip if already deployed (scheduled runs only)
         if: github.event_name == 'schedule'
@@ -198,6 +224,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Validate checkout integrity
+        run: |
+          git sparse-checkout disable || true
+          if [ ! -f aragora/live/package-lock.json ]; then
+            echo "::error::Missing aragora/live/package-lock.json after checkout"
+            echo "pwd: $(pwd)"
+            echo "Top-level files:"
+            ls -la
+            echo "aragora/live listing:"
+            ls -la aragora/live || true
+            exit 1
+          fi
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/smoke-offline.yml
+++ b/.github/workflows/smoke-offline.yml
@@ -32,6 +32,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Validate checkout integrity
+        run: |
+          git sparse-checkout disable || true
+          if [ ! -f pyproject.toml ]; then
+            echo "::error::Missing pyproject.toml after checkout"
+            echo "pwd: $(pwd)"
+            echo "Top-level files:"
+            ls -la
+            exit 1
+          fi
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add a checkout integrity guard after checkout in `deploy-frontend.yml` (all jobs)
- add a checkout integrity guard after checkout in `smoke-offline.yml`
- disable sparse-checkout drift (`git sparse-checkout disable || true`) before dependency setup
- fail fast with diagnostics when `aragora/live/package-lock.json` or `pyproject.toml` is missing

## Why
Recent failures on `main` show self-hosted runners occasionally start jobs with incomplete checkouts, causing:
- setup-node cache path resolution failure in Deploy Frontend
- intermittent missing root files in Offline Golden Path

## Validation
- workflow YAML checks passed in pre-commit
- scoped to CI workflow files only
