### PR TITLE
fix(aragora-debate): correct README model default and CHANGELOG link

### DIFF
--- a/aragora-debate/CHANGELOG.md
+++ b/aragora-debate/CHANGELOG.md
@@ -58,6 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PEP 561** `py.typed` marker for type checker support.
 - **235 tests** covering Arena, Receipt, types, agents, events, convergence, trickster, evidence, cross-analysis, and mock styles.
 
-[0.2.3]: https://github.com/an0mium/aragora/compare/aragora-debate-v0.2.2...aragora-debate-v0.2.3
+[0.2.3]: https://github.com/an0mium/aragora/compare/aragora-debate-v0.2.0...aragora-debate-v0.2.3
 [0.2.0]: https://github.com/an0mium/aragora/compare/aragora-debate-v0.1.0...aragora-debate-v0.2.0
 [0.1.0]: https://github.com/an0mium/aragora/releases/tag/aragora-debate-v0.1.0

--- a/aragora-debate/README.md
+++ b/aragora-debate/README.md
@@ -298,7 +298,7 @@ DebateConfig(
 | Anthropic | `ClaudeAgent` | `pip install aragora-debate[anthropic]` | `claude-sonnet-4-5-20250929` |
 | OpenAI | `OpenAIAgent` | `pip install aragora-debate[openai]` | `gpt-4o` |
 | Mistral | `MistralAgent` | `pip install aragora-debate[mistral]` | `mistral-large-latest` |
-| Google | `GeminiAgent` | `pip install aragora-debate[gemini]` | `gemini-2.0-flash` |
+| Google | `GeminiAgent` | `pip install aragora-debate[gemini]` | `gemini-3.1-pro-preview` |
 | Mock | `MockAgent` | *(included)* | N/A |
 
 Use the factory for quick setup:

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -110,11 +110,19 @@ Minimal adversarial debate engine. Zero dependencies.
 pip install aragora-debate
 ```
 
-| File | Purpose | LOC |
-|------|---------|-----|
-| `types.py` | Core types (Agent, Message, Critique, Vote, etc.) | ~350 |
-| `arena.py` | Debate orchestrator (propose → critique → vote) | ~280 |
-| `receipt.py` | Decision receipts with HMAC-SHA256 signing | ~200 |
+| File | Purpose |
+|------|---------|
+| `types.py` | Core types (Agent, Message, Critique, Vote, DebateConfig, etc.) |
+| `arena.py` | Debate orchestrator (propose → critique → vote) |
+| `debate.py` | High-level 5-line Debate API + `create_agent` factory |
+| `receipt.py` | Decision receipts with HMAC-SHA256 signing |
+| `agents.py` | Provider agents (Claude, OpenAI, Mistral, Gemini) |
+| `evidence.py` | Evidence quality scoring + hollow consensus detection |
+| `convergence.py` | Convergence tracking across rounds (stdlib only) |
+| `trickster.py` | Evidence-powered challenge injection |
+| `cross_analysis.py` | Cross-proposal evidence validation |
+| `events.py` | Event/callback system for real-time monitoring |
+| `_mock.py` / `styled_mock.py` | Mock agents for testing and demos |
 
 **When to use:** You want adversarial debate without the full platform.
 Embed in existing AI pipelines, CrewAI workflows, or LangGraph chains.


### PR DESCRIPTION
## Summary
- Fix README GeminiAgent default model: gemini-2.0-flash → gemini-3.1-pro-preview (matches code)
- Fix CHANGELOG v0.2.3 comparison link (referenced non-existent v0.2.2 tag)
- Update PACKAGING.md file listing (3 modules → 14 modules)

Package verified: build succeeds, twine check passes, 236 tests pass, CLI demo works with zero API keys.

## Test plan
- [x] \`python -m build\` succeeds
- [x] \`twine check\` passes
- [x] 236 package tests pass
- [x] CLI demo runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)