### PR TITLE
docs: add run-007 duplicate-suppression results and gating decision

### DIFF
--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -119,7 +119,7 @@ Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. A
 
 See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
 
-### Dogfood Telemetry (Runs 003-006)
+### Dogfood Telemetry (Runs 003-007)
 
 | Run | Objective | Result | Blocking Metric |
 |---|---|---|---|
@@ -127,6 +127,7 @@ See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation p
 | Run 004 | Re-test with timeout hardening + deterministic timeout receipts | **No-go (quality delta)** | Timeout rate = **1.0** (both variants timed out) |
 | Run 005 | Reduced-latency A/B to force completion + scoring | **Partial go** | Quality score remained **0.0** for both variants under strict section contract |
 | Run 006 | Enforce required output sections + grounding fail-closed, then rescore | **Partial go** | Duplicate existing create-ratio remains high (**0.4643** enhanced) |
+| Run 007 | Prompt-only duplicate suppression experiment (control vs focused) | **No-go (blocker regression)** | Duplicate existing create-ratio worsened (**0.3846 -> 0.7143**) |
 
 What improved in Run 004:
 - Timeout failures are now machine-parseable (`ARAGORA_TIMEOUT_JSON` + timeout report files).
@@ -142,13 +143,17 @@ What improved in Run 006:
 - Grounded-path quality improved in the enhanced variant (`verified_paths_ratio` 0.7647 -> **0.8235**).
 - Timeout rate stayed at **0.0** with fail-closed grounding enabled.
 
+What improved in Run 007:
+- Strict structure and practicality held (`quality_score_10 = 9.0`, `practicality_score_10 = 10.0`) in both control and focused-retry runs.
+- Grounding stayed strong (`verified_paths_ratio = 1.0` in both scored variants).
+
 What still blocks production-grade planning quality:
-- Duplicate existing create proposals remain too high (baseline **0.6923**, enhanced **0.4643**).
-- Output still contains synthetic path-like tokens that degrade grounding signal quality.
+- Duplicate existing create proposals remain the primary blocker, and prompt-only suppression made it worse in run-007.
+- The pipeline still needs deterministic duplicate-create detection/repair rather than relying on instruction wording.
 
 Roadmap implication:
 - Keep strict required-section headings and grounding fail-closed gates as benchmark defaults.
-- Add deterministic defects for duplicate-create proposals against existing repo paths.
+- Add deterministic defects for duplicate-create proposals against existing repo paths (next gating milestone).
 - Add normalization/cleanup for synthetic path-like tokens before grounding assessment.
 
 ---

--- a/docs/plans/dogfood-run-001-spec.md
+++ b/docs/plans/dogfood-run-001-spec.md
@@ -613,3 +613,72 @@ Summary:
 - **GO** for quality-comparable A/B benchmarking under strict section contract.
 - **Partial GO** for grounding: floor gate passed, but path quality still has synthetic-token noise.
 - **NO-GO** for duplicate suppression target until deterministic duplicate-create checks are added to quality defects.
