### PR TITLE
ci: unblock self-hosted PR checks by hardening pip fallback

### DIFF
--- a/.github/actions/setup-python-safe/action.yml
+++ b/.github/actions/setup-python-safe/action.yml
@@ -33,13 +33,35 @@ runs:
       if: steps.setup-python.outcome == 'failure'
       shell: bash
       run: |
+        set -euo pipefail
         echo "::warning::actions/setup-python failed — falling back to system Python"
+        PY_BIN=""
         for cmd in python${{ inputs.python-version }} python3 python; do
           if command -v "$cmd" &>/dev/null; then
             echo "Found $cmd: $("$cmd" --version)"
-            sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python
-            sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python3
+            PY_BIN="$(command -v "$cmd")"
             break
           fi
         done
-        python --version || { echo "::error::No Python interpreter found"; exit 1; }
+        if [[ -z "${PY_BIN}" ]]; then
+          echo "::error::No Python interpreter found"
+          exit 1
+        fi
+
+        sudo ln -sf "${PY_BIN}" /usr/local/bin/python
+        sudo ln -sf "${PY_BIN}" /usr/local/bin/python3
+
+        # Make pip reliably available on self-hosted runners even when
+        # actions/setup-python fails and no pip shim is on PATH.
+        /usr/local/bin/python -m ensurepip --upgrade || true
+        /usr/local/bin/python -m pip --version
+
+        cat <<'EOF' | sudo tee /usr/local/bin/pip >/dev/null
+        #!/usr/bin/env bash
+        exec /usr/local/bin/python -m pip "$@"
+        EOF
+        sudo chmod +x /usr/local/bin/pip
+        sudo ln -sf /usr/local/bin/pip /usr/local/bin/pip3
+
+        python --version
+        pip --version || /usr/local/bin/python -m pip --version

--- a/.github/workflows/pr-admission-controller.yml
+++ b/.github/workflows/pr-admission-controller.yml
@@ -41,9 +41,44 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: ./.github/actions/setup-python-safe
+        id: setup-python
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+        continue-on-error: true
+
+      - name: Fallback to system Python
+        if: steps.setup-python.outcome == 'failure'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::warning::actions/setup-python failed — falling back to system Python"
+          PY_BIN=""
+          for cmd in python3.11 python3 python; do
+            if command -v "$cmd" &>/dev/null; then
+              PY_BIN="$(command -v "$cmd")"
+              echo "Found $cmd: $("$cmd" --version)"
+              break
+            fi
+          done
+          if [[ -z "${PY_BIN}" ]]; then
+            echo "::error::No Python interpreter found"
+            exit 1
+          fi
+
+          sudo ln -sf "${PY_BIN}" /usr/local/bin/python
+          sudo ln -sf "${PY_BIN}" /usr/local/bin/python3
+          /usr/local/bin/python -m ensurepip --upgrade || true
+
+          cat <<'EOF' | sudo tee /usr/local/bin/pip >/dev/null
+          #!/usr/bin/env bash
+          exec /usr/local/bin/python -m pip "$@"
+          EOF
+          sudo chmod +x /usr/local/bin/pip
+          sudo ln -sf /usr/local/bin/pip /usr/local/bin/pip3
+
+          python --version
+          pip --version || /usr/local/bin/python -m pip --version
 
       - name: Resolve PR number
         id: resolve

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install (dev)
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+          python -m pip install -e ".[dev]"
 
       - name: Run release-readiness gate
         # Keep this gate deterministic: never rely on optional external

--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install security tools and project
         run: |
           python -m pip install --upgrade pip
-          pip install bandit[toml] pip-audit safety
+          python -m pip install bandit[toml] pip-audit safety
           bash scripts/ci_install_project.sh
 
       # ---------------------------------------------------------------
@@ -100,7 +100,7 @@ jobs:
       # ---------------------------------------------------------------
       - name: "BLOCKING: Verify Python lockfile freshness"
         run: |
-          pip install uv
+          python -m pip install uv
           uv lock --check || { echo "::error::uv.lock is stale. Run 'uv lock' locally."; exit 1; }
 
       # ---------------------------------------------------------------

--- a/.github/workflows/smoke-offline.yml
+++ b/.github/workflows/smoke-offline.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install aragora in isolated environment
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          python -m pip install -e ".[dev,test]"
 
       - name: Run offline golden-path unit tests
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          python -m pip install -e ".[dev,test]"
 
       - name: Run smoke tests
         run: |
@@ -119,7 +119,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          python -m pip install -e ".[dev,test]"
 
       - name: Verify offline/demo behavior tests
         run: |
@@ -176,7 +176,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          python -m pip install -e ".[dev,test]"
 
       - name: Run server smoke tests
         run: |
@@ -237,7 +237,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e ".[dev,test]"
+          python -m pip install -e ".[dev,test]"
 
       - name: Run decision-to-action smoke scenario
         env:


### PR DESCRIPTION
## Summary
- harden `.github/actions/setup-python-safe` fallback so self-hosted runners always get a usable `pip`/`pip3` shim via `python -m pip`
- normalize critical required workflows to use `python -m pip install ...` instead of bare `pip install ...`
- inline setup/fallback logic in `pr-admission-controller.yml` to avoid dependency on local-action resolution in that advisory workflow

## Changed files
- `.github/actions/setup-python-safe/action.yml`
- `.github/workflows/smoke.yml`
- `.github/workflows/smoke-offline.yml`
- `.github/workflows/security-gate.yml`
- `.github/workflows/release-readiness.yml`
- `.github/workflows/pr-admission-controller.yml`

## Why
Recent PR runs on `runs-on: aragora` failed early with `pip: command not found` after fallback setup. This patch makes the fallback deterministic and removes PATH dependence from critical install steps.
