### PR TITLE
fix(ci): resolve python>=3.10 for SDK parity checks

### DIFF
--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -110,44 +110,65 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
+      - name: Resolve Python runtime
+        id: sdk_parity_python
+        shell: bash
+        run: |
+          set -euo pipefail
+          PYTHON_BIN=""
+          for candidate in python3.13 python3.12 python3.11 python3.10 python3 python; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              PYTHON_BIN="$(command -v "$candidate")"
+              break
+            fi
+          done
+          if [[ -z "$PYTHON_BIN" ]]; then
+            echo "::error::Python runtime not found on runner"
+            exit 1
+          fi
+          PYTHON_VERSION="$("$PYTHON_BIN" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+          if ! "$PYTHON_BIN" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'; then
+            echo "::error::Python >=3.10 required for sdk-parity, found ${PYTHON_VERSION} at ${PYTHON_BIN}"
+            exit 1
+          fi
+          echo "Using Python ${PYTHON_VERSION} at ${PYTHON_BIN}"
+          "$PYTHON_BIN" -m ensurepip --upgrade || true
+          "$PYTHON_BIN" -m pip install --upgrade pip
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          echo "python_bin=$PYTHON_BIN" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .
+          "${{ steps.sdk_parity_python.outputs.python_bin }}" -m pip install --user -e .
 
       - name: Check Version Alignment
-        run: python scripts/check_version_alignment.py
+        run: ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_version_alignment.py
 
       - name: Check SDK Parity
         run: |
           # Blocking gate: fail on any drift regression beyond tracked baseline
-          python scripts/check_sdk_parity.py \
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_sdk_parity.py \
             --strict \
             --baseline scripts/baselines/check_sdk_parity.json \
             --budget scripts/baselines/check_sdk_parity_budget.json
 
       - name: Check Namespace SDK Parity
         run: |
-          python scripts/check_sdk_namespace_parity.py --strict --baseline scripts/baselines/check_sdk_namespace_parity.json
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_sdk_namespace_parity.py --strict --baseline scripts/baselines/check_sdk_namespace_parity.json
 
       - name: Check Cross-Language SDK Parity
         run: |
-          python scripts/check_cross_sdk_parity.py \
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_cross_sdk_parity.py \
             --strict \
             --baseline scripts/baselines/cross_sdk_parity.json
 
       - name: Generate JSON Report
         if: always()
         run: |
-          python scripts/check_sdk_parity.py --json > parity-report.json || true
-          python scripts/check_sdk_namespace_parity.py --json > namespace-parity-report.json || true
-          python scripts/check_cross_sdk_parity.py --json > cross-sdk-parity-report.json || true
-          python scripts/contract_drift_report.py --json-out contract-drift-summary.json --md-out contract-drift-summary.md || true
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_sdk_parity.py --json > parity-report.json || true
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_sdk_namespace_parity.py --json > namespace-parity-report.json || true
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/check_cross_sdk_parity.py --json > cross-sdk-parity-report.json || true
+          ${{ steps.sdk_parity_python.outputs.python_bin }} scripts/contract_drift_report.py --json-out contract-drift-summary.json --md-out contract-drift-summary.md || true
 
       - name: Upload Parity Report
         if: always()


### PR DESCRIPTION
## Summary
- replace setup-python in sdk-parity-run with runner-native python resolver
- enforce Python >=3.10 for parity scripts
- run parity scripts via resolved interpreter to avoid AL2023 setup-python 3.11 failures
