### PR TITLE
fix(ci): use python -m pip for self-hosted runner compatibility

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install and test
         run: |
-          pip install -e ".[dev]" pytest-timeout httpx
+          python -m pip install -e ".[dev]" pytest-timeout httpx
           pytest tests/test_handlers_debates.py tests/test_api_handler.py \
             --timeout=60 -x --tb=short
         env:

--- a/.github/workflows/sdk-parity.yml
+++ b/.github/workflows/sdk-parity.yml
@@ -134,13 +134,19 @@ jobs:
           fi
           mkdir -p "$RUNNER_TEMP/bin"
           ln -sf "$PY_BIN" "$RUNNER_TEMP/bin/python"
+          # Create pip wrapper so bare `pip` works even when not on PATH
+          cat > "$RUNNER_TEMP/bin/pip" <<'PIPWRAP'
+          #!/usr/bin/env bash
+          exec python -m pip "$@"
+          PIPWRAP
+          chmod +x "$RUNNER_TEMP/bin/pip"
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           "$PY_BIN" --version
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          python -m pip install -e .
 
       - name: Check Version Alignment
         run: python scripts/check_version_alignment.py


### PR DESCRIPTION
## Summary

- Fix `pip: command not found` on AL2023 self-hosted runners where `~/.local/bin` isn't on PATH
- `sdk-parity.yml`: Use `python -m pip` + add pip wrapper in toolchain fallback
- `deploy-ec2.yml`: Use `python -m pip` in test step

Root cause: `actions/setup-python@v5` can't find Python 3.11 in tool cache on some runners, falls through to system Python. The fallback step creates a `python` symlink but not `pip`. `python -m pip` works because `python` is symlinked correctly.

## Test plan

- [ ] sdk-parity required check passes on this PR
- [ ] Verify pip wrapper works when setup-python falls back

🤖 Generated with [Claude Code](https://claude.com/claude-code)