### PR TITLE
fix(coordination): serialize lease and queue claims

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -502,7 +502,6 @@ class DevCoordinationStore:
         }
 
     def list_active_leases(self) -> list[WorkLease]:
-        self.reap_expired_leases()
         now = _utcnow()
         conn = self._connect()
         try:
@@ -681,44 +680,37 @@ class DevCoordinationStore:
         normalized_paths = [
             _normalize_claim(item) for item in claimed_paths or [] if str(item).strip()
         ]
-        conflicts = self.find_conflicting_leases(
-            allowed_globs=normalized_globs,
-            claimed_paths=normalized_paths,
-            owner_session_id=owner_session_id,
-        )
-        if conflicts and not allow_overlap:
-            self._publish(
-                "conflict_detected",
-                track=branch,
-                data={
-                    "task_id": task_id,
-                    "worktree_path": worktree_path,
-                    "conflicts": conflicts,
-                },
-            )
-            raise LeaseConflictError(conflicts)
-
+        self.reap_expired_leases()
         now = _utcnow()
-        lease = WorkLease(
-            lease_id=str(uuid.uuid4())[:12],
-            task_id=task_id,
-            title=title or task_id,
-            owner_agent=owner_agent,
-            owner_session_id=owner_session_id,
-            branch=branch,
-            worktree_path=str(Path(worktree_path).resolve()),
-            allowed_globs=normalized_globs,
-            claimed_paths=normalized_paths,
-            expected_tests=list(expected_tests or []),
-            status=LeaseStatus.ACTIVE.value,
-            created_at=now.isoformat(),
-            updated_at=now.isoformat(),
-            expires_at=(now + timedelta(hours=ttl_hours)).isoformat(),
-            metadata=dict(metadata or {}),
-        )
-
         conn = self._connect()
         try:
+            conn.execute("BEGIN IMMEDIATE")
+            conflicts = self._find_conflicting_leases_locked(
+                conn,
+                allowed_globs=normalized_globs,
+                claimed_paths=normalized_paths,
+                owner_session_id=owner_session_id,
+            )
+            if conflicts and not allow_overlap:
+                raise LeaseConflictError(conflicts)
+
+            lease = WorkLease(
+                lease_id=str(uuid.uuid4())[:12],
+                task_id=task_id,
+                title=title or task_id,
+                owner_agent=owner_agent,
+                owner_session_id=owner_session_id,
+                branch=branch,
+                worktree_path=str(Path(worktree_path).resolve()),
+                allowed_globs=normalized_globs,
+                claimed_paths=normalized_paths,
+                expected_tests=list(expected_tests or []),
+                status=LeaseStatus.ACTIVE.value,
+                created_at=now.isoformat(),
+                updated_at=now.isoformat(),
+                expires_at=(now + timedelta(hours=ttl_hours)).isoformat(),
+                metadata=dict(metadata or {}),
+            )
             conn.execute(
                 "INSERT INTO leases VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (
@@ -740,6 +732,18 @@ class DevCoordinationStore:
                 ),
             )
             conn.commit()
+        except LeaseConflictError:
+            conn.rollback()
+            self._publish(
+                "conflict_detected",
+                track=branch,
+                data={
+                    "task_id": task_id,
+                    "worktree_path": worktree_path,
+                    "conflicts": conflicts,
+                },
+            )
+            raise
         finally:
             conn.close()
 
@@ -764,6 +768,66 @@ class DevCoordinationStore:
                 mode="exclusive",
             )
         return lease
