### PR TITLE
feat(debate): auto-inject codebase inventory for self-improvement debates

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -961,7 +961,30 @@ def cmd_ask(args: argparse.Namespace) -> None:
                 "This task was interpreted from an ambiguous input and requires confirmation."
             )
 
-    codebase_context_requested = bool(getattr(args, "codebase_context", False))
+    # Auto-detect self-improvement tasks and enable codebase context injection
+    _SELF_IMPROVEMENT_KEYWORDS = {
+        "improve",
+        "refactor",
+        "codebase",
+        "aragora",
+        "architecture",
+        "module",
+        "component",
+        "self-improve",
+        "dogfood",
+    }
+    task_lower = task.lower()
+    auto_codebase_context = getattr(args, "mode", None) == "orchestrator" or any(
+        kw in task_lower for kw in _SELF_IMPROVEMENT_KEYWORDS
+    )
+    codebase_context_requested = (
+        bool(getattr(args, "codebase_context", False)) or auto_codebase_context
+    )
+    if auto_codebase_context and not getattr(args, "codebase_context", False):
+        print(
+            "[context] auto-enabling codebase context (self-improvement task detected)",
+            file=sys.stderr,
+        )
     codebase_context_repo: Path | None = None
     if codebase_context_requested:
         from aragora.debate.context_engineering import (
@@ -1030,6 +1053,26 @@ def cmd_ask(args: argparse.Namespace) -> None:
                     f"[context-engineering] no context injected ({reason})",
                     file=sys.stderr,
                 )
+
+    # Always inject static inventory for codebase-context tasks as a lightweight fallback
+    if codebase_context_requested:
+        try:
+            from aragora.debate.codebase_context import build_static_inventory
+
+            repo_raw = getattr(args, "codebase_context_path", None) or os.getcwd()
+            inventory = build_static_inventory(repo_root=str(repo_raw))
+            if inventory:
+                if context:
+                    context = f"{inventory}\n\n{context}"
+                else:
+                    context = inventory
+                if args.verbose:
+                    print(
+                        f"[context] static inventory injected chars={len(inventory)}",
+                        file=sys.stderr,
+                    )
+        except Exception as e:  # noqa: BLE001 - best-effort enrichment
+            print(f"[context] static inventory failed: {e}", file=sys.stderr)
 
     agents = args.agents
     rounds = args.rounds
@@ -1847,6 +1890,21 @@ def cmd_ask(args: argparse.Namespace) -> None:
                 print(f"[quality] defect: {defect}")
     elif post_consensus_quality:
         print("[quality] skipped=no_contract reason=no_explicit_output_contract_detected")
+
+    # Post-debate path verification for codebase-context tasks
+    if codebase_context_requested and hasattr(result, "final_answer") and result.final_answer:
+        try:
+            from aragora.debate.repo_grounding import (
+                assess_repo_grounding,
+                format_path_verification_summary,
+            )
+
+            repo_raw = getattr(args, "codebase_context_path", None) or os.getcwd()
+            grounding_report = assess_repo_grounding(result.final_answer, repo_root=str(repo_raw))
+            summary = format_path_verification_summary(grounding_report)
+            print(f"\n{summary}")
+        except Exception as e:  # noqa: BLE001 - best-effort post-debate check
+            logger.debug("Post-debate path verification failed: %s", e)
 
     # Display explanation if --explain was requested
     if explain:

--- a/aragora/debate/codebase_context.py
+++ b/aragora/debate/codebase_context.py
@@ -15,6 +15,7 @@ Usage:
 from __future__ import annotations
 
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -193,7 +194,147 @@ class CodebaseContextProvider:
             logger.debug("KM sync skipped: %s", e)
 
 
