### PR TITLE
ci: make PR admission monitor advisory and non-blocking

### DIFF
--- a/.github/workflows/pr-admission-controller.yml
+++ b/.github/workflows/pr-admission-controller.yml
@@ -14,11 +14,6 @@ on:
         required: false
         default: "1"
         type: string
-      enforce:
-        description: "Apply enforcement actions"
-        required: false
-        default: true
-        type: boolean
 
 permissions:
   contents: read
@@ -50,24 +45,20 @@ jobs:
             echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Enforce admission controller
+      - name: Run admission monitor (non-blocking)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         shell: bash
         run: |
           MAX_READY="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.max_ready_per_stream || '1' }}"
-          ENFORCE_FLAG=""
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ github.event.inputs.enforce }}" = "true" ]; then
-              ENFORCE_FLAG="--enforce"
-            fi
-          else
-            ENFORCE_FLAG="--enforce"
-          fi
-
+          set +e
           python scripts/pr_admission_controller.py \
             --repo "${GITHUB_REPOSITORY}" \
             --pr-number "${{ steps.resolve.outputs.pr_number }}" \
-            --max-ready-per-stream "${MAX_READY}" \
-            ${ENFORCE_FLAG}
+            --max-ready-per-stream "${MAX_READY}"
+          rc=$?
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::Admission monitor exited with code $rc (non-blocking by policy)"
+          fi

--- a/docs/AGENT_ASSIGNMENTS.md
+++ b/docs/AGENT_ASSIGNMENTS.md
@@ -7,8 +7,8 @@
 Use these rules before reading track-level assignments:
 
 1. One active ready PR at a time per stream. All other PRs in that stream must stay draft with auto-merge disabled.
-2. Admission controller is authoritative: `.github/workflows/pr-admission-controller.yml` and `scripts/pr_admission_controller.py` enforce ready-lane policy.
-3. Stale-run GC is mandatory before retriggers: run `python3 scripts/pr_stale_run_gc.py --repo synaptent/aragora --max-runs 500` (with `GITHUB_TOKEN`) to clear stale queued runs.
+2. Admission monitor is advisory: `.github/workflows/pr-admission-controller.yml` and `scripts/pr_admission_controller.py` report ready-lane pressure without blocking pushes.
+3. Stale-run GC is recommended before bulk retriggers: run `python3 scripts/pr_stale_run_gc.py --repo synaptent/aragora --max-runs 500` (with `GITHUB_TOKEN`) to clear stale queued runs.
 4. Before starting work, post ownership in this file (branch, PR number, touched paths, owner handle, timestamp).
 5. If repo state changes unexpectedly (detached HEAD, unknown edits, disappearing worktree), stop and move to a fresh worktree from `origin/main` before continuing.
 6. No derivative PRs touching the same files as an active owner without explicit handoff in writing.

--- a/docs/CI_LANES.md
+++ b/docs/CI_LANES.md
@@ -4,11 +4,11 @@ Aragora uses a two-lane CI architecture to balance fast feedback for development
 
 ## Control Plane Guardrails
 
-The lane system is now enforced by automation, not just convention:
+The lane system uses automation for visibility and cleanup, not merge blocking:
 
-- **PR admission controller:** `.github/workflows/pr-admission-controller.yml` runs `scripts/pr_admission_controller.py` and blocks PRs when ready-lane policy is violated.
+- **PR admission monitor:** `.github/workflows/pr-admission-controller.yml` runs `scripts/pr_admission_controller.py` and reports ready-lane pressure without mutating PR state.
 - **Stale-run GC:** `.github/workflows/pr-stale-run-gc.yml` runs `scripts/pr_stale_run_gc.py` to cancel orphaned or stale-SHA runs that consume runner capacity.
-- **Single ready lane per stream:** only one non-draft PR should remain active per stream; all other PRs in that stream stay draft until promoted.
+- **Single ready lane per stream (recommended):** keep one non-draft PR active per stream for predictable queue behavior.
 
 Operator quick commands:
 

--- a/docs/debate/AGENT_ASSIGNMENTS.md
+++ b/docs/debate/AGENT_ASSIGNMENTS.md
@@ -7,8 +7,8 @@
 Use these rules before reading track-level assignments:
 
 1. One active ready PR at a time per stream. All other PRs in that stream must stay draft with auto-merge disabled.
-2. Admission controller is authoritative: `.github/workflows/pr-admission-controller.yml` and `scripts/pr_admission_controller.py` enforce ready-lane policy.
-3. Stale-run GC is mandatory before retriggers: run `python3 scripts/pr_stale_run_gc.py --repo synaptent/aragora --max-runs 500` (with `GITHUB_TOKEN`) to clear stale queued runs.
+2. Admission monitor is advisory: `.github/workflows/pr-admission-controller.yml` and `scripts/pr_admission_controller.py` report ready-lane pressure without blocking pushes.
+3. Stale-run GC is recommended before bulk retriggers: run `python3 scripts/pr_stale_run_gc.py --repo synaptent/aragora --max-runs 500` (with `GITHUB_TOKEN`) to clear stale queued runs.
 4. Before starting work, post ownership in this file (branch, PR number, touched paths, owner handle, timestamp).
 5. If repo state changes unexpectedly (detached HEAD, unknown edits, disappearing worktree), stop and move to a fresh worktree from `origin/main` before continuing.
 6. No derivative PRs touching the same files as an active owner without explicit handoff in writing.

