### PR TITLE
cli: harden ask timeout handling and CLI subprocess cleanup

### DIFF
--- a/aragora/agents/cli_agents.py
+++ b/aragora/agents/cli_agents.py
@@ -18,6 +18,9 @@ import json
 import logging
 import os
 import re
+import signal
+import threading
+import time
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
@@ -42,6 +45,10 @@ if TYPE_CHECKING:
 # Configurable via ARAGORA_MAX_CLI_SUBPROCESSES environment variable
 _MAX_CLI_SUBPROCESSES = int(os.environ.get("ARAGORA_MAX_CLI_SUBPROCESSES", "10"))
 _subprocess_semaphore = asyncio.Semaphore(_MAX_CLI_SUBPROCESSES)
+
+# Track active CLI subprocess PIDs so timeout handlers can perform best-effort cleanup.
+_tracked_cli_pids: set[int] = set()
+_tracked_cli_pids_lock = threading.Lock()
 
 # Maximum prompt size to pass as CLI argument (avoids E2BIG error)
 # Prompts larger than this should be passed via stdin where supported
@@ -69,6 +76,7 @@ __all__ = [
     "QwenCLIAgent",
     "DeepseekCLIAgent",
     "KiloCodeAgent",
+    "terminate_tracked_cli_processes",
     "MAX_CLI_PROMPT_CHARS",
     "MAX_CONTEXT_CHARS",
     "MAX_MESSAGE_CHARS",
@@ -77,6 +85,109 @@ __all__ = [
 ]
 
 logger = logging.getLogger(__name__)
+
+
+def _track_cli_pid(pid: int | None) -> None:
+    if not isinstance(pid, int) or pid <= 0:
+        return
+    with _tracked_cli_pids_lock:
+        _tracked_cli_pids.add(pid)
+
+
+def _untrack_cli_pid(pid: int | None) -> None:
+    if not isinstance(pid, int) or pid <= 0:
+        return
+    with _tracked_cli_pids_lock:
+        _tracked_cli_pids.discard(pid)
+
+
+def terminate_tracked_cli_processes(grace_seconds: float = 0.2) -> dict[str, int]:
+    """Best-effort cleanup of tracked CLI subprocesses.
+
+    This is intentionally synchronous so timeout handlers can call it from
+    non-async contexts (for example strict wall-clock signal paths).
+    """
+    with _tracked_cli_pids_lock:
+        tracked = list(_tracked_cli_pids)
+
+    if not tracked:
+        return {"tracked": 0, "terminated": 0, "killed": 0, "remaining": 0}
+
+    terminated = 0
+    killed = 0
+    remaining_pids: set[int] = set()
+    unknown_state_pids: set[int] = set()
+
+    # First attempt a graceful terminate.
+    for pid in tracked:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            terminated += 1
+        except ProcessLookupError:
+            _untrack_cli_pid(pid)
+            continue
+        except (PermissionError, OSError):
+            unknown_state_pids.add(pid)
+
+    # Allow a brief grace period for process exit.
+    if grace_seconds > 0:
+        time.sleep(min(grace_seconds, 1.0))
+
+    # Force-kill any process still alive (or whose state is unknown).
+    for pid in tracked:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            _untrack_cli_pid(pid)
+            continue
+        except (PermissionError, OSError):
+            # Cannot verify state; keep as remaining and do not attempt further signals.
+            unknown_state_pids.add(pid)
+            continue
+
+        try:
+            os.kill(pid, signal.SIGKILL)
+            killed += 1
+        except ProcessLookupError:
+            _untrack_cli_pid(pid)
+            continue
+        except (PermissionError, OSError):
+            unknown_state_pids.add(pid)
+            continue
+
+        # After SIGKILL, check if process is gone and clear tracking.
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            _untrack_cli_pid(pid)
+        except (PermissionError, OSError):
+            unknown_state_pids.add(pid)
+        else:
+            remaining_pids.add(pid)
+
+    # Final pass: capture any remaining live tracked PIDs.
+    for pid in tracked:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            _untrack_cli_pid(pid)
+            continue
+        except (PermissionError, OSError):
+            unknown_state_pids.add(pid)
+            continue
+        else:
+            remaining_pids.add(pid)
+
+    with _tracked_cli_pids_lock:
+        current_remaining = len(_tracked_cli_pids)
+    remaining = max(current_remaining, len(remaining_pids) + len(unknown_state_pids))
+
+    return {
+        "tracked": len(tracked),
+        "terminated": terminated,
+        "killed": killed,
+        "remaining": remaining,
+    }
 
 
 class CLIAgent(CritiqueMixin, Agent):
@@ -289,6 +400,7 @@ class CLIAgent(CritiqueMixin, Agent):
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
+                _track_cli_pid(getattr(proc, "pid", None))
 
                 # Also sanitize stdin input (used by ClaudeAgent)
                 sanitized_input = self._sanitize_cli_arg(input_text) if input_text else None
@@ -350,6 +462,14 @@ class CLIAgent(CritiqueMixin, Agent):
                     proc.kill()
                     await proc.wait()  # Ensure process is fully cleaned up
                 raise TimeoutError(f"CLI command timed out after {self.timeout}s")
+            except asyncio.CancelledError:
+                # Ensure subprocess cleanup when outer timeout/cancellation interrupts.
+                if self._circuit_breaker is not None:
+                    self._circuit_breaker.record_failure()
+                if proc and proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
+                raise
             except AgentCircuitOpenError:
                 # Don't record circuit open errors as failures - just re-raise
                 raise
@@ -362,6 +482,9 @@ class CLIAgent(CritiqueMixin, Agent):
                     proc.kill()
                     await proc.wait()  # Cleanup zombie processes
                 raise
+            finally:
+                if proc is not None:
+                    _untrack_cli_pid(getattr(proc, "pid", None))
 
     def _build_context_prompt(
         self,

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -252,6 +252,52 @@ def _append_context_file(context: str, context_file: str) -> str:
     return content
 
 
+def _cleanup_cli_subprocesses_for_timeout() -> dict[str, int]:
+    """Best-effort cleanup for CLI subprocesses after timeout."""
+    try:
+        from aragora.agents.cli_agents import terminate_tracked_cli_processes
+
+        return terminate_tracked_cli_processes()
+    except Exception as e:  # noqa: BLE001 - timeout cleanup must never crash CLI
+        logger.warning("Failed to clean up tracked CLI subprocesses: %s", e)
+        return {"tracked": 0, "terminated": 0, "killed": 0, "remaining": 0}
+
+
+def _emit_timeout_failure_payload(
+    *,
+    error_type: str,
+    timeout_seconds: int,
+    elapsed_seconds: float,
+    task: str,
+    agents_str: str,
+    mode: str | None,
+    cleanup: dict[str, int],
+) -> None:
+    """Emit machine-parseable timeout payload for benchmark/scoring harnesses."""
+    task_value = str(task or "")
+    payload = {
+        "status": "timeout",
+        "error_type": error_type,
+        "timeout_seconds": int(timeout_seconds),
+        "elapsed_seconds": round(max(0.0, float(elapsed_seconds)), 3),
+        "task_preview": task_value[:240],
+        "task_length": len(task_value),
+        "agents": _split_agents_list(agents_str),
+        "mode": mode or "default",
+        "cleanup": cleanup,
+        "final_answer": "",
+    }
+    encoded = json.dumps(payload, sort_keys=True)
+    print(f"ARAGORA_TIMEOUT_JSON={encoded}")
+
+    report_path_raw = os.environ.get("ARAGORA_ASK_TIMEOUT_REPORT_PATH")
+    if report_path_raw:
+        try:
+            Path(report_path_raw).expanduser().write_text(encoded + "\n", encoding="utf-8")
+        except OSError as e:
+            logger.warning("Failed to write timeout report %s: %s", report_path_raw, e)
+
+
 def _looks_like_self_improvement_task(task: str) -> bool:
     """Heuristic detection for codebase self-improvement prompts."""
     lowered = (task or "").lower()
@@ -1903,6 +1949,16 @@ def cmd_ask(args: argparse.Namespace) -> None:
             result = asyncio.run(_run_with_timeout())
     except _StrictWallClockTimeout:
         elapsed = time.monotonic() - start_time
+        cleanup = _cleanup_cli_subprocesses_for_timeout()
+        _emit_timeout_failure_payload(
+            error_type="strict_wall_clock_timeout",
+            timeout_seconds=debate_timeout,
+            elapsed_seconds=elapsed,
+            task=raw_task,
+            agents_str=agents,
+            mode=getattr(args, "mode", None),
+            cleanup=cleanup,
+        )
         print(
             f"Debate timed out after {debate_timeout}s (strict wall-clock; elapsed={elapsed:.2f}s)",
             file=sys.stderr,
@@ -1910,6 +1966,16 @@ def cmd_ask(args: argparse.Namespace) -> None:
         raise SystemExit(1)
     except asyncio.TimeoutError:
         elapsed = time.monotonic() - start_time
+        cleanup = _cleanup_cli_subprocesses_for_timeout()
+        _emit_timeout_failure_payload(
+            error_type="async_wait_for_timeout",
+            timeout_seconds=debate_timeout,
+            elapsed_seconds=elapsed,
+            task=raw_task,
+            agents_str=agents,
+            mode=getattr(args, "mode", None),
+            cleanup=cleanup,
+        )
         print(
             f"Debate timed out after {debate_timeout}s (async wait_for; elapsed={elapsed:.2f}s)",
             file=sys.stderr,

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import argparse
+import json
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -165,9 +167,79 @@ def test_cmd_ask_strict_wall_clock_timeout_exits(monkeypatch, capsys):
             debate_cmd.cmd_ask(args)
 
     assert exc_info.value.code == 1
-    err = capsys.readouterr().err
+    captured = capsys.readouterr()
+    err = captured.err
+    timeout_line = next(
+        line for line in captured.out.splitlines() if line.startswith("ARAGORA_TIMEOUT_JSON=")
+    )
+    payload = json.loads(timeout_line.split("=", 1)[1])
     assert "Debate timed out after 1s" in err
     assert "strict wall-clock" in err
+    assert payload["status"] == "timeout"
+    assert payload["error_type"] == "strict_wall_clock_timeout"
+    assert payload["timeout_seconds"] == 1
+    assert payload["final_answer"] == ""
+
+
+def test_cmd_ask_async_timeout_emits_machine_payload(monkeypatch, capsys):
+    """Async wait_for timeout should emit machine-readable timeout JSON."""
+    from aragora.cli.commands import debate as debate_cmd
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+
+    args = argparse.Namespace(
+        task="async timeout test",
+        agents="claude,openai",
+        rounds=2,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=False,
+        api=False,
+        local=True,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+        timeout=1,
+    )
+
+    with patch.object(debate_cmd.asyncio, "run", side_effect=asyncio.TimeoutError()):
+        with pytest.raises(SystemExit) as exc_info:
+            debate_cmd.cmd_ask(args)
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    err = captured.err
+    timeout_line = next(
+        line for line in captured.out.splitlines() if line.startswith("ARAGORA_TIMEOUT_JSON=")
+    )
+    payload = json.loads(timeout_line.split("=", 1)[1])
+    assert "Debate timed out after 1s" in err
+    assert "async wait_for" in err
+    assert payload["status"] == "timeout"
+    assert payload["error_type"] == "async_wait_for_timeout"
+    assert payload["timeout_seconds"] == 1
+    assert payload["final_answer"] == ""
 
 
 def test_cmd_ask_quality_fail_closed_requires_contract(monkeypatch, capsys):

--- a/tests/test_cli_agents.py
+++ b/tests/test_cli_agents.py
@@ -11,10 +11,12 @@ Tests cover:
 
 import asyncio
 import json
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+import aragora.agents.cli_agents as cli_agents_mod
 from aragora.agents.cli_agents import (
     CLIAgent,
     ClaudeAgent,
@@ -122,6 +124,25 @@ class TestCLIAgentRunCli:
             mock_proc.wait.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_cancelled_error_kills_process(self, agent):
+        """Should kill process when coroutine is cancelled."""
+        with patch("asyncio.create_subprocess_exec") as mock_exec:
+            mock_proc = AsyncMock()
+            mock_proc.pid = 4242
+            mock_proc.returncode = None
+            mock_proc.communicate = AsyncMock(side_effect=asyncio.CancelledError())
+            mock_proc.kill = MagicMock()
+            mock_proc.wait = AsyncMock()
+            mock_exec.return_value = mock_proc
+
+            with pytest.raises(asyncio.CancelledError):
+                await agent._run_cli(["sleep", "100"])
+
+            mock_proc.kill.assert_called_once()
+            mock_proc.wait.assert_called_once()
+            assert 4242 not in cli_agents_mod._tracked_cli_pids
+
+    @pytest.mark.asyncio
     async def test_error_kills_process(self, agent):
         """Should kill process on error."""
         with patch("asyncio.create_subprocess_exec") as mock_exec:
@@ -208,6 +229,51 @@ class TestCLIAgentBuildContextPrompt:
 
         # Total should not exceed limit significantly
         assert len(result) <= MAX_CONTEXT_CHARS + 1000
+
+
+class TestTrackedCLISubprocessCleanup:
+    """Tests for tracked subprocess cleanup helpers."""
+
+    def test_terminate_tracked_cli_processes_noop_when_empty(self):
+        """Cleanup should return zeroed summary when nothing is tracked."""
+        with cli_agents_mod._tracked_cli_pids_lock:
+            cli_agents_mod._tracked_cli_pids.clear()
+        summary = cli_agents_mod.terminate_tracked_cli_processes(grace_seconds=0.0)
+        assert summary == {"tracked": 0, "terminated": 0, "killed": 0, "remaining": 0}
+
+    def test_terminate_tracked_cli_processes_sends_term_then_kill(self, monkeypatch):
+        """Cleanup should send SIGTERM then SIGKILL for stuck processes."""
+        with cli_agents_mod._tracked_cli_pids_lock:
+            cli_agents_mod._tracked_cli_pids.clear()
+            cli_agents_mod._tracked_cli_pids.add(11111)
+
+        alive = {"value": True}
+        calls: list[tuple[int, int]] = []
+
+        def _fake_kill(pid: int, sig: int) -> None:
+            calls.append((pid, sig))
+            if sig == 0:
+                if alive["value"]:
+                    return
+                raise ProcessLookupError()
+            if sig == signal.SIGTERM:
+                return
+            if sig == signal.SIGKILL:
+                alive["value"] = False
+                return
+            raise AssertionError(f"Unexpected signal {sig}")
+
+        monkeypatch.setattr(cli_agents_mod.os, "kill", _fake_kill)
+        monkeypatch.setattr(cli_agents_mod.time, "sleep", lambda _s: None)
+
+        summary = cli_agents_mod.terminate_tracked_cli_processes(grace_seconds=0.0)
+
+        assert summary["tracked"] == 1
+        assert summary["terminated"] == 1
+        assert summary["killed"] == 1
+        assert summary["remaining"] == 0
+        assert (11111, signal.SIGTERM) in calls
+        assert (11111, signal.SIGKILL) in calls
 
 
 class TestCLIAgentParseCritique:


### PR DESCRIPTION
## Summary
- emit machine-parseable timeout payloads from `aragora ask` on both strict wall-clock and async wait timeouts
- write optional timeout payload report via `ARAGORA_ASK_TIMEOUT_REPORT_PATH`
- add best-effort tracked CLI subprocess cleanup for timeout paths
- make `CLIAgent._run_cli()` kill/wait subprocesses on `asyncio.CancelledError`

## Why
Dogfood runs timed out with empty/non-deterministic outputs and could leave CLI subprocesses running. This makes timeout failures parseable for harnesses and improves cleanup behavior.

## Validation
- `/Users/armand/.pyenv/versions/3.11.11/bin/python3 -m pytest tests/cli/test_offline_golden_path.py::test_cmd_ask_strict_wall_clock_timeout_exits tests/cli/test_offline_golden_path.py::test_cmd_ask_async_timeout_emits_machine_payload tests/test_cli_agents.py::TestCLIAgentRunCli::test_cancelled_error_kills_process tests/test_cli_agents.py::TestTrackedCLISubprocessCleanup -q`
- `/Users/armand/.pyenv/versions/3.11.11/bin/python3 -m pytest tests/debate/test_codebase_context.py tests/debate/test_repo_grounding.py tests/cli/test_offline_golden_path.py tests/test_cli_main.py::TestCommandHandlers::test_cmd_ask_runs_debate tests/test_cli_agents.py::TestCLIAgentRunCli::test_cancelled_error_kills_process tests/test_cli_agents.py::TestTrackedCLISubprocessCleanup -q`
