### PR TITLE
fix(inbox): remove demo fallbacks from inbox mutation paths

### DIFF
--- a/aragora/live/src/components/inbox/SharedInboxView.tsx
+++ b/aragora/live/src/components/inbox/SharedInboxView.tsx
@@ -71,82 +71,13 @@ const PRIORITY_COLORS: Record<string, string> = {
   low: 'text-blue-400 bg-blue-500/10',
 };
 
-// Demo data (prefixed with _ as currently unused fallback data)
-const _DEMO_INBOX: SharedInbox = {
-  id: 'inbox_demo',
-  workspace_id: 'ws_demo',
-  name: 'Support Inbox',
-  description: 'Customer support emails',
-  email_address: 'support@company.com',
-  connector_type: 'gmail',
-  team_members: ['user1', 'user2', 'user3'],
-  admins: ['admin1'],
-  message_count: 47,
-  unread_count: 12,
-};
-
-const _DEMO_MESSAGES: SharedInboxMessage[] = [
-  {
-    id: 'msg_1',
-    inbox_id: 'inbox_demo',
-    email_id: 'email_123',
-    subject: 'URGENT: Production issue affecting customers',
-    from_address: 'ops@acmecorp.com',
-    to_addresses: ['support@company.com'],
-    snippet: 'We are experiencing critical downtime on our production servers...',
-    received_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
-    status: 'open',
-    tags: ['urgent', 'production'],
-    priority: 'critical',
-    notes: [],
-  },
-  {
-    id: 'msg_2',
-    inbox_id: 'inbox_demo',
-    email_id: 'email_124',
-    subject: 'Question about billing',
-    from_address: 'finance@clientinc.com',
-    to_addresses: ['support@company.com'],
-    snippet: 'Hi, I noticed a discrepancy in our last invoice...',
-    received_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
-    status: 'assigned',
-    assigned_to: 'user1',
-    assigned_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
-    tags: ['billing'],
-    priority: 'medium',
-    notes: [{ text: 'Checking with finance team', author: 'user1', created_at: new Date(Date.now() - 30 * 60 * 1000).toISOString() }],
-  },
-  {
-    id: 'msg_3',
-    inbox_id: 'inbox_demo',
-    email_id: 'email_125',
-    subject: 'Feature request: Dark mode',
-    from_address: 'user@startup.io',
-    to_addresses: ['support@company.com'],
-    snippet: 'Would love to see a dark mode option in the app...',
-    received_at: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
-    status: 'resolved',
-    assigned_to: 'user2',
-    resolved_at: new Date(Date.now() - 12 * 60 * 60 * 1000).toISOString(),
-    resolved_by: 'user2',
-    tags: ['feature-request'],
-    priority: 'low',
-    notes: [],
-  },
-];
-
-const DEMO_TEAM: TeamMember[] = [
-  { id: 'user1', name: 'Alice Chen', email: 'alice@company.com' },
-  { id: 'user2', name: 'Bob Smith', email: 'bob@company.com' },
-  { id: 'user3', name: 'Carol Davis', email: 'carol@company.com' },
-];
 
 export function SharedInboxView({
   apiBase,
   workspaceId,
   authToken,
   currentUserId = 'user1',
-  teamMembers = DEMO_TEAM,
+  teamMembers = [],
 }: SharedInboxViewProps) {
   const [inboxes, setInboxes] = useState<SharedInbox[]>([]);
   const [selectedInbox, setSelectedInbox] = useState<SharedInbox | null>(null);
@@ -251,26 +182,15 @@ export function SharedInboxView({
       );
 
       if (!response.ok) {
-        // Update locally for demo
-        setMessages(messages.map(m =>
-          m.id === messageId
-            ? { ...m, assigned_to: userId, status: 'assigned', assigned_at: new Date().toISOString() }
-            : m
-        ));
-        setAssignModalOpen(false);
+        setError(`Failed to assign message: ${response.status} ${response.statusText}`);
         return;
       }
 
       await fetchMessages();
       setAssignModalOpen(false);
-    } catch {
-      // Update locally for demo
-      setMessages(messages.map(m =>
-        m.id === messageId
-          ? { ...m, assigned_to: userId, status: 'assigned', assigned_at: new Date().toISOString() }
-          : m
-      ));
-      setAssignModalOpen(false);
+    } catch (error) {
+      console.error('Assign failed:', error);
+      setError(`Failed to assign message: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
 
@@ -289,19 +209,14 @@ export function SharedInboxView({
       );
 
       if (!response.ok) {
-        // Update locally for demo
-        setMessages(messages.map(m =>
-          m.id === messageId ? { ...m, status } : m
-        ));
+        setError(`Failed to update status: ${response.status} ${response.statusText}`);
         return;
       }
 
       await fetchMessages();
-    } catch {
-      // Update locally for demo
-      setMessages(messages.map(m =>
-        m.id === messageId ? { ...m, status } : m
-      ));
+    } catch (error) {
+      console.error('Status change failed:', error);
+      setError(`Failed to update status: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }
   };
 

--- a/aragora/live/src/components/inbox/TriageRulesPanel.tsx
+++ b/aragora/live/src/components/inbox/TriageRulesPanel.tsx
@@ -75,66 +75,6 @@ const ACTION_OPTIONS: { value: ActionType; label: string; icon: string; needsTar
   { value: 'forward', label: 'Forward To', icon: '➡️', needsTarget: true },
 ];
 
-// Demo rules for when API is unavailable (prefixed with _ as currently unused fallback)
-const _DEMO_RULES: TriageRule[] = [
-  {
-    id: 'rule-1',
-    name: 'Urgent Customer Issues',
-    description: 'Route urgent customer emails to support team',
-    conditions: [
-      { field: 'subject', operator: 'contains', value: 'urgent' },
-      { field: 'sender_domain', operator: 'contains', value: 'customer' },
-    ],
-    condition_logic: 'OR',
-    actions: [
-      { type: 'assign', target: 'support-team' },
-      { type: 'label', target: 'urgent' },
-      { type: 'notify', target: 'slack:#support-alerts' },
-    ],
-    priority: 1,
-    enabled: true,
-    created_at: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(),
-    updated_at: new Date().toISOString(),
-    stats: { total_matches: 47, last_matched: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() },
-  },
-  {
-    id: 'rule-2',
-    name: 'Security Alerts',
-    description: 'Auto-escalate security-related emails',
-    conditions: [
-      { field: 'subject', operator: 'contains', value: 'security' },
-      { field: 'priority', operator: 'equals', value: 'critical' },
-    ],
-    condition_logic: 'AND',
-    actions: [
-      { type: 'escalate', target: 'security-team' },
-      { type: 'label', target: 'security-alert' },
-    ],
-    priority: 0,
-    enabled: true,
-    created_at: new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString(),
-    updated_at: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
-    stats: { total_matches: 12 },
-  },
-  {
-    id: 'rule-3',
-    name: 'Newsletter Archive',
-    description: 'Auto-archive newsletters and marketing emails',
-    conditions: [
-      { field: 'from', operator: 'contains', value: 'newsletter' },
-    ],
-    condition_logic: 'AND',
-    actions: [
-      { type: 'archive' },
-      { type: 'label', target: 'newsletter' },
-    ],
-    priority: 10,
-    enabled: false,
-    created_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
-    updated_at: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(),
-    stats: { total_matches: 234 },
-  },
-];
 
 export function TriageRulesPanel({
   apiBase,
@@ -229,7 +169,7 @@ export function TriageRulesPanel({
 
   const handleToggleRule = async (ruleId: string, enabled: boolean) => {
     try {
-      await fetch(`${apiBase}/api/v1/inbox/routing/rules/${ruleId}`, {
+      const response = await fetch(`${apiBase}/api/v1/inbox/routing/rules/${ruleId}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -237,27 +177,40 @@ export function TriageRulesPanel({
         },
         body: JSON.stringify({ enabled }),
       });
-    } catch {
-      // Ignore API errors in demo mode
-    }
 
-    // Update locally
-    setRules(rules.map(r => r.id === ruleId ? { ...r, enabled } : r));
+      if (!response.ok) {
+        setError(`Failed to toggle rule: ${response.status} ${response.statusText}`);
+        return;
+      }
+
+      // Update locally only after successful API call
+      setRules(rules.map(r => r.id === ruleId ? { ...r, enabled } : r));
+    } catch (error) {
+      console.error('Toggle rule failed:', error);
+      setError(`Failed to toggle rule: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   };
 
   const handleDeleteRule = async (ruleId: string) => {
     if (!confirm('Are you sure you want to delete this rule?')) return;
 
     try {
-      await fetch(`${apiBase}/api/v1/inbox/routing/rules/${ruleId}`, {
+      const response = await fetch(`${apiBase}/api/v1/inbox/routing/rules/${ruleId}`, {
         method: 'DELETE',
         headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
       });
-    } catch {
-      // Ignore API errors in demo mode
-    }
 
-    setRules(rules.filter(r => r.id !== ruleId));
+      if (!response.ok) {
+        setError(`Failed to delete rule: ${response.status} ${response.statusText}`);
+        return;
+      }
+
+      // Update locally only after successful API call
+      setRules(rules.filter(r => r.id !== ruleId));
+    } catch (error) {
+      console.error('Delete rule failed:', error);
+      setError(`Failed to delete rule: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   };
 
   const handleTestRule = async (rule: TriageRule) => {
@@ -272,8 +225,8 @@ export function TriageRulesPanel({
       });
 
       if (!response.ok) {
-        // Demo mode - simulate test
-        alert(`Rule "${rule.name}" would match approximately ${Math.floor(Math.random() * 20) + 5} emails`);
+        const errorText = await response.text();
+        setError(`Failed to test rule: ${response.status} ${errorText || response.statusText}`);
         return;
       }
 

--- a/aragora/server/handlers/features/connectors.py
+++ b/aragora/server/handlers/features/connectors.py
@@ -576,58 +576,29 @@ class ConnectorsHandler(SecureHandler):
         )
 
     async def _run_sync(self, sync_id: str, connector_id: str) -> None:
-        """Background task to run sync operation."""
+        """Background task to run sync operation.
+
+        Real connector sync required -- use the Gmail connector directly.
+        This stub marks the sync as failed since simulated sync has been removed.
+        """
         sync_job = _sync_jobs.get(sync_id)
         connector = _connectors.get(connector_id)
 
         if not sync_job or not connector:
             return
 
-        try:
-            # Simulate sync progress
-            total_items = 100 + int(uuid4().int % 1000)
-            sync_job["items_total"] = total_items
+        sync_job["status"] = "failed"
+        sync_job["error_message"] = "Real connector sync required -- use Gmail connector directly"
+        sync_job["completed_at"] = datetime.now(timezone.utc).isoformat()
+        connector["status"] = "error"
+        connector["error_message"] = "Real connector sync required -- use Gmail connector directly"
+        _sync_history.append(dict(sync_job))
 
-            for i in range(total_items):
-                # Check if cancelled
-                if sync_job["status"] == "cancelled":
-                    break
-
-                # Simulate processing
-                await asyncio.sleep(0.05)
-                sync_job["items_processed"] = i + 1
-                sync_job["progress"] = (i + 1) / total_items
-
-            # Mark as complete
-            if sync_job["status"] != "cancelled":
-                sync_job["status"] = "completed"
-                connector["status"] = "connected"
-                connector["last_sync"] = datetime.now(timezone.utc).isoformat()
-                connector["items_synced"] = (
-                    connector.get("items_synced", 0) + sync_job["items_processed"]
-                )
-
-            sync_job["completed_at"] = datetime.now(timezone.utc).isoformat()
-            duration = (
-                datetime.fromisoformat(sync_job["completed_at"].replace("Z", "+00:00"))
-                - datetime.fromisoformat(sync_job["started_at"].replace("Z", "+00:00"))
-            ).total_seconds()
-            sync_job["duration_seconds"] = int(duration)
-
-            # Add to history
-            _sync_history.append(dict(sync_job))
-
-            logger.info("Completed sync %s for connector %s", sync_id, connector_id)
-
-        except (ConnectionError, TimeoutError, OSError, ValueError, KeyError, TypeError) as e:
-            sync_job["status"] = "failed"
-            sync_job["error_message"] = "Sync operation failed"
-            sync_job["completed_at"] = datetime.now(timezone.utc).isoformat()
-            connector["status"] = "error"
-            connector["error_message"] = "Sync operation failed"
-            _sync_history.append(dict(sync_job))
-
-            logger.error("Sync %s failed: %s", sync_id, e)
+        logger.error(
+            "Sync %s for connector %s failed: simulated sync removed, real connector required",
+            sync_id,
+            connector_id,
+        )
 
     async def _cancel_sync(self, request: Any, sync_id: str) -> dict[str, Any]:
         """Cancel a running sync operation."""
@@ -658,21 +629,12 @@ class ConnectorsHandler(SecureHandler):
             return self._error_response(400, "Invalid request body")
 
         connector_id = body.get("connector_id")
-        config = body.get("config", {})
-
-        # In production, this would actually test the connection
-        # For now, simulate a test
-        await asyncio.sleep(1)
-
-        # Simulate success/failure based on config
-        has_required_fields = bool(config)
-        success = has_required_fields
 
         return self._json_response(
-            200,
+            501,
             {
-                "success": success,
-                "message": "Connection successful" if success else "Missing required configuration",
+                "success": False,
+                "error": "Real connector test required -- use Gmail connector directly",
                 "connector_id": connector_id,
             },
         )

--- a/aragora/server/handlers/shared_inbox/inbox_handlers.py
+++ b/aragora/server/handlers/shared_inbox/inbox_handlers.py
@@ -233,9 +233,13 @@ async def handle_list_shared_inboxes(
                         "total": len(stored_inboxes),
                     }
             except (OSError, RuntimeError, ValueError, KeyError) as e:
-                logger.warning("[SharedInbox] Failed to load from store, using cache: %s", e)
+                logger.error("[SharedInbox] Failed to load from store: %s", e)
+                return {
+                    "success": False,
+                    "error": "Storage operation failed",
+                }
 
-        # Fallback to in-memory
+        # No persistent store available -- use in-memory
         with _storage_lock:
             inboxes = [
                 inbox.to_dict()
@@ -370,9 +374,11 @@ async def handle_get_inbox_messages(
                                     ]
                                 total_count = len(all_messages)
                         except (OSError, RuntimeError, ValueError, KeyError) as e:
-                            # Fall back to page count + offset
-                            logger.debug("Error counting messages, using fallback: %s", e)
-                            total_count = offset + len(messages_data)
+                            logger.error("Error counting messages: %s", e)
+                            return {
+                                "success": False,
+                                "error": "Storage operation failed",
+                            }
 
                     return {
                         "success": True,
@@ -382,9 +388,13 @@ async def handle_get_inbox_messages(
                         "offset": offset,
                     }
             except (OSError, RuntimeError, ValueError, KeyError) as e:
-                logger.warning("[SharedInbox] Failed to load messages from store: %s", e)
+                logger.error("[SharedInbox] Failed to load messages from store: %s", e)
+                return {
+                    "success": False,
+                    "error": "Storage operation failed",
+                }
 
-        # Fallback to in-memory
+        # No persistent store available -- use in-memory
         with _storage_lock:
             if inbox_id not in _inbox_messages:
                 return {"success": False, "error": "Inbox not found"}

--- a/aragora/server/handlers/shared_inbox/rule_handlers.py
+++ b/aragora/server/handlers/shared_inbox/rule_handlers.py
@@ -341,31 +341,13 @@ async def handle_list_routing_rules(
                     "offset": offset,
                 }
             except (OSError, RuntimeError, ValueError, KeyError) as e:
-                logger.warning("[SharedInbox] Failed to load rules from RulesStore: %s", e)
+                logger.error("[SharedInbox] Failed to load rules from RulesStore: %s", e)
+                return {
+                    "success": False,
+                    "error": "Storage operation failed",
+                }
 
-        # Try email store as fallback
-        email_store = _get_store()
-        if email_store:
-            try:
-                rules = email_store.list_routing_rules(
-                    workspace_id=workspace_id,
-                    inbox_id=inbox_id,
-                    enabled_only=enabled_only,
-                )
-                if rules is not None:
-                    total = len(rules)
-                    rules = rules[offset : offset + limit]
-                    return {
-                        "success": True,
-                        "rules": rules,
-                        "total": total,
-                        "limit": limit,
-                        "offset": offset,
-                    }
-            except (OSError, RuntimeError, ValueError, KeyError) as e:
-                logger.warning("[SharedInbox] Failed to load rules from email store: %s", e)
-
-        # Fallback to in-memory
+        # No persistent store available -- use in-memory
         with _storage_lock:
             all_rules = [
                 rule.to_dict()
@@ -732,17 +714,6 @@ async def handle_test_routing_rule(
                     rule = RoutingRule.from_dict(rule_data)
             except (OSError, RuntimeError, ValueError, KeyError) as e:
                 logger.warning("[SharedInbox] Failed to load rule from RulesStore: %s", e)
-
-        # Try email store as fallback
-        if not rule:
-            email_store = _get_store()
-            if email_store:
-                try:
-                    rule_data = email_store.get_routing_rule(rule_id)
-                    if rule_data:
-                        rule = RoutingRule.from_dict(rule_data)
-                except (OSError, RuntimeError, ValueError, KeyError) as e:
-                    logger.warning("[SharedInbox] Failed to load rule from email store: %s", e)
 
         # Fallback to in-memory
         if not rule:

--- a/tests/handlers/shared_inbox/test_inbox_handlers.py
+++ b/tests/handlers/shared_inbox/test_inbox_handlers.py
@@ -378,7 +378,7 @@ class TestListSharedInboxes:
         assert result["inboxes"][0]["id"] == "si1"
 
     @pytest.mark.asyncio
-    async def test_list_store_error_falls_back_to_memory(self, patch_store):
+    async def test_list_store_error_returns_failure(self, patch_store):
         store = patch_store
         store.list_shared_inboxes.side_effect = OSError("store down")
         inbox = _make_inbox(inbox_id="i1", workspace_id="ws_1")
@@ -386,8 +386,8 @@ class TestListSharedInboxes:
             _shared_inboxes["i1"] = inbox
 
         result = await handle_list_shared_inboxes(workspace_id="ws_1")
-        assert result["success"] is True
-        assert result["total"] == 1
+        assert result["success"] is False
+        assert "storage" in result["error"].lower() or "failed" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_list_store_empty_falls_back_to_memory(self, patch_store):
@@ -613,7 +613,7 @@ class TestGetInboxMessages:
         assert result["messages"][0]["id"] == "m1"
 
     @pytest.mark.asyncio
-    async def test_get_messages_store_error_falls_back(self, patch_store):
+    async def test_get_messages_store_error_returns_failure(self, patch_store):
         store = patch_store
         store.get_inbox_messages.side_effect = RuntimeError("db down")
         m1 = _make_message(message_id="m1", inbox_id="i1")
@@ -621,8 +621,8 @@ class TestGetInboxMessages:
             _inbox_messages["i1"] = {"m1": m1}
 
         result = await handle_get_inbox_messages(inbox_id="i1")
-        assert result["success"] is True
-        assert result["total"] == 1
+        assert result["success"] is False
+        assert "storage" in result["error"].lower() or "failed" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_get_messages_store_uses_list_inbox_messages_fallback(self, mock_store):

--- a/tests/handlers/shared_inbox/test_rule_handlers.py
+++ b/tests/handlers/shared_inbox/test_rule_handlers.py
@@ -710,8 +710,8 @@ class TestListRoutingRules:
         assert result["total"] == 1
 
     @pytest.mark.asyncio
-    async def test_list_rules_store_failure_falls_back(self):
-        """Falls back to in-memory when rules_store fails."""
+    async def test_list_rules_store_failure_returns_error(self):
+        """Returns error when rules_store fails instead of silently falling back."""
         rules_store = MagicMock()
         rules_store.list_rules.side_effect = RuntimeError("nope")
         rule = _make_routing_rule(workspace_id="ws_fb")
@@ -722,50 +722,8 @@ class TestListRoutingRules:
             patch(f"{MODULE}._get_store", return_value=None),
         ):
             result = await handle_list_routing_rules(workspace_id="ws_fb")
-        assert result["success"] is True
-        assert result["total"] == 1
-
-    @pytest.mark.asyncio
-    async def test_list_email_store_fallback(self):
-        """Falls back to email store when rules_store returns None."""
-        email_store = MagicMock()
-        email_store.list_routing_rules.return_value = [
-            {"id": "es_1", "name": "Email Store Rule"},
-        ]
-        with (
-            patch(f"{MODULE}._get_rules_store", return_value=None),
-            patch(f"{MODULE}._get_store", return_value=email_store),
-        ):
-            result = await handle_list_routing_rules(workspace_id="ws_1")
-        assert result["success"] is True
-        assert result["rules"][0]["id"] == "es_1"
-        assert result["total"] == 1
-
-    @pytest.mark.asyncio
-    async def test_list_email_store_returns_none_falls_to_memory(self):
-        """Falls through to in-memory when email store returns None."""
-        email_store = MagicMock()
-        email_store.list_routing_rules.return_value = None
-        with (
-            patch(f"{MODULE}._get_rules_store", return_value=None),
-            patch(f"{MODULE}._get_store", return_value=email_store),
-        ):
-            result = await handle_list_routing_rules(workspace_id="ws_1")
-        assert result["success"] is True
-        assert result["rules"] == []
-
-    @pytest.mark.asyncio
-    async def test_list_email_store_failure_falls_to_memory(self):
-        """Falls through to in-memory when email store raises."""
-        email_store = MagicMock()
-        email_store.list_routing_rules.side_effect = OSError("fail")
-        with (
-            patch(f"{MODULE}._get_rules_store", return_value=None),
-            patch(f"{MODULE}._get_store", return_value=email_store),
-        ):
-            result = await handle_list_routing_rules(workspace_id="ws_1")
-        assert result["success"] is True
-        assert result["rules"] == []
+        assert result["success"] is False
+        assert "storage" in result["error"].lower() or "failed" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_list_inbox_id_filter(self, mock_stores):
@@ -1441,14 +1399,13 @@ class TestTestRoutingRule:
         assert result["match_count"] == 3
 
     @pytest.mark.asyncio
-    async def test_test_rule_from_email_store(self):
-        """Falls back to email_store when rules_store returns None."""
-        rule_data = _make_routing_rule().to_dict()
-        email_store = MagicMock()
-        email_store.get_routing_rule.return_value = rule_data
+    async def test_test_rule_no_stores_falls_to_memory(self):
+        """Falls back to in-memory when no persistent stores available."""
+        rule = _make_routing_rule()
+        with _storage_lock:
+            _routing_rules["rule_abc123"] = rule
         with (
             patch(f"{MODULE}._get_rules_store", return_value=None),
-            patch(f"{MODULE}._get_store", return_value=email_store),
             patch(f"{MODULE}.evaluate_rule_for_test", return_value=0),
         ):
             result = await handle_test_routing_rule(
@@ -1459,16 +1416,15 @@ class TestTestRoutingRule:
         assert result["match_count"] == 0
 
     @pytest.mark.asyncio
-    async def test_test_rule_rules_store_failure_falls_back(self):
-        """Falls back to email_store when rules_store raises."""
-        rule_data = _make_routing_rule().to_dict()
+    async def test_test_rule_rules_store_failure_falls_to_memory(self):
+        """Falls back to in-memory when rules_store raises (email store fallback removed)."""
         rules_store = MagicMock()
         rules_store.get_rule.side_effect = RuntimeError("fail")
-        email_store = MagicMock()
-        email_store.get_routing_rule.return_value = rule_data
+        rule = _make_routing_rule()
+        with _storage_lock:
+            _routing_rules["rule_abc123"] = rule
         with (
             patch(f"{MODULE}._get_rules_store", return_value=rules_store),
-            patch(f"{MODULE}._get_store", return_value=email_store),
             patch(f"{MODULE}.evaluate_rule_for_test", return_value=2),
         ):
             result = await handle_test_routing_rule(
@@ -1479,26 +1435,19 @@ class TestTestRoutingRule:
         assert result["match_count"] == 2
 
     @pytest.mark.asyncio
-    async def test_test_rule_email_store_failure_falls_to_memory(self):
-        """Falls back to memory when email_store raises."""
+    async def test_test_rule_not_in_any_store_returns_not_found(self):
+        """Returns not found when rule is not in any store."""
         rules_store = MagicMock()
-        rules_store.get_rule.return_value = None  # not in rules_store
-        email_store = MagicMock()
-        email_store.get_routing_rule.side_effect = OSError("fail")
-        rule = _make_routing_rule()
-        with _storage_lock:
-            _routing_rules["rule_abc123"] = rule
+        rules_store.get_rule.return_value = None
         with (
             patch(f"{MODULE}._get_rules_store", return_value=rules_store),
-            patch(f"{MODULE}._get_store", return_value=email_store),
-            patch(f"{MODULE}.evaluate_rule_for_test", return_value=1),
         ):
             result = await handle_test_routing_rule(
-                rule_id="rule_abc123",
+                rule_id="rule_nonexistent",
                 workspace_id="ws_test",
             )
-        assert result["success"] is True
-        assert result["match_count"] == 1
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
 
     @pytest.mark.asyncio
     async def test_test_rule_zero_matches(self, mock_stores):


### PR DESCRIPTION
## Summary
Remove silent demo degradation from inbox/shared-inbox code paths. Mutations now fail visibly instead of silently succeeding with fake data.

**Frontend (3 files):**
- SharedInboxView.tsx: Delete demo data constants, replace catch-block local updates with error display
- TriageRulesPanel.tsx: Delete demo rules, replace silent API error ignoring with error display
- inbox/page.tsx: Keep legacy endpoint fallbacks (these are real API fallbacks, not demo behavior)

**Backend (4 files):**
- connectors.py: Replace simulated sync loop (sleep + fake progress) with error stub
- inbox_handlers.py: Replace store-to-in-memory fallbacks with error responses
- rule_handlers.py: Remove email store fallback cascades

**Tests updated:** 7 test methods renamed/rewritten to expect error responses instead of fallback behavior.

## Context
Blocking gap #3 from the [dogfood plan](docs/plans/2026-03-06-openrouter-inbox-dogfood-plan.md): "The inbox/shared-inbox path cannot quietly degrade to demo or local-only behavior."

## Test plan
- [x] 1105 tests pass across shared-inbox handlers and connectors
- [x] 0 regressions
- [ ] Manual verification that frontend shows error states

🤖 Generated with [Claude Code](https://claude.com/claude-code)