### PR TITLE
fix(onboarding): preserve flow analytics continuity

### DIFF
--- a/aragora/server/debate_controller.py
+++ b/aragora/server/debate_controller.py
@@ -1425,46 +1425,54 @@ class DebateController:
                 user_id = config.metadata.get("user_id") if config.metadata else None
                 org_id = config.metadata.get("organization_id") if config.metadata else None
                 flow_id = config.metadata.get("flow_id") if config.metadata else None
-                if user_id:
+                tracked_user_id = user_id if isinstance(user_id, str) and user_id else None
+                tracked_org_id = org_id if isinstance(org_id, str) and org_id else None
+                if not isinstance(flow_id, str):
+                    flow_id = None
+                if tracked_user_id:
                     try:
                         from aragora.storage.repositories.onboarding import (
                             get_onboarding_repository,
                         )
 
                         repo = get_onboarding_repository()
-                        flow = repo.get_flow(user_id, org_id)
-                        if flow:
-                            flow_id = flow.get("id") or flow_id
+                        flow = repo.get_flow(tracked_user_id, tracked_org_id)
+                        if flow and isinstance(flow.get("id"), str):
+                            flow_id = flow["id"]
+                            flow_metadata = flow.get("metadata", {})
+                            if not isinstance(flow_metadata, dict):
+                                flow_metadata = {}
                             repo.update_flow(
                                 flow["id"],
                                 {
                                     "metadata": {
-                                        **flow.get("metadata", {}),
+                                        **flow_metadata,
                                         "receipt_id": receipt_id,
                                     }
                                 },
                             )
-                        try:
-                            from aragora.server.handlers.onboarding import _track_event
-
-                            _track_event(
-                                "first_receipt_generated",
-                                str(user_id),
-                                str(org_id) if org_id is not None else None,
-                                {
-                                    "flow_id": flow_id,
-                                    "debate_id": debate_id,
-                                    "receipt_id": receipt_id,
-                                },
-                            )
-                        except (ImportError, AttributeError, TypeError, ValueError) as e:
-                            logger.debug("Could not track onboarding receipt event: %s", e)
                     except (ImportError, KeyError, TypeError, OSError) as e:
                         # ImportError: onboarding repository not available
                         # KeyError: missing flow data
                         # TypeError: unexpected flow structure
                         # OSError: database access errors
                         logger.debug("Could not update onboarding flow with receipt: %s", e)
+                    if isinstance(flow_id, str):
+                        try:
+                            from aragora.server.handlers.onboarding import _track_event
+
+                            _track_event(
+                                "first_receipt_generated",
+                                tracked_user_id,
+                                tracked_org_id,
+                                {
+                                    "flow_id": flow_id,
+                                    "debate_id": debate_id,
+                                    "receipt_id": receipt_id,
+                                },
+                            )
+                        except (ImportError, AttributeError, TypeError, ValueError, OSError) as e:
+                            logger.debug("Could not track onboarding receipt event: %s", e)
 
         except (ImportError, ValueError, TypeError, OSError, KeyError) as e:
             # ImportError: receipt store module not available