+def _extract_table(text: str, header_pattern: str) -> list[str]:
+    """Extract rows from a markdown table matching a header pattern."""
+    lines = text.splitlines()
+    in_table = False
+    rows: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if header_pattern in stripped:
+            in_table = True
+            continue
+        if in_table:
+            if stripped.startswith("|") and not stripped.startswith("|--"):
+                rows.append(stripped)
+            elif stripped.startswith("|--"):
+                continue  # separator row
+            elif not stripped:
+                # blank line ends the table
+                break
+            else:
+                break
+    return rows
+
+
+def _verify_paths(paths: list[str], root: Path) -> dict[str, bool]:
+    """Check which paths exist on disk."""
+    result: dict[str, bool] = {}
+    for p in paths:
+        result[p] = (root / p).exists()
+    return result
+
+
+def _extract_feature_status(text: str) -> str:
+    """Extract feature status sections from CLAUDE.md."""
+    lines = text.splitlines()
+    output: list[str] = []
+    capturing = False
+    for line in lines:
+        stripped = line.strip()
+        if (
+            stripped.startswith("**Core (stable):**")
+            or stripped.startswith("**Integrated:**")
+            or stripped.startswith("**Enterprise")
+        ):
+            capturing = True
+            output.append(stripped)
+            continue
+        if capturing:
+            if stripped.startswith("##") or stripped.startswith("| "):
+                break
+            if stripped.startswith("- ") or stripped.startswith("**"):
+                output.append(stripped)
+            elif not stripped:
+                output.append("")
+            else:
+                break
+    return "\n".join(output).strip()
+
+
+def build_static_inventory(
+    repo_root: str | None = None,
+    max_chars: int = 20_000,
+) -> str:
+    """Build a static codebase inventory from CLAUDE.md for debate context injection.
+
+    Reads the quick reference table and feature status sections from CLAUDE.md,
+    validates paths against the filesystem, and returns a compact inventory string.
+
+    No API calls, no async, no indexing — just reads 1 markdown file.
+
+    Args:
+        repo_root: Repository root path. Defaults to cwd.
+        max_chars: Maximum characters in the output.
+
+    Returns:
+        Structured codebase inventory string, or empty string on failure.
+    """
+    root = Path(repo_root or os.getcwd())
+    claude_md = root / "CLAUDE.md"
+
+    if not claude_md.exists():
+        logger.warning("CLAUDE.md not found at %s", claude_md)
+        return ""
+
+    try:
+        content = claude_md.read_text(encoding="utf-8")
+    except OSError as e:
+        logger.warning("Failed to read CLAUDE.md: %s", e)
+        return ""
+
+    sections: list[str] = []
+    sections.append("## CODEBASE INVENTORY (DO NOT PROPOSE FEATURES THAT ALREADY EXIST)")
+    sections.append("")
+    sections.append("The following modules and features already exist in this codebase.")
+    sections.append(
+        "Before proposing new files or features, verify they don't duplicate existing ones."
+    )
+    sections.append("")
+
+    # Extract quick reference table
+    table_rows = _extract_table(content, "| What | Where |")
+    if table_rows:
+        # Parse paths from table and verify
+        all_paths: list[str] = []
+        for row in table_rows:
+            cells = [c.strip().strip("`") for c in row.split("|") if c.strip()]
+            if len(cells) >= 2:
+                path = cells[1].strip().rstrip("/")
+                if path and "/" in path:
+                    all_paths.append(path)
+
+        verified = _verify_paths(all_paths, root)
+
+        sections.append("### Module Map")
+        for row in table_rows:
+            cells = [c.strip() for c in row.split("|") if c.strip()]
+            if len(cells) >= 2:
+                path = cells[1].strip().strip("`").rstrip("/")
+                exists = verified.get(path, False)
+                marker = "" if exists else " [MISSING]"
+                key_files = cells[2] if len(cells) >= 3 else ""
+                sections.append(f"- **{cells[0]}**: `{path}`{marker} — {key_files}")
+
+        sections.append("")
+
+    # Extract feature status
+    feature_status = _extract_feature_status(content)
+    if feature_status:
+        sections.append("### Feature Status")
+        sections.append(feature_status)
+        sections.append("")
+
+    inventory = "\n".join(sections)
+
+    if len(inventory) > max_chars:
+        inventory = inventory[:max_chars].rstrip() + "\n...[truncated]"
+
+    return inventory
+
+
 __all__ = [
     "CodebaseContextConfig",
     "CodebaseContextProvider",
+    "build_static_inventory",
 ]

--- a/aragora/debate/repo_grounding.py
+++ b/aragora/debate/repo_grounding.py
@@ -252,3 +252,40 @@ def assess_repo_grounding(
         first_batch_concreteness=first_batch_concreteness,
         practicality_score_10=round(min(10.0, max(0.0, practicality_score)), 2),
     )
