### PR TITLE
feat(routing): session circuit-breaker for OpenRouter pinning

### DIFF
--- a/aragora/routing/__init__.py
+++ b/aragora/routing/__init__.py
@@ -58,6 +58,11 @@ from aragora.routing.provider_config import (
     get_estimated_cost,
 )
 from aragora.routing.provider_router import ProviderRouter, get_provider_router
+from aragora.routing.session_circuit_breaker import (
+    SessionCircuitBreaker,
+    get_session_circuit_breaker,
+    reset_session_circuit_breaker,
+)
 
 __all__ = [
     # Agent selection
@@ -97,4 +102,8 @@ __all__ = [
     "get_estimated_cost",
     "ProviderRouter",
     "get_provider_router",
+    # Session circuit breaker
+    "SessionCircuitBreaker",
+    "get_session_circuit_breaker",
+    "reset_session_circuit_breaker",
 ]

--- a/aragora/routing/session_circuit_breaker.py
+++ b/aragora/routing/session_circuit_breaker.py
@@ -1,0 +1,268 @@
+"""Session-scoped circuit breaker for OpenRouter pinning.
+
+When a direct provider (Anthropic, OpenAI, Gemini, etc.) fails due to
+auth or quota errors, the session circuit breaker permanently marks that
+provider as unavailable for the remainder of the process lifetime.
+Transient errors (5xx) use a threshold: 3 failures within a sliding
+5-minute window before pinning.
+
+This prevents thrashing dead providers and keeps the session on
+OpenRouter once a hard failure is detected.
+
+Usage:
+    from aragora.routing.session_circuit_breaker import get_session_circuit_breaker
+
+    cb = get_session_circuit_breaker()
+    cb.mark_provider_failed("anthropic", reason="401 Unauthorized")
+
+    if not cb.is_provider_available("anthropic"):
+        # route through OpenRouter instead
+        provider = cb.get_fallback_provider()
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "SessionCircuitBreaker",
+    "ProviderFailure",
+    "get_session_circuit_breaker",
+    "reset_session_circuit_breaker",
+]
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+# Status codes that cause immediate (permanent) session pinning.
+AUTH_FAILURE_CODES = frozenset({401, 403})
+QUOTA_FAILURE_CODES = frozenset({429})
+PERMANENT_FAILURE_CODES = AUTH_FAILURE_CODES | QUOTA_FAILURE_CODES
+
+# Status codes treated as transient -- require repeated failures to pin.
+TRANSIENT_FAILURE_CODES = frozenset({500, 502, 503})
+
+# Transient failure thresholds.
+TRANSIENT_FAILURE_THRESHOLD = 3
+TRANSIENT_WINDOW_SECONDS = 300.0  # 5 minutes
+
+# OpenRouter is the fallback and should never be pinned as failed.
+FALLBACK_PROVIDER = "openrouter"
+
+
+class FailureCategory(Enum):
+    """Classification of provider failure."""
+
+    AUTH = "auth"
+    QUOTA = "quota"
+    TRANSIENT = "transient"
+
+
+@dataclass
+class ProviderFailure:
+    """Record of a provider failure event."""
+
+    provider: str
+    status_code: int
+    reason: str
+    category: FailureCategory
+    timestamp: float = field(default_factory=time.monotonic)
+
+
+class SessionCircuitBreaker:
+    """In-memory, session-scoped circuit breaker for provider routing.
+
+    Thread-safe. Resets only when the process restarts.
+
+    Pinning rules:
+    - Auth failures (401, 403): immediate permanent pin.
+    - Quota failures (429): immediate permanent pin.
+    - Transient failures (500, 502, 503): pin after ``TRANSIENT_FAILURE_THRESHOLD``
+      failures within ``TRANSIENT_WINDOW_SECONDS``.
+    - OpenRouter is never pinned (it is the fallback destination).
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # Providers permanently pinned as failed.
+        self._pinned: dict[str, ProviderFailure] = {}
+        # Sliding window of transient failures per provider.
+        self._transient_failures: dict[str, list[ProviderFailure]] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def mark_provider_failed(
+        self,
+        provider: str,
+        reason: str,
+        status_code: int = 0,
+    ) -> None:
+        """Record a provider failure.
+
+        Auth/quota errors pin the provider immediately. Transient errors
+        accumulate and pin only after the threshold is breached.
+
+        Args:
+            provider: Provider name (e.g. ``"anthropic"``, ``"openai"``).
+            reason: Human-readable failure reason for logging.
+            status_code: HTTP status code that triggered the failure.
+                If 0, the category is inferred from ``reason`` keywords.
+        """
+        if provider == FALLBACK_PROVIDER:
+            logger.debug(
+                "Ignoring failure for fallback provider %s: %s",
+                FALLBACK_PROVIDER,
+                reason,
+            )
+            return
+
+        category = self._categorize(status_code, reason)
+        failure = ProviderFailure(
+            provider=provider,
+            status_code=status_code,
+            reason=reason,
+            category=category,
+        )
+
+        with self._lock:
+            if provider in self._pinned:
+                logger.debug(
+                    "Provider %s already pinned as failed, ignoring new failure: %s",
+                    provider,
+                    reason,
+                )
+                return
+
+            if category in (FailureCategory.AUTH, FailureCategory.QUOTA):
+                self._pinned[provider] = failure
+                logger.warning(
+                    "Provider %s permanently failed for session (%s): %s",
+                    provider,
+                    category.value,
+                    reason,
+                )
+                return
+
+            # Transient: accumulate in sliding window.
+            window = self._transient_failures.setdefault(provider, [])
+            window.append(failure)
+
+            # Prune entries outside the window.
+            cutoff = time.monotonic() - TRANSIENT_WINDOW_SECONDS
+            window[:] = [f for f in window if f.timestamp >= cutoff]
+
+            if len(window) >= TRANSIENT_FAILURE_THRESHOLD:
+                self._pinned[provider] = failure
+                logger.warning(
+                    "Provider %s pinned after %d transient failures in %.0fs: %s",
+                    provider,
+                    len(window),
+                    TRANSIENT_WINDOW_SECONDS,
+                    reason,
+                )
+                # Clean up transient tracking.
+                del self._transient_failures[provider]
+
+    def is_provider_available(self, provider: str) -> bool:
+        """Check whether a provider is still usable this session.
+
+        Returns ``True`` if the provider has not been pinned as failed.
+        OpenRouter always returns ``True``.
+        """
+        if provider == FALLBACK_PROVIDER:
+            return True
+        with self._lock:
+            return provider not in self._pinned
+
+    def get_fallback_provider(self) -> str:
+        """Return the name of the fallback provider (always ``"openrouter"``)."""
+        return FALLBACK_PROVIDER
+
+    def get_session_status(self) -> dict:
+        """Return a snapshot of all tracked provider states.
+
+        Returns:
+            Dict with keys:
+
+            - ``pinned_providers``: mapping of provider name to failure info.
+            - ``transient_failures``: mapping of provider name to current
+              failure count in the sliding window.
+            - ``fallback_provider``: the fallback provider name.
+        """
+        with self._lock:
+            now = time.monotonic()
+            cutoff = now - TRANSIENT_WINDOW_SECONDS
+
+            pinned_info: dict[str, dict] = {}
+            for provider, failure in self._pinned.items():
+                pinned_info[provider] = {
+                    "status_code": failure.status_code,
+                    "reason": failure.reason,
+                    "category": failure.category.value,
+                    "timestamp": failure.timestamp,
+                }
+
+            transient_info: dict[str, int] = {}
+            for provider, failures in self._transient_failures.items():
+                active = [f for f in failures if f.timestamp >= cutoff]
+                if active:
+                    transient_info[provider] = len(active)
+
+        return {
+            "pinned_providers": pinned_info,
+            "transient_failures": transient_info,
+            "fallback_provider": FALLBACK_PROVIDER,
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _categorize(status_code: int, reason: str) -> FailureCategory:
+        """Determine failure category from status code and reason text."""
+        if status_code in AUTH_FAILURE_CODES:
+            return FailureCategory.AUTH
+        if status_code in QUOTA_FAILURE_CODES:
+            return FailureCategory.QUOTA
+
+        # Keyword-based fallback when status code is ambiguous or zero.
+        reason_lower = reason.lower()
+        auth_keywords = {"unauthorized", "forbidden", "invalid api key", "expired"}
+        quota_keywords = {"quota", "rate limit", "too many requests", "billing", "credit"}
+        if any(kw in reason_lower for kw in auth_keywords):
+            return FailureCategory.AUTH
+        if any(kw in reason_lower for kw in quota_keywords):
+            return FailureCategory.QUOTA
+
+        return FailureCategory.TRANSIENT
+
+
+# ------------------------------------------------------------------
+# Module-level singleton
+# ------------------------------------------------------------------
+
+_session_cb: SessionCircuitBreaker | None = None
+_singleton_lock = threading.Lock()
+
+
+def get_session_circuit_breaker() -> SessionCircuitBreaker:
+    """Get or create the process-wide ``SessionCircuitBreaker`` singleton."""
+    global _session_cb
+    if _session_cb is None:
+        with _singleton_lock:
+            if _session_cb is None:
+                _session_cb = SessionCircuitBreaker()
+    return _session_cb
+
+
+def reset_session_circuit_breaker() -> None:
+    """Reset the singleton (primarily for testing)."""
+    global _session_cb
+    with _singleton_lock:
+        _session_cb = None

--- a/tests/routing/test_session_circuit_breaker.py
+++ b/tests/routing/test_session_circuit_breaker.py
@@ -1,0 +1,306 @@
+"""Tests for session-scoped circuit breaker with OpenRouter pinning."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from aragora.routing.session_circuit_breaker import (
+    FALLBACK_PROVIDER,
+    TRANSIENT_FAILURE_THRESHOLD,
+    TRANSIENT_WINDOW_SECONDS,
+    FailureCategory,
+    SessionCircuitBreaker,
+    get_session_circuit_breaker,
+    reset_session_circuit_breaker,
+)
+
+
+@pytest.fixture()
+def cb() -> SessionCircuitBreaker:
+    """Fresh circuit breaker for each test."""
+    return SessionCircuitBreaker()
+
+
+# ------------------------------------------------------------------
+# Auth failures: immediate permanent pin
+# ------------------------------------------------------------------
+
+
+class TestAuthFailurePinning:
+    """Auth errors (401, 403) immediately pin the provider."""
+
+    def test_401_pins_provider(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401 Unauthorized", status_code=401)
+        assert not cb.is_provider_available("anthropic")
+
+    def test_403_pins_provider(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("openai", reason="403 Forbidden", status_code=403)
+        assert not cb.is_provider_available("openai")
+
+    def test_auth_keyword_pins_without_status_code(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("gemini", reason="Invalid API key", status_code=0)
+        assert not cb.is_provider_available("gemini")
+
+    def test_auth_pin_is_permanent(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401 Unauthorized", status_code=401)
+        # Even after a long delay the provider stays pinned.
+        assert not cb.is_provider_available("anthropic")
+
+    def test_auth_pin_shows_in_session_status(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="Expired key", status_code=401)
+        status = cb.get_session_status()
+        assert "anthropic" in status["pinned_providers"]
+        info = status["pinned_providers"]["anthropic"]
+        assert info["category"] == "auth"
+        assert info["status_code"] == 401
+
+
+# ------------------------------------------------------------------
+# Quota failures: immediate permanent pin
+# ------------------------------------------------------------------
+
+
+class TestQuotaFailurePinning:
+    """Quota errors (429) immediately pin the provider."""
+
+    def test_429_pins_provider(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="429 Too Many Requests", status_code=429)
+        assert not cb.is_provider_available("anthropic")
+
+    def test_quota_keyword_pins_without_status_code(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("openai", reason="Quota exceeded", status_code=0)
+        assert not cb.is_provider_available("openai")
+
+    def test_rate_limit_keyword_pins(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("gemini", reason="Rate limit reached", status_code=0)
+        assert not cb.is_provider_available("gemini")
+
+    def test_billing_keyword_pins(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed(
+            "anthropic", reason="Billing issue: credit exhausted", status_code=0
+        )
+        assert not cb.is_provider_available("anthropic")
+
+    def test_quota_pin_shows_in_session_status(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("openai", reason="429", status_code=429)
+        status = cb.get_session_status()
+        info = status["pinned_providers"]["openai"]
+        assert info["category"] == "quota"
+
+
+# ------------------------------------------------------------------
+# Transient failures: threshold-based pinning
+# ------------------------------------------------------------------
+
+
+class TestTransientFailurePinning:
+    """Transient errors (500, 502, 503) pin only after threshold breached."""
+
+    def test_single_transient_does_not_pin(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="500 Internal Server Error", status_code=500)
+        assert cb.is_provider_available("anthropic")
+
+    def test_two_transient_does_not_pin(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="502 Bad Gateway", status_code=502)
+        cb.mark_provider_failed("anthropic", reason="503 Service Unavailable", status_code=503)
+        assert cb.is_provider_available("anthropic")
+
+    def test_three_transient_within_window_pins(self, cb: SessionCircuitBreaker) -> None:
+        for i in range(TRANSIENT_FAILURE_THRESHOLD):
+            cb.mark_provider_failed("anthropic", reason=f"500 error #{i + 1}", status_code=500)
+        assert not cb.is_provider_available("anthropic")
+
+    def test_transient_outside_window_does_not_pin(self, cb: SessionCircuitBreaker) -> None:
+        """Failures spread over > 5 minutes should not accumulate."""
+        # Record 2 failures normally.
+        cb.mark_provider_failed("anthropic", reason="500 error #1", status_code=500)
+        cb.mark_provider_failed("anthropic", reason="500 error #2", status_code=500)
+
+        # Simulate the third failure arriving after the window expires
+        # by patching time.monotonic to jump forward.
+        original_monotonic = time.monotonic
+        offset = TRANSIENT_WINDOW_SECONDS + 1.0
+
+        def shifted_monotonic() -> float:
+            return original_monotonic() + offset
+
+        with patch("time.monotonic", side_effect=shifted_monotonic):
+            with patch(
+                "aragora.routing.session_circuit_breaker.time.monotonic",
+                side_effect=shifted_monotonic,
+            ):
+                cb.mark_provider_failed("anthropic", reason="500 error #3", status_code=500)
+
+        # The first two should have been pruned, so only 1 failure in window.
+        assert cb.is_provider_available("anthropic")
+
+    def test_transient_shows_in_session_status(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="500 error", status_code=500)
+        status = cb.get_session_status()
+        assert "anthropic" not in status["pinned_providers"]
+        assert status["transient_failures"]["anthropic"] == 1
+
+    def test_pinned_transient_shows_in_pinned(self, cb: SessionCircuitBreaker) -> None:
+        for i in range(TRANSIENT_FAILURE_THRESHOLD):
+            cb.mark_provider_failed("anthropic", reason=f"500 #{i + 1}", status_code=500)
+        status = cb.get_session_status()
+        assert "anthropic" in status["pinned_providers"]
+        assert status["pinned_providers"]["anthropic"]["category"] == "transient"
+        # Transient tracking should be cleaned up after pinning.
+        assert "anthropic" not in status["transient_failures"]
+
+
+# ------------------------------------------------------------------
+# OpenRouter is never pinned (the safety net)
+# ------------------------------------------------------------------
+
+
+class TestOpenRouterNeverPinned:
+    """OpenRouter is the fallback and must always remain available."""
+
+    def test_openrouter_auth_failure_ignored(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("openrouter", reason="401 Unauthorized", status_code=401)
+        assert cb.is_provider_available("openrouter")
+
+    def test_openrouter_quota_failure_ignored(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("openrouter", reason="429 Rate Limited", status_code=429)
+        assert cb.is_provider_available("openrouter")
+
+    def test_openrouter_transient_failure_ignored(self, cb: SessionCircuitBreaker) -> None:
+        for _ in range(10):
+            cb.mark_provider_failed("openrouter", reason="500 error", status_code=500)
+        assert cb.is_provider_available("openrouter")
+
+
+# ------------------------------------------------------------------
+# Fallback provider
+# ------------------------------------------------------------------
+
+
+class TestFallbackProvider:
+    """get_fallback_provider always returns 'openrouter'."""
+
+    def test_returns_openrouter(self, cb: SessionCircuitBreaker) -> None:
+        assert cb.get_fallback_provider() == "openrouter"
+
+    def test_returns_openrouter_when_all_pinned(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401", status_code=401)
+        cb.mark_provider_failed("openai", reason="429", status_code=429)
+        cb.mark_provider_failed("gemini", reason="403", status_code=403)
+        assert cb.get_fallback_provider() == "openrouter"
+
+    def test_fallback_constant(self) -> None:
+        assert FALLBACK_PROVIDER == "openrouter"
+
+
+# ------------------------------------------------------------------
+# Multiple independent providers
+# ------------------------------------------------------------------
+
+
+class TestMultipleProviders:
+    """Providers are tracked independently."""
+
+    def test_one_pinned_others_available(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401", status_code=401)
+        assert not cb.is_provider_available("anthropic")
+        assert cb.is_provider_available("openai")
+        assert cb.is_provider_available("gemini")
+
+    def test_multiple_pinned_independently(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401", status_code=401)
+        cb.mark_provider_failed("openai", reason="429", status_code=429)
+        assert not cb.is_provider_available("anthropic")
+        assert not cb.is_provider_available("openai")
+        assert cb.is_provider_available("gemini")
+
+    def test_session_status_shows_all_pinned(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401", status_code=401)
+        cb.mark_provider_failed("openai", reason="429", status_code=429)
+        status = cb.get_session_status()
+        assert len(status["pinned_providers"]) == 2
+        assert "anthropic" in status["pinned_providers"]
+        assert "openai" in status["pinned_providers"]
+
+    def test_duplicate_failure_does_not_double_pin(self, cb: SessionCircuitBreaker) -> None:
+        cb.mark_provider_failed("anthropic", reason="401 first", status_code=401)
+        cb.mark_provider_failed("anthropic", reason="401 second", status_code=401)
+        status = cb.get_session_status()
+        # Should still only have one entry with the first reason.
+        assert status["pinned_providers"]["anthropic"]["reason"] == "401 first"
+
+
+# ------------------------------------------------------------------
+# Initially-available state
+# ------------------------------------------------------------------
+
+
+class TestInitialState:
+    """A fresh circuit breaker has all providers available."""
+
+    def test_unknown_provider_is_available(self, cb: SessionCircuitBreaker) -> None:
+        assert cb.is_provider_available("some-new-provider")
+
+    def test_empty_session_status(self, cb: SessionCircuitBreaker) -> None:
+        status = cb.get_session_status()
+        assert status["pinned_providers"] == {}
+        assert status["transient_failures"] == {}
+        assert status["fallback_provider"] == "openrouter"
+
+
+# ------------------------------------------------------------------
+# Singleton accessor
+# ------------------------------------------------------------------
+
+
+class TestSingleton:
+    """get_session_circuit_breaker returns a process-wide singleton."""
+
+    def test_returns_same_instance(self) -> None:
+        reset_session_circuit_breaker()
+        try:
+            cb1 = get_session_circuit_breaker()
+            cb2 = get_session_circuit_breaker()
+            assert cb1 is cb2
+        finally:
+            reset_session_circuit_breaker()
+
+    def test_reset_clears_singleton(self) -> None:
+        reset_session_circuit_breaker()
+        cb1 = get_session_circuit_breaker()
+        reset_session_circuit_breaker()
+        cb2 = get_session_circuit_breaker()
+        assert cb1 is not cb2
+
+
+# ------------------------------------------------------------------
+# Failure categorization
+# ------------------------------------------------------------------
+
+
+class TestFailureCategorization:
+    """_categorize classifies failures correctly."""
+
+    def test_401_is_auth(self) -> None:
+        assert SessionCircuitBreaker._categorize(401, "") == FailureCategory.AUTH
+
+    def test_403_is_auth(self) -> None:
+        assert SessionCircuitBreaker._categorize(403, "") == FailureCategory.AUTH
+
+    def test_429_is_quota(self) -> None:
+        assert SessionCircuitBreaker._categorize(429, "") == FailureCategory.QUOTA
+
+    def test_500_is_transient(self) -> None:
+        assert SessionCircuitBreaker._categorize(500, "") == FailureCategory.TRANSIENT
+
+    def test_0_with_auth_keyword_is_auth(self) -> None:
+        assert SessionCircuitBreaker._categorize(0, "Unauthorized access") == FailureCategory.AUTH
+
+    def test_0_with_quota_keyword_is_quota(self) -> None:
+        assert SessionCircuitBreaker._categorize(0, "Rate limit exceeded") == FailureCategory.QUOTA
+
+    def test_0_with_unknown_reason_is_transient(self) -> None:
+        assert SessionCircuitBreaker._categorize(0, "Something broke") == FailureCategory.TRANSIENT


### PR DESCRIPTION
## Summary

- Adds `SessionCircuitBreaker` that tracks failed providers per session and permanently pins them as unavailable after auth/quota errors
- Auth failures (401, 403) and quota failures (429) trigger immediate pinning
- Transient errors (500, 502, 503) use a threshold of 3 failures within a 5-minute sliding window
- OpenRouter is never pinned (it's the fallback destination)
- Thread-safe singleton via `get_session_circuit_breaker()`

## Blocking gap addressed

This is Gap #4 from the [inbox trust wedge dogfood plan](docs/plans/2026-03-06-openrouter-inbox-dogfood-plan.md):
> Direct provider agent types must fail over fast and stay failed over for the session after auth/quota failures instead of thrashing dead providers.

## Test plan

- [x] 37 new tests pass covering all pinning rules, threshold behavior, and edge cases
- [x] 284 existing routing tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)