### PR TITLE
feat(coordination): add fleet integration worker

### DIFF
--- a/aragora/cli/commands/worktree.py
+++ b/aragora/cli/commands/worktree.py
@@ -23,6 +23,8 @@ from pathlib import Path
 
 from aragora.worktree import (
     AutopilotRequest,
+    FleetIntegrationWorker,
+    FleetIntegrationWorkerConfig,
     resolve_repo_root,
     run_autopilot,
 )
@@ -154,6 +156,32 @@ Workflow:
     queue_list_p.add_argument("--status", default="", help="Filter by queue status")
     queue_list_p.add_argument("--json", action="store_true", help="Emit JSON output")
 
+    queue_process_p = wt_sub.add_parser(
+        "fleet-queue-process-next",
+        help="Validate or integrate the next merge queue item",
+    )
+    queue_process_p.add_argument(
+        "--worker-session-id",
+        required=True,
+        help="Integrator worker session ID",
+    )
+    queue_process_p.add_argument(
+        "--target-branch",
+        default="main",
+        help="Target branch to validate/merge into (default: main)",
+    )
+    queue_process_p.add_argument(
+        "--execute",
+        action="store_true",
+        help="Attempt the actual merge after validation",
+    )
+    queue_process_p.add_argument(
+        "--test-gate",
+        action="store_true",
+        help="Use BranchCoordinator's test-gated merge path when executing",
+    )
+    queue_process_p.add_argument("--json", action="store_true", help="Emit JSON output")
+
     # autopilot
     auto_p = wt_sub.add_parser(
         "autopilot",
@@ -220,7 +248,7 @@ def cmd_worktree(args: argparse.Namespace) -> None:
     if not action:
         print(
             "Usage: aragora worktree "
-            "{create|list|merge|merge-all|conflicts|cleanup|fleet-status|fleet-claims|fleet-claim|fleet-release|fleet-queue-add|fleet-queue-list|autopilot}"
+            "{create|list|merge|merge-all|conflicts|cleanup|fleet-status|fleet-claims|fleet-claim|fleet-release|fleet-queue-add|fleet-queue-list|fleet-queue-process-next|autopilot}"
         )
         print("Run 'aragora worktree --help' for details.")
         return
@@ -250,6 +278,9 @@ def cmd_worktree(args: argparse.Namespace) -> None:
         return
     if action == "fleet-queue-list":
         _cmd_worktree_fleet_queue_list(args, repo_path=repo_root)
+        return
+    if action == "fleet-queue-process-next":
+        _cmd_worktree_fleet_queue_process_next(args, repo_path=repo_root)
         return
 
     from aragora.nomic.branch_coordinator import (
@@ -574,6 +605,38 @@ def _cmd_worktree_fleet_queue_list(args: argparse.Namespace, *, repo_path: Path)
             f"p{item.get('priority', 0)} {item.get('branch', '')} "
             f"(session={item.get('session_id', '')})"
         )
+
+
+def _cmd_worktree_fleet_queue_process_next(args: argparse.Namespace, *, repo_path: Path) -> None:
+    """Process the next queued merge item with the fleet integration worker."""
+    worker = FleetIntegrationWorker(
+        repo_path=repo_path,
+        config=FleetIntegrationWorkerConfig(
+            target_branch=str(getattr(args, "target_branch", "main")),
+            execute_with_test_gate=bool(getattr(args, "test_gate", False)),
+        ),
+    )
+    outcome = asyncio.run(
+        worker.process_next(
+            worker_session_id=str(args.worker_session_id),
+            execute=bool(getattr(args, "execute", False)),
+        )
+    )
+    payload = outcome.to_dict()
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return
+    branch = payload.get("branch") or "(none)"
+    item_id = payload.get("queue_item_id") or "-"
+    print(
+        f"{payload.get('action', 'processed')}: {branch} [{item_id}] "
+        f"status={payload.get('queue_status', '')}"
+    )
+    if payload.get("error"):
+        print(f"  error: {payload['error']}")
+    conflicts = payload.get("conflicts") or []
+    if conflicts:
+        print(f"  conflicts({len(conflicts)}): {', '.join(str(item) for item in conflicts)}")
 
 
 def _cmd_worktree_autopilot(args: argparse.Namespace, *, repo_path: Path, base_branch: str) -> None:

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -11,6 +11,7 @@ Provides REST API endpoints for:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,10 @@ from aragora.worktree.fleet import (
     FleetCoordinationStore,
     build_fleet_rows,
     resolve_repo_root,
+)
+from aragora.worktree.integration_worker import (
+    FleetIntegrationWorker,
+    FleetIntegrationWorkerConfig,
 )
 
 logger = logging.getLogger(__name__)
@@ -761,6 +766,39 @@ class CoordinationHandlerMixin:
         )
         status_code = 200 if result.get("duplicate") else 201
         return json_response(result, status=status_code)
