### PR TITLE
[codex] add closed-loop backbone contracts and spec gates

### DIFF
--- a/aragora/pipeline/backbone_contracts.py
+++ b/aragora/pipeline/backbone_contracts.py
@@ -1,0 +1,384 @@
+"""Canonical handoff artifacts for Aragora's closed-loop backbone.
+
+This module is intentionally thin. It does not replace the existing rich
+types in prompt_engine, interrogation, debate, planning, or receipts.
+It normalizes those shapes into stable handoff artifacts so the stages can
+compose without implicit contracts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, is_dataclass
+from typing import Any
+
+
+def _string_list(values: Any) -> list[str]:
+    if values is None:
+        return []
+    if isinstance(values, str):
+        value = values.strip()
+        return [value] if value else []
+    if not isinstance(values, list | tuple):
+        return [str(values).strip()] if str(values).strip() else []
+    output: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str):
+            text = value.strip()
+        elif is_dataclass(value):
+            text = str(asdict(value))
+        else:
+            text = str(value).strip()
+        if text:
+            output.append(text)
+    return output
+
+
+def _criterion_to_text(criterion: Any) -> str:
+    if criterion is None:
+        return ""
+    if isinstance(criterion, str):
+        return criterion.strip()
+    description = getattr(criterion, "description", "") or ""
+    measurement = getattr(criterion, "measurement", "") or ""
+    target = getattr(criterion, "target", "") or ""
+    parts = [str(description).strip(), str(measurement).strip(), str(target).strip()]
+    return " | ".join(part for part in parts if part)
+
+
+def _risk_mitigations(risks: Any) -> list[str]:
+    mitigations: list[str] = []
+    if not isinstance(risks, list | tuple):
+        return mitigations
+    for risk in risks:
+        if isinstance(risk, dict):
+            mitigation = str(risk.get("mitigation", "")).strip()
+        else:
+            mitigation = str(getattr(risk, "mitigation", "")).strip()
+        if mitigation:
+            mitigations.append(mitigation)
+    return mitigations
+
+
+@dataclass
+class IntakeBundle:
+    source_kind: str
+    raw_intent: str
+    context_refs: list[dict[str, Any]] = field(default_factory=list)
+    trust_tiers: list[str] = field(default_factory=list)
+    origin_metadata: dict[str, Any] = field(default_factory=dict)
+    taint_flags: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_prompt_intent(
+        cls,
+        intent: Any,
+        *,
+        source_kind: str = "prompt_intent",
+        trust_tiers: list[str] | None = None,
+        taint_flags: list[str] | None = None,
+        origin_metadata: dict[str, Any] | None = None,
+    ) -> IntakeBundle:
+        return cls(
+            source_kind=source_kind,
+            raw_intent=str(getattr(intent, "raw_prompt", "")).strip(),
+            context_refs=list(getattr(intent, "related_knowledge", []) or []),
+            trust_tiers=list(trust_tiers or ["operator-authored"]),
+            origin_metadata=dict(origin_metadata or {}),
+            taint_flags=list(taint_flags or []),
+        )
+
+
+@dataclass
+class SpecBundle:
+    title: str
+    problem_statement: str
+    objectives: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    acceptance_criteria: list[str] = field(default_factory=list)
+    verification_plan: list[str] = field(default_factory=list)
+    rollback_plan: list[str] = field(default_factory=list)
+    owner_file_scopes: list[str] = field(default_factory=list)
+    open_questions: list[str] = field(default_factory=list)
+    confidence: float = 0.0
+    source_kind: str = ""
+    provenance_refs: list[dict[str, Any]] = field(default_factory=list)
+    taint_flags: list[str] = field(default_factory=list)
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["missing_required_fields"] = list(self.missing_required_fields)
+        data["is_execution_grade"] = self.is_execution_grade
+        return data
+
+    @property
+    def missing_required_fields(self) -> list[str]:
+        missing: list[str] = []
+        if not self.constraints:
+            missing.append("constraints")
+        if not self.acceptance_criteria:
+            missing.append("acceptance_criteria")
+        if not self.verification_plan:
+            missing.append("verification_plan")
+        if not self.rollback_plan:
+            missing.append("rollback_plan")
+        if not self.owner_file_scopes:
+            missing.append("owner_file_scopes")
+        return missing
+
+    @property
+    def is_execution_grade(self) -> bool:
+        return not self.missing_required_fields
+
+    @classmethod
+    def from_prompt_spec(
+        cls,
+        spec: Any,
+        *,
+        validation: Any | None = None,
+        taint_flags: list[str] | None = None,
+    ) -> SpecBundle:
+        criteria = [
+            text
+            for text in (_criterion_to_text(item) for item in getattr(spec, "success_criteria", []))
+            if text
+        ]
+        file_changes = getattr(spec, "file_changes", []) or []
+        file_scopes = [
+            str(getattr(item, "path", "") or item.get("path", "")).strip()
+            for item in file_changes
+            if str(getattr(item, "path", "") or item.get("path", "")).strip()
+        ]
+        provenance = getattr(spec, "provenance", None)
+        provenance_refs = [provenance.to_dict()] if hasattr(provenance, "to_dict") else []
+        provenance_refs.extend(list(getattr(spec, "provenance_chain", []) or []))
+
+        return cls(
+            title=str(getattr(spec, "title", "")).strip() or "Untitled specification",
+            problem_statement=str(getattr(spec, "problem_statement", "")).strip(),
+            objectives=_string_list(getattr(spec, "proposed_solution", "")),
+            constraints=_string_list(getattr(spec, "constraints", [])),
+            acceptance_criteria=criteria,
+            verification_plan=list(criteria),
+            rollback_plan=_risk_mitigations(
+                getattr(spec, "risks", []) or getattr(spec, "risk_register", [])
+            ),
+            owner_file_scopes=file_scopes,
+            open_questions=[],
+            confidence=float(
+                getattr(validation, "overall_confidence", getattr(spec, "confidence", 0.0)) or 0.0
+            ),
+            source_kind="prompt_engine_spec",
+            provenance_refs=provenance_refs,
+            taint_flags=list(taint_flags or []),
+            extras={"validation_passed": getattr(validation, "passed", None)},
+        )
+
+    @classmethod
+    def from_interrogation_result(
+        cls,
+        result: Any,
+        *,
+        taint_flags: list[str] | None = None,
+    ) -> SpecBundle:
+        crystallized = getattr(result, "crystallized_spec", None)
+        legacy_spec = getattr(result, "spec", None)
+
+        if crystallized is not None and hasattr(crystallized, "requirements"):
+            objectives = [
+                str(getattr(item, "description", "")).strip()
+                for item in getattr(crystallized, "requirements", [])
+                if str(getattr(item, "description", "")).strip()
+            ]
+            constraints = _string_list(getattr(crystallized, "constraints", []))
+            rollback_plan = _risk_mitigations(getattr(crystallized, "risks", []))
+            title = str(getattr(crystallized, "title", "")).strip() or "Interrogation specification"
+            problem_statement = str(getattr(crystallized, "problem_statement", "")).strip()
+            acceptance_criteria = _string_list(getattr(crystallized, "success_criteria", []))
+        else:
+            objectives = [
+                str(getattr(item, "description", "")).strip()
+                for item in getattr(legacy_spec, "requirements", [])
+                if str(getattr(item, "description", "")).strip()
+            ]
+            constraints = []
+            rollback_plan = []
+            title = "Interrogation specification"
+            problem_statement = str(getattr(legacy_spec, "problem_statement", "")).strip()
+            acceptance_criteria = _string_list(getattr(legacy_spec, "success_criteria", []))
+
+        open_questions = []
+        for question in getattr(result, "prioritized_questions", []) or []:
+            text = str(getattr(question, "question", "")).strip()
+            answer = str(getattr(question, "answer", "")).strip()
+            if text and not answer:
+                open_questions.append(text)
+
+        return cls(
+            title=title,
+            problem_statement=problem_statement,
+            objectives=objectives,
+            constraints=constraints,
+            acceptance_criteria=acceptance_criteria,
+            verification_plan=list(acceptance_criteria),
+            rollback_plan=rollback_plan,
+            owner_file_scopes=[],
+            open_questions=open_questions,
+            confidence=0.0,
+            source_kind="interrogation_result",
+            provenance_refs=[],
+            taint_flags=list(taint_flags or []),
+            extras={"dimensions": list(getattr(result, "dimensions", []) or [])},
+        )
+
+    @classmethod
+    def from_interrogation_spec(
+        cls,
+        spec: Any,
+        *,
+        open_questions: list[str] | None = None,
+        taint_flags: list[str] | None = None,
+    ) -> SpecBundle:
+        requirements = getattr(spec, "requirements", []) or []
+        objectives = [
+            str(getattr(item, "description", "")).strip()
+            for item in requirements
+            if str(getattr(item, "description", "")).strip()
+        ]
+        acceptance_criteria = _string_list(getattr(spec, "success_criteria", []))
+        risks = getattr(spec, "risks", []) or []
+        rollback_plan = _string_list(risks)
+        return cls(
+            title="Interrogation specification",
+            problem_statement=str(getattr(spec, "problem_statement", "")).strip(),
+            objectives=objectives,
+            constraints=[],
+            acceptance_criteria=acceptance_criteria,
+            verification_plan=list(acceptance_criteria),
+            rollback_plan=rollback_plan,
+            owner_file_scopes=[],
+            open_questions=list(open_questions or []),
+            confidence=0.0,
+            source_kind="interrogation_spec",
+            provenance_refs=[],
+            taint_flags=list(taint_flags or []),
+            extras={"context_summary": str(getattr(spec, "context_summary", "")).strip()},
+        )
+
+
+@dataclass
+class ReceiptEnvelope:
+    receipt_id: str
+    artifact_hash: str
+    verdict: str
+    confidence: float = 0.0
+    signature: str = ""
+    policy_gate_result: dict[str, Any] = field(default_factory=dict)
+    provenance_chain: list[dict[str, Any]] = field(default_factory=list)
+    taint_summary: dict[str, Any] = field(default_factory=dict)
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_pipeline_receipt(
+        cls,
+        receipt: dict[str, Any],
+        *,
+        policy_gate_result: dict[str, Any] | None = None,
+        taint_summary: dict[str, Any] | None = None,
+    ) -> ReceiptEnvelope:
+        status = str(receipt.get("execution", {}).get("status", "unknown")).strip()
+        verdict = "pass" if status in {"completed", "success", "succeeded"} else status or "unknown"
+        provenance = receipt.get("provenance", {}) or {}
+        flattened_chain: list[dict[str, Any]] = []
+        if isinstance(provenance, dict):
+            for stage_name, items in provenance.items():
+                for item in items or []:
+                    if isinstance(item, dict):
+                        flattened_chain.append({"stage": stage_name, **item})
+
+        return cls(
+            receipt_id=str(receipt.get("receipt_id", "")).strip(),
+            artifact_hash=str(
+                receipt.get("artifact_hash") or receipt.get("content_hash", "")
+            ).strip(),
+            verdict=verdict,
+            confidence=float(receipt.get("confidence", 0.0) or 0.0),
+            signature=str(receipt.get("signature", "")).strip(),
+            policy_gate_result=dict(policy_gate_result or {}),
+            provenance_chain=flattened_chain,
+            taint_summary=dict(taint_summary or {}),
+            extras={
+                "pipeline_id": receipt.get("pipeline_id"),
+                "generated_at": receipt.get("generated_at"),
+            },
+        )
+
+
+@dataclass
+class OutcomeFeedbackRecord:
+    receipt_ref: str
+    pipeline_id: str
+    run_type: str
+    domain: str
+    objective_fidelity: float
+    quality_outcome: dict[str, Any] = field(default_factory=dict)
+    execution_outcome: dict[str, Any] = field(default_factory=dict)
+    settlement_hooks: list[dict[str, Any]] = field(default_factory=list)
+    calibration_updates: list[dict[str, Any]] = field(default_factory=list)
+    next_action_recommendation: str = ""
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_pipeline_outcome(
+        cls,
+        outcome: Any,
+        *,
+        receipt_ref: str,
+        next_action_recommendation: str = "",
+    ) -> OutcomeFeedbackRecord:
+        quality_score = float(getattr(outcome, "overall_quality_score", 0.0) or 0.0)
+        execution_outcome = {
+            "execution_succeeded": bool(getattr(outcome, "execution_succeeded", False)),
+            "tests_passed": int(getattr(outcome, "tests_passed", 0) or 0),
+            "tests_failed": int(getattr(outcome, "tests_failed", 0) or 0),
+            "files_changed": int(getattr(outcome, "files_changed", 0) or 0),
+            "rollback_triggered": bool(getattr(outcome, "rollback_triggered", False)),
+        }
+        quality_outcome = {
+            "overall_quality_score": quality_score,
+            "spec_completeness": float(getattr(outcome, "spec_completeness", 0.0) or 0.0),
+            "human_interventions": int(getattr(outcome, "human_interventions", 0) or 0),
+        }
+
+        if not next_action_recommendation:
+            if execution_outcome["execution_succeeded"]:
+                next_action_recommendation = "promote_or_settle"
+            elif execution_outcome["tests_failed"] > 0:
+                next_action_recommendation = "run_bug_fix_loop"
+            else:
+                next_action_recommendation = "review_manually"
+
+        return cls(
+            receipt_ref=receipt_ref,
+            pipeline_id=str(getattr(outcome, "pipeline_id", "")).strip(),
+            run_type=str(getattr(outcome, "run_type", "")).strip(),
+            domain=str(getattr(outcome, "domain", "")).strip(),
+            objective_fidelity=quality_score,
+            quality_outcome=quality_outcome,
+            execution_outcome=execution_outcome,
+            settlement_hooks=[],
+            calibration_updates=[],
+            next_action_recommendation=next_action_recommendation,
+            extras={"total_duration_s": float(getattr(outcome, "total_duration_s", 0.0) or 0.0)},
+        )

--- a/aragora/pipeline/decision_plan/factory.py
+++ b/aragora/pipeline/decision_plan/factory.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import hashlib
 import re
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from aragora.core_types import DebateResult
 from aragora.implement.types import ImplementPlan, ImplementTask
+from aragora.pipeline.backbone_contracts import SpecBundle
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     BudgetAllocation,
@@ -27,6 +28,9 @@ from aragora.pipeline.verification_plan import (
     VerificationPlan,
     VerificationType,
 )
+
+if TYPE_CHECKING:
+    from aragora.prompt_engine.spec_validator import ValidationResult
 
 _EXECUTION_MODE_ALIASES = {
     "execute_workflow": "workflow",
@@ -77,6 +81,9 @@ class DecisionPlanFactory:
         metadata: dict[str, Any] | None = None,
         implement_plan: ImplementPlan | None = None,
         implementation_profile: ImplementationProfile | dict[str, Any] | None = None,
+        specification: Any | None = None,
+        validation_result: ValidationResult | Any | None = None,
+        fail_closed_spec_validation: bool | None = None,
     ) -> DecisionPlan:
         """Create a DecisionPlan from a DebateResult.
 