+
+
+def format_path_verification_summary(report: RepoGroundingReport) -> str:
+    """Format a RepoGroundingReport into a human-readable CLI summary.
+
+    Args:
+        report: The grounding report from assess_repo_grounding().
+
+    Returns:
+        Multi-line string suitable for printing to stderr.
+    """
+    lines: list[str] = []
+    total = len(report.mentioned_paths)
+    verified = len(report.existing_paths)
+    new = len(report.new_paths)
+    missing = len(report.missing_paths)
+
+    lines.append(
+        f"[path-check] {verified}/{total} paths verified ({report.path_existence_rate:.0%})"
+    )
+
+    if new:
+        lines.append(f"[path-check] {new} new file(s) proposed (parent dir exists)")
+    if missing:
+        lines.append(f"[path-check] {missing} path(s) NOT FOUND:")
+        for p in report.missing_paths:
+            lines.append(f"  - {p}")
+
+    lines.append(
+        f"[path-check] practicality={report.practicality_score_10}/10"
+        f" concreteness={report.first_batch_concreteness:.2f}"
+    )
+
+    if report.placeholder_hits:
+        lines.append(f"[path-check] placeholders detected: {', '.join(report.placeholder_hits)}")
+
+    return "\n".join(lines)

--- a/tests/debate/test_codebase_context.py
+++ b/tests/debate/test_codebase_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from pathlib import Path
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aragora.debate.codebase_context import (
     CodebaseContextConfig,
     CodebaseContextProvider,
+    build_static_inventory,
 )
 
 
@@ -198,3 +200,94 @@ class TestGetSummary:
 
         summary = provider.get_summary(max_tokens=50)
         assert len(summary) <= 250  # 50 * 4 + truncation
+
+
+# ---------------------------------------------------------------------------
+# build_static_inventory
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def fake_repo(tmp_path):
+    """Create a minimal fake repo with CLAUDE.md."""
+    claude_md = tmp_path / "CLAUDE.md"
+    claude_md.write_text(
+        """\
+## Quick Reference
+
+| What | Where | Key Files |
+|------|-------|-----------|
+| Debate engine | `aragora/debate/` | `orchestrator.py`, `consensus.py` |
+| CLI | `aragora/cli/` | `main.py`, `parser.py` |
+| Memory | `aragora/memory/` | `continuum/`, `consensus.py` |
+
+## Feature Status
+
+**Core (stable):**
+- Debate orchestration (Arena, consensus, convergence)
+- Memory systems (CritiqueStore, ContinuumMemory)
+- ELO rankings and tournaments
+
+**Integrated:**
+- Knowledge Mound - STABLE Phase A2
+- Pulse (trending topics) - STABLE
+
+**Enterprise (production-ready):**
+- Authentication - OIDC/SAML SSO, MFA
+""",
+        encoding="utf-8",
+    )
+    # Create some dirs to make paths "exist"
+    (tmp_path / "aragora" / "debate").mkdir(parents=True)
+    (tmp_path / "aragora" / "cli").mkdir(parents=True)
+    # aragora/memory/ intentionally NOT created to test [MISSING]
+    return tmp_path
+
+
+class TestBuildStaticInventory:
+    def test_returns_nonempty_for_valid_repo(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo))
+        assert result
+        assert "CODEBASE INVENTORY" in result
+
+    def test_contains_module_map(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo))
+        assert "Module Map" in result
+        assert "Debate engine" in result
+        assert "CLI" in result
+
+    def test_verifies_paths(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo))
+        # debate/ and cli/ exist, memory/ does not
+        assert "aragora/debate" in result
+        assert "aragora/cli" in result
+        assert "[MISSING]" in result  # memory/ doesn't exist
+
+    def test_contains_feature_status(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo))
+        assert "Feature Status" in result
+        assert "Core (stable)" in result
+        assert "Debate orchestration" in result
+
+    def test_max_chars_truncation(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo), max_chars=100)
+        assert len(result) <= 115  # small buffer for truncation marker
+        assert result.endswith("[truncated]")
+
+    def test_missing_claude_md(self, tmp_path):
+        result = build_static_inventory(repo_root=str(tmp_path))
+        assert result == ""
+
+    def test_do_not_propose_warning(self, fake_repo):
+        result = build_static_inventory(repo_root=str(fake_repo))
+        assert "DO NOT PROPOSE FEATURES THAT ALREADY EXIST" in result
+
+    def test_real_repo_if_available(self):
+        """Integration test: runs against the real repo if CLAUDE.md exists."""
+        repo = Path(__file__).resolve().parent.parent.parent
+        if not (repo / "CLAUDE.md").exists():
+            pytest.skip("Not running from within aragora repo")
+        result = build_static_inventory(repo_root=str(repo))
+        assert len(result) > 500
+        assert "CODEBASE INVENTORY" in result
+        assert "Debate engine" in result

