### PR TITLE
feat(live): production readiness — public pages, mobile nav, auth guards

### DIFF
--- a/aragora/live/src/app/(app)/analytics/page.tsx
+++ b/aragora/live/src/app/(app)/analytics/page.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, type ReactNode } from 'react';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { useBackend } from '@/components/BackendSelector';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { useAragoraClient } from '@/hooks/useAragoraClient';
 import { useAsyncData } from '@/hooks/useAsyncData';
 
@@ -468,6 +469,7 @@ export default function AnalyticsPage() {
   ];
 
   return (
+    <ProtectedRoute>
     <>
       <Scanlines opacity={0.02} />
       <CRTVignette />
@@ -981,5 +983,6 @@ export default function AnalyticsPage() {
         </footer>
       </main>
     </>
+    </ProtectedRoute>
   );
 }

--- a/aragora/live/src/app/(app)/costs/page.tsx
+++ b/aragora/live/src/app/(app)/costs/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense } from 'react';
 import { CostDashboard } from '@/components/costs/CostDashboard';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 
 function LoadingFallback() {
   return (
@@ -19,10 +20,12 @@ function LoadingFallback() {
 
 export default function CostsPage() {
   return (
+    <ProtectedRoute>
     <div className="container mx-auto px-4 py-6 max-w-6xl">
       <Suspense fallback={<LoadingFallback />}>
         <CostDashboard />
       </Suspense>
     </div>
+    </ProtectedRoute>
   );
 }

--- a/aragora/live/src/app/(app)/settings/page.tsx
+++ b/aragora/live/src/app/(app)/settings/page.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback } from 'react';
 import dynamic from 'next/dynamic';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { useSWRFetch, invalidateCachePattern } from '@/hooks/useSWRFetch';
 import { API_BASE_URL } from '@/config';
 
@@ -630,6 +631,7 @@ export default function SettingsPage() {
   ];
 
   return (
+    <ProtectedRoute>
     <>
       <Scanlines opacity={0.02} />
       <CRTVignette />
@@ -798,5 +800,6 @@ export default function SettingsPage() {
         />
       )}
     </>
+    </ProtectedRoute>
   );
 }

--- a/aragora/live/src/app/(app)/usage/page.tsx
+++ b/aragora/live/src/app/(app)/usage/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { ProtectedRoute } from '@/components/auth/ProtectedRoute';
 import { UsageBreakdown } from '@/components/dashboard/UsageBreakdown';
 import { BudgetStatus } from '@/components/dashboard/BudgetStatus';
 import { ROIMetrics } from '@/components/dashboard/ROIMetrics';
@@ -39,6 +40,7 @@ export default function UsagePage() {
   };
 
   return (
+    <ProtectedRoute>
     <>
       <Scanlines opacity={0.02} />
       <CRTVignette />
@@ -139,5 +141,6 @@ export default function UsagePage() {
         </div>
       </main>
     </>
+    </ProtectedRoute>
   );
 }

--- a/aragora/live/src/app/(standalone)/about/layout.tsx
+++ b/aragora/live/src/app/(standalone)/about/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About — Aragora',
+  description:
+    'Aragora is the Decision Integrity Platform — orchestrating 43 agent types to adversarially vet decisions, then delivering audit-ready decision receipts to any channel.',
+  openGraph: {
+    title: 'About — Aragora',
+    description:
+      'The Decision Integrity Platform. Multiple AI models debate your decisions with confidence scores and full audit trails.',
+  },
+};
+
+export default function AboutLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/aragora/live/src/app/(standalone)/eu-ai-act/layout.tsx
+++ b/aragora/live/src/app/(standalone)/eu-ai-act/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'EU AI Act Compliance — Aragora',
+  description:
+    'Classify your AI system risk level, generate compliance bundles, and prepare for EU AI Act deadlines. Interactive risk assessment with article-level guidance.',
+  openGraph: {
+    title: 'EU AI Act Compliance — Aragora',
+    description:
+      'Classify risk, generate compliance bundles, and meet EU AI Act deadlines with Aragora.',
+  },
+};
+
+export default function EuAiActLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/aragora/live/src/app/(standalone)/layout.tsx
+++ b/aragora/live/src/app/(standalone)/layout.tsx
@@ -1,4 +1,10 @@
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+
 export default function StandaloneLayout({ children }: { children: React.ReactNode }) {
   // No AppShell - pages in this group provide their own headers/navigation
-  return <>{children}</>;
+  return (
+    <ErrorBoundary componentName="Standalone Page">
+      {children}
+    </ErrorBoundary>
+  );
 }

