### PR TITLE
fix(ci): cache-based deploy tracking for reliable scheduled deploys

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -117,37 +117,25 @@ jobs:
             exit 1
           fi
 
-      - name: Ensure GitHub CLI is available
+      - name: Check if SHA already deployed (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          if command -v gh >/dev/null 2>&1; then
-            gh --version | head -1
-            exit 0
-          fi
-          echo "::warning::gh CLI missing on runner; installing fallback package"
-          if command -v sudo >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y gh
-          else
-            apt-get update
-            apt-get install -y gh
-          fi
-          gh --version | head -1
+        id: deploy-cache
+        uses: actions/cache/restore@v4
+        with:
+          key: frontend-deployed-${{ github.sha }}
+          path: .deploy-marker
 
-      - name: Skip if already deployed (scheduled runs only)
+      - name: Set skip output
         if: github.event_name == 'schedule'
         id: skip-check
         run: |
-          LAST_DEPLOY_SHA=$(gh run list --workflow=deploy-frontend.yml --status=success --limit=1 --json headSha -q '.[0].headSha' 2>/dev/null || echo "")
-          if [ -n "$LAST_DEPLOY_SHA" ] && [ "$LAST_DEPLOY_SHA" = "${{ github.sha }}" ]; then
+          if [ "${{ steps.deploy-cache.outputs.cache-hit }}" = "true" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Already deployed this SHA (${{ github.sha }}), skipping"
+            echo "SHA ${{ github.sha }} was previously deployed, skipping"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "New commit detected, proceeding"
+            echo "SHA ${{ github.sha }} not yet deployed, proceeding"
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
 
       - name: Validate Vercel configuration
         if: steps.skip-check.outputs.skip != 'true'
@@ -230,6 +218,17 @@ jobs:
             VERIFY_FRONTEND_SOFT_FAIL=1 \
               bash scripts/verify_frontend_routes.sh "$DEPLOY_URL"
           fi
+
+      - name: Mark SHA as deployed
+        if: steps.skip-check.outputs.skip != 'true'
+        run: echo "${{ github.sha }}" > .deploy-marker
+
+      - name: Cache deploy marker
+        if: steps.skip-check.outputs.skip != 'true'
+        uses: actions/cache/save@v4
+        with:
+          key: frontend-deployed-${{ github.sha }}
+          path: .deploy-marker
 
   deploy-docker:
     name: Build & Push Frontend Docker Image


### PR DESCRIPTION
## Summary
- Replace self-referencing `gh run list --status=success` skip logic with Actions cache-based tracking
- After a successful Vercel deploy, save a cache marker keyed by the deployed SHA
- Scheduled runs restore the cache — only skip if the SHA was actually deployed (not just if a workflow "succeeded" by skipping)
- Removes the gh CLI bootstrap step (no longer needed)

## The Bug
The old skip logic used `gh run list --workflow=deploy-frontend.yml --status=success --limit=1` to find the last deployed SHA. But runs that skip the deploy step (because the SHA was already deployed) also complete with status "success". This created a self-referencing loop: once a SHA was deployed, all subsequent scheduled runs would see a "successful" skip-run with the same SHA and skip forever.

## The Fix
Use GitHub Actions cache (`actions/cache/save` and `actions/cache/restore`) to track which SHAs were actually deployed to Vercel. Cache entries are only created after the Vercel deploy + verification steps succeed. Skipped runs never create cache entries, breaking the self-referencing loop.

## Test plan
- [ ] Push a frontend change to main → deploy-vercel job should deploy and create cache marker
- [ ] Wait for next scheduled run → should detect cache hit and skip (correct: same SHA already deployed)
- [ ] Push another frontend change → next run should detect cache miss and deploy (correct: new SHA)
- [ ] Manual `workflow_dispatch` should always deploy (skip logic only applies to schedule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)