### PR TITLE
feat(debate): wire marketplace templates to team selection, add Pydantic validation (#292)

### DIFF
--- a/aragora/debate/team_selector.py
+++ b/aragora/debate/team_selector.py
@@ -202,6 +202,7 @@ class TeamSelector:
         feedback_loop: Any | None = None,
         continuum_memory: ContinuumMemory | None = None,
         control_plane_registry: Any | None = None,
+        marketplace_registry: Any | None = None,
     ):
         self.elo_system = elo_system
         # Auto-detect default CalibrationTracker if none provided.
@@ -252,6 +253,8 @@ class TeamSelector:
                     "proceeding without health filtering"
                 )
         self.control_plane_registry = control_plane_registry
+        # Marketplace registry for template-based team selection
+        self.marketplace_registry = marketplace_registry
         self.pulse_manager: Any = None  # Set externally or via Arena
         self.specialist_registry: Any = None  # Set externally or via Arena
         self._culture_recommendations_cache: dict[str, list[str]] = {}
@@ -2026,3 +2029,85 @@ class TeamSelector:
             strategy: New delegation strategy to use
         """
         self.delegation_strategy = strategy
+
+    def select_from_template(self, template_name: str) -> list[str]:
+        """Return agent names (or role names) derived from a marketplace template.
+
+        Looks up ``template_name`` in the marketplace registry and extracts the
+        set of agent/role identifiers that the template prescribes.
+
+        - For :class:`~aragora.marketplace.models.DebateTemplate`: returns the
+          ``role`` value from each entry in ``agent_roles``.
+        - For :class:`~aragora.marketplace.models.AgentTemplate`: returns a
+          single-element list containing the ``agent_type``.
+        - If the template is not found, logs a warning and returns ``[]``.
+
+        Args:
+            template_name: The ``metadata.id`` of the marketplace template to
+                           look up (e.g. ``"oxford-style"``).
+
+        Returns:
+            A list of agent/role name strings, or ``[]`` on failure.
+        """
+        if not template_name:
+            return []
+
+        # Resolve the registry to use: prefer the one injected at construction
+        # time, but fall back to constructing a default TemplateRegistry so the
+        # method works even without explicit injection.
+        registry = self.marketplace_registry
+        if registry is None:
+            try:
+                from aragora.marketplace.registry import TemplateRegistry
+
+                registry = TemplateRegistry()
+            except (ImportError, OSError, RuntimeError, TypeError, ValueError) as exc:
+                logger.warning(
+                    "select_from_template: could not initialise TemplateRegistry: %s", exc
+                )
+                return []
+
+        try:
+            template = registry.get(template_name)
+        except (OSError, RuntimeError, TypeError, ValueError, AttributeError) as exc:
+            logger.warning(
+                "select_from_template: registry lookup failed for %r: %s", template_name, exc
+            )
+            return []
+
+        if template is None:
+            logger.warning(
+                "select_from_template: template %r not found in marketplace registry",
+                template_name,
+            )
+            return []
+
+        try:
+            from aragora.marketplace.models import DebateTemplate, AgentTemplate
+
+            if isinstance(template, DebateTemplate):
+                # Extract the 'role' key from each agent_roles entry
+                roles: list[str] = []
+                for entry in template.agent_roles:
+                    role = entry.get("role") if isinstance(entry, dict) else str(entry)
+                    if role:
+                        roles.append(role)
+                return roles
+
+            if isinstance(template, AgentTemplate):
+                return [template.agent_type]
+
+            # WorkflowTemplate or unknown type — return empty list
+            logger.warning(
+                "select_from_template: template %r has unsupported type %s",
+                template_name,
+                type(template).__name__,
+            )
+            return []
+        except (ImportError, AttributeError, TypeError) as exc:
+            logger.warning(
+                "select_from_template: failed to extract agents from template %r: %s",
+                template_name,
+                exc,
+            )
+            return []

--- a/aragora/server/handlers/debates/create.py
+++ b/aragora/server/handlers/debates/create.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from aragora.resilience import with_timeout_sync
 from aragora.server.http_utils import run_async
+from aragora.server.validation.pydantic_models import validate_debate_request
 from aragora.server.validation.schema import (
     DEBATE_START_SCHEMA,
     validate_against_schema,
@@ -175,6 +176,14 @@ class CreateOperationsMixin:
         validation_result = _get_validate_against_schema()(body, DEBATE_START_SCHEMA)
         if not validation_result.is_valid:
             return error_response(validation_result.error, 400)
+
+        # Pydantic v2 strict validation (question length, rounds bounds, agents limit)
+        # Only applies when the body contains a 'question' field (the primary field);
+        # requests using the legacy 'task' field bypass this layer to preserve compatibility.
+        if "question" in body:
+            _pydantic_req, _pydantic_err = validate_debate_request(body)
+            if _pydantic_err is not None:
+                return error_response(_pydantic_err, 422)
 
         # Spam check for debate content
         spam_result = self._check_spam_content(body)

--- a/aragora/server/validation/pydantic_models.py
+++ b/aragora/server/validation/pydantic_models.py
@@ -1,0 +1,108 @@
+"""
+Pydantic v2 request models for Aragora server endpoints.
+
+These models provide strict input validation with clear error messages and are
+used alongside (not instead of) the existing JSON-schema-based validation.
+The Pydantic layer gives typed field access and richer constraint checking.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class DebateRequest(BaseModel):
+    """Validated input model for debate creation endpoints.
+
+    Accepts the union of fields accepted by POST /api/v1/debates and
+    POST /api/v1/debate-this.
+
+    Example (minimal)::
+
+        req = DebateRequest(question="Should we adopt microservices?")
+
+    Example (full)::
+
+        req = DebateRequest(
+            question="Should we adopt microservices?",
+            rounds=5,
+            agents=["claude", "gpt"],
+        )
+    """
+
+    question: str = Field(..., min_length=10, max_length=2000)
+    rounds: int = Field(default=3, ge=1, le=10)
+    agents: list[str] = Field(default_factory=list, max_length=10)
+
+    # Optional passthrough fields accepted by the existing handler
+    auto_select: bool = False
+    use_trending: bool = False
+    consensus: str = Field(default="majority", max_length=64)
+    context: str | None = Field(default=None, max_length=10000)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("question")
+    @classmethod
+    def question_not_empty(cls, v: str) -> str:
+        """Reject blank / whitespace-only questions."""
+        stripped = v.strip()
+        if not stripped:
+            raise ValueError("question cannot be blank")
+        return stripped
+
+    @field_validator("agents", mode="before")
+    @classmethod
+    def parse_agents(cls, v: Any) -> list[str]:
+        """Accept comma-separated string OR a proper list."""
+        if isinstance(v, str):
+            return [a.strip() for a in v.split(",") if a.strip()]
+        return v
+
+    def to_handler_dict(self) -> dict[str, Any]:
+        """Return a dict compatible with the existing debate handler body format."""
+        d: dict[str, Any] = {
+            "question": self.question,
+            "rounds": self.rounds,
+            "auto_select": self.auto_select,
+            "use_trending": self.use_trending,
+            "consensus": self.consensus,
+            "metadata": self.metadata,
+        }
+        if self.agents:
+            d["agents"] = self.agents
+        if self.context is not None:
+            d["context"] = self.context
+        return d
+
+
+def validate_debate_request(body: dict[str, Any]) -> tuple[DebateRequest | None, str | None]:
+    """Validate a raw request body dict against :class:`DebateRequest`.
+
+    Args:
+        body: Parsed JSON body from the HTTP request.
+
+    Returns:
+        A ``(DebateRequest, None)`` tuple on success, or
+        ``(None, error_message)`` on validation failure.
+    """
+    try:
+        request = DebateRequest.model_validate(body)
+        return request, None
+    except Exception as exc:  # noqa: BLE001 – pydantic.ValidationError is the expected type
+        # Collect all field errors into a single human-readable string
+        try:
+            # pydantic v2 ValidationError
+            errors = exc.errors()  # type: ignore[union-attr]
+            messages = []
+            for err in errors:
+                loc = " -> ".join(str(p) for p in err.get("loc", []))
+                msg = err.get("msg", str(err))
+                messages.append(f"{loc}: {msg}" if loc else msg)
+            return None, "; ".join(messages)
+        except AttributeError:
+            return None, str(exc)
+
+
+__all__ = ["DebateRequest", "validate_debate_request"]