--- a/aragora/live/src/app/(standalone)/signup/layout.tsx
+++ b/aragora/live/src/app/(standalone)/signup/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Sign Up — Aragora',
+  description:
+    'Create a free Aragora account. 10 debates per month, 3 agents per debate, markdown receipts. No credit card required.',
+  openGraph: {
+    title: 'Sign Up — Aragora',
+    description: 'Create a free account and start debating decisions with multiple AI models.',
+  },
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/aragora/live/src/app/layout.tsx
+++ b/aragora/live/src/app/layout.tsx
@@ -61,7 +61,7 @@ export const metadata: Metadata = {
     images: [{ url: '/aragora-logo.png', width: 512, height: 512, alt: 'Aragora' }],
   },
   twitter: {
-    card: 'summary',
+    card: 'summary_large_image',
     title: 'ARAGORA // LIVE',
     description: 'Multiple AI models debate your decisions. Confidence scores, minority opinions, and full audit trails.',
     images: ['/aragora-logo.png'],
@@ -72,8 +72,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
-  userScalable: false,
   viewportFit: 'cover',
   themeColor: [
     { media: '(prefers-color-scheme: dark)', color: '#0a0a0a' },

--- a/aragora/live/src/components/landing/Header.tsx
+++ b/aragora/live/src/components/landing/Header.tsx
@@ -1,76 +1,224 @@
 'use client';
 
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useTheme } from '@/context/ThemeContext';
 import { Logo } from '@/components/Logo';
 import { ThemeSelector } from './ThemeSelector';
 
+const NAV_LINKS = [
+  { href: '#how-it-works', label: 'How it works', anchor: true },
+  { href: '/pricing', label: 'Pricing', anchor: false },
+  { href: '/eu-ai-act', label: 'Compliance', anchor: false },
+  { href: '/login', label: 'Log in', anchor: false },
+];
+
 export function Header() {
   const { theme } = useTheme();
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Close menu on route change
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [mobileOpen]);
+
+  // Prevent body scroll when menu open
+  useEffect(() => {
+    if (mobileOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => { document.body.style.overflow = ''; };
+  }, [mobileOpen]);
+
+  const toggleMenu = useCallback(() => setMobileOpen((o) => !o), []);
+
+  const bgColor = theme === 'dark'
+    ? 'rgba(10,10,10,0.85)'
+    : theme === 'professional'
+      ? 'rgba(255,255,255,0.85)'
+      : 'rgba(250,249,247,0.85)';
 
   return (
-    <header
-      className="sticky top-0 z-50 backdrop-blur-sm"
-      style={{
-        backgroundColor: theme === 'dark' ? 'rgba(10,10,10,0.85)' : theme === 'professional' ? 'rgba(255,255,255,0.85)' : 'rgba(250,249,247,0.85)',
-        borderBottom: '1px solid var(--border)',
-        fontFamily: 'var(--font-landing)',
-      }}
-    >
-      <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-        {/* Logo mark + Wordmark */}
-        <div className="flex items-center gap-3">
-          <Logo size="lg" pixelSize={28} />
-          <Link href="/landing" className="flex items-center">
-            <span
-            className="font-bold"
+    <>
+      <header
+        className="sticky top-0 z-50 backdrop-blur-sm"
+        style={{
+          backgroundColor: bgColor,
+          borderBottom: '1px solid var(--border)',
+          fontFamily: 'var(--font-landing)',
+        }}
+      >
+        <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
+          {/* Logo mark + Wordmark */}
+          <div className="flex items-center gap-3">
+            <Logo size="lg" pixelSize={28} />
+            <Link href="/landing" className="flex items-center">
+              <span
+                className="font-bold"
+                style={{
+                  color: 'var(--accent)',
+                  fontSize: '14px',
+                  fontFamily: "'JetBrains Mono', monospace",
+                  letterSpacing: '0.15em',
+                }}
+              >
+                {'> ARAGORA'}
+              </span>
+            </Link>
+          </div>
+
+          {/* Desktop nav + Theme selector */}
+          <div className="flex items-center gap-6">
+            <nav className="hidden sm:flex items-center gap-5">
+              {NAV_LINKS.map((link) =>
+                link.anchor ? (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    className="text-sm transition-colors hover:opacity-80"
+                    style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
+                  >
+                    {link.label}
+                  </a>
+                ) : (
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="text-sm transition-colors hover:opacity-80"
+                    style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
+                  >
+                    {link.label}
+                  </Link>
+                ),
+              )}
+            </nav>
+            <ThemeSelector />
+
+            {/* Mobile hamburger */}
+            <button
+              className="sm:hidden flex flex-col justify-center items-center w-8 h-8 gap-[5px] cursor-pointer"
+              onClick={toggleMenu}
+              aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileOpen}
+              style={{ background: 'none', border: 'none', padding: 0 }}
+            >
+              <span
+                className="block w-5 h-[1.5px] transition-all duration-200 origin-center"
+                style={{
+                  backgroundColor: 'var(--text-muted)',
+                  transform: mobileOpen ? 'translateY(3.25px) rotate(45deg)' : 'none',
+                }}
+              />
+              <span
+                className="block w-5 h-[1.5px] transition-all duration-200 origin-center"
+                style={{
+                  backgroundColor: 'var(--text-muted)',
+                  transform: mobileOpen ? 'translateY(-3.25px) rotate(-45deg)' : 'none',
+                }}
+              />
+            </button>
+          </div>
+        </div>
+      </header>
+
+      {/* Mobile nav overlay */}
+      {mobileOpen && (
+        <div
+          className="fixed inset-0 z-40 sm:hidden"
+          onClick={() => setMobileOpen(false)}
+          aria-hidden="true"
+          style={{ backgroundColor: 'rgba(0,0,0,0.3)' }}
+        />
+      )}
+
+      {/* Mobile nav panel */}
+      <div
+        className="fixed left-0 right-0 z-45 sm:hidden overflow-hidden transition-all duration-250 ease-out"
+        style={{
+          top: '57px', // header height
+          maxHeight: mobileOpen ? '400px' : '0',
+          opacity: mobileOpen ? 1 : 0,
+          backgroundColor: bgColor,
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+          borderBottom: mobileOpen ? '1px solid var(--border)' : 'none',
+          zIndex: 45,
+        }}
+      >
+        <nav
+          className="max-w-5xl mx-auto px-4 py-4 flex flex-col gap-1"
+          style={{ fontFamily: 'var(--font-landing)' }}
+        >
+          {NAV_LINKS.map((link) => {
+            const isActive = !link.anchor && pathname === link.href;
+            const linkStyle = {
+              color: isActive ? 'var(--accent)' : 'var(--text-muted)',
+              fontFamily: 'var(--font-landing)',
+              fontSize: '15px',
+              padding: '12px 8px',
+              borderRadius: 'var(--radius-card)',
+              backgroundColor: isActive ? 'var(--surface)' : 'transparent',
+              display: 'block',
+              transition: 'background-color 0.15s, color 0.15s',
+            };
+
+            return link.anchor ? (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileOpen(false)}
+                style={linkStyle}
+              >
+                {link.label}
+              </a>
+            ) : (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setMobileOpen(false)}
+                style={linkStyle}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+
+          {/* Divider */}
+          <div style={{ height: '1px', backgroundColor: 'var(--border)', margin: '4px 8px' }} />
+
+          {/* Sign up CTA */}
+          <Link
+            href="/signup"
+            onClick={() => setMobileOpen(false)}
+            className="text-center font-semibold transition-opacity hover:opacity-80"
             style={{
-              color: 'var(--accent)',
               fontSize: '14px',
-              fontFamily: "'JetBrains Mono', monospace",
-              letterSpacing: '0.15em',
+              fontFamily: 'var(--font-landing)',
+              borderRadius: 'var(--radius-button)',
+              backgroundColor: 'var(--accent)',
+              color: 'var(--bg)',
+              padding: '12px 24px',
+              margin: '4px 8px',
             }}
           >
-            {'> ARAGORA'}
-            </span>
+            Sign up free
           </Link>
-        </div>
-
-        {/* Nav links + Theme selector */}
-        <div className="flex items-center gap-6">
-          <nav className="hidden sm:flex items-center gap-5">
-            <a
-              href="#how-it-works"
-              className="text-sm transition-colors hover:opacity-80"
-              style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-            >
-              How it works
-            </a>
-            <a
-              href="/pricing"
-              className="text-sm transition-colors hover:opacity-80"
-              style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-            >
-              Pricing
-            </a>
-            <Link
-              href="/eu-ai-act"
-              className="text-sm transition-colors hover:opacity-80"
-              style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-            >
-              Compliance
-            </Link>
-            <Link
-              href="/login"
-              className="text-sm transition-colors hover:opacity-80"
-              style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-            >
-              Log in
-            </Link>
-          </nav>
-          <ThemeSelector />
-        </div>
+        </nav>
       </div>
-    </header>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- **Root redirect**: `page.tsx` at `/` checks `localStorage` tokens — redirects to `/demo` (authenticated) or `/landing` (anonymous). Fixes 404 in static-export mode.
- **Public pricing page**: Standalone `/pricing` wraps existing `PricingSection` + FAQ. Moved authenticated billing to `(app)/billing/`.
- **Public about page**: Standalone `/about` with logo, WhyAragora, Capabilities, use cases. Tri-theme CSS variables.
- **API connectivity banner**: Pings `/api/health` every 30s, shows dismissible banner when unreachable.
- **Mobile navigation**: Hamburger menu with slide-down panel, body scroll lock, ESC close, route-change auto-close.
- **SEO metadata**: Per-page `layout.tsx` files for all 5 standalone pages (landing, pricing, about, eu-ai-act, signup).
- **ErrorBoundary**: Wraps standalone layout for graceful error recovery.
- **Auth guards**: `ProtectedRoute` on settings, analytics, usage, costs pages.
- **Accessibility**: Removed `maximumScale`/`userScalable` viewport restrictions (WCAG 2.1 AA).
- **Social previews**: Upgraded Twitter card to `summary_large_image`.

## Test plan

- [ ] Visit `/` without tokens → redirects to `/landing`
- [ ] Visit `/` with tokens → redirects to `/demo`
- [ ] Visit `/pricing` without auth → public pricing page renders with all 3 themes
- [ ] Visit `/about` without auth → public about page renders
- [ ] Stop API server → connectivity banner appears at page bottom
- [ ] Mobile viewport: hamburger menu opens/closes, links navigate correctly
- [ ] Settings/analytics/usage/costs redirect to login when unauthenticated
- [ ] `npx tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)