--- a/aragora/server/handlers/onboarding.py
+++ b/aragora/server/handlers/onboarding.py
@@ -1210,6 +1210,13 @@ async def handle_quick_debate(
             existing_flow = _onboarding_flows.get(flow_key)
             if existing_flow:
                 flow_id = existing_flow.id
+        if flow_id is None:
+            try:
+                repo_flow = get_onboarding_repository().get_flow(user_id, organization_id)
+                if repo_flow and isinstance(repo_flow.get("id"), str):
+                    flow_id = repo_flow["id"]
+            except (KeyError, TypeError, AttributeError, OSError):
+                flow_id = None
 
         # Find template
         template = next(

--- a/tests/handlers/test_onboarding.py
+++ b/tests/handlers/test_onboarding.py
@@ -1058,6 +1058,36 @@ class TestQuickDebate:
             event = next(e for e in _analytics_events if e["event_type"] == "quick_debate_started")
             assert event["data"]["flow_id"] == "onb_test123"
 
+    @pytest.mark.asyncio
+    async def test_quick_debate_recovers_repo_flow_id_when_memory_missing(
+        self, handler, _mock_repo
+    ):
+        _mock_repo.get_flow.return_value = {"id": "onb_repo_123", "metadata": {}}
+        with (
+            patch("aragora.server.stream.SyncEventEmitter", return_value=MagicMock()),
+            patch("aragora.server.debate_factory.DebateFactory", return_value=MagicMock()),
+            patch("aragora.server.debate_controller.DebateController") as mock_controller_cls,
+        ):
+            mock_controller = mock_controller_cls.return_value
+            mock_response = MagicMock()
+            mock_response.success = True
+            mock_response.debate_id = "debate_quick_123"
+            mock_response.error = None
+            mock_response.status_code = 200
+            mock_controller.start_debate.return_value = mock_response
+
+            result = await handler.handle(
+                "/api/v1/onboarding/quick-debate",
+                method="POST",
+                data={"profile": "developer", "topic": "Quick debate topic"},
+                user_id="test-user-001",
+            )
+
+        assert _status(result) == 200
+        with _analytics_lock:
+            event = next(e for e in _analytics_events if e["event_type"] == "quick_debate_started")
+            assert event["data"]["flow_id"] == "onb_repo_123"
+
 
 # ============================================================================
 # GET /api/v1/onboarding/analytics

--- a/tests/test_debate_controller.py
+++ b/tests/test_debate_controller.py
@@ -801,6 +801,53 @@ class TestDebateControllerRunDebate:
         assert payload["debate_id"] == "test_123"
         assert payload["receipt_id"]
 
+    @patch("aragora.server.handlers.onboarding._track_event")
+    @patch("aragora.storage.repositories.onboarding.get_onboarding_repository")
+    @patch("aragora.storage.receipt_store.get_receipt_store")
+    @patch("aragora.server.debate_controller.update_debate_status")
+    def test_run_debate_tracks_onboarding_receipt_event_when_repo_update_fails(
+        self,
+        mock_update,
+        mock_get_receipt_store,
+        mock_get_onboarding_repo,
+        mock_track_event,
+    ):
+        """Receipt analytics should still be emitted if the repo update path fails."""
+        from aragora.server.debate_factory import DebateConfig
+
+        mock_store = Mock()
+        mock_get_receipt_store.return_value = mock_store
+
+        onboarding_repo = Mock()
+        onboarding_repo.get_flow.return_value = {"id": "onb_flow_1", "metadata": {}}
+        onboarding_repo.update_flow.side_effect = OSError("database locked")
+        mock_get_onboarding_repo.return_value = onboarding_repo
+
+        controller = DebateController(factory=self.factory, emitter=self.emitter)
+        config = DebateConfig(
+            question="Should we adopt this architecture?",
+            agents_str="agent1",
+            rounds=1,
+            debate_id="test_123",
+            metadata={
+                "is_onboarding": True,
+                "user_id": "user_1",
+                "organization_id": "org_1",
+                "flow_id": "flow_fallback",
+            },
+        )
+
+        controller._run_debate(config, "test_123")
+
+        mock_track_event.assert_called_once()
+        event_type, user_id, org_id, payload = mock_track_event.call_args[0]
+        assert event_type == "first_receipt_generated"
+        assert user_id == "user_1"
+        assert org_id == "org_1"
+        assert payload["flow_id"] == "onb_flow_1"
+        assert payload["debate_id"] == "test_123"
+        assert payload["receipt_id"]
+
     @patch("aragora.server.debate_controller.update_debate_status")
     def test_run_debate_handles_validation_error(self, mock_update):
         """Should handle ValueError gracefully."""


### PR DESCRIPTION
## Summary
- keep `first_receipt_generated` analytics events even when onboarding repo metadata updates fail
- recover onboarding `flow_id` for quick debates from the persistent repo when the in-memory cache is cold
- add regression tests for both paths

## Validation
- pytest -q tests/test_debate_controller.py
- pytest -q tests/handlers/test_onboarding.py