### PR TITLE
docs: record dogfood run-005 A/B completion and scoring metrics

### DIFF
--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -119,23 +119,31 @@ Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. A
 
 See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
 
-### Dogfood Telemetry (Runs 003-004)
+### Dogfood Telemetry (Runs 003-005)
 
 | Run | Objective | Result | Blocking Metric |
 |---|---|---|---|
 | Run 003 | Baseline vs enhanced quality comparison after context injection wiring | **No-go** | Final answer payload missing in both variants |
 | Run 004 | Re-test with timeout hardening + deterministic timeout receipts | **No-go (quality delta)** | Timeout rate = **1.0** (both variants timed out) |
+| Run 005 | Reduced-latency A/B to force completion + scoring | **Partial go** | Quality score remained **0.0** for both variants under strict section contract |
 
 What improved in Run 004:
 - Timeout failures are now machine-parseable (`ARAGORA_TIMEOUT_JSON` + timeout report files).
 - Benchmark classification is deterministic (infra timeout vs low-quality output).
 
+What improved in Run 005:
+- Both baseline and enhanced variants completed with final answer payloads (timeout rate **0.0**).
+- Objective scorer (`scripts/dogfood_score.py`) produced comparable A/B outputs.
+- Enhanced variant reduced duplicate existing-component create proposals (0.50 -> 0.00 in the scored run).
+
 What still blocks meaningful quality comparison:
-- Debate runs frequently exceed wall-clock budget before final synthesis payload is emitted.
+- Structured section contract compliance is inconsistent (both runs scored 0.0 quality under strict required-section headings).
+- Grounded path quality still varies run-to-run and requires fail-closed gating to enforce floor quality.
 
 Roadmap implication:
 - Treat runtime stability as a gating dependency for context-quality A/B claims.
 - Enforce grounding gates on completed outputs (`--grounding-fail-closed`, verified path ratio threshold) before accepting benchmark wins.
+- Add explicit output-section contract requirements to dogfood prompts so quality scoring is apples-to-apples.
 
 ---
 

--- a/docs/plans/dogfood-run-001-spec.md
+++ b/docs/plans/dogfood-run-001-spec.md
@@ -484,3 +484,63 @@ This dissent is wrong in the specific case (the tasks duplicate existing work) b
 1. Add grounding fail-closed guardrails (`--grounding-fail-closed`, min verified path ratio) so completed runs can be auto-gated for practical utility.
 2. Keep timeout report emission as mandatory benchmark artifact.
 3. Raise per-run timeout and/or reduce agent/round load until at least one run completes with final answer text.
+
+---
+
+## Dogfood Run 005 Results (Reduced-Latency Completion A/B)
+
+### Date
+- 2026-03-03
+
+### Goal
+- Achieve completed baseline and enhanced runs with real final answer payloads, then score objectively.
+
+### Configuration
+- **Team**: 2 agents via OpenRouter (`gemini-2.0-flash-001` proposer, `gpt-4o` synthesizer)
+- **Rounds**: 1
+- **Consensus**: majority
+- **Runtime controls**: `--no-post-consensus-quality --no-learn --no-calibration --no-evidence-weighting --no-trending`
+- **Baseline timeout**: 420s
+- **Enhanced timeout**: 420s
+- **Enhanced context mode**: `--mode orchestrator --codebase-context` (static context only; no harness/rlm expansion)
+
+### Execution Results
+
+| Variant | Exit | Duration | Final answer present | Timeout |
+|---|---:|---:|---:|---:|
+| Baseline | 0 | 160.15s | Yes | No |
+| Enhanced | 0 | 193.76s | Yes | No |
+
+### Objective Score (`scripts/dogfood_score.py`)
+
+| Metric | Baseline | Enhanced |
+|---|---:|---:|
+| Composite score | 0.3794 | **0.4468** |
+| Verified existing path ratio | **0.5000** | 0.3571 |
+| Duplicate existing create-ratio (lower is better) | 0.5000 | **0.0000** |
+| Practicality score (deterministic) | **3.97** | 3.59 |
+| Quality score (section-contract) | 0.0 | 0.0 |
+
+Summary:
+- **Winner by composite score**: Enhanced
+- **Timeout rate**: 0.0 (both runs completed)
+
+### Interpretation
+1. Runtime stability goal succeeded: both runs completed and produced scoreable outputs.
+2. Enhanced context reduced “create-new-when-already-exists” behavior (duplicate-create ratio improved from 0.50 to 0.00).
+3. Enhanced context did not improve structured output compliance: both outputs missed required section headings under the strict score contract, leaving quality score at 0.0.
+4. Path grounding is still mixed: enhanced output referenced fewer verifiable existing paths in this run.
+
+### Artifacts
+- `/tmp/dogfood_run005/a_baseline_stdout.txt`
+- `/tmp/dogfood_run005/a_baseline_stderr.txt`
+- `/tmp/dogfood_run005/a_baseline_status.json`
+- `/tmp/dogfood_run005/a_enhanced_stdout.txt`
+- `/tmp/dogfood_run005/a_enhanced_stderr.txt`
+- `/tmp/dogfood_run005/a_enhanced_status.json`
+- `/tmp/dogfood_run005/score_a.json`
+- `/tmp/dogfood_run005/score_a.md`
+
+### Gate Decision
+- **Partial GO**: runtime and scoring harness are now usable for A/B.
+- **No GO for quality claims** until output structure contract is enforced at generation time (e.g., required section headings + grounding fail-closed).


### PR DESCRIPTION
## Summary
- execute dogfood run-005 A/B with reduced-latency settings to force completed payloads
- score baseline vs enhanced with `scripts/dogfood_score.py`
- record run-005 metrics, artifacts, and gate decision in roadmap/spec docs

## Run-005 headline
- baseline: exit 0, 160.15s, final answer present
- enhanced: exit 0, 193.76s, final answer present
- timeout rate: 0.0
- composite winner: enhanced (0.4468 vs 0.3794)
- caveat: strict section-contract quality remained 0.0 for both outputs

## Artifacts
- `/tmp/dogfood_run005/a_baseline_status.json`
- `/tmp/dogfood_run005/a_enhanced_status.json`
- `/tmp/dogfood_run005/score_a.json`
- `/tmp/dogfood_run005/score_a.md`
