### PR TITLE
fix(typecheck): reduce core reasoning and ranking debt

### DIFF
--- a/aragora/ranking/elo.py
+++ b/aragora/ranking/elo.py
@@ -270,12 +270,16 @@ class EloSystem(KMAdapterMixin):
     """
 
     # Class-level cache for leaderboard data (shared across instances)
-    _leaderboard_cache: TTLCache[list] = TTLCache(maxsize=50, ttl_seconds=CACHE_TTL_LEADERBOARD)
+    _leaderboard_cache: TTLCache[list[AgentRating]] = TTLCache(
+        maxsize=50, ttl_seconds=CACHE_TTL_LEADERBOARD
+    )
     _rating_cache: TTLCache[AgentRating] = TTLCache(
         maxsize=200, ttl_seconds=CACHE_TTL_RECENT_MATCHES
     )
-    _stats_cache: TTLCache[dict] = TTLCache(maxsize=10, ttl_seconds=CACHE_TTL_LB_STATS)
-    _calibration_cache: TTLCache[list] = TTLCache(maxsize=20, ttl_seconds=CACHE_TTL_CALIBRATION_LB)
+    _stats_cache: TTLCache[dict[str, Any]] = TTLCache(maxsize=10, ttl_seconds=CACHE_TTL_LB_STATS)
+    _calibration_cache: TTLCache[list[AgentRating]] = TTLCache(
+        maxsize=20, ttl_seconds=CACHE_TTL_CALIBRATION_LB
+    )
 
     def __init__(
         self,
@@ -387,7 +391,7 @@ class EloSystem(KMAdapterMixin):
         self._rating_cache.set(cache_key, rating)
         return rating
 
-    def _rating_from_row(self, row: tuple) -> AgentRating:
+    def _rating_from_row(self, row: tuple[Any, ...]) -> AgentRating:
         """Create AgentRating from a database row (leaderboard query format)."""
         return AgentRating(
             agent_name=row[0],
@@ -794,23 +798,23 @@ class EloSystem(KMAdapterMixin):
         """Get ELO history for an agent."""
         return self._leaderboard_engine.get_elo_history(agent_name, limit)
 
-    def get_recent_matches(self, limit: int = 10) -> list[dict]:
+    def get_recent_matches(self, limit: int = 10) -> list[dict[str, Any]]:
         """Get recent match results with ELO changes."""
         return self._leaderboard_engine.get_recent_matches(limit)
 
-    def get_head_to_head(self, agent_a: str, agent_b: str) -> dict:
+    def get_head_to_head(self, agent_a: str, agent_b: str) -> dict[str, Any]:
         """Get head-to-head statistics between two agents."""
         return self._leaderboard_engine.get_head_to_head(agent_a, agent_b)
 
-    def get_stats(self, use_cache: bool = True) -> dict:
+    def get_stats(self, use_cache: bool = True) -> dict[str, Any]:
         """Get overall system statistics."""
         return self._leaderboard_engine.get_stats(use_cache)
 
-    def get_snapshot_leaderboard(self, limit: int = 20) -> list[dict]:
+    def get_snapshot_leaderboard(self, limit: int = 20) -> list[dict[str, Any]]:
         """Get leaderboard from JSON snapshot file."""
         return _get_snapshot_leaderboard(self.db_path, self.get_leaderboard, limit)
 
-    def get_cached_recent_matches(self, limit: int = 10) -> list[dict]:
+    def get_cached_recent_matches(self, limit: int = 10) -> list[dict[str, Any]]:
         """Get recent matches from cache if available."""
         return _get_cached_recent_matches(self.db_path, self.get_recent_matches, limit)
 
@@ -838,7 +842,9 @@ class EloSystem(KMAdapterMixin):
         """Get agents ranked by calibration score."""
         return _get_calibration_leaderboard(self._db, self._calibration_cache, limit, use_cache)
 
-    def get_agent_calibration_history(self, agent_name: str, limit: int = 50) -> list[dict]:
+    def get_agent_calibration_history(
+        self, agent_name: str, limit: int = 50
+    ) -> list[dict[str, Any]]:
         """Get recent predictions made by an agent."""
         return _get_agent_calibration_history(self._db, agent_name, limit)
 
@@ -856,11 +862,13 @@ class EloSystem(KMAdapterMixin):
         """Record a domain-specific prediction."""
         self._domain_calibration_engine.record_prediction(agent_name, domain, confidence, correct)
 
-    def get_domain_calibration(self, agent_name: str, domain: str | None = None) -> dict:
+    def get_domain_calibration(self, agent_name: str, domain: str | None = None) -> dict[str, Any]:
         """Get calibration statistics for an agent."""
         return self._domain_calibration_engine.get_domain_stats(agent_name, domain)
 
-    def get_calibration_by_bucket(self, agent_name: str, domain: str | None = None) -> list[dict]:
+    def get_calibration_by_bucket(
+        self, agent_name: str, domain: str | None = None
+    ) -> list[dict[str, Any]]:
         """Get calibration broken down by confidence bucket."""
         buckets = self._domain_calibration_engine.get_calibration_curve(agent_name, domain)
         return [
@@ -920,11 +928,11 @@ class EloSystem(KMAdapterMixin):
             b_win=b_win,
         )
 
-    def update_relationships_batch(self, updates: list[dict]) -> None:
+    def update_relationships_batch(self, updates: list[dict[str, Any]]) -> None:
         """Batch update multiple agent relationships."""
         self.relationship_tracker.update_batch(updates)
 
-    def get_relationship_raw(self, agent_a: str, agent_b: str) -> dict | None:
+    def get_relationship_raw(self, agent_a: str, agent_b: str) -> dict[str, Any] | None:
         """Get raw relationship data between two agents."""
         stats = self.relationship_tracker.get_raw(agent_a, agent_b)
         if stats is None:
@@ -944,7 +952,9 @@ class EloSystem(KMAdapterMixin):
             "b_wins_over_a": stats.b_wins_over_a,
         }
 
-    def get_all_relationships_for_agent(self, agent_name: str, limit: int = 100) -> list[dict]:
+    def get_all_relationships_for_agent(
+        self, agent_name: str, limit: int = 100
+    ) -> list[dict[str, Any]]:
         """Get all relationships involving an agent."""
         _validate_agent_name(agent_name)
         stats_list = self.relationship_tracker.get_all_for_agent(agent_name, limit)
@@ -966,7 +976,7 @@ class EloSystem(KMAdapterMixin):
             for s in stats_list
         ]
 
-    def compute_relationship_metrics(self, agent_a: str, agent_b: str) -> dict:
+    def compute_relationship_metrics(self, agent_a: str, agent_b: str) -> dict[str, Any]:
         """Compute rivalry and alliance scores between two agents."""
         metrics = self.relationship_tracker.compute_metrics(agent_a, agent_b)
         return {
@@ -980,7 +990,9 @@ class EloSystem(KMAdapterMixin):
             "head_to_head": metrics.head_to_head,
         }
 
-    def _compute_metrics_from_raw(self, agent_a: str, agent_b: str, raw: dict) -> dict:
+    def _compute_metrics_from_raw(
+        self, agent_a: str, agent_b: str, raw: dict[str, Any]
+    ) -> dict[str, Any]:
         """Compute relationship metrics from raw data (no database call)."""
         stats = RelationshipStats(
             agent_a=raw.get("agent_a", agent_a),
@@ -1006,7 +1018,7 @@ class EloSystem(KMAdapterMixin):
             "debate_count": metrics.debate_count,
         }
 
-    def get_rivals(self, agent_name: str, limit: int = 5) -> list[dict]:
+    def get_rivals(self, agent_name: str, limit: int = 5) -> list[dict[str, Any]]:
         """Get agent's top rivals by rivalry score."""
         _validate_agent_name(agent_name)
         metrics_list = self.relationship_tracker.get_rivals(agent_name, limit)
