### PR TITLE
fix(swarm): detached worker collection and commit prompt

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -300,6 +300,7 @@ class SwarmSupervisor:
                 )
                 item["status"] = "dispatched"
                 item["pid"] = worker.pid
+                item["initial_head"] = worker.initial_head
                 launched.append(worker)
             except (FileNotFoundError, RuntimeError, OSError) as exc:
                 item["status"] = "dispatch_failed"
@@ -357,7 +358,12 @@ class SwarmSupervisor:
         return completed
 
     async def collect_finished_results(self, run_id: str) -> list[WorkerProcess]:
-        """Collect only workers that have already finished."""
+        """Collect only workers that have already finished.
+
+        Tries in-memory process collection first (same-process workers).
+        Falls back to detached PID-based collection for workers spawned
+        by a previous process (e.g. --dispatch-only mode).
+        """
         record = self.store.get_supervisor_run(run_id)
         if record is None:
             raise KeyError(f"Unknown supervisor run: {run_id}")
@@ -368,7 +374,34 @@ class SwarmSupervisor:
             for item in work_orders
             if str(item.get("status", "")) == "dispatched"
         ]
+
+        # Try in-memory collection first (same process that launched workers)
         finished = await self.launcher.collect_finished(work_order_ids=dispatched_ids)
+
+        # Fall back to detached collection for workers not in memory
+        # (parent process restarted, or --dispatch-only mode)
+        finished_ids = {w.work_order_id for w in finished}
+        for item in work_orders:
+            woid = str(item.get("work_order_id", "")).strip()
+            if str(item.get("status", "")) != "dispatched":
+                continue
+            if woid in finished_ids:
+                continue
+            worktree_path = str(item.get("worktree_path", "")).strip()
+            if not worktree_path:
+                continue
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id=woid,
+                agent=str(item.get("target_agent", "codex")),
+                worktree_path=worktree_path,
+                branch=str(item.get("branch", "main")),
+                pid=item.get("pid"),
+                initial_head=str(item.get("initial_head", "")),
+                auto_commit=self.launcher.config.auto_commit,
+            )
+            if result is not None:
+                finished.append(result)
+
         if not finished:
             return []
 

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -181,8 +182,16 @@ class WorkerLauncher:
                 timeout=effective_timeout,
             )
             worker.exit_code = proc.returncode
-            worker.stdout = stdout_bytes.decode(errors="replace")
-            worker.stderr = stderr_bytes.decode(errors="replace")
+            # In detached mode, stdout/stderr are file handles, not PIPE —
+            # communicate() returns (None, None).
+            if stdout_bytes is not None:
+                worker.stdout = stdout_bytes.decode(errors="replace")
+            else:
+                worker.stdout = self._read_log_file(worker.worktree_path, "stdout")
+            if stderr_bytes is not None:
+                worker.stderr = stderr_bytes.decode(errors="replace")
+            else:
+                worker.stderr = self._read_log_file(worker.worktree_path, "stderr")
         except asyncio.TimeoutError:
             proc.kill()
             await proc.wait()
@@ -366,8 +375,11 @@ class WorkerLauncher:
             parts.append(f"Constraints:\n{constraints_text}")
 
         parts.append(
-            "After completing the task, run the tests listed above to verify "
-            "your changes work correctly. Commit your changes with a descriptive message."
+            "IMPORTANT: After completing the task, you MUST:\n"
+            "1. Run the tests listed above to verify your changes work correctly.\n"
+            "2. Stage all changed files with `git add -A`.\n"
+            '3. Commit with a descriptive message using `git commit -m "..."`. '
+            "Do NOT skip the commit step."
         )
 
         return "\n\n".join(parts)
@@ -436,6 +448,84 @@ class WorkerLauncher:
             if path:
                 changed.add(path)
         return sorted(changed)
+
+    @classmethod
+    async def collect_detached_result(
+        cls,
+        *,
+        work_order_id: str,
+        agent: str,
+        worktree_path: str,
+        branch: str,
+        pid: int | None = None,
+        initial_head: str = "",
+        auto_commit: bool = True,
+    ) -> WorkerProcess | None:
+        """Collect results from a detached worker by checking PID and worktree state.
+
+        Returns None if the worker is still running (PID alive).
+        Returns a WorkerProcess with collected results if finished.
+        """
+        if pid is not None and cls._is_pid_running(pid):
+            return None
+
+        worker = WorkerProcess(
+            work_order_id=work_order_id,
+            agent=agent,
+            worktree_path=worktree_path,
+            branch=branch,
+            pid=pid,
+            initial_head=initial_head,
+        )
+
+        worker.stdout = cls._read_log_file(worktree_path, "stdout")
+        worker.stderr = cls._read_log_file(worktree_path, "stderr")
+        worker.exit_code = 0
+        worker.completed_at = datetime.now(UTC).isoformat()
+        worker.diff = await cls._collect_diff(worktree_path)
+
+        if auto_commit and worker.diff:
+            await cls._auto_commit(worker)
+
+        worker.head_sha = await cls._git_output(worktree_path, "rev-parse", "HEAD")
+        worker.commit_shas = await cls._collect_commit_shas(
+            worktree_path,
+            initial_head=initial_head,
+            head_sha=worker.head_sha,
+        )
+        worker.changed_paths = await cls._collect_changed_paths(
+            worktree_path,
+            initial_head=initial_head,
+            head_sha=worker.head_sha,
+        )
+
+        logger.info(
+            "Collected detached worker %s: commits=%d changed_paths=%d",
+            work_order_id,
+            len(worker.commit_shas),
+            len(worker.changed_paths),
+        )
+        return worker
+
+    @staticmethod
+    def _is_pid_running(pid: int) -> bool:
+        """Check if a process with the given PID is still alive."""
+        try:
+            os.kill(pid, 0)
+            return True
+        except (ProcessLookupError, PermissionError):
+            return False
+        except OSError:
+            return False
+
+    @staticmethod
+    def _read_log_file(worktree_path: str, stream: str) -> str:
+        """Read a detached worker's log file (stdout or stderr)."""
+        log_path = Path(worktree_path) / f".swarm_worker_{stream}.log"
+        try:
+            return log_path.read_text(errors="replace")
+        except (FileNotFoundError, OSError):
+            return ""
 
     @staticmethod
     async def _auto_commit(worker: WorkerProcess) -> None:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -85,11 +85,11 @@ class TestBuildPrompt:
         assert "race condition" in prompt
         assert "aragora/auth/oidc.py" in prompt
         assert "python -m pytest tests/auth/ -q" in prompt
