### PR TITLE
fix(ci): prefer python3.10+ for required lint/typecheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -137,7 +137,7 @@ jobs:
             echo "::error::Python runtime not found on runner"
             exit 1
           fi
-          PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')"
+          PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
           if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
             echo "::error::Python >=3.10 required for lint checks, found ${PYTHON_VERSION} at ${PYTHON_BIN}"
             exit 1
@@ -369,7 +369,7 @@ jobs:
             echo "::error::Python runtime not found on runner"
             exit 1
           fi
-          PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f\"{sys.version_info.major}.{sys.version_info.minor}\")')"
+          PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
           if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
             echo "::error::Python >=3.10 required for typecheck, found ${PYTHON_VERSION} at ${PYTHON_BIN}"
             exit 1


### PR DESCRIPTION
## Summary
- prefer python3.13/3.12/3.11/3.10 before falling back to python3/python
- enforce Python >=3.10 in required lint/typecheck runtime resolution
- preserve runner-native execution path while preventing 3.9 toolchain failures

## Context
 failed on some self-hosted runners where  maps to 3.9, causing editable install failures ().
