### PR TITLE
feat(prompt-engine): add optional WS streaming path

### DIFF
--- a/aragora/live/src/app/(app)/prompt-engine/page.tsx
+++ b/aragora/live/src/app/(app)/prompt-engine/page.tsx
@@ -229,14 +229,15 @@ export default function PromptEnginePage() {
   const engine = usePromptEngine();
   const [prompt, setPrompt] = useState('');
   const [profile, setProfile] = useState<ProfileKey>('founder');
+  const [useStreaming, setUseStreaming] = useState(true);
 
   const handleSubmit = useCallback(
     (e: React.FormEvent) => {
       e.preventDefault();
       if (!prompt.trim() || engine.isRunning) return;
-      engine.runPipeline(prompt.trim(), { profile });
+      engine.runPipeline(prompt.trim(), { profile, useWebSocket: useStreaming });
     },
-    [prompt, profile, engine],
+    [prompt, profile, engine, useStreaming],
   );
 
   const handleAnswer = useCallback(
@@ -292,6 +293,16 @@ export default function PromptEnginePage() {
                 ))}
               </select>
             </div>
+            <label className="flex items-center gap-1.5 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={useStreaming}
+                onChange={(e) => setUseStreaming(e.target.checked)}
+                disabled={engine.isRunning}
+                className="accent-acid-cyan"
+              />
+              <span className="text-acid-green/60 font-mono text-xs">Stream</span>
+            </label>
             <button
               type="submit"
               disabled={!prompt.trim() || engine.isRunning}

