### PR TITLE
feat(live): restore standalone landing/pricing metadata layouts

### DIFF
--- a/aragora/live/src/app/(standalone)/landing/layout.tsx
+++ b/aragora/live/src/app/(standalone)/landing/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Aragora — AI Models That Debate Your Decisions',
+  description:
+    'Ask any question and multiple AI models argue every angle, then deliver a verdict with confidence scores, minority opinions, and a full audit trail.',
+  openGraph: {
+    title: 'Aragora — AI Models That Debate Your Decisions',
+    description:
+      'Multiple AI models argue every angle. Confidence scores, minority opinions, full audit trails.',
+  },
+};
+
+export default function LandingLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/aragora/live/src/app/(standalone)/pricing/layout.tsx
+++ b/aragora/live/src/app/(standalone)/pricing/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Pricing — Aragora',
+  description:
+    'Start free with 10 debates per month. Upgrade to Pro for unlimited debates, CI/CD integration, and cross-debate memory. Enterprise plans include SSO, SOC 2, and self-hosted deployment.',
+  openGraph: {
+    title: 'Pricing — Aragora',
+    description:
+      'Start free. Scale when ready. Bring your own API keys — Aragora never marks up LLM costs.',
+  },
+};
+
+export default function PricingLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}


### PR DESCRIPTION
## Summary
- restore `aragora/live/src/app/(standalone)/landing/layout.tsx`
- restore `aragora/live/src/app/(standalone)/pricing/layout.tsx`

## Context
These files existed as untracked worktree artifacts during preserve cleanup. This PR salvages them into source control on a clean branch so they are not lost.

## Scope
Intentionally limited to the two recovered layout files only.