### PR TITLE
docs: add dogfood run-006 A/B results and reconcile repo-state context

### DIFF
--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -119,13 +119,14 @@ Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. A
 
 See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
 
-### Dogfood Telemetry (Runs 003-005)
+### Dogfood Telemetry (Runs 003-006)
 
 | Run | Objective | Result | Blocking Metric |
 |---|---|---|---|
 | Run 003 | Baseline vs enhanced quality comparison after context injection wiring | **No-go** | Final answer payload missing in both variants |
 | Run 004 | Re-test with timeout hardening + deterministic timeout receipts | **No-go (quality delta)** | Timeout rate = **1.0** (both variants timed out) |
 | Run 005 | Reduced-latency A/B to force completion + scoring | **Partial go** | Quality score remained **0.0** for both variants under strict section contract |
+| Run 006 | Enforce required output sections + grounding fail-closed, then rescore | **Partial go** | Duplicate existing create-ratio remains high (**0.4643** enhanced) |
 
 What improved in Run 004:
 - Timeout failures are now machine-parseable (`ARAGORA_TIMEOUT_JSON` + timeout report files).
@@ -136,14 +137,19 @@ What improved in Run 005:
 - Objective scorer (`scripts/dogfood_score.py`) produced comparable A/B outputs.
 - Enhanced variant reduced duplicate existing-component create proposals (0.50 -> 0.00 in the scored run).
 
-What still blocks meaningful quality comparison:
-- Structured section contract compliance is inconsistent (both runs scored 0.0 quality under strict required-section headings).
-- Grounded path quality still varies run-to-run and requires fail-closed gating to enforce floor quality.
+What improved in Run 006:
+- Required section contract compliance is now stable in both variants (`quality_score_10 = 9.0`, `practicality_score_10 = 9.74`).
+- Grounded-path quality improved in the enhanced variant (`verified_paths_ratio` 0.7647 -> **0.8235**).
+- Timeout rate stayed at **0.0** with fail-closed grounding enabled.
+
+What still blocks production-grade planning quality:
+- Duplicate existing create proposals remain too high (baseline **0.6923**, enhanced **0.4643**).
+- Output still contains synthetic path-like tokens that degrade grounding signal quality.
 
 Roadmap implication:
-- Treat runtime stability as a gating dependency for context-quality A/B claims.
-- Enforce grounding gates on completed outputs (`--grounding-fail-closed`, verified path ratio threshold) before accepting benchmark wins.
-- Add explicit output-section contract requirements to dogfood prompts so quality scoring is apples-to-apples.
+- Keep strict required-section headings and grounding fail-closed gates as benchmark defaults.
+- Add deterministic defects for duplicate-create proposals against existing repo paths.
+- Add normalization/cleanup for synthetic path-like tokens before grounding assessment.
 
 ---
 

--- a/docs/plans/dogfood-run-001-spec.md
+++ b/docs/plans/dogfood-run-001-spec.md
@@ -544,3 +544,72 @@ Summary:
 ### Gate Decision
 - **Partial GO**: runtime and scoring harness are now usable for A/B.
 - **No GO for quality claims** until output structure contract is enforced at generation time (e.g., required section headings + grounding fail-closed).
