### PR TITLE
fix(pipeline): harden self-improve hard checks and dry-run handoff

### DIFF
--- a/.github/workflows/self-improve-hard-checks.yml
+++ b/.github/workflows/self-improve-hard-checks.yml
@@ -258,7 +258,7 @@ jobs:
           python3 scripts/run_dogfood_benchmark.py \
             --base-report docs/plans/dogfood_pipeline_self_improve_base_report.json \
             --runs 1 \
-            --timeout 900 \
+            --timeout 450 \
             --output /tmp/dogfood_pipeline_self_improve_benchmark_ci.json \
             --enforce-pipeline-hard-checks \
             --require-pipeline-hard-checks-presence

--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -860,8 +860,11 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         print(f"  {i}. {objective}")
     print()
 
-    if not execute and not dry_run:
-        print("Handoff not executed (planning mode).")
+    if not execute:
+        if dry_run:
+            print("Handoff skipped in dry-run mode unless --execute is set.")
+        else:
+            print("Handoff not executed (planning mode).")
         print("\nTo execute the handoff:")
         cmd = f'aragora pipeline self-improve "{goal}" --execute'
         if budget_limit is not None:
@@ -880,7 +883,7 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         if plan_quality_fail_closed:
             cmd += " --plan-quality-fail-closed"
         print(f"  {cmd}")
-        print("\nTo preview the plan first:")
+        print("\nTo preview the handoff plan only:")
         print(f"  {cmd} --dry-run")
         print()
         return

--- a/scripts/run_dogfood_benchmark.py
+++ b/scripts/run_dogfood_benchmark.py
@@ -32,6 +32,12 @@ PROVIDER_CALLS_RE = re.compile(r"Provider calls detected:\s*(?P<flag>True|False)
 QUALITY_GATE_RE = re.compile(r"\[QUALITY GATE\]\s+(?P<verdict>PASS|FAIL)", re.IGNORECASE)
 TOP_TRACK_RE = re.compile(r"^\s*1\.\s+\[(?P<track>[a-z_]+)\]", re.IGNORECASE | re.MULTILINE)
 TRACK_LINE_RE = re.compile(r"^\s*\d+\.\s+\[(?P<track>[a-z_]+)\]", re.IGNORECASE | re.MULTILINE)
+REQUIRED_HARD_CHECK_KEYS = (
+    "execution_path_live",
+    "quality_gate_pass",
+    "top_track_is_infra_or_security",
+    "no_cross_track_clones",
+)
 
 
 def _utc_now() -> str:
@@ -130,8 +136,9 @@ def _extract_pipeline_checks(stdout: str) -> dict[str, Any]:
         ),
     }
     checks_present = any(value is not None for value in checks.values())
