### PR TITLE
fix(ci): restore broken workflow expressions and docs deploy recovery

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,7 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -238,7 +238,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: |
@@ -188,7 +188,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -339,7 +339,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install dependencies
@@ -481,7 +481,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
 
       - name: Install dependencies

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install k6
         run: |
@@ -454,7 +454,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/publish-aragora-debate.yml
+++ b/.github/workflows/publish-aragora-debate.yml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
@@ -98,7 +99,7 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install package with dev deps
         run: python -m pip install -e ".[dev]"
@@ -127,6 +128,7 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"
@@ -69,7 +70,7 @@ jobs:
       - name: Setup Python ${{ matrix.python-version }}
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -101,6 +102,7 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
           if [[ ! -f pyproject.toml ]]; then
             echo "::warning::pyproject.toml missing after checkout; attempting recovery"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
@@ -712,7 +712,7 @@ jobs:
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.validate.outputs.version }}
           name: Release v${{ needs.validate.outputs.version }}

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1094,7 +1094,7 @@ jobs:
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:
-          python-version: "${{"
+          python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 


### PR DESCRIPTION
## Summary
- restore truncated  expressions in GitHub workflows that were breaking main push runs
- run checkout recovery from repo root in workflows with subdirectory defaults so recovery can succeed when the subdir is missing
- update  to  to match the rest of the repo

## Validation
- 
- Workflow pip policy check passed
