### PR TITLE
feat(cli): aragora compliance export for EU AI Act bundles

### DIFF
--- a/aragora/cli/commands/compliance.py
+++ b/aragora/cli/commands/compliance.py
@@ -5,6 +5,7 @@ Provides CLI access to EU AI Act compliance tooling and the compliance framework
 - aragora compliance audit <receipt_file>  -- Generate conformity report
 - aragora compliance classify <description> -- Classify use case by risk level
 - aragora compliance eu-ai-act generate    -- Generate full artifact bundle (Art. 9, 12-15)
+- aragora compliance export                -- Export structured compliance bundle for a debate
 - aragora compliance --generate-artifacts  -- Shorthand for eu-ai-act generate
 - aragora compliance status                -- Show compliance framework status
 - aragora compliance report                -- Generate a compliance framework report
@@ -167,6 +168,11 @@ def add_compliance_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Free-text description of the AI use case",
     )
 
+    # -- aragora compliance export --
+    from aragora.cli.commands.compliance_export import add_export_subparser
+
+    add_export_subparser(sub)
+
     # -- aragora compliance eu-ai-act generate --
     eu_p = sub.add_parser(
         "eu-ai-act",
@@ -258,6 +264,10 @@ def cmd_compliance(args: argparse.Namespace) -> None:
         _cmd_audit(args)
     elif command == "classify":
         _cmd_classify(args)
+    elif command == "export":
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        cmd_compliance_export(args)
     elif command == "eu-ai-act":
         eu_command = getattr(args, "eu_ai_act_command", None)
         if eu_command == "generate":
@@ -271,7 +281,7 @@ def cmd_compliance(args: argparse.Namespace) -> None:
             print("Omit receipt_file to generate a demonstration bundle with synthetic data.")
             sys.exit(1)
     else:
-        print("Usage: aragora compliance {status,report,check,audit,classify,eu-ai-act}")
+        print("Usage: aragora compliance {status,report,check,audit,classify,export,eu-ai-act}")
         print()
         print("  Framework commands (offline):")
         print("    status     Show compliance framework status")
@@ -281,6 +291,7 @@ def cmd_compliance(args: argparse.Namespace) -> None:
         print("  EU AI Act commands:")
         print("    audit      Generate EU AI Act conformity report from a receipt")
         print("    classify   Classify a use case by EU AI Act risk level")
+        print("    export     Export structured compliance bundle for a debate")
         print("    eu-ai-act  Generate compliance artifact bundles (Articles 12/13/14)")
         sys.exit(1)
 

--- a/aragora/cli/commands/compliance_export.py
+++ b/aragora/cli/commands/compliance_export.py
@@ -1,0 +1,928 @@
+"""
+EU AI Act compliance export CLI command.
+
+Generates a structured compliance bundle from a debate ID, mapping Aragora
+decision artifacts to EU AI Act articles:
+
+  Article  9: Risk management   -> decision receipt with risk assessment
+  Article 12: Record-keeping    -> full audit trail (provenance chain)
+  Article 13: Transparency      -> agent participation + reasoning
+  Article 14: Human oversight   -> voting record, dissent, escalation
+  Article 15: Accuracy          -> confidence scores, calibration data
+
+Usage:
+    aragora compliance export \\
+        --framework eu-ai-act \\
+        --debate-id <ID> \\
+        --output-dir ./compliance-pack \\
+        [--format markdown|html|json] \\
+        [--include-receipts] \\
+        [--include-audit-trail] \\
+        [--demo]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Supported frameworks (extensible)
+SUPPORTED_FRAMEWORKS = ("eu-ai-act",)
+
+# EU AI Act article mapping
+EU_AI_ACT_ARTICLES = {
+    "article_9": {
+        "number": "Article 9",
+        "title": "Risk Management System",
+        "requirement": (
+            "Identify and analyze known and reasonably foreseeable risks. "
+            "Establish, implement, document, and maintain a risk management system."
+        ),
+    },
+    "article_12": {
+        "number": "Article 12",
+        "title": "Record-Keeping (Automatic Logging)",
+        "requirement": (
+            "Technically allow for automatic recording of events ('logs') "
+            "over the lifetime of the system, enabling traceability."
+        ),
+    },
+    "article_13": {
+        "number": "Article 13",
+        "title": "Transparency and Provision of Information to Deployers",
+        "requirement": (
+            "Be sufficiently transparent for deployers to interpret output "
+            "and use it appropriately. Document agent identities, reasoning, "
+            "and decision rationale."
+        ),
+    },
+    "article_14": {
+        "number": "Article 14",
+        "title": "Human Oversight",
+        "requirement": (
+            "Enable effective human oversight including ability to understand "
+            "output, decide not to use the system, override, and intervene."
+        ),
+    },
+    "article_15": {
+        "number": "Article 15",
+        "title": "Accuracy, Robustness and Cybersecurity",
+        "requirement": (
+            "Achieve appropriate levels of accuracy, robustness, and "
+            "cybersecurity. Be resilient to errors, faults, and attacks."
+        ),
+    },
+}
+
+
+def add_export_subparser(sub: argparse._SubParsersAction) -> None:
+    """Register the 'export' subcommand under 'compliance'."""
+    export_p = sub.add_parser(
+        "export",
+        help="Export a structured compliance bundle for a debate",
+        description=(
+            "Export a structured compliance bundle mapping debate artifacts to "
+            "regulatory framework requirements (e.g. EU AI Act Articles 9, 12-15). "
+            "Use --demo to generate a sample bundle without a real debate."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    export_p.add_argument(
+        "--framework",
+        default="eu-ai-act",
+        choices=list(SUPPORTED_FRAMEWORKS),
+        help="Compliance framework to export against (default: eu-ai-act)",
+    )
+    export_p.add_argument(
+        "--debate-id",
+        dest="debate_id",
+        help="Debate ID to export compliance pack for",
+    )
+    export_p.add_argument(
+        "--receipt-file",
+        dest="receipt_file",
+        help="Path to an existing receipt JSON file (alternative to --debate-id)",
+    )
+    export_p.add_argument(
+        "--output-dir",
+        dest="output_dir",
+        default="./compliance-pack",
+        help="Output directory for the compliance bundle (default: ./compliance-pack)",
+    )
+    export_p.add_argument(
+        "--format",
+        dest="output_format",
+        choices=["markdown", "html", "json"],
+        default="markdown",
+        help="Output format for report files (default: markdown)",
+    )
+    export_p.add_argument(
+        "--include-receipts",
+        dest="include_receipts",
+        action="store_true",
+        default=True,
+        help="Include decision receipts in the bundle (default: True)",
+    )
+    export_p.add_argument(
+        "--include-audit-trail",
+        dest="include_audit_trail",
+        action="store_true",
+        default=True,
+        help="Include full audit trail in the bundle (default: True)",
+    )
+    export_p.add_argument(
+        "--demo",
+        action="store_true",
+        help="Generate a sample compliance bundle from synthetic data",
+    )
+
+
+def cmd_compliance_export(args: argparse.Namespace) -> None:
+    """Execute the compliance export command."""
+    framework = getattr(args, "framework", "eu-ai-act")
+    debate_id = getattr(args, "debate_id", None)
+    receipt_file = getattr(args, "receipt_file", None)
+    output_dir = getattr(args, "output_dir", "./compliance-pack")
+    output_format = getattr(args, "output_format", "markdown")
+    include_receipts = getattr(args, "include_receipts", True)
+    include_audit_trail = getattr(args, "include_audit_trail", True)
+    demo = getattr(args, "demo", False)
+
+    if framework not in SUPPORTED_FRAMEWORKS:
+        print(f"Error: Unsupported framework '{framework}'.", file=sys.stderr)
+        print(f"Supported: {', '.join(SUPPORTED_FRAMEWORKS)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load receipt data
+    receipt_dict = _resolve_receipt(debate_id, receipt_file, demo)
+
+    # Generate the compliance bundle
+    bundle = _generate_compliance_bundle(
+        receipt_dict=receipt_dict,
+        framework=framework,
+        include_receipts=include_receipts,
+        include_audit_trail=include_audit_trail,
+    )
+
+    # Write to output directory
+    _write_bundle(bundle, output_dir, output_format)
+
+    # Print summary
+    _print_summary(bundle, output_dir, output_format)
+
+
+def _resolve_receipt(
+    debate_id: str | None,
+    receipt_file: str | None,
+    demo: bool,
+) -> dict[str, Any]:
+    """Resolve a receipt dictionary from debate ID, file, or demo mode."""
+    if demo:
+        print("Generating compliance bundle from synthetic demo data.")
+        print()
+        return _synthetic_receipt()
+
+    if receipt_file:
+        try:
+            with open(receipt_file) as f:
+                return json.load(f)
+        except FileNotFoundError:
+            print(f"Error: Receipt file not found: {receipt_file}", file=sys.stderr)
+            sys.exit(1)
+        except json.JSONDecodeError as exc:
+            print(f"Error: Invalid JSON in receipt file: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    if debate_id:
+        return _load_receipt_for_debate(debate_id)
+
+    # No source specified
+    print(
+        "Error: Provide --debate-id, --receipt-file, or --demo.",
+        file=sys.stderr,
+    )
+    print(
+        "\nUse --demo to generate a sample compliance bundle:\n"
+        "  aragora compliance export --demo --output-dir ./compliance-pack",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def _load_receipt_for_debate(debate_id: str) -> dict[str, Any]:
+    """Attempt to load a receipt for the given debate ID.
+
+    Looks in the default data directory for receipt files, and falls back
+    to the gauntlet storage if available.
+    """
+    # Try common receipt file paths
+    candidate_paths = [
+        os.path.expanduser(f"~/.aragora/receipts/{debate_id}.json"),
+        os.path.expanduser(f"~/.aragora/debates/{debate_id}/receipt.json"),
+        f"./receipts/{debate_id}.json",
+        f"./{debate_id}.json",
+    ]
+
+    for path in candidate_paths:
+        if os.path.exists(path):
+            try:
+                with open(path) as f:
+                    return json.load(f)
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Failed to load receipt from %s: %s", path, exc)
+
+    # Try gauntlet storage
+    try:
+        from aragora.gauntlet.storage import ReceiptStorage
+
+        storage = ReceiptStorage()
+        receipt = storage.load(debate_id)
+        if receipt is not None:
+            if hasattr(receipt, "to_dict"):
+                return receipt.to_dict()
+            if isinstance(receipt, dict):
+                return receipt
+    except (ImportError, AttributeError, OSError) as exc:
+        logger.debug("Gauntlet storage unavailable: %s", exc)
+
+    print(
+        f"Error: No receipt found for debate ID '{debate_id}'.",
+        file=sys.stderr,
+    )
+    print(
+        "\nLooked in:\n"
+        + "\n".join(f"  - {p}" for p in candidate_paths)
+        + "\n  - Gauntlet receipt storage",
+        file=sys.stderr,
+    )
+    print(
+        "\nUse --demo to generate a sample compliance bundle:\n"
+        "  aragora compliance export --demo --output-dir ./compliance-pack",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Bundle generation
+# ---------------------------------------------------------------------------
+
+
+def _generate_compliance_bundle(
+    receipt_dict: dict[str, Any],
+    framework: str,
+    include_receipts: bool,
+    include_audit_trail: bool,
+) -> dict[str, Any]:
+    """Build the compliance bundle from receipt data."""
+    from aragora.compliance.eu_ai_act import (
+        ComplianceArtifactGenerator,
+        ConformityReportGenerator,
+        RiskClassifier,
+    )
+
+    receipt_id = receipt_dict.get("receipt_id", "unknown")
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    # Risk classification
+    classifier = RiskClassifier()
+    classification = classifier.classify_receipt(receipt_dict)
+
+    # Conformity report
+    report_gen = ConformityReportGenerator(classifier=classifier)
+    conformity = report_gen.generate(receipt_dict)
+
+    # Full artifact bundle (Art. 12, 13, 14)
+    artifact_gen = ComplianceArtifactGenerator()
+    artifact_bundle = artifact_gen.generate(receipt_dict)
+
+    # Extract per-article data
+    receipt_data = _build_receipt_section(receipt_dict) if include_receipts else None
+    audit_trail = _build_audit_trail(receipt_dict) if include_audit_trail else None
+    transparency = _build_transparency_report(receipt_dict, conformity)
+    human_oversight = _build_human_oversight(receipt_dict, conformity)
+    accuracy = _build_accuracy_report(receipt_dict, conformity)
+
+    # Compute integrity hash
+    hash_input = json.dumps(
+        {
+            "receipt_id": receipt_id,
+            "framework": framework,
+            "timestamp": timestamp,
+            "classification": classification.risk_level.value,
+            "conformity": conformity.overall_status,
+        },
+        sort_keys=True,
+    )
+    integrity_hash = hashlib.sha256(hash_input.encode()).hexdigest()
+
+    return {
+        "meta": {
+            "framework": framework,
+            "receipt_id": receipt_id,
+            "generated_at": timestamp,
+            "integrity_hash": integrity_hash,
+            "compliance_deadline": "2026-08-02",
+            "regulation": "EU AI Act (Regulation 2024/1689)",
+        },
+        "risk_classification": classification.to_dict(),
+        "conformity_report": conformity.to_dict(),
+        "receipt": receipt_data,
+        "audit_trail": audit_trail,
+        "transparency_report": transparency,
+        "human_oversight": human_oversight,
+        "accuracy_report": accuracy,
+        "article_artifacts": {
+            "article_12": artifact_bundle.article_12.to_dict(),
+            "article_13": artifact_bundle.article_13.to_dict(),
+            "article_14": artifact_bundle.article_14.to_dict(),
+        },
+    }
+
+
+def _build_receipt_section(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Extract decision receipt data for the bundle."""
+    return {
+        "receipt_id": receipt.get("receipt_id", ""),
+        "timestamp": receipt.get("timestamp", ""),
+        "input_summary": receipt.get("input_summary", ""),
+        "verdict": receipt.get("verdict", ""),
+        "confidence": receipt.get("confidence", 0.0),
+        "verdict_reasoning": receipt.get("verdict_reasoning", ""),
+        "risk_summary": receipt.get("risk_summary", {}),
+        "robustness_score": receipt.get("robustness_score", 0.0),
+        "dissenting_views": receipt.get("dissenting_views", []),
+        "artifact_hash": receipt.get("artifact_hash", ""),
+        "signature": receipt.get("signature", ""),
+    }
+
+
+def _build_audit_trail(receipt: dict[str, Any]) -> dict[str, Any]:
+    """Build chronological audit trail from provenance chain."""
+    provenance = receipt.get("provenance_chain", [])
+    events = []
+    for i, entry in enumerate(provenance):
+        if isinstance(entry, dict):
+            events.append(
+                {
+                    "sequence": i + 1,
+                    "event_type": entry.get("event_type", "unknown"),
+                    "timestamp": entry.get("timestamp", ""),
+                    "actor": entry.get("actor", "system"),
+                }
+            )
+
+    config = receipt.get("config_used", {})
+    return {
+        "total_events": len(events),
+        "events": events,
+        "protocol": config.get("protocol", "adversarial"),
+        "rounds": config.get("rounds", 0),
+        "integrity_mechanism": "SHA-256 hash chain",
+        "retention_basis": "Art. 26(6) -- minimum 6 months for high-risk systems",
+    }
+
+
+def _build_transparency_report(
+    receipt: dict[str, Any],
+    conformity: Any,
+) -> dict[str, Any]:
+    """Build transparency report (Article 13 mapping)."""
+    consensus = receipt.get("consensus_proof", {}) or {}
+    supporting = consensus.get("supporting_agents", [])
+    dissenting_agents = consensus.get("dissenting_agents", [])
+    all_agents = sorted(set(supporting + dissenting_agents))
+    dissenting_views = receipt.get("dissenting_views", [])
+
+    # Find Art. 13 mapping status from conformity
+    art13_status = "unknown"
+    for m in conformity.article_mappings:
+        if m.article == "Article 13":
+            art13_status = m.status
+            break
+
+    return {
+        "article": "Article 13",
+        "status": art13_status,
+        "agents_participating": all_agents,
+        "agent_count": len(all_agents),
+        "supporting_agents": supporting,
+        "dissenting_agents": dissenting_agents,
+        "verdict_reasoning": receipt.get("verdict_reasoning", ""),
+        "dissenting_views": dissenting_views,
+        "consensus_method": consensus.get("method", ""),
+        "agreement_ratio": consensus.get("agreement_ratio", 0.0),
+    }
+
+
+def _build_human_oversight(
+    receipt: dict[str, Any],
+    conformity: Any,
+) -> dict[str, Any]:
+    """Build human oversight report (Article 14 mapping)."""
+    config = receipt.get("config_used", {})
+    provenance = receipt.get("provenance_chain", [])
+    dissenting_views = receipt.get("dissenting_views", [])
+
+    # Detect human involvement
+    human_events = []
+    for entry in provenance:
+        if isinstance(entry, dict):
+            etype = entry.get("event_type", "")
+            if etype in ("human_approval", "plan_approved", "human_override"):
+                human_events.append(entry)
+
+    has_human_oversight = bool(human_events) or config.get("require_approval", False)
+
+    # Find Art. 14 mapping status
+    art14_status = "unknown"
+    for m in conformity.article_mappings:
+        if m.article == "Article 14":
+            art14_status = m.status
+            break
+
+    # Build voting record
+    vote_events = [
+        entry
+        for entry in provenance
+        if isinstance(entry, dict) and entry.get("event_type") == "vote_cast"
+    ]
+
+    return {
+        "article": "Article 14",
+        "status": art14_status,
+        "human_oversight_detected": has_human_oversight,
+        "oversight_model": "Human-in-the-Loop (HITL)"
+        if has_human_oversight
+        else "Human-on-the-Loop (HOTL)",
+        "human_events": human_events,
+        "voting_record": {
+            "total_votes": len(vote_events),
+            "votes": vote_events,
+        },
+        "dissenting_views": dissenting_views,
+        "require_approval": config.get("require_approval", False),
+        "approver": config.get("approver", ""),
+        "escalation_available": True,
+        "override_available": True,
+        "stop_available": True,
+    }
+
+
+def _build_accuracy_report(
+    receipt: dict[str, Any],
+    conformity: Any,
+) -> dict[str, Any]:
+    """Build accuracy and robustness report (Article 15 mapping)."""
+    confidence = receipt.get("confidence", 0.0)
+    robustness = receipt.get("robustness_score", 0.0)
+
+    # Find Art. 15 mapping status
+    art15_status = "unknown"
+    for m in conformity.article_mappings:
+        if m.article == "Article 15":
+            art15_status = m.status
+            break
+
+    return {
+        "article": "Article 15",
+        "status": art15_status,
+        "confidence": confidence,
+        "robustness_score": robustness,
+        "integrity_hash_present": bool(receipt.get("artifact_hash")),
+        "signature_present": bool(receipt.get("signature")),
+        "attacks_attempted": receipt.get("attacks_attempted", 0),
+        "attacks_successful": receipt.get("attacks_successful", 0),
+        "probes_run": receipt.get("probes_run", 0),
+        "vulnerabilities_found": receipt.get("vulnerabilities_found", 0),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output writers
+# ---------------------------------------------------------------------------
+
+
+def _write_bundle(
+    bundle: dict[str, Any],
+    output_dir: str,
+    fmt: str,
+) -> None:
+    """Write the compliance bundle to the output directory."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Always write the full bundle as JSON
+    bundle_json_path = os.path.join(output_dir, "bundle.json")
+    with open(bundle_json_path, "w") as f:
+        json.dump(bundle, f, indent=2, default=str)
+
+    ext = _format_extension(fmt)
+
+    # Write individual files
+    if bundle.get("receipt") is not None:
+        _write_artifact(
+            os.path.join(output_dir, f"receipt.{ext}"),
+            "Decision Receipt",
+            bundle["receipt"],
+            fmt,
+            article_ref=EU_AI_ACT_ARTICLES["article_9"],
+        )
+
+    if bundle.get("audit_trail") is not None:
+        _write_artifact(
+            os.path.join(output_dir, f"audit_trail.{ext}"),
+            "Audit Trail",
+            bundle["audit_trail"],
+            fmt,
+            article_ref=EU_AI_ACT_ARTICLES["article_12"],
+        )
+
+    _write_artifact(
+        os.path.join(output_dir, f"transparency_report.{ext}"),
+        "Transparency Report",
+        bundle["transparency_report"],
+        fmt,
+        article_ref=EU_AI_ACT_ARTICLES["article_13"],
+    )
+
+    _write_artifact(
+        os.path.join(output_dir, f"human_oversight.{ext}"),
+        "Human Oversight Report",
+        bundle["human_oversight"],
+        fmt,
+        article_ref=EU_AI_ACT_ARTICLES["article_14"],
+    )
+
+    _write_artifact(
+        os.path.join(output_dir, f"accuracy_report.{ext}"),
+        "Accuracy and Robustness Report",
+        bundle["accuracy_report"],
+        fmt,
+        article_ref=EU_AI_ACT_ARTICLES["article_15"],
+    )
+
+    # Write README manifest
+    _write_manifest(output_dir, bundle, fmt)
+
+
+def _format_extension(fmt: str) -> str:
+    """Map format name to file extension."""
+    return {"markdown": "md", "html": "html", "json": "json"}.get(fmt, "md")
+
+
+def _write_artifact(
+    path: str,
+    title: str,
+    data: dict[str, Any],
+    fmt: str,
+    article_ref: dict[str, Any] | None = None,
+) -> None:
+    """Write a single artifact file."""
+    if fmt == "json":
+        content = json.dumps(data, indent=2, default=str)
+    elif fmt == "html":
+        content = _render_html(title, data, article_ref)
+    else:
+        content = _render_markdown(title, data, article_ref)
+
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def _render_markdown(
+    title: str,
+    data: dict[str, Any],
+    article_ref: dict[str, Any] | None = None,
+) -> str:
+    """Render data as markdown."""
+    lines = [f"# {title}", ""]
+
+    if article_ref:
+        lines.append(f"**{article_ref['number']}:** {article_ref['title']}")
+        lines.append("")
+        lines.append(f"> {article_ref['requirement']}")
+        lines.append("")
+        lines.append("---")
+        lines.append("")
+
+    for key, value in data.items():
+        readable_key = key.replace("_", " ").title()
+        if isinstance(value, list):
+            lines.append(f"## {readable_key}")
+            lines.append("")
+            if value and isinstance(value[0], dict):
+                # Table format for list of dicts
+                if value:
+                    headers = list(value[0].keys())
+                    lines.append(
+                        "| " + " | ".join(h.replace("_", " ").title() for h in headers) + " |"
+                    )
+                    lines.append("| " + " | ".join("---" for _ in headers) + " |")
+                    for item in value:
+                        row = " | ".join(str(item.get(h, ""))[:60] for h in headers)
+                        lines.append(f"| {row} |")
+                lines.append("")
+            else:
+                for item in value:
+                    lines.append(f"- {item}")
+                lines.append("")
+        elif isinstance(value, dict):
+            lines.append(f"## {readable_key}")
+            lines.append("")
+            for k, v in value.items():
+                rk = k.replace("_", " ").title()
+                if isinstance(v, list):
+                    lines.append(f"**{rk}:**")
+                    for item in v:
+                        lines.append(f"- {item}")
+                elif isinstance(v, dict):
+                    lines.append(f"**{rk}:** (see bundle.json for details)")
+                else:
+                    lines.append(f"**{rk}:** {v}")
+            lines.append("")
+        else:
+            lines.append(f"**{readable_key}:** {value}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def _render_html(
+    title: str,
+    data: dict[str, Any],
+    article_ref: dict[str, Any] | None = None,
+) -> str:
+    """Render data as minimal HTML."""
+    from html import escape
+
+    parts = [
+        "<!DOCTYPE html>",
+        "<html lang='en'>",
+        "<head>",
+        f"  <title>{escape(title)}</title>",
+        "  <meta charset='utf-8'>",
+        "  <style>",
+        "    body { font-family: system-ui, sans-serif; max-width: 900px; margin: 2rem auto; padding: 0 1rem; }",
+        "    table { border-collapse: collapse; width: 100%; margin: 1rem 0; }",
+        "    th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }",
+        "    th { background: #f5f5f5; }",
+        "    .status-pass { color: #16a34a; font-weight: bold; }",
+        "    .status-partial { color: #d97706; font-weight: bold; }",
+        "    .status-fail { color: #dc2626; font-weight: bold; }",
+        "    blockquote { border-left: 4px solid #3b82f6; padding-left: 1rem; color: #475569; }",
+        "    code { background: #f1f5f9; padding: 2px 6px; border-radius: 4px; }",
+        "  </style>",
+        "</head>",
+        "<body>",
+        f"  <h1>{escape(title)}</h1>",
+    ]
+
+    if article_ref:
+        parts.append(
+            f"  <p><strong>{escape(article_ref['number'])}:</strong> {escape(article_ref['title'])}</p>"
+        )
+        parts.append(f"  <blockquote>{escape(article_ref['requirement'])}</blockquote>")
+        parts.append("  <hr>")
+
+    for key, value in data.items():
+        readable_key = escape(key.replace("_", " ").title())
+        if isinstance(value, list) and value and isinstance(value[0], dict):
+            parts.append(f"  <h2>{readable_key}</h2>")
+            headers = list(value[0].keys())
+            parts.append("  <table>")
+            parts.append(
+                "    <tr>"
+                + "".join(f"<th>{escape(h.replace('_', ' ').title())}</th>" for h in headers)
+                + "</tr>"
+            )
+            for item in value:
+                parts.append(
+                    "    <tr>"
+                    + "".join(f"<td>{escape(str(item.get(h, '')))}</td>" for h in headers)
+                    + "</tr>"
+                )
+            parts.append("  </table>")
+        elif isinstance(value, list):
+            parts.append(f"  <h2>{readable_key}</h2>")
+            parts.append("  <ul>")
+            for item in value:
+                parts.append(f"    <li>{escape(str(item))}</li>")
+            parts.append("  </ul>")
+        elif isinstance(value, dict):
+            parts.append(f"  <h2>{readable_key}</h2>")
+            parts.append("  <dl>")
+            for k, v in value.items():
+                rk = escape(k.replace("_", " ").title())
+                parts.append(f"    <dt><strong>{rk}</strong></dt>")
+                parts.append(f"    <dd>{escape(str(v))}</dd>")
+            parts.append("  </dl>")
+        else:
+            parts.append(f"  <p><strong>{readable_key}:</strong> {escape(str(value))}</p>")
+
+    parts.append("</body>")
+    parts.append("</html>")
+    return "\n".join(parts)
+
+
+def _write_manifest(
+    output_dir: str,
+    bundle: dict[str, Any],
+    fmt: str,
+) -> None:
+    """Write the README manifest describing the compliance bundle."""
+    ext = _format_extension(fmt)
+    meta = bundle.get("meta", {})
+    classification = bundle.get("risk_classification", {})
+    conformity = bundle.get("conformity_report", {})
+
+    lines = [
+        "# EU AI Act Compliance Bundle",
+        "",
+        f"**Generated:** {meta.get('generated_at', '')}",
+        f"**Receipt ID:** {meta.get('receipt_id', '')}",
+        f"**Integrity Hash:** `{meta.get('integrity_hash', '')}`",
+        f"**Risk Level:** {classification.get('risk_level', 'unknown').upper()}",
+        f"**Conformity Status:** {conformity.get('overall_status', 'unknown').upper()}",
+        f"**Compliance Deadline:** {meta.get('compliance_deadline', '2026-08-02')}",
+        "",
+        "---",
+        "",
+        "## Artifacts",
+        "",
+        "| File | EU AI Act Article | Description |",
+        "|------|-------------------|-------------|",
+        "| `bundle.json` | All | Complete compliance bundle (machine-readable) |",
+        f"| `receipt.{ext}` | Article 9 | Decision receipt with risk assessment |",
+        f"| `audit_trail.{ext}` | Article 12 | Chronological audit log with provenance |",
+        f"| `transparency_report.{ext}` | Article 13 | Agent participation and reasoning |",
+        f"| `human_oversight.{ext}` | Article 14 | Voting record, dissent, escalation |",
+        f"| `accuracy_report.{ext}` | Article 15 | Confidence scores, robustness metrics |",
+        "| `README.md` | -- | This manifest |",
+        "",
+        "---",
+        "",
+        "## Article Mapping",
+        "",
+        "| Article | Requirement | Status |",
+        "|---------|-------------|--------|",
+    ]
+
+    for mapping in conformity.get("article_mappings", []):
+        status_label = {
+            "satisfied": "PASS",
+            "partial": "PARTIAL",
+            "not_satisfied": "FAIL",
+            "not_applicable": "N/A",
+        }.get(mapping.get("status", ""), mapping.get("status", ""))
+        lines.append(
+            f"| {mapping.get('article', '')} | "
+            f"{mapping.get('requirement', '')[:60]} | "
+            f"{status_label} |"
+        )
+
+    if conformity.get("recommendations"):
+        lines.append("")
+        lines.append("## Recommendations")
+        lines.append("")
+        for i, rec in enumerate(conformity["recommendations"], 1):
+            lines.append(f"{i}. {rec}")
+
+    lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append("*Generated by Aragora Decision Integrity Platform*")
+    lines.append("")
+
+    manifest_path = os.path.join(output_dir, "README.md")
+    with open(manifest_path, "w") as f:
+        f.write("\n".join(lines))
+
+
+def _print_summary(
+    bundle: dict[str, Any],
+    output_dir: str,
+    fmt: str,
+) -> None:
+    """Print a summary to stdout."""
+    meta = bundle.get("meta", {})
+    classification = bundle.get("risk_classification", {})
+    conformity = bundle.get("conformity_report", {})
+    ext = _format_extension(fmt)
+
+    print("EU AI Act Compliance Bundle Exported")
+    print("=" * 50)
+    print(f"Receipt ID:      {meta.get('receipt_id', '')}")
+    print(f"Risk Level:      {classification.get('risk_level', '').upper()}")
+    print(f"Conformity:      {conformity.get('overall_status', '').upper()}")
+    print(f"Integrity Hash:  {meta.get('integrity_hash', '')[:16]}...")
+    print(f"Deadline:        {meta.get('compliance_deadline', '2026-08-02')}")
+    print()
+
+    # Article status table
+    print("Article Compliance Summary:")
+    for mapping in conformity.get("article_mappings", []):
+        status_display = {
+            "satisfied": "PASS",
+            "partial": "PARTIAL",
+            "not_satisfied": "FAIL",
+            "not_applicable": "N/A",
+        }.get(mapping.get("status", ""), mapping.get("status", ""))
+        article = mapping.get("article", "")
+        requirement = mapping.get("requirement", "")[:50]
+        print(f"  {article:<12s} {requirement:<52s} [{status_display}]")
+
+    print()
+    print(f"Output directory: {output_dir}/")
+    print("  bundle.json                    Full bundle (JSON)")
+    print(f"  receipt.{ext:<24s}  Art. 9  Risk management")
+    print(f"  audit_trail.{ext:<20s}  Art. 12 Record-keeping")
+    print(f"  transparency_report.{ext:<12s}  Art. 13 Transparency")
+    print(f"  human_oversight.{ext:<16s}  Art. 14 Human oversight")
+    print(f"  accuracy_report.{ext:<16s}  Art. 15 Accuracy & robustness")
+    print("  README.md                      Manifest")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Synthetic demo receipt
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_receipt() -> dict[str, Any]:
+    """Generate a synthetic receipt for demo/sample output."""
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "receipt_id": "DEMO-RCP-001",
+        "gauntlet_id": "demo-gauntlet-001",
+        "timestamp": now,
+        "input_summary": (
+            "Evaluate AI-powered recruitment and CV screening system for "
+            "automated candidate filtering in hiring decisions."
+        ),
+        "input_hash": hashlib.sha256(b"demo-input").hexdigest(),
+        "risk_summary": {
+            "total": 4,
+            "critical": 0,
+            "high": 1,
+            "medium": 2,
+            "low": 1,
+        },
+        "attacks_attempted": 8,
+        "attacks_successful": 1,
+        "probes_run": 12,
+        "vulnerabilities_found": 2,
+        "verdict": "CONDITIONAL",
+        "confidence": 0.78,
+        "robustness_score": 0.72,
+        "verdict_reasoning": (
+            "The recruitment screening system meets accuracy thresholds but "
+            "requires additional bias auditing before full deployment. "
+            "Demographic parity gaps detected in the gender dimension."
+        ),
+        "dissenting_views": [
+            "Agent-Challenger: demographic parity gap exceeds 5% threshold for employment AI"
+        ],
+        "consensus_proof": {
+            "reached": True,
+            "confidence": 0.78,
+            "supporting_agents": ["claude-analyst", "mistral-auditor", "gpt4-ethics"],
+            "dissenting_agents": ["gemini-challenger"],
+            "method": "weighted_majority",
+            "agreement_ratio": 0.75,
+            "evidence_hash": hashlib.sha256(b"demo-evidence").hexdigest(),
+        },
+        "provenance_chain": [
+            {"event_type": "debate_started", "timestamp": now, "actor": "system"},
+            {"event_type": "proposal_submitted", "timestamp": now, "actor": "claude-analyst"},
+            {"event_type": "critique_submitted", "timestamp": now, "actor": "gemini-challenger"},
+            {"event_type": "revision_submitted", "timestamp": now, "actor": "mistral-auditor"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "claude-analyst"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "gpt4-ethics"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "gemini-challenger"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "mistral-auditor"},
+            {
+                "event_type": "human_approval",
+                "timestamp": now,
+                "actor": "compliance-officer@org.example.com",
+            },
+            {"event_type": "receipt_generated", "timestamp": now, "actor": "system"},
+        ],
+        "schema_version": "1.0",
+        "artifact_hash": hashlib.sha256(b"demo-artifact").hexdigest(),
+        "signature": "ed25519:demo_signature",
+        "config_used": {
+            "protocol": "adversarial",
+            "rounds": 3,
+            "require_approval": True,
+            "human_in_loop": True,
+            "approver": "compliance-officer@org.example.com",
+        },
+    }

--- a/tests/cli/test_compliance_export.py
+++ b/tests/cli/test_compliance_export.py
@@ -1,0 +1,548 @@
+"""Tests for the compliance export CLI command.
+
+Tests cover:
+- Demo mode (synthetic data)
+- Receipt file loading
+- Missing inputs (error handling)
+- Markdown, HTML, and JSON format output
+- Article mapping completeness
+- Manifest generation
+- Bundle integrity hash
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_receipt() -> dict:
+    """A minimal receipt dict for testing."""
+    import hashlib
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc).isoformat()
+    return {
+        "receipt_id": "TEST-RCP-001",
+        "gauntlet_id": "test-gauntlet-001",
+        "timestamp": now,
+        "input_summary": (
+            "Evaluate AI-powered recruitment and CV screening system for "
+            "automated candidate filtering in hiring decisions."
+        ),
+        "input_hash": hashlib.sha256(b"test-input").hexdigest(),
+        "risk_summary": {
+            "total": 3,
+            "critical": 0,
+            "high": 1,
+            "medium": 1,
+            "low": 1,
+        },
+        "attacks_attempted": 5,
+        "attacks_successful": 0,
+        "probes_run": 8,
+        "vulnerabilities_found": 1,
+        "verdict": "APPROVED",
+        "confidence": 0.85,
+        "robustness_score": 0.80,
+        "verdict_reasoning": "The hiring system passed all adversarial checks.",
+        "dissenting_views": ["Agent-Critic: minor bias concern in age dimension"],
+        "consensus_proof": {
+            "reached": True,
+            "confidence": 0.85,
+            "supporting_agents": ["claude-analyst", "gpt4-auditor"],
+            "dissenting_agents": ["gemini-critic"],
+            "method": "weighted_majority",
+            "agreement_ratio": 0.67,
+            "evidence_hash": hashlib.sha256(b"test-evidence").hexdigest(),
+        },
+        "provenance_chain": [
+            {"event_type": "debate_started", "timestamp": now, "actor": "system"},
+            {"event_type": "proposal_submitted", "timestamp": now, "actor": "claude-analyst"},
+            {"event_type": "critique_submitted", "timestamp": now, "actor": "gemini-critic"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "claude-analyst"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "gpt4-auditor"},
+            {"event_type": "vote_cast", "timestamp": now, "actor": "gemini-critic"},
+            {"event_type": "human_approval", "timestamp": now, "actor": "hr@test.com"},
+            {"event_type": "receipt_generated", "timestamp": now, "actor": "system"},
+        ],
+        "schema_version": "1.0",
+        "artifact_hash": hashlib.sha256(b"test-artifact").hexdigest(),
+        "signature": "ed25519:test_signature",
+        "config_used": {
+            "protocol": "adversarial",
+            "rounds": 3,
+            "require_approval": True,
+            "human_in_loop": True,
+            "approver": "hr@test.com",
+        },
+    }
+
+
+@pytest.fixture()
+def receipt_file(sample_receipt: dict, tmp_path: Path) -> Path:
+    """Write sample receipt to a temp file and return path."""
+    path = tmp_path / "receipt.json"
+    path.write_text(json.dumps(sample_receipt))
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Module import tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImport:
+    """Verify the module can be imported without side effects."""
+
+    def test_import_compliance_export(self):
+        from aragora.cli.commands import compliance_export  # noqa: F401
+
+    def test_import_cmd_function(self):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        assert callable(cmd_compliance_export)
+
+    def test_import_add_export_subparser(self):
+        from aragora.cli.commands.compliance_export import add_export_subparser
+
+        assert callable(add_export_subparser)
+
+
+# ---------------------------------------------------------------------------
+# Demo mode
+# ---------------------------------------------------------------------------
+
+
+class TestDemoMode:
+    """Test --demo flag generates output without real data."""
+
+    def test_demo_creates_output_dir(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "demo-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        assert output_dir.exists()
+        assert (output_dir / "bundle.json").exists()
+
+    def test_demo_creates_all_markdown_files(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "demo-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir), output_format="markdown")
+        cmd_compliance_export(args)
+
+        expected_files = [
+            "bundle.json",
+            "receipt.md",
+            "audit_trail.md",
+            "transparency_report.md",
+            "human_oversight.md",
+            "accuracy_report.md",
+            "README.md",
+        ]
+        for fname in expected_files:
+            assert (output_dir / fname).exists(), f"Missing: {fname}"
+
+    def test_demo_bundle_json_has_required_keys(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "demo-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        assert "meta" in bundle
+        assert "risk_classification" in bundle
+        assert "conformity_report" in bundle
+        assert "receipt" in bundle
+        assert "audit_trail" in bundle
+        assert "transparency_report" in bundle
+        assert "human_oversight" in bundle
+        assert "accuracy_report" in bundle
+
+    def test_demo_integrity_hash_present(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "demo-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        assert len(bundle["meta"]["integrity_hash"]) == 64  # SHA-256 hex
+
+    def test_demo_risk_classification_is_high(self, tmp_path: Path):
+        """Synthetic receipt is an HR/employment use case => HIGH risk."""
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "demo-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        assert bundle["risk_classification"]["risk_level"] == "high"
+
+
+# ---------------------------------------------------------------------------
+# Receipt file mode
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptFileMode:
+    """Test loading receipt from a JSON file."""
+
+    def test_receipt_file_produces_bundle(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "from-file"
+        args = _make_args(receipt_file=str(receipt_file), output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        assert (output_dir / "bundle.json").exists()
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        assert bundle["meta"]["receipt_id"] == "TEST-RCP-001"
+
+    def test_receipt_file_not_found_exits(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        args = _make_args(
+            receipt_file="/nonexistent/receipt.json", output_dir=str(tmp_path / "out")
+        )
+        with pytest.raises(SystemExit):
+            cmd_compliance_export(args)
+
+    def test_invalid_json_exits(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not json {{{")
+        args = _make_args(receipt_file=str(bad_file), output_dir=str(tmp_path / "out"))
+        with pytest.raises(SystemExit):
+            cmd_compliance_export(args)
+
+
+# ---------------------------------------------------------------------------
+# Missing input
+# ---------------------------------------------------------------------------
+
+
+class TestMissingInput:
+    """Test error handling when no input is provided."""
+
+    def test_no_input_exits_with_helpful_message(self, tmp_path: Path, capsys):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        args = _make_args(output_dir=str(tmp_path / "out"))
+        with pytest.raises(SystemExit):
+            cmd_compliance_export(args)
+
+        captured = capsys.readouterr()
+        assert "--demo" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Output formats
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormats:
+    """Test markdown, HTML, and JSON output."""
+
+    def test_json_format(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "json-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir), output_format="json")
+        cmd_compliance_export(args)
+
+        for name in [
+            "receipt",
+            "audit_trail",
+            "transparency_report",
+            "human_oversight",
+            "accuracy_report",
+        ]:
+            path = output_dir / f"{name}.json"
+            assert path.exists(), f"Missing: {name}.json"
+            data = json.loads(path.read_text())
+            assert isinstance(data, dict)
+
+    def test_html_format(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "html-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir), output_format="html")
+        cmd_compliance_export(args)
+
+        for name in [
+            "receipt",
+            "audit_trail",
+            "transparency_report",
+            "human_oversight",
+            "accuracy_report",
+        ]:
+            path = output_dir / f"{name}.html"
+            assert path.exists(), f"Missing: {name}.html"
+            content = path.read_text()
+            assert "<html" in content
+            assert "</html>" in content
+
+    def test_markdown_format_contains_article_references(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "md-pack"
+        args = _make_args(demo=True, output_dir=str(output_dir), output_format="markdown")
+        cmd_compliance_export(args)
+
+        # Check that transparency report references Article 13
+        transparency = (output_dir / "transparency_report.md").read_text()
+        assert "Article 13" in transparency
+
+        # Check that human oversight references Article 14
+        oversight = (output_dir / "human_oversight.md").read_text()
+        assert "Article 14" in oversight
+
+        # Check accuracy references Article 15
+        accuracy = (output_dir / "accuracy_report.md").read_text()
+        assert "Article 15" in accuracy
+
+
+# ---------------------------------------------------------------------------
+# Article mapping completeness
+# ---------------------------------------------------------------------------
+
+
+class TestArticleMapping:
+    """Verify all five articles are covered in the bundle."""
+
+    def test_all_articles_present_in_conformity(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "articles"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        articles_found = {m["article"] for m in bundle["conformity_report"]["article_mappings"]}
+        assert "Article 9" in articles_found
+        assert "Article 12" in articles_found
+        assert "Article 13" in articles_found
+        assert "Article 14" in articles_found
+        assert "Article 15" in articles_found
+
+    def test_article_artifacts_present(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "artifacts"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        bundle = json.loads((output_dir / "bundle.json").read_text())
+        assert "article_12" in bundle["article_artifacts"]
+        assert "article_13" in bundle["article_artifacts"]
+        assert "article_14" in bundle["article_artifacts"]
+
+
+# ---------------------------------------------------------------------------
+# Manifest (README)
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    """Test README.md manifest generation."""
+
+    def test_readme_contains_file_listing(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "manifest"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        readme = (output_dir / "README.md").read_text()
+        assert "bundle.json" in readme
+        assert "receipt.md" in readme
+        assert "audit_trail.md" in readme
+        assert "Article 9" in readme
+        assert "Article 12" in readme
+        assert "Article 13" in readme
+        assert "Article 14" in readme
+        assert "Article 15" in readme
+
+    def test_readme_contains_integrity_hash(self, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "manifest-hash"
+        args = _make_args(demo=True, output_dir=str(output_dir))
+        cmd_compliance_export(args)
+
+        readme = (output_dir / "README.md").read_text()
+        assert "Integrity Hash" in readme
+
+
+# ---------------------------------------------------------------------------
+# Transparency report content
+# ---------------------------------------------------------------------------
+
+
+class TestTransparencyReport:
+    """Test that transparency report includes agent participation."""
+
+    def test_agents_listed(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "transparency"
+        args = _make_args(
+            receipt_file=str(receipt_file),
+            output_dir=str(output_dir),
+            output_format="json",
+        )
+        cmd_compliance_export(args)
+
+        data = json.loads((output_dir / "transparency_report.json").read_text())
+        assert data["agent_count"] >= 2
+        assert len(data["agents_participating"]) >= 2
+
+    def test_dissenting_views_included(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "dissent"
+        args = _make_args(
+            receipt_file=str(receipt_file),
+            output_dir=str(output_dir),
+            output_format="json",
+        )
+        cmd_compliance_export(args)
+
+        data = json.loads((output_dir / "transparency_report.json").read_text())
+        assert len(data["dissenting_views"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Human oversight report
+# ---------------------------------------------------------------------------
+
+
+class TestHumanOversightReport:
+    """Test that human oversight data is correctly extracted."""
+
+    def test_human_oversight_detected(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "oversight"
+        args = _make_args(
+            receipt_file=str(receipt_file),
+            output_dir=str(output_dir),
+            output_format="json",
+        )
+        cmd_compliance_export(args)
+
+        data = json.loads((output_dir / "human_oversight.json").read_text())
+        assert data["human_oversight_detected"] is True
+        assert data["oversight_model"] == "Human-in-the-Loop (HITL)"
+        assert data["require_approval"] is True
+
+    def test_voting_record_present(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "votes"
+        args = _make_args(
+            receipt_file=str(receipt_file),
+            output_dir=str(output_dir),
+            output_format="json",
+        )
+        cmd_compliance_export(args)
+
+        data = json.loads((output_dir / "human_oversight.json").read_text())
+        assert data["voting_record"]["total_votes"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Accuracy report
+# ---------------------------------------------------------------------------
+
+
+class TestAccuracyReport:
+    """Test accuracy and robustness metrics."""
+
+    def test_confidence_and_robustness(self, receipt_file: Path, tmp_path: Path):
+        from aragora.cli.commands.compliance_export import cmd_compliance_export
+
+        output_dir = tmp_path / "accuracy"
+        args = _make_args(
+            receipt_file=str(receipt_file),
+            output_dir=str(output_dir),
+            output_format="json",
+        )
+        cmd_compliance_export(args)
+
+        data = json.loads((output_dir / "accuracy_report.json").read_text())
+        assert data["confidence"] == 0.85
+        assert data["robustness_score"] == 0.80
+        assert data["integrity_hash_present"] is True
+        assert data["signature_present"] is True
+
+
+# ---------------------------------------------------------------------------
+# Subparser registration
+# ---------------------------------------------------------------------------
+
+
+class TestSubparserRegistration:
+    """Test that the export subcommand registers correctly."""
+
+    def test_compliance_command_dispatches_export(self, tmp_path: Path):
+        """Verify the compliance dispatcher routes to export."""
+        from aragora.cli.commands.compliance import cmd_compliance
+
+        output_dir = tmp_path / "dispatch"
+        args = _make_args(
+            demo=True,
+            output_dir=str(output_dir),
+            compliance_command="export",
+        )
+        # Also set the generate_artifacts flag to False to avoid fallthrough
+        args.generate_artifacts = False
+        cmd_compliance(args)
+
+        assert (output_dir / "bundle.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_args(**kwargs) -> mock.MagicMock:
+    """Create a Namespace-like object with defaults for compliance export."""
+    defaults = {
+        "framework": "eu-ai-act",
+        "debate_id": None,
+        "receipt_file": None,
+        "output_dir": "./compliance-pack",
+        "output_format": "markdown",
+        "include_receipts": True,
+        "include_audit_trail": True,
+        "demo": False,
+        "generate_artifacts": False,
+        "compliance_command": None,
+    }
+    defaults.update(kwargs)
+    args = mock.MagicMock()
+    for key, value in defaults.items():
+        setattr(args, key, value)
+    # Make getattr work correctly for compliance_export's getattr calls
+    args.__contains__ = lambda self, key: key in defaults
+    return args


### PR DESCRIPTION
## Summary
- New CLI command: \`aragora compliance export --framework eu-ai-act\`
- Maps to Articles 9 (risk), 12 (record-keeping), 13 (transparency), 14 (human oversight), 15 (accuracy)
- Three input modes: \`--debate-id\`, \`--receipt-file\`, \`--demo\`
- Three output formats: markdown, HTML, JSON + integrity-hashed bundle.json
- Reuses existing ComplianceArtifactGenerator, ConformityReportGenerator, RiskClassifier

EU AI Act enforcement begins August 2, 2026. This packages existing receipt/audit infrastructure into a single command for compliance export.

## Test plan
- [x] 50/50 tests pass (25 new + 25 existing compliance tests)
- [x] Zero regressions
- [ ] Manual test with \`--demo\` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)