### PR TITLE
fix(ci): wire setup-python fallback guards

### DIFF
--- a/.github/workflows/self-improve-hard-checks.yml
+++ b/.github/workflows/self-improve-hard-checks.yml
@@ -67,6 +67,7 @@ jobs:
           fi
 
       - name: Set up Python
+        id: setup-python
         uses: ./.github/actions/setup-python-safe
         with:
           python-version: "3.11"
@@ -173,6 +174,7 @@ jobs:
           fi
 
       - name: Set up Python
+        id: setup-python
         uses: ./.github/actions/setup-python-safe
         with:
           python-version: "3.11"


### PR DESCRIPTION
## Summary
- add missing `id: setup-python` to both setup-python-safe steps in self-improve-hard-checks
- make the existing fallback condition `steps.setup-python.outcome == failure` actually resolvable

## Validation
- pre-commit hooks
- YAML parse of `.github/workflows/self-improve-hard-checks.yml`