### PR TITLE
ci(self-improve): enforce hard-check workflow and dogfood timeout robustness

### DIFF
--- a/.github/workflows/self-improve-hard-checks.yml
+++ b/.github/workflows/self-improve-hard-checks.yml
@@ -1,0 +1,202 @@
+name: Self-Improve Hard Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+    paths:
+      - "aragora/cli/commands/pipeline.py"
+      - "aragora/pipeline/idea_to_execution.py"
+      - "aragora/nomic/meta_planner.py"
+      - "aragora/nomic/meta_planner_utils.py"
+      - "scripts/run_dogfood_ab_pairs.py"
+      - "scripts/run_dogfood_benchmark.py"
+      - "scripts/ci_core_suites.sh"
+      - "docs/plans/dogfood_pipeline_integration_fixture.json"
+      - "docs/plans/dogfood_pipeline_self_improve_base_report.json"
+      - "tests/cli/test_pipeline_command.py"
+      - "tests/nomic/test_meta_planner.py"
+      - "tests/nomic/test_improvement_queue.py"
+      - "tests/nomic/testfixer/test_event_integration.py"
+      - ".github/workflows/self-improve-hard-checks.yml"
+  schedule:
+    - cron: "20 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      run_live_dogfood:
+        description: "Run live dogfood hard-check jobs"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: self-improve-hard-checks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  hard-check-tests:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    name: Self-Improve Hard Check Tests
+    runs-on: aragora
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            ls -la
+            exit 1
+          fi
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,test]"
+          pip install pytest-timeout
+
+      - name: Run hard-check test suites
+        run: |
+          pytest -q \
+            tests/cli/test_pipeline_command.py \
+            tests/nomic/test_meta_planner.py \
+            tests/nomic/test_improvement_queue.py \
+            tests/nomic/testfixer/test_event_integration.py \
+            --timeout=180 --tb=short
+        env:
+          PYTHONPATH: .
+
+  live-dogfood-hard-checks:
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_live_dogfood == 'true')
+    name: Live Dogfood Hard Checks
+    runs-on: aragora
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            exit 1
+          fi
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev,test]"
+
+      - name: Validate provider secrets
+        env:
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -z "${OPENROUTER_API_KEY}" && -z "${OPENAI_API_KEY}" && -z "${ANTHROPIC_API_KEY}" ]]; then
+            echo "::error::At least one model provider API key is required for live dogfood."
+            exit 1
+          fi
+
+      - name: Run integration-vague A/B dogfood profile
+        run: |
+          python3 scripts/run_dogfood_ab_pairs.py \
+            --pairs 1 \
+            --timeout-seconds 180 \
+            --prompt-profile integration_vague \
+            --output-root /tmp/dogfood_ab_integration_vague_ci
+
+      - name: Run pipeline self-improve hard-check benchmark
+        run: |
+          python3 scripts/run_dogfood_benchmark.py \
+            --base-report docs/plans/dogfood_pipeline_self_improve_base_report.json \
+            --runs 1 \
+            --timeout 300 \
+            --output /tmp/dogfood_pipeline_self_improve_benchmark_ci.json \
+            --enforce-pipeline-hard-checks \
+            --require-pipeline-hard-checks-presence
+
+      - name: Evaluate hard-check telemetry thresholds
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          benchmark_path = Path("/tmp/dogfood_pipeline_self_improve_benchmark_ci.json")
+          aggregate_path = Path("/tmp/dogfood_ab_integration_vague_ci/aggregate_summary.json")
+          if not benchmark_path.exists():
+              print("::error::Missing benchmark output")
+              sys.exit(1)
+
+          benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
+          summary = benchmark.get("summary", {})
+          checks = summary.get("pipeline_hard_checks", {})
+          rates = checks.get("check_pass_rates", {}) or {}
+          execution_path_live = rates.get("execution_path_live")
+          quality_gate_pass = rates.get("quality_gate_pass")
+          fallback_rate = None if execution_path_live is None else round(1.0 - float(execution_path_live), 4)
+          quality_fail_rate = None if quality_gate_pass is None else round(1.0 - float(quality_gate_pass), 4)
+
+          lines = [
+              "## Self-Improve Hard Check Telemetry",
+              "",
+              f"- execution_path_live pass rate: {execution_path_live}",
+              f"- quality_gate_pass pass rate: {quality_gate_pass}",
+              f"- inferred fallback_rate: {fallback_rate}",
+              f"- inferred quality_fail_rate: {quality_fail_rate}",
+          ]
+
+          if aggregate_path.exists():
+              aggregate = json.loads(aggregate_path.read_text(encoding="utf-8"))
+              lines.append(
+                  f"- A/B timeout_rate: {aggregate.get('mean_timeout_rate')}"
+              )
+
+          summary_path = Path(__import__('os').environ['GITHUB_STEP_SUMMARY'])
+          summary_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+          if fallback_rate is not None and fallback_rate > 0.10:
+              print(f"::error::fallback_rate {fallback_rate} exceeds 0.10 threshold")
+              sys.exit(1)
+          if quality_fail_rate is not None and quality_fail_rate > 0.20:
+              print(f"::error::quality_fail_rate {quality_fail_rate} exceeds 0.20 threshold")
+              sys.exit(1)
+          PY
+
+      - name: Upload dogfood artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: self-improve-hard-check-artifacts
+          path: |
+            /tmp/dogfood_ab_integration_vague_ci
+            /tmp/dogfood_pipeline_self_improve_benchmark_ci.json

