### PR TITLE
fix(inbox): make trust wedge types dogfood-ready

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -109,8 +109,7 @@ async def _run_triage(batch_size: int, auto_approve: bool) -> None:
             from aragora.inbox.cli_review import CLIReviewLoop
 
             loop = CLIReviewLoop()
-            for decision in decisions:
-                loop.review(decision)
+            loop.review_batch(decisions)
         except ImportError:
             # CLI review not available — print summary
             _print_decisions(decisions)

--- a/aragora/inbox/cli_review.py
+++ b/aragora/inbox/cli_review.py
@@ -21,6 +21,7 @@ from typing import Any, Callable
 
 from aragora.inbox.trust_wedge import (
     AllowedAction,
+    InboxWedgeAction,
     ReceiptState,
     TriageDecision,
 )
@@ -176,9 +177,10 @@ class CLIReviewLoop:
             self._print(f"  Invalid. Choose from: {', '.join(valid_actions)}")
 
         old_action = decision.final_action
-        decision.final_action = new_action
+        parsed_action = InboxWedgeAction.parse(new_action)
+        decision.final_action = parsed_action
         if decision.intent:
-            decision.intent.action = new_action
+            decision.intent.action = parsed_action
         # Reset state to CREATED (re-sign needed)
         decision.receipt_state = ReceiptState.CREATED.value
         self._print(f"  -> EDITED: {old_action} -> {new_action}")

--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -23,6 +23,7 @@ from aragora.inbox.auto_approval import AutoApprovalPolicy
 from aragora.inbox.trust_wedge import (
     ActionIntent,
     AllowedAction,
+    InboxWedgeAction,
     ReceiptState,
     TriageDecision,
     compute_content_hash,
@@ -211,10 +212,12 @@ class InboxTriageRunner:
         elif isinstance(debate_result, dict):
             rationale = str(debate_result.get("final_answer", ""))
 
+        parsed_action = InboxWedgeAction.parse(action)
+
         intent = ActionIntent(
             provider="arena-consensus",
             message_id=message_id,
-            action=action,
+            action=parsed_action,
             content_hash=content_hash,
             synthesized_rationale=rationale[:500],
             confidence=confidence,
@@ -227,7 +230,7 @@ class InboxTriageRunner:
         intent._snippet = msg.get("snippet", body[:120])  # type: ignore[attr-defined]
 
         decision = TriageDecision(
-            final_action=action,
+            final_action=parsed_action,
             confidence=confidence,
             dissent_summary=dissent,
             auto_approval_eligible=False,

--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -126,7 +126,7 @@ class ReceiptState(str, Enum):
     EXPIRED = "expired"
 
 
-@dataclass(frozen=True)
+@dataclass
 class ActionIntent:
     """Canonical execution intent for a single inbox action."""
 
@@ -228,7 +228,7 @@ class PersistedReceipt:
         }
 
 
-@dataclass(frozen=True)
+@dataclass
 class TriageDecision:
     """Final debated triage decision for the inbox wedge."""
 
@@ -237,6 +237,9 @@ class TriageDecision:
     dissent_summary: str
     receipt_id: str | None = None
     auto_approval_eligible: bool = False
+    receipt_state: str = "created"
+    intent: ActionIntent | None = None
+    provider_route: str = "direct"
     label_id: str | None = None
     blocked_by_policy: bool = False
     cost_usd: float | None = None
@@ -251,6 +254,9 @@ class TriageDecision:
         dissent_summary: str,
         receipt_id: str | None = None,
         auto_approval_eligible: bool = False,
+        receipt_state: str = "created",
+        intent: ActionIntent | None = None,
+        provider_route: str = "direct",
         label_id: str | None = None,
         blocked_by_policy: bool = False,
         cost_usd: float | None = None,
@@ -262,6 +268,9 @@ class TriageDecision:
             dissent_summary=dissent_summary,
             receipt_id=receipt_id,
             auto_approval_eligible=auto_approval_eligible,
+            receipt_state=receipt_state,
+            intent=intent,
+            provider_route=provider_route,
             label_id=label_id,
             blocked_by_policy=blocked_by_policy,
             cost_usd=cost_usd,
@@ -269,17 +278,24 @@ class TriageDecision:
         )
 
     def to_dict(self) -> dict[str, Any]:
-        return {
-            "final_action": self.final_action.value,
+        result: dict[str, Any] = {
+            "final_action": self.final_action.value
+            if isinstance(self.final_action, Enum)
+            else self.final_action,
             "confidence": self.confidence,
             "dissent_summary": self.dissent_summary,
             "receipt_id": self.receipt_id,
             "auto_approval_eligible": self.auto_approval_eligible,
+            "receipt_state": self.receipt_state,
+            "provider_route": self.provider_route,
             "label_id": self.label_id,
             "blocked_by_policy": self.blocked_by_policy,
             "cost_usd": self.cost_usd,
             "latency_seconds": self.latency_seconds,
         }
+        if self.intent is not None:
+            result["intent"] = self.intent.to_dict()
+        return result
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- Make ActionIntent and TriageDecision mutable so CLI review loop can update fields
- Add receipt_state, intent, provider_route fields to TriageDecision for receipt tracking
- Use InboxWedgeAction.parse() for type-safe action parsing in triage_runner and cli_review
- Switch triage CLI to review_batch() for batch processing

## Test plan
- [x] 90 inbox tests passing
- [x] ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)