--- a/tests/debate/test_repo_grounding.py
+++ b/tests/debate/test_repo_grounding.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from aragora.debate.repo_grounding import assess_repo_grounding
+from aragora.debate.repo_grounding import (
+    RepoGroundingReport,
+    assess_repo_grounding,
+    format_path_verification_summary,
+)
 
 
 def test_assess_repo_grounding_with_existing_paths():
@@ -44,3 +48,42 @@ def test_assess_repo_grounding_penalizes_placeholders_and_missing_paths():
     assert "new_marker" in report.placeholder_hits
     assert report.placeholder_rate > 0.0
     assert report.practicality_score_10 < 5.0
+
+
+def test_format_path_verification_summary_all_verified():
+    report = RepoGroundingReport(
+        mentioned_paths=["aragora/debate/orchestrator.py", "aragora/cli/main.py"],
+        existing_paths=["aragora/debate/orchestrator.py", "aragora/cli/main.py"],
+        missing_paths=[],
+        new_paths=[],
+        path_existence_rate=1.0,
+        placeholder_hits=[],
+        placeholder_rate=0.0,
+        first_batch_concreteness=0.8,
+        practicality_score_10=9.5,
+    )
+    summary = format_path_verification_summary(report)
+    assert "2/2 paths verified" in summary
+    assert "100%" in summary
+    assert "NOT FOUND" not in summary
+    assert "practicality=9.5/10" in summary
+
+
+def test_format_path_verification_summary_with_missing():
+    report = RepoGroundingReport(
+        mentioned_paths=["a.py", "b.py", "c.py"],
+        existing_paths=["a.py"],
+        missing_paths=["c.py"],
+        new_paths=["b.py"],
+        path_existence_rate=0.5,
+        placeholder_hits=["tbd"],
+        placeholder_rate=0.05,
+        first_batch_concreteness=0.35,
+        practicality_score_10=4.2,
+    )
+    summary = format_path_verification_summary(report)
+    assert "1/3 paths verified" in summary
+    assert "1 new file(s) proposed" in summary
+    assert "1 path(s) NOT FOUND" in summary
+    assert "c.py" in summary
+    assert "placeholders detected: tbd" in summary


### PR DESCRIPTION
## Summary
- Auto-inject codebase inventory (~10K chars from CLAUDE.md) into debate context for self-improvement tasks
- Auto-detect self-improvement tasks via keyword matching or `--mode orchestrator`
- Post-debate path verification prints grounded/missing/new path stats
- Fixes the root cause of dogfood run 001 failure: agents proposing files that already exist

## What changed
- `aragora/debate/codebase_context.py` — `build_static_inventory()`: reads CLAUDE.md module map + feature status, validates paths against filesystem
- `aragora/debate/repo_grounding.py` — `format_path_verification_summary()`: human-readable CLI output for path verification
- `aragora/cli/commands/debate.py` — auto-detection, inventory injection, post-debate verification
- 26 tests passing (8 new for inventory, 2 new for path formatting)

## Also includes
- `.claude/hooks/worktree-transcript-link.sh` — fixes claude-mem Stop hook failure in worktree sessions (symlinks transcripts)

## Test plan
- [x] `pytest tests/debate/test_codebase_context.py tests/debate/test_repo_grounding.py` — 26 passed
- [x] `build_static_inventory()` produces 10,416 chars against real repo
- [x] Syntax check on all modified files
- [ ] Re-run dogfood debate with `--codebase-context` flag (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)