-    hard_checks_pass = checks_present and all(
-        value is True for value in checks.values() if value is not None
+    required_checks_present = all(checks.get(key) is not None for key in REQUIRED_HARD_CHECK_KEYS)
+    hard_checks_pass = required_checks_present and all(
+        checks.get(key) is True for key in REQUIRED_HARD_CHECK_KEYS
     )
 
     return {
@@ -143,6 +150,7 @@ def _extract_pipeline_checks(stdout: str) -> dict[str, Any]:
         "top_track": top_track,
         "track_lines": track_lines,
         "checks": checks,
+        "required_checks_present": required_checks_present,
         "hard_checks_pass": hard_checks_pass,
     }
 
@@ -256,22 +264,23 @@ def _summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
         for blocker in run.get("runtime_blockers") or []:
             blocker_counts[blocker] = blocker_counts.get(blocker, 0) + 1
 
-    check_keys = [
-        "execution_path_live",
-        "quality_gate_pass",
-        "top_track_is_infra_or_security",
-        "no_cross_track_clones",
-    ]
+    check_keys = list(REQUIRED_HARD_CHECK_KEYS)
     check_pass_rates: dict[str, float | None] = {}
     for key in check_keys:
         values = [
             run.get("pipeline_checks", {}).get("checks", {}).get(key) for run in pipeline_present
         ]
-        bool_values = [bool(v) for v in values if v is not None]
-        if not bool_values:
+        if not values:
             check_pass_rates[key] = None
         else:
-            check_pass_rates[key] = round(sum(bool_values) / len(bool_values), 4)
+            pass_count = sum(1 for value in values if value is True)
+            check_pass_rates[key] = round(pass_count / len(values), 4)
+
+    required_present_runs = [
+        run
+        for run in pipeline_present
+        if run.get("pipeline_checks", {}).get("required_checks_present")
+    ]
 
     return {
         "total_runs": total,
@@ -306,6 +315,7 @@ def _summarize(runs: list[dict[str, Any]]) -> dict[str, Any]:
         },
         "pipeline_hard_checks": {
             "present_runs": len(pipeline_present),
+            "required_checks_present_runs": len(required_present_runs),
             "hard_check_pass_runs": len(pipeline_hard_pass),
             "hard_check_pass_rate": (
                 round(len(pipeline_hard_pass) / len(pipeline_present), 4)

--- a/tests/cli/test_pipeline_command.py
+++ b/tests/cli/test_pipeline_command.py
@@ -268,6 +268,22 @@ class TestPipelineSelfImproveCommand:
         assert _FakeIdeaToExecutionPipeline.run_calls == 1
         assert _FakeIdeaToExecutionPipeline.from_ideas_calls == 1
 
+    def test_self_improve_dry_run_without_execute_skips_handoff(self, capsys):
+        args = self._args(execute=False, dry_run=True)
+        _FakeIdeaToExecutionPipeline.reset()
+
+        with (
+            patch.dict("sys.modules", _fake_module_payload()),
+            patch("aragora.cli.commands.pipeline._run_self_improve_handoff") as mock_handoff,
+        ):
+            _cmd_pipeline_self_improve(args)
+
+        out = capsys.readouterr().out
+        assert "Handoff skipped in dry-run mode" in out
+        mock_handoff.assert_not_called()
+        assert _FakeIdeaToExecutionPipeline.run_calls == 1
+        assert _FakeIdeaToExecutionPipeline.from_ideas_calls == 1
+
     def test_self_improve_execute_calls_handoff_with_ranked_objective(self):
         args = self._args(execute=True, max_goals=1)
         _FakeIdeaToExecutionPipeline.reset()

--- a/tests/scripts/test_run_dogfood_benchmark.py
+++ b/tests/scripts/test_run_dogfood_benchmark.py
@@ -1,0 +1,87 @@
+"""Tests for scripts/run_dogfood_benchmark.py hard-check enforcement semantics."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure scripts/ is importable.
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_dogfood_benchmark  # noqa: E402
+
+
+def _run_template(checks: dict[str, bool | None]) -> dict[str, object]:
+    return {
+        "timed_out": False,
+        "exit_code": 0,
+        "duration_seconds": 1.0,
+        "quality": {
+            "present": False,
+            "verdict": None,
+            "score": None,
+            "practicality": None,
+            "loops": None,
+            "upgraded": None,
+        },
+        "pipeline_checks": {
+            "present": True,
+            "checks": checks,
+            "required_checks_present": all(v is not None for v in checks.values()),
+            "hard_checks_pass": all(v is True for v in checks.values()),
+        },
+        "runtime_blockers": [],
+    }
+
+
+class TestExtractPipelineChecks:
+    def test_missing_required_checks_never_passes_hard_checks(self) -> None:
+        stdout = "  1. [core] Tighten planning contract\n"
+        checks = run_dogfood_benchmark._extract_pipeline_checks(stdout)
+
+        assert checks["present"] is True
+        assert checks["required_checks_present"] is False
+        assert checks["hard_checks_pass"] is False
+
+    def test_all_required_checks_present_and_true_passes(self) -> None:
+        stdout = "\n".join(
+            [
+                "Execution path: live",
+                "[QUALITY GATE] PASS",
+                "  1. [core] Tighten planning contract",
+            ]
+        )
+        checks = run_dogfood_benchmark._extract_pipeline_checks(stdout)
+
+        assert checks["present"] is True
+        assert checks["required_checks_present"] is True
+        assert checks["checks"]["execution_path_live"] is True
+        assert checks["checks"]["quality_gate_pass"] is True
+        assert checks["checks"]["top_track_is_infra_or_security"] is True
+        assert checks["checks"]["no_cross_track_clones"] is True
+        assert checks["hard_checks_pass"] is True
+
+
+class TestSummarizeHardCheckRates:
+    def test_missing_values_count_as_failed_rate(self) -> None:
+        runs = [
+            _run_template(
+                {
+                    "execution_path_live": None,
+                    "quality_gate_pass": True,
+                    "top_track_is_infra_or_security": True,
+                    "no_cross_track_clones": True,
+                }
+            )
+        ]
+
+        summary = run_dogfood_benchmark._summarize(runs)
+        hard_checks = summary["pipeline_hard_checks"]
+
+        assert hard_checks["present_runs"] == 1
+        assert hard_checks["required_checks_present_runs"] == 0
+        assert hard_checks["hard_check_pass_runs"] == 0
+        assert hard_checks["check_pass_rates"]["execution_path_live"] == 0.0
+        assert hard_checks["check_pass_rates"]["quality_gate_pass"] == 1.0


### PR DESCRIPTION
## Summary
- skip self-improve handoff whenever `--execute` is not set (including `--dry-run`) to avoid long no-op runs
- tighten dogfood pipeline hard-check semantics so required keys must all be present and true before pass
- treat missing required hard-check values as failed in benchmark pass-rate reporting
- add regression tests for benchmark hard-check extraction/summarization and dry-run handoff skip behavior
- retune CI benchmark timeout back to 450s now that dry-run avoids handoff work

## Validation
- `python -m pytest -q tests/cli/test_pipeline_command.py tests/scripts/test_run_dogfood_benchmark.py`
- result: `12 passed`
