### PR TITLE
fix(quality): exclude 'add' from duplicate-create scoring

### DIFF
--- a/aragora/debate/output_quality.py
+++ b/aragora/debate/output_quality.py
@@ -48,7 +48,16 @@ _THRESHOLD_LINE_RE = re.compile(
 )
 _JSON_BLOCK_RE = re.compile(r"```json\s*(.*?)```", re.DOTALL | re.IGNORECASE)
 _GENERIC_CODE_BLOCK_RE = re.compile(r"```\s*(.*?)```", re.DOTALL)
+# Verbs that unambiguously mean "make something new from scratch".
+# NOTE: "add" is intentionally EXCLUDED — it usually means "add feature to
+# existing file" (modify), not "create a new file".  Including it caused
+# massive false-positive duplicate-create scoring (runs 008h–011).
 _CREATE_ACTION_RE = re.compile(
+    r"(?i)\b(create|build|scaffold|introduce|implement\s+new|spin\s+up)\b"
+)
+# Broader set including "add" — only used for _repair_duplicate_create_lines
+# where the context (line references an existing path) disambiguates.
+_CREATE_OR_ADD_ACTION_RE = re.compile(
     r"(?i)\b(create|add|build|scaffold|introduce|implement\s+new|spin\s+up)\b"
 )
 _DUPLICATE_CREATE_MAX_RATIO = 0.25
@@ -1190,7 +1199,11 @@ def _repair_duplicate_create_lines(text: str, repo_root: Path) -> str:
     for raw_line in text.splitlines():
         line = raw_line
         stripped = line.strip()
-        if not stripped or "new file" in stripped.lower() or not _CREATE_ACTION_RE.search(line):
+        if (
+            not stripped
+            or "new file" in stripped.lower()
+            or not _CREATE_OR_ADD_ACTION_RE.search(line)
+        ):
             out_lines.append(line)
             continue
 

--- a/tests/debate/test_output_quality.py
+++ b/tests/debate/test_output_quality.py
@@ -885,6 +885,39 @@ If error_rate > 2% for 10m, rollback by disabling feature flag.
     assert ratio_after is None or ratio_after <= 0.25
 
 
+def test_add_to_existing_file_not_counted_as_duplicate_create(tmp_path):
+    """'Add X to existing_file.py' is a modify action, not a duplicate-create."""
+    (tmp_path / "aragora" / "analytics").mkdir(parents=True)
+    (tmp_path / "aragora" / "analytics" / "dashboard.py").write_text("# existing")
+    (tmp_path / "aragora" / "audit").mkdir(parents=True)
+    (tmp_path / "aragora" / "audit" / "orchestrator.py").write_text("# existing")
+    (tmp_path / "aragora" / "resilience").mkdir(parents=True)
+    (tmp_path / "aragora" / "resilience" / "circuit_breaker.py").write_text("# existing")
+
+    answer = """\
+## Owner module / file paths
+- `aragora/analytics/dashboard.py` (add real-time quality dashboards)
+- `aragora/audit/orchestrator.py` (add mode transition logging)
+- `aragora/resilience/circuit_breaker.py` (add debate-specific patterns)
+"""
+    ratio = compute_duplicate_existing_create_ratio(answer, tmp_path)
+    # "add" to existing files is a modify action — should NOT be counted as
+    # duplicate-create.  Ratio should be None (no create-verb lines) or 0.
+    assert ratio is None or ratio == 0.0
+
+
+def test_repair_still_rewrites_add_targeting_existing_paths(tmp_path):
+    """Repair function still rewrites 'add' to 'modify' for existing paths."""
+    from aragora.debate.output_quality import _repair_duplicate_create_lines
+
+    (tmp_path / "aragora" / "debate").mkdir(parents=True)
+    (tmp_path / "aragora" / "debate" / "quality.py").write_text("# existing")
+
+    text = "- Add aragora/debate/quality.py new validation checks."
+    repaired = _repair_duplicate_create_lines(text, tmp_path)
+    assert "modify" in repaired.lower()
+
+
 # ---------------------------------------------------------------------------
 # Deterministic path repair tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `add` from `_CREATE_ACTION_RE` (the scoring regex) because "add X to existing_file.py" is a modify action, not a duplicate-create
- Creates `_CREATE_OR_ADD_ACTION_RE` for the repair function that still rewrites verbs

## Problem

Dogfood runs 008h–011 showed `duplicate_existing_create_ratio = 1.0` on enhanced outputs that were correctly proposing "add feature to existing file." Lines like:
```
aragora/analytics/dashboard.py (add real-time quality dashboards)
```
were scored as duplicate-create because `add` was in the create-verb regex.

## Impact

- Scoring no longer penalizes modify-in-place proposals
- Repair function still rewrites `add` → `modify` for existing paths (separate broader regex)
- 36 tests pass (34 existing + 2 new regression tests)

## Test plan
- [x] `pytest tests/debate/test_output_quality.py` — 36 passed
- [x] Verified "add to existing file" returns ratio=None
- [x] Verified "create existing file" still returns ratio=1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)