+
+    def _find_conflicting_leases_locked(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        allowed_globs: list[str],
+        claimed_paths: list[str],
+        owner_session_id: str | None = None,
+        exclude_lease_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        normalized_globs = [_normalize_claim(item) for item in allowed_globs if str(item).strip()]
+        normalized_paths = [_normalize_claim(item) for item in claimed_paths if str(item).strip()]
+        conflicts: list[dict[str, Any]] = []
+        now = _utcnow()
+        rows = conn.execute("SELECT * FROM leases ORDER BY created_at ASC").fetchall()
+        active_leases = [
+            lease
+            for lease in (WorkLease.from_row(row) for row in rows)
+            if lease.status == LeaseStatus.ACTIVE.value and _parse_dt(lease.expires_at) > now
+        ]
+        tracked_sessions = {lease.owner_session_id for lease in active_leases}
+        for lease in active_leases:
+            if exclude_lease_id and lease.lease_id == exclude_lease_id:
+                continue
+            if lease.overlaps(normalized_globs, normalized_paths):
+                conflicts.append(
+                    {
+                        "lease_id": lease.lease_id,
+                        "task_id": lease.task_id,
+                        "title": lease.title,
+                        "owner_agent": lease.owner_agent,
+                        "owner_session_id": lease.owner_session_id,
+                        "branch": lease.branch,
+                        "worktree_path": lease.worktree_path,
+                        "allowed_globs": lease.allowed_globs,
+                        "claimed_paths": lease.claimed_paths,
+                        "expires_at": lease.expires_at,
+                    }
+                )
+        for claim in self.fleet_store.list_claims():
+            session_id = str(claim.get("session_id", "")).strip()
+            if owner_session_id and session_id == owner_session_id:
+                continue
+            if session_id in tracked_sessions:
+                continue
+            path = _normalize_claim(str(claim.get("path", "")))
+            if not path:
+                continue
+            if not _claims_overlap([path], normalized_globs, normalized_paths):
+                continue
+            conflicts.append(
+                {
+                    "source": "fleet_claim",
+                    "session_id": session_id,
+                    "branch": str(claim.get("branch", "")),
+                    "path": path,
+                    "mode": str(claim.get("mode", "exclusive")),
+                }
+            )
+        return conflicts
 
     def heartbeat_lease(self, lease_id: str, ttl_hours: float | None = None) -> WorkLease:
         conn = self._connect()

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -12,6 +12,7 @@ Provides REST API endpoints for:
 from __future__ import annotations
 
 import logging
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -570,7 +571,7 @@ class CoordinationHandlerMixin:
             from aragora.nomic.dev_coordination import DevCoordinationStore
 
             coordination_summary = DevCoordinationStore(repo_root=repo_root).status_summary()
-        except (ImportError, RuntimeError, OSError, ValueError) as exc:
+        except (ImportError, RuntimeError, OSError, ValueError, sqlite3.Error) as exc:
             coordination_summary = {"error": str(exc), "counts": {}}
         claims_by_session: dict[str, list[str]] = {}
         for claim in claims:

--- a/aragora/worktree/fleet.py
+++ b/aragora/worktree/fleet.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import subprocess
@@ -273,6 +274,7 @@ class FleetCoordinationStore:
     def __init__(self, repo_root: Path):
         self.repo_root = resolve_repo_root(repo_root)
         self.path = self.repo_root / ".aragora" / "fleet_coordination.json"
+        self.lock_path = self.repo_root / ".aragora" / "fleet_coordination.lock"
 
     @staticmethod
     def _default_state() -> dict[str, Any]:
@@ -298,6 +300,18 @@ class FleetCoordinationStore:
         tmp_path = self.path.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
         tmp_path.replace(self.path)
+
+    def _mutate_state(self, mutator: Any) -> Any:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock_path.open("a+", encoding="utf-8") as lock_handle:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+            try:
+                state = self._load()
+                result = mutator(state)
+                self._save(state)
+                return result
+            finally:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
 
     def _normalize_claim_path(self, path_text: str) -> str:
         raw = path_text.strip()
@@ -333,85 +347,95 @@ class FleetCoordinationStore:
         if mode not in {"exclusive", "shared"}:
             raise ValueError("mode must be one of: exclusive, shared")
 
-        state = self._load()
-        claims = [c for c in state["claims"] if isinstance(c, dict)]
-        now = datetime.now(timezone.utc).isoformat()
-        normalized = [self._normalize_claim_path(path) for path in paths]
-        normalized = sorted({item for item in normalized if item})
+        def mutate(state: dict[str, Any]) -> dict[str, Any]:
+            claims = [c for c in state["claims"] if isinstance(c, dict)]
+            now = datetime.now(timezone.utc).isoformat()
+            normalized = [self._normalize_claim_path(path) for path in paths]
+            normalized = sorted({item for item in normalized if item})
 
-        conflicts: list[dict[str, str]] = []
-        claimed: list[str] = []
-        for path in normalized:
-            conflict_rows = [
-                c
-                for c in claims
-                if str(c.get("path", "")) == path
-                and str(c.get("session_id", "")) != session_id
-                and ("exclusive" in {str(c.get("mode", "exclusive")), mode})
-            ]
-            if conflict_rows:
-                for row in conflict_rows:
-                    conflicts.append(
-                        {
-                            "path": path,
-                            "session_id": str(row.get("session_id", "")),
-                            "branch": str(row.get("branch", "")),
-                        }
-                    )
-                continue
-
-            existing = next(
-                (
+            conflicts: list[dict[str, str]] = []
+            claimed: list[str] = []
+            for path in normalized:
+                conflict_rows = [
                     c
                     for c in claims
-                    if str(c.get("path", "")) == path and str(c.get("session_id", "")) == session_id
-                ),
-                None,
-            )
-            if existing is not None:
-                existing["updated_at"] = now
-                existing["mode"] = mode
-                if branch:
-                    existing["branch"] = branch
-            else:
-                claims.append(
-                    {
-                        "session_id": session_id,
-                        "path": path,
-                        "branch": branch or "",
-                        "mode": mode,
-                        "claimed_at": now,
-                        "updated_at": now,
-                    }
-                )
-            claimed.append(path)
+                    if str(c.get("path", "")) == path
+                    and str(c.get("session_id", "")) != session_id
+                    and ("exclusive" in {str(c.get("mode", "exclusive")), mode})
+                ]
+                if conflict_rows:
+                    for row in conflict_rows:
+                        conflicts.append(
+                            {
+                                "path": path,
+                                "session_id": str(row.get("session_id", "")),
+                                "branch": str(row.get("branch", "")),
+                            }
+                        )
+                    continue
 
-        state["claims"] = claims
-        self._save(state)
-        return {"session_id": session_id, "mode": mode, "claimed": claimed, "conflicts": conflicts}
+                existing = next(
+                    (
+                        c
+                        for c in claims
+                        if str(c.get("path", "")) == path
+                        and str(c.get("session_id", "")) == session_id
+                    ),
+                    None,
+                )
+                if existing is not None:
+                    existing["updated_at"] = now
+                    existing["mode"] = mode
+                    if branch:
+                        existing["branch"] = branch
+                else:
+                    claims.append(
+                        {
+                            "session_id": session_id,
+                            "path": path,
+                            "branch": branch or "",
+                            "mode": mode,
+                            "claimed_at": now,
+                            "updated_at": now,
+                        }
+                    )
+                claimed.append(path)
+
+            state["claims"] = claims
+            return {
+                "session_id": session_id,
+                "mode": mode,
+                "claimed": claimed,
+                "conflicts": conflicts,
+            }
+
+        return self._mutate_state(mutate)
 
     def release_paths(self, *, session_id: str, paths: list[str] | None = None) -> dict[str, Any]:
-        state = self._load()
-        claims = [c for c in state["claims"] if isinstance(c, dict)]
-        path_filter: set[str] | None = None
-        if paths:
-            normalized = [self._normalize_claim_path(path) for path in paths]
-            path_filter = {item for item in normalized if item}
+        def mutate(state: dict[str, Any]) -> dict[str, Any]:
+            claims = [c for c in state["claims"] if isinstance(c, dict)]
+            path_filter: set[str] | None = None
+            if paths:
+                normalized = [self._normalize_claim_path(path) for path in paths]
+                path_filter = {item for item in normalized if item}
 
-        kept: list[dict[str, Any]] = []
-        released = 0
-        for claim in claims:
-            owner = str(claim.get("session_id", ""))
-            path = str(claim.get("path", ""))
-            should_release = owner == session_id and (path_filter is None or path in path_filter)
-            if should_release:
-                released += 1
-                continue
-            kept.append(claim)
+            kept: list[dict[str, Any]] = []
+            released = 0
+            for claim in claims:
+                owner = str(claim.get("session_id", ""))
+                path = str(claim.get("path", ""))
+                should_release = owner == session_id and (
+                    path_filter is None or path in path_filter
+                )
+                if should_release:
+                    released += 1
+                    continue
+                kept.append(claim)
 
-        state["claims"] = kept
-        self._save(state)
-        return {"session_id": session_id, "released": released}
+            state["claims"] = kept
+            return {"session_id": session_id, "released": released}
+
+        return self._mutate_state(mutate)
 
     def enqueue_merge(
         self,
@@ -424,33 +448,35 @@ class FleetCoordinationStore:
     ) -> dict[str, Any]:
         if not branch.strip():
             raise ValueError("branch is required")
-        state = self._load()
-        queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
-        normalized_branch = branch.strip()
 
-        for item in queue:
-            if (
-                str(item.get("branch", "")) == normalized_branch
-                and str(item.get("status", "queued")) in ACTIVE_QUEUE_STATUSES
-            ):
-                return {"queued": False, "item": item, "duplicate": True}
+        def mutate(state: dict[str, Any]) -> dict[str, Any]:
+            queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
+            normalized_branch = branch.strip()
 
-        now = datetime.now(timezone.utc).isoformat()
-        row = {
-            "id": f"mq-{uuid.uuid4().hex[:12]}",
-            "session_id": session_id,
-            "branch": normalized_branch,
-            "priority": max(0, min(int(priority), 100)),
-            "title": title.strip(),
-            "status": "queued",
-            "created_at": now,
-            "updated_at": now,
-            "metadata": metadata or {},
-        }
-        queue.append(row)
-        state["merge_queue"] = queue
-        self._save(state)
-        return {"queued": True, "item": row, "duplicate": False}
+            for item in queue:
+                if (
+                    str(item.get("branch", "")) == normalized_branch
+                    and str(item.get("status", "queued")) in ACTIVE_QUEUE_STATUSES
+                ):
+                    return {"queued": False, "item": item, "duplicate": True}
+
+            now = datetime.now(timezone.utc).isoformat()
+            row = {
+                "id": f"mq-{uuid.uuid4().hex[:12]}",
+                "session_id": session_id,
+                "branch": normalized_branch,
+                "priority": max(0, min(int(priority), 100)),
+                "title": title.strip(),
+                "status": "queued",
+                "created_at": now,
+                "updated_at": now,
+                "metadata": metadata or {},
+            }
+            queue.append(row)
+            state["merge_queue"] = queue
+            return {"queued": True, "item": row, "duplicate": False}
+
+        return self._mutate_state(mutate)
 
     def claim_next_merge(
         self,
@@ -464,26 +490,36 @@ class FleetCoordinationStore:
         if to_status not in MERGE_QUEUE_ALLOWED_STATUSES:
             raise ValueError(f"unknown merge queue status: {to_status}")
 
-        state = self._load()
-        queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
-        candidates = [q for q in queue if str(q.get("status", "")) == from_status]
-        if not candidates:
-            return None
-        candidates.sort(
-            key=lambda row: (
-                -int(row.get("priority", 0)),
-                str(row.get("created_at", "")),
+        def mutate(state: dict[str, Any]) -> dict[str, Any] | None:
+            queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
+            candidates = [q for q in queue if str(q.get("status", "")) == from_status]
+            if not candidates:
+                return None
+            candidates.sort(
+                key=lambda row: (
+                    -int(row.get("priority", 0)),
+                    str(row.get("created_at", "")),
+                )
             )
-        )
-        chosen_id = str(candidates[0].get("id", ""))
-        if not chosen_id:
+            chosen_id = str(candidates[0].get("id", ""))
+            if not chosen_id:
+                return None
+            now = datetime.now(timezone.utc).isoformat()
+            for item in queue:
+                if str(item.get("id", "")) != chosen_id:
+                    continue
+                item["status"] = to_status
+                metadata_obj = item.get("metadata")
+                if not isinstance(metadata_obj, dict):
+                    metadata_obj = {}
+                metadata_obj["worker_session_id"] = worker_session_id
+                item["metadata"] = metadata_obj
+                item["updated_at"] = now
+                state["merge_queue"] = queue
+                return item
             return None
-        updated = self.update_merge_queue_item(
-            item_id=chosen_id,
-            status=to_status,
-            metadata={"worker_session_id": worker_session_id},
-        )
-        return updated
+
+        return self._mutate_state(mutate)
 
     def update_merge_queue_item(
         self,
@@ -492,31 +528,39 @@ class FleetCoordinationStore:
         status: str | None = None,
         metadata: dict[str, Any] | None = None,
         title: str | None = None,
+        expected_status: str | None = None,
     ) -> dict[str, Any]:
         if status is not None and status not in MERGE_QUEUE_ALLOWED_STATUSES:
             raise ValueError(f"unknown merge queue status: {status}")
+        if expected_status is not None and expected_status not in MERGE_QUEUE_ALLOWED_STATUSES:
+            raise ValueError(f"unknown merge queue status: {expected_status}")
 
-        state = self._load()
-        queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
-        now = datetime.now(timezone.utc).isoformat()
-        for item in queue:
-            if str(item.get("id", "")) != item_id:
-                continue
-            if status is not None:
-                item["status"] = status
-            if title is not None:
-                item["title"] = title.strip()
-            if metadata:
-                existing_metadata = item.get("metadata")
-                if not isinstance(existing_metadata, dict):
-                    existing_metadata = {}
-                existing_metadata.update(metadata)
-                item["metadata"] = existing_metadata
-            item["updated_at"] = now
-            state["merge_queue"] = queue
-            self._save(state)
-            return item
-        raise KeyError(f"Unknown merge queue item: {item_id}")
+        def mutate(state: dict[str, Any]) -> dict[str, Any]:
+            queue = [q for q in state["merge_queue"] if isinstance(q, dict)]
+            now = datetime.now(timezone.utc).isoformat()
+            for item in queue:
+                if str(item.get("id", "")) != item_id:
+                    continue
+                if expected_status is not None and str(item.get("status", "")) != expected_status:
+                    raise KeyError(
+                        f"Merge queue item {item_id} is no longer in status {expected_status}"
+                    )
+                if status is not None:
+                    item["status"] = status
+                if title is not None:
+                    item["title"] = title.strip()
+                if metadata:
+                    existing_metadata = item.get("metadata")
+                    if not isinstance(existing_metadata, dict):
+                        existing_metadata = {}
+                    existing_metadata.update(metadata)
+                    item["metadata"] = existing_metadata
+                item["updated_at"] = now
+                state["merge_queue"] = queue
+                return item
+            raise KeyError(f"Unknown merge queue item: {item_id}")
+
+        return self._mutate_state(mutate)
 
     def list_merge_queue(self, status: str | None = None) -> list[dict[str, Any]]:
         state = self._load()

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -399,6 +400,35 @@ class TestFleetStatus:
         assert data["total"] == 1
         assert data["worktrees"][0]["session_id"] == "session-a"
         assert data["worktrees"][0]["claimed_paths"] == ["aragora/x.py"]
+
+    @patch(
+        "aragora.nomic.dev_coordination.DevCoordinationStore.status_summary",
+        side_effect=sqlite3.OperationalError("database is locked"),
+    )
+    @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
+    @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    def test_fleet_status_handles_sqlite_coordination_error(
+        self,
+        mock_resolve,
+        mock_build,
+        mock_store_cls,
+        _mock_status_summary,
+        handler: ControlPlaneHandler,
+    ):
+        mock_resolve.return_value = Path(__file__).resolve().parents[3]
+        mock_build.return_value = []
+        store = MagicMock()
+        store.list_claims.return_value = []
+        store.list_merge_queue.return_value = []
+        mock_store_cls.return_value = store
+
+        result = handler._handle_fleet_status({})
+
+        assert result.status_code == 200
+        data = json.loads(result.body)
+        assert data["coordination"]["counts"] == {}
+        assert "database is locked" in data["coordination"]["error"]
 
     @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -255,6 +255,85 @@ def test_reap_expired_leases_releases_fleet_claims(store: DevCoordinationStore) 
     assert store.fleet_store.list_claims() == []
 
 
+def test_status_summary_does_not_reap_expired_leases(store: DevCoordinationStore) -> None:
+    lease = store.claim_lease(
+        task_id="clb-status-read",
+        title="Status read should be side-effect free",
+        owner_agent="codex",
+        owner_session_id="sess-status",
+        branch="codex/status",
+        worktree_path="/tmp/wt-status",
+        claimed_paths=["aragora/server/auth_checks.py"],
+        ttl_hours=2.0,
+    )
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE leases SET expires_at = ?, updated_at = ? WHERE lease_id = ?",
+            (
+                "2000-01-01T00:00:00+00:00",
+                "2000-01-01T00:00:00+00:00",
+                lease.lease_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    summary = store.status_summary()
+
+    assert summary["counts"]["active_leases"] == 0
+    assert summary["counts"]["fleet_claims"] == 1
+    claims = store.fleet_store.list_claims()
+    assert len(claims) == 1
+    assert claims[0]["session_id"] == "sess-status"
+
+
+def test_claim_lease_reaps_expired_claims_before_conflict_check(
+    store: DevCoordinationStore,
+) -> None:
+    lease = store.claim_lease(
+        task_id="clb-reclaim",
+        title="Original lease",
+        owner_agent="codex",
+        owner_session_id="sess-old",
+        branch="codex/old",
+        worktree_path="/tmp/wt-old",
+        claimed_paths=["aragora/server/auth_checks.py"],
+        ttl_hours=2.0,
+    )
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE leases SET expires_at = ?, updated_at = ? WHERE lease_id = ?",
+            (
+                "2000-01-01T00:00:00+00:00",
+                "2000-01-01T00:00:00+00:00",
+                lease.lease_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    replacement = store.claim_lease(
+        task_id="clb-reclaim-2",
+        title="Replacement lease",
+        owner_agent="claude",
+        owner_session_id="sess-new",
+        branch="codex/new",
+        worktree_path="/tmp/wt-new",
+        claimed_paths=["aragora/server/auth_checks.py"],
+    )
+
+    claims = store.fleet_store.list_claims()
+    assert replacement.is_active is True
+    assert len(claims) == 1
+    assert claims[0]["session_id"] == "sess-new"
+
+
 def test_scan_salvage_sources_finds_worktree_and_stash(
     repo: Path, store: DevCoordinationStore
 ) -> None:

--- a/tests/worktree/test_fleet.py
+++ b/tests/worktree/test_fleet.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from aragora.worktree.fleet import (
     FleetCoordinationStore,
     infer_orchestration_pattern,
@@ -85,3 +87,24 @@ def test_update_merge_queue_item_persists_status_and_metadata(tmp_path: Path) ->
     assert updated["metadata"]["receipt_id"] == "rcpt-1"
     listed = store.list_merge_queue()
     assert listed[0]["status"] == "integrating"
+
+
+def test_update_merge_queue_item_enforces_expected_status(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    queued = store.enqueue_merge(session_id="session-a", branch="codex/session-a", priority=50)
+    item_id = queued["item"]["id"]
+
+    store.update_merge_queue_item(
+        item_id=item_id,
+        status="validating",
+        expected_status="queued",
+        metadata={"worker_session_id": "integrator-1"},
+    )
+
+    with pytest.raises(KeyError):
+        store.update_merge_queue_item(
+            item_id=item_id,
+            status="integrating",
+            expected_status="queued",
+            metadata={"worker_session_id": "integrator-2"},
+        )


### PR DESCRIPTION
## Summary
- make lease acquisition transactional with sqlite `BEGIN IMMEDIATE`
- lock fleet coordination state mutations and keep fleet status reads side-effect free
- handle `sqlite3.Error` when rendering coordination fleet status

## Validation
- `ruff check aragora/nomic/dev_coordination.py aragora/worktree/fleet.py aragora/server/handlers/control_plane/coordination.py tests/nomic/test_dev_coordination.py tests/worktree/test_fleet.py tests/handlers/control_plane/test_coordination.py`
- `pytest -q tests/nomic/test_dev_coordination.py tests/worktree/test_fleet.py tests/handlers/control_plane/test_coordination.py`