--- a/tests/debate/test_marketplace_team_selection.py
+++ b/tests/debate/test_marketplace_team_selection.py
@@ -1,0 +1,136 @@
+"""
+Tests for marketplace template → TeamSelector wiring (Epic #292, T1).
+
+Verifies that TeamSelector.select_from_template:
+- Returns agent names from a known DebateTemplate's agent_roles
+- Returns empty list for unknown template names (graceful failure)
+- Works with both built-in templates and custom registered templates
+"""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestSelectFromTemplate:
+    """Tests for TeamSelector.select_from_template."""
+
+    @pytest.fixture
+    def selector(self):
+        """Create a minimal TeamSelector."""
+        from aragora.debate.team_selector import TeamSelector
+
+        return TeamSelector()
+
+    def test_select_from_known_debate_template_returns_nonempty_list(self, selector):
+        """select_from_template with a known debate template ID returns a non-empty list."""
+        result = selector.select_from_template("oxford-style")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_select_from_known_debate_template_returns_strings(self, selector):
+        """Returned items are strings (agent names or role names)."""
+        result = selector.select_from_template("oxford-style")
+        for item in result:
+            assert isinstance(item, str), f"Expected str, got {type(item)}: {item!r}"
+
+    def test_select_from_unknown_template_returns_empty_list(self, selector):
+        """Unknown template name returns empty list (graceful failure)."""
+        result = selector.select_from_template("nonexistent-template-xyz-123")
+        assert result == []
+
+    def test_select_from_brainstorm_template(self, selector):
+        """brainstorm-session template resolves to agent roles."""
+        result = selector.select_from_template("brainstorm-session")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_select_from_code_review_template(self, selector):
+        """code-review-session template resolves to agent roles."""
+        result = selector.select_from_template("code-review-session")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_select_from_agent_template_returns_agent_type(self, selector):
+        """AgentTemplate (not DebateTemplate) returns the agent_type as list."""
+        result = selector.select_from_template("devil-advocate")
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_select_from_template_is_async_compatible(self, selector):
+        """select_from_template can be called as a coroutine."""
+        import asyncio
+        import inspect
+
+        # The method should either be async or sync but callable
+        method = getattr(selector, "select_from_template", None)
+        assert method is not None, "TeamSelector must have select_from_template method"
+
+    def test_empty_template_name_returns_empty_list(self, selector):
+        """Empty string template name returns empty list."""
+        result = selector.select_from_template("")
+        assert result == []
+
+    def test_select_from_template_with_custom_registry(self):
+        """select_from_template works with a custom-registered template."""
+        from aragora.debate.team_selector import TeamSelector
+        from aragora.marketplace.models import (
+            AgentTemplate,
+            TemplateMetadata,
+            TemplateCategory,
+        )
+
+        # Use a custom in-memory registry for isolation
+        from aragora.marketplace.registry import TemplateRegistry
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = TemplateRegistry(db_path=Path(tmpdir) / "test_marketplace.db")
+
+            custom_template = AgentTemplate(
+                metadata=TemplateMetadata(
+                    id="custom-analyst",
+                    name="Custom Analyst",
+                    description="A custom analysis agent",
+                    version="1.0.0",
+                    author="test",
+                    category=TemplateCategory.ANALYSIS,
+                ),
+                agent_type="claude",
+                system_prompt="You are an analyst.",
+                capabilities=["analysis"],
+            )
+            registry.register(custom_template)
+
+            selector = TeamSelector(marketplace_registry=registry)
+            result = selector.select_from_template("custom-analyst")
+            assert isinstance(result, list)
+            assert len(result) > 0
+
+
+class TestSelectFromTemplateIntegration:
+    """Integration tests confirming marketplace lookup path works end-to-end."""
+
+    def test_selector_has_select_from_template_method(self):
+        """TeamSelector exposes select_from_template."""
+        from aragora.debate.team_selector import TeamSelector
+
+        assert hasattr(TeamSelector, "select_from_template")
+        assert callable(getattr(TeamSelector, "select_from_template"))
+
+    def test_oxford_style_roles_match_template_definition(self):
+        """oxford-style template agent_roles are reflected in select_from_template result."""
+        from aragora.debate.team_selector import TeamSelector
+        from aragora.marketplace.registry import TemplateRegistry
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            registry = TemplateRegistry(db_path=Path(tmpdir) / "test_marketplace.db")
+            selector = TeamSelector(marketplace_registry=registry)
+            result = selector.select_from_template("oxford-style")
+
+            # oxford-style has 4 agent_roles; result should reflect them
+            assert len(result) == 4