@@ -1022,7 +1034,7 @@ class EloSystem(KMAdapterMixin):
             for m in metrics_list
         ]
 
-    def get_allies(self, agent_name: str, limit: int = 5) -> list[dict]:
+    def get_allies(self, agent_name: str, limit: int = 5) -> list[dict[str, Any]]:
         """Get agent's top allies by alliance score."""
         _validate_agent_name(agent_name)
         metrics_list = self.relationship_tracker.get_allies(agent_name, limit)
@@ -1061,7 +1073,7 @@ class EloSystem(KMAdapterMixin):
             session_id=session_id,
         )
 
-    def get_vulnerability_summary(self, agent_name: str) -> dict:
+    def get_vulnerability_summary(self, agent_name: str) -> dict[str, Any]:
         """Get summary of agent's red team history."""
         summary = self.redteam_integrator.get_vulnerability_summary(agent_name)
         return {
@@ -1115,7 +1127,7 @@ class EloSystem(KMAdapterMixin):
         )
         return net_change
 
-    def get_verification_impact(self, agent_name: str) -> dict:
+    def get_verification_impact(self, agent_name: str) -> dict[str, Any]:
         """Get summary of verification impact on an agent's ELO."""
         _validate_agent_name(agent_name)
         return calculate_verification_impact(self._db, agent_name)
@@ -1144,23 +1156,23 @@ class EloSystem(KMAdapterMixin):
             bonus_k_factor,
         )
 
-    def get_voting_accuracy(self, agent_name: str) -> dict:
+    def get_voting_accuracy(self, agent_name: str) -> dict[str, Any]:
         """Get voting accuracy statistics for an agent."""
         return _get_voting_accuracy(self, agent_name)
 
