### PR TITLE
fix(ci): run deploy-ec2 smoke tests on hosted python

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -51,7 +51,7 @@ jobs:
   # ---------------------------------------------------------------------------
   test:
     if: ${{ github.event.inputs.skip_tests != 'true' }}
-    runs-on: aragora
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -79,12 +79,13 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: ./.github/actions/setup-python-safe
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Install and test
         run: |
+          python -m pip install --upgrade pip
           python -m pip install -e ".[dev]" pytest-timeout httpx
           python -m pytest tests/test_handlers_debates.py tests/test_api_handler.py \
             --timeout=60 -x --tb=short


### PR DESCRIPTION
## Summary
- move the `Deploy to EC2` pre-deploy test job to `ubuntu-latest`
- use `actions/setup-python@v5` for a guaranteed Python 3.11 toolchain there
- keep the actual deploy jobs unchanged on the current runner lane

## Why
The failing `Deploy to EC2` runs on `main` are coming from the test job resolving `python` to 3.9 on the self-hosted runner, which violates `aragora`'s `>=3.10` requirement. Only the pre-deploy smoke test needs Python, so this isolates that dependency onto a deterministic hosted runner without broadening the deploy blast radius.

## Validation
- `python - <<'PY' ... yaml.safe_load(...)`
- `python scripts/check_workflow_pip_install_policy.py`
- `python -m pytest tests/scripts/test_check_workflow_pip_install_policy.py -q`
  - `5 passed`
