### PR TITLE
dogfood: add grounding gates, scoring harness, and CI install-root hardening

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,7 @@ on:
       - 'tests/memory/test_benchmark.py'
       - 'tests/rlm/test_benchmark.py'
       - 'scripts/check_benchmark_regression.py'
+      - 'scripts/ci_install_project.sh'
       - 'pyproject.toml'
       - '.github/workflows/benchmark.yml'
   pull_request:
@@ -31,6 +32,7 @@ on:
       - 'tests/memory/test_benchmark.py'
       - 'tests/rlm/test_benchmark.py'
       - 'scripts/check_benchmark_regression.py'
+      - 'scripts/ci_install_project.sh'
       - 'pyproject.toml'
   schedule:
     # Run daily at 2 AM UTC to track performance trends
@@ -75,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          bash scripts/ci_install_project.sh --extras test
           pip install pytest-benchmark
 
       - name: Run benchmark tests
@@ -134,7 +136,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          bash scripts/ci_install_project.sh --extras test
 
       - name: Run orchestration speed smoke benchmark
         run: |
@@ -168,7 +170,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          bash scripts/ci_install_project.sh --extras test
           pip install pytest-benchmark
 
       - name: Run PR benchmarks
@@ -183,8 +185,8 @@ jobs:
 
       - name: Run main benchmarks
         run: |
+          bash scripts/ci_install_project.sh --extras test --project-dir main-branch
           cd main-branch
-          pip install -e ".[test]"
           pytest tests/benchmarks/test_performance.py \
             --benchmark-only \
             --benchmark-json=../main-benchmark.json \
@@ -236,7 +238,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          bash scripts/ci_install_project.sh --extras test
 
       - name: Run latency tests
         run: |
@@ -273,7 +275,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[test]"
+          bash scripts/ci_install_project.sh --extras test
 
       - name: Run baseline comparison
         id: baseline

--- a/.github/workflows/core-suites.yml
+++ b/.github/workflows/core-suites.yml
@@ -10,6 +10,7 @@ on:
       - 'pyproject.toml'
       - 'requirements.txt'
       - 'scripts/ci_core_suites.sh'
+      - 'scripts/ci_install_project.sh'
       - '.github/workflows/core-suites.yml'
   push:
     branches: [main]
@@ -19,6 +20,7 @@ on:
       - 'pyproject.toml'
       - 'requirements.txt'
       - 'scripts/ci_core_suites.sh'
+      - 'scripts/ci_install_project.sh'
       - '.github/workflows/core-suites.yml'
   workflow_dispatch:
 
@@ -45,7 +47,7 @@ jobs:
       - name: Install (dev)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          bash scripts/ci_install_project.sh --extras dev
 
       - name: Run core suites
         run: bash scripts/ci_core_suites.sh
@@ -68,7 +70,7 @@ jobs:
       - name: Install (dev)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          bash scripts/ci_install_project.sh --extras dev
 
       - name: Run OpenClaw + auth/RBAC security boundary suites
         run: |

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -15,6 +15,7 @@ on:
       - 'aragora/live/package-lock.json'
       - 'sdk/typescript/package.json'
       - 'sdk/typescript/package-lock.json'
+      - 'scripts/ci_install_project.sh'
       - '.github/workflows/security-gate.yml'
   workflow_call:
     # Allow release.yml to call this workflow as a reusable gate
@@ -49,7 +50,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install bandit[toml] pip-audit safety
-          pip install -e .
+          bash scripts/ci_install_project.sh
 
       # ---------------------------------------------------------------
       # Bandit: static analysis for Python security issues

--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -1263,6 +1263,43 @@ def cmd_ask(args: argparse.Namespace) -> None:
         0, int(getattr(args, "quality_extra_assessment_rounds", 2))
     )
     quality_fail_closed = bool(getattr(args, "quality_fail_closed", False))
