### PR TITLE
feat(pipeline): ExecutionAttemptRecord and deliberation bundle (CLB-005, CLB-006, CLB-007)

### DIFF
--- a/aragora/pipeline/backbone_contracts.py
+++ b/aragora/pipeline/backbone_contracts.py
@@ -398,6 +398,69 @@ class DeliberationBundle:
 
 
 @dataclass
+class ExecutionAttemptRecord:
+    """Stable handoff artifact for a single execution attempt.
+
+    Normalizes outputs from plan execution and task execution into a compatible
+    shape so that receipt generation, outcome feedback, and verification replay
+    can consume results without depending on specific executor internals.
+    """
+
+    attempt_id: str
+    plan_id: str = ""
+    status: str = "unknown"  # "succeeded", "failed", "blocked", "unknown"
+    tests_passed: int = 0
+    tests_failed: int = 0
+    files_changed: int = 0
+    diff_summary: str = ""
+    artifacts: list[str] = field(default_factory=list)
+    policy_decision: dict[str, Any] = field(default_factory=dict)
+    taint_flags: list[str] = field(default_factory=list)
+    duration_s: float = 0.0
+    error_message: str = ""
+    extras: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_plan_outcome(
+        cls,
+        outcome: Any,
+        *,
+        attempt_id: str,
+        plan_id: str = "",
+        policy_decision: dict[str, Any] | None = None,
+        taint_flags: list[str] | None = None,
+        artifacts: list[str] | None = None,
+        diff_summary: str = "",
+    ) -> ExecutionAttemptRecord:
+        """Normalize a PipelineOutcome (or duck-typed equivalent) into a stable attempt record."""
+        succeeded = bool(getattr(outcome, "execution_succeeded", False))
+        status = "succeeded" if succeeded else "failed"
+
+        return cls(
+            attempt_id=attempt_id,
+            plan_id=plan_id or str(getattr(outcome, "pipeline_id", "") or ""),
+            status=status,
+            tests_passed=int(getattr(outcome, "tests_passed", 0) or 0),
+            tests_failed=int(getattr(outcome, "tests_failed", 0) or 0),
+            files_changed=int(getattr(outcome, "files_changed", 0) or 0),
+            diff_summary=diff_summary,
+            artifacts=list(artifacts or []),
+            policy_decision=dict(policy_decision or {}),
+            taint_flags=list(taint_flags or []),
+            duration_s=float(getattr(outcome, "total_duration_s", 0.0) or 0.0),
+            error_message=str(getattr(outcome, "error_message", "") or ""),
+            extras={
+                "run_type": str(getattr(outcome, "run_type", "") or ""),
+                "domain": str(getattr(outcome, "domain", "") or ""),
+                "spec_completeness": float(getattr(outcome, "spec_completeness", 0.0) or 0.0),
+            },
+        )
+
+
+@dataclass
 class OutcomeFeedbackRecord:
     receipt_ref: str
     pipeline_id: str

--- a/tests/pipeline/test_backbone_contracts.py
+++ b/tests/pipeline/test_backbone_contracts.py
@@ -4,6 +4,7 @@ from aragora.interrogation.crystallizer import CrystallizedSpec, MoSCoWItem
 from aragora.interrogation.engine import InterrogationResult, PrioritizedQuestion
 from aragora.pipeline.backbone_contracts import (
     DeliberationBundle,
+    ExecutionAttemptRecord,
     IntakeBundle,
     OutcomeFeedbackRecord,
     ReceiptEnvelope,
@@ -265,3 +266,79 @@ def test_outcome_feedback_record_from_pipeline_outcome_derives_next_action() -> 
     assert record.objective_fidelity == outcome.overall_quality_score
     assert record.execution_outcome["tests_failed"] == 2
     assert record.next_action_recommendation == "run_bug_fix_loop"
+
+
+def test_execution_attempt_record_from_plan_outcome_captures_stable_shape() -> None:
+    outcome = PipelineOutcome(
+        pipeline_id="pipe-002",
+        run_type="automated",
+        domain="infrastructure",
+        spec_completeness=0.9,
+        execution_succeeded=True,
+        tests_passed=10,
+        tests_failed=0,
+        files_changed=3,
+        total_duration_s=18.5,
+    )
+
+    record = ExecutionAttemptRecord.from_plan_outcome(
+        outcome,
+        attempt_id="attempt-001",
+        plan_id="plan-abc",
+        policy_decision={"allowed": True, "reason": "within budget"},
+        taint_flags=["external_dependency"],
+        artifacts=["dist/output.tar.gz", "reports/test-results.xml"],
+        diff_summary="3 files changed, 42 insertions, 5 deletions",
+    )
+
+    assert record.attempt_id == "attempt-001"
+    assert record.plan_id == "plan-abc"
+    assert record.status == "succeeded"
+    assert record.tests_passed == 10
+    assert record.tests_failed == 0
+    assert record.files_changed == 3
+    assert record.policy_decision == {"allowed": True, "reason": "within budget"}
+    assert record.taint_flags == ["external_dependency"]
+    assert record.artifacts == ["dist/output.tar.gz", "reports/test-results.xml"]
+    assert record.diff_summary == "3 files changed, 42 insertions, 5 deletions"
+
+
+def test_execution_attempt_record_from_plan_outcome_failed_sets_status_failed() -> None:
+    outcome = PipelineOutcome(
+        pipeline_id="pipe-003",
+        run_type="automated",
+        domain="backend",
+        spec_completeness=0.5,
+        execution_succeeded=False,
+        tests_passed=2,
+        tests_failed=5,
+        files_changed=1,
+        total_duration_s=5.0,
+    )
+
+    record = ExecutionAttemptRecord.from_plan_outcome(outcome, attempt_id="attempt-002")
+
+    assert record.status == "failed"
+    assert record.tests_failed == 5
+
+
+def test_execution_attempt_record_to_dict_is_serializable() -> None:
+    outcome = PipelineOutcome(
+        pipeline_id="pipe-004",
+        run_type="manual",
+        domain="frontend",
+        execution_succeeded=True,
+        tests_passed=5,
+        tests_failed=0,
+        files_changed=2,
+        total_duration_s=8.0,
+    )
+
+    record = ExecutionAttemptRecord.from_plan_outcome(outcome, attempt_id="a3")
+    d = record.to_dict()
+
+    assert isinstance(d, dict)
+    assert d["attempt_id"] == "a3"
+    assert d["status"] == "succeeded"
+    assert "policy_decision" in d
+    assert "artifacts" in d


### PR DESCRIPTION
## Summary
Three closed-loop backbone artifacts in `backbone_contracts.py`:

- **CLB-006**: `DeliberationBundle` — normalizes `DebateResult` outputs preserving provenance, unresolved risks (debate cruxes), and agent diversity scores across stage boundaries
- **CLB-005**: Quality gate in `DecisionPlanFactory.from_debate_result()` — stores deliberation bundle in plan metadata, halts `ApprovalMode.NEVER` when `quality_verdict == "failed"`, accepts explicit bundle parameter
- **CLB-007**: `ExecutionAttemptRecord` — normalizes execution attempt artifacts (status, tests, artifacts, diff, policy decisions) into a stable shape compatible across plan and task execution paths

## Closes
Closes #688 (CLB-006)
Closes #687 (CLB-005)
Closes #689 (CLB-007)

## Test plan
- [x] 8 deliberation bundle tests in `test_backbone_contracts.py`
- [x] 3 execution attempt record tests in `test_backbone_contracts.py`
- [x] 5 quality gate tests in `test_decision_plan.py`
- [x] 1512 pipeline tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)