--- a/tests/server/handlers/test_debate_pydantic_validation.py
+++ b/tests/server/handlers/test_debate_pydantic_validation.py
@@ -1,0 +1,233 @@
+"""
+Tests for Pydantic v2 input validation on debate endpoints (Epic #292, T3).
+
+Tests confirm:
+- Valid payloads pass validation
+- Invalid payloads return 422 (or similar error) from validate_debate_request
+- Field constraints are enforced (question length, rounds bounds, agents list size)
+- The DebateRequest model is importable and correctly structured
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+
+class TestDebateRequestModel:
+    """Unit tests for the DebateRequest Pydantic model."""
+
+    def test_import_debate_request(self):
+        """DebateRequest can be imported."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        assert DebateRequest is not None
+
+    def test_valid_minimal_request(self):
+        """A request with just a long-enough question is valid."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(question="Should we adopt microservices architecture?")
+        assert req.question == "Should we adopt microservices architecture?"
+        assert req.rounds == 3  # default
+        assert req.agents == []  # default
+
+    def test_valid_full_request(self):
+        """A request with all fields set is valid."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(
+            question="What is the best approach for distributed caching?",
+            rounds=5,
+            agents=["claude", "gpt"],
+        )
+        assert req.rounds == 5
+        assert req.agents == ["claude", "gpt"]
+
+    def test_question_too_short_raises(self):
+        """Question shorter than 10 chars raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(question="Short")
+
+    def test_blank_question_raises(self):
+        """Blank/whitespace question raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(question="          ")
+
+    def test_question_too_long_raises(self):
+        """Question longer than 2000 chars raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(question="x" * 2001)
+
+    def test_rounds_below_minimum_raises(self):
+        """rounds < 1 raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(
+                question="Should we use microservices instead of monoliths?",
+                rounds=0,
+            )
+
+    def test_rounds_above_maximum_raises(self):
+        """rounds > 10 raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(
+                question="Should we use microservices instead of monoliths?",
+                rounds=11,
+            )
+
+    def test_agents_list_too_long_raises(self):
+        """agents list with more than 10 entries raises ValidationError."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        with pytest.raises(ValidationError):
+            DebateRequest(
+                question="Should we use microservices instead of monoliths?",
+                agents=[f"agent_{i}" for i in range(11)],
+            )
+
+    def test_question_stripped_of_whitespace(self):
+        """Leading/trailing whitespace is stripped from question."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(question="  What is the best deployment strategy?  ")
+        assert req.question == "What is the best deployment strategy?"
+
+    def test_agents_parsed_from_comma_string(self):
+        """agents can be provided as a comma-separated string."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(
+            question="Should we use microservices instead of monoliths?",
+            agents="claude, gpt, gemini",  # type: ignore[arg-type]
+        )
+        assert req.agents == ["claude", "gpt", "gemini"]
+
+    def test_to_handler_dict_contains_question(self):
+        """to_handler_dict() returns a dict containing the question."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(question="What is the best deployment strategy?")
+        d = req.to_handler_dict()
+        assert "question" in d
+        assert d["question"] == "What is the best deployment strategy?"
+
+    def test_to_handler_dict_contains_rounds(self):
+        """to_handler_dict() contains rounds."""
+        from aragora.server.validation.pydantic_models import DebateRequest
+
+        req = DebateRequest(question="What is the best deployment strategy?", rounds=7)
+        d = req.to_handler_dict()
+        assert d["rounds"] == 7
+
+
+class TestValidateDebateRequest:
+    """Tests for the validate_debate_request helper function."""
+
+    def test_valid_payload_returns_model(self):
+        """Valid body returns (DebateRequest, None)."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        req, err = validate_debate_request(
+            {"question": "Should we adopt microservices architecture?"}
+        )
+        assert req is not None
+        assert err is None
+
+    def test_invalid_payload_returns_error_string(self):
+        """Invalid body returns (None, error_message) with non-empty message."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        req, err = validate_debate_request({"question": "Short"})
+        assert req is None
+        assert err is not None
+        assert len(err) > 0
+
+    def test_blank_question_returns_error(self):
+        """Blank question returns error message, not an exception."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        req, err = validate_debate_request({"question": "   "})
+        assert req is None
+        assert err is not None
+
+    def test_rounds_out_of_range_returns_error(self):
+        """rounds=0 returns error string."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        req, err = validate_debate_request(
+            {
+                "question": "Should we adopt microservices architecture?",
+                "rounds": 0,
+            }
+        )
+        assert req is None
+        assert err is not None
+
+    def test_error_is_human_readable(self):
+        """Error message for invalid payload is human-readable text."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        _, err = validate_debate_request({"question": "Too short"})
+        # Should mention the field or constraint
+        assert err is not None
+        assert isinstance(err, str)
+        assert len(err.strip()) > 10
+
+    def test_missing_question_returns_error(self):
+        """Missing question field returns error (question is required)."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        req, err = validate_debate_request({"rounds": 3})
+        assert req is None
+        assert err is not None
+
+
+class TestDebateCreateEndpointPydanticIntegration:
+    """Tests that confirm the create endpoint wires in Pydantic validation.
+
+    These tests call validate_debate_request directly (as the handler does)
+    to confirm the 422 path is reachable. Full handler integration tests are
+    in test_debates_handler.py.
+    """
+
+    def test_pydantic_validates_before_spam_check(self):
+        """Pydantic validation rejects payload before spam check runs."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        # Too short — Pydantic should reject
+        req, err = validate_debate_request({"question": "Hi"})
+        assert req is None
+        assert err is not None
+
+    def test_pydantic_accepts_valid_debate_payload(self):
+        """A realistic debate payload passes Pydantic validation."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        payload = {
+            "question": "Should small teams adopt trunk-based development?",
+            "rounds": 3,
+            "agents": ["claude", "gpt"],
+            "auto_select": False,
+        }
+        req, err = validate_debate_request(payload)
+        assert req is not None
+        assert err is None
+
+    def test_validation_returns_422_compatible_error(self):
+        """Error from validate_debate_request is a string suitable for a 422 response."""
+        from aragora.server.validation.pydantic_models import validate_debate_request
+
+        _, err = validate_debate_request({"question": "Short"})
+        # Error string should be non-empty and not a traceback
+        assert err is not None
+        assert "\n" not in err or len(err.splitlines()) <= 3

--- a/tests/server/handlers/test_debates.py
+++ b/tests/server/handlers/test_debates.py
@@ -528,7 +528,11 @@ class TestDecisionRouterIntegration:
             )
 
             # Mock other dependencies
-            with patch.object(handler, "read_json_body", return_value={"question": "Test?"}):
+            with patch.object(
+                handler,
+                "read_json_body",
+                return_value={"question": "Should we adopt microservices?"},
+            ):
                 with patch.object(handler, "_check_spam_content", return_value=None):
                     with patch(
                         "aragora.server.handlers.debates.handler.validate_against_schema"


### PR DESCRIPTION
## Summary

Implements T1 and T3 of Epic #292 (Debate marketplace + Pydantic v2 validation).

- **T1**: `TeamSelector.select_from_template(template_name)` — looks up a marketplace template by ID and returns a list of agent/role names. Accepts an optional `marketplace_registry` dependency at construction time; falls back to a default `TemplateRegistry` automatically. `DebateTemplate` returns role strings from `agent_roles`; `AgentTemplate` returns `[agent_type]`. Unknown names return `[]` with a warning log.

- **T3**: `DebateRequest` Pydantic v2 model in `aragora/server/validation/pydantic_models.py`. Enforces: `question` 10–2000 chars, `rounds` 1–10, `agents` max 10 items. Strips leading/trailing whitespace from question; accepts comma-separated agent strings. Wired into `_create_debate` handler — requests with a `question` field are validated; invalid payloads return 422.

T2 (cartography), T4 (spectate→cartography), T5 (replay) are follow-up items.

## Test plan

- [x] `tests/debate/test_marketplace_team_selection.py` — 11 tests, all passing
- [x] `tests/server/handlers/test_debate_pydantic_validation.py` — 22 tests, all passing
- [x] `tests/server/handlers/test_debates.py` — existing tests still pass (fixed one test that used a 5-char question that now correctly fails Pydantic validation)
- [x] `tests/server/handlers/test_debates_handler.py` — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)