### PR TITLE
fix: Shoggoth branding leak, share persistence, result UX

### DIFF
--- a/aragora/live/src/components/DebateResultPreview.tsx
+++ b/aragora/live/src/components/DebateResultPreview.tsx
@@ -147,26 +147,33 @@ export function DebateResultPreview({ result }: DebateResultPreviewProps) {
     if (typeof navigator.share === 'function') {
       try {
         await navigator.share({ title: 'Aragora Debate', text: shareText, url: shareUrl });
+        // Native share sheet provides its own feedback
         return;
       } catch {
         // User cancelled or share failed — fall through to clipboard
       }
     }
 
-    // Clipboard fallback
+    // Clipboard fallback — always show visual feedback regardless of copy success
     try {
       await navigator.clipboard.writeText(shareUrl);
     } catch {
       // Fallback for older browsers without clipboard API
-      const textarea = document.createElement('textarea');
-      textarea.value = shareUrl;
-      textarea.style.position = 'fixed';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textarea);
+      try {
+        const textarea = document.createElement('textarea');
+        textarea.value = shareUrl;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+      } catch {
+        // Even execCommand failed — feedback still shown below so user
+        // can use the "View full debate" link to get the URL manually
+      }
     }
+    // Always show confirmation so the user knows the action registered
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };
@@ -242,28 +249,55 @@ export function DebateResultPreview({ result }: DebateResultPreviewProps) {
         )}
       </div>
 
