### PR TITLE
feat(coordination): add dedicated integration target workspace

### DIFF
--- a/aragora/worktree/__init__.py
+++ b/aragora/worktree/__init__.py
@@ -23,6 +23,7 @@ from aragora.worktree.integration_worker import (
     FleetIntegrationWorker,
     FleetIntegrationWorkerConfig,
 )
+from aragora.worktree.integration_target_workspace import FleetIntegrationTargetWorkspace
 
 __all__ = [
     "AUTOPILOT_ACTIONS",
@@ -40,4 +41,5 @@ __all__ = [
     "FleetIntegrationOutcome",
     "FleetIntegrationWorker",
     "FleetIntegrationWorkerConfig",
+    "FleetIntegrationTargetWorkspace",
 ]

--- a/aragora/worktree/integration_target_workspace.py
+++ b/aragora/worktree/integration_target_workspace.py
@@ -1,0 +1,125 @@
+"""Dedicated integration target workspace for fleet merges."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from aragora.worktree.autopilot import resolve_repo_root
+
+
+def _sanitize_path_component(value: str) -> str:
+    """Normalize a path component for filesystem-safe branch directories."""
+    sanitized = value.replace("\\", "-").replace("/", "-").strip()
+    return sanitized or "default"
+
+
+@dataclass
+class FleetIntegrationTargetWorkspace:
+    """Manage a dedicated clone used for fleet merge validation/execution."""
+
+    repo_root: Path
+    target_branch: str = "main"
+    workspace_path: Path | None = None
+
+    def __post_init__(self) -> None:
+        self.repo_root = resolve_repo_root(self.repo_root)
+        if self.workspace_path is None:
+            self.workspace_path = (
+                self._git_common_dir()
+                / "aragora"
+                / "integration-targets"
+                / _sanitize_path_component(self.target_branch)
+            )
+
+    def _git_common_dir(self) -> Path:
+        result = self._run_git("rev-parse", "--git-common-dir")
+        common_dir = Path(result.stdout.strip())
+        if common_dir.is_absolute():
+            return common_dir.resolve()
+        return (self.repo_root / common_dir).resolve()
+
+    def _run_git(
+        self,
+        *args: str,
+        cwd: Path | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 -- fixed git command arguments
+            ["git", *args],
+            cwd=cwd or self.repo_root,
+            capture_output=True,
+            text=True,
+            check=check,
+        )
+
+    def _ensure_clone(self) -> None:
+        if self.workspace_path is None:
+            raise RuntimeError("integration workspace path is not configured")
+        if (self.workspace_path / ".git").exists():
+            return
+        self.workspace_path.parent.mkdir(parents=True, exist_ok=True)
+        self._run_git("clone", "--shared", str(self.repo_root), str(self.workspace_path))
+
+    def _ensure_identity(self) -> None:
+        if self.workspace_path is None:
+            raise RuntimeError("integration workspace path is not configured")
+
+        fallbacks = {
+            "user.name": "Aragora Fleet Integrator",
+            "user.email": "fleet@aragora.local",
+        }
+        for key, fallback in fallbacks.items():
+            clone_value = self._run_git(
+                "config", "--get", key, cwd=self.workspace_path, check=False
+            ).stdout.strip()
+            if clone_value:
+                continue
+
+            source_value = self._run_git("config", "--get", key, check=False).stdout.strip()
+            effective_value = source_value or fallback
+            self._run_git("config", key, effective_value, cwd=self.workspace_path)
+
+    def ensure_ready(self, source_branch: str) -> Path:
+        """Ensure the integration workspace is ready to validate a source branch."""
+        if self.workspace_path is None:
+            raise RuntimeError("integration workspace path is not configured")
+
+        self._ensure_clone()
+        self._run_git(
+            "remote",
+            "set-url",
+            "origin",
+            str(self.repo_root),
+            cwd=self.workspace_path,
+            check=False,
+        )
+        self._run_git("fetch", "origin", self.target_branch, cwd=self.workspace_path)
+        self._run_git(
+            "checkout",
+            "-B",
+            self.target_branch,
+            f"origin/{self.target_branch}",
+            cwd=self.workspace_path,
+        )
+        self._ensure_identity()
+
+        if source_branch != self.target_branch:
+            fetch_result = self._run_git(
+                "fetch",
+                "origin",
+                f"{source_branch}:{source_branch}",
+                cwd=self.workspace_path,
+                check=False,
+            )
+            if fetch_result.returncode != 0:
+                message = (fetch_result.stderr or fetch_result.stdout).strip()
+                raise RuntimeError(
+                    f"Failed to materialize source branch {source_branch}: {message}"
+                )
+
+        return self.workspace_path
+
+
+__all__ = ["FleetIntegrationTargetWorkspace"]

--- a/aragora/worktree/integration_worker.py
+++ b/aragora/worktree/integration_worker.py
@@ -21,6 +21,9 @@ from aragora.nomic.branch_coordinator import (
     BranchCoordinatorConfig,
 )
 from aragora.worktree.fleet import FleetCoordinationStore
+from aragora.worktree.integration_target_workspace import (
+    FleetIntegrationTargetWorkspace,
+)
 
 
 @dataclass
@@ -29,6 +32,8 @@ class FleetIntegrationWorkerConfig:
 
     target_branch: str = "main"
     execute_with_test_gate: bool = False
+    use_dedicated_integration_workspace: bool = True
+    integration_workspace_path: Path | None = None
 
 
 @dataclass
@@ -72,18 +77,14 @@ class FleetIntegrationWorker:
         fleet_store: FleetCoordinationStore | None = None,
         branch_coordinator: BranchCoordinator | None = None,
         reconciler: GitReconciler | None = None,
+        integration_workspace: FleetIntegrationTargetWorkspace | None = None,
     ) -> None:
         self.repo_path = (repo_path or Path.cwd()).resolve()
         self.config = config or FleetIntegrationWorkerConfig()
         self.fleet_store = fleet_store or FleetCoordinationStore(self.repo_path)
-        self.branch_coordinator = branch_coordinator or BranchCoordinator(
-            repo_path=self.repo_path,
-            config=BranchCoordinatorConfig(
-                base_branch=self.config.target_branch,
-                use_worktrees=True,
-            ),
-        )
-        self.reconciler = reconciler or GitReconciler(repo_path=self.repo_path)
+        self.branch_coordinator = branch_coordinator
+        self.reconciler = reconciler
+        self.integration_workspace = integration_workspace
 
     @staticmethod
     def _is_checkout_constraint(error: str | None) -> bool:
@@ -92,6 +93,34 @@ class FleetIntegrationWorker:
             return False
         lowered = error.lower()
         return "failed to checkout target branch" in lowered and "already checked out" in lowered
+
+    def _merge_engines(self, source_branch: str) -> tuple[BranchCoordinator, GitReconciler, Path]:
+        """Resolve merge engines, optionally via a dedicated integration workspace."""
+        if self.branch_coordinator is not None and self.reconciler is not None:
+            return self.branch_coordinator, self.reconciler, self.repo_path
+
+        engine_repo_path = self.repo_path
+        if self.config.use_dedicated_integration_workspace:
+            workspace = self.integration_workspace or FleetIntegrationTargetWorkspace(
+                repo_root=self.repo_path,
+                target_branch=self.config.target_branch,
+                workspace_path=self.config.integration_workspace_path,
+            )
+            self.integration_workspace = workspace
+            engine_repo_path = workspace.ensure_ready(source_branch=source_branch)
+
+        if self.branch_coordinator is None:
+            self.branch_coordinator = BranchCoordinator(
+                repo_path=engine_repo_path,
+                config=BranchCoordinatorConfig(
+                    base_branch=self.config.target_branch,
+                    use_worktrees=True,
+                ),
+            )
+        if self.reconciler is None:
+            self.reconciler = GitReconciler(repo_path=engine_repo_path)
+
+        return self.branch_coordinator, self.reconciler, engine_repo_path
 
     async def process_next(
         self,
@@ -116,10 +145,11 @@ class FleetIntegrationWorker:
         item_id = str(item.get("id", ""))
         branch = str(item.get("branch", ""))
         metadata = dict(item.get("metadata") or {})
-        changed_files = self.reconciler.get_changed_files(branch, self.config.target_branch)
-        commits_ahead = self.reconciler.get_commits_ahead(branch, self.config.target_branch)
+        branch_coordinator, reconciler, engine_repo_path = self._merge_engines(source_branch=branch)
+        changed_files = reconciler.get_changed_files(branch, self.config.target_branch)
+        commits_ahead = reconciler.get_commits_ahead(branch, self.config.target_branch)
 
-        conflict_infos = self.reconciler.detect_conflicts(branch, self.config.target_branch)
+        conflict_infos = reconciler.detect_conflicts(branch, self.config.target_branch)
         conflict_details = [
             {
                 "file_path": info.file_path,
@@ -136,6 +166,7 @@ class FleetIntegrationWorker:
             "reconciler_conflicts": conflict_details,
             "changed_files": changed_files,
             "commits_ahead": commits_ahead,
+            "integration_workspace_path": str(engine_repo_path),
         }
 
         if conflict_details:
@@ -156,7 +187,7 @@ class FleetIntegrationWorker:
                 metadata=dict(updated.get("metadata") or {}),
             )
 
-        dry_run = await self.branch_coordinator.safe_merge(
+        dry_run = await branch_coordinator.safe_merge(
             branch,
             self.config.target_branch,
             dry_run=True,
@@ -208,12 +239,12 @@ class FleetIntegrationWorker:
         )
 
         if self.config.execute_with_test_gate:
-            merge_result = await self.branch_coordinator.safe_merge_with_gate(
+            merge_result = await branch_coordinator.safe_merge_with_gate(
                 branch,
                 target=self.config.target_branch,
             )
         else:
-            merge_result = await self.branch_coordinator.safe_merge(
+            merge_result = await branch_coordinator.safe_merge(
                 branch,
                 self.config.target_branch,
                 dry_run=False,

--- a/tests/worktree/test_integration_target_workspace.py
+++ b/tests/worktree/test_integration_target_workspace.py
@@ -1,0 +1,63 @@
+"""Tests for the dedicated fleet integration target workspace."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from aragora.worktree.integration_target_workspace import FleetIntegrationTargetWorkspace
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- fixed command arguments in tests
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(cwd, "git", *args)
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "checkout", "-b", "feature/test")
+    (repo / "feature.py").write_text("VALUE = 1\n")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-m", "feature")
+    _git(repo, "checkout", "main")
+    return repo
+
+
+def test_ensure_ready_clones_repo_and_materializes_source_branch(tmp_path: Path) -> None:
+    repo = _make_git_repo(tmp_path)
+    workspace = FleetIntegrationTargetWorkspace(repo_root=repo, target_branch="main")
+
+    clone_path = workspace.ensure_ready(source_branch="feature/test")
+
+    assert clone_path.exists()
+    current_branch = _git(clone_path, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    assert current_branch == "main"
+    source_branch_exists = _git(clone_path, "show-ref", "--verify", "refs/heads/feature/test")
+    assert source_branch_exists.returncode == 0
+
+
+def test_ensure_ready_defaults_workspace_under_git_common_dir(tmp_path: Path) -> None:
+    repo = _make_git_repo(tmp_path)
+    workspace = FleetIntegrationTargetWorkspace(repo_root=repo, target_branch="main")
+
+    clone_path = workspace.ensure_ready(source_branch="feature/test")
+    common_dir = _git(repo, "rev-parse", "--git-common-dir").stdout.strip()
+    common_dir_path = (repo / common_dir).resolve()
+
+    assert str(clone_path).startswith(str(common_dir_path))

--- a/tests/worktree/test_integration_worker.py
+++ b/tests/worktree/test_integration_worker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -10,11 +11,43 @@ import pytest
 from aragora.coordination.reconciler import ConflictCategory, ConflictInfo
 from aragora.nomic.branch_coordinator import MergeResult
 from aragora.worktree.fleet import FleetCoordinationStore
+from aragora.worktree.integration_target_workspace import FleetIntegrationTargetWorkspace
 from aragora.worktree.integration_worker import FleetIntegrationWorker
 
 
 def _checkout_error() -> str:
     return "Failed to checkout target branch main: 'main' is already checked out at /tmp/main"
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 -- fixed command arguments in tests
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(cwd, "git", *args)
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "checkout", "-b", "feature/test")
+    (repo / "feature.py").write_text("VALUE = 1\n")
+    _git(repo, "add", "feature.py")
+    _git(repo, "commit", "-m", "feature")
+    _git(repo, "checkout", "main")
+    return repo
 
 
 @pytest.mark.asyncio
