### PR TITLE
hotfix(landing): fix Footer JSX closing tag and restore button spacing

### DIFF
--- a/aragora/live/src/components/landing/Footer.tsx
+++ b/aragora/live/src/components/landing/Footer.tsx
@@ -38,7 +38,7 @@ export function Footer() {
         </p>
 
         {/* CTA buttons */}
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-10">
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4" style={{ marginBottom: '48px' }}>
           <Link
             href="/playground"
             className="text-sm font-semibold transition-opacity hover:opacity-80 cursor-pointer inline-block"
@@ -53,7 +53,7 @@ export function Footer() {
             }}
           >
             Try it now
-          </button>
+          </Link>
           <Link
             href="/signup"
             className="text-sm font-semibold transition-colors hover:opacity-80"


### PR DESCRIPTION
## Summary

- Fixes `TS17002: Expected corresponding JSX closing tag for 'Link'` — PR #603 changed `<button>` to `<Link href="/playground">` but left the closing tag as `</button>` instead of `</Link>`, blocking all deploys
- Restores `marginBottom: 48px` on the CTA button row (was set by #604, reverted to `mb-10` by #603)

## Root cause

Deploy has been failing since #603 merged due to this TS compile error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)