### PR TITLE
fix(rbac): secure prompt-engine handler and pass enforcement gate

### DIFF
--- a/aragora/server/handlers/prompt_engine/handler.py
+++ b/aragora/server/handlers/prompt_engine/handler.py
@@ -16,19 +16,19 @@ import logging
 from typing import Any
 
 from ..base import (
-    BaseHandler,
     HandlerResult,
     error_response,
     handle_errors,
     json_response,
 )
+from ..secure import SecureHandler
 
 logger = logging.getLogger(__name__)
 
 _MAX_BODY = 1 * 1024 * 1024  # 1 MB
 
 
-class PromptEngineHandler(BaseHandler):
+class PromptEngineHandler(SecureHandler):
     """Handler for the prompt-to-specification engine."""
 
     ROUTES = [

--- a/tests/rbac/test_handler_enforcement.py
+++ b/tests/rbac/test_handler_enforcement.py
@@ -417,6 +417,8 @@ ALLOWED_WITHOUT_RBAC = frozenset(
         "notifications/history",
         # Pipeline re-export module (actual handler is in pipeline/plans.py)
         "pipeline/__init__",
+        # Prompt engine package re-export (handler.py provides protection)
+        "prompt_engine/__init__",
         # Demo/example handlers (non-production, no auth required)
         "demo/__init__",
         "demo/adversarial_demo",


### PR DESCRIPTION
## Summary
- switch `PromptEngineHandler` from `BaseHandler` to `SecureHandler`
- allowlist `prompt_engine/__init__` as a package re-export in RBAC enforcement test

## Why
Current `main` fails RBAC enforcement because prompt-engine modules are detected as unprotected:
- `prompt_engine/handler` was not extending a secure base class
- `prompt_engine/__init__` is a non-handler re-export module and should be explicitly allowlisted

## Validation
- `pytest -q tests/rbac/test_handler_enforcement.py -k "all_handlers_have_authorization or no_handler_bypasses_middleware"`
  - `2 passed, 4 deselected`