@@ -202,3 +235,25 @@ async def test_process_next_marks_execution_conflicts_blocked(tmp_path: Path) ->
     assert outcome.queue_status == "blocked"
     assert outcome.conflicts == ["aragora/x.py"]
     assert store.list_merge_queue()[0]["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_process_next_uses_dedicated_integration_workspace(tmp_path: Path) -> None:
+    repo = _make_git_repo(tmp_path)
+    store = FleetCoordinationStore(repo)
+    store.enqueue_merge(session_id="session-a", branch="feature/test", priority=60)
+
+    worker = FleetIntegrationWorker(
+        repo_path=repo,
+        fleet_store=store,
+        integration_workspace=FleetIntegrationTargetWorkspace(
+            repo_root=repo,
+            target_branch="main",
+        ),
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "validated"
+    assert outcome.queue_status == "needs_human"
+    assert outcome.metadata["integration_workspace_path"] != str(repo)


### PR DESCRIPTION
## Summary
- add a dedicated clone helper for fleet integration validation and execution
- update the fleet integration worker to use that workspace lazily by default
- add focused regression tests covering the dedicated workspace path and lazy-init behavior

## Why
This avoids the current worker colliding with whichever worktree already owns `main` during merge validation and execution.

## Validation
- `ruff check aragora/worktree/integration_target_workspace.py aragora/worktree/integration_worker.py aragora/worktree/__init__.py tests/worktree/test_integration_target_workspace.py tests/worktree/test_integration_worker.py`
- `python -m pytest tests/worktree/test_integration_target_workspace.py tests/worktree/test_integration_worker.py tests/cli/test_worktree_command.py tests/handlers/control_plane/test_coordination.py -q`
  - `70 passed`
