### PR TITLE
fix(ci): deploy-secure aws: command not found on macOS runners

### DIFF
--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -260,13 +260,19 @@ jobs:
 
       - name: Fix AWS CLI path
         run: |
-          # AWS CLI v2 standalone binary lives at /usr/local/bin/aws on AL2023.
-          # actions/setup-python can shadow /usr/bin/aws (Python wrapper) by
-          # changing sys.executable, breaking the awscli import. Prefer v2.
+          # Find AWS CLI v2 in common locations, or install via pip3 and add its
+          # scripts directory to PATH. pip3 install alone does not update PATH.
           if /usr/local/bin/aws --version 2>/dev/null; then
             echo "/usr/local/bin" >> "$GITHUB_PATH"
+          elif /opt/homebrew/bin/aws --version 2>/dev/null; then
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          elif command -v aws 2>/dev/null; then
+            echo "aws already in PATH: $(which aws)"
           else
             pip3 install awscli --quiet
+            SCRIPTS=$(python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))")
+            echo "$SCRIPTS" >> "$GITHUB_PATH"
+            echo "Installed awscli via pip3, scripts at: $SCRIPTS"
           fi
 
       - name: Get staging instance IDs
@@ -688,13 +694,19 @@ jobs:
 
       - name: Fix AWS CLI path
         run: |
-          # AWS CLI v2 standalone binary lives at /usr/local/bin/aws on AL2023.
-          # actions/setup-python can shadow /usr/bin/aws (Python wrapper) by
-          # changing sys.executable, breaking the awscli import. Prefer v2.
+          # Find AWS CLI v2 in common locations, or install via pip3 and add its
+          # scripts directory to PATH. pip3 install alone does not update PATH.
           if /usr/local/bin/aws --version 2>/dev/null; then
             echo "/usr/local/bin" >> "$GITHUB_PATH"
+          elif /opt/homebrew/bin/aws --version 2>/dev/null; then
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          elif command -v aws 2>/dev/null; then
+            echo "aws already in PATH: $(which aws)"
           else
             pip3 install awscli --quiet
+            SCRIPTS=$(python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))")
+            echo "$SCRIPTS" >> "$GITHUB_PATH"
+            echo "Installed awscli via pip3, scripts at: $SCRIPTS"
           fi
 
       - name: Get production instance IDs
@@ -1121,13 +1133,19 @@ jobs:
 
       - name: Fix AWS CLI path
         run: |
-          # AWS CLI v2 standalone binary lives at /usr/local/bin/aws on AL2023.
-          # actions/setup-python can shadow /usr/bin/aws (Python wrapper) by
-          # changing sys.executable, breaking the awscli import. Prefer v2.
+          # Find AWS CLI v2 in common locations, or install via pip3 and add its
+          # scripts directory to PATH. pip3 install alone does not update PATH.
           if /usr/local/bin/aws --version 2>/dev/null; then
             echo "/usr/local/bin" >> "$GITHUB_PATH"
+          elif /opt/homebrew/bin/aws --version 2>/dev/null; then
+            echo "/opt/homebrew/bin" >> "$GITHUB_PATH"
+          elif command -v aws 2>/dev/null; then
+            echo "aws already in PATH: $(which aws)"
           else
             pip3 install awscli --quiet
+            SCRIPTS=$(python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))")
+            echo "$SCRIPTS" >> "$GITHUB_PATH"
+            echo "Installed awscli via pip3, scripts at: $SCRIPTS"
           fi
 
       - name: Get DR instance IDs


### PR DESCRIPTION
## Problem

All 5 recent `deploy-secure.yml` runs fail at **Get staging instance IDs** with:
```
aws: command not found (exit 127)
```

The previous fix (PR #657) added a `Fix AWS CLI path` step that correctly handles the case where `/usr/local/bin/aws` exists — but the **else branch** only runs `pip3 install awscli --quiet` without updating `$GITHUB_PATH`. So `aws` lands in pip's scripts directory (e.g. `~/Library/Python/3.x/bin/` on the macOS Hetzner runner) which is never added to PATH.

## Fix

Updated all three `Fix AWS CLI path` steps (staging, production, DR):

1. Check `/usr/local/bin/aws` → add to GITHUB_PATH (existing)
2. Check `/opt/homebrew/bin/aws` → add to GITHUB_PATH (new: macOS Homebrew)  
3. `command -v aws` → already in PATH, no-op (new: short-circuit)
4. Else: `pip3 install awscli --quiet` + resolve scripts dir via `sysconfig.get_path('scripts')` → add to GITHUB_PATH (bug fix: was missing the PATH update)

## Test plan
- [ ] Push to main triggers `deploy-secure.yml` and `Get staging instance IDs` step passes
- [ ] All three runner paths (staging/production/DR) no longer fail with exit 127

🤖 Generated with [Claude Code](https://claude.com/claude-code)