### PR TITLE
fix(ci): harden checkout-integrity usage for merge-critical workflows

### DIFF
--- a/.github/workflows/aragora-gauntlet.yml
+++ b/.github/workflows/aragora-gauntlet.yml
@@ -34,14 +34,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,14 +34,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -180,14 +183,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -207,14 +213,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,14 +36,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -83,14 +86,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -157,14 +163,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -201,14 +210,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -255,14 +267,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -316,14 +331,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -420,14 +438,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -468,14 +489,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -527,14 +551,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -571,14 +598,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -682,14 +712,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -740,14 +773,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -49,14 +49,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -107,14 +110,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -431,14 +437,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -48,14 +48,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -26,14 +26,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -74,14 +77,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -35,14 +35,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -85,14 +88,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -135,14 +141,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
@@ -187,14 +196,17 @@ jobs:
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git reset --hard || true
+            git clean -ffdx || true
             git sparse-checkout disable || true
             git fetch --no-tags origin "${GITHUB_SHA:-HEAD}" || true
+            git checkout -f "${GITHUB_SHA:-HEAD}" || true
             if git rev-parse --verify FETCH_HEAD >/dev/null 2>&1; then
               git reset --hard FETCH_HEAD
             else
               git reset --hard HEAD
             fi
-            git clean -ffd || true
+            git clean -ffdx || true
           fi
           if [[ ! -f pyproject.toml ]]; then
             echo "::error::Repository checkout is incomplete (pyproject.toml missing)"


### PR DESCRIPTION
## Summary
- remove dependency on local composite action path for checkout integrity in merge-critical workflows
- inline a robust checkout recovery step immediately after `actions/checkout` in:
  - lint
  - sdk-parity
  - sdk-test
  - openapi
  - coverage
  - release-readiness
  - aragora-gauntlet
- preserve existing gate behavior while recovering from stale sparse-checkout state on self-hosted runners

## Why
CI was failing before test logic with errors like:
"Can't find action.yml under .github/actions/checkout-integrity".
This happens when reused self-hosted workspaces retain sparse-checkout state and local action paths disappear.

Inlining recovery removes that dependency and self-heals checkout state in-place.

## Validation
- pre-commit checks passed (`check yaml`, guard hooks)
- `python3 scripts/check_required_check_priority_policy.py`
- `python3 scripts/check_deploy_secure_sha_guard.py`