@@ -136,6 +143,35 @@ class DecisionPlanFactory:
             if profile.thread_id_by_platform and "thread_id_by_platform" not in merged_metadata:
                 merged_metadata["thread_id_by_platform"] = profile.thread_id_by_platform
 
+        if specification is not None:
+            spec_bundle = DecisionPlanFactory.validate_execution_grade_specification(
+                specification,
+                validation_result=validation_result,
+                fail_closed=(
+                    approval_mode == ApprovalMode.NEVER
+                    if fail_closed_spec_validation is None
+                    else fail_closed_spec_validation
+                ),
+            )
+            merged_metadata["spec_bundle"] = {
+                "title": spec_bundle.title,
+                "problem_statement": spec_bundle.problem_statement,
+                "objectives": spec_bundle.objectives,
+                "constraints": spec_bundle.constraints,
+                "acceptance_criteria": spec_bundle.acceptance_criteria,
+                "verification_plan": spec_bundle.verification_plan,
+                "rollback_plan": spec_bundle.rollback_plan,
+                "owner_file_scopes": spec_bundle.owner_file_scopes,
+                "open_questions": spec_bundle.open_questions,
+                "confidence": spec_bundle.confidence,
+                "source_kind": spec_bundle.source_kind,
+                "taint_flags": spec_bundle.taint_flags,
+            }
+            if spec_bundle.missing_required_fields:
+                merged_metadata["spec_bundle_missing_fields"] = list(
+                    spec_bundle.missing_required_fields
+                )
+
         plan = DecisionPlan(
             debate_id=result.debate_id,
             task=result.task,
@@ -172,6 +208,24 @@ class DecisionPlanFactory:
             plan.status = PlanStatus.APPROVED
 
         return plan
+
+    @staticmethod
+    def validate_execution_grade_specification(
+        specification: Any,
+        *,
+        validation_result: ValidationResult | Any | None = None,
+        fail_closed: bool = False,
+    ) -> SpecBundle:
+        """Normalize a prompt/interrogation specification to the canonical spec bundle.
+
+        When ``fail_closed`` is true, incomplete execution-grade specifications raise
+        ``ValueError`` so automated lanes cannot proceed silently.
+        """
+        bundle = SpecBundle.from_prompt_spec(specification, validation=validation_result)
+        if fail_closed and bundle.missing_required_fields:
+            missing = ", ".join(bundle.missing_required_fields)
+            raise ValueError(f"Specification is not execution-grade: missing {missing}")
+        return bundle
 
     @staticmethod
     def from_implement_plan(

--- a/aragora/prompt_engine/spec_validator.py
+++ b/aragora/prompt_engine/spec_validator.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from aragora.pipeline.backbone_contracts import SpecBundle
 from aragora.prompt_engine.types import Specification
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,7 @@ class SpecValidator:
         """Structural validation without LLM calls."""
         issues: list[str] = []
         role_results: dict[ValidatorRole, dict[str, Any]] = {}
+        execution_bundle = SpecBundle.from_prompt_spec(spec)
 
         # Devil's advocate: completeness
         da_issues: list[str] = []
@@ -69,6 +71,8 @@ class SpecValidator:
             da_issues.append("Missing problem statement")
         if not solution:
             da_issues.append("Missing proposed solution")
+        for field_name in execution_bundle.missing_required_fields:
+            da_issues.append(f"Missing execution-grade field: {field_name}")
         da_passed = not da_issues
         role_results[ValidatorRole.DEVILS_ADVOCATE] = {
             "passed": da_passed,
@@ -115,6 +119,8 @@ class SpecValidator:
         ux_issues: list[str] = []
         if not criteria:
             ux_issues.append("No success criteria defined")
+        if not execution_bundle.verification_plan:
+            ux_issues.append("No verification plan defined")
         ux_passed = not ux_issues
         role_results[ValidatorRole.UX_ADVOCATE] = {
             "passed": ux_passed,
@@ -130,6 +136,10 @@ class SpecValidator:
             mitigation = getattr(risk, "mitigation", "") or ""
             if not mitigation:
                 td_issues.append(f"Unmitigated risk: {desc}")
+        if not execution_bundle.rollback_plan:
+            td_issues.append("No rollback plan defined")
+        if not execution_bundle.owner_file_scopes:
+            td_issues.append("No owner file scopes defined")
         td_passed = not td_issues
         role_results[ValidatorRole.TECH_DEBT_AUDITOR] = {
             "passed": td_passed,

--- a/aragora/server/handlers/interrogation/handler.py
+++ b/aragora/server/handlers/interrogation/handler.py
@@ -11,6 +11,7 @@ from typing import Any
 from aiohttp import web
 
 from aragora.interrogation.engine import InterrogationEngine
+from aragora.pipeline.backbone_contracts import SpecBundle
 from aragora.rbac.decorators import require_permission
 
 logger = logging.getLogger(__name__)
@@ -298,6 +299,10 @@ class InterrogationHandler:
             return web.json_response({"error": "Session not found"}, status=404)
 
         spec = await self._crystallize_spec(state)
+        spec_bundle = SpecBundle.from_interrogation_spec(
+            spec,
+            open_questions=[q.text for q in state.unanswered],
+        )
 
         return web.json_response(
             {
@@ -318,6 +323,7 @@ class InterrogationHandler:
                         "risks": spec.risks,
                         "context_summary": spec.context_summary,
                     },
+                    "spec_bundle": spec_bundle.to_dict(),
                     "goal_text": spec.to_goal_text(),
                 }
             }

--- a/aragora/server/handlers/prompt_engine/handler.py
+++ b/aragora/server/handlers/prompt_engine/handler.py
@@ -15,6 +15,8 @@ import json
 import logging
 from typing import Any
 
+from aragora.pipeline.backbone_contracts import SpecBundle
+
 from ..base import (
     HandlerResult,
     error_response,
@@ -130,10 +132,12 @@ class PromptEngineHandler(SecureHandler):
 
         validator = SpecValidator()
         validation = validator.validate_heuristic(result.specification)
+        spec_bundle = SpecBundle.from_prompt_spec(result.specification, validation=validation)
 
         return json_response(
             {
                 "specification": result.specification.to_dict(),
+                "spec_bundle": spec_bundle.to_dict(),
                 "intent": result.intent.to_dict(),
                 "questions": [q.to_dict() for q in result.questions],
                 "research": result.research.to_dict() if result.research else None,
@@ -291,8 +295,11 @@ class PromptEngineHandler(SecureHandler):
         builder = SpecBuilder()
         context = data.get("context")
         spec = asyncio.run(builder.build(intent, questions, research, context))
+        spec_bundle = SpecBundle.from_prompt_spec(spec)
 
-        return json_response({"specification": spec.to_dict()})
+        return json_response(
+            {"specification": spec.to_dict(), "spec_bundle": spec_bundle.to_dict()}
+        )
 
     def _handle_validate(self, handler: Any) -> HandlerResult:
         """Validate a specification via SpecValidator."""
@@ -305,7 +312,7 @@ class PromptEngineHandler(SecureHandler):
             return error_response("specification is required", 400)
 
         from aragora.prompt_engine import SpecValidator
-        from aragora.prompt_engine.types import RiskItem, Specification
+        from aragora.prompt_engine.types import RiskItem, SpecFile, Specification
 
         risks = []
         for r in spec_data.get("risks", []) + spec_data.get("risk_register", []):
@@ -318,6 +325,17 @@ class PromptEngineHandler(SecureHandler):
                         mitigation=r.get("mitigation", ""),
                     )
                 )
+        file_changes = []
+        for item in spec_data.get("file_changes", []):
+            if isinstance(item, dict):
+                file_changes.append(
+                    SpecFile(
+                        path=item.get("path", ""),
+                        action=item.get("action", "modify"),
+                        description=item.get("description", ""),
+                        estimated_lines=int(item.get("estimated_lines", 0) or 0),
+                    )
+                )
 
         spec = Specification(
             title=spec_data.get("title", ""),
@@ -326,11 +344,14 @@ class PromptEngineHandler(SecureHandler):
             implementation_plan=spec_data.get("implementation_plan", []),
             success_criteria=spec_data.get("success_criteria", []),
             estimated_effort=spec_data.get("estimated_effort", ""),
+            file_changes=file_changes,
             risks=risks,
             confidence=spec_data.get("confidence", 0.0),
         )
+        spec.constraints = spec_data.get("constraints", [])
 
         validator = SpecValidator()
         result = validator.validate_heuristic(spec)
+        spec_bundle = SpecBundle.from_prompt_spec(spec, validation=result)
 
-        return json_response({"validation": result.to_dict()})
+        return json_response({"validation": result.to_dict(), "spec_bundle": spec_bundle.to_dict()})

--- a/docs/architecture/CLOSED_LOOP_BACKBONE.md
+++ b/docs/architecture/CLOSED_LOOP_BACKBONE.md
@@ -1,0 +1,423 @@
+# Closed-Loop Backbone Architecture
+
+Last updated: 2026-03-06
+Status: Target architecture
+
+This document defines the canonical backbone for Aragora's product and self-improvement flows.
+It complements:
+
+1. `docs/CANONICAL_GOALS.md`
+2. `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md`
+3. `docs/status/NEXT_STEPS_CANONICAL.md`
+4. `docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md`
+
+## Purpose
+
+Aragora already contains most of the needed subsystems:
+
+- IdeaCloud and Pulse for intake
+- interrogation and prompt engine for vague-prompt upgrading
+- debate and quality gating for adversarial validation
+- plan/dependency/workflow layers for execution planning
+- execution bridges and handlers for action
+- receipts, compliance artifacts, and policy layers for control
+- outcome feedback and Nomic for self-improvement
+
+The problem is not missing pieces. The problem is that these pieces can still behave like parallel stacks.
+
+This document fixes that by declaring one canonical backbone.
+
+## The Canonical Backbone
+
+```mermaid
+flowchart LR
+    A["Intake Sources"] --> B["IntakeBundle"]
+    B --> C["Interrogation / Prompt Upgrade"]
+    C --> D["SpecBundle"]
+    D --> E["Debate + Quality Gate"]
+    E --> F["DeliberationBundle"]
+    F --> G["DecisionPlanBundle"]
+    G --> H["Controlled Execution"]
+    H --> I["ExecutionBundle"]
+    I --> J["Verify + Bug-Fix"]
+    J --> K["VerificationBundle"]
+    K --> L["Receipt + Policy Gate"]
+    L --> M["ReceiptEnvelope"]
+    M --> N["OutcomeFeedbackRecord"]
+    N --> O["Nomic Reprioritization"]
+    O -. "new goals / retries" .-> B
+```
+
+## First Principle
+
+One system, one backbone.
+
+These are not separate architectures:
+
+1. user prompt to pipeline
+2. IdeaCloud to pipeline
+3. self-improve / Nomic
+4. debate-to-execution
+
+They are all entrypoints into the same backbone at different stages.
+
+## Architectural Rules
+
+1. All serious automation must pass through named handoff artifacts.
+2. Execution cannot be triggered directly from raw prompts or raw idea graphs.
+3. Receipts are the control primitive for high-impact execution.
+4. Dissent, provenance, and taint must survive stage transitions.
+5. Nomic uses the same backbone as product flows; it is not exempt from the control plane.
+
+## Canonical Stages
+
+### Stage 0: Intake and Context Assembly
+
+Purpose:
+normalize all upstream inputs into one intake artifact.
+
+Canonical producers:
+
+1. Prompt Engine and interrogation handlers
+2. Pipeline canvas
+3. IdeaCloud export and cluster promotion
+4. Pulse / KM / Obsidian retrieval
+5. self-improve goal creation
+
+Current anchors:
+
+- `aragora/interrogation/engine.py`
+- `aragora/server/handlers/interrogation/handler.py`
+- `aragora/server/handlers/prompt_engine/handler.py`
+- `aragora/ideacloud/adapters/pipeline_bridge.py`
+- `aragora/pipeline/input_extension.py`
+
+Canonical artifact:
+`IntakeBundle`
+
+Required fields:
+
+1. `source_kind`
+2. `raw_intent`
+3. `context_refs`
+4. `trust_tiers`
+5. `origin_metadata`
+6. `taint_flags`
+
+Boundary:
+intake may collect and enrich context, but it does not authorize execution.
+
+### Stage 1: Interrogation and Specification
+
+Purpose:
+turn vague intent into an execution-grade spec.
+
+Current anchors:
+
+- `aragora/interrogation/engine.py`
+- `aragora/prompt_engine/*`
+- `aragora/pipeline/decision_plan/factory.py`
+
+Canonical artifact:
+`SpecBundle`
+
+Required fields:
+
+1. `problem_statement`
+2. `objectives`
+3. `constraints`
+4. `acceptance_criteria`
+5. `verification_plan`
+6. `rollback_plan`
+7. `owner_file_scopes`
+8. `open_questions`
+
+Boundary:
+specification may block or request clarification; it does not mutate the world.
+
+### Stage 2: Deliberation and Quality Validation
+
+Purpose:
+stress-test the spec and intended action using heterogeneous debate.
+
+Current anchors:
+
+- `aragora/debate/orchestrator.py`
+- `aragora/debate/post_debate_coordinator.py`
+- `aragora/pipeline/decision_integrity.py`
+- `aragora/pipeline/unified_orchestrator.py`
+
+Canonical artifact:
+`DeliberationBundle`
+
+Required fields:
+
+1. `proposal_summary`
+2. `dissent_ledger`
+3. `quality_verdict`
+4. `quality_scores`
+5. `provider_diversity_report`
+6. `provenance_refs`
+7. `unresolved_risks`
+
+Boundary:
+debate produces a decision package, not direct execution.
+
+### Stage 3: Planning
+
+Purpose:
+map validated intent into executable tasks, dependencies, gates, and approvals.
+
+Current anchors:
+
+- `aragora/pipeline/decision_plan/core.py`
+- `aragora/pipeline/decision_plan/factory.py`
+- `aragora/pipeline/verification_plan.py`
+- `aragora/pipeline/dag_operations.py`
+
+Canonical artifact:
+`DecisionPlanBundle`
+
+Required fields:
+
+1. `steps`
+2. `dependencies`
+3. `execution_mode`
+4. `approval_requirements`
+5. `verification_targets`
+6. `rollback_targets`
+7. `budget_and_policy_constraints`
+
+Boundary:
+planning can schedule work, but policy and receipt gates still govern execution.
+
+### Stage 4: Controlled Execution
+
+Purpose:
+run the plan through approved execution bridges and track concrete attempts.
+
+Current anchors:
+
+- `aragora/pipeline/executor.py`
+- `aragora/pipeline/execution_bridge.py`
+- `aragora/server/handlers/pipeline/execute.py`
+- `aragora/server/handlers/tasks/execution.py`
+- `aragora/server/handlers/workflows/execution.py`
+
+Canonical artifact:
+`ExecutionBundle`
+
+Required fields:
+
+1. `attempts`
+2. `artifacts`
+3. `diffs`
+4. `logs`
+5. `policy_decisions`
+6. `execution_status`
+
+Boundary:
+execution performs work, but it does not decide for itself whether the result is acceptable.
+
+### Stage 5: Verification and Self-Repair
+
+Purpose:
+evaluate outcomes, retry safe repairs, and determine whether the result is promotable.
+
+Current anchors:
+
+- `aragora/pipeline/unified_orchestrator.py`
+- `aragora/pipeline/outcome_feedback.py`
+- `aragora/pipeline/verification_plan.py`
+- bug-fix integrations reachable through `apply_fix_and_retest`
+
+Canonical artifact:
+`VerificationBundle`
+
+Required fields:
+
+1. `checks_run`
+2. `check_results`
+3. `bug_fix_attempts`
+4. `final_verification_status`
+5. `remaining_failures`
+
+Boundary:
+self-repair may improve a failing execution attempt, but it does not rewrite the original intent or silently bypass policy.
+
+### Stage 6: Receipt and Policy Gate
+
+Purpose:
+convert a verified or blocked outcome into a control-plane artifact.
+
+Current anchors:
+
+- `aragora/pipeline/receipt_generator.py`
+- `aragora/server/handlers/pipeline/receipts.py`
+- `aragora/server/handlers/receipts.py`
+- `aragora/control_plane/policy.py`
+- gauntlet receipt handlers
+
+Canonical artifact:
+`ReceiptEnvelope`
+
+Required fields:
+
+1. `receipt_id`
+2. `artifact_hash`
+3. `signature`
+4. `verdict`
+5. `confidence`
+6. `dissent`
+7. `taint_summary`
+8. `policy_gate_result`
+9. `provenance_chain`
+
+Boundary:
+the receipt is not just an audit artifact. For high-impact automation it is the execution-control artifact.
+
+### Stage 7: Outcome Feedback and Settlement
+
+Purpose:
+record what happened, what failed, what settled, and what should influence future trust.
+
+Current anchors:
+
+- `aragora/pipeline/outcome_feedback.py`
+- settlement and calibration subsystems
+- compliance artifact generators
+
+Canonical artifact:
+`OutcomeFeedbackRecord`
+
+Required fields:
+
+1. `receipt_ref`
+2. `objective_fidelity`
+3. `quality_outcome`
+4. `execution_outcome`
+5. `settlement_hooks`
+6. `calibration_updates`
+7. `next_action_recommendation`
+
+Boundary:
+feedback is reusable learning data, not just logging.
+
+### Stage 8: Nomic Reprioritization
+
+Purpose:
+convert outcomes into future improvement work.
+
+Current anchors:
+
+- `scripts/nomic_loop.py`
+- `aragora/pipeline/meta_loop.py`
+- `aragora/server/handlers/self_improve.py`
+- `aragora/nomic/*`
+
+Canonical behavior:
+
+1. Nomic consumes `OutcomeFeedbackRecord` and `ReceiptEnvelope`.
+2. New self-improvement goals re-enter the backbone through `IntakeBundle` or `SpecBundle`.
+3. Nomic does not bypass receipt, verification, or policy stages for meaningful actions.
+
+## Trust and Taint Model
+
+The architecture needs explicit trust tiers because context injection is a first-class risk.
+
+Canonical trust tiers:
+
+1. operator-authored
+2. signed trusted repo/config
+3. internal retrieved knowledge
+4. external retrieved content
+5. model-generated content
+
+Rules:
+
+1. trust tier must be attached at intake time
+2. taint must propagate across artifacts if lower-trust context materially shaped the output
+3. receipts must expose taint summaries for human review and policy decisions
+
+This is the architectural home for roadmap items:
+
+1. G2: taint tracking
+2. G1: signed context manifests
+3. G4: mandatory external verification
+4. G3: runtime model attestation
+
+## Canonical Boundaries
+
+### IdeaCloud
+
+Role:
+intake, clustering, promotion, and export.
+
+Must not:
+directly authorize execution or act as a parallel planning engine.
+
+### Prompt Engine and Interrogation
+
+Role:
+upgrade vague intent into a spec.
+
+Must not:
+directly trigger execution without passing through deliberation, planning, and receipt logic.
+
+### Debate and Gauntlet
+
+Role:
+produce adversarially validated decision packages.
+
+Must not:
+be treated as sufficient authority for execution on their own.
+
+### Execution and Bug-Fix
+
+Role:
+run plans and repair failed attempts inside bounded policy.
+
+Must not:
+change objectives silently or bypass receipt/policy gates.
+
+### Nomic
+
+Role:
+learn from outcomes and originate new improvement goals.
+
+Must not:
+be a side-channel around the same control plane imposed on user-driven flows.
+
+## Canonical Entry Point Mapping
+
+| Entry point | Normalize to | Notes |
+|---|---|---|
+| Prompt engine run | `IntakeBundle` -> `SpecBundle` | default vague-prompt path |
+| Interrogation API | `IntakeBundle` -> `SpecBundle` | clarification-first path |
+| IdeaCloud export/promote | `IntakeBundle` | idea graph enters backbone here |
+| Pipeline canvas run | `SpecBundle` or `DecisionPlanBundle` | depending on stage state |
+| Self-improve start | `IntakeBundle` or `SpecBundle` | same backbone, different producer |
+
+## Canonical Golden Path
+
+The first path Aragora should make boring and reliable is:
+
+1. user submits vague prompt or promoted idea cluster
+2. system emits `SpecBundle`
+3. debate emits `DeliberationBundle`
+4. plan emits `DecisionPlanBundle`
+5. execution emits `ExecutionBundle`
+6. verify and bug-fix emit `VerificationBundle`
+7. receipt layer emits `ReceiptEnvelope`
+8. feedback layer emits `OutcomeFeedbackRecord`
+9. Nomic uses that record for reprioritization
+
+If a path cannot do this, it is not yet a canonical production path.
+
+## What This Architecture Deliberately Avoids
+
+1. multiple orchestration stacks with separate contracts
+2. direct prompt-to-action shortcuts
+3. hidden quality-gate downgrades in automated lanes
+4. detached self-improvement loops that ignore product receipts and outcomes
+5. treating compliance and security as post-hoc documentation rather than control-plane behavior

--- a/docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md
+++ b/docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md
@@ -1,0 +1,264 @@
+# Closed-Loop Backbone: 2-Week Execution Plan
+
+Last updated: 2026-03-06
+Status: Active implementation plan
+Owner: Platform program (Backend, Frontend, QA, Security, Product)
+
+This plan operationalizes the architecture in `docs/architecture/CLOSED_LOOP_BACKBONE.md`.
+It complements, and does not supersede, `docs/status/NEXT_STEPS_CANONICAL.md`.
+Issue-ready breakdown: `docs/plans/2026-03-06-closed-loop-backbone-implementation-tickets.md`
+
+## Objective
+
+Establish one canonical closed loop for Aragora:
+
+`vague intent or idea intake -> interrogation/spec -> debate + quality gate -> plan -> controlled execution -> verify + self-repair -> signed receipt -> outcome feedback -> nomic reprioritization`
+
+The point of this sprint is not adding more surfaces. The point is to make the existing surfaces compose into one reliable system.
+
+## Constraints
+
+1. Canonical reliability and security gates remain blocking:
+   - test isolation
+   - connector exception hygiene
+   - offline/demo golden path
+   - SDK/version alignment
+   - self-host readiness
+   - pentest closure gate
+2. High-impact automation must remain receipt-gated.
+3. New work should prefer wiring existing components over creating parallel orchestration paths.
+
+## End-of-Sprint Definition of Done
+
+By day 14, Aragora should have all of the following:
+
+1. One documented canonical backbone with named handoff artifacts.
+2. One fail-closed spec path from vague prompt to execution-grade task/spec.
+3. One canonical orchestration path from debated decision to execution attempt.
+4. One post-execution loop for verification, bug-fix, receipt generation, and outcome feedback.
+5. One end-to-end golden path test from intake to receipt.
+6. One dogfood benchmark profile that exercises the full loop and emits machine-readable outcomes.
+7. One explicit security overlay for context taint, external verification policy, and pentest/red-team hooks.
+
+## Non-Goals
+
+1. New broad product surfaces.
+2. Marketplace/federation/comms expansion.
+3. Replacing working subsystems that only need wiring.
+4. Treating self-improvement as a separate architecture from user-driven execution.
+
+## Canonical Workstreams
+
+### Workstream A: Freeze the Backbone and Entry Contracts
+
+Goal: define the one backbone every serious flow must use.
+
+Primary files:
+- `docs/architecture/CLOSED_LOOP_BACKBONE.md`
+- `aragora/pipeline/unified_orchestrator.py`
+- `aragora/pipeline/decision_plan/core.py`
+- `aragora/pipeline/outcome_feedback.py`
+- `aragora/pipeline/receipt_generator.py`
+
+Acceptance:
+1. Every major entrypoint maps to one of the canonical handoff artifacts.
+2. No stage is allowed to skip directly from prompt or idea intake to execution.
+3. Nomic, IdeaCloud, Prompt Engine, and Canvas flows are described as producers/consumers of the same backbone, not alternate architectures.
+
+### Workstream B: Fail-Closed Prompt and Spec Upgrading
+
+Goal: underspecified prompts cannot flow into execution as soft prose.
+
+Primary files:
+- `aragora/interrogation/engine.py`
+- `aragora/server/handlers/interrogation/handler.py`
+- `aragora/server/handlers/prompt_engine/handler.py`
+- `aragora/pipeline/decision_plan/factory.py`
+- `aragora/prompt_engine/spec_validator.py`
+
+Acceptance:
+1. Execution-grade specs must include constraints, acceptance criteria, verification plan, rollback, and owner file scopes.
+2. Missing required fields block downstream execution rather than degrading silently.
+3. User-facing and self-improve flows emit the same spec shape.
+
+### Workstream C: Canonical Deliberation to Plan Handoff
+
+Goal: debate output becomes a durable decision package, not just a final answer string.
+
+Primary files:
+- `aragora/debate/orchestrator.py`
+- `aragora/debate/post_debate_coordinator.py`
+- `aragora/pipeline/decision_integrity.py`
+- `aragora/pipeline/decision_plan/factory.py`
+- `aragora/pipeline/unified_orchestrator.py`
+
+Acceptance:
+1. Debate output carries dissent, quality result, and provenance into planning.
+2. Quality gate failure blocks planning in automated lanes.
+3. Plan creation consumes structured debate artifacts rather than lossy text extraction where possible.
+
+### Workstream D: Execution, Verification, and Self-Repair
+
+Goal: execution is observable, retryable, and policy-bounded.
+
+Primary files:
+- `aragora/pipeline/executor.py`
+- `aragora/pipeline/execution_bridge.py`
+- `aragora/pipeline/unified_orchestrator.py`
+- `aragora/server/handlers/pipeline/execute.py`
+- `aragora/server/handlers/tasks/execution.py`
+
+Acceptance:
+1. The canonical path emits execution attempt artifacts with status, diff, and verification payloads.
+2. Bug-fix logic runs after failed verification, not as an unrelated sidecar.
+3. High-impact execution still requires policy and receipt validation.
+
+### Workstream E: Receipt, Outcome Feedback, and Nomic Reuse
+
+Goal: receipts become the control primitive and outcomes become reusable learning data.
+
+Primary files:
+- `aragora/pipeline/receipt_generator.py`
+- `aragora/pipeline/outcome_feedback.py`
+- `aragora/server/handlers/pipeline/receipts.py`
+- `aragora/server/handlers/receipts.py`
+- `aragora/server/handlers/self_improve.py`
+- `aragora/pipeline/meta_loop.py`
+
+Acceptance:
+1. Every canonical run produces a receipt or an explicit blocked/no-receipt outcome.
+2. Outcome feedback writes enough structure for Nomic reprioritization.
+3. Self-improve consumes the same outcome/receipt data model as user-driven flows.
+
+### Workstream F: Security Overlay and Release Gate
+
+Goal: the backbone is explicit about AI-native attacks and release risk.
+
+Primary files:
+- `docs/plans/2026-03-05-ai-attack-vector-resistance-design.md`
+- `docs/security/THREAT_MODEL.md`
+- `scripts/check_pentest_findings.py`
+- `.github/workflows/security.yml`
+- `aragora/control_plane/policy.py`
+
+Acceptance:
+1. Context taint, external verification policy, and pentest findings are visible in the backbone.
+2. High-impact automated decisions have an explicit external-verifier insertion point.
+3. External pentest remains a release gate, not a documentation note.
+
+## Day-by-Day Plan
+
+### Days 1-2: Backbone Freeze
+
+1. Publish target architecture and handoff artifacts.
+2. Identify which current entrypoints normalize to `IntakeBundle` and which already start at `SpecBundle`.
+3. Mark any bypasses that go prompt -> execute or idea -> execute without canonical handoff artifacts.
+
+Deliverables:
+- `docs/architecture/CLOSED_LOOP_BACKBONE.md`
+- implementation issue list for bypasses
+
+### Days 3-4: Fail-Closed Spec Path
+
+1. Align interrogation and prompt-engine outputs on one execution-grade spec schema.
+2. Enforce required fields in validator/factory layers.
+3. Ensure self-improve goals can enter the same spec path.
+
+Deliverables:
+- one canonical spec contract
+- tests for pass/fail completeness
+
+### Days 5-6: Deliberation Package to Plan
+
+1. Carry dissent, quality score, and provenance into planning.
+2. Ensure automated lanes stop on failed quality gate.
+3. Remove any lossy translation that drops high-value debate metadata before planning.
+
+Deliverables:
+- structured debate-to-plan contract
+- regression tests for dissent/quality preservation
+
+### Days 7-8: Execution and Self-Repair
+
+1. Standardize execution attempt artifact shape.
+2. Run verification before receipt issuance.
+3. Make bug-fix loop the first-class recovery path after failed verification.
+
+Deliverables:
+- execution attempt contract
+- verify/fix/retest path in canonical orchestrator
+
+### Days 9-10: Receipt, Feedback, Nomic Reuse
+
+1. Standardize receipt envelope for successful and blocked outcomes.
+2. Write outcome feedback in a way Nomic can consume directly.
+3. Ensure self-improve and user flows converge on the same feedback/receipt primitives.
+
+Deliverables:
+- receipt envelope contract
+- outcome feedback contract
+
+### Days 11-12: Security Overlay
+
+1. Add explicit context-taint and trust-tier handling to the architecture and implementation backlog.
+2. Define the external-verifier insertion point for high-impact actions.
+3. Verify pentest/red-team hooks are reflected in release gating.
+
+Deliverables:
+- threat-to-stage mapping
+- implementation backlog for G2 -> G1 -> G4 -> G3
+
+### Days 13-14: Proof Run
+
+1. Run one end-to-end golden path test from intake to receipt.
+2. Run one dogfood profile that exercises the closed loop.
+3. Record blockers, missing artifacts, and bypasses as explicit defects.
+
+Deliverables:
+- green golden-path test
+- dogfood artifact bundle
+- closeout report with next sprint carryovers
+
+## Canonical Entry Points To Normalize
+
+These entry points should converge onto the backbone instead of staying as parallel systems:
+
+1. Prompt Engine
+   - `aragora/server/handlers/prompt_engine/handler.py`
+2. Interrogation
+   - `aragora/server/handlers/interrogation/handler.py`
+3. Pipeline Canvas / universal graph
+   - `aragora/server/handlers/canvas_pipeline.py`
+   - `aragora/server/handlers/pipeline/*.py`
+4. IdeaCloud export/promote flow
+   - `aragora/ideacloud/adapters/pipeline_bridge.py`
+   - `aragora/ideacloud/core.py`
+5. Self-improve / Nomic
+   - `aragora/server/handlers/self_improve.py`
+   - `scripts/nomic_loop.py`
+
+## Required Tests and Gates
+
+The sprint is not complete without the following:
+
+1. One E2E test covering:
+   - intake
+   - spec
+   - debate
+   - plan
+   - execute
+   - verify
+   - receipt
+2. One dogfood profile covering the same stages.
+3. Canonical project gates remain green:
+   - `scripts/check_connector_exception_handling.py`
+   - `scripts/check_self_host_compose.py`
+   - `scripts/check_pentest_findings.py`
+   - `scripts/run_offline_golden_path.sh`
+
+## Decision Rules During the Sprint
+
+1. If a feature needs a parallel pipeline, stop and justify it against the closed-loop backbone.
+2. If a flow cannot emit the canonical artifact for its stage, it is incomplete.
+3. If a high-impact path cannot produce a valid receipt, it cannot auto-execute.
+4. If the sprint ends with multiple orchestration paths still bypassing the backbone, the sprint is not complete even if individual features improved.

--- a/docs/plans/2026-03-06-closed-loop-backbone-implementation-tickets.md
+++ b/docs/plans/2026-03-06-closed-loop-backbone-implementation-tickets.md
@@ -1,0 +1,236 @@
+# Closed-Loop Backbone: Implementation Tickets
+
+Last updated: 2026-03-06
+Status: Issue-ready breakdown
+
+This file translates `docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md`
+into issue-sized implementation tickets.
+
+## Ticket vs Issue
+
+In practice:
+
+1. a `ticket` is the work item
+2. an `issue` is the tracker record for that work item in GitHub, Linear, or another system
+
+So for this sprint, treat them as the same thing unless there is a reason to split one ticket into multiple tracker records.
+
+## Recommended Order
+
+1. Backbone contracts and adapters
+2. Fail-closed spec validation
+3. Debate-to-plan preservation
+4. Execution artifact normalization
+5. Verification and self-repair normalization
+6. Receipt and outcome feedback normalization
+7. Security overlay and taint propagation
+8. Golden-path and dogfood proof runs
+
+## Platform Contracts
+
+### CLB-001: Add canonical backbone contract module
+
+Owner:
+Platform
+
+Primary files:
+- `aragora/pipeline/backbone_contracts.py`
+- `tests/pipeline/test_backbone_contracts.py`
+
+Acceptance:
+1. canonical bundle types exist for intake, spec, receipt, and outcome feedback
+2. adapters normalize Prompt Engine, Interrogation, receipt, and outcome types
+3. missing execution-grade spec fields are surfaced explicitly
+
+### CLB-002: Document current entrypoint-to-contract normalization
+
+Owner:
+Platform
+
+Primary files:
+- `docs/architecture/CLOSED_LOOP_BACKBONE.md`
+- `docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md`
+
+Acceptance:
+1. Prompt Engine, Interrogation, IdeaCloud, Canvas, and Nomic entrypoints map to canonical bundles
+2. known bypasses are called out explicitly
+
+## Prompt and Spec Path
+
+### CLB-003: Unify Prompt Engine and Interrogation on one execution-grade spec contract
+
+Owner:
+Backend
+
+Primary files:
+- `aragora/interrogation/engine.py`
+- `aragora/server/handlers/interrogation/handler.py`
+- `aragora/server/handlers/prompt_engine/handler.py`
+- `aragora/pipeline/backbone_contracts.py`
+
+Acceptance:
+1. both paths emit a shared spec bundle shape
+2. unanswered questions and missing execution fields are preserved
+
+### CLB-004: Enforce fail-closed execution-grade validation
+
+Owner:
+Backend
+
+Primary files:
+- `aragora/prompt_engine/spec_validator.py`
+- `aragora/pipeline/decision_plan/factory.py`
+- `tests/prompt_engine/`
+- `tests/pipeline/`
+
+Acceptance:
+1. missing constraints, acceptance criteria, verification material, rollback, or file scopes block automated lanes
+2. manual lanes can surface warnings without silently auto-executing
+
+## Deliberation and Planning
+
+### CLB-005: Preserve dissent and quality verdict into planning
+
+Owner:
+Reasoning + Backend
+
+Primary files:
+- `aragora/debate/orchestrator.py`
+- `aragora/debate/post_debate_coordinator.py`
+- `aragora/pipeline/decision_integrity.py`
+- `aragora/pipeline/decision_plan/factory.py`
+
+Acceptance:
+1. plan creation can consume structured dissent and quality outputs
+2. automated planning halts on failed quality verdict
+
+### CLB-006: Add canonical deliberation bundle adapter
+
+Owner:
+Platform
+
+Primary files:
+- `aragora/pipeline/backbone_contracts.py`
+- `tests/pipeline/test_backbone_contracts.py`
+
+Acceptance:
+1. debate outputs can be normalized into a stable handoff artifact
+2. provenance, unresolved risks, and diversity data are not lost
+
+## Execution and Verification
+
+### CLB-007: Normalize execution attempt artifacts
+
+Owner:
+Backend
+
+Primary files:
+- `aragora/pipeline/executor.py`
+- `aragora/pipeline/execution_bridge.py`
+- `aragora/server/handlers/pipeline/execute.py`
+- `aragora/server/handlers/tasks/execution.py`
+
+Acceptance:
+1. execution attempt output has a stable shape for status, artifacts, diff, and policy decisions
+2. plan execution and task execution use compatible shapes
+
+### CLB-008: Make bug-fix loop first-class after verification failure
+
+Owner:
+Backend
+
+Primary files:
+- `aragora/pipeline/unified_orchestrator.py`
+- `aragora/pipeline/verification_plan.py`
+- `tests/pipeline/test_unified_orchestrator.py`
+
+Acceptance:
+1. failed verification routes into bounded self-repair
+2. retest result is carried forward into receipt/outcome layers
+
+## Receipt and Feedback
+
+### CLB-009: Normalize receipt envelope across pipeline outcomes
+
+Owner:
+Backend + Compliance
+
+Primary files:
+- `aragora/pipeline/receipt_generator.py`
+- `aragora/server/handlers/pipeline/receipts.py`
+- `aragora/server/handlers/receipts.py`
+
+Acceptance:
+1. successful and blocked outcomes share a consistent receipt envelope
+2. policy result, taint summary, and provenance are always available
+
+### CLB-010: Normalize outcome feedback for Nomic reuse
+
+Owner:
+Platform + Nomic
+
+Primary files:
+- `aragora/pipeline/outcome_feedback.py`
+- `aragora/pipeline/meta_loop.py`
+- `aragora/server/handlers/self_improve.py`
+
+Acceptance:
+1. outcome feedback records carry receipt reference and next-action guidance
+2. Nomic can reprioritize from the same record used by product flows
+
+## Security Overlay
+
+### CLB-011: Introduce canonical trust-tier and taint propagation fields
+
+Owner:
+Security + Platform
+
+Primary files:
+- `aragora/pipeline/backbone_contracts.py`
+- intake-related handlers and adapters
+- receipt generation layers
+
+Acceptance:
+1. trust tier is attached at intake
+2. taint can propagate into spec, deliberation, and receipt layers
+
+### CLB-012: Add external-verifier insertion point for high-impact actions
+
+Owner:
+Security + Control Plane
+
+Primary files:
+- `aragora/control_plane/policy.py`
+- receipt/policy handlers
+- execution handlers
+
+Acceptance:
+1. high-impact actions can require independent external verification before final promotion
+2. policy result is carried into the receipt envelope
+
+## Proof
+
+### CLB-013: Add canonical golden-path test
+
+Owner:
+QA + Platform
+
+Primary files:
+- `tests/pipeline/`
+- relevant handler/orchestrator tests
+
+Acceptance:
+1. one test covers intake -> spec -> debate -> plan -> execute -> verify -> receipt
+2. failures identify the broken contract stage
+
+### CLB-014: Add closed-loop dogfood profile
+
+Owner:
+QA + Reasoning
+
+Primary files:
+- dogfood scripts and docs under `docs/plans/`
+
+Acceptance:
+1. one dogfood run emits machine-readable artifacts for each canonical stage
+2. the run fails if required stage artifacts are absent

--- a/tests/pipeline/test_backbone_contracts.py
+++ b/tests/pipeline/test_backbone_contracts.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from aragora.interrogation.crystallizer import CrystallizedSpec, MoSCoWItem
+from aragora.interrogation.engine import InterrogationResult, PrioritizedQuestion
+from aragora.pipeline.backbone_contracts import (
+    IntakeBundle,
+    OutcomeFeedbackRecord,
+    ReceiptEnvelope,
+    SpecBundle,
+)
+from aragora.pipeline.outcome_feedback import PipelineOutcome
+from aragora.prompt_engine.spec_validator import ValidationResult, ValidatorRole
+from aragora.prompt_engine.types import PromptIntent, RiskItem, Specification, SpecFile
+
+
+def test_intake_bundle_from_prompt_intent_preserves_core_fields() -> None:
+    intent = PromptIntent(
+        raw_prompt="Improve onboarding flow",
+        intent_type="improvement",
+        related_knowledge=[{"source": "km", "id": "doc-1"}],
+    )
+
+    bundle = IntakeBundle.from_prompt_intent(
+        intent,
+        trust_tiers=["operator-authored", "internal-retrieved"],
+        taint_flags=["external_note"],
+        origin_metadata={"entrypoint": "prompt_engine"},
+    )
+
+    assert bundle.raw_intent == "Improve onboarding flow"
+    assert bundle.context_refs == [{"source": "km", "id": "doc-1"}]
+    assert bundle.trust_tiers == ["operator-authored", "internal-retrieved"]
+    assert bundle.taint_flags == ["external_note"]
+    assert bundle.origin_metadata["entrypoint"] == "prompt_engine"
+
+
+def test_spec_bundle_from_prompt_spec_surfaces_missing_execution_fields() -> None:
+    spec = Specification(
+        title="Onboarding improvements",
+        problem_statement="Users drop off too early.",
+        proposed_solution="Tighten the onboarding flow and clarify next steps.",
+        success_criteria=["Increase activation conversion", "Reduce first-session confusion"],
+        file_changes=[
+            SpecFile(
+                path="aragora/live/src/app/(app)/onboarding/page.tsx",
+                action="modify",
+                description="Improve onboarding copy",
+            )
+        ],
+        risks=[
+            RiskItem(
+                description="UX regression",
+                likelihood="medium",
+                impact="medium",
+                mitigation="Keep old copy behind a rollout guard.",
+            )
+        ],
+        confidence=0.72,
+    )
+    validation = ValidationResult(
+        role_results={ValidatorRole.UX_ADVOCATE: {"passed": True, "confidence": 0.9}},
+        overall_confidence=0.91,
+        passed=True,
+    )
+
+    bundle = SpecBundle.from_prompt_spec(spec, validation=validation)
+
+    assert bundle.title == "Onboarding improvements"
+    assert bundle.objectives == ["Tighten the onboarding flow and clarify next steps."]
+    assert bundle.acceptance_criteria == [
+        "Increase activation conversion",
+        "Reduce first-session confusion",
+    ]
+    assert bundle.verification_plan == bundle.acceptance_criteria
+    assert bundle.rollback_plan == ["Keep old copy behind a rollout guard."]
+    assert bundle.owner_file_scopes == ["aragora/live/src/app/(app)/onboarding/page.tsx"]
+    assert bundle.confidence == 0.91
+    assert bundle.source_kind == "prompt_engine_spec"
+    assert bundle.missing_required_fields == ["constraints"]
+    assert bundle.is_execution_grade is False
+
+
+def test_spec_bundle_from_interrogation_result_preserves_constraints_and_open_questions() -> None:
+    crystallized = CrystallizedSpec(
+        title="Execution-grade spec",
+        problem_statement="Turn a vague request into a concrete implementation plan.",
+        requirements=[
+            MoSCoWItem(description="Capture owner files", priority="must"),
+            MoSCoWItem(description="Define rollback path", priority="must"),
+        ],
+        success_criteria=["Every generated task has acceptance criteria"],
+        risks=[
+            {"risk": "Spec drift", "mitigation": "Block execution when required fields are absent"}
+        ],
+        constraints=["No direct prompt-to-execute path"],
+    )
+    result = InterrogationResult(
+        original_prompt="Make the pipeline safer",
+        dimensions=["safety", "execution"],
+        research_summary="Current path allows soft degradation.",
+        prioritized_questions=[
+            PrioritizedQuestion(
+                question="Should automated runs fail closed on missing rollback plans?",
+                why_it_matters="Execution safety depends on it.",
+                priority_score=0.95,
+            )
+        ],
+        crystallized_spec=crystallized,
+    )
+
+    bundle = SpecBundle.from_interrogation_result(result)
+
+    assert bundle.title == "Execution-grade spec"
+    assert bundle.constraints == ["No direct prompt-to-execute path"]
+    assert bundle.acceptance_criteria == ["Every generated task has acceptance criteria"]
+    assert bundle.rollback_plan == ["Block execution when required fields are absent"]
+    assert bundle.open_questions == ["Should automated runs fail closed on missing rollback plans?"]
+    assert bundle.owner_file_scopes == []
+    assert "owner_file_scopes" in bundle.missing_required_fields
+
+
+def test_receipt_envelope_from_pipeline_receipt_flattens_provenance() -> None:
+    receipt = {
+        "receipt_id": "receipt-123",
+        "pipeline_id": "pipe-001",
+        "generated_at": "2026-03-06T12:00:00Z",
+        "content_hash": "abc123",
+        "provenance": {
+            "ideas": [{"id": "i1", "label": "Idea"}],
+            "goals": [{"id": "g1", "label": "Goal"}],
+        },
+        "execution": {"status": "completed"},
+    }
+
+    envelope = ReceiptEnvelope.from_pipeline_receipt(
+        receipt,
+        policy_gate_result={"allowed": True},
+        taint_summary={"tainted": False},
+    )
+
+    assert envelope.receipt_id == "receipt-123"
+    assert envelope.artifact_hash == "abc123"
+    assert envelope.verdict == "pass"
+    assert envelope.policy_gate_result == {"allowed": True}
+    assert envelope.taint_summary == {"tainted": False}
+    assert envelope.provenance_chain == [
+        {"stage": "ideas", "id": "i1", "label": "Idea"},
+        {"stage": "goals", "id": "g1", "label": "Goal"},
+    ]
+
+
+def test_outcome_feedback_record_from_pipeline_outcome_derives_next_action() -> None:
+    outcome = PipelineOutcome(
+        pipeline_id="pipe-001",
+        run_type="user_project",
+        domain="product",
+        spec_completeness=0.8,
+        execution_succeeded=False,
+        tests_passed=3,
+        tests_failed=2,
+        files_changed=1,
+        total_duration_s=42.0,
+    )
+
+    record = OutcomeFeedbackRecord.from_pipeline_outcome(
+        outcome,
+        receipt_ref="receipt-123",
+    )
+
+    assert record.receipt_ref == "receipt-123"
+    assert record.pipeline_id == "pipe-001"
+    assert record.objective_fidelity == outcome.overall_quality_score
+    assert record.execution_outcome["tests_failed"] == 2
+    assert record.next_action_recommendation == "run_bug_fix_loop"

--- a/tests/pipeline/test_decision_plan.py
+++ b/tests/pipeline/test_decision_plan.py
@@ -30,6 +30,8 @@ from aragora.pipeline.decision_plan import (
     record_plan_outcome,
 )
 from aragora.pipeline.risk_register import RiskLevel
+from aragora.prompt_engine.spec_validator import ValidationResult, ValidatorRole
+from aragora.prompt_engine.types import RiskItem, Specification, SpecFile
 
 
 # ---------------------------------------------------------------------------
@@ -177,6 +179,88 @@ class TestDecisionPlanFactory:
 
         assert len(plan.implement_plan.tasks) == 1
         assert plan.implement_plan.tasks[0].complexity == "complex"
+
+    def test_validate_execution_grade_specification_fail_closed(self):
+        spec = Specification(
+            title="Incomplete spec",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["Criterion"],
+        )
+
+        with pytest.raises(ValueError, match="execution-grade"):
+            DecisionPlanFactory.validate_execution_grade_specification(spec, fail_closed=True)
+
+    def test_from_debate_result_blocks_incomplete_spec_for_never_mode(self):
+        spec = Specification(
+            title="Incomplete spec",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["Criterion"],
+        )
+
+        with pytest.raises(ValueError, match="owner_file_scopes"):
+            DecisionPlanFactory.from_debate_result(
+                _make_result(),
+                approval_mode=ApprovalMode.NEVER,
+                specification=spec,
+            )
+
+    def test_from_debate_result_records_missing_spec_fields_for_manual_lane(self):
+        spec = Specification(
+            title="Incomplete spec",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["Criterion"],
+        )
+
+        plan = DecisionPlanFactory.from_debate_result(
+            _make_result(),
+            approval_mode=ApprovalMode.ALWAYS,
+            specification=spec,
+        )
+
+        assert "spec_bundle" in plan.metadata
+        assert sorted(plan.metadata["spec_bundle_missing_fields"]) == [
+            "constraints",
+            "owner_file_scopes",
+            "rollback_plan",
+        ]
+
+    def test_from_debate_result_accepts_execution_grade_spec_in_auto_lane(self):
+        spec = Specification(
+            title="Execution-grade spec",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["Criterion"],
+            file_changes=[
+                SpecFile(path="aragora/pipeline/example.py", action="modify", description="Change")
+            ],
+            risks=[
+                RiskItem(
+                    description="Regression risk",
+                    likelihood="medium",
+                    impact="medium",
+                    mitigation="Use staged rollback",
+                )
+            ],
+        )
+        spec.constraints = ["Keep existing API contract stable"]
+        validation = ValidationResult(
+            role_results={ValidatorRole.DEVILS_ADVOCATE: {"passed": True, "confidence": 0.9}},
+            overall_confidence=0.9,
+            passed=True,
+        )
+
+        plan = DecisionPlanFactory.from_debate_result(
+            _make_result(),
+            approval_mode=ApprovalMode.NEVER,
+            specification=spec,
+            validation_result=validation,
+        )
+
+        assert plan.metadata["spec_bundle"]["title"] == "Execution-grade spec"
+        assert "spec_bundle_missing_fields" not in plan.metadata
 
 
 # ---------------------------------------------------------------------------

--- a/tests/prompt_engine/test_spec_validator.py
+++ b/tests/prompt_engine/test_spec_validator.py
@@ -21,12 +21,21 @@ class _FakeRisk:
 
 
 @dataclass
+class _FakeFile:
+    path: str
+
+
+@dataclass
 class _FakeSpec:
+    title: str = ""
     problem_statement: str = ""
     proposed_solution: str = ""
     implementation_plan: list = field(default_factory=list)
     risks: list = field(default_factory=list)
     success_criteria: list = field(default_factory=list)
+    constraints: list = field(default_factory=list)
+    file_changes: list = field(default_factory=list)
+    confidence: float = 0.0
 
 
 class TestValidatorRole:
@@ -73,11 +82,14 @@ class TestSpecValidatorHeuristic:
 
     def test_complete_spec_passes(self):
         spec = _FakeSpec(
+            title="Settings search",
             problem_statement="Users can't find settings",
             proposed_solution="Add settings search",
             implementation_plan=["step1", "step2"],
+            constraints=["Keep existing navigation stable"],
             risks=[_FakeRisk(description="Complexity", mitigation="Incremental rollout")],
             success_criteria=["Users find settings 50% faster"],
+            file_changes=[_FakeFile(path="aragora/live/src/app/settings/page.tsx")],
         )
         result = self.validator.validate_heuristic(spec)
         assert result.passed is True
@@ -94,6 +106,7 @@ class TestSpecValidatorHeuristic:
         da = result.role_results[ValidatorRole.DEVILS_ADVOCATE]
         assert da["passed"] is False
         assert any("Missing problem statement" in i for i in da["issues"])
+        assert any("Missing execution-grade field: constraints" in i for i in da["issues"])
 
     def test_missing_proposed_solution(self):
         spec = _FakeSpec(
@@ -157,11 +170,14 @@ class TestSpecValidatorHeuristic:
         spec = _FakeSpec(
             problem_statement="Problem",
             proposed_solution="Solution",
+            constraints=["Keep scope narrow"],
+            file_changes=[_FakeFile(path="aragora/server/handlers/example.py")],
         )
         result = self.validator.validate_heuristic(spec)
         ux = result.role_results[ValidatorRole.UX_ADVOCATE]
         assert ux["passed"] is False
         assert any("No success criteria" in i for i in ux["issues"])
+        assert any("No verification plan" in i for i in ux["issues"])
 
     def test_unmitigated_risk_flagged_by_tech_debt(self):
         spec = _FakeSpec(
@@ -169,17 +185,36 @@ class TestSpecValidatorHeuristic:
             proposed_solution="Solution",
             risks=[_FakeRisk(description="Performance regression", mitigation="")],
             success_criteria=["criterion"],
+            constraints=["Do not add new dependencies"],
+            file_changes=[_FakeFile(path="aragora/pipeline/example.py")],
         )
         result = self.validator.validate_heuristic(spec)
         td = result.role_results[ValidatorRole.TECH_DEBT_AUDITOR]
         assert td["passed"] is False
         assert any("Unmitigated risk" in i for i in td["issues"])
+        assert any("No rollback plan defined" in i for i in td["issues"])
+
+    def test_missing_owner_file_scopes_fails_execution_grade(self):
+        spec = _FakeSpec(
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["criterion"],
+            constraints=["Constraint"],
+            risks=[_FakeRisk(description="Regression", mitigation="Use staged rollout")],
+        )
+        result = self.validator.validate_heuristic(spec)
+        td = result.role_results[ValidatorRole.TECH_DEBT_AUDITOR]
+        assert td["passed"] is False
+        assert any("No owner file scopes defined" in i for i in td["issues"])
 
     def test_all_roles_present_in_results(self):
         spec = _FakeSpec(
             problem_statement="Problem",
             proposed_solution="Solution",
             success_criteria=["criterion"],
+            constraints=["Constraint"],
+            risks=[_FakeRisk(description="Regression", mitigation="Rollback")],
+            file_changes=[_FakeFile(path="aragora/example.py")],
         )
         result = self.validator.validate_heuristic(spec)
         for role in ValidatorRole:
@@ -190,6 +225,9 @@ class TestSpecValidatorHeuristic:
             problem_statement="Problem",
             proposed_solution="Solution",
             success_criteria=["criterion"],
+            constraints=["Constraint"],
+            risks=[_FakeRisk(description="Regression", mitigation="Rollback")],
+            file_changes=[_FakeFile(path="aragora/example.py")],
         )
         result = self.validator.validate_heuristic(spec)
         confidences = [r["confidence"] for r in result.role_results.values()]
@@ -204,6 +242,9 @@ class TestSpecValidatorAsync:
             problem_statement="Problem",
             proposed_solution="Solution",
             success_criteria=["criterion"],
+            constraints=["Constraint"],
+            risks=[_FakeRisk(description="Regression", mitigation="Rollback")],
+            file_changes=[_FakeFile(path="aragora/example.py")],
         )
         result = asyncio.run(validator.validate(spec))
         assert isinstance(result, ValidationResult)

--- a/tests/server/handlers/interrogation/test_handler.py
+++ b/tests/server/handlers/interrogation/test_handler.py
@@ -228,6 +228,7 @@ class TestInterrogationHandler:
         data = json.loads(response.body)["data"]
         assert data["session_id"] == session_id
         assert "spec" in data
+        assert "spec_bundle" in data
         spec = data["spec"]
         assert "problem_statement" in spec
         assert "requirements" in spec
@@ -235,6 +236,8 @@ class TestInterrogationHandler:
         assert "success_criteria" in spec
         assert "risks" in spec
         assert "context_summary" in spec
+        assert data["spec_bundle"]["source_kind"] == "interrogation_spec"
+        assert "owner_file_scopes" in data["spec_bundle"]["missing_required_fields"]
         assert "goal_text" in data
 
     @pytest.mark.asyncio

--- a/tests/server/handlers/test_prompt_engine_handler.py
+++ b/tests/server/handlers/test_prompt_engine_handler.py
@@ -171,9 +171,24 @@ class TestValidate:
                     "title": "Test Spec",
                     "problem_statement": "A problem",
                     "proposed_solution": "A solution",
+                    "constraints": ["Keep the API stable"],
                     "success_criteria": ["It works"],
                     "implementation_plan": ["Step 1", "Step 2"],
-                    "risks": [],
+                    "file_changes": [
+                        {
+                            "path": "aragora/server/handlers/example.py",
+                            "action": "modify",
+                            "description": "Update handler",
+                        }
+                    ],
+                    "risks": [
+                        {
+                            "description": "Regression",
+                            "likelihood": "medium",
+                            "impact": "medium",
+                            "mitigation": "Rollback quickly",
+                        }
+                    ],
                     "risk_register": [],
                     "confidence": 0.9,
                 }
@@ -185,6 +200,7 @@ class TestValidate:
 
         assert parsed["status"] == 200
         assert parsed["data"]["validation"]["passed"] is True
+        assert parsed["data"]["spec_bundle"]["missing_required_fields"] == []
 
     def test_validate_fails_without_problem(self, handler: PromptEngineHandler) -> None:
         req = _make_handler_request(
@@ -207,6 +223,7 @@ class TestValidate:
 
         assert parsed["status"] == 200
         assert parsed["data"]["validation"]["passed"] is False
+        assert "constraints" in parsed["data"]["spec_bundle"]["missing_required_fields"]
 
     def test_validate_missing_spec_returns_400(self, handler: PromptEngineHandler) -> None:
         req = _make_handler_request({})
@@ -265,6 +282,7 @@ class TestRunPipeline:
 
         assert parsed["status"] == 200
         assert parsed["data"]["specification"]["title"] == "Test"
+        assert "spec_bundle" in parsed["data"]
         assert parsed["data"]["validation"]["passed"] is True
         assert "stages_completed" in parsed["data"]
 


### PR DESCRIPTION
## Summary

This PR lays down the first implementation slice for the closed-loop backbone work. It introduces a canonical contract layer for intake/spec/receipt/outcome handoffs, makes execution-grade specification gaps explicit, and starts enforcing fail-closed behavior in automated planning lanes.

It also adds the architecture and execution docs that define the canonical backbone and breaks the rollout into issue-sized implementation tickets.

## Problem

Aragora already has most of the needed subsystems for the intended closed loop, but they are still joined by implicit, inconsistent handoffs.

That creates three concrete problems:

1. prompt-engine and interrogation outputs are not normalized into one execution-oriented contract
2. automated planning can proceed without an execution-grade spec, which makes downstream execution and verification weaker than the architecture intends
3. the repo lacks a single canonical backbone doc and issue-ready implementation breakdown for finishing the loop

In practice, this means components can work in isolation while still failing to compose into a reliable `idea -> spec -> deliberate -> plan -> execute -> verify -> receipt -> feedback -> nomic` path.

## Root Cause

The system has rich local types, but no stable cross-stage contract layer. Spec validation was heuristic, but the missing execution-grade fields were not surfaced in a normalized artifact that higher layers could consistently consume. As a result, handlers, planning, and future receipt/feedback wiring had no single contract to anchor on.

## Fix

This PR adds that anchor and uses it immediately in the spec path.

### Canonical contract layer

- add `aragora/pipeline/backbone_contracts.py`
- introduce normalized bundles for:
  - `IntakeBundle`
  - `SpecBundle`
  - `ReceiptEnvelope`
  - `OutcomeFeedbackRecord`
- add adapters from prompt-engine specs, interrogation results/specs, pipeline receipts, and pipeline outcomes
- serialize execution-grade signals directly in `SpecBundle.to_dict()` including:
  - `missing_required_fields`
  - `is_execution_grade`

### Execution-grade spec enforcement

- extend `SpecValidator` so missing execution-grade fields are surfaced as validation issues
- require automated decision-plan lanes to fail closed when a provided spec is not execution-grade
- keep manual/non-automated lanes usable by carrying missing-field warnings in plan metadata instead of pretending the spec is complete

### Handler integration

- prompt-engine handlers now return normalized `spec_bundle` data alongside specification and validation responses
- interrogation crystallization now returns a normalized `spec_bundle` as well

### Architecture and planning docs

- add `docs/architecture/CLOSED_LOOP_BACKBONE.md`
- add `docs/plans/2026-03-06-closed-loop-backbone-2-week-plan.md`
- add `docs/plans/2026-03-06-closed-loop-backbone-implementation-tickets.md`
- open the corresponding GitHub issues `#683` through `#696`

## Effect on Users and Operators

This does not add a new end-user feature yet. It makes the backbone more trustworthy and more composable.

For operators and future automation flows, the effect is:

- incomplete specs are now explicitly visible as incomplete
- automated lanes can block before unsafe or underspecified execution planning
- prompt-engine and interrogation outputs are easier to consume consistently in downstream planning and feedback loops
- the remaining closed-loop work now has one architectural reference and an issue-ready rollout plan

## Validation

Focused validation run in this branch:

- `python -m pytest tests/server/handlers/test_prompt_engine_handler.py tests/server/handlers/interrogation/test_handler.py tests/pipeline/test_backbone_contracts.py tests/prompt_engine/test_spec_validator.py tests/pipeline/test_decision_plan.py -q`
  - `111 passed`
- `ruff check aragora/pipeline/backbone_contracts.py aragora/pipeline/decision_plan/factory.py aragora/prompt_engine/spec_validator.py aragora/server/handlers/interrogation/handler.py aragora/server/handlers/prompt_engine/handler.py tests/pipeline/test_backbone_contracts.py tests/pipeline/test_decision_plan.py tests/prompt_engine/test_spec_validator.py tests/server/handlers/interrogation/test_handler.py tests/server/handlers/test_prompt_engine_handler.py`
  - `All checks passed`

## Follow-up

This is the first backbone slice, not the full loop. The next logical issues after this are:

- `#685` unify prompt-engine and interrogation on the same execution-grade spec contract end-to-end
- `#687` and `#688` preserve deliberation/dissent into planning with a canonical deliberation bundle
- `#689` through `#694` normalize execution, receipt, feedback, taint, and external verification in the same pattern