--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -564,6 +564,9 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         ideas = [goal]
 
     pipeline_result = None
+    execution_path = "unknown"
+    live_stages_completed = 0
+    provider_calls_detected = False
     try:
         from aragora.pipeline.idea_to_execution import (
             IdeaToExecutionPipeline,
@@ -582,7 +585,6 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         ideas_text = "\n".join(ideas)
 
         result = None
-        execution_path = "unknown"
 
         if pipeline_mode == "live":
             # Live mode: async pipeline with debate/API stages
@@ -802,6 +804,18 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
     if quality_gate_failed and not plan_quality_fail_closed:
         print("[QUALITY GATE] Continuing in warn-only mode.")
 
+    avg_fidelity = sum(fidelity_scores) / len(fidelity_scores) if fidelity_scores else -1.0
+    print(
+        "[self-improve-metrics] "
+        f"execution_path={execution_path} "
+        f"live_stages_completed={live_stages_completed} "
+        f"provider_calls_detected={provider_calls_detected} "
+        f"quality_verdict={quality_verdict} "
+        f"quality_score_10={quality_score_10:.2f} "
+        f"practicality_score_10={practicality_score_10:.2f} "
+        f"avg_objective_fidelity={avg_fidelity:.2f}"
+    )
+
     # Enqueue pipeline results to improvement queue for bidirectional handoff
     if pipeline_result is not None:
         try:
@@ -811,7 +825,6 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
             )
 
             queue = get_improvement_queue()
-            avg_fidelity = sum(fidelity_scores) / len(fidelity_scores) if fidelity_scores else -1.0
             file_hints: list[str] = []
             goal_graph = getattr(pipeline_result, "goal_graph", None)
             if goal_graph is not None and hasattr(goal_graph, "goals"):

--- a/docs/plans/dogfood_pipeline_self_improve_base_report.json
+++ b/docs/plans/dogfood_pipeline_self_improve_base_report.json
@@ -1,0 +1,20 @@
+{
+  "description": "Base command for pipeline self-improve hard-check benchmark.",
+  "command": [
+    "python3",
+    "-m",
+    "aragora.cli.main",
+    "pipeline",
+    "self-improve",
+    "Please describe the relationship between the completed dogfood stress test, the ideas-to-execution pipeline, the self-improvement pipeline, the heterogeneous agent codebase assessment/coding-change pipeline, and the self bug-fixing pipeline. Can all of these be more tightly integrated? This is intentionally vague and poorly specified; treat it as a dogfooding prompt and produce an execution-ready integration plan.",
+    "--dry-run",
+    "--pipeline-mode",
+    "live",
+    "--plan-quality-min-score",
+    "6.0",
+    "--plan-quality-min-practicality",
+    "5.0",
+    "--max-goals",
+    "1"
+  ]
+}

