### PR TITLE
fix(synthesis): wire repo paths + split prompts + Epic #294 pipeline completion

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -1716,6 +1716,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
         current_answer: str,
         defects: list[str],
         attempt_num: int,
+        repo_hint: str = "",
     ) -> tuple[str | None, str | None]:
         if quality_contract is None:
             return (None, None)
@@ -1727,10 +1728,11 @@ def cmd_ask(args: argparse.Namespace) -> None:
             contract=quality_contract,
             current_answer=current_answer,
             defects=defects,
+            repo_hint=repo_hint,
         )
         role_hint = (
-            "You are a post-consensus quality upgrader. Keep core ideas, "
-            "fix defects, and preserve required section order."
+            "You are a structured action plan writer. Convert analysis into "
+            "concrete, path-grounded action items. Never reproduce essays."
         )
         return await _attempt_targeted_revision(
             prompt=prompt,
@@ -1751,6 +1753,12 @@ def cmd_ask(args: argparse.Namespace) -> None:
         )
 
         repo_root = os.getcwd()
+        # Generate repo path hint once for all repair prompts so the LLM
+        # can ground file references to real repository paths.
+        from aragora.debate.phases.synthesis_generator import SynthesisGenerator
+
+        _repo_hint = SynthesisGenerator._get_repo_path_hint()
+
         metadata = getattr(result, "metadata", None)
         if not isinstance(metadata, dict):
             metadata = {}
@@ -1778,6 +1786,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
                     current_answer=current_answer,
                     defects=current_report.defects,
                     attempt_num=loop_idx,
+                    repo_hint=_repo_hint,
                 )
                 if not repaired:
                     attempts.append(
@@ -1885,6 +1894,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
                     practicality_score_10=best_report.practicality_score_10,
                     target_practicality_10=quality_practical_min_score,
                     defects=best_report.defects,
+                    repo_hint=_repo_hint,
                 )
                 revised, provider = await _attempt_targeted_revision(
                     prompt=concretize_prompt,
@@ -1951,6 +1961,7 @@ def cmd_ask(args: argparse.Namespace) -> None:
                         f"Raise practicality score to >= {quality_practical_min_score:.2f}.",
                         "Ground owner paths to existing repository files.",
                     ],
