### PR TITLE
ci: cancel queued PR runs on PR close

### DIFF
--- a/.github/workflows/pr-close-cancel-runs.yml
+++ b/.github/workflows/pr-close-cancel-runs.yml
@@ -1,0 +1,64 @@
+name: PR Close Run Cancel
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: pr-close-cancel-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  cancel-closed-pr-runs:
+    name: Cancel queued/in-progress runs for closed PR
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Cancel active pull_request runs for head branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = context.payload.pull_request.head.ref;
+            const statuses = ["queued", "in_progress", "pending", "waiting", "requested"];
+            const events = ["pull_request", "pull_request_target"];
+
+            const runIds = new Set();
+            for (const event of events) {
+              for (const status of statuses) {
+                const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+                  owner,
+                  repo,
+                  event,
+                  branch,
+                  status,
+                  per_page: 100,
+                });
+                for (const run of runs) {
+                  if (statuses.includes(run.status)) {
+                    runIds.add(run.id);
+                  }
+                }
+              }
+            }
+
+            let cancelled = 0;
+            for (const runId of runIds) {
+              try {
+                await github.rest.actions.cancelWorkflowRun({ owner, repo, run_id: runId });
+                cancelled += 1;
+                core.info(`cancelled run ${runId}`);
+              } catch (err) {
+                core.warning(`failed to cancel ${runId}: ${err.message}`);
+              }
+            }
+
+            core.info(`branch=${branch} active_runs_seen=${runIds.size} cancelled=${cancelled}`);


### PR DESCRIPTION
## Summary
- add a lightweight workflow that listens for `pull_request.closed`
- cancel queued/in-progress `pull_request` and `pull_request_target` runs for the closed PR branch
- reduce stale run backlogs without adding merge gates

## Why
This keeps CI throughput high by removing zombie runs after PR close, with no impact on merge autonomy.