--- a/docs/plans/self_improve_hard_checks_rollout.md
+++ b/docs/plans/self_improve_hard_checks_rollout.md
@@ -1,0 +1,41 @@
+# Self-Improve Hard Checks Rollout
+
+## Objective
+Roll out live-path and quality-gate hard checks safely, then tighten policy after one week of runtime signals.
+
+## Week 0 (Immediately)
+1. Keep `pipeline self-improve` in live-default mode.
+2. Enforce fail-closed for CI/dogfood profiles.
+3. Keep interactive/manual usage in warn-only mode.
+4. Run integration-vague dogfood profile on schedule and manual dispatch.
+
+## Telemetry Signals
+Collect and track:
+1. `execution_path` distribution (`live`, `heuristic-fallback`, `heuristic`).
+2. `provider_calls_detected` rate for live mode.
+3. `quality_verdict` pass/fail counts.
+4. `quality_score_10` and `practicality_score_10` trend.
+5. `avg_objective_fidelity` trend.
+6. Improvement queue backlog growth and age.
+
+Source:
+`[self-improve-metrics] ...` lines emitted by `aragora pipeline self-improve`.
+
+## Alert Thresholds (Week 0)
+1. `heuristic-fallback` > 10% over 24h: investigate provider health/config.
+2. quality gate fail rate > 20% over 24h: inspect planner drift and contract fit.
+3. `provider_calls_detected=false` in live mode > 5%: investigate canned/non-live paths.
+4. improvement queue backlog growth > 2x week baseline: inspect consumer throughput.
+
+## Week 1 Tightening Criteria
+Promote fail-closed beyond CI/dogfood only if all are true for 7 days:
+1. `execution_path=live` in >= 95% of runs.
+2. quality gate pass rate >= 90%.
+3. no sustained queue backlog growth (> 1.2x baseline).
+4. no recurring objective-fidelity regression incidents.
+
+## Week 1 Actions
+1. Raise `plan_quality_min_score` from 6.0 to 7.0 in default profile.
+2. Raise `plan_quality_min_practicality` from 5.0 to 6.0 in default profile.
+3. Enable fail-closed by default for non-interactive automated runners.
+4. Keep manual interactive mode warn-only for one additional cycle, then reassess.

--- a/scripts/ci_core_suites.sh
+++ b/scripts/ci_core_suites.sh
@@ -18,6 +18,10 @@ pytest -q \
   tests/knowledge/test_knowledge_pipeline.py::TestKnowledgePipelineIntegration::test_full_pipeline_text_input \
   tests/pipeline/test_decision_integrity.py::TestBuildDecisionIntegrityPackage::test_defaults_include_receipt_and_plan \
   tests/server/test_decision_integrity_utils.py::test_build_payload_executes_hybrid \
+  tests/cli/test_pipeline_command.py \
+  tests/nomic/test_meta_planner.py \
+  tests/nomic/test_improvement_queue.py \
+  tests/nomic/testfixer/test_event_integration.py \
   tests/connectors/chat/test_chat_base.py \
   tests/connectors/chat/test_base.py \
   tests/connectors/chat/test_chat_base_defaults.py

--- a/scripts/run_dogfood_ab_pairs.py
+++ b/scripts/run_dogfood_ab_pairs.py
@@ -154,8 +154,17 @@ def _run_command(
         return int(proc.returncode), proc.stdout, proc.stderr, elapsed, False
     except subprocess.TimeoutExpired as exc:
         elapsed = round(time.monotonic() - started, 3)
-        stdout = exc.stdout or ""
-        stderr = (exc.stderr or "") + f"\nDebate timed out after {timeout_seconds}s"
+        stdout_raw = exc.stdout or ""
+        stderr_raw = exc.stderr or ""
+        if isinstance(stdout_raw, bytes):
+            stdout = stdout_raw.decode("utf-8", errors="replace")
+        else:
+            stdout = stdout_raw
+        if isinstance(stderr_raw, bytes):
+            stderr = stderr_raw.decode("utf-8", errors="replace")
+        else:
+            stderr = stderr_raw
+        stderr = stderr + f"\nDebate timed out after {timeout_seconds}s"
         return 124, stdout, stderr, elapsed, True
 
 

--- a/scripts/run_dogfood_benchmark.py
+++ b/scripts/run_dogfood_benchmark.py
@@ -56,7 +56,22 @@ def _override_timeout(command: list[str], timeout_seconds: int) -> list[str]:
             raise ValueError("Malformed command: --timeout flag has no value")
         cmd[idx + 1] = str(timeout_seconds)
         return cmd
-    cmd.extend(["--timeout", str(timeout_seconds)])
+
+    # Only append --timeout when command targets `aragora ... ask`.
+    # Other subcommands (for example `pipeline self-improve`) may not
+    # accept a timeout flag.
+    subcommand = None
+    if "aragora.cli.main" in cmd:
+        module_idx = cmd.index("aragora.cli.main")
+        if module_idx + 1 < len(cmd):
+            subcommand = cmd[module_idx + 1]
+    elif "aragora" in cmd:
+        cli_idx = cmd.index("aragora")
+        if cli_idx + 1 < len(cmd):
+            subcommand = cmd[cli_idx + 1]
+
+    if subcommand == "ask":
+        cmd.extend(["--timeout", str(timeout_seconds)])
     return cmd
 
 
@@ -156,8 +171,17 @@ def _run_once(command: list[str], timeout_seconds: int) -> dict[str, Any]:
     except subprocess.TimeoutExpired as exc:
         timed_out = True
         exit_code = 124
-        stdout = exc.stdout or ""
-        stderr = (exc.stderr or "") + f"\nDebate timed out after {timeout_seconds}s"
+        stdout_raw = exc.stdout or ""
+        stderr_raw = exc.stderr or ""
+        if isinstance(stdout_raw, bytes):
+            stdout = stdout_raw.decode("utf-8", errors="replace")
+        else:
+            stdout = stdout_raw
+        if isinstance(stderr_raw, bytes):
+            stderr = stderr_raw.decode("utf-8", errors="replace")
+        else:
+            stderr = stderr_raw
+        stderr = stderr + f"\nDebate timed out after {timeout_seconds}s"
     ended = time.monotonic()
 
     quality = _extract_quality(stdout)
@@ -323,6 +347,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "(execution_path/live, quality gate pass, top-track class, clone check)."
         ),
     )