-      {/* Proposals */}
-      <div className="border border-[var(--border)] p-4">
-        <h3 className="text-sm text-[var(--acid-green)] mb-4 font-bold font-mono">
-          Proposals
-        </h3>
-        <div className="space-y-4">
-          {Object.entries(result.proposals).map(([agent, content]) => (
-            <div key={agent}>
-              <h4 className={`text-sm font-bold mb-1 font-mono flex items-center gap-2 ${agentColor(agent)}`}>
-                <span
-                  className="w-2.5 h-2.5 rounded-full inline-block shrink-0"
-                  style={{ backgroundColor: agentDot(agent) }}
-                />
-                {agent}
-              </h4>
-              <div className="text-xs text-[var(--text-muted)] leading-relaxed prose-sm prose-invert max-w-none [&_h1]:text-sm [&_h1]:font-bold [&_h1]:text-[var(--text)] [&_h1]:mt-3 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-bold [&_h2]:text-[var(--text)] [&_h2]:mt-3 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-bold [&_h3]:text-[var(--text)] [&_h3]:mt-2 [&_h3]:mb-1 [&_p]:mb-2 [&_strong]:text-[var(--text)] [&_em]:text-[var(--text-muted)] [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:mb-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:mb-2 [&_li]:mb-0.5 [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--accent)] [&_blockquote]:pl-3 [&_blockquote]:italic">
-                <Markdown>{content}</Markdown>
+      {/* Proposals — hidden when single-agent and verdict duplicates the proposal */}
+      {(() => {
+        const proposalEntries = Object.entries(result.proposals);
+        const isSingleAgent = proposalEntries.length === 1;
+        const singleProposalText = isSingleAgent ? proposalEntries[0][1] : '';
+        const verdictDuplicatesProposal =
+          isSingleAgent &&
+          result.final_answer &&
+          singleProposalText.trim() === result.final_answer.trim();
+
+        // When single-agent result duplicates, show a merged "Result" section instead
+        if (verdictDuplicatesProposal) {
+          return (
+            <div className="border border-[var(--acid-green)]/30 p-4">
+              <h3 className="text-sm text-[var(--acid-green)] mb-3 font-bold font-mono">
+                Result
+              </h3>
+              <div className="text-sm text-[var(--text)] leading-relaxed max-w-none [&_h1]:text-base [&_h1]:font-bold [&_h1]:mt-4 [&_h1]:mb-2 [&_h2]:text-sm [&_h2]:font-bold [&_h2]:mt-3 [&_h2]:mb-1 [&_h3]:text-sm [&_h3]:font-bold [&_h3]:mt-2 [&_h3]:mb-1 [&_p]:mb-2 [&_strong]:font-bold [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:mb-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:mb-2 [&_li]:mb-0.5 [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--accent)] [&_blockquote]:pl-3 [&_blockquote]:italic [&_blockquote]:text-[var(--text-muted)]">
+                <Markdown>{result.final_answer}</Markdown>
               </div>
             </div>
-          ))}
-        </div>
-      </div>
+          );
+        }
+
+        // Multi-agent or non-duplicate: show Proposals section as before
+        return (
+          <div className="border border-[var(--border)] p-4">
+            <h3 className="text-sm text-[var(--acid-green)] mb-4 font-bold font-mono">
+              Proposals
+            </h3>
+            <div className="space-y-4">
+              {proposalEntries.map(([agent, content]) => (
+                <div key={agent}>
+                  <h4 className={`text-sm font-bold mb-1 font-mono flex items-center gap-2 ${agentColor(agent)}`}>
+                    <span
+                      className="w-2.5 h-2.5 rounded-full inline-block shrink-0"
+                      style={{ backgroundColor: agentDot(agent) }}
+                    />
+                    {agent}
+                  </h4>
+                  <div className="text-xs text-[var(--text-muted)] leading-relaxed prose-sm prose-invert max-w-none [&_h1]:text-sm [&_h1]:font-bold [&_h1]:text-[var(--text)] [&_h1]:mt-3 [&_h1]:mb-1 [&_h2]:text-xs [&_h2]:font-bold [&_h2]:text-[var(--text)] [&_h2]:mt-3 [&_h2]:mb-1 [&_h3]:text-xs [&_h3]:font-bold [&_h3]:text-[var(--text)] [&_h3]:mt-2 [&_h3]:mb-1 [&_p]:mb-2 [&_strong]:text-[var(--text)] [&_em]:text-[var(--text-muted)] [&_ul]:list-disc [&_ul]:pl-4 [&_ul]:mb-2 [&_ol]:list-decimal [&_ol]:pl-4 [&_ol]:mb-2 [&_li]:mb-0.5 [&_blockquote]:border-l-2 [&_blockquote]:border-[var(--accent)] [&_blockquote]:pl-3 [&_blockquote]:italic">
+                    <Markdown>{content}</Markdown>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })()}
 
       {/* Critiques (first 3) */}
       {result.critiques.length > 0 && (
@@ -321,8 +355,11 @@ export function DebateResultPreview({ result }: DebateResultPreviewProps) {
         </div>
       )}
 
-      {/* Verdict — visible to everyone */}
-      {result.final_answer && (
+      {/* Verdict — hidden when single-agent result already shown as merged "Result" */}
+      {result.final_answer && !(
+        Object.keys(result.proposals).length === 1 &&
+        Object.values(result.proposals)[0]?.trim() === result.final_answer.trim()
+      ) && (
         <div className="border border-[var(--acid-green)]/30 p-4">
           <h3 className="text-sm text-[var(--acid-green)] mb-3 font-bold font-mono">
             Verdict

--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -1541,6 +1541,9 @@ class PlaygroundHandler(BaseHandler):
         # Oracle mode (consult / divine / commune)
         mode = str(body.get("mode", "") or "").strip() or "consult"
 
+        # Source: "oracle" for Oracle page, "landing" for main site, etc.
+        source = str(body.get("source", "") or "").strip() or "oracle"
+
         # Session ID for follow-up conversation memory
         session_id = str(body.get("session_id", "") or "").strip() or None
 
@@ -1557,7 +1560,13 @@ class PlaygroundHandler(BaseHandler):
         agent_count = max(_MIN_AGENTS, min(agent_count, _MAX_AGENTS))
 
         return self._run_debate(
-            topic, rounds, agent_count, question=question, mode=mode, session_id=session_id
+            topic,
+            rounds,
+            agent_count,
+            question=question,
+            mode=mode,
+            session_id=session_id,
+            source=source,
         )
 
     def _run_debate(
@@ -1568,18 +1577,43 @@ class PlaygroundHandler(BaseHandler):
         question: str | None = None,
         mode: str = "consult",
         session_id: str | None = None,
+        source: str = "oracle",
     ) -> HandlerResult:
         if question:
-            # Oracle mode: try real LLM response first
-            oracle_result = _try_oracle_response(
-                mode=mode, question=question, topic=topic, session_id=session_id
-            )
+            if source == "oracle":
+                # Oracle mode: try real LLM response first (Shoggoth language)
+                oracle_result = _try_oracle_response(
+                    mode=mode, question=question, topic=topic, session_id=session_id
+                )
+            else:
+                # Landing/other source: use multi-perspective tentacles with
+                # professional language (no Shoggoth/Oracle branding)
+                oracle_result = _try_oracle_tentacles(
+                    mode=mode,
+                    question=question,
+                    agent_count=agent_count,
+                    topic=topic,
+                    source=source,
+                    summary_depth="none",
+                )
             if oracle_result:
-                return json_response(oracle_result)
-            logger.info("Oracle LLM call failed — returning placeholder instead of irrelevant mock")
-            # Return an Oracle-themed placeholder instead of a generic mock debate
-            # (the generic mock talks about microservices which is nonsensical for Oracle)
+                return self._persist_and_respond(
+                    json_response(oracle_result),
+                    topic,
+                    source,
+                )
+            logger.info("LLM call failed — returning placeholder instead of irrelevant mock")
             debate_id = uuid.uuid4().hex[:16]
+            if source == "oracle":
+                placeholder_name = "oracle"
+                placeholder_text = (
+                    "The Oracle is gathering its thoughts... The tentacles will speak momentarily."
+                )
+            else:
+                placeholder_name = "analyst"
+                placeholder_text = (
+                    "The analysis is being prepared. Our AI panel will respond momentarily."
+                )
             return json_response(
                 {
                     "id": debate_id,
@@ -1590,14 +1624,12 @@ class PlaygroundHandler(BaseHandler):
                     "confidence": 0.5,
                     "verdict": "pending",
                     "duration_seconds": 0.1,
-                    "participants": ["oracle"],
-                    "proposals": {
-                        "oracle": "The Oracle is gathering its thoughts... The tentacles will speak momentarily."
-                    },
+                    "participants": [placeholder_name],
+                    "proposals": {placeholder_name: placeholder_text},
                     "critiques": [],
                     "votes": [],
                     "dissenting_views": [],
-                    "final_answer": "The Oracle is gathering its thoughts... The tentacles will speak momentarily.",
+                    "final_answer": placeholder_text,
                     "receipt_hash": None,
                 }
             )
@@ -1868,7 +1900,13 @@ class PlaygroundHandler(BaseHandler):
         if not has_api_keys:
             # Fall back to mock debate with a note
             result = self._run_debate(
-                topic, rounds, agent_count, question=question, mode=mode, session_id=session_id
+                topic,
+                rounds,
+                agent_count,
+                question=question,
+                mode=mode,
+                session_id=session_id,
+                source=source,
             )
             if result is None:
                 return error_response("Playground unavailable", 503)
@@ -1895,7 +1933,11 @@ class PlaygroundHandler(BaseHandler):
             )
             if tentacle_result:
                 tentacle_result["upgrade_cta"] = _build_upgrade_cta()
-                return json_response(tentacle_result)
+                return self._persist_and_respond(
+                    json_response(tentacle_result),
+                    topic,
+                    source,
+                )
             logger.info("Oracle tentacles failed, trying live debate factory")
 
         # Try live debate — fall back to mock if it fails
@@ -1906,7 +1948,13 @@ class PlaygroundHandler(BaseHandler):
                 live_result.status_code,
             )
             mock_result = self._run_debate(
-                topic, rounds, agent_count, question=question, mode=mode, session_id=session_id
+                topic,
+                rounds,
+                agent_count,
+                question=question,
+                mode=mode,
+                session_id=session_id,
+                source=source,
             )
             if mock_result is not None:
                 import json as _json


### PR DESCRIPTION
## Summary

Consolidated visual QA fixes from #618 + #619 (Footer.tsx already merged in #620):

- **P0 — Share URL persistence**: Oracle/tentacle response paths returned `json_response()` directly, bypassing `_persist_and_respond()`. Debates were never saved to `debate_store`, so the public viewer at `/debate/{id}` returned 404. All LLM response paths now persist correctly.
- **P1 — Shoggoth branding leak**: Landing page debates (`source="landing"`) were routed to Oracle single-response path because `_run_debate()` keyed on `question` presence without checking `source`. Now extracts `source` from request body and routes landing requests to multi-perspective tentacles with professional `_LANDING_ROLE_PROMPTS`. Placeholder text is source-aware.
- **P2 — Proposals = Verdict duplication**: Single-agent debates showed identical content in both sections. Detects when sole proposal matches `final_answer` and renders a merged "Result" section.
- **P3 — Share button no feedback**: Always shows "LINK COPIED!" even when clipboard API fails, with nested fallback try/catch.

Supersedes: #618 (closed), #619 (closed), #616 (closed)

## Test plan
- [x] `pytest tests/server/handlers/test_playground*.py` — 38/38 pass (1 pre-existing)
- [x] Python syntax check — OK
- [x] Pre-commit hooks pass (ruff, secrets, etc.)
- [ ] Verify landing debate uses professional prompts (no Shoggoth)
- [ ] Verify `/debate/{id}` share URLs resolve after debate
- [ ] Verify single-agent result shows merged "Result" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)