### PR TITLE
docs: document swarm, inbox trust wedge, and dev coordination features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ repo — editing files in the main directory causes concurrent overwrites.
 | Scheduler | `aragora/scheduler/` | Automated scheduling for audits, access reviews, DR drills |
 | Services | `aragora/services/` | ServiceRegistry pattern with email prioritization |
 | Streaming | `aragora/streaming/` | WebSocket/Kafka/RabbitMQ connection hardening |
-| Swarm | `aragora/swarm/` | User-facing orchestration: interrogate → spec → dispatch → merge |
+| Swarm | `aragora/swarm/` | Supervisor-backed orchestration: interrogate → spec → dispatch → reconcile |
 | Sync | `aragora/sync/` | Directory sync with incremental change detection |
 | Tasks | `aragora/tasks/` | Task management and tracking |
 | Telemetry | `aragora/telemetry/` | Convenience re-export of observability subsystem |
@@ -458,6 +458,13 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 - Active Introspection - per-round agent performance tracking via `enable_introspection` (proposals, critiques, influence)
 - Argument Verification - structural soundness checking via `auto_verify_arguments` in PostDebateConfig
 - Outcome Feedback - systematic error detection → Nomic Loop goals via `auto_outcome_feedback` in PostDebateConfig
+- Swarm Supervisor - bounded work orders, managed worktrees, lease-based worker coordination
+- Worker Launcher - spawns Claude Code / Codex CLI processes in isolated worktrees
+- Swarm Reconciler - periodic lease renewal, dispatch, result collection
+- Dev Coordination - work leases, completion receipts, integration decisions, salvage queue
+- Session Circuit-Breaker - auth-state pinning (401/403), provider rotation after failures
+- Inbox Trust Wedge - receipt-gated email actions: Gmail → debate → signed receipt → execute
+- Smart Provider Routing - Pareto optimizer for cost/quality/latency tradeoffs
 
 **Enterprise (production-ready):**
 - Authentication - OIDC/SAML SSO, MFA (TOTP/HOTP), API key management, SCIM 2.0 provisioning
@@ -512,7 +519,7 @@ See `docs/STATUS.md` for 74+ detailed feature statuses.
 | `docs/verticals/FINANCIAL.md` | Financial services vertical guide (risk, SOX, audit) |
 | `docs/verticals/LEGAL.md` | Legal vertical guide (contracts, due diligence, litigation) |
 | `docs/resilience/RESILIENCE_PATTERNS.md` | Circuit breakers, retry, timeout, health monitoring |
-| `docs/CLI_REFERENCE.md` | Complete reference for all 35 CLI commands with examples |
+| `docs/CLI_REFERENCE.md` | Complete reference for all 40+ CLI commands with examples |
 | `docs/FEATURE_GAP_LIST.md` | Feature backlog: planned, partial, and scaffolded features by priority |
 | `docs/guides/PIPELINE_GUIDE.md` | 4-stage Idea-to-Execution pipeline usage guide |
 | `docs/guides/MODES_GUIDE.md` | Operational modes guide (standard + advanced: RedTeam, DeepAudit, Probing) |

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -496,20 +496,54 @@ aragora skills list
 
 ### `aragora swarm`
 
-**Purpose:** Launch the full swarm lifecycle: interrogate a goal → generate a spec → dispatch to agents → report results.
+**Purpose:** Launch the full swarm lifecycle: interrogate a goal → generate a spec → dispatch to agents → report results. Supervisor-backed with lease coordination, managed worktrees, and periodic reconciliation.
 
-**Usage:** `aragora swarm "<goal>" [options]`
+**Usage:** `aragora swarm [run|status|reconcile] "<goal>" [options]`
+
+**Subcommands:**
+- `run "<goal>"` — decompose goal, provision worktrees, dispatch workers (default)
+- `status [--run-id <id>] [--json]` — show active/recent supervisor runs
+- `reconcile [--run-id <id> | --all-runs]` — top up leases, dispatch ready workers, collect results
 
 **Key options:**
 - `--skip-interrogation` — bypass the clarification phase
-- `--spec <file>` — load a pre-written YAML spec
+- `--spec <file>` — load a pre-written SwarmSpec YAML file
 - `--budget-limit <usd>`, `--dry-run`, `--profile <cto|...>`
 - `--from-obsidian <vault>` — load goals from an Obsidian vault