-    def get_voting_accuracy_batch(self, agent_names: list[str]) -> dict[str, dict]:
+    def get_voting_accuracy_batch(self, agent_names: list[str]) -> dict[str, dict[str, Any]]:
         """Get voting accuracy statistics for multiple agents in one query."""
         return _get_voting_accuracy_batch(self, agent_names)
 
     def get_learning_efficiency(
         self, agent_name: str, domain: str | None = None, window_debates: int = 20
-    ) -> dict:
+    ) -> dict[str, Any]:
         """Compute learning efficiency for an agent based on ELO improvement rate."""
         return _get_learning_efficiency(self, agent_name, domain, window_debates)
 
     def get_learning_efficiency_batch(
         self, agent_names: list[str], domain: str | None = None, window_debates: int = 20
-    ) -> dict[str, dict]:
+    ) -> dict[str, dict[str, Any]]:
         """Get learning efficiency for multiple agents with batch optimization."""
         return _get_learning_efficiency_batch(self, agent_names, domain, window_debates)
 

--- a/aragora/reasoning/belief.py
+++ b/aragora/reasoning/belief.py
@@ -47,11 +47,11 @@ def __getattr__(name: str) -> Any:
 class _BeliefAdapterProtocol(Protocol):
     """Protocol for BeliefAdapter methods used in BeliefNetwork."""
 
-    def search_beliefs(self, query: str, limit: int, min_confidence: float) -> list[dict]:
+    def search_beliefs(self, query: str, limit: int, min_confidence: float) -> list[dict[str, Any]]:
         """Search for related beliefs."""
         ...
 
-    def search_cruxes(self, query: str, limit: int) -> list[dict]:
+    def search_cruxes(self, query: str, limit: int) -> list[dict[str, Any]]:
         """Search for historical cruxes."""
         ...
 
@@ -140,7 +140,7 @@ class BeliefDistribution:
                 kl += p_self * math.log2(p_self / p_other)
         return kl
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, float]:
         return {
             "p_true": self.p_true,
             "p_false": self.p_false,
@@ -163,7 +163,7 @@ class BeliefDistribution:
         return cls(p_true=0.5, p_false=0.5, p_unknown=0.0)
 
     @classmethod
-    def from_dict(cls, data: dict) -> BeliefDistribution:
+    def from_dict(cls, data: dict[str, Any]) -> BeliefDistribution:
         """Deserialize from dictionary."""
         return cls(
             p_true=data.get("p_true", 0.5),
@@ -227,7 +227,7 @@ class BeliefNode:
         self.update_count += 1
         self.last_update = datetime.now().isoformat()
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "node_id": self.node_id,
             "claim_id": self.claim_id,
@@ -243,7 +243,7 @@ class BeliefNode:
         }
 
     @classmethod
-    def from_dict(cls, data: dict) -> BeliefNode:
+    def from_dict(cls, data: dict[str, Any]) -> BeliefNode:
         """Deserialize from dictionary."""
         return cls(
             node_id=data["node_id"],
@@ -336,7 +336,7 @@ class PropagationResult:
     node_posteriors: dict[str, BeliefDistribution]
     centralities: dict[str, float]
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "converged": self.converged,
             "iterations": self.iterations,
@@ -397,7 +397,7 @@ class BeliefNetwork:
         topic: str,
         limit: int = 10,
         min_confidence: float = 0.7,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         """Query Knowledge Mound for related beliefs (reverse flow).
 
         This enables seeding the belief network with prior knowledge.
@@ -427,7 +427,7 @@ class BeliefNetwork:
         self,
         topic: str,
         limit: int = 5,
-    ) -> list[dict]:
+    ) -> list[dict[str, Any]]:
         """Query Knowledge Mound for historical cruxes (reverse flow).
 
         This enables predicting which claims are likely to be cruxes
@@ -977,7 +977,7 @@ class BeliefNetwork:
 
         return "\n".join(lines)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize network to dictionary."""
         return {
             "debate_id": self.debate_id,
@@ -1003,7 +1003,7 @@ class BeliefNetwork:
         return json.dumps(self.to_dict(), indent=indent, default=str)
 
     @classmethod
-    def from_dict(cls, data: dict) -> BeliefNetwork:
+    def from_dict(cls, data: dict[str, Any]) -> BeliefNetwork:
         """Deserialize network from dictionary."""
         network = cls(
             debate_id=data.get("debate_id"),


### PR DESCRIPTION
## Summary
- tighten container annotations in `aragora/reasoning/belief.py` for the core module mypy gate
- tighten leaderboard, calibration, and relationship return types in `aragora/ranking/elo.py`
- reduce the push-only "Core Module Type Safety" error surface without touching the dirty root workspace

## Validation
- `python3 -m ruff check aragora/reasoning/belief.py aragora/ranking/elo.py`
- `python3 -m mypy aragora/reasoning/belief.py aragora/ranking/elo.py --config-file pyproject.toml --no-error-summary --follow-imports=silent`
- `python3 -m pytest tests/test_reasoning_belief.py tests/ranking/test_elo_system.py -q`
