### PR TITLE
fix(landing): remove old sections cluttering landing page

### DIFF
--- a/aragora/live/src/components/landing/LandingPage.tsx
+++ b/aragora/live/src/components/landing/LandingPage.tsx
@@ -3,12 +3,8 @@
 import { useTheme } from '@/context/ThemeContext';
 import { Header } from './Header';
 import { HeroSection } from './HeroSection';
-import { HowItWorksSection } from './HowItWorksSection';
 import { ProblemSection } from './ProblemSection';
-import { FeatureShowcase } from './FeatureShowcase';
-import { IntegrationsGrid } from './IntegrationsGrid';
-import { LiveDemoSection } from './LiveDemoSection';
-import { DeveloperSection } from './DeveloperSection';
+import { HowItWorksSection } from './HowItWorksSection';
 import { PricingSection } from './PricingSection';
 import { Footer } from './Footer';
 
@@ -27,12 +23,8 @@ export function LandingPage() {
     >
       <Header />
       <HeroSection />
-      <HowItWorksSection />
       <ProblemSection />
-      <FeatureShowcase />
-      <IntegrationsGrid />
-      <LiveDemoSection />
-      <DeveloperSection />
+      <HowItWorksSection />
       <PricingSection />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- Remove FeatureShowcase, IntegrationsGrid, LiveDemoSection, and DeveloperSection from the landing page
- These sections were left over from the old landing page and clutter the redesigned layout
- Landing page now renders exactly 5 lean sections: Hero → Problem → HowItWorks → Pricing → Footer

## Context
Follow-up to PR #491 (tri-theme landing page redesign). The section cleanup was accidentally not included in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)