+                    repo_hint=_repo_hint,
                 )
                 revised, provider = await _attempt_targeted_revision(
                     prompt=assessment_prompt,

--- a/aragora/debate/output_quality.py
+++ b/aragora/debate/output_quality.py
@@ -108,15 +108,23 @@ def _extract_sections(markdown: str) -> list[dict[str, Any]]:
     sections: list[dict[str, Any]] = []
     for idx, match in enumerate(matches):
         title = match.group(2).strip()
+        level = len(match.group(1))
         start = match.end()
-        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(markdown)
+        # Section content extends until the next header at the SAME or higher
+        # level (same or fewer # chars).  Sub-headers (e.g. ### within ##)
+        # are included as content of the parent section.
+        end = len(markdown)
+        for later in matches[idx + 1 :]:
+            if len(later.group(1)) <= level:
+                end = later.start()
+                break
         content = markdown[start:end].strip()
         sections.append(
             {
                 "title": title,
                 "normalized": _normalize_heading(title),
                 "content": content,
-                "level": len(match.group(1)),
+                "level": level,
                 "start": match.start(),
                 "end": end,
             }
@@ -789,7 +797,14 @@ def validate_output_against_contract(
         defects.append("Owner module / file paths is missing concrete repo paths.")
     if contract.require_repo_path_existence and contract.require_owner_paths:
         if grounding.path_existence_rate < 0.67:
-            defects.append("Owner module / file paths are weakly grounded to existing repo files.")
+            msg = "Owner module / file paths are weakly grounded to existing repo files."
+            if grounding.missing_paths:
+                bad = ", ".join(grounding.missing_paths[:5])
+                msg += f" Non-existent paths: {bad}."
+            if grounding.existing_paths:
+                good = ", ".join(grounding.existing_paths[:3])
+                msg += f" Valid paths: {good}."
+            defects.append(msg)
     if contract.require_practicality_checks and grounding.practicality_score_10 < 5.0:
         defects.append("Output practicality is too low for execution handoff.")
     if contract.require_json_payload and not has_valid_json_payload:
@@ -835,6 +850,9 @@ def validate_output_against_contract(
         # model's fault.  They still penalise the quality score but don't
         # hard-fail the verdict.
         "Duplicate section heading",
+        # Duplicate-create ratio can be a false positive when tasks modify
+        # or add to existing files (e.g. "Create dataclass in existing.py").
+        "Duplicate-create proposals target existing",
     )
     hard_defects = [d for d in defects if not d.startswith(_SOFT_DEFECT_PREFIXES)]
     soft_defect_count = len(defects) - len(hard_defects)
@@ -876,6 +894,7 @@ def build_upgrade_prompt(
     contract: OutputContract,
     current_answer: str,
     defects: list[str],
+    repo_hint: str = "",
 ) -> str:
     """Build a focused repair prompt for the upgrade-to-good loop."""
     defect_lines = (
@@ -885,18 +904,33 @@ def build_upgrade_prompt(
         f"{idx}. {section}" for idx, section in enumerate(contract.required_sections, start=1)
     )
     hard_rules = build_contract_context_block(contract)
+    repo_block = (
+        f"\n\nREPOSITORY FILE REFERENCE (use ONLY these paths — do NOT invent paths):\n{repo_hint}\n"
+        if repo_hint
+        else ""
+    )
 
     return (
-        "You are performing a post-consensus quality repair pass.\n"
-        "Preserve intent, improve structure, and fix only quality defects.\n"
-        "Return ONLY the revised markdown answer.\n\n"
-        f"Task:\n{task}\n\n"
+        "TASK: Rewrite the answer below as a STRUCTURED ACTION PLAN.\n"
+        "Do NOT reproduce the essay/analysis. EXTRACT concrete actions from it.\n"
+        "Return ONLY the structured markdown with these section headers.\n\n"
+        "Your output MUST start with `## Ranked High-Level Tasks` — no preamble, no prose.\n\n"
+        f"{repo_block}"
         "Required sections (exact order):\n"
         f"{contract_lines}\n\n"
-        "Defects to fix:\n"
+        "Rules for each section:\n"
+        "- Ranked High-Level Tasks: action verb + real file path + pytest verify command\n"
+        "- Suggested Subtasks: independently testable with specific pytest commands\n"
+        "- Owner module / file paths: ONLY paths from the REPOSITORY FILE REFERENCE\n"
+        "- Test Plan: specific test file references, not generic phrases\n"
+        "- Gate Criteria: comparison operators with numbers (>= 80%, < 250ms)\n"
+        "- Rollback Plan: trigger condition AND rollback action\n"
+        "- JSON Payload: valid JSON mirroring section content\n\n"
+        "Defects in the current answer:\n"
         f"{defect_lines}\n\n"
         f"{hard_rules}\n\n"
-        "Current answer:\n"
+        f"Original question:\n{task}\n\n"
+        "Current answer (extract actions from this, do NOT copy it as prose):\n"
         f"{current_answer}"
     )
 
@@ -909,6 +943,7 @@ def build_concretization_prompt(
     practicality_score_10: float,
     target_practicality_10: float,
     defects: list[str],
+    repo_hint: str = "",
 ) -> str:
     """Build a focused prompt for post-consensus concretization/upgrading."""
     defect_lines = "\n".join(f"- {defect}" for defect in defects) if defects else "- None listed."
@@ -916,28 +951,33 @@ def build_concretization_prompt(
         f"{idx}. {section}" for idx, section in enumerate(contract.required_sections, start=1)
     )
     hard_rules = build_contract_context_block(contract)
+    repo_block = (
+        f"\nREPOSITORY FILE REFERENCE (use ONLY these paths — do NOT invent paths):\n{repo_hint}\n"
+        if repo_hint
+        else ""
+    )
     return (
-        "You are performing a post-consensus concretization pass for execution readiness.\n"
-        "Keep the core strategy, but make the first execution batch practical and testable.\n"
-        "Return ONLY revised markdown output.\n\n"
-        f"Task:\n{task}\n\n"
+        "TASK: Rewrite the answer below as a STRUCTURED ACTION PLAN with real file paths.\n"
+        "Do NOT reproduce essays or analysis. EXTRACT concrete actions.\n"
+        "Your output MUST start with `## Ranked High-Level Tasks` — no preamble.\n"
+        "Return ONLY the structured markdown.\n\n"
         f"Current practicality score (0-10): {practicality_score_10}\n"
         f"Target practicality score (0-10): {target_practicality_10}\n\n"
+        f"{repo_block}"
+        f"Original question:\n{task}\n\n"
         "Required sections (exact order):\n"
         f"{contract_lines}\n\n"
         "Concretization requirements:\n"
-        "- Replace placeholders ([NEW], [INFERRED], TBD, TODO) with concrete decisions.\n"
-        "- First ranked tasks must include explicit file paths and measurable gate criteria.\n"
-        "- Each task line: start with an action verb, reference a file path, use 6+ words.\n"
-        "- Test Plan: each test item must reference a specific test file (e.g. test_output_quality.py).\n"
-        "- Gate Criteria: use comparison operators with numbers (e.g. >= 80%, < 250ms, > 95%).\n"
-        "- Suggested subtasks must be independently testable.\n"
-        "- Keep rollback trigger->action mappings explicit.\n"
-        "- Keep JSON payload synchronized with revised sections.\n\n"
+        "- Each task line: action verb + file path from REPOSITORY FILE REFERENCE + pytest verify command.\n"
+        "- CRITICAL: ALL file paths MUST come from the REPOSITORY FILE REFERENCE above. Do NOT invent paths.\n"
+        "- Gate Criteria: use comparison operators with numbers (>= 80%, < 250ms, > 95%).\n"
+        "- Rollback Plan: explicit trigger condition AND rollback action.\n"
+        "- JSON Payload: valid JSON mirroring section content.\n"
+        "- Replace ALL placeholders ([NEW], [INFERRED], TBD, TODO, '[Section not produced]') with real content.\n\n"
         "Defects to fix:\n"
         f"{defect_lines}\n\n"
         f"{hard_rules}\n\n"
-        "Current answer:\n"
+        "Current answer (extract actions from this, do NOT copy it as prose):\n"
         f"{current_answer}"
     )
 

--- a/aragora/debate/phases/synthesis_generator.py
+++ b/aragora/debate/phases/synthesis_generator.py
@@ -89,9 +89,8 @@ class SynthesisGenerator:
                 "No proposals were generated. One or more agents may have failed to respond."
             )
             ctx.result.synthesis = synthesis
-            # Only set final_answer if the consensus phase didn't already set one
-            if not ctx.result.final_answer:
-                ctx.result.final_answer = synthesis
+            # Synthesis is the definitive final answer — always overwrite.
+            ctx.result.final_answer = synthesis
             self._emit_synthesis_events(ctx, synthesis, "fallback")
             self._generate_export_links(ctx)
             return True
@@ -113,9 +112,8 @@ class SynthesisGenerator:
         if synthesis:
             # Store synthesis in result
             ctx.result.synthesis = synthesis
-            # Only set final_answer if the consensus phase didn't already set one
-            if not ctx.result.final_answer:
-                ctx.result.final_answer = synthesis
+            # Synthesis is the definitive final answer — always overwrite.
+            ctx.result.final_answer = synthesis
 
             # Emit explicit synthesis event (guaranteed delivery)
             self._emit_synthesis_events(ctx, synthesis, synthesis_source)
@@ -135,13 +133,15 @@ class SynthesisGenerator:
                 model="claude-opus-4-5-20251101",
             )
 
-            # Build synthesis prompt
-            synthesis_prompt = self._build_synthesis_prompt(ctx)
+            # Build synthesis prompt — split into system (format) and user (content)
+            system_prompt, user_prompt = self._build_synthesis_prompt_parts(ctx)
+            synthesizer.system_prompt = system_prompt
 
             # Generate synthesis with timeout (60s to fit within phase budget)
+            # Pass user_prompt WITHOUT context_messages to avoid essay-pattern priming
             with streaming_task_context("synthesis-agent:opus_synthesis"):
                 synthesis = await asyncio.wait_for(
-                    synthesizer.generate(synthesis_prompt, ctx.context_messages),
+                    synthesizer.generate(user_prompt),
                     timeout=60.0,
                 )
             synthesis = await self._ensure_complete_synthesis(
@@ -171,10 +171,11 @@ class SynthesisGenerator:
                     name="synthesis-agent-fallback",
                     model="claude-sonnet-4-20250514",
                 )
-                synthesis_prompt = self._build_synthesis_prompt(ctx)
+                system_prompt, user_prompt = self._build_synthesis_prompt_parts(ctx)
+                synthesizer.system_prompt = system_prompt
                 with streaming_task_context("synthesis-agent-fallback:sonnet_synthesis"):
                     synthesis = await asyncio.wait_for(
-                        synthesizer.generate(synthesis_prompt, ctx.context_messages),
+                        synthesizer.generate(user_prompt),
                         timeout=30.0,
                     )
                 synthesis = await self._ensure_complete_synthesis(
@@ -467,31 +468,16 @@ class SynthesisGenerator:
         synthesis += "\n*Note: This synthesis was automatically generated from agent proposals.*"
         return synthesis
 
-    def _build_synthesis_prompt(self, ctx: DebateContext) -> str:
-        """Build prompt for final synthesis generation.
-
-        When a quality output contract is available in the context, the synthesis
-        uses the contract's required sections as the output structure instead of
-        the default generic structure.  This ensures the debate's final answer
-        naturally satisfies the post-consensus quality validator.
-
-        Args:
-            ctx: The DebateContext with proposals, critiques, and task
-
-        Returns:
-            Formatted synthesis prompt string
-        """
+    def _prepare_synthesis_parts(self, ctx: DebateContext) -> tuple[str, str, str, str]:
+        """Extract task, proposals, critiques, and contract from context."""
         proposals = ctx.proposals
-        # DebateContext uses 'round_critiques', not 'critiques'
         critiques = getattr(ctx, "round_critiques", []) or getattr(ctx, "critiques", []) or []
         task = ctx.env.task if ctx.env else "Unknown task"
 
-        # Format proposals
         proposals_text = "\n\n---\n\n".join(
             f"**{agent}**:\n{prop[:1500]}" for agent, prop in proposals.items()
         )
 
-        # Format critiques (if any)
         critiques_text = ""
         if critiques:
             critique_items = []
@@ -501,13 +487,32 @@ class SynthesisGenerator:
                     critique_items.append(f"- {c.agent} on {c.target}: {summary}")
             critiques_text = "\n".join(critique_items)
 
-        # Check if a quality output contract is available in the context.
-        # If none is explicitly provided, use the default contract so that
-        # every synthesis goes through the contract-guided path.
         contract_block = self._extract_contract_block(ctx)
         if not contract_block:
             contract_block = self._default_output_contract()
 
+        return task, proposals_text, critiques_text, contract_block
+
+    def _build_synthesis_prompt(self, ctx: DebateContext) -> str:
+        """Build prompt for final synthesis generation (single string).
+
+        For backwards compatibility. Prefer _build_synthesis_prompt_parts
+        which separates system and user content.
+        """
+        task, proposals_text, critiques_text, contract_block = self._prepare_synthesis_parts(ctx)
+        system, user = self._build_contract_guided_prompt(
+            task, proposals_text, critiques_text, contract_block
+        )
+        return f"{system}\n\n{user}"
+
+    def _build_synthesis_prompt_parts(self, ctx: DebateContext) -> tuple[str, str]:
+        """Build synthesis prompt as (system_prompt, user_prompt) tuple.
+
+        Separates format constraints (system) from debate content (user)
+        so the model treats structural requirements as instructions, not
+        just another part of the conversation.
+        """
+        task, proposals_text, critiques_text, contract_block = self._prepare_synthesis_parts(ctx)
         return self._build_contract_guided_prompt(
             task, proposals_text, critiques_text, contract_block
         )
@@ -648,91 +653,77 @@ Required sections:
         proposals_text: str,
         critiques_text: str,
         contract_block: str,
-    ) -> str:
-        """Build synthesis prompt that uses the quality contract's section structure."""
+    ) -> tuple[str, str]:
+        """Build synthesis prompt as (system_prompt, user_prompt) tuple.
+
+        System prompt contains format constraints and repo paths.
+        User prompt contains debate content to synthesize.
+        """
         repo_hint = self._get_repo_path_hint()
         repo_section = (
-            f"\n\n## REPOSITORY FILE REFERENCE (USE THESE PATHS — DO NOT INVENT PATHS)\n{repo_hint}"
+            f"\nREPOSITORY FILE REFERENCE (use ONLY these paths — do NOT invent paths):\n{repo_hint}"
             if repo_hint
             else ""
         )
 
-        return f"""You are Claude Opus 4.5, tasked with creating the DEFINITIVE synthesis of this multi-agent AI debate.
+        system = f"""You are a structured action plan writer. You convert debate analysis into executable action plans.
+
+CRITICAL OUTPUT FORMAT — NON-NEGOTIABLE:
+
+Your ENTIRE output must use EXACTLY these 7 section headers in order.
+Do NOT write prose, essays, analysis, preamble, or commentary.
+Your VERY FIRST output token must be: ## Ranked High-Level Tasks
+
+Required headers (in this exact order, using ## markdown):
+1. ## Ranked High-Level Tasks
+2. ## Suggested Subtasks
+3. ## Owner module / file paths
+4. ## Test Plan
+5. ## Rollback Plan
+6. ## Gate Criteria
+7. ## JSON Payload
+
+VIOLATIONS (any of these = failure):
+- Writing ANY text before "## Ranked High-Level Tasks"
+- Adding extra ## headers (no "## Summary", "## Analysis", "## Recommendation", "## Preamble")
+- Putting placeholder text like "[Section not produced]", "TBD", "TODO"
+- Inventing file paths not in REPOSITORY FILE REFERENCE
+- Writing vague lines like "Improve X" — use specific actions like "Add validation to `path/file.py:function()`"
+
+EVERY task line must include: action verb + real file path + pytest verify command.
 {repo_section}
 
-## ORIGINAL QUESTION
-{task}
-
-## AGENT FINAL PROPOSALS
-{proposals_text}
-
-## KEY CRITIQUES
-{critiques_text if critiques_text else "No critiques recorded."}
-
-## OUTPUT FORMAT REQUIREMENTS (MANDATORY)
 {contract_block}
 
-## CONCRETE EXAMPLE (follow this style exactly)
+EXAMPLE (follow this exact style):
 
 ## Ranked High-Level Tasks
-1. **Refactor `aragora/debate/orchestrator.py:Arena.run()` to emit phase-transition events** — Add `self._emit("phase_change", phase=name)` calls at each phase boundary. Verify: `pytest tests/debate/test_orchestrator.py::test_phase_events -v`
-2. **Update `aragora/debate/phases/synthesis_generator.py:SynthesisGenerator._build_synthesis_prompt()` to include repo path context** — Verify: `pytest tests/debate/test_output_quality.py -v`
+1. **Refactor `aragora/debate/orchestrator.py:Arena.run()` to emit phase-transition events** — Verify: `pytest tests/debate/test_orchestrator.py -v`
+2. **Update `aragora/debate/consensus.py:detect_consensus()` to weight by evidence quality** — Verify: `pytest tests/debate/test_consensus.py -v`
 
 ## Suggested Subtasks
-- Add `PhaseEvent` dataclass to `aragora/events/schema.py` — Verify: `pytest tests/events/test_schema.py::test_phase_event`
-- Wire event emission in `aragora/debate/phases/consensus_phase.py:ConsensusPhase.run()` — Verify: `pytest tests/debate/test_consensus.py -v`
+- Add `PhaseEvent` dataclass to `aragora/events/schema.py` — Verify: `pytest tests/events/test_schema.py -v`
 
 ## Owner module / file paths
-- `aragora/debate/orchestrator.py` (Arena class, run method)
-- `aragora/events/schema.py` (PhaseEvent dataclass)
-- `tests/debate/test_orchestrator.py` (new test_phase_events test)
+- `aragora/debate/orchestrator.py`
+- `aragora/events/schema.py`
 
-(end of example — your output must follow this pattern with REAL paths from the REPOSITORY FILE REFERENCE above)
+(continue with Test Plan, Rollback Plan, Gate Criteria, JSON Payload)"""
 
-## YOUR TASK
-Synthesize the debate into a single comprehensive answer.
+        user = f"""Extract actionable items from this debate and produce the structured action plan.
+Do NOT reproduce the proposals as prose. EXTRACT specific actions, file paths, and test commands.
 
-STRUCTURAL REQUIREMENT (NON-NEGOTIABLE):
-Your output MUST start with `## Ranked High-Level Tasks` and use ONLY these 7 section headers as `## Heading` markdown:
-1. `## Ranked High-Level Tasks`
-2. `## Suggested Subtasks`
-3. `## Owner module / file paths`
-4. `## Test Plan`
-5. `## Rollback Plan`
-6. `## Gate Criteria`
-7. `## JSON Payload`
+QUESTION: {task}
 
-Do NOT add any other `##` headers. Do NOT write an executive summary, diagnosis, or architecture section before the first required header. Your FIRST line of content must be `## Ranked High-Level Tasks`.
+AGENT PROPOSALS:
+{proposals_text}
 
-Critical rules:
-- Use EXACTLY the required section headings as `## Heading` markdown headers, in the specified order.
-- Each section must have **substantive content** — at least 2-3 specific, actionable items drawn from the debate.
-- **PATH GROUNDING (CRITICAL)**: Every file path you mention MUST come from the REPOSITORY FILE REFERENCE at the top. Do NOT invent paths like `src/aragora/core/...` or `aragora/protocols/...` — these directories do not exist. The actual codebase uses `aragora/debate/`, `aragora/agents/`, `aragora/pipeline/`, etc. If you need a new file, mark it `NEW: aragora/existing_dir/new_file.py`.
-- For "Ranked High-Level Tasks": EVERY task must include:
-  - An action verb (add, create, implement, update, refactor, wire, test)
-  - A real file path + class/function name (e.g., `aragora/debate/orchestrator.py:Arena.run()`)
-  - A pytest command to verify (e.g., `pytest tests/debate/test_X.py::test_name -v`)
-- For "Suggested Subtasks": Each must be independently testable with a specific pytest command.
-- For "Owner module / file paths": reference ONLY paths from the REPOSITORY FILE REFERENCE above.
-- For "Test Plan": each test item must reference a specific test file. Do NOT use generic phrases like "run unit tests".
-- For "Gate Criteria": include specific thresholds with comparison operators + numbers (e.g., "coverage >= 80%", "error_rate < 1%"). Every criterion MUST contain a comparison operator.
-- For "Rollback Plan": include explicit trigger conditions AND rollback actions.
-- For "JSON Payload": produce valid JSON that mirrors the section content.
-- Preserve DISSENT: if agents disagreed, note it in the relevant section.
+CRITIQUES:
+{critiques_text if critiques_text else "No critiques recorded."}
 
-## BAD vs GOOD (do NOT produce lines like the BAD examples)
+Remember: Start your response with ## Ranked High-Level Tasks — no preamble."""
 
-BAD: "Improve the consensus detection system"
-GOOD: "Update `aragora/debate/consensus.py:detect_consensus()` to emit convergence events — Verify: `pytest tests/debate/test_consensus.py -v`"
-
-BAD: "Enhance error handling across the codebase"
-GOOD: "Add circuit-breaker fallback in `aragora/resilience/circuit_breaker.py:CircuitBreaker.call()` with threshold >= 3 failures in 60s — Verify: `pytest tests/resilience/test_circuit_breaker.py -v`"
-
-BAD: "Consider implementing better monitoring"
-GOOD: "Wire `aragora/observability/metrics.py:emit_debate_metrics()` into `aragora/debate/orchestrator.py:Arena.run()` post-consensus — p95 latency <= 250ms — Verify: `pytest tests/observability/test_metrics.py -v`"
-- Do NOT use placeholder text like TBD, TODO, "as needed", or "to be determined".
-
-Write authoritatively. This is the FINAL WORD on this debate."""
+        return system, user
 
     @staticmethod
     def _build_default_synthesis_prompt(task: str, proposals_text: str, critiques_text: str) -> str:
@@ -780,7 +771,7 @@ Your response MUST be approximately 1200 words to provide comprehensive coverage
             return synthesis
 
         _TASK_SECTION_RE = _re.compile(
-            r"(?i)^##\s+(?:ranked\s+high.level\s+tasks|suggested\s+subtasks|test\s+plan)",
+            r"(?i)^#{2,3}\s+(?:ranked\s+high.level\s+tasks|suggested\s+subtasks|test\s+plan)",
         )
         _PATH_IN_LINE = _re.compile(r"(?:/?[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+")
         _PYTEST_IN_LINE = _re.compile(r"(?i)\bpytest\b")

--- a/aragora/debate/repo_grounding.py
+++ b/aragora/debate/repo_grounding.py
@@ -54,6 +54,9 @@ _HEDGING_TIERS: list[tuple[float, dict[str, re.Pattern[str]]]] = [
             "placeholder": re.compile(r"\bplaceholder\b", re.IGNORECASE),
             "fill_me": re.compile(r"<\s*fill[^>]*>", re.IGNORECASE),
             "tk": re.compile(r"\btk\b", re.IGNORECASE),
+            "not_produced": re.compile(
+                r"\[(?:section )?not produced|requires (?:LLM |concretization)", re.IGNORECASE
+            ),
             "ellipsis_trail": re.compile(r"\.\.\.\s*$"),
         },
     ),
@@ -113,8 +116,15 @@ def _extract_sections(markdown: str) -> list[dict[str, Any]]:
     sections: list[dict[str, Any]] = []
     for idx, match in enumerate(matches):
         title = match.group(2).strip()
+        level = len(match.group(1))
         start = match.end()
-        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(markdown)
+        # Section content extends until the next header at the same or higher
+        # level.  Sub-headers (### within ##) are content, not boundaries.
+        end = len(markdown)
+        for later in matches[idx + 1 :]:
+            if len(later.group(1)) <= level:
+                end = later.start()
+                break
         sections.append(
             {
                 "title": title,

--- a/tests/debate/test_output_quality.py
+++ b/tests/debate/test_output_quality.py
@@ -224,7 +224,7 @@ def test_build_concretization_prompt_contains_practicality_target():
     )
     assert "Current practicality score (0-10): 4.2" in prompt
     assert "Target practicality score (0-10): 7.0" in prompt
-    assert "Replace placeholders" in prompt
+    assert "Replace ALL placeholders" in prompt
 
 
 def test_apply_deterministic_quality_repairs_is_additive():
@@ -787,8 +787,8 @@ def test_derive_contract_short_without_context_stays_minimal():
     assert contract.required_sections == []
 
 
-def test_duplicate_existing_create_ratio_detected_as_hard_defect(tmp_path):
-    """Create/add/build targeting existing files should hard-fail quality."""
+def test_duplicate_existing_create_ratio_detected_as_soft_defect(tmp_path):
+    """Create/add/build targeting existing files is a soft defect (not hard-fail)."""
     (tmp_path / "aragora" / "debate").mkdir(parents=True)
     (tmp_path / "aragora" / "debate" / "output_quality.py").write_text("# existing", "utf-8")
     (tmp_path / "tests" / "debate").mkdir(parents=True)
@@ -822,7 +822,8 @@ If error_rate > 2% for 10m, rollback by disabling feature flag.
 - quality_score_10 >= 7.0
 """
     report = validate_output_against_contract(answer, contract, repo_root=str(tmp_path))
-    assert report.verdict == "needs_work"
+    # Duplicate-create is now a soft defect — doesn't block verdict at high scores
+    assert report.verdict == "good"
     assert report.duplicate_existing_create_ratio is not None
     assert report.duplicate_existing_create_ratio > 0.25
     assert any("Duplicate-create proposals target existing repo paths" in d for d in report.defects)


### PR DESCRIPTION
## Summary

**Synthesis Fix (6 root causes):**
- Synthesis output was silently discarded: consensus set `final_answer` to agent essay; synthesis only overwrote when empty. Now synthesis always overwrites.
- Upgrade/concretize prompts ran blind on paths: added `repo_hint` parameter wiring.
- System/user prompt separation: format constraints in system prompt, debate content in user prompt.
- Section parser: `_extract_sections` now respects header levels (### is content within ##).
- Duplicate-create: downgraded from hard defect to soft defect.
- Quality upgrade role hint: changed from "fix defects" to "extract concrete actions."

**Dogfood Benchmark 014 (5 runs):**
- 4/5 passed: quality=10.0, practicality=8.59-8.90, path grounding=100%
- 1 run rejected by fail-closed gate (still scored 9.09/8.07)
- vs benchmark 013: pass rate 20% -> 80%, practicality 5.94 -> 8.66 (+46%)

**Epic #294 (Pipeline) sub-tasks:**
- T3: Sandbox feedback loop test (5 tests)
- T5: Pipeline telemetry GET endpoint (11 tests)
- T6: E2E golden path test (2 new tests)

## Test plan
- [x] `pytest tests/debate/test_output_quality.py tests/debate/test_repo_grounding.py` (59 pass)
- [x] `pytest tests/pipeline/test_pipeline_e2e.py` (19 pass)
- [x] `pytest tests/pipeline/test_sandbox_feedback.py` (5 pass)
- [x] `pytest tests/server/handlers/test_pipeline_telemetry.py` (11 pass)
- [x] Dogfood benchmark: 4/5 pass rate, mean practicality 8.66

🤖 Generated with [Claude Code](https://claude.com/claude-code)