### PR TITLE
fix(swarm): fix --dispatch-only to actually dispatch and detach workers

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -85,7 +85,9 @@ def cmd_swarm(args: argparse.Namespace) -> None:
     all_runs = bool(getattr(args, "all_runs", False))
     dispatch_only = bool(getattr(args, "dispatch_only", False))
     no_wait = bool(getattr(args, "no_wait", False))
-    dispatch_workers = not (no_dispatch or dispatch_only)
+    dispatch_workers = not no_dispatch
+    if dispatch_only:
+        no_wait = True
 
     # Phase 2: User profile
     profile_str = getattr(args, "profile", "ceo")

--- a/aragora/swarm/commander.py
+++ b/aragora/swarm/commander.py
@@ -232,7 +232,10 @@ class SwarmCommander:
             wait: If True, reconcile until the run reaches a stable stop condition.
         """
         self._spec = spec
-        supervisor = SwarmSupervisor(repo_root=repo_path or Path.cwd())
+        from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher
+
+        launcher = WorkerLauncher(config=LaunchConfig(detach=not wait))
+        supervisor = SwarmSupervisor(repo_root=repo_path or Path.cwd(), launcher=launcher)
         run = supervisor.start_run(
             spec=spec,
             target_branch=target_branch,

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -77,6 +77,7 @@ class LaunchConfig:
     auto_commit: bool = True
     use_managed_session_script: bool = True
     base_branch: str = "main"
+    detach: bool = False
 
 
 class WorkerLauncher:
@@ -120,12 +121,27 @@ class WorkerLauncher:
             worktree_path,
         )
 
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=worktree_path,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
+        if self.config.detach:
+            log_dir = Path(worktree_path)
+            stdout_file = open(log_dir / ".swarm_worker_stdout.log", "w")  # noqa: SIM115
+            stderr_file = open(log_dir / ".swarm_worker_stderr.log", "w")  # noqa: SIM115
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=worktree_path,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                start_new_session=True,
+            )
+        else:
+            stdout_file = None
+            stderr_file = None
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=worktree_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
 
         worker = WorkerProcess(
             work_order_id=work_order_id,


### PR DESCRIPTION
## Summary
- `--dispatch-only` was incorrectly setting `dispatch=False` — now correctly dispatches then exits
- Workers died with SIGPIPE (exit 141) when parent exited — added detach mode with log files and `start_new_session=True`
- Validated with real Codex worker: spawned in managed worktree, ran to exit 0, modified `docs/CLI_REFERENCE.md`

## Test plan
- [x] 100 swarm tests passing
- [x] Real Codex worker dispatch validated end-to-end
- [x] ruff check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)