+- `--dispatch-only` — provision worktrees without waiting for results
+- `--no-wait` — fire-and-forget dispatch
 
 **Examples:**
 ```bash
 aragora swarm "Make the dashboard faster"
-aragora swarm "Add auth" --budget-limit 10 --dry-run
+aragora swarm run "Add auth" --budget-limit 10 --dry-run
+aragora swarm status --json
+aragora swarm reconcile --all-runs
+```
+
+---
+
+### `aragora triage`
+
+**Purpose:** Inbox triage via adversarial debate with receipt-gated actions. The trust wedge entry point: fetch Gmail → debate → signed receipt → CLI approval → execute.
+
+**Usage:** `aragora triage [run|status] [options]`
+
+**Subcommands:**
+- `run` — fetch and triage unread emails
+- `status` — show triage session status
+
+**Key options (run):**
+- `--batch <n>` — number of emails to process (default: 5)
+- `--auto-approve` — use narrow auto-approval policy (ARCHIVE/STAR/LABEL/IGNORE only)
+- `--provider <name>` — LLM provider for triage debate
+- `--rounds <n>` — number of debate rounds
+
+**Examples:**
+```bash
+aragora triage run --batch 5
+aragora triage run --batch 10 --auto-approve
+aragora triage status
 ```
 
 ---

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -1,6 +1,6 @@
 # Aragora Feature Discovery Guide
 
-*Complete catalog of 220+ features for developers exploring Aragora capabilities*
+*Complete catalog of 230+ features for developers exploring Aragora capabilities*
 
 This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
 
@@ -22,7 +22,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 220+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
+**Total**: 230+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
 
 ---
 
@@ -97,6 +97,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Agent Spec** | Stable | Unified specification parsing (`provider\|model\|persona\|role`) | `aragora/agents/spec.py` |
 | **Airlock Proxy** | Stable | Agent resilience with circuit breaker via `use_airlock` | `aragora/agents/airlock.py` |
 | **Fallback Chain** | Stable | Automatic OpenRouter fallback on 429 errors | `aragora/agents/fallback.py` |
+| **Session Circuit-Breaker** | Stable | Auth-state pinning (401/403), provider rotation after failures | `aragora/routing/session_circuit_breaker.py` |
 | **Rate Limiter** | Stable | Per-provider rate limiting | `aragora/agents/api_agents/rate_limiter.py` |
 | **Personas** | Stable | Configurable agent personalities | `aragora/agents/personas.py` |
 | **Calibration** | Stable | Agent performance calibration tracking | `aragora/agents/calibration.py` |
@@ -502,6 +503,20 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | **Prompt Engine** | Stable | Transforms vague prompts into validated specifications via debate | `aragora/prompt_engine/conductor.py`, `aragora/prompt_engine/spec_builder.py` |
 | **Interrogation Engine** | Stable | Debate-driven prompt clarification with prioritized questions | `aragora/interrogation/engine.py`, `aragora/interrogation/crystallizer.py` |
 | **Swarm Orchestrator** | Stable | End-to-end user flow: interrogate → spec → dispatch → merge → report | `aragora/swarm/commander.py`, `aragora/swarm/reporter.py` |
+| **Swarm Supervisor** | Stable | Bounded work orders, managed worktrees, lease-based coordination | `aragora/swarm/supervisor.py` |
+| **Worker Launcher** | Stable | Spawns Claude Code / Codex CLI processes in isolated worktrees | `aragora/swarm/worker_launcher.py` |
+| **Swarm Reconciler** | Stable | Periodic lease renewal, dispatch, result collection | `aragora/swarm/reconciler.py` |
+
+### Inbox Trust Wedge
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Trust Wedge Core** | Stable | Receipt-gated email actions: Gmail → debate → signed receipt → execute | `aragora/inbox/trust_wedge.py` |
+| **Triage Runner** | Stable | Batch email triage with adversarial debate decisions | `aragora/inbox/triage_runner.py` |
+| **Receipt-Gated Executor** | Stable | Only executes actions with previously persisted approved receipts | `aragora/inbox/receipt_gated_executor.py` |
+| **CLI Review Loop** | Stable | Interactive CLI approval for triage decisions | `aragora/inbox/cli_review.py` |
+| **Auto-Approval Policy** | Stable | Narrow auto-approval rules (ARCHIVE/STAR/LABEL/IGNORE only) | `aragora/inbox/auto_approval.py` |
+| **Gmail OAuth Setup** | Stable | One-time OAuth credential setup for Gmail integration | `scripts/gmail_oauth_setup.py` |
 
 ### Gauntlet (Compliance Testing)
 