+
+    @api_endpoint(
+        method="POST",
+        path="/api/v1/coordination/fleet/merge-queue/process-next",
+        summary="Validate or integrate the next merge queue item",
+        tags=["Coordination"],
+    )
+    @require_permission("coordination:workspaces.write")
+    def _handle_fleet_merge_process_next(self, body: dict[str, Any]) -> HandlerResult:
+        """Process one queued merge item using the fleet integration worker."""
+        worker_session_id = str(body.get("worker_session_id", "")).strip()
+        if not worker_session_id:
+            return error_response("worker_session_id is required", 400)
+
+        repo_root = self._fleet_repo_root()
+        target_branch = str(body.get("target_branch", "main")).strip() or "main"
+        execute = bool(body.get("execute", False))
+        test_gate = bool(body.get("test_gate", False))
+
+        worker = FleetIntegrationWorker(
+            repo_path=repo_root,
+            config=FleetIntegrationWorkerConfig(
+                target_branch=target_branch,
+                execute_with_test_gate=test_gate,
+            ),
+        )
+        outcome = asyncio.run(
+            worker.process_next(
+                worker_session_id=worker_session_id,
+                execute=execute,
+            )
+        )
+        return json_response(outcome.to_dict())
 
 
 __all__ = ["CoordinationHandlerMixin"]

--- a/aragora/worktree/__init__.py
+++ b/aragora/worktree/__init__.py
@@ -18,6 +18,11 @@ from aragora.worktree.fleet import (
     build_fleet_rows,
     infer_orchestration_pattern,
 )