--- a/scripts/pr_admission_controller.py
+++ b/scripts/pr_admission_controller.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-"""PR admission controller for multi-agent CI lane governance.
+"""PR admission monitor for multi-agent CI lane governance.
 
 Policy:
 - At most ``max_ready_per_stream`` open ready PRs per stream.
 - Stream can be set via label prefixes: ``lane:``, ``lane/``, ``stream:``, ``stream/``.
 - If no stream label exists, infer stream from changed files.
 
-When ``--enforce`` is enabled and the current PR is over capacity for its stream:
-- convert PR back to draft
-- disable auto-merge (if enabled)
-- post an explanatory PR comment
+This monitor is intentionally non-blocking: it reports admission pressure but
+never mutates PR state (no draft conversion, no auto-merge disable).
 """
 
 from __future__ import annotations
@@ -241,30 +239,11 @@ class GitHubClient:
         return True, "disabled"
 
 
-def _build_block_comment(
-    *,
-    stream: str,
-    max_ready_per_stream: int,
-    admitted_prs: set[int],
-    current_pr_number: int,
-) -> str:
-    admitted_text = ", ".join(f"#{n}" for n in sorted(admitted_prs)) or "(none)"
-    return (
-        "⚠️ PR Admission Controller blocked this PR from staying ready-for-review.\n\n"
-        f"- Stream: `{stream}`\n"
-        f"- Allowed ready PRs in this stream: `{max_ready_per_stream}`\n"
-        f"- Currently admitted PR(s): {admitted_text}\n"
-        f"- This PR: `#{current_pr_number}` was converted back to draft.\n\n"
-        "To proceed: merge/close the admitted PR, then mark this PR ready again."
-    )
-
-
 def evaluate_admission(
     *,
     client: GitHubClient,
     current_pr_number: int,
     max_ready_per_stream: int,
-    enforce: bool,
 ) -> int:
     current_pr = client.get_pull(current_pr_number)
     if str(current_pr.get("state", "")).lower() != "open":
@@ -317,36 +296,14 @@ def evaluate_admission(
         return 0
 
     print(
-        f"Admission blocked for PR #{current_pr_number} in stream '{current_stream}'. "
-        f"Admitted: {admitted_text}"
-    )
-    if not enforce:
-        return 2
-
-    pr_node_id = str(current_pr.get("node_id", ""))
-    if not pr_node_id:
-        raise GitHubApiError(f"PR #{current_pr_number} is missing node_id")
-
-    converted, converted_msg = client.convert_pull_to_draft(pr_node_id)
-    disabled, disabled_msg = client.disable_auto_merge(pr_node_id)
-    comment = _build_block_comment(
-        stream=current_stream,
-        max_ready_per_stream=max_ready_per_stream,
-        admitted_prs=admitted,
-        current_pr_number=current_pr_number,
-    )
-    client.add_issue_comment(current_pr_number, comment)
-
-    print(
-        f"Enforcement applied to PR #{current_pr_number}: "
-        f"converted={converted} ({converted_msg}), "
-        f"auto_merge_disabled={disabled} ({disabled_msg})"
+        f"Admission advisory for PR #{current_pr_number} in stream '{current_stream}': "
+        f"over capacity. Admitted: {admitted_text}. No blocking action taken."
     )
     return 0
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="PR admission controller")
+    parser = argparse.ArgumentParser(description="PR admission monitor")
     parser.add_argument(
         "--repo",
         default=os.environ.get("GITHUB_REPOSITORY", ""),
@@ -362,7 +319,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--enforce",
         action="store_true",
-        help="Apply enforcement (convert overflow PRs to draft)",
+        help="Deprecated no-op; monitor is non-blocking",
     )
     return parser.parse_args(argv)
 
@@ -379,6 +336,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.max_ready_per_stream < 1:
         print("--max-ready-per-stream must be >= 1", file=sys.stderr)
         return 1
+    if args.enforce:
+        print("Warning: --enforce is deprecated and has no effect (non-blocking policy).")
 
     try:
         client = GitHubClient(repo=args.repo, token=token)
@@ -386,10 +345,9 @@ def main(argv: list[str] | None = None) -> int:
             client=client,
             current_pr_number=args.pr_number,
             max_ready_per_stream=args.max_ready_per_stream,
-            enforce=bool(args.enforce),
         )
     except (GitHubApiError, ValueError) as exc:
-        print(f"Admission controller error: {exc}", file=sys.stderr)
+        print(f"Admission monitor error: {exc}", file=sys.stderr)
         return 1
 
 


### PR DESCRIPTION
## Summary
- convert PR admission behavior to advisory-only (non-blocking)
- keep stale-run GC + hygiene guidance
- update docs to reflect throughput-first policy

## Changes
1. `scripts/pr_admission_controller.py`
- remove blocking enforcement path from runtime behavior
- monitor now always reports pressure and exits `0` on policy overflow
- keep `--enforce` as a deprecated no-op for compatibility (prints warning)

2. `.github/workflows/pr-admission-controller.yml`
- remove `workflow_dispatch` `enforce` input
- stop passing `--enforce`
- make monitor step explicitly non-blocking (warn on non-zero script exit)

3. Docs
- `docs/CI_LANES.md`: admission monitor is visibility, not blocking
- `docs/AGENT_ASSIGNMENTS.md` and `docs/debate/AGENT_ASSIGNMENTS.md`: switch from authoritative admission to advisory monitor; keep stale-run GC recommendation

## Validation
- `python -m pytest tests/scripts/test_pr_admission_controller.py tests/scripts/test_pr_stale_run_gc.py -q`
- Result: `10 passed`