+    grounding_fail_closed = bool(getattr(args, "grounding_fail_closed", False))
+    grounding_min_verified_paths = float(getattr(args, "grounding_min_verified_paths", 0.8))
+    if not 0.0 <= grounding_min_verified_paths <= 1.0:
+        print(
+            "Invalid --grounding-min-verified-paths: expected value in [0.0, 1.0].",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    def _assess_and_enforce_grounding(final_answer_text: str) -> None:
+        from aragora.debate.repo_grounding import (
+            assess_repo_grounding,
+            format_path_verification_summary,
+        )
+
+        report = assess_repo_grounding(
+            str(final_answer_text or ""),
+            repo_root=str(codebase_context_repo or Path.cwd()),
+        )
+        print(format_path_verification_summary(report))
+
+        if not grounding_fail_closed:
+            return
+
+        total = len(report.mentioned_paths)
+        verified_existing = len(report.existing_paths)
+        verified_ratio = (verified_existing / total) if total else 0.0
+        if total == 0 or verified_ratio < grounding_min_verified_paths:
+            print(
+                (
+                    "Debate failed grounding gate: verified existing path ratio "
+                    f"{verified_ratio:.2f} is below required "
+                    f"{grounding_min_verified_paths:.2f} (existing={verified_existing}, total={total})."
+                ),
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
 
     quality_contract = None
     quality_contract_source = "none"
@@ -1402,21 +1439,12 @@ def cmd_ask(args: argparse.Namespace) -> None:
                 timeout_seconds=debate_timeout,
             )
             _print_debate_result(result, verbose=args.verbose)
-            if codebase_context_requested:
-                from aragora.debate.repo_grounding import (
-                    assess_repo_grounding,
-                    format_path_verification_summary,
-                )
-
+            if codebase_context_requested or grounding_fail_closed:
                 final_answer = getattr(result, "final_answer", None)
                 if not final_answer:
                     consensus = getattr(result, "consensus", None)
                     final_answer = getattr(consensus, "final_answer", "") if consensus else ""
-                report = assess_repo_grounding(
-                    str(final_answer or ""),
-                    repo_root=str(codebase_context_repo or Path.cwd()),
-                )
-                print(format_path_verification_summary(report))
+                _assess_and_enforce_grounding(str(final_answer or ""))
             if decision_integrity:
                 package = _build_decision_integrity_api(
                     server_url=server_url,
@@ -1989,17 +2017,8 @@ def cmd_ask(args: argparse.Namespace) -> None:
     print("FINAL ANSWER:")
     print("=" * 60)
     print(result.final_answer)
-    if codebase_context_requested:
-        from aragora.debate.repo_grounding import (
-            assess_repo_grounding,
-            format_path_verification_summary,
-        )
-
-        report = assess_repo_grounding(
-            str(getattr(result, "final_answer", "") or ""),
-            repo_root=str(codebase_context_repo or Path.cwd()),
-        )
-        print(format_path_verification_summary(report))
+    if codebase_context_requested or grounding_fail_closed:
+        _assess_and_enforce_grounding(str(getattr(result, "final_answer", "") or ""))
 
     quality_meta = None
     if isinstance(getattr(result, "metadata", None), dict):

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -232,6 +232,23 @@ def _add_ask_parser(subparsers) -> None:
         help="Exclude test files from codebase context indexing",
     )
     ask_parser.add_argument(
+        "--grounding-fail-closed",
+        action="store_true",
+        help=(
+            "Exit non-zero when final output is weakly grounded to existing repository paths "
+            "(requires path-check to meet --grounding-min-verified-paths)"
+        ),
+    )
+    ask_parser.add_argument(
+        "--grounding-min-verified-paths",
+        type=float,
+        default=0.8,
+        help=(
+            "Minimum ratio (0.0-1.0) of existing repo paths required when "
+            "--grounding-fail-closed is enabled (default: 0.8)"
+        ),
+    )
+    ask_parser.add_argument(
         "--no-learn", dest="learn", action="store_false", help="Don't store patterns"
     )
     ask_parser.add_argument(

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -119,6 +119,24 @@ Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. A
 
 See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
 
+### Dogfood Telemetry (Runs 003-004)
+
+| Run | Objective | Result | Blocking Metric |
+|---|---|---|---|
+| Run 003 | Baseline vs enhanced quality comparison after context injection wiring | **No-go** | Final answer payload missing in both variants |
+| Run 004 | Re-test with timeout hardening + deterministic timeout receipts | **No-go (quality delta)** | Timeout rate = **1.0** (both variants timed out) |
+
+What improved in Run 004:
+- Timeout failures are now machine-parseable (`ARAGORA_TIMEOUT_JSON` + timeout report files).
+- Benchmark classification is deterministic (infra timeout vs low-quality output).
+
+What still blocks meaningful quality comparison:
+- Debate runs frequently exceed wall-clock budget before final synthesis payload is emitted.
+
+Roadmap implication:
+- Treat runtime stability as a gating dependency for context-quality A/B claims.
+- Enforce grounding gates on completed outputs (`--grounding-fail-closed`, verified path ratio threshold) before accepting benchmark wins.
+
 ---
 
 ## Architectural Principles: The Terrarium Model

--- a/docs/plans/dogfood-run-001-spec.md
+++ b/docs/plans/dogfood-run-001-spec.md
@@ -433,3 +433,54 @@ This dissent is wrong in the specific case (the tasks duplicate existing work) b
 2. Ensure post-timeout behavior emits a deterministic failure payload (not empty stdout) so scoring harness can distinguish infra failure from low-quality output.
 3. Add a focused regression test around strict timeout + child subprocess cleanup for CLI agent runs.
 4. Re-run A/B benchmark only after timeout regression is fixed.
+
+---
+
+## Dogfood Run 004 Results (Timeout-Hardened A/B)
+
+### Date
+- 2026-03-03
+
+### Goal
+- Re-run baseline vs enhanced comparison after timeout hardening to ensure non-empty machine-readable failure artifacts and objective scoring.
+
+### Benchmark Configuration
+- **Baseline**:
+  - `aragora ask <task> --agents openrouter(claude/gpt/gemini) --rounds 1 --consensus majority --timeout 240 --local --no-post-consensus-quality`
+- **Enhanced**:
+  - same command + `--mode orchestrator --codebase-context --codebase-context-harnesses --codebase-context-kilocode --codebase-context-rlm --codebase-context-timeout 180 --codebase-context-max-chars 100000`
+
+### Objective Score (via `scripts/dogfood_score.py`)
+
+| Metric | Baseline | Enhanced |
+|---|---:|---:|
+| Exit code | 1 | 1 |
+| Timeout | Yes | Yes |
+| Timeout seconds | 240 | 300 |
+| Final answer payload chars | 0 | 0 |
+| Composite score | 0.0 | 0.0 |
+| Winner | tie | tie |
+
+### Key Findings
+1. **Timeout artifact reliability is fixed**: both runs emitted deterministic `ARAGORA_TIMEOUT_JSON` payloads and wrote timeout report files.
+2. **A/B quality comparison still blocked**: both variants timed out before producing a final answer payload.
+3. **Enhanced context path executes further**: orchestrator lifecycle stages (`PIPE_START` through `PIPE_DONE`) are now consistently visible before timeout.
+4. **Residual runtime issue remains**: async cancellation/cleanup still surfaces resource warnings and occasional context teardown errors under strict timeout pressure.
+
+### Artifacts
+- `/tmp/dogfood_run004/baseline_stdout.txt`
+- `/tmp/dogfood_run004/baseline_stderr.txt`
+- `/tmp/dogfood_run004/baseline_timeout_report.json`
+- `/tmp/dogfood_run004/enhanced_stdout.txt`
+- `/tmp/dogfood_run004/enhanced_stderr.txt`
+- `/tmp/dogfood_run004/enhanced_timeout_report.json`
+- `/tmp/dogfood_run004/score.json`
+- `/tmp/dogfood_run004/score.md`
+
+### Gate Decision
+- **NO-GO for quality delta** (again): benchmark can now classify failures deterministically, but still cannot compare output quality without at least one completed final answer.
+
+### Run 005 Preconditions
+1. Add grounding fail-closed guardrails (`--grounding-fail-closed`, min verified path ratio) so completed runs can be auto-gated for practical utility.
+2. Keep timeout report emission as mandatory benchmark artifact.
+3. Raise per-run timeout and/or reduce agent/round load until at least one run completes with final answer text.

--- a/scripts/ci_install_project.sh
+++ b/scripts/ci_install_project.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXTRAS=""
+PROJECT_DIR=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --extras)
+      EXTRAS="${2:-}"
+      shift 2
+      ;;
+    --project-dir)
+      PROJECT_DIR="${2:-}"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+has_project_markers() {
+  local dir="$1"
+  [[ -f "${dir}/pyproject.toml" || -f "${dir}/setup.py" ]]
+}
+
+resolve_project_root() {
+  local start="$1"
+  [[ -n "$start" ]] || return 1
+  local dir
+  dir="$(cd "$start" 2>/dev/null && pwd -P)" || return 1
+  while [[ "$dir" != "/" ]]; do
+    if has_project_markers "$dir"; then
+      printf '%s\n' "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  if has_project_markers "/"; then
+    printf '/\n'
+    return 0
+  fi
+  return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_HINT="$(cd "${SCRIPT_DIR}/.." && pwd -P)"
+
+declare -a CANDIDATES=()
+if [[ -n "$PROJECT_DIR" ]]; then
+  CANDIDATES+=("$PROJECT_DIR")
+fi
+CANDIDATES+=("$PWD")
+if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+  CANDIDATES+=("${GITHUB_WORKSPACE}")
+fi
+CANDIDATES+=("$REPO_HINT")
+
+PROJECT_ROOT=""
+for candidate in "${CANDIDATES[@]}"; do
+  if root="$(resolve_project_root "$candidate" 2>/dev/null)"; then
+    PROJECT_ROOT="$root"
+    break
+  fi
+done
+
+if [[ -z "$PROJECT_ROOT" ]]; then
+  echo "::error::Could not find pyproject.toml/setup.py for editable install." >&2
+  echo "PWD=$PWD" >&2
+  echo "GITHUB_WORKSPACE=${GITHUB_WORKSPACE:-}" >&2
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+echo "[ci-install] project_root=$PROJECT_ROOT extras=${EXTRAS:-none}"
+
+if [[ -n "$EXTRAS" ]]; then
+  python -m pip install -e ".[${EXTRAS}]"
+else
+  python -m pip install -e .
+fi

--- a/scripts/dogfood_score.py
+++ b/scripts/dogfood_score.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Score baseline vs enhanced dogfood debate outputs with deterministic metrics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from aragora.debate.output_quality import OutputContract, validate_output_against_contract
+from aragora.debate.repo_grounding import assess_repo_grounding, extract_repo_paths
+
+
+TIMEOUT_PREFIX = "ARAGORA_TIMEOUT_JSON="
+CREATE_ACTION_RE = re.compile(
+    r"(?i)\b(create|add|build|scaffold|introduce|implement new|spin up)\b"
+)
+
+STANDARD_SECTIONS = [
+    "Ranked High-Level Tasks",
+    "Suggested Subtasks",
+    "Owner module / file paths",
+    "Test Plan",
+    "Rollback Plan",
+    "Gate Criteria",
+]
+
+
+@dataclass
+class RunMetrics:
+    name: str
+    timed_out: bool
+    timeout_seconds: int | None
+    elapsed_seconds: float | None
+    final_answer_chars: int
+    quality_score_10: float | None
+    practicality_score_10: float | None
+    verified_paths_ratio: float | None
+    duplicate_existing_create_ratio: float | None
+    mentioned_paths: int
+    existing_paths: int
+    missing_paths: int
+    new_paths: int
+    defects: list[str]
+    timeout_payload: dict[str, Any] | None
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def _load_timeout_payload(report_path: Path | None, stdout_text: str) -> dict[str, Any] | None:
+    if report_path and report_path.exists():
+        raw = _read_text(report_path).strip()
+        if raw:
+            try:
+                return json.loads(raw)
+            except json.JSONDecodeError:
+                pass
+
+    for line in stdout_text.splitlines():
+        if not line.startswith(TIMEOUT_PREFIX):
+            continue
+        raw = line[len(TIMEOUT_PREFIX) :].strip()
+        if not raw:
+            continue
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+def _extract_final_answer(stdout_text: str) -> str:
+    marker = "FINAL ANSWER:"
+    if marker not in stdout_text:
+        return ""
+    idx = stdout_text.find(marker)
+    chunk = stdout_text[idx + len(marker) :]
+    lines = chunk.splitlines()
+    # Remove leading separators/empty lines after marker.
+    while lines and (not lines[0].strip() or set(lines[0].strip()) <= {"="}):
+        lines.pop(0)
+
+    stop_prefixes = (
+        "[path-check]",
+        "[quality]",
+        "WHY THIS ANSWER:",
+        "DISSENTING VIEWS:",
+        TIMEOUT_PREFIX,
+    )
+    out_lines: list[str] = []
+    for line in lines:
+        if line.strip().startswith(stop_prefixes):
+            break
+        out_lines.append(line)
+    return "\n".join(out_lines).strip()
+
+
+def _duplicate_existing_create_ratio(answer: str, repo_root: Path) -> float | None:
+    if not answer.strip():
+        return None
+
+    total_create_paths = 0
+    duplicate_existing = 0
+    for raw_line in answer.splitlines():
+        line = raw_line.strip()
+        if not line or not CREATE_ACTION_RE.search(line):
+            continue
+        paths = extract_repo_paths(line)
+        if not paths:
+            continue
+        for rel in paths:
+            total_create_paths += 1
+            if (repo_root / rel).exists():
+                duplicate_existing += 1
+
+    if total_create_paths == 0:
+        return None
+    return round(duplicate_existing / total_create_paths, 4)
+
+
+def _score_run(
+    name: str,
+    stdout_path: Path,
+    timeout_report_path: Path | None,
+    repo_root: Path,
+) -> RunMetrics:
+    stdout_text = _read_text(stdout_path)
+    timeout_payload = _load_timeout_payload(timeout_report_path, stdout_text)
+    final_answer = _extract_final_answer(stdout_text)
+
+    timed_out = bool(timeout_payload and timeout_payload.get("status") == "timeout")
+    timeout_seconds = (
+        int(timeout_payload["timeout_seconds"])
+        if timeout_payload and "timeout_seconds" in timeout_payload
+        else None
+    )
+    elapsed_seconds = (
+        float(timeout_payload["elapsed_seconds"])
+        if timeout_payload and "elapsed_seconds" in timeout_payload
+        else None
+    )
+
+    if not final_answer:
+        return RunMetrics(
+            name=name,
+            timed_out=timed_out,
+            timeout_seconds=timeout_seconds,
+            elapsed_seconds=elapsed_seconds,
+            final_answer_chars=0,
+            quality_score_10=None,
+            practicality_score_10=None,
+            verified_paths_ratio=None,
+            duplicate_existing_create_ratio=None,
+            mentioned_paths=0,
+            existing_paths=0,
+            missing_paths=0,
+            new_paths=0,
+            defects=["no_final_answer_payload"],
+            timeout_payload=timeout_payload,
+        )
+
+    contract = OutputContract(
+        required_sections=STANDARD_SECTIONS,
+        require_json_payload=False,
+        require_gate_thresholds=True,
+        require_rollback_triggers=True,
+        require_owner_paths=True,
+        require_repo_path_existence=True,
+        require_practicality_checks=True,
+    )
+    quality = validate_output_against_contract(final_answer, contract, repo_root=str(repo_root))
+    grounding = assess_repo_grounding(
+        final_answer, repo_root=str(repo_root), require_owner_paths=True
+    )
+
+    total_paths = len(grounding.mentioned_paths)
+    verified_ratio = (
+        round(len(grounding.existing_paths) / total_paths, 4) if total_paths > 0 else 0.0
+    )
+    duplicate_ratio = _duplicate_existing_create_ratio(final_answer, repo_root)
+
+    return RunMetrics(
+        name=name,
+        timed_out=timed_out,
+        timeout_seconds=timeout_seconds,
+        elapsed_seconds=elapsed_seconds,
+        final_answer_chars=len(final_answer),
+        quality_score_10=quality.quality_score_10,
+        practicality_score_10=quality.practicality_score_10,
+        verified_paths_ratio=verified_ratio,
+        duplicate_existing_create_ratio=duplicate_ratio,
+        mentioned_paths=total_paths,
+        existing_paths=len(grounding.existing_paths),
+        missing_paths=len(grounding.missing_paths),
+        new_paths=len(grounding.new_paths),
+        defects=list(quality.defects),
+        timeout_payload=timeout_payload,
+    )
+
+
+def _composite_score(run: RunMetrics) -> float:
+    if run.timed_out or run.final_answer_chars == 0:
+        return 0.0
+
+    verified = run.verified_paths_ratio if run.verified_paths_ratio is not None else 0.0
+    dup_penalty = (
+        1.0 - run.duplicate_existing_create_ratio
+        if run.duplicate_existing_create_ratio is not None
+        else 1.0
+    )
+    quality = (run.quality_score_10 or 0.0) / 10.0
+    practical = (run.practicality_score_10 or 0.0) / 10.0
+
+    # Weighted blend emphasizing path grounding and practical quality.
+    score = (0.35 * verified) + (0.25 * dup_penalty) + (0.2 * quality) + (0.2 * practical)
+    return round(score, 4)
+
+
+def _build_summary(baseline: RunMetrics, enhanced: RunMetrics) -> dict[str, Any]:
+    baseline_score = _composite_score(baseline)
+    enhanced_score = _composite_score(enhanced)
+    timeout_rate = round(
+        (int(baseline.timed_out) + int(enhanced.timed_out)) / 2.0,
+        4,
+    )
+
+    winner = "tie"
+    if enhanced_score > baseline_score:
+        winner = "enhanced"
+    elif baseline_score > enhanced_score:
+        winner = "baseline"
+
+    return {
+        "timeout_rate": timeout_rate,
+        "composite_scores": {"baseline": baseline_score, "enhanced": enhanced_score},
+        "deltas": {
+            "quality_score_10": (
+                None
+                if baseline.quality_score_10 is None or enhanced.quality_score_10 is None
+                else round(enhanced.quality_score_10 - baseline.quality_score_10, 4)
+            ),
+            "practicality_score_10": (
+                None
+                if baseline.practicality_score_10 is None or enhanced.practicality_score_10 is None
+                else round(enhanced.practicality_score_10 - baseline.practicality_score_10, 4)
+            ),
+            "verified_paths_ratio": (
+                None
+                if baseline.verified_paths_ratio is None or enhanced.verified_paths_ratio is None
+                else round(enhanced.verified_paths_ratio - baseline.verified_paths_ratio, 4)
+            ),
+            "duplicate_existing_create_ratio": (
+                None
+                if baseline.duplicate_existing_create_ratio is None
+                or enhanced.duplicate_existing_create_ratio is None
+                else round(
+                    enhanced.duplicate_existing_create_ratio
+                    - baseline.duplicate_existing_create_ratio,
+                    4,
+                )
+            ),
+        },
+        "winner": winner,
+    }
+
+
+def _write_markdown(
+    path: Path, baseline: RunMetrics, enhanced: RunMetrics, summary: dict[str, Any]
+) -> None:
+    lines = [
+        "# Dogfood A/B Score",
+        "",
+        "| Metric | Baseline | Enhanced |",
+        "|---|---:|---:|",
+        f"| timed_out | {baseline.timed_out} | {enhanced.timed_out} |",
+        f"| quality_score_10 | {baseline.quality_score_10} | {enhanced.quality_score_10} |",
+        f"| practicality_score_10 | {baseline.practicality_score_10} | {enhanced.practicality_score_10} |",
+        f"| verified_paths_ratio | {baseline.verified_paths_ratio} | {enhanced.verified_paths_ratio} |",
+        f"| duplicate_existing_create_ratio | {baseline.duplicate_existing_create_ratio} | {enhanced.duplicate_existing_create_ratio} |",
+        f"| composite_score | {summary['composite_scores']['baseline']} | {summary['composite_scores']['enhanced']} |",
+        "",
+        f"- timeout_rate: {summary['timeout_rate']}",
+        f"- winner: {summary['winner']}",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-stdout", required=True)
+    parser.add_argument("--enhanced-stdout", required=True)
+    parser.add_argument("--baseline-timeout-report")
+    parser.add_argument("--enhanced-timeout-report")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--output-md")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = Path(args.repo_root).expanduser().resolve()
+
+    baseline = _score_run(
+        name="baseline",
+        stdout_path=Path(args.baseline_stdout).expanduser(),
+        timeout_report_path=(
+            Path(args.baseline_timeout_report).expanduser()
+            if args.baseline_timeout_report
+            else None
+        ),
+        repo_root=repo_root,
+    )
+    enhanced = _score_run(
+        name="enhanced",
+        stdout_path=Path(args.enhanced_stdout).expanduser(),
+        timeout_report_path=(
+            Path(args.enhanced_timeout_report).expanduser()
+            if args.enhanced_timeout_report
+            else None
+        ),
+        repo_root=repo_root,
+    )
+    summary = _build_summary(baseline, enhanced)
+
+    payload = {
+        "baseline": asdict(baseline),
+        "enhanced": asdict(enhanced),
+        "summary": summary,
+    }
+
+    output_json = Path(args.output_json).expanduser()
+    output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.output_md:
+        _write_markdown(Path(args.output_md).expanduser(), baseline, enhanced, summary)
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -242,6 +242,123 @@ def test_cmd_ask_async_timeout_emits_machine_payload(monkeypatch, capsys):
     assert payload["final_answer"] == ""
 
 
+def test_cmd_ask_grounding_fail_closed_rejects_ungrounded_output(monkeypatch, capsys):
+    """Grounding fail-closed should reject outputs without verifiable repo paths."""
+    from aragora.cli.commands import debate as debate_cmd
+    from aragora.core import DebateResult
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+
+    args = argparse.Namespace(
+        task="Grounding gate test",
+        agents="claude,openai",
+        rounds=1,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=False,
+        api=False,
+        local=True,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+        timeout=30,
+        post_consensus_quality=False,
+        grounding_fail_closed=True,
+        grounding_min_verified_paths=0.8,
+    )
+
+    result = DebateResult(
+        task=args.task, final_answer="No concrete file paths are listed.", metadata={}
+    )
+
+    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock, return_value=result):
+        with pytest.raises(SystemExit) as exc_info:
+            debate_cmd.cmd_ask(args)
+
+    assert exc_info.value.code == 1
+    assert "Debate failed grounding gate" in capsys.readouterr().err
+
+
+def test_cmd_ask_grounding_fail_closed_accepts_grounded_output(monkeypatch, capsys):
+    """Grounding fail-closed should pass when existing repo path ratio meets threshold."""
+    from aragora.cli.commands import debate as debate_cmd
+    from aragora.core import DebateResult
+
+    monkeypatch.delenv("ARAGORA_OFFLINE", raising=False)
+
+    args = argparse.Namespace(
+        task="Grounding gate pass test",
+        agents="claude,openai",
+        rounds=1,
+        consensus="judge",
+        context="",
+        learn=True,
+        db=":memory:",
+        demo=False,
+        api=False,
+        local=True,
+        graph=False,
+        matrix=False,
+        decision_integrity=False,
+        auto_select=False,
+        auto_select_config=None,
+        enable_verticals=False,
+        vertical=None,
+        calibration=True,
+        evidence_weighting=True,
+        trending=True,
+        mode=None,
+        api_url="http://localhost:8080",
+        api_key=None,
+        verbose=False,
+        graph_rounds=3,
+        branch_threshold=0.7,
+        max_branches=3,
+        scenario=None,
+        matrix_rounds=3,
+        di_include_context=False,
+        di_plan_strategy="single_task",
+        di_execution_mode=None,
+        timeout=30,
+        post_consensus_quality=False,
+        grounding_fail_closed=True,
+        grounding_min_verified_paths=0.5,
+    )
+
+    result = DebateResult(
+        task=args.task,
+        final_answer="Update aragora/cli/commands/debate.py and tests/cli/test_offline_golden_path.py.",
+        metadata={},
+    )
+
+    with patch.object(debate_cmd, "run_debate", new_callable=AsyncMock, return_value=result):
+        debate_cmd.cmd_ask(args)
+
+    out = capsys.readouterr().out
+    assert "[path-check] grounded=" in out
+
+
 def test_cmd_ask_quality_fail_closed_requires_contract(monkeypatch, capsys):
     """Fail-closed quality mode should reject runs without an explicit contract."""
     from aragora.cli.commands import debate as debate_cmd

--- a/tests/debate/test_presets_extended.py
+++ b/tests/debate/test_presets_extended.py
@@ -203,3 +203,27 @@ class TestCLIPresetChoices:
         assert args.codebase_context_rlm is False
         assert args.codebase_context_max_chars == 80000
         assert args.codebase_context_timeout == 240
+
+    def test_grounding_gate_flags_parse(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "ask",
+                "test question",
+                "--grounding-fail-closed",
+                "--grounding-min-verified-paths",
+                "0.9",
+            ]
+        )
+        assert args.grounding_fail_closed is True
+        assert args.grounding_min_verified_paths == 0.9
+
+    def test_grounding_gate_defaults(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["ask", "test question"])
+        assert args.grounding_fail_closed is False
+        assert args.grounding_min_verified_paths == 0.8