@@ -582,6 +597,15 @@ Used in: audit pipeline (`aragora/audit/`), bug detection (`aragora/audit/bug_de
 | 2 | Design | Architecture planning |
 | 3 | Implement | Code generation (Codex/Claude) |
 | 4 | Verify | Tests and checks |
+
+### Development Coordination
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **DevCoordinationStore** | Stable | Work leases, completion receipts, integration decisions | `aragora/nomic/dev_coordination.py` |
+| **NomicPipelineBridge** | Stable | Bounded work orders bridging pipeline specs to worktree tasks | `aragora/nomic/pipeline_bridge.py` |
+| **Fleet Integration Worker** | Stable | Automated integration target workspace management | `aragora/worktree/integration_worker.py` |
+| **Salvage Queue** | Stable | Recovery of dirty worktrees and stashed work | `aragora/coordination/salvage.py` |
 
 ### Autonomous Operations
 

--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -141,6 +141,10 @@ These items were planned and are now shipped:
 | Dogfood backbone profile script | Mar 2026 |
 | PR watch daemon fleet (3 Mac machines, 30 reviews/hour) | Mar 2026 |
 | Dev swarm coordination layer (lease-aware) | Mar 2026 |
+| Swarm supervisor + worker launcher + reconciler (PRs #744-746) | Mar 2026 |
+| Inbox trust wedge — receipt-gated email actions (PRs #731-742) | Mar 2026 |
+| Session circuit-breaker — auth-state pinning (PRs #736, #740) | Mar 2026 |
+| Gmail OAuth setup helper (PR #741) | Mar 2026 |
 | Semantic convergence — 5 modules migrated to embeddings (PR #723) | Mar 2026 |
 | Smart provider routing Phase 1 — Pareto optimizer + 8-model pricing (PR #724) | Mar 2026 |
 | EU AI Act playbook GTM polish + Art. 10/11/43/49 appendix (PR #725) | Mar 2026 |

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -223,6 +223,6 @@ pytest tests/ -x -q --timeout=10  # Run a quick subset
 |----------|-------------|
 | [API Reference](api/API_REFERENCE.md) | REST API documentation |
 | [SDK Guide](SDK_GUIDE.md) | Comprehensive Python and TypeScript SDK guide |
-| [Feature Discovery](FEATURE_DISCOVERY.md) | Full catalog of 220+ features |
+| [Feature Discovery](FEATURE_DISCOVERY.md) | Full catalog of 230+ features |
 | [Enterprise Features](enterprise/ENTERPRISE_FEATURES.md) | SSO, RBAC, multi-tenancy, compliance |
 | [Status](STATUS.md) | Feature implementation status |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -23,10 +23,24 @@
 - **Comms Hub completion** (PR #726): Template persistence, router event wiring, E2E tests (Epic #293 closed)
 - **OpenClaw E2E core loop** (PR #727): CodeImplementationTask, SpecExtractor, ComputerUseActionBundle
 
-### Inbox Trust Wedge (Active Development)
-- Contracts: AllowedAction enum, TriageDecision, CLIReviewLoop, AutoApprovalPolicy, InboxTriageRunner
-- Attestation fix: receipt persisted BEFORE execution gate, DurableFileSigner
-- Demo fallback removal: SharedInboxView, TriageRulesPanel stripped of silent fallbacks
+### Inbox Trust Wedge — All Blocking Gaps Closed
+- **Trust Wedge Core**: Gmail → adversarial debate → signed receipt → CLI approval → gmail.modify
+- **Contracts**: AllowedAction enum (ARCHIVE/STAR/LABEL/IGNORE), TriageDecision, ReceiptState lifecycle (CREATED→APPROVED→EXECUTED→EXPIRED)
+- **Attestation**: Receipt persisted BEFORE execution gate, DurableFileSigner at `~/.aragora/signing.key`
+- **Demo fallback removal**: SharedInboxView, TriageRulesPanel stripped of silent fallbacks (fail-closed)
+- **Session circuit-breaker** (PR #736, #740): Auth-state pinning on 401/403, QuotaFallbackMixin wired
+- **Gmail OAuth setup** (PR #741): One-time credential setup via `scripts/gmail_oauth_setup.py`
+- **CLI**: `aragora triage run --batch 5 [--auto-approve]`, `aragora triage status`
+- **PRs merged**: #730, #731→#742, #732, #733→#742, #736, #740, #741
+
+### Swarm System — Supervisor-Backed Orchestration
+- **Supervisor** (PR #744): SupervisorRun lifecycle (PLANNED→ACTIVE→COMPLETED), bounded work orders, lease coordination
+- **Worker Launcher** (PR #744): Spawns `claude -p` / `codex exec --full-auto` in managed worktrees
+- **E2E Dispatch** (PR #745): `run_supervised_from_spec()` chains dispatch + collect after start_run
+- **Reconciler** (PR #746): Periodic loop — top up leases, dispatch ready workers, collect finished results
+- **Dev Coordination** (PR #744): WorkLease, CompletionReceipt, IntegrationDecision, SalvageCandidate
+- **CLI**: `aragora swarm run "goal"`, `aragora swarm status [--json]`, `aragora swarm reconcile --all-runs`
+- **98 tests** (89 swarm + 9 reconciler)
 
 ### Codebase Metrics (March 6, 2026)
 - **Python modules**: 3,700+

--- a/docs/STRANDED_FEATURES_AUDIT.md
+++ b/docs/STRANDED_FEATURES_AUDIT.md
@@ -1,7 +1,7 @@
 # Stranded Features Audit
 
 **Date:** 2026-02-24
-**Scope:** Full audit of 220+ features to identify stranded (built but disconnected) capabilities and wire the highest-value ones into the live product.
+**Scope:** Full audit of 230+ features to identify stranded (built but disconnected) capabilities and wire the highest-value ones into the live product.
 
 ## Methodology
 

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -1,6 +1,6 @@
 # Aragora Feature Discovery Guide
 
-*Complete catalog of 220+ features for developers exploring Aragora capabilities*
+*Complete catalog of 230+ features for developers exploring Aragora capabilities*
 
 This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
 
@@ -22,7 +22,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 220+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
+**Total**: 230+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
 
 ---
 
@@ -97,6 +97,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Agent Spec** | Stable | Unified specification parsing (`provider\|model\|persona\|role`) | `aragora/agents/spec.py` |
 | **Airlock Proxy** | Stable | Agent resilience with circuit breaker via `use_airlock` | `aragora/agents/airlock.py` |
 | **Fallback Chain** | Stable | Automatic OpenRouter fallback on 429 errors | `aragora/agents/fallback.py` |
+| **Session Circuit-Breaker** | Stable | Auth-state pinning (401/403), provider rotation after failures | `aragora/routing/session_circuit_breaker.py` |
 | **Rate Limiter** | Stable | Per-provider rate limiting | `aragora/agents/api_agents/rate_limiter.py` |
 | **Personas** | Stable | Configurable agent personalities | `aragora/agents/personas.py` |
 | **Calibration** | Stable | Agent performance calibration tracking | `aragora/agents/calibration.py` |
@@ -502,6 +503,20 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | **Prompt Engine** | Stable | Transforms vague prompts into validated specifications via debate | `aragora/prompt_engine/conductor.py`, `aragora/prompt_engine/spec_builder.py` |
 | **Interrogation Engine** | Stable | Debate-driven prompt clarification with prioritized questions | `aragora/interrogation/engine.py`, `aragora/interrogation/crystallizer.py` |
 | **Swarm Orchestrator** | Stable | End-to-end user flow: interrogate → spec → dispatch → merge → report | `aragora/swarm/commander.py`, `aragora/swarm/reporter.py` |
+| **Swarm Supervisor** | Stable | Bounded work orders, managed worktrees, lease-based coordination | `aragora/swarm/supervisor.py` |
+| **Worker Launcher** | Stable | Spawns Claude Code / Codex CLI processes in isolated worktrees | `aragora/swarm/worker_launcher.py` |
+| **Swarm Reconciler** | Stable | Periodic lease renewal, dispatch, result collection | `aragora/swarm/reconciler.py` |
+
+### Inbox Trust Wedge
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Trust Wedge Core** | Stable | Receipt-gated email actions: Gmail → debate → signed receipt → execute | `aragora/inbox/trust_wedge.py` |
+| **Triage Runner** | Stable | Batch email triage with adversarial debate decisions | `aragora/inbox/triage_runner.py` |
+| **Receipt-Gated Executor** | Stable | Only executes actions with previously persisted approved receipts | `aragora/inbox/receipt_gated_executor.py` |
+| **CLI Review Loop** | Stable | Interactive CLI approval for triage decisions | `aragora/inbox/cli_review.py` |
+| **Auto-Approval Policy** | Stable | Narrow auto-approval rules (ARCHIVE/STAR/LABEL/IGNORE only) | `aragora/inbox/auto_approval.py` |
+| **Gmail OAuth Setup** | Stable | One-time OAuth credential setup for Gmail integration | `scripts/gmail_oauth_setup.py` |
 
 ### Gauntlet (Compliance Testing)
 
@@ -582,6 +597,15 @@ Used in: audit pipeline (`aragora/audit/`), bug detection (`aragora/audit/bug_de
 | 2 | Design | Architecture planning |
 | 3 | Implement | Code generation (Codex/Claude) |
 | 4 | Verify | Tests and checks |
+
+### Development Coordination
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **DevCoordinationStore** | Stable | Work leases, completion receipts, integration decisions | `aragora/nomic/dev_coordination.py` |
+| **NomicPipelineBridge** | Stable | Bounded work orders bridging pipeline specs to worktree tasks | `aragora/nomic/pipeline_bridge.py` |
+| **Fleet Integration Worker** | Stable | Automated integration target workspace management | `aragora/worktree/integration_worker.py` |
+| **Salvage Queue** | Stable | Recovery of dirty worktrees and stashed work | `aragora/coordination/salvage.py` |
 
 ### Autonomous Operations
 

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -23,10 +23,24 @@
 - **Comms Hub completion** (PR #726): Template persistence, router event wiring, E2E tests (Epic #293 closed)
 - **OpenClaw E2E core loop** (PR #727): CodeImplementationTask, SpecExtractor, ComputerUseActionBundle
 
-### Inbox Trust Wedge (Active Development)
-- Contracts: AllowedAction enum, TriageDecision, CLIReviewLoop, AutoApprovalPolicy, InboxTriageRunner
-- Attestation fix: receipt persisted BEFORE execution gate, DurableFileSigner
-- Demo fallback removal: SharedInboxView, TriageRulesPanel stripped of silent fallbacks
+### Inbox Trust Wedge — All Blocking Gaps Closed
+- **Trust Wedge Core**: Gmail → adversarial debate → signed receipt → CLI approval → gmail.modify
+- **Contracts**: AllowedAction enum (ARCHIVE/STAR/LABEL/IGNORE), TriageDecision, ReceiptState lifecycle (CREATED→APPROVED→EXECUTED→EXPIRED)
+- **Attestation**: Receipt persisted BEFORE execution gate, DurableFileSigner at `~/.aragora/signing.key`
+- **Demo fallback removal**: SharedInboxView, TriageRulesPanel stripped of silent fallbacks (fail-closed)
+- **Session circuit-breaker** (PR #736, #740): Auth-state pinning on 401/403, QuotaFallbackMixin wired
+- **Gmail OAuth setup** (PR #741): One-time credential setup via `scripts/gmail_oauth_setup.py`
+- **CLI**: `aragora triage run --batch 5 [--auto-approve]`, `aragora triage status`
+- **PRs merged**: #730, #731→#742, #732, #733→#742, #736, #740, #741
+
+### Swarm System — Supervisor-Backed Orchestration
+- **Supervisor** (PR #744): SupervisorRun lifecycle (PLANNED→ACTIVE→COMPLETED), bounded work orders, lease coordination
+- **Worker Launcher** (PR #744): Spawns `claude -p` / `codex exec --full-auto` in managed worktrees
+- **E2E Dispatch** (PR #745): `run_supervised_from_spec()` chains dispatch + collect after start_run
+- **Reconciler** (PR #746): Periodic loop — top up leases, dispatch ready workers, collect finished results
+- **Dev Coordination** (PR #744): WorkLease, CompletionReceipt, IntegrationDecision, SalvageCandidate
+- **CLI**: `aragora swarm run "goal"`, `aragora swarm status [--json]`, `aragora swarm reconcile --all-runs`
+- **98 tests** (89 swarm + 9 reconciler)
 
 ### Codebase Metrics (March 6, 2026)
 - **Python modules**: 3,700+


### PR DESCRIPTION
## Summary

Follow-up documentation hygiene pass covering features merged after PR #738 (PRs #730-#746).

**New feature documentation:**
- **Swarm Supervisor system** (PRs #744-746): Supervisor lifecycle, Worker Launcher, Reconciler
- **Inbox Trust Wedge** (PRs #731-742): Receipt-gated email actions, triage runner, CLI review, auto-approval, Gmail OAuth
- **Dev Coordination** (PR #744): WorkLease, CompletionReceipt, IntegrationDecision, SalvageCandidate
- **Session Circuit-Breaker** (PRs #736, #740): Auth-state pinning, provider rotation

**Files updated (9):**
- `CLAUDE.md` — 8 new integrated features, CLI count 35→40+
- `docs/CLI_REFERENCE.md` — expanded `aragora swarm`, new `aragora triage`
- `docs/FEATURE_DISCOVERY.md` — 4 new sections, feature count 220+→230+
- `docs/FEATURE_GAP_LIST.md` — 4 new completed items
- `docs/STATUS.md` — Trust Wedge upgraded, Swarm System section added
- `docs/START_HERE.md`, `docs/STRANDED_FEATURES_AUDIT.md` — feature count
- `docs/status/` copies synced

## Test plan
- [ ] Verify no broken links in updated docs
- [ ] Spot-check CLI commands match parser registrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)