### PR TITLE
ci: composite checkout-integrity action with git-fetch recovery

### DIFF
--- a/.github/actions/checkout-integrity/action.yml
+++ b/.github/actions/checkout-integrity/action.yml
@@ -1,0 +1,21 @@
+name: "Verify checkout integrity"
+description: "Ensures checkout is complete, recovers from sparse-checkout corruption"
+runs:
+  using: "composite"
+  steps:
+    - name: Verify checkout integrity
+      shell: bash
+      run: |
+        if [[ ! -f pyproject.toml ]]; then
+          echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+          git sparse-checkout disable || true
+          git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+          git reset --hard FETCH_HEAD
+          git clean -ffd || true
+        fi
+        if [[ ! -f pyproject.toml ]]; then
+          echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+          echo "PWD=$(pwd)"
+          ls -la
+          exit 1
+        fi

--- a/.github/workflows/aragora-gauntlet.yml
+++ b/.github/workflows/aragora-gauntlet.yml
@@ -29,22 +29,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/aragora-review-demo.yml
+++ b/.github/workflows/aragora-review-demo.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Aragora Multi-Agent Code Review
         uses: ./.github/actions/aragora-code-review
         with:

--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Detect autopilot-relevant changes
         id: filter
         run: |
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/backup-verification.yml
+++ b/.github/workflows/backup-verification.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -76,6 +78,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -107,6 +111,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -60,6 +60,8 @@ jobs:
         with:
           fetch-depth: 0  # Full history for benchmark comparison
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -128,6 +130,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -156,11 +160,15 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Checkout main for comparison
         uses: actions/checkout@v4
         with:
           ref: main
           path: main-branch
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -230,6 +238,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -266,6 +276,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Checkout main for baseline
         uses: actions/checkout@v4
         with:
           ref: main
           path: main-branch
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -133,6 +135,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/.github/workflows/capability-gap.yml
+++ b/.github/workflows/capability-gap.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/connector-registry.yml
+++ b/.github/workflows/connector-registry.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -44,6 +44,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/core-suites.yml
+++ b/.github/workflows/core-suites.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -61,6 +63,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -154,11 +156,15 @@ jobs:
       - name: Checkout PR
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
           path: base
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -161,6 +163,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
@@ -414,6 +418,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -44,18 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate checkout integrity
-        run: |
-          git sparse-checkout disable || true
-          if [ ! -f aragora/live/package-lock.json ]; then
-            echo "::error::Missing aragora/live/package-lock.json after checkout"
-            echo "pwd: $(pwd)"
-            echo "Top-level files:"
-            ls -la
-            echo "aragora/live listing:"
-            ls -la aragora/live || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -104,18 +93,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate checkout integrity
-        run: |
-          git sparse-checkout disable || true
-          if [ ! -f aragora/live/package-lock.json ]; then
-            echo "::error::Missing aragora/live/package-lock.json after checkout"
-            echo "pwd: $(pwd)"
-            echo "Top-level files:"
-            ls -la
-            echo "aragora/live listing:"
-            ls -la aragora/live || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Ensure GitHub CLI is available
         if: github.event_name == 'schedule'
@@ -242,18 +220,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate checkout integrity
-        run: |
-          git sparse-checkout disable || true
-          if [ ! -f aragora/live/package-lock.json ]; then
-            echo "::error::Missing aragora/live/package-lock.json after checkout"
-            echo "pwd: $(pwd)"
-            echo "Top-level files:"
-            ls -la
-            echo "aragora/live listing:"
-            ls -la aragora/live || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -30,6 +30,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/deploy-multi-region.yml
+++ b/.github/workflows/deploy-multi-region.yml
@@ -56,6 +56,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -85,6 +87,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -126,6 +130,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -164,6 +170,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -57,6 +57,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -85,6 +87,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Validate Vercel configuration
         run: |
@@ -167,6 +171,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4
@@ -556,6 +562,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Extract version from pyproject.toml
         id: version
         run: |
@@ -129,6 +131,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Extract version from pyproject.toml
         id: version
         run: |
@@ -206,6 +210,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Extract version from pyproject.toml
         id: version
         run: |