### PR DESCRIPTION
## Summary
- run dogfood run-004 A/B benchmark (baseline vs codebase-context enhanced) with timeout artifact capture
- add `scripts/dogfood_score.py` to score baseline/enhanced runs on:
  - `% verified paths`
  - `% duplicate existing-module create-proposals`
  - timeout status/rate
  - quality/practicality scores (when final answer payload exists)
- add grounding fail-closed controls to `aragora ask`:
  - `--grounding-fail-closed`
  - `--grounding-min-verified-paths`
- enforce grounding gate in both API and local ask flows using repo path verification
- harden CI workflow install assumptions by introducing `scripts/ci_install_project.sh` and using it in:
  - `.github/workflows/core-suites.yml`
  - `.github/workflows/benchmark.yml`
  - `.github/workflows/security-gate.yml`
- document run-004 metrics and gate decision in roadmap/spec docs

## Dogfood run-004 result
- baseline timeout: yes (`240s`)
- enhanced timeout: yes (`300s`)
- timeout artifacts: deterministic `ARAGORA_TIMEOUT_JSON` emitted and persisted for both runs
- objective score: tie (`0.0` vs `0.0`) due no final answer payload from either run

## Validation
- `python3 -m pytest tests/cli/test_offline_golden_path.py tests/debate/test_presets_extended.py tests/debate/test_codebase_context.py tests/debate/test_repo_grounding.py tests/test_cli_main.py::TestCommandHandlers::test_cmd_ask_runs_debate -q`
- `python3 -m pytest tests/cli/test_offline_golden_path.py tests/debate/test_presets_extended.py -q`
- `python3 -m ruff check aragora/cli/commands/debate.py aragora/cli/parser.py scripts/dogfood_score.py tests/cli/test_offline_golden_path.py tests/debate/test_presets_extended.py`