+from aragora.worktree.integration_worker import (
+    FleetIntegrationOutcome,
+    FleetIntegrationWorker,
+    FleetIntegrationWorkerConfig,
+)
 
 __all__ = [
     "AUTOPILOT_ACTIONS",
@@ -32,4 +37,7 @@ __all__ = [
     "FleetCoordinationStore",
     "build_fleet_rows",
     "infer_orchestration_pattern",
+    "FleetIntegrationOutcome",
+    "FleetIntegrationWorker",
+    "FleetIntegrationWorkerConfig",
 ]

--- a/aragora/worktree/integration_worker.py
+++ b/aragora/worktree/integration_worker.py
@@ -1,0 +1,273 @@
+"""Fleet merge-queue worker backed by existing merge engines.
+
+The worker turns FleetCoordinationStore's merge queue into an actual
+integration lane. It does not invent a new merge implementation; instead it:
+
+- claims queued work via FleetCoordinationStore
+- validates mergeability using GitReconciler + BranchCoordinator dry-runs
+- optionally performs the merge via BranchCoordinator
+- persists queue lifecycle state back to FleetCoordinationStore
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from aragora.coordination.reconciler import GitReconciler
+from aragora.nomic.branch_coordinator import (
+    BranchCoordinator,
+    BranchCoordinatorConfig,
+)
+from aragora.worktree.fleet import FleetCoordinationStore
+
+
+@dataclass
+class FleetIntegrationWorkerConfig:
+    """Configuration for processing fleet merge queue items."""
+
+    target_branch: str = "main"
+    execute_with_test_gate: bool = False
+
+
+@dataclass
+class FleetIntegrationOutcome:
+    """Result of processing one fleet merge queue item."""
+
+    queue_item_id: str | None
+    branch: str | None
+    queue_status: str
+    action: str
+    dry_run_success: bool = False
+    merge_commit_sha: str | None = None
+    conflicts: list[str] = field(default_factory=list)
+    conflict_details: list[dict[str, Any]] = field(default_factory=list)
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "queue_item_id": self.queue_item_id,
+            "branch": self.branch,
+            "queue_status": self.queue_status,
+            "action": self.action,
+            "dry_run_success": self.dry_run_success,
+            "merge_commit_sha": self.merge_commit_sha,
+            "conflicts": list(self.conflicts),
+            "conflict_details": [dict(item) for item in self.conflict_details],
+            "error": self.error,
+            "metadata": dict(self.metadata),
+        }
+
+
+class FleetIntegrationWorker:
+    """Process FleetCoordinationStore merge queue items."""
+
+    def __init__(
+        self,
+        repo_path: Path | None = None,
+        *,
+        config: FleetIntegrationWorkerConfig | None = None,
+        fleet_store: FleetCoordinationStore | None = None,
+        branch_coordinator: BranchCoordinator | None = None,
+        reconciler: GitReconciler | None = None,
+    ) -> None:
+        self.repo_path = (repo_path or Path.cwd()).resolve()
+        self.config = config or FleetIntegrationWorkerConfig()
+        self.fleet_store = fleet_store or FleetCoordinationStore(self.repo_path)
+        self.branch_coordinator = branch_coordinator or BranchCoordinator(
+            repo_path=self.repo_path,
+            config=BranchCoordinatorConfig(
+                base_branch=self.config.target_branch,
+                use_worktrees=True,
+            ),
+        )
+        self.reconciler = reconciler or GitReconciler(repo_path=self.repo_path)
+
+    @staticmethod
+    def _is_checkout_constraint(error: str | None) -> bool:
+        """Return True when merge execution is blocked by target checkout ownership."""
+        if not error:
+            return False
+        lowered = error.lower()
+        return "failed to checkout target branch" in lowered and "already checked out" in lowered
+
+    async def process_next(
+        self,
+        *,
+        worker_session_id: str,
+        execute: bool = False,
+    ) -> FleetIntegrationOutcome:
+        """Claim and process the next queued merge item."""
+        item = self.fleet_store.claim_next_merge(
+            worker_session_id=worker_session_id,
+            from_status="queued",
+            to_status="validating",
+        )
+        if item is None:
+            return FleetIntegrationOutcome(
+                queue_item_id=None,
+                branch=None,
+                queue_status="idle",
+                action="no_work",
+            )
+
+        item_id = str(item.get("id", ""))
+        branch = str(item.get("branch", ""))
+        metadata = dict(item.get("metadata") or {})
+        changed_files = self.reconciler.get_changed_files(branch, self.config.target_branch)
+        commits_ahead = self.reconciler.get_commits_ahead(branch, self.config.target_branch)
+
+        conflict_infos = self.reconciler.detect_conflicts(branch, self.config.target_branch)
+        conflict_details = [
+            {
+                "file_path": info.file_path,
+                "category": info.category.value,
+                "description": info.description,
+                "auto_resolvable": info.auto_resolvable,
+            }
+            for info in conflict_infos
+        ]
+
+        validation_metadata = {
+            **metadata,
+            "validated_by": worker_session_id,
+            "reconciler_conflicts": conflict_details,
+            "changed_files": changed_files,
+            "commits_ahead": commits_ahead,
+        }
+
+        if conflict_details:
+            updated = self.fleet_store.update_merge_queue_item(
+                item_id=item_id,
+                status="blocked",
+                metadata=validation_metadata | {"validation_error": "merge conflicts detected"},
+            )
+            return FleetIntegrationOutcome(
+                queue_item_id=item_id,
+                branch=branch,
+                queue_status=str(updated.get("status", "blocked")),
+                action="blocked",
+                dry_run_success=False,
+                conflicts=[detail["file_path"] for detail in conflict_details],
+                conflict_details=conflict_details,
+                error="merge conflicts detected",
+                metadata=dict(updated.get("metadata") or {}),
+            )
+
+        dry_run = await self.branch_coordinator.safe_merge(
+            branch,
+            self.config.target_branch,
+            dry_run=True,
+        )
+        validation_metadata |= {
+            "dry_run_success": dry_run.success,
+            "dry_run_conflicts": list(dry_run.conflicts),
+        }
+
+        if not dry_run.success:
+            status = "needs_human" if self._is_checkout_constraint(dry_run.error) else "blocked"
+            action = "needs_human" if status == "needs_human" else "blocked"
+            updated = self.fleet_store.update_merge_queue_item(
+                item_id=item_id,
+                status=status,
+                metadata=validation_metadata
+                | {"validation_error": dry_run.error or "dry-run merge failed"},
+            )
+            return FleetIntegrationOutcome(
+                queue_item_id=item_id,
+                branch=branch,
+                queue_status=str(updated.get("status", status)),
+                action=action,
+                dry_run_success=False,
+                conflicts=list(dry_run.conflicts),
+                error=dry_run.error,
+                metadata=dict(updated.get("metadata") or {}),
+            )
+
+        if not execute:
+            updated = self.fleet_store.update_merge_queue_item(
+                item_id=item_id,
+                status="needs_human",
+                metadata=validation_metadata | {"validated_only": True},
+            )
+            return FleetIntegrationOutcome(
+                queue_item_id=item_id,
+                branch=branch,
+                queue_status=str(updated.get("status", "needs_human")),
+                action="validated",
+                dry_run_success=True,
+                metadata=dict(updated.get("metadata") or {}),
+            )
+
+        self.fleet_store.update_merge_queue_item(
+            item_id=item_id,
+            status="integrating",
+            metadata=validation_metadata | {"executed_by": worker_session_id},
+        )
+
+        if self.config.execute_with_test_gate:
+            merge_result = await self.branch_coordinator.safe_merge_with_gate(
+                branch,
+                target=self.config.target_branch,
+            )
+        else:
+            merge_result = await self.branch_coordinator.safe_merge(
+                branch,
+                self.config.target_branch,
+                dry_run=False,
+            )
+
+        if merge_result.success:
+            updated = self.fleet_store.update_merge_queue_item(
+                item_id=item_id,
+                status="merged",
+                metadata=validation_metadata
+                | {
+                    "executed_by": worker_session_id,
+                    "merge_commit_sha": merge_result.commit_sha,
+                },
+            )
+            return FleetIntegrationOutcome(
+                queue_item_id=item_id,
+                branch=branch,
+                queue_status=str(updated.get("status", "merged")),
+                action="merged",
+                dry_run_success=True,
+                merge_commit_sha=merge_result.commit_sha,
+                metadata=dict(updated.get("metadata") or {}),
+            )
+
+        fail_status = (
+            "needs_human"
+            if self._is_checkout_constraint(merge_result.error)
+            else ("blocked" if merge_result.conflicts else "failed")
+        )
+        updated = self.fleet_store.update_merge_queue_item(
+            item_id=item_id,
+            status=fail_status,
+            metadata=validation_metadata
+            | {
+                "executed_by": worker_session_id,
+                "merge_error": merge_result.error,
+                "merge_conflicts": list(merge_result.conflicts),
+            },
+        )
+        return FleetIntegrationOutcome(
+            queue_item_id=item_id,
+            branch=branch,
+            queue_status=str(updated.get("status", fail_status)),
+            action="needs_human" if fail_status == "needs_human" else "failed",
+            dry_run_success=True,
+            conflicts=list(merge_result.conflicts),
+            error=merge_result.error,
+            metadata=dict(updated.get("metadata") or {}),
+        )
+
+
+__all__ = [
+    "FleetIntegrationOutcome",
+    "FleetIntegrationWorker",
+    "FleetIntegrationWorkerConfig",
+]

--- a/tests/cli/test_worktree_command.py
+++ b/tests/cli/test_worktree_command.py
@@ -5,18 +5,20 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.cli.commands.worktree import (
     _cmd_worktree_fleet_claim,
     _cmd_worktree_fleet_queue_add,
     _cmd_worktree_fleet_queue_list,
+    _cmd_worktree_fleet_queue_process_next,
     _cmd_worktree_fleet_release,
     _cmd_worktree_fleet_status,
     _cmd_worktree_autopilot,
     add_worktree_parser,
     cmd_worktree,
 )
+from aragora.worktree.integration_worker import FleetIntegrationOutcome
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -138,6 +140,27 @@ class TestWorktreeParser:
         assert args.session_id == "s-1"
         assert args.paths == ["a.py", "b.py"]
         assert args.mode == "shared"
+
+    def test_fleet_queue_process_next_parse(self):
+        args = _parser().parse_args(
+            [
+                "worktree",
+                "fleet-queue-process-next",
+                "--worker-session-id",
+                "integrator-1",
+                "--target-branch",
+                "release",
+                "--execute",
+                "--test-gate",
+                "--json",
+            ]
+        )
+        assert args.wt_action == "fleet-queue-process-next"
+        assert args.worker_session_id == "integrator-1"
+        assert args.target_branch == "release"
+        assert args.execute is True
+        assert args.test_gate is True
+        assert args.json is True
 
 
 class TestWorktreeDispatch:
@@ -392,3 +415,28 @@ class TestWorktreeFleetOwnership:
         _cmd_worktree_fleet_queue_list(list_args, repo_path=tmp_path)
         out = capsys.readouterr().out
         assert "Merge queue: 1" in out
+
+    @patch("aragora.cli.commands.worktree.FleetIntegrationWorker")
+    def test_fleet_queue_process_next_cli(self, mock_worker_cls, capsys, tmp_path: Path):
+        worker = MagicMock()
+        worker.process_next = AsyncMock(
+            return_value=FleetIntegrationOutcome(
+                queue_item_id="mq-1",
+                branch="codex/x",
+                queue_status="needs_human",
+                action="validated",
+                dry_run_success=True,
+            )
+        )
+        mock_worker_cls.return_value = worker
+
+        args = argparse.Namespace(
+            worker_session_id="integrator-1",
+            target_branch="main",
+            execute=False,
+            test_gate=False,
+            json=False,
+        )
+        _cmd_worktree_fleet_queue_process_next(args, repo_path=tmp_path)
+        out = capsys.readouterr().out
+        assert "validated: codex/x [mq-1] status=needs_human" in out

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -21,6 +21,7 @@ from aragora.coordination.cross_workspace import (
     SharingScope,
 )
 from aragora.server.handlers.control_plane import ControlPlaneHandler
+from aragora.worktree.integration_worker import FleetIntegrationOutcome
 
 
 # ============================================================================
@@ -494,6 +495,44 @@ class TestFleetStatus:
         assert listing.status_code == 200
         listing_data = json.loads(listing.body)
         assert listing_data["total"] == 1
+
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    @patch("aragora.server.handlers.control_plane.coordination.FleetIntegrationWorker")
+    def test_fleet_merge_process_next(
+        self, mock_worker_cls, mock_resolve, handler: ControlPlaneHandler
+    ):
+        mock_resolve.return_value = Path("/tmp/repo")
+        worker = MagicMock()
+        worker.process_next = AsyncMock(
+            return_value=FleetIntegrationOutcome(
+                queue_item_id="mq-1",
+                branch="codex/x",
+                queue_status="needs_human",
+                action="validated",
+                dry_run_success=True,
+            )
+        )
+        mock_worker_cls.return_value = worker
+
+        result = handler._handle_fleet_merge_process_next(
+            {
+                "worker_session_id": "integrator-1",
+                "target_branch": "main",
+                "execute": False,
+                "test_gate": False,
+            }
+        )
+
+        assert result.status_code == 200
+        data = json.loads(result.body)
+        assert data["queue_item_id"] == "mq-1"
+        assert data["action"] == "validated"
+
+    def test_fleet_merge_process_next_requires_worker_session_id(
+        self, handler: ControlPlaneHandler
+    ):
+        result = handler._handle_fleet_merge_process_next({})
+        assert result.status_code == 400
 
 
 # ============================================================================

--- a/tests/worktree/test_integration_worker.py
+++ b/tests/worktree/test_integration_worker.py
@@ -1,0 +1,204 @@
+"""Tests for the fleet integration worker."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aragora.coordination.reconciler import ConflictCategory, ConflictInfo
+from aragora.nomic.branch_coordinator import MergeResult
+from aragora.worktree.fleet import FleetCoordinationStore
+from aragora.worktree.integration_worker import FleetIntegrationWorker
+
+
+def _checkout_error() -> str:
+    return "Failed to checkout target branch main: 'main' is already checked out at /tmp/main"
+
+
+@pytest.mark.asyncio
+async def test_process_next_returns_idle_when_queue_empty(tmp_path: Path) -> None:
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=FleetCoordinationStore(tmp_path),
+        branch_coordinator=MagicMock(),
+        reconciler=MagicMock(),
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "no_work"
+    assert outcome.queue_status == "idle"
+
+
+@pytest.mark.asyncio
+async def test_process_next_blocks_on_reconciler_conflicts(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    queued = store.enqueue_merge(session_id="session-a", branch="codex/conflicted", priority=60)
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock()
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 2
+    reconciler.detect_conflicts.return_value = [
+        ConflictInfo(
+            file_path="aragora/x.py",
+            category=ConflictCategory.UNKNOWN,
+            auto_resolvable=False,
+            description="CONFLICT (content): Merge conflict in aragora/x.py",
+        )
+    ]
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "blocked"
+    assert outcome.queue_status == "blocked"
+    assert outcome.queue_item_id == queued["item"]["id"]
+    branch_coordinator.safe_merge.assert_not_called()
+    assert store.list_merge_queue()[0]["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_process_next_marks_checkout_constraint_needs_human(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.enqueue_merge(session_id="session-a", branch="codex/checkout-locked", priority=60)
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        return_value=MergeResult(
+            source_branch="codex/checkout-locked",
+            target_branch="main",
+            success=False,
+            error=_checkout_error(),
+        )
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 1
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "needs_human"
+    assert outcome.queue_status == "needs_human"
+    assert outcome.error == _checkout_error()
+    assert store.list_merge_queue()[0]["status"] == "needs_human"
+
+
+@pytest.mark.asyncio
+async def test_process_next_validates_without_execute(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.enqueue_merge(session_id="session-a", branch="codex/ready", priority=60)
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        return_value=MergeResult(
+            source_branch="codex/ready",
+            target_branch="main",
+            success=True,
+        )
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 3
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "validated"
+    assert outcome.queue_status == "needs_human"
+    assert outcome.dry_run_success is True
+    assert store.list_merge_queue()[0]["metadata"]["validated_only"] is True
+
+
+@pytest.mark.asyncio
+async def test_process_next_executes_merge_successfully(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.enqueue_merge(session_id="session-a", branch="codex/ready", priority=60)
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        side_effect=[
+            MergeResult(source_branch="codex/ready", target_branch="main", success=True),
+            MergeResult(
+                source_branch="codex/ready",
+                target_branch="main",
+                success=True,
+                commit_sha="abc123",
+            ),
+        ]
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 3
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1", execute=True)
+
+    assert outcome.action == "merged"
+    assert outcome.queue_status == "merged"
+    assert outcome.merge_commit_sha == "abc123"
+    assert store.list_merge_queue()[0]["metadata"]["merge_commit_sha"] == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_process_next_marks_execution_conflicts_blocked(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.enqueue_merge(session_id="session-a", branch="codex/ready", priority=60)
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        side_effect=[
+            MergeResult(source_branch="codex/ready", target_branch="main", success=True),
+            MergeResult(
+                source_branch="codex/ready",
+                target_branch="main",
+                success=False,
+                error="Merge failed",
+                conflicts=["aragora/x.py"],
+            ),
+        ]
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 3
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1", execute=True)
+
+    assert outcome.action == "failed"
+    assert outcome.queue_status == "blocked"
+    assert outcome.conflicts == ["aragora/x.py"]
+    assert store.list_merge_queue()[0]["status"] == "blocked"


### PR DESCRIPTION
## Summary
- add a real fleet integration worker that validates queued branches and optionally executes merges through the existing merge engines
- expose queue processing through the `aragora worktree` CLI and the fleet control-plane API
- treat target-branch checkout ownership as a `needs_human` coordination constraint instead of a false merge conflict

## Validation
- `ruff check aragora/worktree/integration_worker.py aragora/worktree/__init__.py aragora/cli/commands/worktree.py aragora/server/handlers/control_plane/coordination.py tests/worktree/test_integration_worker.py tests/cli/test_worktree_command.py tests/handlers/control_plane/test_coordination.py`
- `python -m pytest tests/worktree/test_integration_worker.py tests/cli/test_worktree_command.py tests/handlers/control_plane/test_coordination.py -q`