@@ -279,6 +285,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Build images locally
         run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -42,6 +42,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -201,6 +203,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -240,6 +244,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -82,6 +84,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -112,6 +116,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -158,6 +164,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -120,6 +122,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         if: ${{ vars.AWS_CI_ENABLED == 'true' }}
@@ -241,6 +245,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Create additional databases
         run: |
@@ -370,6 +376,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Configure AWS credentials via OIDC
         if: ${{ vars.AWS_CI_ENABLED == 'true' }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -36,6 +36,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -218,6 +220,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -296,6 +300,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,9 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -56,22 +59,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -126,6 +114,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -148,6 +138,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -182,22 +174,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -238,6 +215,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -322,6 +301,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -348,6 +329,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -387,6 +370,8 @@ jobs:
         with:
           fetch-depth: 0  # Full history for comprehensive scanning
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Skip Gitleaks when license is missing
         if: env.GITLEAKS_LICENSE == ''
         run: |
@@ -409,6 +394,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -500,6 +487,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Count TODOs and enforce baseline
         run: |
           CURRENT=$(grep -rn "TODO\|FIXME\|HACK\|XXX" aragora/ --include="*.py" 2>/dev/null | wc -l | tr -d ' ')
@@ -536,6 +525,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/live-deploy-mode-gate.yml
+++ b/.github/workflows/live-deploy-mode-gate.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Resolve deploy mode
         id: mode
         run: |

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -64,6 +64,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -417,6 +419,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/merge-group-frontend-typecheck.yml
+++ b/.github/workflows/merge-group-frontend-typecheck.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -20,6 +20,8 @@ jobs:
           sparse-checkout: scripts/verify_frontend_routes.sh
           sparse-checkout-cone-mode: false
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Check Frontend Critical Routes
         run: |
           FRONTEND_URL="${LIVE_FRONTEND_BASE_URL:-https://aragora.ai}"

--- a/.github/workflows/new-features.yml
+++ b/.github/workflows/new-features.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -82,6 +84,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -118,6 +122,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -143,6 +149,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -199,6 +207,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/nightly-full-matrix.yml
+++ b/.github/workflows/nightly-full-matrix.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -79,6 +81,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -105,6 +109,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -67,6 +69,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/nomic-ci.yml
+++ b/.github/workflows/nomic-ci.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Need full history for diff
+
+      - uses: ./.github/actions/checkout-integrity
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Detect OpenAPI-relevant changes
         id: filter
         run: |
@@ -80,6 +82,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -383,6 +387,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Download generated spec
         uses: actions/download-artifact@v4

--- a/.github/workflows/pr-debate.yml
+++ b/.github/workflows/pr-debate.yml
@@ -40,6 +40,8 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -75,6 +77,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -133,6 +137,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-aragora-debate.yml
+++ b/.github/workflows/publish-aragora-debate.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -102,6 +104,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-aragora.yml
+++ b/.github/workflows/publish-aragora.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -44,6 +46,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -76,6 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -43,6 +43,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -76,6 +78,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-vscode.yml
+++ b/.github/workflows/publish-vscode.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/quality-smoke.yml
+++ b/.github/workflows/quality-smoke.yml
@@ -28,6 +28,9 @@ jobs:
       quality: ${{ steps.filter.outputs.quality }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -51,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Repo hygiene guard
         run: python scripts/guard_repo_clean.py --check-working-tree
 
@@ -56,6 +58,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -95,6 +99,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -126,6 +132,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -186,6 +194,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -252,6 +262,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -283,6 +295,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -366,6 +380,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -427,6 +443,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -484,6 +502,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -76,6 +78,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -116,6 +120,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/sdk-generate.yml
+++ b/.github/workflows/sdk-generate.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -103,6 +105,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -140,6 +144,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -20,6 +20,9 @@ jobs:
       relevant: ${{ steps.filter.outputs.relevant }}
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
+
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -46,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -30,6 +30,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Detect SDK relevant changes
         id: filter
         uses: dorny/paths-filter@v3
@@ -59,6 +61,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -87,6 +91,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -118,6 +124,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -99,6 +101,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,6 +54,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -77,6 +79,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -110,6 +114,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -139,6 +145,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -237,6 +245,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -254,6 +264,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -274,6 +286,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for scanning all commits
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@v2

--- a/.github/workflows/smoke-offline.yml
+++ b/.github/workflows/smoke-offline.yml
@@ -32,16 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate checkout integrity
-        run: |
-          git sparse-checkout disable || true
-          if [ ! -f pyproject.toml ]; then
-            echo "::error::Missing pyproject.toml after checkout"
-            echo "pwd: $(pwd)"
-            echo "Top-level files:"
-            ls -la
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -32,22 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -88,22 +73,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -135,22 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -191,22 +146,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/status-page.yml
+++ b/.github/workflows/status-page.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Validate Docker Compose
         run: |
           docker compose -f deploy/uptime-kuma/docker-compose.yml config
@@ -96,6 +98,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Deploy to staging
         run: |
           echo "Staging deployment would run here"
@@ -112,6 +116,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Check deployment secrets
         id: deploy_secrets
@@ -234,6 +240,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/templates/aragora-gauntlet-template.yml
+++ b/.github/workflows/templates/aragora-gauntlet-template.yml
@@ -74,6 +74,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/templates/aragora-review-template.yml
+++ b/.github/workflows/templates/aragora-review-template.yml
@@ -46,6 +46,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,22 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -193,6 +178,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -233,6 +220,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -259,22 +248,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -325,22 +299,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git reset --hard HEAD || true
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            git rev-parse --show-toplevel || true
-            ls -la
-            find . -maxdepth 3 -name pyproject.toml -print || true
-            exit 1
-          fi
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -379,6 +338,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -460,6 +421,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -497,6 +460,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -551,6 +516,8 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -573,6 +540,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -607,6 +576,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Check for high-risk path changes
         uses: dorny/paths-filter@v3
@@ -667,6 +638,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -723,6 +696,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -749,6 +724,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -834,6 +811,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -887,6 +866,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Check shard results
         run: |
@@ -1069,6 +1050,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -1141,6 +1124,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -1175,6 +1160,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -1238,6 +1225,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Check for frontend changes
         uses: dorny/paths-filter@v3
         id: changes
@@ -1278,6 +1267,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -1310,6 +1301,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -1357,6 +1350,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
@@ -1450,6 +1445,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -1497,6 +1494,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
@@ -1525,6 +1524,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - uses: ./.github/actions/checkout-integrity
 
       - name: Set up Python 3.11
         uses: actions/setup-python@v5

--- a/.github/workflows/testfixer-auto.yml
+++ b/.github/workflows/testfixer-auto.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/weekly-epistemic-kpis.yml
+++ b/.github/workflows/weekly-epistemic-kpis.yml
@@ -30,6 +30,8 @@ jobs:
             scripts/extract_weekly_epistemic_kpis.py
           sparse-checkout-cone-mode: false
 
+      - uses: ./.github/actions/checkout-integrity
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- Extracts checkout integrity guard into reusable composite action at `.github/actions/checkout-integrity/action.yml`
- Fixes recovery by adding `git fetch --no-tags origin` before `git reset --hard` (re-downloads missing blobs from sparse-checkout corruption)
- Replaces 6 inline guards (in `lint.yml`, `test.yml`, `smoke.yml`, `smoke-offline.yml`, `deploy-frontend.yml`, `aragora-gauntlet.yml`) with the composite action
- Adds the guard to all 179 checkout steps across 60 workflow files and 2 templates

## Why
Self-hosted runners retain stale sparse-checkout state between jobs. The old inline guard detected the problem (`pyproject.toml` missing) but couldn't recover because `git reset --hard HEAD` restores nothing when blobs were never fetched. The new composite action fetches blobs first, then resets.

## Test plan
- [ ] Verify YAML validation passes: `python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]"`
- [ ] Verify all 179 checkout steps are guarded (0 unguarded)
- [ ] Verify no inline guards remain in workflow files (only in composite action)
- [ ] CI lint and typecheck pass
- [ ] Test on self-hosted runner with intentionally corrupted sparse-checkout state

🤖 Generated with [Claude Code](https://claude.com/claude-code)