### PR TITLE
ci(gauntlet): add checkout integrity recovery guard

### DIFF
--- a/.github/workflows/aragora-gauntlet.yml
+++ b/.github/workflows/aragora-gauntlet.yml
@@ -29,6 +29,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify checkout integrity
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git reset --hard HEAD || true
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            git rev-parse --show-toplevel || true
+            ls -la
+            find . -maxdepth 3 -name pyproject.toml -print || true
+            exit 1
+          fi
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add a checkout-integrity verification step to `.github/workflows/aragora-gauntlet.yml`
- auto-recover from sparse/incomplete checkout before `pip install -e .`
- fail fast with diagnostics if `pyproject.toml` is still missing

## Why
Recent Gauntlet runs failed during install with `pyproject.toml` missing due to incomplete checkout state on runner workspace reuse. This aligns Gauntlet with the existing resilience pattern already used by lint/typecheck jobs.

## Validation
- `python3` YAML parse for `.github/workflows/aragora-gauntlet.yml`
- local pre-commit hooks passed on commit