### PR TITLE
fix(build): use Turbopack for Vercel production builds

### DIFF
--- a/aragora/live/package.json
+++ b/aragora/live/package.json
@@ -11,7 +11,7 @@
     "clean": "rm -rf .next",
     "prebuild": "(npm run validate-env || echo 'Env validation skipped (missing ts-node)') && npm run clean",
     "build": "npm run build:runtime",
-    "build:runtime": "LIVE_DEPLOY_MODE=runtime NEXT_PUBLIC_WS_URL=wss://api.aragora.ai NEXT_PUBLIC_API_URL=https://api.aragora.ai next build --webpack",
+    "build:runtime": "LIVE_DEPLOY_MODE=runtime NEXT_PUBLIC_WS_URL=wss://api.aragora.ai NEXT_PUBLIC_API_URL=https://api.aragora.ai next build",
     "build:standalone": "NEXT_OUTPUT=standalone NEXT_PUBLIC_WS_URL=wss://api.aragora.ai NEXT_PUBLIC_API_URL=https://api.aragora.ai next build --webpack",
     "build:local": "NEXT_OUTPUT=standalone next build --webpack",
     "build:export": "NEXT_OUTPUT=export NEXT_PUBLIC_WS_URL=wss://api.aragora.ai NEXT_PUBLIC_API_URL=https://api.aragora.ai next build --webpack",


### PR DESCRIPTION
## Summary
- Removes `--webpack` flag from `build:runtime` script in `aragora/live/package.json`
- **Root cause**: Next.js 16.1.6 defaults to Turbopack for production builds. The `--webpack` flag forced legacy webpack which does not generate `page_client-reference-manifest.js` at the `(app)/` route group root, causing all Vercel deployments to fail with `ENOENT` on that file
- **Impact**: This was blocking all production deployments of aragora.ai

## Fix
Single line change: remove `--webpack` from `npm run build:runtime`. Turbopack (Next.js 16 default) correctly generates the RSC client reference manifest at the route group root.

## Deployment
aragora.ai has already been manually deployed via `vercel deploy --prebuilt` with this fix applied — the landing page UI improvements are now live.

This PR ensures future CI-triggered deployments also succeed.

## Test plan
- [x] `npm run build:runtime` runs without `--webpack` and generates `page_client-reference-manifest.js` at `(app)/`
- [x] `vercel build` + `vercel deploy --prebuilt` succeeded (deployed to production)
- [x] aragora.ai returns HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)