+
+---
+
+## Dogfood Run 006 Results (Section Contract + Grounding Fail-Closed A/B)
+
+### Date
+- 2026-03-03
+
+### Goal
+- Enforce required section headings and grounding fail-closed during generation, then compare baseline vs enhanced context quality with deterministic scoring.
+
+### Configuration
+- **Team**: 2 agents via OpenRouter (`gemini-2.0-flash-001` proposer, `gpt-4o` synthesizer)
+- **Rounds**: 1
+- **Consensus**: majority
+- **Hard gates in run command**:
+  - `--required-sections "Ranked High-Level Tasks,Suggested Subtasks,Owner module / file paths,Test Plan,Rollback Plan,Gate Criteria"`
+  - `--grounding-fail-closed --grounding-min-verified-paths 0.35`
+  - `--quality-min-score 7 --quality-practical-min-score 5 --quality-upgrade-max-loops 1`
+- **Enhanced context mode**: `--mode orchestrator --codebase-context --codebase-context-max-chars 60000`
+- **Timeout**: 420s per run
+
+### Execution Results
+
+| Variant | Exit | Duration | Final answer present | Timeout |
+|---|---:|---:|---:|---:|
+| Baseline | 0 | 351.53s | Yes | No |
+| Enhanced | 0 | 327.56s | Yes | No |
+
+### Objective Score (`scripts/dogfood_score.py`)
+
+| Metric | Baseline | Enhanced |
+|---|---:|---:|
+| Composite score | 0.7194 | **0.7970** |
+| Verified existing path ratio | 0.7647 | **0.8235** |
+| Duplicate existing create-ratio (lower is better) | 0.6923 | **0.4643** |
+| Practicality score (deterministic) | 9.74 | 9.74 |
+| Quality score (section-contract) | 9.0 | 9.0 |
+
+Summary:
+- **Winner by composite score**: Enhanced
+- **Timeout rate**: 0.0 (both runs completed)
+
+### Interpretation
+1. Structured output quality recovered from run-005 failure mode: both variants met required-section contract and scored high (`quality_score_10 = 9.0`).
+2. Enhanced codebase context improved grounding (`verified_paths_ratio` +0.0588) and reduced duplicate-create behavior (`duplicate_existing_create_ratio` -0.2280) versus baseline.
+3. Duplicate-create behavior is still too high in absolute terms, so this is not yet production-grade planning output.
+4. Grounding quality is good enough for fail-closed floor checks at 0.35 but still needs stricter policy to consistently hit higher thresholds.
+
+### Repository State Note (Overall Situation)
+- Run-006 was executed from a **clean disposable worktree** at `origin/main` (`codex/reconcile-worktrees-20260303-224514`) to avoid contamination from unrelated local edits in the primary checkout.
+- At run time, primary checkout was on `fix/deploy-skip-logic` with unrelated landing-page modifications and untracked assets; these were intentionally not touched.
+- Previously “valuable” `integrate/valuable-worktrees-20260304` content was already reconciled into `main` as `feat(landing): render markdown in debate results (#553)`.
+
+### Artifacts
+- `/tmp/dogfood_run006/run006_baseline_stdout.txt`
+- `/tmp/dogfood_run006/run006_baseline_stderr.txt`
+- `/tmp/dogfood_run006/run006_baseline_status.json`
+- `/tmp/dogfood_run006/run006_enhanced_stdout.txt`
+- `/tmp/dogfood_run006/run006_enhanced_stderr.txt`
+- `/tmp/dogfood_run006/run006_enhanced_status.json`
+- `/tmp/dogfood_run006/run006_enhanced_codebase_context.md`
+- `/tmp/dogfood_run006/run006_score.json`
+- `/tmp/dogfood_run006/run006_score.md`
+
+### Gate Decision
+- **GO** for quality-comparable A/B benchmarking under strict section contract.
+- **Partial GO** for grounding: floor gate passed, but path quality still has synthetic-token noise.
+- **NO-GO** for duplicate suppression target until deterministic duplicate-create checks are added to quality defects.


### PR DESCRIPTION
## Summary
- run dogfood run-006 baseline/enhanced with required-section contract and grounding fail-closed
- score outputs with \
- record run-006 telemetry, gate decision, and repository-state reconciliation note in planning docs

## Run-006 headline
- baseline: exit 0, 351.53s, final answer present
- enhanced: exit 0, 327.56s, final answer present
- timeout rate: 0.0
- quality_score_10: 9.0 (both)
- practicality_score_10: 9.74 (both)
- verified_paths_ratio: 0.7647 -> 0.8235 (enhanced)
- duplicate_existing_create_ratio: 0.6923 -> 0.4643 (enhanced)
- composite winner: enhanced (0.7970 vs 0.7194)

## Artifacts
- /tmp/dogfood_run006/run006_baseline_status.json
- /tmp/dogfood_run006/run006_enhanced_status.json
- /tmp/dogfood_run006/run006_score.json
- /tmp/dogfood_run006/run006_score.md
