### PR TITLE
docs(coordination): add live single-lane PR override rules

### DIFF
--- a/docs/AGENT_ASSIGNMENTS.md
+++ b/docs/AGENT_ASSIGNMENTS.md
@@ -2,6 +2,17 @@
 
 **Purpose:** Suggested focus areas for AI coding agents to minimize conflicts.
 
+## Live Coordination Override (March 4, 2026)
+
+Use these rules before reading track-level assignments:
+
+1. One active ready PR at a time per stream. All other PRs must be draft with auto-merge disabled.
+2. Current CI lane owner: `#540` (`fix/ci-integrity-consolidated`). Do not open parallel CI-hardening PRs until `#540` lands or is explicitly replaced.
+3. Context-engineering baseline already landed in `main` via `#529`. Do not open derivative PRs for `codebase_context.py`, `repo_grounding.py`, or `cli/commands/debate.py` without explicit owner handoff.
+4. Before starting work, post ownership in this file (branch, PR number, touched paths, owner handle, timestamp).
+5. If repo state changes unexpectedly (detached HEAD, unknown edits, disappearing worktree), stop and move to a fresh worktree from `origin/main` before continuing.
+6. CI queue hygiene: cancel queued PR runs for closed branches before retriggering checks on the active lane.
+
 ---
 
 ## Recommended Agent Setup

--- a/docs/debate/AGENT_ASSIGNMENTS.md
+++ b/docs/debate/AGENT_ASSIGNMENTS.md
@@ -2,6 +2,17 @@
 
 **Purpose:** Suggested focus areas for AI coding agents to minimize conflicts.
 
+## Live Coordination Override (March 4, 2026)
+
+Use these rules before reading track-level assignments:
+
+1. One active ready PR at a time per stream. All other PRs must be draft with auto-merge disabled.
+2. Current CI lane owner: `#540` (`fix/ci-integrity-consolidated`). Do not open parallel CI-hardening PRs until `#540` lands or is explicitly replaced.
+3. Context-engineering baseline already landed in `main` via `#529`. Do not open derivative PRs for `codebase_context.py`, `repo_grounding.py`, or `cli/commands/debate.py` without explicit owner handoff.
+4. Before starting work, post ownership in this file (branch, PR number, touched paths, owner handle, timestamp).
+5. If repo state changes unexpectedly (detached HEAD, unknown edits, disappearing worktree), stop and move to a fresh worktree from `origin/main` before continuing.
+6. CI queue hygiene: cancel queued PR runs for closed branches before retriggering checks on the active lane.
+
 ---
 
 ## Recommended Agent Setup


### PR DESCRIPTION
Adds explicit single-lane override guidance to coordination assignment docs for high-churn merge windows.