### PR TITLE
feat(debate): expand repo hint limits for better practicality scores

### DIFF
--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -536,21 +536,39 @@ Required sections:
    Do NOT write qualitative-only criteria like "tests should pass" — always include a number.
 7. JSON Payload — machine-readable summary"""
 
+    # Directories most relevant to self-improvement tasks get more file slots.
+    _PRIORITY_DIRS = frozenset(
+        {
+            "debate",
+            "nomic",
+            "pipeline",
+            "cli",
+            "server",
+            "agents",
+            "knowledge",
+            "memory",
+            "control_plane",
+            "audit",
+            "gauntlet",
+        }
+    )
+
     @staticmethod
     def _get_repo_path_hint() -> str:
         """Generate a compact listing of real repo paths for grounding.
 
         Dynamically discovers all subdirectories under ``aragora/`` plus key
-        test/script directories. Caps output by line and character budgets so
-        repo hints do not starve the synthesis prompt.
+        test/script directories. Priority directories (debate, nomic, pipeline,
+        etc.) get more file slots so synthesis agents can reference real paths
+        instead of inventing them.
         """
         try:
             from pathlib import Path
 
             repo_root = Path(os.getcwd())
             lines: list[str] = []
-            max_lines = 24
-            max_chars = 1800
+            max_lines = 150
+            max_chars = 12000
 
             # 1. Top-level project files
             top_files = [
@@ -574,23 +592,34 @@ Required sections:
                     suffixes = {".py"}
                     if "live" in str(subdir):
                         suffixes.update({".ts", ".tsx"})
+                    is_priority = subdir.name in SynthesisGenerator._PRIORITY_DIRS
+                    file_limit = 12 if is_priority else 8
                     files = sorted(
                         f.name
                         for f in dp.iterdir()
                         if f.is_file() and f.suffix in suffixes and f.name != "__init__.py"
-                    )[:3]
+                    )[:file_limit]
                     if files:
                         lines.append(f"  {subdir}/: {', '.join(files)}")
                         if sum(len(line) + 1 for line in lines) >= max_chars:
                             break
 
             # 3. Key test and script directories
-            for d in ("tests/debate", "tests/cli", "tests/pipeline", "scripts"):
+            for d in (
+                "tests/debate",
+                "tests/cli",
+                "tests/pipeline",
+                "tests/nomic",
+                "tests/agents",
+                "tests/server",
+                "tests/knowledge",
+                "scripts",
+            ):
                 if len(lines) >= max_lines:
                     break
                 dp = repo_root / d
                 if dp.is_dir():
-                    files = sorted(f.name for f in dp.iterdir() if f.suffix == ".py")[:3]
+                    files = sorted(f.name for f in dp.iterdir() if f.suffix == ".py")[:8]
                     if files:
                         lines.append(f"  {d}/: {', '.join(files)}")
                         if sum(len(line) + 1 for line in lines) >= max_chars:

--- a/tests/debate/phases/test_synthesis_generator.py
+++ b/tests/debate/phases/test_synthesis_generator.py
@@ -197,8 +197,10 @@ class TestBuildSynthesisPrompt:
         gen = SynthesisGenerator()
         prompt = gen._build_synthesis_prompt(ctx)
 
-        # Should be truncated to 1500 chars
-        assert len(prompt) < 6000
+        # Proposal should be truncated to ~1500 chars; total prompt includes
+        # repo path hints (~12K) plus base template, so verify the full 5000-
+        # char proposal is not present (i.e. it was actually truncated).
+        assert "x" * 5000 not in prompt
 
 
 class TestCombineProposalsAsSynthesis:


### PR DESCRIPTION
## Summary
- Expand synthesis generator repo hints from 24 lines/1800 chars to 150 lines/12000 chars
- Priority directories (debate, nomic, pipeline, cli, etc.) now show 12 files instead of 3
- All 122 aragora/ subdirs now covered (was only ~20 before hitting the cap)
- Test directories expanded: added tests/nomic, tests/agents, tests/server, tests/knowledge

## Why
Synthesis agents could only see 20% of the codebase structure, causing them to invent file paths (path_existence: 0.45, concreteness: 0.25). This is the last remaining planned improvement for boosting practicality scores from 3.5/10 toward 5.0+/10.

## Test plan
- [x] 120/120 synthesis phase tests pass
- [x] 51/51 repo grounding + output quality tests pass
- [x] 2353/2354 full debate suite pass (1 pre-existing checkpoint failure)
- [x] Key directories verified present: debate, nomic, pipeline, server, knowledge, tests/debate
- [x] Priority dirs show 12 files (verified debate/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)