-        assert "Commit your changes" in prompt
+        assert "git commit" in prompt
 
     def test_empty_work_order(self):
         prompt = WorkerLauncher._build_prompt({})
-        assert "Commit your changes" in prompt
+        assert "git commit" in prompt
 
     def test_metadata_acceptance_criteria(self):
         wo = {
@@ -270,6 +270,120 @@ class TestLaunchAndWait:
 
         assert result.exit_code == 0
         assert result.stdout == "done"
+
+
+class TestWaitDetached:
+    @pytest.mark.asyncio
+    async def test_wait_handles_none_stdout_stderr(self):
+        """wait() should not crash when communicate() returns (None, None) in detached mode."""
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False, detach=True))
+
+        worker = WorkerProcess(
+            work_order_id="wo-detach",
+            agent="codex",
+            worktree_path="/tmp/wt",
+            branch="main",
+            pid=100,
+        )
+        launcher._workers["wo-detach"] = worker
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(None, None))
+        mock_proc.returncode = 0
+        launcher._processes["wo-detach"] = mock_proc
+
+        with (
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="log output"),
+        ):
+            result = await launcher.wait("wo-detach")
+
+        assert result.exit_code == 0
+        assert result.stdout == "log output"
+        assert result.stderr == "log output"
+        assert result.completed_at is not None
+
+
+class TestCollectDetachedResult:
+    @pytest.mark.asyncio
+    async def test_returns_none_if_pid_running(self):
+        with patch.object(WorkerLauncher, "_is_pid_running", return_value=True):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-1",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=12345,
+            )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_collects_results_when_pid_dead(self):
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_auto_commit", new_callable=AsyncMock),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-2",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=99999,
+                initial_head="def456",
+            )
+
+        assert result is not None
+        assert result.exit_code == 0
+        assert result.head_sha == "abc123"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.stdout == "some output"
+
+    @pytest.mark.asyncio
+    async def test_collects_without_pid(self):
+        """When no PID is stored, always collect (assume finished)."""
+        with (
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-3",
+                agent="claude",
+                worktree_path="/tmp/wt",
+                branch="main",
+            )
+
+        assert result is not None
+        assert result.exit_code == 0
+
+
+class TestIsPidRunning:
+    def test_current_process_is_running(self):
+        import os
+
+        assert WorkerLauncher._is_pid_running(os.getpid()) is True
+
+    def test_nonexistent_pid(self):
+        # PID 4000000 is very unlikely to exist
+        assert WorkerLauncher._is_pid_running(4000000) is False
+
+
+class TestReadLogFile:
+    def test_reads_existing_log(self, tmp_path: Path):
+        log_file = tmp_path / ".swarm_worker_stdout.log"
+        log_file.write_text("hello world")
+        assert WorkerLauncher._read_log_file(str(tmp_path), "stdout") == "hello world"
+
+    def test_returns_empty_for_missing(self, tmp_path: Path):
+        assert WorkerLauncher._read_log_file(str(tmp_path), "stdout") == ""
 
 
 class TestActiveWorkers:


### PR DESCRIPTION
## Summary
- **wait() crash fix**: `proc.communicate()` returns `(None, None)` for detached workers (file-based stdout/stderr). Previously crashed with `AttributeError: 'NoneType' has no attribute 'decode'`. Now reads from `.swarm_worker_{stdout,stderr}.log` files.
- **Post-restart collection**: After parent exits (`--dispatch-only`), `aragora swarm reconcile` couldn't find workers because they only existed in-memory. Added `collect_detached_result()` that checks PID liveness via `os.kill(pid, 0)` and collects results from worktree artifacts. Supervisor's `collect_finished_results` falls back to this automatically.
- **Stronger commit prompt**: Codex workers completed work but didn't commit. Replaced soft "Commit your changes" with explicit `git add -A` + `git commit -m "..."` instructions with MUST/Do NOT language.
- **initial_head persistence**: Work order records now store `initial_head` so detached collection can compute commit deltas after parent process restart.

## Test plan
- [x] 99 swarm tests pass (8 new tests for detached collection, PID checking, log reading)
- [x] Existing `wait()` tests still pass (piped mode unchanged)
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)