### PR TITLE
fix(ci): use python -m pytest on EC2 runners

### DIFF
--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Install and test
         run: |
           python -m pip install -e ".[dev]" pytest-timeout httpx
-          pytest tests/test_handlers_debates.py tests/test_api_handler.py \
+          python -m pytest tests/test_handlers_debates.py tests/test_api_handler.py \
             --timeout=60 -x --tb=short
         env:
           PYTHONPATH: .

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Run quick tests
         run: |
-          pytest tests/test_handlers_debates.py tests/test_api_handler.py \
+          python -m pytest tests/test_handlers_debates.py tests/test_api_handler.py \
             --timeout=60 -x --tb=short
         env:
           PYTHONPATH: .


### PR DESCRIPTION
## Summary
- Previous fix (PR #653) resolved `pip: command not found` but `pytest` binary also isn't in PATH on EC2 self-hosted runners
- Changes `pytest` → `python -m pytest` in deploy-secure.yml and deploy-lightsail.yml
- This is the final piece needed to unblock backend deployments

## Test plan
- [ ] deploy-secure.yml test job passes end-to-end
- [ ] Backend deployment completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)