### PR TITLE
fix(landing): remove sidebar and example chips from landing page

### DIFF
--- a/aragora/live/src/components/landing/Header.tsx
+++ b/aragora/live/src/components/landing/Header.tsx
@@ -2,13 +2,11 @@
 
 import Link from 'next/link';
 import { useTheme } from '@/context/ThemeContext';
-import { useLayout } from '@/context/LayoutContext';
 import { Logo } from '@/components/Logo';
 import { ThemeSelector } from './ThemeSelector';
 
 export function Header() {
   const { theme } = useTheme();
-  const { toggleLeftSidebar } = useLayout();
 
   return (
     <header
@@ -22,7 +20,7 @@ export function Header() {
       <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
         {/* Logo mark + Wordmark */}
         <div className="flex items-center gap-3">
-          <Logo size="lg" pixelSize={28} onClick={toggleLeftSidebar} />
+          <Logo size="lg" pixelSize={28} />
           <Link href="/landing" className="flex items-center">
             <span
             className="font-bold"

--- a/aragora/live/src/components/landing/HeroSection.tsx
+++ b/aragora/live/src/components/landing/HeroSection.tsx
@@ -18,13 +18,6 @@ const ASCII_BANNER = `    \u2584\u2584\u2584       \u2588\u2588\u2580\u2588\u258
      \u2591   \u2592     \u2591\u2591   \u2591   \u2591   \u2592   \u2591 \u2591   \u2591 \u2591 \u2591 \u2591 \u2592    \u2591\u2591   \u2591   \u2591   \u2592
          \u2591  \u2591   \u2591           \u2591  \u2591      \u2591     \u2591 \u2591     \u2591           \u2591  \u2591`;
 
-const EXAMPLE_TOPICS = [
-  'Should we adopt microservices?',
-  'Build vs buy our auth system',
-  'Is remote-first the right policy?',
-  'Should we raise a Series A now?',
-];
-
 const PROGRESS_MESSAGES = [
   'Assembling analyst panel...',
   'Agents debating your question...',
@@ -306,41 +299,6 @@ export function HeroSection(props: Partial<HeroSectionProps> & Record<string, un
             {isRunning ? 'Agents debating...' : isDark ? '> Start Debate' : 'Start Debate'}
           </button>
         </form>
-
-        {/* Example topic chips — reduce blank-textarea friction */}
-        {!isRunning && !result && (
-          <div className="flex flex-wrap justify-center gap-2 mt-6 max-w-xl mx-auto">
-            {EXAMPLE_TOPICS.map((topic) => (
-              <button
-                key={topic}
-                type="button"
-                onClick={() => { setQuestion(topic); }}
-                className="text-xs transition-all hover:scale-[1.02] cursor-pointer"
-                style={{
-                  fontFamily: 'var(--font-landing)',
-                  color: 'var(--text-muted)',
-                  backgroundColor: 'var(--surface)',
-                  border: '1px solid var(--border)',
-                  borderRadius: 'var(--radius-button)',
-                  padding: '8px 14px',
-                  opacity: 0.7,
-                }}
-                onMouseEnter={(e) => {
-                  e.currentTarget.style.borderColor = 'var(--accent)';
-                  e.currentTarget.style.color = 'var(--accent)';
-                  e.currentTarget.style.opacity = '1';
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.borderColor = 'var(--border)';
-                  e.currentTarget.style.color = 'var(--text-muted)';
-                  e.currentTarget.style.opacity = '0.7';
-                }}
-              >
-                {isDark ? `> ${topic}` : topic}
-              </button>
-            ))}
-          </div>
-        )}
 
         {/* Loading state */}
         {isRunning && (

--- a/aragora/live/src/components/landing/LandingPage.tsx
+++ b/aragora/live/src/components/landing/LandingPage.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
 import { useTheme } from '@/context/ThemeContext';
-import { useLayout } from '@/context/LayoutContext';
-import { LeftSidebar } from '@/components/layout/LeftSidebar';
 import { Header } from './Header';
 import { HeroSection } from './HeroSection';
 import { HowItWorksSection } from './HowItWorksSection';
@@ -16,18 +13,6 @@ import { Footer } from './Footer';
 
 export function LandingPage() {
   const { theme } = useTheme();
-  const { leftSidebarOpen, leftSidebarWidth, closeLeftSidebar, isMobile } = useLayout();
-
-  // Sidebar starts closed on the landing page.
-  // LayoutProvider auto-opens it on desktop; setTimeout ensures our close
-  // runs after the provider's initialization effect.
-  const closedOnMountRef = useRef(false);
-  useEffect(() => {
-    if (!closedOnMountRef.current) {
-      closedOnMountRef.current = true;
-      setTimeout(closeLeftSidebar, 0);
-    }
-  }, [closeLeftSidebar]);
 
   return (
     <div
@@ -39,24 +24,15 @@ export function LandingPage() {
       }}
       data-landing-theme={theme}
     >
-      {/* Collapsible sidebar — self-hides when closed */}
-      <LeftSidebar />
-
-      {/* Main content — shifts right when sidebar is open on desktop */}
-      <div
-        className="transition-all duration-200"
-        style={{ marginLeft: !isMobile && leftSidebarOpen ? leftSidebarWidth : 0 }}
-      >
-        <Header />
-        <HeroSection />
-        <HowItWorksSection />
-        <ProblemSection />
-        <FeatureShowcase />
-        <IntegrationsGrid />
-        <LiveDemoSection />
-        <PricingSection />
-        <Footer />
-      </div>
+      <Header />
+      <HeroSection />
+      <HowItWorksSection />
+      <ProblemSection />
+      <FeatureShowcase />
+      <IntegrationsGrid />
+      <LiveDemoSection />
+      <PricingSection />
+      <Footer />
     </div>
   );
 }

--- a/aragora/live/src/components/landing/__tests__/LandingPage.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/LandingPage.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { LandingPage } from '../LandingPage';
 
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ theme: 'dark', setTheme: jest.fn() }),
+}));
+
 // Mock all child components to isolate LandingPage logic
 jest.mock('../Header', () => ({
   Header: () => <header data-testid="header">Header</header>,
@@ -8,43 +12,36 @@ jest.mock('../Header', () => ({
 
 jest.mock('../HeroSection', () => ({
   HeroSection: () => (
-    <div data-testid="hero-section">
-      <a href="/playground">TRY A FREE DEBATE</a>
-      <a href="/login">SIGN IN FOR REAL AI MODELS</a>
-    </div>
+    <div data-testid="hero-section">Hero</div>
   ),
 }));
 
-jest.mock('../VerticalCards', () => ({
-  VerticalCards: () => <section data-testid="vertical-cards">Vertical Cards</section>,
+jest.mock('../HowItWorksSection', () => ({
+  HowItWorksSection: () => <section data-testid="how-it-works">How It Works</section>,
 }));
 
-jest.mock('../WhyAragoraSection', () => ({
-  WhyAragoraSection: () => <section data-testid="why-aragora">Why Aragora</section>,
+jest.mock('../ProblemSection', () => ({
+  ProblemSection: () => <section data-testid="problem">Problem</section>,
 }));
 
-jest.mock('../DebateProtocolSection', () => ({
-  DebateProtocolSection: () => (
-    <section data-testid="debate-protocol">Debate Protocol</section>
-  ),
+jest.mock('../FeatureShowcase', () => ({
+  FeatureShowcase: () => <section data-testid="features">Features</section>,
 }));
 
-jest.mock('../CapabilitiesSection', () => ({
-  CapabilitiesSection: () => (
-    <section data-testid="capabilities">Capabilities</section>
-  ),
+jest.mock('../IntegrationsGrid', () => ({
+  IntegrationsGrid: () => <section data-testid="integrations">Integrations</section>,
 }));
 
-jest.mock('../TrustSection', () => ({
-  TrustSection: () => <section data-testid="trust">Trust</section>,
-}));
-
-jest.mock('../Footer', () => ({
-  Footer: () => <footer data-testid="footer">Footer</footer>,
+jest.mock('../LiveDemoSection', () => ({
+  LiveDemoSection: () => <section data-testid="live-demo">Live Demo</section>,
 }));
 
 jest.mock('../PricingSection', () => ({
   PricingSection: () => <section data-testid="pricing-section">Pricing</section>,
+}));
+
+jest.mock('../Footer', () => ({
+  Footer: () => <footer data-testid="footer">Footer</footer>,
 }));
 
 describe('LandingPage', () => {
@@ -53,45 +50,32 @@ describe('LandingPage', () => {
   });
 
   describe('initial render', () => {
-    it('renders all page sections in correct order', () => {
+    it('renders all page sections', () => {
       render(<LandingPage />);
 
       expect(screen.getByTestId('header')).toBeInTheDocument();
       expect(screen.getByTestId('hero-section')).toBeInTheDocument();
-      expect(screen.getByTestId('vertical-cards')).toBeInTheDocument();
-      expect(screen.getByTestId('why-aragora')).toBeInTheDocument();
-      expect(screen.getByTestId('debate-protocol')).toBeInTheDocument();
-      expect(screen.getByTestId('capabilities')).toBeInTheDocument();
-      expect(screen.getByTestId('trust')).toBeInTheDocument();
+      expect(screen.getByTestId('how-it-works')).toBeInTheDocument();
+      expect(screen.getByTestId('problem')).toBeInTheDocument();
+      expect(screen.getByTestId('features')).toBeInTheDocument();
+      expect(screen.getByTestId('integrations')).toBeInTheDocument();
+      expect(screen.getByTestId('live-demo')).toBeInTheDocument();
+      expect(screen.getByTestId('pricing-section')).toBeInTheDocument();
       expect(screen.getByTestId('footer')).toBeInTheDocument();
     });
 
-    it('renders main element with proper classes', () => {
-      render(<LandingPage />);
+    it('renders container with min-h-screen', () => {
+      const { container } = render(<LandingPage />);
 
-      const main = screen.getByRole('main');
-      expect(main).toHaveClass('min-h-screen');
+      const wrapper = container.firstElementChild;
+      expect(wrapper).toHaveClass('min-h-screen');
     });
 
-    it('renders dual CTA buttons in hero section', () => {
+    it('does not render a sidebar', () => {
       render(<LandingPage />);
 
-      expect(screen.getByText('TRY A FREE DEBATE')).toBeInTheDocument();
-      expect(screen.getByText('SIGN IN FOR REAL AI MODELS')).toBeInTheDocument();
-    });
-
-    it('links playground CTA to /playground', () => {
-      render(<LandingPage />);
-
-      const playgroundLink = screen.getByText('TRY A FREE DEBATE').closest('a');
-      expect(playgroundLink).toHaveAttribute('href', '/playground');
-    });
-
-    it('links sign-in CTA to /login', () => {
-      render(<LandingPage />);
-
-      const loginLink = screen.getByText('SIGN IN FOR REAL AI MODELS').closest('a');
-      expect(loginLink).toHaveAttribute('href', '/login');
+      // Landing page should not include any sidebar
+      expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove `LeftSidebar` from landing page entirely (fixes sidebar auto-opening on desktop)
- Remove sidebar toggle from landing Header logo click
- Remove example topic chips from HeroSection
- Update stale `LandingPage` tests to match current component structure

The sidebar kept re-opening because `LayoutContext` auto-opens on desktop, racing with LandingPage's `setTimeout(closeLeftSidebar, 0)` effect. The proper fix: the marketing landing page shouldn't include the app sidebar at all — it has its own `Header` with nav links.

## Test plan
- [x] `next build` passes
- [x] LandingPage unit tests pass (3/3)
- [ ] Visual QA: verify no sidebar appears on landing page load
- [ ] Verify logo click no longer opens sidebar on landing

🤖 Generated with [Claude Code](https://claude.com/claude-code)