+    parser.add_argument(
+        "--require-pipeline-hard-checks-presence",
+        action="store_true",
+        help=(
+            "When enforcing hard checks, also fail if no run emitted pipeline hard-check signals."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -375,6 +406,12 @@ def main(argv: list[str] | None = None) -> int:
         checks = payload["summary"].get("pipeline_hard_checks", {})
         present_runs = int(checks.get("present_runs") or 0)
         pass_runs = int(checks.get("hard_check_pass_runs") or 0)
+        if args.require_pipeline_hard_checks_presence and present_runs == 0:
+            print(
+                "[dogfood-benchmark] enforce-pipeline-hard-checks failed: no pipeline checks present",
+                flush=True,
+            )
+            return 1
         if present_runs > 0 and pass_runs < present_runs:
             print(
                 "[dogfood-benchmark] enforce-pipeline-hard-checks failed: "


### PR DESCRIPTION
## Summary
Implements the next-step operational hardening after PR #652 in best order:
1. Run dogfood integration-vague profile and capture blockers
2. Enforce hard checks in CI paths
3. Add telemetry thresholds and alerting behavior
4. Add week-one tightening rollout guidance

## What changed
- Added dedicated workflow: `.github/workflows/self-improve-hard-checks.yml`
  - PR hard-check test gate for self-improve pipeline paths
  - Scheduled/manual live dogfood hard-check run
  - Threshold evaluation for fallback/quality-fail rates
- Extended core required suite inputs in `scripts/ci_core_suites.sh` to include self-improve hard-check tests.
- Fixed timeout robustness bugs in dogfood runners:
  - `scripts/run_dogfood_ab_pairs.py` now safely decodes `TimeoutExpired` byte payloads.
  - `scripts/run_dogfood_benchmark.py` now safely decodes `TimeoutExpired` byte payloads.
  - `scripts/run_dogfood_benchmark.py` only injects `--timeout` for `aragora ... ask` commands.
  - Added `--require-pipeline-hard-checks-presence` enforcement option.
- Added benchmark base command fixture:
  - `docs/plans/dogfood_pipeline_self_improve_base_report.json`
- Added rollout runbook:
  - `docs/plans/self_improve_hard_checks_rollout.md`
- Added structured telemetry line in pipeline self-improve output:
  - `[self-improve-metrics] execution_path=... quality_verdict=... avg_objective_fidelity=...`

## Dogfood run evidence (local)
- `python3 scripts/run_dogfood_ab_pairs.py --pairs 1 --timeout-seconds 45 --prompt-profile integration_vague ...`
  - control timed out cleanly (`exit=124`)
  - focused failed cleanly (`exit=1`)
  - no timeout-handler crash after fix
- `python3 scripts/run_dogfood_benchmark.py ... --enforce-pipeline-hard-checks --require-pipeline-hard-checks-presence`
  - fails cleanly with explicit reason when no hard-check signals are present

## Validation
- `python -m pytest tests/cli/test_pipeline_command.py tests/nomic/test_meta_planner.py tests/nomic/test_improvement_queue.py tests/nomic/testfixer/test_event_integration.py -q`
- `ruff check` on changed Python files
- `python -m py_compile` for changed scripts/CLI files
