### PR TITLE
ci: bootstrap gh CLI on self-hosted runners for review/deploy workflows

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -91,6 +91,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Ensure GitHub CLI is available
+        if: github.event_name == 'schedule'
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version | head -1
+            exit 0
+          fi
+          echo "::warning::gh CLI missing on runner; installing fallback package"
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y gh
+          else
+            apt-get update
+            apt-get install -y gh
+          fi
+          gh --version | head -1
+
       - name: Skip if already deployed (scheduled runs only)
         if: github.event_name == 'schedule'
         id: skip-check

--- a/.github/workflows/pr-debate.yml
+++ b/.github/workflows/pr-debate.yml
@@ -46,6 +46,22 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Ensure GitHub CLI is available
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version | head -1
+            exit 0
+          fi
+          echo "::warning::gh CLI missing on runner; installing fallback package"
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y gh
+          else
+            apt-get update
+            apt-get install -y gh
+          fi
+          gh --version | head -1
+
       - name: Install aragora from base branch
         run: |
           pip install --upgrade pip

--- a/.github/workflows/templates/aragora-review-template.yml
+++ b/.github/workflows/templates/aragora-review-template.yml
@@ -52,6 +52,22 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Ensure GitHub CLI is available
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version | head -1
+            exit 0
+          fi
+          echo "::warning::gh CLI missing on runner; installing fallback package"
+          if command -v sudo >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y gh
+          else
+            apt-get update
+            apt-get install -y gh
+          fi
+          gh --version | head -1
+
       - name: Install Aragora
         run: pip install aragora
 


### PR DESCRIPTION
## Summary
- add a fallback step to install `gh` when missing on self-hosted runners
- apply fallback to:
  - `.github/workflows/pr-debate.yml`
  - `.github/workflows/deploy-frontend.yml` (scheduled branch)
  - `.github/workflows/templates/aragora-review-template.yml`

## Why
Recent failures show `gh: command not found` on self-hosted runners, which hard-fails PR review/deploy workflows before meaningful checks run.

## Validation
- YAML parse check for all edited workflows
- pre-commit hooks passed (`check yaml`, etc.)
