### PR TITLE
feat(inbox): trust wedge contracts, CLI review, and triage runner

### DIFF
--- a/aragora/inbox/auto_approval.py
+++ b/aragora/inbox/auto_approval.py
@@ -1,0 +1,136 @@
+"""
+Auto-Approval Policy for inbox triage decisions.
+
+Encapsulates the rules that determine whether a triage decision can be
+automatically approved without human review.
+
+Rules:
+- Only ARCHIVE, STAR, IGNORE are auto-approvable (not LABEL -- requires
+  manual label selection).
+- Confidence >= 0.85.
+- No dissent block flag (non-empty ``dissent_summary`` blocks auto-approval).
+- Receipt must be in CREATED state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aragora.inbox.trust_wedge import (
+    AllowedAction,
+    ReceiptState,
+    TriageDecision,
+)
+
+logger = logging.getLogger(__name__)
+
+# Actions that may be auto-approved (LABEL excluded -- needs manual choice)
+_AUTO_APPROVABLE_ACTIONS: frozenset[str] = frozenset(
+    {
+        AllowedAction.ARCHIVE.value,
+        AllowedAction.STAR.value,
+        AllowedAction.IGNORE.value,
+    }
+)
+
+_DEFAULT_CONFIDENCE_THRESHOLD = 0.85
+
+
+class AutoApprovalPolicy:
+    """Policy engine deciding whether a triage decision can skip human review.
+
+    Parameters
+    ----------
+    confidence_threshold:
+        Minimum confidence required for auto-approval. Defaults to 0.85.
+    """
+
+    def __init__(
+        self,
+        *,
+        confidence_threshold: float = _DEFAULT_CONFIDENCE_THRESHOLD,
+    ) -> None:
+        self._confidence_threshold = confidence_threshold
+
+    @property
+    def confidence_threshold(self) -> float:
+        return self._confidence_threshold
+
+    def can_auto_approve(self, decision: TriageDecision) -> bool:
+        """Check whether *decision* is eligible for auto-approval.
+
+        Returns ``True`` only when ALL of the following hold:
+
+        1. ``final_action`` is in the auto-approvable set.
+        2. ``confidence >= confidence_threshold``.
+        3. ``dissent_summary`` is empty (no dissent block).
+        4. ``receipt_state`` is CREATED.
+        """
+        if decision.final_action not in _AUTO_APPROVABLE_ACTIONS:
+            logger.debug(
+                "Auto-approval blocked: action %s not auto-approvable",
+                decision.final_action,
+            )
+            return False
+
+        if decision.confidence < self._confidence_threshold:
+            logger.debug(
+                "Auto-approval blocked: confidence %.2f < threshold %.2f",
+                decision.confidence,
+                self._confidence_threshold,
+            )
+            return False
+
+        if decision.dissent_summary:
+            logger.debug(
+                "Auto-approval blocked: dissent present (%s)",
+                decision.dissent_summary[:80],
+            )
+            return False
+
+        if decision.receipt_state != ReceiptState.CREATED.value:
+            logger.debug(
+                "Auto-approval blocked: receipt state %s (expected CREATED)",
+                decision.receipt_state,
+            )
+            return False
+
+        return True
+
+    def auto_approve(self, decision: TriageDecision) -> bool:
+        """Attempt to auto-approve *decision*.
+
+        If the policy allows, transitions the receipt state to APPROVED
+        and returns ``True``. Otherwise leaves the decision unchanged
+        and returns ``False``.
+        """
+        if not self.can_auto_approve(decision):
+            return False
+
+        decision.receipt_state = ReceiptState.APPROVED.value
+        decision.auto_approval_eligible = True
+        logger.info(
+            "Auto-approved triage decision: receipt=%s action=%s confidence=%.2f",
+            decision.receipt_id,
+            decision.final_action,
+            decision.confidence,
+        )
+        return True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "confidence_threshold": self._confidence_threshold,
+            "auto_approvable_actions": sorted(_AUTO_APPROVABLE_ACTIONS),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> AutoApprovalPolicy:
+        return cls(
+            confidence_threshold=float(
+                data.get("confidence_threshold", _DEFAULT_CONFIDENCE_THRESHOLD)
+            ),
+        )
+
+
+__all__ = ["AutoApprovalPolicy"]

--- a/aragora/inbox/cli_review.py
+++ b/aragora/inbox/cli_review.py
@@ -1,0 +1,208 @@
+"""
+CLI Review Loop for inbox triage decisions.
+
+Presents triage decisions to the user in a simple terminal interface
+and allows approve/reject/edit/skip actions. Uses ``input()`` for
+interaction -- no curses dependency.
+
+Usage::
+
+    from aragora.inbox.cli_review import CLIReviewLoop
+    from aragora.inbox.trust_wedge import TriageDecision
+
+    loop = CLIReviewLoop()
+    results = loop.review_batch(decisions)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from aragora.inbox.trust_wedge import (
+    AllowedAction,
+    ReceiptState,
+    TriageDecision,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CLIReviewLoop:
+    """Interactive CLI loop for reviewing inbox triage decisions.
+
+    Parameters
+    ----------
+    input_fn:
+        Callable used to read user input. Defaults to the built-in
+        ``input``. Override in tests to supply scripted responses.
+    print_fn:
+        Callable used for output. Defaults to built-in ``print``.
+    on_approve:
+        Optional callback ``(decision) -> None`` fired after a decision
+        is approved.
+    on_reject:
+        Optional callback ``(decision) -> None`` fired after a decision
+        is rejected.
+    """
+
+    def __init__(
+        self,
+        *,
+        input_fn: Callable[..., str] | None = None,
+        print_fn: Callable[..., Any] | None = None,
+        on_approve: Callable[[TriageDecision], None] | None = None,
+        on_reject: Callable[[TriageDecision], None] | None = None,
+    ) -> None:
+        self._input = input_fn or input
+        self._print = print_fn or print
+        self._on_approve = on_approve
+        self._on_reject = on_reject
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def review_batch(self, decisions: list[TriageDecision]) -> list[dict[str, Any]]:
+        """Process a list of triage decisions sequentially.
+
+        Returns a list of result dicts, one per decision, with keys:
+        ``receipt_id``, ``action_taken`` (approve/reject/edit/skip),
+        ``final_action``.
+        """
+        results: list[dict[str, Any]] = []
+        total = len(decisions)
+
+        self._print(f"\n--- Inbox Triage Review ({total} items) ---\n")
+
+        for idx, decision in enumerate(decisions, start=1):
+            self._print(f"[{idx}/{total}]")
+            result = self._review_single(decision)
+            results.append(result)
+            self._print("")  # blank line between items
+
+        approved = sum(1 for r in results if r["action_taken"] == "approve")
+        rejected = sum(1 for r in results if r["action_taken"] == "reject")
+        skipped = sum(1 for r in results if r["action_taken"] == "skip")
+        edited = sum(1 for r in results if r["action_taken"] == "edit")
+
+        self._print(
+            f"--- Review complete: {approved} approved, {rejected} rejected, "
+            f"{edited} edited, {skipped} skipped ---"
+        )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _review_single(self, decision: TriageDecision) -> dict[str, Any]:
+        """Present one decision and collect the user's choice."""
+        self._display_decision(decision)
+
+        while True:
+            choice = (
+                self._input("  [a]pprove / [r]eject / [e]dit action / [s]kip > ").strip().lower()
+            )
+
+            if choice in ("a", "approve"):
+                return self._handle_approve(decision)
+            if choice in ("r", "reject"):
+                return self._handle_reject(decision)
+            if choice in ("e", "edit"):
+                return self._handle_edit(decision)
+            if choice in ("s", "skip"):
+                return self._handle_skip(decision)
+
+            self._print("  Invalid choice. Please enter a, r, e, or s.")
+
+    def _display_decision(self, decision: TriageDecision) -> None:
+        """Print a human-readable summary of a triage decision."""
+        intent = decision.intent
+        subject = "(unknown)"
+        sender = "(unknown)"
+        snippet = ""
+
+        if intent:
+            # Intent metadata may carry email details if attached
+            subject = getattr(intent, "_subject", subject)
+            sender = getattr(intent, "_sender", sender)
+            snippet = getattr(intent, "_snippet", snippet)
+
+        self._print(f"  Subject : {subject}")
+        self._print(f"  Sender  : {sender}")
+        if snippet:
+            self._print(f"  Snippet : {snippet[:120]}")
+        self._print(f"  Action  : {decision.final_action}")
+        self._print(f"  Conf.   : {decision.confidence:.0%}")
+        if decision.dissent_summary:
+            self._print(f"  Dissent : {decision.dissent_summary}")
+        self._print(f"  Receipt : {decision.receipt_id}")
+
+    def _handle_approve(self, decision: TriageDecision) -> dict[str, Any]:
+        decision.receipt_state = ReceiptState.APPROVED.value
+        self._print("  -> APPROVED")
+        logger.info(
+            "Triage approved: receipt=%s action=%s", decision.receipt_id, decision.final_action
+        )
+        if self._on_approve:
+            self._on_approve(decision)
+        return {
+            "receipt_id": decision.receipt_id,
+            "action_taken": "approve",
+            "final_action": decision.final_action,
+        }
+
+    def _handle_reject(self, decision: TriageDecision) -> dict[str, Any]:
+        decision.receipt_state = ReceiptState.EXPIRED.value
+        self._print("  -> REJECTED")
+        logger.info("Triage rejected: receipt=%s", decision.receipt_id)
+        if self._on_reject:
+            self._on_reject(decision)
+        return {
+            "receipt_id": decision.receipt_id,
+            "action_taken": "reject",
+            "final_action": decision.final_action,
+        }
+
+    def _handle_edit(self, decision: TriageDecision) -> dict[str, Any]:
+        valid_actions = [a.value for a in AllowedAction]
+        self._print(f"  Available actions: {', '.join(valid_actions)}")
+        while True:
+            new_action = self._input("  New action > ").strip().lower()
+            if new_action in valid_actions:
+                break
+            self._print(f"  Invalid. Choose from: {', '.join(valid_actions)}")
+
+        old_action = decision.final_action
+        decision.final_action = new_action
+        if decision.intent:
+            decision.intent.action = new_action
+        # Reset state to CREATED (re-sign needed)
+        decision.receipt_state = ReceiptState.CREATED.value
+        self._print(f"  -> EDITED: {old_action} -> {new_action}")
+        logger.info(
+            "Triage edited: receipt=%s %s->%s",
+            decision.receipt_id,
+            old_action,
+            new_action,
+        )
+        return {
+            "receipt_id": decision.receipt_id,
+            "action_taken": "edit",
+            "final_action": new_action,
+        }
+
+    def _handle_skip(self, decision: TriageDecision) -> dict[str, Any]:
+        # Leave receipt_state as CREATED
+        self._print("  -> SKIPPED")
+        logger.info("Triage skipped: receipt=%s", decision.receipt_id)
+        return {
+            "receipt_id": decision.receipt_id,
+            "action_taken": "skip",
+            "final_action": decision.final_action,
+        }
+
+
+__all__ = ["CLIReviewLoop"]

--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -1,0 +1,326 @@
+"""
+Inbox Triage Runner.
+
+Main entry point for the trust wedge. Fetches unread Gmail messages,
+runs adversarial debates on each, builds signed receipts, and routes
+decisions to auto-approval or the CLI review queue.
+
+Usage::
+
+    from aragora.inbox.triage_runner import InboxTriageRunner
+
+    runner = InboxTriageRunner()
+    decisions = await runner.run_triage(batch_size=10, auto_approve=True)
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from aragora.inbox.auto_approval import AutoApprovalPolicy
+from aragora.inbox.trust_wedge import (
+    ActionIntent,
+    AllowedAction,
+    ReceiptState,
+    TriageDecision,
+    compute_content_hash,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_action(debate_result: Any) -> str:
+    """Extract an AllowedAction value from a debate result.
+
+    Falls back to IGNORE if the debate output cannot be mapped.
+    """
+    answer = ""
+    if hasattr(debate_result, "final_answer"):
+        answer = str(getattr(debate_result, "final_answer", ""))
+    elif isinstance(debate_result, dict):
+        answer = str(debate_result.get("final_answer", ""))
+
+    answer_lower = answer.lower()
+    for action in AllowedAction:
+        if action.value in answer_lower:
+            return action.value
+
+    return AllowedAction.IGNORE.value
+
+
+def _extract_confidence(debate_result: Any) -> float:
+    """Extract confidence from a debate result."""
+    if hasattr(debate_result, "confidence"):
+        try:
+            return float(getattr(debate_result, "confidence", 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+    if isinstance(debate_result, dict):
+        try:
+            return float(debate_result.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            return 0.0
+    return 0.0
+
+
+def _extract_dissent(debate_result: Any) -> str:
+    """Extract dissent information from a debate result."""
+    if hasattr(debate_result, "dissenting_views"):
+        views = getattr(debate_result, "dissenting_views", [])
+        if views:
+            return "; ".join(str(v) for v in views[:3])
+    if isinstance(debate_result, dict):
+        views = debate_result.get("dissenting_views", [])
+        if views:
+            return "; ".join(str(v) for v in views[:3])
+    return ""
+
+
+class InboxTriageRunner:
+    """Orchestrates the full inbox triage flow.
+
+    Parameters
+    ----------
+    gmail_connector:
+        An instance of the Gmail connector (or compatible mock).
+        Must support ``list_messages``, ``get_message``, and label
+        operations (``archive_message``, ``star_message``, ``add_label``).
+    auto_approval_policy:
+        Policy governing auto-approval. A default policy is created
+        if none is provided.
+    """
+
+    def __init__(
+        self,
+        gmail_connector: Any | None = None,
+        auto_approval_policy: AutoApprovalPolicy | None = None,
+    ) -> None:
+        self._gmail = gmail_connector
+        self._policy = auto_approval_policy or AutoApprovalPolicy()
+        self._triaged: list[TriageDecision] = []
+
+    @property
+    def triaged(self) -> list[TriageDecision]:
+        """Decisions produced by the most recent ``run_triage`` call."""
+        return list(self._triaged)
+
+    async def run_triage(
+        self,
+        batch_size: int = 10,
+        auto_approve: bool = False,
+    ) -> list[TriageDecision]:
+        """Run the full triage pipeline.
+
+        1. Fetch unread Gmail messages (up to *batch_size*).
+        2. For each message, run an adversarial debate.
+        3. Build an ``ActionIntent`` from the debate result.
+        4. Create a ``TriageDecision`` with receipt.
+        5. If *auto_approve* and the policy allows, auto-approve.
+        6. Otherwise queue for CLI review.
+
+        Returns the list of ``TriageDecision`` objects. Those not
+        auto-approved remain in CREATED state for later review.
+        """
+        messages = await self._fetch_messages(batch_size)
+        logger.info("Fetched %d messages for triage", len(messages))
+
+        decisions: list[TriageDecision] = []
+
+        for msg in messages:
+            try:
+                decision = await self._triage_message(msg)
+                if auto_approve and self._policy.auto_approve(decision):
+                    await self._execute_action(decision)
+                decisions.append(decision)
+            except (RuntimeError, OSError, ValueError, TypeError) as exc:
+                logger.warning(
+                    "Triage failed for message %s: %s",
+                    msg.get("id", "?"),
+                    exc,
+                )
+
+        self._triaged = decisions
+        auto_count = sum(1 for d in decisions if d.receipt_state == ReceiptState.APPROVED.value)
+        logger.info(
+            "Triage complete: %d decisions (%d auto-approved, %d for review)",
+            len(decisions),
+            auto_count,
+            len(decisions) - auto_count,
+        )
+        return decisions
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _fetch_messages(self, batch_size: int) -> list[dict[str, Any]]:
+        """Fetch unread messages from Gmail.
+
+        Returns a list of message dicts with at least ``id``, ``subject``,
+        ``sender``, ``snippet``, and ``body`` keys.
+        """
+        if self._gmail is None:
+            logger.warning("No Gmail connector configured; returning empty batch")
+            return []
+
+        try:
+            message_ids, _ = await self._gmail.list_messages(
+                query="is:unread",
+                max_results=batch_size,
+            )
+        except (RuntimeError, OSError, ConnectionError) as exc:
+            logger.error("Failed to list messages: %s", exc)
+            return []
+
+        messages: list[dict[str, Any]] = []
+        for mid in message_ids[:batch_size]:
+            try:
+                msg = await self._gmail.get_message(mid)
+                if isinstance(msg, dict):
+                    messages.append(msg)
+                elif hasattr(msg, "to_dict"):
+                    messages.append(msg.to_dict())
+                else:
+                    messages.append({"id": mid, "body": str(msg)})
+            except (RuntimeError, OSError, ValueError) as exc:
+                logger.warning("Failed to fetch message %s: %s", mid, exc)
+
+        return messages
+
+    async def _triage_message(self, msg: dict[str, Any]) -> TriageDecision:
+        """Run debate and build a TriageDecision for a single message."""
+        message_id = msg.get("id", str(uuid.uuid4()))
+        body = msg.get("body", msg.get("snippet", ""))
+        content_hash = compute_content_hash(body)
+
+        debate_result = await self._run_debate(msg)
+
+        action = _extract_action(debate_result)
+        confidence = _extract_confidence(debate_result)
+        dissent = _extract_dissent(debate_result)
+        debate_id = getattr(debate_result, "debate_id", None)
+        if debate_id is None and isinstance(debate_result, dict):
+            debate_id = debate_result.get("debate_id")
+        debate_id = debate_id or f"triage-{uuid.uuid4().hex[:12]}"
+
+        rationale = ""
+        if hasattr(debate_result, "final_answer"):
+            rationale = str(getattr(debate_result, "final_answer", ""))
+        elif isinstance(debate_result, dict):
+            rationale = str(debate_result.get("final_answer", ""))
+
+        intent = ActionIntent(
+            provider="arena-consensus",
+            message_id=message_id,
+            action=action,
+            content_hash=content_hash,
+            synthesized_rationale=rationale[:500],
+            confidence=confidence,
+            provider_route="direct",
+            debate_id=debate_id,
+        )
+        # Attach email metadata for CLI display (private attrs)
+        intent._subject = msg.get("subject", "(no subject)")  # type: ignore[attr-defined]
+        intent._sender = msg.get("sender", msg.get("from", "(unknown)"))  # type: ignore[attr-defined]
+        intent._snippet = msg.get("snippet", body[:120])  # type: ignore[attr-defined]
+
+        decision = TriageDecision(
+            final_action=action,
+            confidence=confidence,
+            dissent_summary=dissent,
+            auto_approval_eligible=False,
+            provider_route="direct",
+            intent=intent,
+        )
+
+        return decision
+
+    async def _run_debate(self, msg: dict[str, Any]) -> Any:
+        """Run an adversarial debate on a message.
+
+        Attempts to use the Arena. Falls back to a stub result if the
+        debate engine is unavailable.
+        """
+        subject = msg.get("subject", "")
+        body = msg.get("body", msg.get("snippet", ""))
+        question = (
+            f"Triage this email and recommend an action "
+            f"(archive, star, label, or ignore).\n\n"
+            f"Subject: {subject}\n"
+            f"Body: {body[:2000]}"
+        )
+
+        try:
+            from aragora.core import Environment
+            from aragora.debate.protocol import DebateProtocol
+            from aragora.debate.orchestrator import Arena
+
+            env = Environment(task=question)
+            protocol = DebateProtocol(rounds=2, consensus="majority")
+            arena = Arena(env, agents=[], protocol=protocol)
+            return await arena.run()
+        except ImportError:
+            logger.debug("Debate engine not available; using stub result")
+            return {
+                "final_answer": "ignore",
+                "confidence": 0.5,
+                "debate_id": f"stub-{uuid.uuid4().hex[:8]}",
+            }
+        except (RuntimeError, OSError, ValueError, TypeError) as exc:
+            logger.warning("Debate failed, falling back to ignore: %s", exc)
+            return {
+                "final_answer": "ignore",
+                "confidence": 0.0,
+                "debate_id": f"err-{uuid.uuid4().hex[:8]}",
+            }
+
+    async def _execute_action(self, decision: TriageDecision) -> None:
+        """Execute an approved triage action via the Gmail connector.
+
+        Does NOT wire into the execution safety gate -- that integration
+        is handled separately.
+        """
+        if self._gmail is None:
+            logger.warning("No Gmail connector; skipping execution")
+            return
+
+        intent = decision.intent
+        if intent is None:
+            logger.warning("No intent on decision %s", decision.receipt_id)
+            return
+
+        action = decision.final_action
+        message_id = intent.message_id
+
+        try:
+            if action == AllowedAction.ARCHIVE.value:
+                await self._gmail.archive_message(message_id)
+            elif action == AllowedAction.STAR.value:
+                await self._gmail.star_message(message_id)
+            elif action == AllowedAction.LABEL.value:
+                # Label requires a label_id; skip if not provided
+                logger.info("LABEL action requires manual label selection; skipping")
+            elif action == AllowedAction.IGNORE.value:
+                logger.info("IGNORE action; no Gmail operation needed")
+            else:
+                logger.warning("Unknown action %s; skipping execution", action)
+                return
+
+            decision.receipt_state = ReceiptState.EXECUTED.value
+            logger.info(
+                "Executed triage action: %s on message %s",
+                action,
+                message_id,
+            )
+        except (RuntimeError, OSError, ConnectionError) as exc:
+            logger.error(
+                "Failed to execute action %s on %s: %s",
+                action,
+                message_id,
+                exc,
+            )
+
+
+__all__ = ["InboxTriageRunner"]

--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -1,0 +1,152 @@
+"""
+Canonical contract types for the Inbox Trust Wedge.
+
+These types bind the Gmail triage flow together:
+- AllowedAction: The set of actions the wedge can take on an email
+- ActionIntent: A model's proposed action on a specific email
+- TriageDecision: The final decision after debate, ready for review
+- ReceiptState: Lifecycle states for triage receipts
+
+All dataclasses support ``to_dict()``/``from_dict()`` for serialization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+
+class AllowedAction(str, Enum):
+    """Actions the trust wedge is permitted to take on an email.
+
+    These map to Gmail operations exposed by
+    ``aragora.connectors.enterprise.communication.gmail.labels``.
+    """
+
+    ARCHIVE = "archive"
+    STAR = "star"
+    LABEL = "label"
+    IGNORE = "ignore"
+
+
+class ReceiptState(str, Enum):
+    """Lifecycle states for a triage receipt.
+
+    State machine:
+        CREATED -> APPROVED -> EXECUTED
+        CREATED -> EXPIRED
+        CREATED -> (edit) -> CREATED   (re-sign on edit)
+    """
+
+    CREATED = "created"
+    APPROVED = "approved"
+    EXPIRED = "expired"
+    EXECUTED = "executed"
+
+
+def compute_content_hash(content: str) -> str:
+    """Compute SHA-256 hex digest of email content."""
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class ActionIntent:
+    """A single model's proposed action on an email message.
+
+    Produced by the debate synthesizer after the proposer/critic rounds.
+    """
+
+    provider: str  # which model proposed this
+    message_id: str  # Gmail message ID
+    action: str  # AllowedAction value
+    content_hash: str  # SHA-256 of email content
+    synthesized_rationale: str  # why this action
+    confidence: float  # synthesizer confidence [0.0, 1.0]
+    provider_route: str  # "direct" or "openrouter"
+    debate_id: str  # which debate produced this
+    created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "message_id": self.message_id,
+            "action": self.action,
+            "content_hash": self.content_hash,
+            "synthesized_rationale": self.synthesized_rationale,
+            "confidence": self.confidence,
+            "provider_route": self.provider_route,
+            "debate_id": self.debate_id,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ActionIntent:
+        return cls(
+            provider=data["provider"],
+            message_id=data["message_id"],
+            action=data["action"],
+            content_hash=data["content_hash"],
+            synthesized_rationale=data["synthesized_rationale"],
+            confidence=float(data["confidence"]),
+            provider_route=data["provider_route"],
+            debate_id=data["debate_id"],
+            created_at=data.get("created_at", datetime.now(timezone.utc).isoformat()),
+        )
+
+
+@dataclass
+class TriageDecision:
+    """The final triage decision for an email, ready for user review.
+
+    Wraps an ``ActionIntent`` with consensus metadata and approval status.
+    """
+
+    final_action: str  # AllowedAction value
+    confidence: float
+    dissent_summary: str  # empty if unanimous; describes disagreements
+    receipt_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    auto_approval_eligible: bool = False
+    provider_route: str = "direct"
+    intent: ActionIntent | None = None
+    receipt_state: str = ReceiptState.CREATED.value
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "final_action": self.final_action,
+            "confidence": self.confidence,
+            "dissent_summary": self.dissent_summary,
+            "receipt_id": self.receipt_id,
+            "auto_approval_eligible": self.auto_approval_eligible,
+            "provider_route": self.provider_route,
+            "intent": self.intent.to_dict() if self.intent else None,
+            "receipt_state": self.receipt_state,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TriageDecision:
+        intent = None
+        if data.get("intent"):
+            intent = ActionIntent.from_dict(data["intent"])
+        return cls(
+            final_action=data["final_action"],
+            confidence=float(data["confidence"]),
+            dissent_summary=data.get("dissent_summary", ""),
+            receipt_id=data.get("receipt_id", str(uuid.uuid4())),
+            auto_approval_eligible=data.get("auto_approval_eligible", False),
+            provider_route=data.get("provider_route", "direct"),
+            intent=intent,
+            receipt_state=data.get("receipt_state", ReceiptState.CREATED.value),
+        )
+
+
+__all__ = [
+    "AllowedAction",
+    "ActionIntent",
+    "TriageDecision",
+    "ReceiptState",
+    "compute_content_hash",
+]

--- a/tests/inbox/test_trust_wedge.py
+++ b/tests/inbox/test_trust_wedge.py
@@ -1,0 +1,397 @@
+"""
+Tests for inbox trust wedge contract types, CLI review loop,
+and auto-approval policy.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from aragora.inbox.trust_wedge import (
+    ActionIntent,
+    AllowedAction,
+    ReceiptState,
+    TriageDecision,
+    compute_content_hash,
+)
+from aragora.inbox.cli_review import CLIReviewLoop
+from aragora.inbox.auto_approval import AutoApprovalPolicy
+
+
+# -----------------------------------------------------------------------
+# AllowedAction enum
+# -----------------------------------------------------------------------
+
+
+class TestAllowedAction:
+    def test_values(self) -> None:
+        assert AllowedAction.ARCHIVE.value == "archive"
+        assert AllowedAction.STAR.value == "star"
+        assert AllowedAction.LABEL.value == "label"
+        assert AllowedAction.IGNORE.value == "ignore"
+
+    def test_is_str_enum(self) -> None:
+        assert isinstance(AllowedAction.ARCHIVE, str)
+        assert AllowedAction.ARCHIVE == "archive"
+
+    def test_members_count(self) -> None:
+        assert len(AllowedAction) == 4
+
+
+# -----------------------------------------------------------------------
+# ReceiptState enum
+# -----------------------------------------------------------------------
+
+
+class TestReceiptState:
+    def test_values(self) -> None:
+        assert ReceiptState.CREATED.value == "created"
+        assert ReceiptState.APPROVED.value == "approved"
+        assert ReceiptState.EXPIRED.value == "expired"
+        assert ReceiptState.EXECUTED.value == "executed"
+
+
+# -----------------------------------------------------------------------
+# compute_content_hash
+# -----------------------------------------------------------------------
+
+
+class TestContentHash:
+    def test_deterministic(self) -> None:
+        h1 = compute_content_hash("hello world")
+        h2 = compute_content_hash("hello world")
+        assert h1 == h2
+
+    def test_differs_for_different_content(self) -> None:
+        h1 = compute_content_hash("hello")
+        h2 = compute_content_hash("world")
+        assert h1 != h2
+
+    def test_sha256_length(self) -> None:
+        h = compute_content_hash("test")
+        assert len(h) == 64  # SHA-256 hex digest
+
+
+# -----------------------------------------------------------------------
+# ActionIntent
+# -----------------------------------------------------------------------
+
+
+class TestActionIntent:
+    def _make_intent(self, **overrides: object) -> ActionIntent:
+        defaults: dict = {
+            "provider": "claude-3",
+            "message_id": "msg-123",
+            "action": AllowedAction.ARCHIVE.value,
+            "content_hash": compute_content_hash("body"),
+            "synthesized_rationale": "Low priority newsletter",
+            "confidence": 0.92,
+            "provider_route": "direct",
+            "debate_id": "debate-abc",
+            "created_at": "2026-03-06T12:00:00+00:00",
+        }
+        defaults.update(overrides)
+        return ActionIntent(**defaults)
+
+    def test_creation(self) -> None:
+        intent = self._make_intent()
+        assert intent.provider == "claude-3"
+        assert intent.message_id == "msg-123"
+        assert intent.confidence == 0.92
+
+    def test_to_dict(self) -> None:
+        intent = self._make_intent()
+        d = intent.to_dict()
+        assert d["provider"] == "claude-3"
+        assert d["action"] == "archive"
+        assert isinstance(d["content_hash"], str)
+
+    def test_roundtrip(self) -> None:
+        intent = self._make_intent()
+        d = intent.to_dict()
+        restored = ActionIntent.from_dict(d)
+        assert restored.provider == intent.provider
+        assert restored.message_id == intent.message_id
+        assert restored.confidence == intent.confidence
+        assert restored.action == intent.action
+
+    def test_content_hash_matches_body(self) -> None:
+        body = "Important meeting tomorrow"
+        expected_hash = compute_content_hash(body)
+        intent = self._make_intent(content_hash=expected_hash)
+        assert intent.content_hash == expected_hash
+
+
+# -----------------------------------------------------------------------
+# TriageDecision
+# -----------------------------------------------------------------------
+
+
+class TestTriageDecision:
+    def _make_decision(self, **overrides: object) -> TriageDecision:
+        defaults: dict = {
+            "final_action": AllowedAction.ARCHIVE.value,
+            "confidence": 0.90,
+            "dissent_summary": "",
+            "receipt_id": "receipt-001",
+            "auto_approval_eligible": False,
+            "provider_route": "direct",
+            "intent": None,
+            "receipt_state": ReceiptState.CREATED.value,
+        }
+        defaults.update(overrides)
+        return TriageDecision(**defaults)
+
+    def test_creation(self) -> None:
+        d = self._make_decision()
+        assert d.final_action == "archive"
+        assert d.receipt_state == "created"
+
+    def test_auto_approval_eligible_default(self) -> None:
+        d = self._make_decision()
+        assert d.auto_approval_eligible is False
+
+    def test_to_dict_with_intent(self) -> None:
+        intent = ActionIntent(
+            provider="gpt-4",
+            message_id="msg-456",
+            action="star",
+            content_hash="abc123",
+            synthesized_rationale="Important from boss",
+            confidence=0.95,
+            provider_route="direct",
+            debate_id="debate-xyz",
+        )
+        d = self._make_decision(intent=intent)
+        result = d.to_dict()
+        assert result["intent"]["provider"] == "gpt-4"
+        assert result["intent"]["action"] == "star"
+
+    def test_to_dict_without_intent(self) -> None:
+        d = self._make_decision()
+        result = d.to_dict()
+        assert result["intent"] is None
+
+    def test_roundtrip(self) -> None:
+        intent = ActionIntent(
+            provider="claude-3",
+            message_id="msg-789",
+            action="ignore",
+            content_hash="def456",
+            synthesized_rationale="Spam",
+            confidence=0.88,
+            provider_route="openrouter",
+            debate_id="debate-123",
+        )
+        decision = self._make_decision(
+            final_action="ignore",
+            confidence=0.88,
+            dissent_summary="One agent wanted archive",
+            intent=intent,
+        )
+        d = decision.to_dict()
+        restored = TriageDecision.from_dict(d)
+        assert restored.final_action == "ignore"
+        assert restored.dissent_summary == "One agent wanted archive"
+        assert restored.intent is not None
+        assert restored.intent.provider == "claude-3"
+
+
+# -----------------------------------------------------------------------
+# AutoApprovalPolicy
+# -----------------------------------------------------------------------
+
+
+class TestAutoApprovalPolicy:
+    def _make_decision(self, **overrides: object) -> TriageDecision:
+        defaults: dict = {
+            "final_action": AllowedAction.ARCHIVE.value,
+            "confidence": 0.90,
+            "dissent_summary": "",
+            "receipt_state": ReceiptState.CREATED.value,
+        }
+        defaults.update(overrides)
+        return TriageDecision(**defaults)
+
+    def test_can_auto_approve_archive_high_confidence(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(confidence=0.90)
+        assert policy.can_auto_approve(d) is True
+
+    def test_blocks_label_action(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(final_action=AllowedAction.LABEL.value)
+        assert policy.can_auto_approve(d) is False
+
+    def test_blocks_low_confidence(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(confidence=0.50)
+        assert policy.can_auto_approve(d) is False
+
+    def test_blocks_dissent(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(dissent_summary="Agent disagreed about action")
+        assert policy.can_auto_approve(d) is False
+
+    def test_blocks_non_created_state(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(receipt_state=ReceiptState.APPROVED.value)
+        assert policy.can_auto_approve(d) is False
+
+    def test_auto_approve_transitions_state(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(confidence=0.95)
+        result = policy.auto_approve(d)
+        assert result is True
+        assert d.receipt_state == ReceiptState.APPROVED.value
+        assert d.auto_approval_eligible is True
+
+    def test_auto_approve_returns_false_when_blocked(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(confidence=0.50)
+        result = policy.auto_approve(d)
+        assert result is False
+        assert d.receipt_state == ReceiptState.CREATED.value
+
+    def test_custom_threshold(self) -> None:
+        policy = AutoApprovalPolicy(confidence_threshold=0.95)
+        d = self._make_decision(confidence=0.90)
+        assert policy.can_auto_approve(d) is False
+        d2 = self._make_decision(confidence=0.96)
+        assert policy.can_auto_approve(d2) is True
+
+    def test_star_auto_approvable(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(final_action=AllowedAction.STAR.value, confidence=0.90)
+        assert policy.can_auto_approve(d) is True
+
+    def test_ignore_auto_approvable(self) -> None:
+        policy = AutoApprovalPolicy()
+        d = self._make_decision(final_action=AllowedAction.IGNORE.value, confidence=0.90)
+        assert policy.can_auto_approve(d) is True
+
+    def test_to_dict_roundtrip(self) -> None:
+        policy = AutoApprovalPolicy(confidence_threshold=0.92)
+        d = policy.to_dict()
+        restored = AutoApprovalPolicy.from_dict(d)
+        assert restored.confidence_threshold == 0.92
+
+
+# -----------------------------------------------------------------------
+# CLIReviewLoop
+# -----------------------------------------------------------------------
+
+
+class TestCLIReviewLoop:
+    def _make_decision(self, **overrides: object) -> TriageDecision:
+        defaults: dict = {
+            "final_action": AllowedAction.ARCHIVE.value,
+            "confidence": 0.90,
+            "dissent_summary": "",
+            "receipt_id": "test-receipt",
+            "receipt_state": ReceiptState.CREATED.value,
+        }
+        defaults.update(overrides)
+        return TriageDecision(**defaults)
+
+    def test_approve_flow(self) -> None:
+        inputs = iter(["a"])
+        output: list[str] = []
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *args: output.append(str(args)),
+        )
+        decision = self._make_decision()
+        results = loop.review_batch([decision])
+        assert len(results) == 1
+        assert results[0]["action_taken"] == "approve"
+        assert decision.receipt_state == ReceiptState.APPROVED.value
+
+    def test_reject_flow(self) -> None:
+        inputs = iter(["r"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+        )
+        decision = self._make_decision()
+        results = loop.review_batch([decision])
+        assert results[0]["action_taken"] == "reject"
+        assert decision.receipt_state == ReceiptState.EXPIRED.value
+
+    def test_skip_flow(self) -> None:
+        inputs = iter(["s"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+        )
+        decision = self._make_decision()
+        results = loop.review_batch([decision])
+        assert results[0]["action_taken"] == "skip"
+        assert decision.receipt_state == ReceiptState.CREATED.value
+
+    def test_edit_flow(self) -> None:
+        inputs = iter(["e", "star"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+        )
+        decision = self._make_decision(final_action="archive")
+        results = loop.review_batch([decision])
+        assert results[0]["action_taken"] == "edit"
+        assert results[0]["final_action"] == "star"
+        assert decision.final_action == "star"
+
+    def test_invalid_then_valid_choice(self) -> None:
+        inputs = iter(["x", "z", "a"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+        )
+        decision = self._make_decision()
+        results = loop.review_batch([decision])
+        assert results[0]["action_taken"] == "approve"
+
+    def test_approve_callback(self) -> None:
+        approved: list[TriageDecision] = []
+        inputs = iter(["a"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+            on_approve=lambda d: approved.append(d),
+        )
+        decision = self._make_decision()
+        loop.review_batch([decision])
+        assert len(approved) == 1
+        assert approved[0].receipt_id == "test-receipt"
+
+    def test_reject_callback(self) -> None:
+        rejected: list[TriageDecision] = []
+        inputs = iter(["r"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+            on_reject=lambda d: rejected.append(d),
+        )
+        decision = self._make_decision()
+        loop.review_batch([decision])
+        assert len(rejected) == 1
+
+    def test_batch_multiple_decisions(self) -> None:
+        inputs = iter(["a", "r", "s"])
+        loop = CLIReviewLoop(
+            input_fn=lambda _prompt="": next(inputs),
+            print_fn=lambda *_args: None,
+        )
+        decisions = [
+            self._make_decision(receipt_id="r1"),
+            self._make_decision(receipt_id="r2"),
+            self._make_decision(receipt_id="r3"),
+        ]
+        results = loop.review_batch(decisions)
+        assert len(results) == 3
+        assert results[0]["action_taken"] == "approve"
+        assert results[1]["action_taken"] == "reject"
+        assert results[2]["action_taken"] == "skip"


### PR DESCRIPTION
## Summary
Core contract layer for the inbox trust wedge (Track 1 of the two-track plan):

- **ActionIntent**: Model's proposed action on an email (provider, message_id, content_hash, debate linkage)
- **TriageDecision**: Wraps intent with consensus metadata, receipt state, auto-approval eligibility
- **AllowedAction**: Enum restricting v1 to ARCHIVE, STAR, LABEL, IGNORE only
- **ReceiptState**: State machine (CREATED → APPROVED → EXECUTED → EXPIRED)
- **CLIReviewLoop**: Approve/Reject/Edit/Skip flow for manual triage review
- **AutoApprovalPolicy**: Confidence >= 0.85, no dissent, safe actions only (not LABEL)
- **InboxTriageRunner**: Orchestrates Gmail fetch → debate → receipt → approval

## Context
From the [dogfood plan](docs/plans/2026-03-06-openrouter-inbox-dogfood-plan.md): "Make one path real enough to trust and use daily."

## Test plan
- [x] 35 new tests pass (contracts, CLI flows, auto-approval rules)
- [x] 70 existing inbox tests pass (0 regressions)
- [ ] Integration with attestation fix (separate PR)
- [ ] End-to-end Gmail triage run

🤖 Generated with [Claude Code](https://claude.com/claude-code)