### PR TITLE
feat(coordination): sync salvage work into global queue

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -16,6 +16,7 @@ The design intentionally builds on existing Aragora orchestration patterns:
 from __future__ import annotations
 
 import argparse
+import asyncio
 import hashlib
 import json
 import sqlite3
@@ -28,7 +29,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from aragora.nomic.event_bus import EventBus
-from aragora.nomic.global_work_queue import WorkItem, WorkStatus, WorkType
+from aragora.nomic.global_work_queue import GlobalWorkQueue, WorkItem, WorkStatus, WorkType
 from aragora.worktree.fleet import FleetCoordinationStore
 
 UTC = timezone.utc
@@ -1220,6 +1221,64 @@ class DevCoordinationStore:
         )
         return items
 
+    async def sync_pending_work_queue(
+        self,
+        queue: GlobalWorkQueue | None = None,
+        *,
+        complete_missing: bool = True,
+    ) -> dict[str, int]:
+        """Project pending integration/salvage items into the global work queue."""
+        work_queue = queue or GlobalWorkQueue(storage_dir=self.repo_root / ".work_queue")
+        await work_queue.initialize()
+
+        desired_items = {item.id: item for item in self.pending_work_items()}
+        existing_items = {item.id: item for item in await work_queue.list_items(limit=10_000)}
+        managed_prefixes = ("integration:", "salvage:")
+
+        counts = {
+            "created": 0,
+            "updated": 0,
+            "reopened": 0,
+            "completed": 0,
+            "skipped_active": 0,
+            "open_items": len(desired_items),
+        }
+
+        for item_id, item in desired_items.items():
+            existing = existing_items.get(item_id)
+            if existing and existing.status in (WorkStatus.CLAIMED, WorkStatus.IN_PROGRESS):
+                counts["skipped_active"] += 1
+                continue
+
+            await work_queue.upsert(item, allow_reopen=True, preserve_claimed=True)
+            if existing is None:
+                counts["created"] += 1
+            elif existing.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
+                counts["reopened"] += 1
+            else:
+                counts["updated"] += 1
+
+        if complete_missing:
+            for item_id, existing in existing_items.items():
+                if not item_id.startswith(managed_prefixes) or item_id in desired_items:
+                    continue
+                if existing.status in (
+                    WorkStatus.CLAIMED,
+                    WorkStatus.IN_PROGRESS,
+                    WorkStatus.COMPLETED,
+                    WorkStatus.FAILED,
+                ):
+                    continue
+                completed = await work_queue.complete(
+                    item_id,
+                    result={"source": "dev_coordination", "reason": "no_longer_pending"},
+                )
+                if completed is not None:
+                    counts["completed"] += 1
+
+        await work_queue.reprioritize()
+        return counts
+
     def scan_salvage_sources(
         self,
         *,
@@ -1584,6 +1643,12 @@ def _build_parser() -> argparse.ArgumentParser:
     salvage.add_argument("--max-stashes", type=int, default=25)
     salvage.add_argument("--json", action="store_true")
 
+    sync_queue = sub.add_parser(
+        "sync-queue",
+        help="Project pending integration/salvage items into the global work queue",
+    )
+    sync_queue.add_argument("--json", action="store_true")
+
     reap = sub.add_parser("reap", help="Expire stale leases and release mirrored fleet claims")
     reap.add_argument("--json", action="store_true")
 
@@ -1699,6 +1764,17 @@ def main() -> int:
             print(json.dumps(payload, indent=2))  # noqa: T201
         else:
             print(payload["count"])  # noqa: T201
+        return 0
+
+    if args.command == "sync-queue":
+        payload = {
+            "ok": True,
+            "counts": asyncio.run(store.sync_pending_work_queue()),
+        }
+        if args.json:
+            print(json.dumps(payload, indent=2))  # noqa: T201
+        else:
+            print(json.dumps(payload["counts"], indent=2))  # noqa: T201
         return 0
 
     if args.command == "reap":

--- a/aragora/nomic/global_work_queue.py
+++ b/aragora/nomic/global_work_queue.py
@@ -435,6 +435,53 @@ class GlobalWorkQueue:
 
             return work
 
+    async def upsert(
+        self,
+        work: WorkItem,
+        *,
+        priority: int | None = None,
+        allow_reopen: bool = False,
+        preserve_claimed: bool = True,
+    ) -> WorkItem:
+        """Create or refresh a work item without stomping active claims."""
+        async with self._lock:
+            existing = self._items.get(work.id)
+
+            if (
+                existing
+                and preserve_claimed
+                and existing.status
+                in (
+                    WorkStatus.CLAIMED,
+                    WorkStatus.IN_PROGRESS,
+                )
+            ):
+                return existing
+
+            if priority is not None:
+                work.base_priority = priority
+
+            if existing:
+                work.created_at = existing.created_at
+                work.assigned_to = existing.assigned_to
+
+            if existing and existing.status in (WorkStatus.COMPLETED, WorkStatus.FAILED):
+                if not allow_reopen:
+                    return existing
+                self._completed.discard(work.id)
+
+            work.updated_at = datetime.now(timezone.utc)
+            work.status = WorkStatus.PENDING
+            if work.is_ready(self._completed):
+                work.status = WorkStatus.READY
+
+            self._items[work.id] = work
+            self._add_to_heap(work)
+            await self._save_queue()
+
+            logger.debug("Upserted work %s with priority %s", work.id, work.computed_priority)
+            return work
+
     async def pop(
         self,
         work_type: WorkType | None = None,

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -14,6 +14,7 @@ from aragora.nomic.dev_coordination import (
     LeaseConflictError,
     SalvageStatus,
 )
+from aragora.nomic.global_work_queue import GlobalWorkQueue, WorkStatus
 
 
 @pytest.fixture()
@@ -357,6 +358,110 @@ def test_scan_salvage_sources_finds_worktree_and_stash(
     work_items = store.pending_work_items()
     assert any(item.metadata.get("source_kind") == "worktree" for item in work_items)
     assert any(item.metadata.get("source_kind") == "stash" for item in work_items)
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_work_queue_projects_items(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    lease = store.claim_lease(
+        task_id="clb-sync",
+        title="Queue sync lane",
+        owner_agent="codex",
+        owner_session_id="sess-sync",
+        branch="codex/sync",
+        worktree_path="/tmp/wt-sync",
+        claimed_paths=["aragora/server/auth_checks.py"],
+    )
+    receipt = store.record_completion(
+        lease_id=lease.lease_id,
+        owner_agent="codex",
+        owner_session_id="sess-sync",
+        branch="codex/sync",
+        worktree_path="/tmp/wt-sync",
+        commit_shas=["abc12345"],
+    )
+    salvage = store.upsert_salvage_candidate(
+        source_kind="stash",
+        source_ref="stash@{0}",
+        stash_ref="stash@{0}",
+        changed_paths=["aragora/server/auth_checks.py"],
+        summary="useful stash",
+        likely_value=0.75,
+    )
+    queue = GlobalWorkQueue(storage_dir=repo / ".work_queue")
+
+    counts = await store.sync_pending_work_queue(queue)
+
+    assert counts["created"] == 2
+    items = await queue.list_items(limit=10)
+    item_ids = {item.id for item in items}
+    assert f"salvage:{salvage.candidate_id}" in item_ids
+    assert any(item_id.startswith("integration:") for item_id in item_ids)
+    integration_item = next(item for item in items if item.id.startswith("integration:"))
+    assert integration_item.metadata["receipt_id"] == receipt.receipt_id
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_work_queue_completes_resolved_items(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    candidate = store.upsert_salvage_candidate(
+        source_kind="stash",
+        source_ref="stash@{0}",
+        stash_ref="stash@{0}",
+        changed_paths=["aragora/server/auth_checks.py"],
+        summary="useful stash",
+        likely_value=0.75,
+    )
+    queue = GlobalWorkQueue(storage_dir=repo / ".work_queue")
+
+    await store.sync_pending_work_queue(queue)
+    store.upsert_salvage_candidate(
+        source_kind="stash",
+        source_ref="stash@{0}",
+        stash_ref="stash@{0}",
+        changed_paths=["aragora/server/auth_checks.py"],
+        summary="useful stash",
+        likely_value=0.75,
+        status=SalvageStatus.DISCARDED,
+    )
+
+    counts = await store.sync_pending_work_queue(queue)
+    work = await queue.get(f"salvage:{candidate.candidate_id}")
+
+    assert counts["completed"] == 1
+    assert work is not None
+    assert work.status == WorkStatus.COMPLETED
+    assert work.metadata["result"]["reason"] == "no_longer_pending"
+
+
+@pytest.mark.asyncio
+async def test_sync_pending_work_queue_reopens_terminal_items(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    candidate = store.upsert_salvage_candidate(
+        source_kind="stash",
+        source_ref="stash@{0}",
+        stash_ref="stash@{0}",
+        changed_paths=["aragora/server/auth_checks.py"],
+        summary="useful stash",
+        likely_value=0.75,
+    )
+    queue = GlobalWorkQueue(storage_dir=repo / ".work_queue")
+
+    await store.sync_pending_work_queue(queue)
+    await queue.complete(
+        f"salvage:{candidate.candidate_id}",
+        result={"source": "test", "reason": "closed early"},
+    )
+
+    counts = await store.sync_pending_work_queue(queue)
+    work = await queue.get(f"salvage:{candidate.candidate_id}")
+
+    assert counts["reopened"] == 1
+    assert work is not None
+    assert work.status in (WorkStatus.PENDING, WorkStatus.READY)
 
 
 def test_release_lease_releases_fleet_claims(store: DevCoordinationStore) -> None:

--- a/tests/nomic/test_global_work_queue.py
+++ b/tests/nomic/test_global_work_queue.py
@@ -600,6 +600,43 @@ class TestGlobalWorkQueuePush:
         assert len(queue._items) == 5
         assert len(queue._heap) == 5
 
+    @pytest.mark.asyncio
+    async def test_upsert_reopens_completed_when_allowed(self, queue: GlobalWorkQueue):
+        await queue.initialize()
+        item = _make_work_item(id="salvage:1", work_type=WorkType.MAINTENANCE)
+        await queue.push(item)
+        await queue.complete(item.id, result={"reason": "done"})
+
+        refreshed = _make_work_item(
+            id="salvage:1",
+            work_type=WorkType.MAINTENANCE,
+            base_priority=80,
+        )
+        stored = await queue.upsert(refreshed, allow_reopen=True)
+
+        assert stored.status == WorkStatus.READY
+        reopened = await queue.get(item.id)
+        assert reopened is not None
+        assert reopened.status == WorkStatus.READY
+
+    @pytest.mark.asyncio
+    async def test_upsert_preserves_claimed_items(self, queue: GlobalWorkQueue):
+        await queue.initialize()
+        item = _make_work_item(id="salvage:2", work_type=WorkType.MAINTENANCE)
+        await queue.push(item)
+        claimed = await queue.pop()
+
+        refreshed = _make_work_item(
+            id="salvage:2",
+            work_type=WorkType.MAINTENANCE,
+            title="Refreshed title",
+        )
+        stored = await queue.upsert(refreshed)
+
+        assert claimed is not None
+        assert stored.status == WorkStatus.CLAIMED
+        assert stored.title == item.title
+
 
 # ===========================================================================
 # GlobalWorkQueue - Pop


### PR DESCRIPTION
## Summary
- add `GlobalWorkQueue.upsert()` so coordination sources can refresh work without stomping claimed items
- add `DevCoordinationStore.sync_pending_work_queue()` plus a `sync-queue` CLI command
- cover salvage/integration queue projection, completion of resolved items, and reopening of terminal items when the source of truth stays open

## Why
Salvage candidates and pending integration reviews were visible in coordination state, but they were not becoming schedulable queue work. This makes them first-class items in Aragora's existing global queue instead of leaving them as manual archaeology.

## Validation
- `ruff check aragora/nomic/global_work_queue.py aragora/nomic/dev_coordination.py tests/nomic/test_global_work_queue.py tests/nomic/test_dev_coordination.py`
- `python -m pytest tests/nomic/test_global_work_queue.py tests/nomic/test_dev_coordination.py -q`
  - `140 passed`