+
+---
+
+## Dogfood Run 007 Results (Duplicate-Suppression Focus)
+
+### Date
+- 2026-03-03
+
+### Goal
+- Test whether prompt-only duplicate-suppression rules can reduce `duplicate_existing_create_ratio` without regressing quality or grounding.
+
+### Configuration
+- **Team**: 2 agents via OpenRouter (`gemini-2.0-flash-001` proposer, `gpt-4o` synthesizer)
+- **Rounds**: 1
+- **Consensus**: majority
+- **Common guardrails**:
+  - `--required-sections "Ranked High-Level Tasks,Suggested Subtasks,Owner module / file paths,Test Plan,Rollback Plan,Gate Criteria"`
+  - `--mode orchestrator --codebase-context --codebase-context-max-chars 60000`
+  - `--quality-min-score 7 --quality-practical-min-score 5 --quality-upgrade-max-loops 1` (focused retry used 2 loops)
+- **Comparison setup**:
+  - **Control**: standard run-006 style task prompt
+  - **Focused**: added explicit anti-duplicate language (`modify/refactor/extend`, no `create/add/build` against existing paths)
+
+### Execution Results
+
+| Variant | Exit | Duration | Final answer present | Notes |
+|---|---:|---:|---:|---|
+| Control | 0 | 321.87s | Yes | Stable structured output |
+| Focused (attempt 1) | 1 | 364.24s | Yes | Grounding fail-closed tripped on placeholder output |
+| Focused (retry) | 0 | 358.70s | Yes | Valid structured output, used for scoring |
+
+### Objective Score (Control vs Focused Retry)
+
+| Metric | Control | Focused Retry |
+|---|---:|---:|
+| Composite score | **0.8839** | 0.8014 |
+| Verified existing path ratio | 1.0000 | 1.0000 |
+| Duplicate existing create-ratio (lower is better) | **0.3846** | 0.7143 |
+| Practicality score (deterministic) | 10.0 | 10.0 |
+| Quality score (section-contract) | 9.0 | 9.0 |
+
+Summary:
+- **Winner by composite score**: Control
+- **Timeout rate**: 0.0
+- **Blocker result**: Prompt-only duplicate-suppression **failed** (duplicate ratio worsened by +0.3297).
+
+### Interpretation
+1. Prompt-only wording is insufficient for duplicate suppression and can backfire while still producing high-quality, fully grounded text.
+2. Quality and grounding remained excellent, so the regression isolates specifically to duplicate-create behavior.
+3. Deterministic enforcement in code (quality defects + repair) is required for the blocker, not stronger prompt phrasing alone.
+
+### Artifacts
+- `/tmp/dogfood_run007/run007_control_stdout.txt`
+- `/tmp/dogfood_run007/run007_control_stderr.txt`
+- `/tmp/dogfood_run007/run007_control_status.json`
+- `/tmp/dogfood_run007/run007_focused_stdout.txt`
+- `/tmp/dogfood_run007/run007_focused_stderr.txt`
+- `/tmp/dogfood_run007/run007_focused_status.json`
+- `/tmp/dogfood_run007/run007_focused_retry_stdout.txt`
+- `/tmp/dogfood_run007/run007_focused_retry_stderr.txt`
+- `/tmp/dogfood_run007/run007_focused_retry_status.json`
+- `/tmp/dogfood_run007/run007_score.json` (control vs focused attempt 1)
+- `/tmp/dogfood_run007/run007_score_retry.json` (control vs focused retry; canonical)
+- `/tmp/dogfood_run007/run007_score_retry.md`
+
+### Gate Decision
+- **GO** for continued strict section + grounding gates (stable).
+- **NO-GO** for prompt-only duplicate suppression.
+- **Next required change**: add deterministic duplicate-create defecting/repair in `aragora/debate/output_quality.py` and gate on `duplicate_existing_create_ratio <= 0.25`.


### PR DESCRIPTION
## Summary
- audit stash safety and preserve all stash entries with backup branch pointers
- run dogfood run-007 focused on duplicate-existing-create suppression (control vs focused)
- record run-007 telemetry and decision in roadmap/spec docs

## Run-007 headline
- control: exit 0, 321.87s, final answer present
- focused attempt 1: exit 1 (grounding fail-closed), placeholder output
- focused retry: exit 0, 358.70s, final answer present
- timeout rate: 0.0
- quality/practicality stayed high (9.0 / 10.0)
- blocker regression: duplicate_existing_create_ratio worsened from 0.3846 to 0.7143 (focused retry)

## Artifacts
- /tmp/stash_audit_20260304.md
- /tmp/dogfood_run007/run007_control_status.json
- /tmp/dogfood_run007/run007_focused_status.json
- /tmp/dogfood_run007/run007_focused_retry_status.json
- /tmp/dogfood_run007/run007_score_retry.json