--- a/aragora/live/src/config.ts
+++ b/aragora/live/src/config.ts
@@ -149,6 +149,9 @@ export const NOMIC_LOOP_WS_URL = resolveWsUrl(
 // Oracle real-time streaming WebSocket — derives from WS_URL base
 export const ORACLE_WS_URL = WS_URL.replace(/\/ws\/?$/, '') + '/ws/oracle';
 
+// Prompt engine pipeline streaming WebSocket
+export const PROMPT_ENGINE_WS_URL = WS_URL.replace(/\/ws\/?$/, '') + '/ws/prompt-engine';
+
 // Helper to detect dev/localhost mode (useful for conditional behavior)
 export const IS_DEV_MODE = !_API_BASE_URL || API_BASE_URL.includes('localhost');
 export const IS_PRODUCTION = _isProductionBuild || (typeof window !== 'undefined' && isProductionEnvironment());

--- a/aragora/live/src/hooks/usePromptEngine.ts
+++ b/aragora/live/src/hooks/usePromptEngine.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useCallback, useRef } from 'react';
-import { API_BASE_URL } from '@/config';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { API_BASE_URL, PROMPT_ENGINE_WS_URL } from '@/config';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -151,9 +151,14 @@ export function usePromptEngine(): UsePromptEngineReturn {
   const [error, setError] = useState<string | null>(null);
   const [stagesCompleted, setStagesCompleted] = useState<string[]>([]);
   const abortRef = useRef<AbortController | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
 
   const reset = useCallback(() => {
     abortRef.current?.abort();
+    if (wsRef.current && wsRef.current.readyState <= WebSocket.OPEN) {
+      wsRef.current.close();
+    }
+    wsRef.current = null;
     setIsRunning(false);
     setCurrentStage('idle');
     setIntent(null);
@@ -182,7 +187,7 @@ export function usePromptEngine(): UsePromptEngineReturn {
     );
   }, []);
 
-  const runPipeline = useCallback(async (prompt: string, options?: PipelineOptions) => {
+  const runPipelineRest = useCallback(async (prompt: string, options?: PipelineOptions) => {
     reset();
     setIsRunning(true);
     setCurrentStage('decompose');
@@ -221,6 +226,104 @@ export function usePromptEngine(): UsePromptEngineReturn {
       setIsRunning(false);
     }
   }, [reset]);
+
+  const runPipelineWs = useCallback((prompt: string, options?: PipelineOptions) => {
+    reset();
+    setIsRunning(true);
+    setCurrentStage('decompose');
+
+    const ws = new WebSocket(PROMPT_ENGINE_WS_URL);
+    wsRef.current = ws;
+    const completed: string[] = [];
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({
+        action: 'run',
+        prompt,
+        profile: options?.profile ?? 'founder',
+        context: null,
+      }));
+    };
+
+    ws.onmessage = (event) => {
+      try {
+        const msg = JSON.parse(event.data);
+
+        switch (msg.type) {
+          case 'prompt_engine_stage':
+            setCurrentStage(msg.stage as PipelineStage);
+            if (!completed.includes(msg.stage)) {
+              completed.push(msg.stage);
+              setStagesCompleted([...completed]);
+            }
+            break;
+
+          case 'prompt_engine_intent':
+            setIntent(msg.intent as PromptIntent);
+            break;
+
+          case 'prompt_engine_questions':
+            setQuestions((msg.questions as ClarifyingQuestion[]) ?? []);
+            break;
+
+          case 'prompt_engine_research':
+            setResearch(msg.research as ResearchReport);
+            break;
+
+          case 'prompt_engine_spec':
+            setSpecification(msg.specification as Specification);
+            break;
+
+          case 'prompt_engine_validation':
+            setValidation(msg.validation as ValidationResult);
+            break;
+
+          case 'prompt_engine_complete':
+            setStagesCompleted(msg.stages_completed ?? completed);
+            setCurrentStage('complete');
+            setIsRunning(false);
+            ws.close();
+            break;
+
+          case 'prompt_engine_error':
+            setError(msg.error ?? 'Pipeline failed');
+            setCurrentStage('error');
+            setIsRunning(false);
+            ws.close();
+            break;
+        }
+      } catch {
+        // Ignore malformed messages
+      }
+    };
+
+    ws.onerror = () => {
+      setError('WebSocket connection failed');
+      setCurrentStage('error');
+      setIsRunning(false);
+    };
+
+    ws.onclose = () => {
+      wsRef.current = null;
+    };
+  }, [reset]);
+
+  const runPipeline = useCallback(async (prompt: string, options?: PipelineOptions) => {
+    if (options?.useWebSocket) {
+      runPipelineWs(prompt, options);
+    } else {
+      await runPipelineRest(prompt, options);
+    }
+  }, [runPipelineRest, runPipelineWs]);
+
+  // Clean up WebSocket on unmount
+  useEffect(() => {
+    return () => {
+      if (wsRef.current && wsRef.current.readyState <= WebSocket.OPEN) {
+        wsRef.current.close();
+      }
+    };
+  }, []);
 
   return {
     isRunning,

--- a/aragora/prompt_engine/spec_builder.py
+++ b/aragora/prompt_engine/spec_builder.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 from aragora.prompt_engine.decomposer import PromptDecomposer
@@ -147,25 +148,21 @@ class SpecBuilder:
     def _parse_spec(self, response: str) -> Specification:
         """Parse LLM response into a Specification."""
         text = response.strip()
-        if text.startswith("```"):
-            text = text.split("\n", 1)[1] if "\n" in text else text[3:]
-        if text.endswith("```"):
-            text = text[:-3]
-        text = text.strip()
 
-        try:
-            data = json.loads(text)
-        except json.JSONDecodeError:
-            start = text.find("{")
-            end = text.rfind("}") + 1
-            if start >= 0 and end > start:
-                try:
-                    data = json.loads(text[start:end])
-                except json.JSONDecodeError:
-                    logger.warning("Could not parse spec response")
-                    return self._fallback_spec(text)
-            else:
-                return self._fallback_spec(text)
+        # Strip markdown code fences (```json ... ``` or ``` ... ```)
+        fence_match = re.search(r"```(?:json)?\s*\n(.*?)```", text, re.DOTALL)
+        if fence_match:
+            text = fence_match.group(1).strip()
+        else:
+            if text.startswith("```"):
+                text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+
+        data = self._extract_json(text)
+        if data is None:
+            return self._fallback_spec(text)
 
         try:
             file_changes = [
@@ -212,6 +209,56 @@ class SpecBuilder:
         except (KeyError, TypeError, ValueError) as e:
             logger.warning("Error building Specification: %s", e)
             return self._fallback_spec(text)
+
+    @staticmethod
+    def _extract_json(text: str) -> dict[str, Any] | None:
+        """Try multiple strategies to extract JSON from LLM response."""
+        # Strategy 1: direct parse
+        try:
+            return json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+        # Strategy 2: find outermost { ... } using brace balancing
+        start = text.find("{")
+        if start < 0:
+            return None
+
+        depth = 0
+        in_string = False
+        escape_next = False
+        for i in range(start, len(text)):
+            c = text[i]
+            if escape_next:
+                escape_next = False
+                continue
+            if c == "\\":
+                escape_next = True
+                continue
+            if c == '"' and not escape_next:
+                in_string = not in_string
+                continue
+            if in_string:
+                continue
+            if c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    try:
+                        return json.loads(text[start : i + 1])
+                    except (json.JSONDecodeError, ValueError):
+                        return None
+
+        # Strategy 3: fallback to rfind
+        end = text.rfind("}") + 1
+        if start >= 0 and end > start:
+            try:
+                return json.loads(text[start:end])
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        return None
 
     @staticmethod
     def _fallback_spec(raw_text: str) -> Specification:


### PR DESCRIPTION
## Summary
- add a prompt-engine UI toggle to run via WebSocket streaming or REST
- wire `usePromptEngine` with a WebSocket execution path and cleanup handling
- add `PROMPT_ENGINE_WS_URL` config for the `/ws/prompt-engine` endpoint
- harden `SpecBuilder` JSON parsing with fenced-block extraction + brace-balanced fallback

## Validation
- `python -m pytest -q tests/prompt_engine/test_prompt_engine.py` (44 passed)
- frontend lint/typecheck scripts unavailable in this worktree runtime (`eslint` not installed), so TS changes were manually reviewed
