### PR TITLE
Tighten documentation hygiene and current-state accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,11 +149,11 @@ Aragora is useful to a 5-person startup on day one and scales to regulated enter
 
 ### 2. Leading-Edge Memory and Context
 
-Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 45 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
+Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 42 registered adapter specs give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (184 Python / 183 TypeScript namespaces). 3,000+ API operations across 2,900+ paths and 260+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack -- not the other way around.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,000+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack -- not the other way around.
 
 ### 4. Multi-Agent Robustness
 
@@ -299,7 +299,7 @@ aragora/
 │   ├── cli_agents.py     # Claude Code, Codex, Gemini CLI, Grok CLI
 │   └── fallback.py       # OpenRouter fallback on quota errors
 ├── gauntlet/       # Adversarial stress testing
-├── knowledge/      # Knowledge Mound with 45 registered adapters
+├── knowledge/      # Knowledge Mound with 42 registered adapter specs
 ├── memory/         # 4-tier memory (fast/medium/slow/glacial)
 ├── server/         # 3,000+ API operations, 260+ WebSocket event types
 ├── pipeline/       # Decision-to-PR generation
@@ -343,7 +343,7 @@ Costs vary by model mix. Use `aragora decide --dry-run` to preview costs before 
 | Gauntlet stress testing | Built-in CLI | No | No | No |
 | Enterprise security (SSO, RBAC, encryption) | Production-ready | No | No | No |
 | Self-improvement (Nomic Loop) | Autonomous with safety gates | No | No | No |
-| Knowledge persistence (45 adapters) | 4-tier memory + Knowledge Mound | Custom | Custom | Custom |
+| Knowledge persistence (42 adapter specs) | 4-tier memory + Knowledge Mound | Custom | Custom | Custom |
 | Channel delivery (Slack, Teams, etc.) | 8 channels built-in | No | No | No |
 
 ---

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,9 @@ Aragora is **98% GA-ready**. The closed-loop backbone (CLB) sprint is now comple
 
 **By the numbers:**
 - 208,000+ tests across 5,000+ test files (0 failures on main)
-- 45 Knowledge Mound adapters registered (up from 34 in Q4 2025)
+- 42 Knowledge Mound adapter specs registered (up from 34 in Q4 2025)
 - 3,000+ API operations across 2,900+ paths
-- 14 RBAC resource types, 8 actions, 360+ permissions
+- 15 RBAC resource types, 8 actions, 420+ named permissions
 - SOC 2 controls framework: 98% implemented
 
 **Completed since January 2026:**
@@ -30,7 +30,7 @@ Aragora is **98% GA-ready**. The closed-loop backbone (CLB) sprint is now comple
 - Dev swarm coordination layer
 
 **Remaining blockers before GA:**
-- External penetration test (vendor-dependent; kickoff target Mar 3, 2026)
+- External penetration test (vendor-dependent; scheduling still pending confirmation and remains the only named GA blocker)
 
 **EU AI Act enforcement date: August 2, 2026** — the compliance CLI and audit trail infrastructure
 position Aragora as a natural adoption path for enterprises facing this deadline.
@@ -100,7 +100,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 - [x] Helm chart for Kubernetes
 
 ### Enterprise Readiness (Ongoing)
-- [ ] Complete third-party penetration testing (kickoff target: Mar 3, 2026 — vendor-dependent, only remaining GA blocker)
+- [ ] Complete third-party penetration testing (vendor-dependent scheduling remains the only named GA blocker)
 - [ ] Deploy public status page at status.aragora.ai
 - [x] Implement quarterly disaster recovery drills (BackupScheduler with DR integration)
 - [x] Finalize data classification policy (runtime enforcement, CI PII gate, evidence bundles)
@@ -189,6 +189,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 ## Q2-Q4 2026 Forward Plan
 
 This section captures the prioritized forward roadmap as of March 2026, organized by quarter and theme.
+Execution priority source of truth: [docs/status/NEXT_STEPS_CANONICAL.md](docs/status/NEXT_STEPS_CANONICAL.md). This roadmap summarizes quarter-level themes and does not supersede canonical execution priorities.
 
 **EU AI Act enforcement: August 2, 2026.** This is a hard external forcing function. The compliance CLI
 (`aragora compliance export`) is already shipping artifact bundles for GPAI transparency requirements.
@@ -199,7 +200,7 @@ for capturing this cohort is now.
 - [x] Agent-first beta: OpenClaw fleet deployed on 3 machines, running `aragora review` on real PRs via REST API
 - [x] GitHub Actions pre-merge gate (`aragora-review-gate.yml` shipped)
 - [x] Public demo at aragora.ai/demo (PR #705; standalone demo page live)
-- [ ] EU AI Act compliance package — full audit bundle documentation and customer playbook
+- [ ] EU AI Act compliance package — final packaging polish, regulator-ready validation, and customer rollout hardening
 - [ ] SOC 2 Type II audit engagement kickoff (controls are ready; external auditor engagement pending)
 
 ### Q3 2026 Priorities
@@ -250,7 +251,7 @@ Submit feature requests: https://github.com/aragora/aragora/discussions
 
 ## Contributing
 
-Aragora is open to contributions. See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for guidelines.
+Aragora is open to contributions. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Priority contribution areas:
 - Evidence connectors for new sources

--- a/aragora/server/openapi/endpoints/sdk_missing.py
+++ b/aragora/server/openapi/endpoints/sdk_missing.py
@@ -17,6 +17,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Support"],
             "summary": "Connect support integration",
+            "description": "Create or authorize a support-system integration used for ticket ingestion and response workflows.",
             "operationId": "createSupportConnect",
             "responses": {"200": _ok_response("Connected", _obj)},
         },
@@ -25,6 +26,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Support"],
             "summary": "Triage support request",
+            "description": "Run triage over a support request and return routing or prioritization metadata.",
             "operationId": "createSupportTriage",
             "responses": {"200": _ok_response("Triage result", _obj)},
         },
@@ -33,6 +35,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Support"],
             "summary": "Auto-respond to support ticket",
+            "description": "Generate and send an automated response for a support ticket using configured support workflows.",
             "operationId": "createSupportAutoRespond",
             "responses": {"200": _ok_response("Response sent", _obj)},
         },
@@ -41,8 +44,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "delete": {
             "tags": ["Support"],
             "summary": "Delete support integration",
+            "description": "Remove a previously configured support integration and revoke its active connection.",
             "operationId": "deleteSupportIntegration",
-            "parameters": [{"name": "support_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "support_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique support integration identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Deleted")},
         },
     },
@@ -50,8 +62,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Support"],
             "summary": "Create support ticket",
+            "description": "Create a new ticket within the specified support integration.",
             "operationId": "createSupportTicket",
-            "parameters": [{"name": "support_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "support_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique support integration identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"201": _ok_response("Ticket created", _obj)},
         },
     },
@@ -59,10 +80,23 @@ SDK_MISSING_ENDPOINTS: dict = {
         "put": {
             "tags": ["Support"],
             "summary": "Update support ticket",
+            "description": "Update ticket fields or workflow state for a ticket in the configured support system.",
             "operationId": "updateSupportTicket",
             "parameters": [
-                {"name": "support_id", "in": "path", "required": True, "schema": _str},
-                {"name": "ticket_id", "in": "path", "required": True, "schema": _str},
+                {
+                    "name": "support_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique support integration identifier.",
+                    "schema": _str,
+                },
+                {
+                    "name": "ticket_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique ticket identifier within the support system.",
+                    "schema": _str,
+                },
             ],
             "responses": {"200": _ok_response("Ticket updated", _obj)},
         },
@@ -71,10 +105,23 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Support"],
             "summary": "Reply to support ticket",
+            "description": "Post a reply to an existing support ticket and return delivery metadata.",
             "operationId": "createSupportTicketReply",
             "parameters": [
-                {"name": "support_id", "in": "path", "required": True, "schema": _str},
-                {"name": "ticket_id", "in": "path", "required": True, "schema": _str},
+                {
+                    "name": "support_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique support integration identifier.",
+                    "schema": _str,
+                },
+                {
+                    "name": "ticket_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique ticket identifier within the support system.",
+                    "schema": _str,
+                },
             ],
             "responses": {"200": _ok_response("Reply sent", _obj)},
         },
@@ -84,6 +131,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Verification"],
             "summary": "List verification proofs",
+            "description": "Return stored verification proofs and associated metadata for prior verification runs.",
             "operationId": "listVerificationProofs",
             "responses": {"200": _ok_response("Proofs list", _arr_obj)},
         },
@@ -92,6 +140,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Verification"],
             "summary": "Validate claims",
+            "description": "Validate supplied claims or evidence and return a verification result payload.",
             "operationId": "createVerificationValidate",
             "responses": {"200": _ok_response("Validation result", _obj)},
         },
@@ -101,6 +150,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Calibration"],
             "summary": "Get calibration curve",
+            "description": "Fetch calibration-curve data used to evaluate model or agent confidence quality.",
             "operationId": "getCalibrationCurve",
             "responses": {"200": _ok_response("Calibration curve data", _obj)},
         },
@@ -109,6 +159,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Calibration"],
             "summary": "Get calibration history",
+            "description": "List historical calibration measurements and snapshots for supported agents or systems.",
             "operationId": "getCalibrationHistory",
             "responses": {"200": _ok_response("Calibration history", _arr_obj)},
         },
@@ -118,8 +169,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Services"],
             "summary": "Get service health",
+            "description": "Return health information for an external or internal service registered with Aragora.",
             "operationId": "getServiceHealth",
-            "parameters": [{"name": "service_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "service_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique service identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Service health", _obj)},
         },
     },
@@ -127,8 +187,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Services"],
             "summary": "Get service metrics",
+            "description": "Return operational metrics for a registered service.",
             "operationId": "getServiceMetrics",
-            "parameters": [{"name": "service_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "service_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique service identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Service metrics", _obj)},
         },
     },
@@ -137,8 +206,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Flips"],
             "summary": "Get flip details",
+            "description": "Retrieve detailed metadata for a recorded flip event.",
             "operationId": "getFlip",
-            "parameters": [{"name": "flip_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "flip_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique flip identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Flip details", _obj)},
         },
     },
@@ -147,6 +225,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Ecommerce"],
             "summary": "Connect ecommerce integration",
+            "description": "Create or authorize an ecommerce integration used for inventory and fulfillment workflows.",
             "operationId": "createEcommerceConnect",
             "responses": {"200": _ok_response("Connected", _obj)},
         },
@@ -155,6 +234,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Ecommerce"],
             "summary": "Sync inventory",
+            "description": "Trigger an inventory synchronization job for a connected ecommerce system.",
             "operationId": "createEcommerceSyncInventory",
             "responses": {"200": _ok_response("Inventory synced", _obj)},
         },
@@ -163,6 +243,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Ecommerce"],
             "summary": "Ship order",
+            "description": "Create or trigger shipment handling for an ecommerce order.",
             "operationId": "createEcommerceShip",
             "responses": {"200": _ok_response("Shipment created", _obj)},
         },
@@ -171,9 +252,16 @@ SDK_MISSING_ENDPOINTS: dict = {
         "delete": {
             "tags": ["Ecommerce"],
             "summary": "Delete ecommerce integration",
+            "description": "Remove a connected ecommerce integration and stop future sync activity.",
             "operationId": "deleteEcommerceIntegration",
             "parameters": [
-                {"name": "integration_id", "in": "path", "required": True, "schema": _str}
+                {
+                    "name": "integration_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique ecommerce integration identifier.",
+                    "schema": _str,
+                }
             ],
             "responses": {"200": _ok_response("Deleted")},
         },
@@ -183,6 +271,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["CRM"],
             "summary": "Connect CRM integration",
+            "description": "Create or authorize a CRM integration for lead sync and enrichment workflows.",
             "operationId": "createCrmConnect",
             "responses": {"200": _ok_response("Connected", _obj)},
         },
@@ -191,6 +280,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["CRM"],
             "summary": "Sync lead to CRM",
+            "description": "Push a lead or contact update into the configured CRM system.",
             "operationId": "createCrmSyncLead",
             "responses": {"200": _ok_response("Lead synced", _obj)},
         },
@@ -199,6 +289,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["CRM"],
             "summary": "Enrich CRM contact",
+            "description": "Run enrichment for a CRM contact and return the updated contact payload.",
             "operationId": "createCrmEnrich",
             "responses": {"200": _ok_response("Contact enriched", _obj)},
         },
@@ -207,9 +298,16 @@ SDK_MISSING_ENDPOINTS: dict = {
         "delete": {
             "tags": ["CRM"],
             "summary": "Delete CRM integration",
+            "description": "Remove a configured CRM integration and revoke its active connection.",
             "operationId": "deleteCrmIntegration",
             "parameters": [
-                {"name": "integration_id", "in": "path", "required": True, "schema": _str}
+                {
+                    "name": "integration_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique CRM integration identifier.",
+                    "schema": _str,
+                }
             ],
             "responses": {"200": _ok_response("Deleted")},
         },
@@ -219,6 +317,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Matches"],
             "summary": "Get match statistics",
+            "description": "Return aggregate statistics for the match system.",
             "operationId": "getMatchStats",
             "responses": {"200": _ok_response("Match statistics", _obj)},
         },
@@ -227,8 +326,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Matches"],
             "summary": "Get match details",
+            "description": "Retrieve a single match record and its associated metadata.",
             "operationId": "getMatch",
-            "parameters": [{"name": "match_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "match_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique match identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Match details", _obj)},
         },
     },
@@ -237,6 +345,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "post": {
             "tags": ["Quotas"],
             "summary": "Request quota increase",
+            "description": "Submit a quota increase request for review.",
             "operationId": "createQuotaIncreaseRequest",
             "responses": {"200": _ok_response("Request submitted", _obj)},
         },
@@ -246,6 +355,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Reputation"],
             "summary": "Get domain reputation scores",
+            "description": "Return domain-level reputation scores or reputation summaries.",
             "operationId": "getReputationDomain",
             "responses": {"200": _ok_response("Domain reputation", _obj)},
         },
@@ -254,6 +364,7 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Reputation"],
             "summary": "Get reputation history",
+            "description": "List historical reputation events or score snapshots.",
             "operationId": "getReputationHistory",
             "responses": {"200": _ok_response("Reputation history", _arr_obj)},
         },
@@ -262,8 +373,17 @@ SDK_MISSING_ENDPOINTS: dict = {
         "get": {
             "tags": ["Reputation"],
             "summary": "Get agent reputation",
+            "description": "Retrieve the current reputation profile for a specific agent.",
             "operationId": "getReputationByAgentId",
-            "parameters": [{"name": "agent_id", "in": "path", "required": True, "schema": _str}],
+            "parameters": [
+                {
+                    "name": "agent_id",
+                    "in": "path",
+                    "required": True,
+                    "description": "Unique agent identifier.",
+                    "schema": _str,
+                }
+            ],
             "responses": {"200": _ok_response("Agent reputation", _obj)},
         },
     },

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -7,10 +7,10 @@
 
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
-| **HTTP API** | 2900+ paths / 3000+ operations | 81.1% |
-| **CLI** | 76 commands | 43.2% |
+| **HTTP API** | 1772 paths / 2100 operations | 81.1% |
+| **CLI** | 34 commands | 43.2% |
 | **SDK (Python)** | 186 namespaces | 70.3% |
-| **SDK (TypeScript)** | 184 namespaces | 70.3% |
+| **SDK (TypeScript)** | 185 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |
 | **Capability Catalog** | 37/37 mapped | 100.0% |
 

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -13,15 +13,15 @@ All aragoradocs should cite these values. Update monthly.
 | Metric | Value | Source |
 |--------|-------|--------|
 | Version | 2.8.0 | pyproject.toml |
-| Python modules | 3,300+ | File count |
+| Python modules | 3,800+ | `aragora/` file count |
 | Lines of code | 1,490,000 | LOC count |
-| Automated tests | 213,000+ | pytest --collect-only |
-| Test files | 4,500+ | File count |
-| API operations | 3,000+ across 2,900+ paths | OpenAPI spec |
-| WebSocket event types | 190+ | Stream modules |
-| SDK namespaces | 184 Python / 183 TypeScript (99.3% parity) | SDK package |
-| Knowledge Mound adapters | 45 | adapter registry |
-| RBAC permissions | 390+ across 165+ resource types | rbac/types.py |
+| Automated tests | 210,000+ | repo-wide `def test_` count |
+| Test files | 5,000+ | `tests/` file count |
+| API operations | 3,700+ across 2,900+ paths | OpenAPI spec |
+| WebSocket event types | 270+ | stream event inventory |
+| SDK namespaces | 186 Python / 185 TypeScript | SDK package |
+| Knowledge Mound adapters | 42 registered adapter specs | adapter factory registry |
+| RBAC permissions | 420+ across 15 core resource types | `rbac/types.py` + permission inventory |
 | Agent types | 43 across 6+ LLM providers | agent registry |
 | Workflow templates | 50+ across 6 categories | template registry |
 | Debate modules | 210+ | debate/ directory |
@@ -57,7 +57,7 @@ Any given AI model can hallucinate, be sycophantic, be biased, or exhibit correl
 
 The system should be useful to small and medium enterprises and organizations, including those in regulated verticals: healthcare (HIPAA, FHIR), financial services (SOX, audit trails), legal (contract review, due diligence, litigation), government/defense (air-gapped deployment), and general compliance (SOC 2, GDPR, EU AI Act). The BYOK model (customers bring own API keys) makes this economically viable with 85%+ gross margins and near-zero inference cost to Aragora.
 
-**Serves:** Enterprise security stack (OIDC/SAML, SCIM, AES-256-GCM, 390+ RBAC permissions), compliance frameworks (9 supported), vertical packages, SME budget controls, per-debate cost estimation, channel delivery (Slack, Teams, email, Discord).
+**Serves:** Enterprise security stack (OIDC/SAML, SCIM, AES-256-GCM, 420+ named permissions across 15 core resource types), compliance frameworks (9 supported), vertical packages, SME budget controls, per-debate cost estimation, channel delivery (Slack, Teams, email, Discord).
 
 #### Pillar 3: Vague Intent to Autonomous Execution
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 76 commands | 43.2% |
+| **CLI** | 34 commands | 43.2% |
 | **SDK (Python)** | 186 namespaces | 70.3% |
 | **SDK (TypeScript)** | 185 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/ENTERPRISE_FEATURES.md
+++ b/docs/ENTERPRISE_FEATURES.md
@@ -104,11 +104,11 @@ Fine-grained role-based access control with hierarchical permissions.
 
 Permissions are defined as `(ResourceType, Action, Scope)` tuples:
 
-- **16 resource types**: Debate, Agent, Workflow, Document, Memory, Culture, KnowledgeNode, AuditSession, AuditFinding, TrainingJob, SpecialistModel, Workspace, Organization, Billing, APIKey
+- **15 resource types**: Debate, Agent, Workflow, Document, Memory, Culture, KnowledgeNode, AuditSession, AuditFinding, TrainingJob, SpecialistModel, Workspace, Organization, Billing, APIKey
 - **8 actions**: Create, Read, Update, Delete, Execute, Export, Share, Admin
 - **4 scope levels**: Global, Organization, Workspace, Resource
 
-**390+ named permissions** across all resource domains, including debates, agents, users, organizations, API keys, memory, workflows, analytics, knowledge, provenance, connectors, devices, repositories, webhooks, gauntlet, marketplace, explainability, findings, decisions, policies, compliance, control plane, finance, receipts, scheduling, billing, sessions, approvals, templates, roles, backups, disaster recovery, data governance (classification, retention, lineage, PII), computer use, and more.
+**420+ named permissions** across all resource domains, including debates, agents, users, organizations, API keys, memory, workflows, analytics, knowledge, provenance, connectors, devices, repositories, webhooks, gauntlet, marketplace, explainability, findings, decisions, policies, compliance, control plane, finance, receipts, scheduling, billing, sessions, approvals, templates, roles, backups, disaster recovery, data governance (classification, retention, lineage, PII), computer use, and more.
 
 ### Default Roles
 
@@ -274,7 +274,7 @@ Aragora implements technical controls aligned with SOC 2 Trust Service Criteria:
 
 | Control | Implementation |
 |---|---|
-| CC6.1 - Logical access security | RBAC v2 with 390+ permissions, OIDC/SAML SSO, MFA |
+| CC6.1 - Logical access security | RBAC v2 with 420+ permissions, OIDC/SAML SSO, MFA |
 | CC6.5 - Secure data disposal | GDPR deletion scheduler with cascade management and erasure verification |
 | CC6.6 - Secure external transmissions | TLS 1.2+ enforced, webhook URL validation, SSRF protection |
 | CC7.1 - Detection of unauthorized activity | Anomaly detection, security audit logging, rate limiting |
@@ -616,7 +616,7 @@ Implementation: `aragora/control_plane/policy.py`, `aragora/control_plane/schedu
 | Capability | Key Numbers |
 |---|---|
 | Authentication | OIDC + SAML SSO, MFA (TOTP/HOTP), SCIM 2.0, API key management |
-| Authorization | 390+ permissions, 7 default roles, 4 scope levels, 16 resource types |
+| Authorization | 420+ permissions, 7 default roles, 4 scope levels, 15 resource types |
 | Multi-tenancy | Full isolation, resource quotas, usage metering, cost attribution |
 | Encryption | AES-256-GCM, field-level encryption, key rotation with versioning |
 | Compliance | SOC 2 controls, GDPR (Art. 17/20), HIPAA framework, EU AI Act artifacts |
@@ -628,4 +628,4 @@ Implementation: `aragora/control_plane/policy.py`, `aragora/control_plane/schedu
 
 ---
 
-*See [COMMERCIAL_OVERVIEW.md](COMMERCIAL_OVERVIEW.md) for pricing and deployment tiers. See [WHY_ARAGORA.md](WHY_ARAGORA.md) for competitive positioning. See [STATUS.md](STATUS.md) for detailed feature implementation status.*
+*See [COMMERCIAL_OVERVIEW.md](COMMERCIAL_OVERVIEW.md) for pricing and deployment tiers. See [WHY_ARAGORA.md](WHY_ARAGORA.md) for competitive positioning. See [status/STATUS.md](status/STATUS.md) for detailed feature implementation status.*

--- a/docs/EU_AI_ACT_COMPLIANCE.md
+++ b/docs/EU_AI_ACT_COMPLIANCE.md
@@ -54,8 +54,8 @@ High-risk AI systems (Article 6 + Annex III) must implement:
   into force       apply            apply            ENFORCEMENT       systems
                                                          ^
                                                          |
-                                              YOU ARE HERE (Feb 2026)
-                                              ~6 months remaining
+                                              YOU ARE HERE (March 2026)
+                                              ~5 months remaining
 ```
 
 ---
@@ -69,14 +69,14 @@ obligations.
 
 | EU AI Act Requirement | Article | Aragora Feature | Module | Status |
 |---|---|---|---|---|
-| Risk management system | Art. 9 | Gauntlet adversarial stress-testing: 3-phase red team attacks, capability probes, scenario matrix. ELO + Brier score calibration tracks per-agent reliability. Art. 9 conformity checking is included in the `ConformityReportGenerator` output. **No dedicated Art. 9 artifact file is generated** — a dedicated artifact bundle is planned (see roadmap). | `aragora/gauntlet/`, `aragora/compliance/eu_ai_act.py` | Conformity checking ✓ / Dedicated artifact: planned |
-| Data governance | Art. 10 | Knowledge Mound with 45 adapters, provenance tracking, validation feedback, contradiction detection, and confidence decay. | `aragora/knowledge/mound/` | Ready |
+| Risk management system | Art. 9 | Gauntlet adversarial stress-testing: 3-phase red team attacks, capability probes, scenario matrix. ELO + Brier score calibration tracks per-agent reliability. `ComplianceArtifactGenerator` emits a dedicated `Article9Artifact` with identified risks, misuse scenarios, mitigations, residual risk level, and monitoring plan. | `aragora/gauntlet/`, `aragora/compliance/eu_ai_act.py` | Ready |
+| Data governance | Art. 10 | Knowledge Mound with 42 registered adapter specs, provenance tracking, validation feedback, contradiction detection, and confidence decay. | `aragora/knowledge/mound/` | Ready |
 | Technical documentation | Art. 11 | Decision receipts capture full system configuration: agents, protocol, consensus thresholds, Annex IV sections auto-populated. | `aragora/export/decision_receipt.py` | Ready |
 | Record-keeping / logging | Art. 12 | `Article12Artifact`: provenance chain event log, Annex IV tech doc summary, reference databases, retention policy (6-month minimum per Art. 26(6)). | `aragora/compliance/eu_ai_act.py` | Ready |
 | Transparency | Art. 13 | `Article13Artifact`: provider identity, intended purpose, accuracy/robustness metrics, known risks (automation bias, hollow consensus, hallucination), output interpretation with confidence context. | `aragora/compliance/eu_ai_act.py` | Ready |
 | Human oversight | Art. 14 | `Article14Artifact`: HITL/HOTL oversight model, automation bias safeguards, override mechanisms (reject, override with reason, reverse), intervention capability (stop debate, cancel decision). | `aragora/compliance/eu_ai_act.py` | Ready |
 | Accuracy, robustness, cybersecurity | Art. 15 | Heterogeneous multi-model consensus (Claude, GPT, Gemini, Mistral), circuit breakers, Trickster hollow-consensus detection, AES-256-GCM encryption, key rotation, RBAC with MFA. | `aragora/resilience/`, `aragora/security/` | Ready |
-| Quality management | Art. 17 | Gauntlet receipts with SHA-256 integrity hashing, calibration tracking, 129,000+ automated tests, observability with Prometheus metrics and OpenTelemetry tracing. | `aragora/gauntlet/`, `aragora/observability/` | Ready |
+| Quality management | Art. 17 | Gauntlet receipts with SHA-256 integrity hashing, calibration tracking, 208,000+ automated tests, observability with Prometheus metrics and OpenTelemetry tracing. | `aragora/gauntlet/`, `aragora/observability/` | Ready |
 | Risk classification | Art. 6 | `RiskClassifier` auto-classifies use cases across all 4 risk tiers and all 8 Annex III high-risk categories using keyword and pattern matching. | `aragora/compliance/eu_ai_act.py` | Ready |
 | Conformity assessment | Art. 43 | `ConformityReportGenerator` maps receipt fields to article requirements, scores compliance per-article, generates markdown or JSON conformity reports. | `aragora/compliance/eu_ai_act.py` | Ready |
 | Explainability | Art. 13(1) | Factor decomposition, counterfactual analysis, evidence chains linking claims to sources, vote pivot analysis showing which arguments changed outcomes. | `aragora/explainability/` | Ready |
@@ -147,7 +147,7 @@ gen = ComplianceArtifactGenerator(
     provider_contact="compliance@yourcompany.com",
     eu_representative="Your Company EU GmbH",
     system_name="Your Decision Platform",
-    system_version="2.6.3",
+    system_version="2.8.0",
 )
 
 bundle = gen.generate(receipt_dict)
@@ -172,7 +172,8 @@ aragora compliance audit receipt.json --format json --output report.json
 ## 4. Compliance Artifact Bundle
 
 The `ComplianceArtifactBundle` packages all EU AI Act compliance evidence into a
-single auditable unit with cryptographic integrity verification.
+single auditable unit with cryptographic integrity verification. The bundle now
+includes dedicated artifacts for Articles 9, 10, 11, 12, 13, 14, 15, and 43.
 
 ### Bundle structure
 
@@ -182,9 +183,14 @@ single auditable unit with cryptographic integrity verification.
 | **integrity_hash** | SHA-256 hash of bundle metadata (tamper detection) |
 | **risk_classification** | RiskLevel + Annex III category + obligations list |
 | **conformity_report** | Per-article status (satisfied/partial/not_satisfied), overall status, recommendations |
+| **article_9** (Risk Management) | Identified risks, foreseeable misuse scenarios, mitigation measures, residual risk level, post-market monitoring plan |
+| **article_10** (Data Governance) | Data sources, quality measures, bias detection methods, training-data provenance, governance policy notes |
+| **article_11** (Technical Documentation) | System description, design specifications, monitoring capabilities, performance metrics, compliance notes |
 | **article_12** (Record-Keeping) | Event log, reference databases, input record with SHA-256 hash, Annex IV technical documentation (3 sections), retention policy (6-month min per Art. 26(6)) |
-| **article_13** (Transparency) | Provider identity + EU representative, intended purpose, accuracy/robustness metrics, 3 known risks (automation bias, hollow consensus, hallucination), output interpretation with confidence context |
-| **article_14** (Human Oversight) | HITL/HOTL oversight model, automation bias safeguards (4 mechanisms), factor decomposition + counterfactuals, override capability (reject/override/reverse), intervention capability (stop/cancel with safe state) |
+| **article_13** (Transparency) | Provider identity + EU representative, intended purpose, accuracy/robustness metrics, known risks, output interpretation with confidence context |
+| **article_14** (Human Oversight) | HITL/HOTL oversight model, automation bias safeguards, factor decomposition + counterfactuals, override capability, intervention capability |
+| **article_15** (Accuracy / Robustness / Cybersecurity) | Consensus confidence, robustness score, adversarial-testing indicators, cryptographic controls, error indicators |
+| **article_43** (Conformity Assessment) | Assessment type, assessor, standards applied, findings, conformity status, compliance notes |
 
 ### Integrity verification
 
@@ -289,6 +295,51 @@ systems must already have conformity documentation in place.
 - Document human oversight procedures (approval gates, override protocols)
 - Prepare calibration reports showing accuracy vs. confidence alignment
 - Perform internal conformity assessment using generated bundles
+
+---
+
+## Appendix: Additional Article Artifacts
+
+### Article 10 — Data and Data Governance
+
+`Article10Artifact` captures data provenance, quality measures, and bias detection
+methods. When no explicit data sources are declared in the receipt, the artifact
+notes this and falls back to platform-level governance defaults (heterogeneous
+model ensemble, adversarial dissent capture, Trickster hollow-consensus detection).
+
+Fields: `data_sources`, `data_quality_measures`, `bias_detection_methods`,
+`training_data_provenance`, `data_governance_policy`, `compliance_notes`.
+
+### Article 11 — Technical Documentation
+
+`Article11Artifact` generates Annex IV-aligned technical documentation including
+system description, design specifications, development process, monitoring
+capabilities, and performance metrics. When receipt fields are absent, defaults
+are auto-generated from platform configuration.
+
+Fields: `system_description`, `design_specifications`, `development_process`,
+`monitoring_capabilities`, `performance_metrics`, `compliance_notes`.
+
+### Article 43 — Conformity Assessment
+
+`Article43Artifact` records conformity assessment metadata: assessment type
+(internal or third-party), assessor identity, applied standards, findings from
+risk analysis, and overall conformity status. Critical risks automatically set
+status to `non_conformant`; high risks set `conditional` when no explicit status
+is provided.
+
+Fields: `assessment_type`, `assessment_date`, `assessor`, `standards_applied`,
+`findings`, `conformity_status`, `compliance_notes`.
+
+### Article 49 — Registration
+
+`Article49Artifact` prepares the data required for EU AI database registration
+per Article 49. It captures provider information, system purpose, risk level,
+and registration identifiers. When no registration ID is present, a compliance
+note flags that registration is required before market placement.
+
+Fields: `registration_id`, `registered_date`, `eu_database_entry`,
+`provider_info`, `system_purpose`, `risk_level`, `compliance_notes`.
 
 ---
 

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -35,7 +35,7 @@ Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / s
 
 ### 3. Extensible and Modular
 
-Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (184 Python / 183 TypeScript namespaces). 3,000+ API operations across 2,900+ paths and 260+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,000+ API operations across 2,900+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
 
 ### 4. Multi-Agent Robustness
 
@@ -466,7 +466,7 @@ aragora context --preview --rlm
 |---------|---------|--------------|
 | **`aragora`** | Full control plane (server, CLI, SDK) | `pip install aragora` |
 | **`aragora-sdk`** | Official Python SDK (remote HTTP API; sync + async + streaming) | `pip install aragora-sdk` |
-| **`@aragora/sdk`** | TypeScript/Node.js SDK (183 namespaces) | `npm install @aragora/sdk` |
+| **`@aragora/sdk`** | TypeScript/Node.js SDK (185 namespaces) | `npm install @aragora/sdk` |
 
 **Deprecated packages** (avoid for new integrations):
 - `aragora-client` -- Legacy async client. Migrate to `aragora-sdk`.

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -2,6 +2,8 @@
 
 *Complete catalog of 230+ features for developers exploring Aragora capabilities*
 
+> Compatibility mirror for older links. The canonical current feature inventory is [status/FEATURE_DISCOVERY.md](status/FEATURE_DISCOVERY.md).
+
 This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
 
 > **Quick Links**: [STATUS.md](STATUS.md) for implementation status | [ENTERPRISE_FEATURES.md](ENTERPRISE_FEATURES.md) for enterprise details | [API_REFERENCE.md](./api/API_REFERENCE.md) for endpoints
@@ -22,7 +24,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 230+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
+**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,700+ API operations
 
 ---
 
@@ -62,7 +64,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Stable | Real-time debate spectating | `aragora/spectate/` |
+| **Spectate** | Partial | Debate spectating exists, but `/api/v1/spectate/stream` is currently served as an SSE snapshot/stub rather than full live streaming | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
 
 ### Configuration
 
@@ -127,20 +129,20 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Memory Streams** | Stable | Event-based memory updates | `aragora/memory/streams.py` | |
 | **Embeddings** | Stable | Semantic embedding for retrieval (OpenAI, Gemini, Ollama) | `aragora/memory/embeddings.py` | |
 | **Critique Store** | Stable | Critique pattern storage | `aragora/memory/store.py` | |
-| **Progressive Memory Search** | Stable | Staged retrieval (index → timeline → entries) | `aragora/server/handlers/memory/memory.py` | |
+| **Progressive Memory Search** | Partial | Staged retrieval (index → timeline → entries); some timeline and batch flows remain backend-conditional and can return `501` | `aragora/server/handlers/memory/memory.py`, `aragora/server/handlers/memory/memory_progressive.py` | |
 | **Memory Viewer** | Stable | HTML viewer for memory inspection | `aragora/server/handlers/memory/memory.py` | |
 | **Tool Usage Capture** | Optional | Opt-in tool usage capture into FAST tier | `aragora/memory/capture.py` | |
-| **Unified Memory Gateway** | Integrated | Fan-out query across ContinuumMemory, KM, Supermemory, claude-mem via `enable_unified_memory` (150 tests) | `aragora/memory/gateway/` | |
-| **ClaudeMemAdapter** | Integrated | KM adapter wrapping claude-mem MCP connector (one of 45 adapters) | `aragora/knowledge/mound/adapters/claude_mem_adapter.py` | |
+| **Unified Memory Gateway** | Integrated | Fan-out query across ContinuumMemory, KM, Supermemory, claude-mem via `enable_unified_memory`; handler availability still depends on optional unified-memory backends | `aragora/memory/gateway.py`, `aragora/memory/retention_gate.py`, `aragora/memory/dedup.py` | |
+| **ClaudeMemAdapter** | Integrated | KM adapter wrapping claude-mem MCP connector (one of 42 registered adapter specs) | `aragora/knowledge/mound/adapters/claude_mem_adapter.py` | |
 
 ### Unified Memory Gateway Components
 
 | Component | Status | Description | Key Files |
 |-----------|--------|-------------|-----------|
-| **MemoryGateway** | Integrated | Unified fan-out query interface across all memory systems | `aragora/memory/gateway/core.py` |
-| **RetentionGate** | Integrated | Titans/MIRAS surprise-driven retain/demote/forget/consolidate decisions | `aragora/memory/gateway/retention.py` |
-| **CrossSystemDedupEngine** | Integrated | SHA-256 exact + Jaccard near-duplicate detection across memory systems | `aragora/memory/gateway/dedup.py` |
-| **RLMMemoryNavigator** | Integrated | REPL helpers for programmatic cross-system memory exploration | `aragora/memory/gateway/rlm_navigator.py` |
+| **MemoryGateway** | Integrated | Unified fan-out query interface across all memory systems | `aragora/memory/gateway.py` |
+| **RetentionGate** | Integrated | Titans/MIRAS surprise-driven retain/demote/forget/consolidate decisions | `aragora/memory/retention_gate.py` |
+| **CrossSystemDedupEngine** | Integrated | SHA-256 exact + Jaccard near-duplicate detection across memory systems | `aragora/memory/dedup.py` |
+| **RLMMemoryNavigator** | Integrated | REPL helpers for programmatic cross-system memory exploration | `aragora/rlm/memory_navigator.py` |
 
 ### Memory Tiers
 
@@ -170,7 +172,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 |---------|--------|-------------|-----------|------|
 | **RLM Factory** | Stable | RLM context management factory | `aragora/rlm/factory.py` | [RLM_GUIDE.md](./guides/RLM_GUIDE.md) |
 | **RLM Bridge** | Stable | Integration bridge for RLM | `aragora/rlm/bridge.py` | |
-| **RLM Handler** | Stable | Request handling | `aragora/rlm/handler.py` | |
+| **RLM Handler** | Partial | Request handling is available, but context storage is still in-memory by default and some streaming flows are backend-conditional | `aragora/server/handlers/rlm.py` | |
 | **Streaming RLM** | Stable | Progressive context loading (top-down, bottom-up, targeted) | `aragora/rlm/streaming.py` | |
 | **RLM Training** | Stable | Experience replay buffer and reward computation | `aragora/rlm/training/` | |
 | **Cognitive Limiter** | Stable | Context management via `use_rlm_limiter` | `aragora/debate/cognitive_limiter_rlm.py` | |
@@ -200,7 +202,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | **KM Resilience** | Stable | ResilientPostgresStore with retry, health, cache invalidation | `aragora/knowledge/mound/resilience.py` | |
 | **SLO Alerting** | Stable | Adapter performance monitoring with Prometheus | `aragora/config/performance_slos.py` | |
 
-### Knowledge Adapters (45 Total)
+### Knowledge Adapters (42 Registered Adapter Specs)
 
 | Adapter | Purpose | Key Files |
 |---------|---------|-----------|
@@ -322,7 +324,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files |
 |---------|--------|-------------|-----------|
-| **Setup Wizard** | Stable | Guided onboarding with SSO/RBAC integration | `aragora/onboarding/wizard.py` |
+| **Setup Wizard** | Partial | Guided onboarding with SSO/RBAC integration; provider coverage in live connection tests and disconnect flows remains incomplete | `aragora/onboarding/wizard.py`, `aragora/server/handlers/oauth_wizard.py` |
 
 ### Coordination System
 
@@ -349,9 +351,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Stable | Bot, OAuth, webhooks, evidence collection | `aragora/connectors/chat/slack/` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Stable | Teams, channels, meetings, JWT verification | `aragora/connectors/chat/teams.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |
@@ -474,8 +476,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | SDK | Status | Namespaces | Key Files |
 |-----|--------|------------|-----------|
-| **Python SDK** | Stable | 184 namespaces | `sdk/python/` |
-| **TypeScript SDK** | Stable | 183 namespaces | `sdk/typescript/` |
+| **Python SDK** | Stable | 186 namespaces | `sdk/python/` |
+| **TypeScript SDK** | Stable | 185 namespaces | `sdk/typescript/` |
 
 ### CLI
 
@@ -483,7 +485,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 |---------|--------|-------------|-----------|
 | **CLI Main** | Stable | Command-line interface | `aragora/cli/main.py` |
 | **REPL** | Stable | Interactive shell | `aragora/cli/repl.py` |
-| **Setup Wizard** | Stable | Guided `aragora setup` for self-hosted | `aragora/cli/setup.py` |
+| **Setup Wizard** | Partial | Guided `aragora setup` for self-hosted; some provider test/disconnect flows remain selectively implemented | `aragora/cli/setup.py`, `aragora/server/handlers/oauth_wizard.py` |
 | **Gauntlet CLI** | Stable | Compliance test runner | `aragora/cli/gt.py` |
 
 ### Workflow Engine
@@ -511,8 +513,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files |
 |---------|--------|-------------|-----------|
-| **Trust Wedge Core** | Stable | Receipt-gated email actions: Gmail → debate → signed receipt → execute | `aragora/inbox/trust_wedge.py` |
-| **Triage Runner** | Stable | Batch email triage with adversarial debate decisions | `aragora/inbox/triage_runner.py` |
+| **Trust Wedge Core** | Integrated | Receipt-gated Gmail actions are shipped; surrounding channel/setup surfaces still have partial or placeholder-backed edges | `aragora/inbox/trust_wedge.py` |
+| **Triage Runner** | Partial | Batch email triage with adversarial debate decisions; can still fall back to stub debates when engine/agent wiring is unavailable | `aragora/inbox/triage_runner.py` |
 | **Receipt-Gated Executor** | Stable | Only executes actions with previously persisted approved receipts | `aragora/inbox/receipt_gated_executor.py` |
 | **CLI Review Loop** | Stable | Interactive CLI approval for triage decisions | `aragora/inbox/cli_review.py` |
 | **Auto-Approval Policy** | Stable | Narrow auto-approval rules (ARCHIVE/STAR/LABEL/IGNORE only) | `aragora/inbox/auto_approval.py` |
@@ -523,7 +525,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
 | **Gauntlet Runner** | Stable | Compliance test execution | `aragora/gauntlet/runner.py` | [GAUNTLET.md](./debate/GAUNTLET.md) |
-| **Decision Receipts** | Stable | SHA-256 cryptographic audit trails | `aragora/gauntlet/receipts.py` | |
+| **Decision Receipts** | Integrated | SHA-256 cryptographic audit trails; anchor verification and export coverage still vary across handler surfaces | `aragora/gauntlet/receipts.py`, `aragora/server/handlers/gauntlet/receipts.py` | |
 | **Findings** | Stable | Compliance findings management | `aragora/gauntlet/findings.py` | |
 | **Gauntlet Defense** | Stable | Attack/defend cycles via `proposer_agent` | `aragora/gauntlet/defense.py` | |
 | **Personas** | Stable | GDPR, SOC2, HIPAA, PCI-DSS, AI Act, NIST CSF | `aragora/gauntlet/personas/` | |

--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -30,7 +30,7 @@
 | Agent-first beta via REST API | **Fleet deployed (12 runners)** | `aragora openclaw watch` polls repos, runs multi-agent review, posts findings. 3 Hetzner + 6 EC2 + 3 local Macs. PR watch daemon on Mac Studio via launchd. |
 | GitHub Actions pre-merge gate | **Workflow created** | `aragora-review-gate.yml` manual-only (workflow_dispatch). Re-enable pull_request trigger when ready. |
 | Public demo at aragora.ai/demo | **Live and verified** | `/demo` (standalone debate), `/demo/pipeline` (pipeline demo), `/demo/instant` (debate replay). All return 200. Landing page CTA wired. |
-| EU AI Act compliance package | **Substantially complete (85/100)** | Art. 9/12/13/14/15 dedicated bundles + CLI export + 7,524 lines compliance code + 300+ tests. Customer playbook needs Art. 10/11/43/49 appendix. **Deadline: Aug 2, 2026.** |
+| EU AI Act compliance package | **Substantially complete (90/100)** | Art. 9/10/11/12/13/14/15/43/49 bundle coverage and customer playbook appendix are shipped. Remaining work is packaging polish, regulator-ready validation, and launch collateral hardening. **Deadline: Aug 2, 2026.** |
 | First 2 enterprise pilot engagements | Not started | Closed partnerships — target fintech + healthcare |
 | Developer onboarding <10 min | **Working (2-5 min)** | `aragora quickstart --demo` (zero-config), `aragora review --demo`, Docker quickstart all verified working. Needs cold-start user testing. |
 
@@ -107,7 +107,7 @@ These items were planned and are now shipped:
 | Feature | Shipped |
 |---------|---------|
 | Nomic Loop end-to-end | Jan 2026 |
-| Knowledge Mound Phase A2 (45 adapters) | Feb 2026 |
+| Knowledge Mound Phase A2 (adapter registry + unified memory hardening) | Feb 2026 |
 | Unified Memory Gateway | Feb 2026 |
 | Retention Gate (Titans/MIRAS) | Feb 2026 |
 | RBAC v2 (14 resource types, 8 actions) | Feb 2026 |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -45,6 +45,12 @@ This index intentionally links to actively maintained docs with validated paths.
 ## Product Status and Planning
 
 - [Status](status/STATUS.md)
+- [Feature Discovery](status/FEATURE_DISCOVERY.md)
+- [Feature Gap List](FEATURE_GAP_LIST.md)
+- [Next Steps (Canonical)](status/NEXT_STEPS_CANONICAL.md)
+- [Active 6-Week Execution Plan](status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md)
+- [Documentation Hygiene Register](status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md)
+- [Roadmap](../ROADMAP.md)
 
 ## Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,8 @@ organizational knowledge and channels**.
 | Document | Description |
 |----------|-------------|
 | [ARCHITECTURE](./architecture/ARCHITECTURE.md) | System architecture overview |
-| [FEATURES](./status/FEATURES.md) | Complete feature documentation |
+| [FEATURE_DISCOVERY](./status/FEATURE_DISCOVERY.md) | Current feature inventory and file map |
+| [FEATURE_GAP_LIST](./FEATURE_GAP_LIST.md) | Planned, partial, and hardening work |
 | [MODES_GUIDE](./guides/MODES_GUIDE.md) | Debate modes (standard, gauntlet, genesis) |
 | [DEBATE_INTERNALS](./debate/DEBATE_INTERNALS.md) | Debate engine internals (Arena, phases, consensus) |
 | [REASONING](./workflow/REASONING.md) | Belief networks, provenance, and claims |
@@ -37,8 +38,17 @@ organizational knowledge and channels**.
 | [CONTROL_PLANE](./reference/CONTROL_PLANE.md) | Control plane architecture |
 | [CONTROL_PLANE_GUIDE](./guides/CONTROL_PLANE_GUIDE.md) | Control plane operations guide |
 | [MEMORY](./knowledge/MEMORY.md) | Memory systems overview |
-| [KNOWLEDGE_MOUND](./knowledge/KNOWLEDGE_MOUND.md) | Centralized knowledge storage with 45 adapters |
+| [KNOWLEDGE_MOUND](./knowledge/KNOWLEDGE_MOUND.md) | Centralized knowledge storage with 42 registered adapter specs |
 | [DOCUMENTS](./reference/DOCUMENTS.md) | Document ingestion and parsing |
+
+## Current Status & Planning
+
+| Document | Description |
+|----------|-------------|
+| [STATUS](./status/STATUS.md) | Current shipped state and recent delivery summary |
+| [NEXT_STEPS_CANONICAL](./status/NEXT_STEPS_CANONICAL.md) | Single source of truth for execution priorities |
+| [EXECUTION_NEXT_6_WEEKS_2026-03-05](./status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md) | Active short-horizon plan |
+| [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](./status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md) | Running roadmap, drift, and feature-gap register |
 
 ### Memory Tiers
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -2,6 +2,7 @@
 
 *Last updated: March 6, 2026*
 
+> Compatibility mirror for older links. The canonical current-status document is [status/STATUS.md](status/STATUS.md).
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](INDEX.md) for the curated technical reference map.
 
 ## March 2026 Sprint — Closed-Loop Backbone, Trust Wedge & Infrastructure
@@ -44,12 +45,12 @@
 
 ### Codebase Metrics (March 6, 2026)
 - **Python modules**: 3,700+
-- **Tests**: 208,000+ across 5,000+ test files
+- **Tests**: 210,000+ across 5,000+ test files
 - **HTTP handlers**: 700+
-- **KM adapters**: 45
+- **KM adapters**: 42 registered adapter specs
 - **Agent types**: 43
 - **API operations**: 3,000+ across 2,900+ paths
-- **RBAC permissions**: 360+
+- **RBAC permissions**: 420+
 - **Version**: v2.8.0
 
 ---
@@ -85,7 +86,7 @@ Massive production hardening sprint: 205,000+ tests (up from 129,000+), comprehe
 - **Type safety**: Fixed RepositoryCrawler API usage, resolve_db_path imports, float/dict type annotations
 - **CDC password**: Replaced example credential with placeholder
 
-### SDK Expansion (184 Python / 183 TypeScript namespaces)
+### SDK Expansion (186 Python / 185 TypeScript namespaces)
 - **13 new TypeScript namespaces**: agent_dashboard, playground, partner, selection, expenses, github, and more
 - **6 new Python namespaces**: control_plane, partner, selection, expenses, github SDK methods
 - **SDK types regenerated** from updated OpenAPI spec

--- a/docs/enterprise/SOC2_CONTROL_MATRIX.md
+++ b/docs/enterprise/SOC2_CONTROL_MATRIX.md
@@ -249,5 +249,5 @@ This document maps Aragora's security controls to SOC 2 Type II Trust Service Cr
 
 - [AICPA Trust Service Criteria](https://www.aicpa.org/interestareas/frc/assuranceadvisoryservices/trustservices)
 - [Aragora Enterprise Features](../ENTERPRISE_FEATURES.md)
-- [Aragora Security Architecture](../CLAUDE.md)
+- [Aragora Security Architecture](../../CLAUDE.md)
 - [Environment Configuration](../reference/ENVIRONMENT.md)

--- a/docs/guides/SME_STARTER_PACK.md
+++ b/docs/guides/SME_STARTER_PACK.md
@@ -198,7 +198,7 @@ SME tier includes simplified role model:
 | **Admin** | Manage integrations, templates, view all debates |
 | **Member** | Run debates, view own results, export receipts |
 
-**Implementation:** `aragora/rbac/` module with 390+ granular permissions across 165+ resource types, mapped to these simplified roles for the SME tier.
+**Implementation:** `aragora/rbac/` module with 420+ granular permission strings across 15 core resource types, mapped to these simplified roles for the SME tier.
 
 ### Compliance
 

--- a/docs/knowledge/KNOWLEDGE_MOUND.md
+++ b/docs/knowledge/KNOWLEDGE_MOUND.md
@@ -485,7 +485,7 @@ await adapter.sync()  # Sync critique patterns to mound
 
 The Knowledge Mound supports bidirectional integration with all major subsystems through specialized adapters. These adapters enable:
 
-- **45 registered adapters** wired via `aragora/knowledge/mound/adapters/factory.py`
+- **42 registered adapter specs** wired via `aragora/knowledge/mound/adapters/factory.py`
 - **Additional adapter files** present but not factory-registered (`extraction`, `nomic_cycle`, `openclaw`, `ranking`)
 
 - **Data Flow IN**: Subsystems automatically sync relevant data to KM

--- a/docs/status/COMMERCIAL_OVERVIEW.md
+++ b/docs/status/COMMERCIAL_OVERVIEW.md
@@ -20,8 +20,8 @@ Aragora is built on five architectural commitments that together produce somethi
 | Pillar | What It Means |
 |--------|---------------|
 | **1. SMB-Ready, Enterprise-Grade** | Useful to a 5-person startup on day one; scales to regulated enterprise without rearchitecting. Security and compliance built in, not bolted on. |
-| **2. Leading-Edge Memory and Context** | 4-tier Continuum Memory, Knowledge Mound (45 adapters), unified memory gateway, and RLM context management enable coherence across long multi-round sessions and large document sets. |
-| **3. Extensible and Modular** | Connectors, SDKs (Python 185 namespaces + TypeScript 183 namespaces), 3,000+ API operations, OpenClaw integration, workflow engine, marketplace. |
+| **2. Leading-Edge Memory and Context** | 4-tier Continuum Memory, Knowledge Mound (42 registered adapter specs), unified memory gateway, and RLM context management enable coherence across long multi-round sessions and large document sets. |
+| **3. Extensible and Modular** | Connectors, SDKs (Python 186 namespaces + TypeScript 185 namespaces), 3,000+ API operations, OpenClaw integration, workflow engine, marketplace. |
 | **4. Multi-Agent Robustness** | Heterogeneous agents (Claude, GPT, Gemini, Grok, Mistral, DeepSeek, Qwen, Kimi) produce outputs more robust, less biased, and higher quality than single models. |
 | **5. Self-Healing and Self-Extending** | Nomic Loop autonomous improvement, red-team stress-testing, multi-agent code editing with human approval gates. |
 
@@ -116,8 +116,8 @@ Aragora is built on five architectural commitments that together produce somethi
 | Observability & Monitoring | 95% | Ready | Prometheus, Grafana, OpenTelemetry |
 | Testing & QA | 98% | Ready | 208,000+ tests across 4,300+ files |
 | Documentation | 95% | Ready | API docs, runbooks, compliance guides |
-| Compliance & Governance | 98% | Ready | RBAC v2 with 390+ permissions, 7 roles, role hierarchy |
-| SDK & Integrations | 98% | Ready | 184 Python / 183 TypeScript namespaces (99.3% parity) |
+| Compliance & Governance | 98% | Ready | RBAC v2 with 420+ permissions, 7 roles, role hierarchy |
+| SDK & Integrations | 98% | Ready | 186 Python / 185 TypeScript namespaces |
 | **OVERALL** | **98%** | **GA Ready** | Enterprise-grade features integrated, 0 mypy errors |
 
 ### Deployment Readiness
@@ -254,11 +254,11 @@ Structured debate for strategic decisions with evidence-based recommendations.
 
 | Capability | Resolution | Status |
 |------------|------------|--------|
-| Fine-grained RBAC | RBAC v2 with 7 roles, 390+ permissions | Complete |
+| Fine-grained RBAC | RBAC v2 with 7 roles, 420+ permissions | Complete |
 | Automated backups | BackupManager with incremental support | Complete |
 | Bot handler consolidation | BotHandlerMixin across 8 platforms | Complete |
-| Python SDK | 185 namespaces with typed clients | Complete |
-| TypeScript SDK | 183 namespaces with full IntelliSense | Complete |
+| Python SDK | 186 namespaces with typed clients | Complete |
+| TypeScript SDK | 185 namespaces with full IntelliSense | Complete |
 | OpenClaw integration | Portable agent governance | Complete |
 | Knowledge Mound Phase A2 | Contradiction detection, confidence decay, RBAC governance | Complete |
 | SLA documentation | Legally-binding service levels | In Progress |

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -1,0 +1,98 @@
+# Documentation Hygiene And Gap Register
+
+Last updated: 2026-03-06
+
+This register is the working record for documentation cleanup, roadmap extraction, and code-vs-doc drift found during the March 2026 hygiene pass.
+
+## Scope
+
+- Keep current-source docs organized and discoverable.
+- Reconcile prominent claims against the codebase and validation scripts.
+- Track roadmap goals that remain future-state.
+- Keep a running list of features that are partial, brittle, placeholder-backed, or under-documented.
+
+## Completed In This Pass
+
+- Fixed broken links in `docs/status/FEATURE_DISCOVERY.md` and `docs/status/STATUS.md`.
+- Verified `docs/status/NEXT_STEPS_CANONICAL.md` points at `EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
+- Reconciled `docs/EU_AI_ACT_COMPLIANCE.md` against `aragora/compliance/eu_ai_act.py`, including Article 9 artifact generation and current March 2026 timeline language.
+- Regenerated `docs/CAPABILITY_MATRIX.md` and `docs-site/docs/contributing/capability-matrix.md` from the YAML source of truth.
+- Added discoverability links for status, roadmap, gap, and hygiene docs from the main indexes.
+- Marked legacy snapshot docs as non-canonical where they were being presented as live status.
+
+## Validation Snapshot
+
+- `python3 scripts/validate_doc_links.py` -> pass
+- `python3 scripts/reconcile_status.py` -> pass
+- `python3 scripts/reconcile_status_docs.py --strict` -> pass after capability-matrix regeneration
+- `python3 scripts/check_agent_registry_sync.py` -> pass (`43` registered, `34` allowlisted)
+- `python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json` -> `99.6%` route coverage
+
+## Current Canonical Metrics Used In This Pass
+
+- Version: `2.8.0`
+- Python modules under `aragora/`: `3,803`
+- Tests: `210,071`
+- Test files under `tests/`: `5,057`
+- OpenAPI paths: `2,981`
+- OpenAPI operations: `3,740`
+- SDK namespaces: `186` Python / `185` TypeScript
+- Registered agent types: `43`
+- Allowlisted agent types: `34`
+- Knowledge Mound adapter specs in `aragora/knowledge/mound/adapters/factory.py`: `42`
+- Unique `@require_permission(...)` strings in `aragora/`: `423`
+
+## Roadmap And Goals Extracted From Current Docs
+
+### Current Focus (March 2026)
+
+- Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
+- Canonical execution priorities are operational hardening, registry/doc drift control, SDK/version alignment, self-host readiness, and pentest closure in `docs/status/NEXT_STEPS_CANONICAL.md`.
+- The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in `docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
+
+### Near-Term Goals (Q2 2026)
+
+- Agent-first beta, GitHub review gate, public demo, EU AI Act package completion, enterprise pilots, and validated fast onboarding remain active in `docs/FEATURE_GAP_LIST.md` and `ROADMAP.md`.
+- The August 2, 2026 EU AI Act deadline remains a major external forcing function across roadmap and compliance docs.
+
+### Longer-Term Goals
+
+- ERC-8004 mainnet deployment, Decision-Integrity UI Workbench expansion, federation, Prover-Estimator, market resolution, and the 8-stage visual canvas remain future-state goals and should stay documented as such.
+
+## Running List: Partial Or Weakly Implemented Features
+
+### Code-Backed Gaps
+
+- OpenAPI drift remains: `9` handler routes are missing from the spec and `11` OpenAPI routes have no handler according to `scripts/validate_openapi_routes.py`.
+- OpenAPI and SDK parity claims are still inflated by spec-only endpoints defined in `aragora/server/openapi/endpoints/sdk_missing.py`.
+- `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
+- `aragora/server/handlers/goal_canvas.py` still returns placeholder data for advancing a canvas into the actions stage.
+- `aragora/server/handlers/spectate_ws.py` still serves `/api/v1/spectate/stream` as an SSE snapshot stub rather than full real-time streaming.
+- `aragora/server/handlers/sme/slack_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
+- `aragora/server/handlers/sme/teams_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
+- `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.
+- `aragora/server/handlers/gauntlet/receipts.py` and the compliance UI still have placeholder or optional anchor-verification paths.
+- `aragora/server/handlers/security_debate.py` exposes an async-status endpoint that is explicitly a placeholder because debates are synchronous and not persisted.
+- `aragora/server/handlers/features/documents_batch.py` returns placeholder chunk retrieval output pending vector-store integration.
+- `aragora/server/handlers/features/connectors.py` still carries `coming_soon` / stubbed connector flows (`gdrive` and related enterprise sync/test paths).
+- `aragora/server/handlers/computer_use_handler.py` does not implement the full action/policy detail surface advertised by the OpenAPI computer-use endpoints.
+- FastAPI receipts currently expose `json`/`markdown`/`sarif`, while legacy handlers still own `html`/`pdf` exports.
+- Receipt delivery is only wired for `slack`, `teams`, `email`, and `discord`, not the broader connector/channel footprint implied elsewhere in the docs.
+- Unified and progressive memory handlers remain backend-conditional and still return `501` when optional backends or methods are unavailable.
+- `aragora/server/fastapi/routes/knowledge.py` can still return `501` when the configured KM backend lacks delete support.
+- `aragora/server/fastapi/routes/workflows.py` can still return `501` when the configured workflow backend lacks step-approval support.
+- `aragora/server/fastapi/routes/pipeline.py` still falls back to in-memory storage or create-without-start behavior when workflow-engine wiring is absent.
+
+### Documentation Positioning Needed
+
+- Slack and Teams integration docs should distinguish between shipped general integrations and still-placeholder SME workspace onboarding/channel enumeration surfaces.
+- `docs/status/FEATURE_DISCOVERY.md` still contains some optimistic `Stable` labels for backend-conditional or placeholder-backed surfaces and should continue to be tightened.
+- RLM and unified memory inventory entries need to reference current file paths (`aragora/server/handlers/rlm.py`, `aragora/memory/gateway.py`, related modules) rather than stale package layouts.
+- Knowledge Mound adapter counts need a dedicated normalization sweep: many current docs still say `45`, while the current factory registry exposes `42` adapter specs.
+- Root-level compatibility mirrors such as `docs/STATUS.md` and `docs/FEATURE_DISCOVERY.md` should remain clearly marked as mirrors so `docs/status/*` stays the canonical current-state surface.
+
+## Remaining Documentation Debt After This Pass
+
+- Historical, pricing, investor, and outreach collateral still contains stale counts in places and was not bulk-rewritten in this pass.
+- Duplicate current-status surfaces still exist for compatibility and should eventually be consolidated into pointer docs once inbound links are audited.
+- A follow-up sweep should normalize current SDK, RBAC, and adapter counts across commercial and enterprise collateral.

--- a/docs/status/FEATURES.md
+++ b/docs/status/FEATURES.md
@@ -1,9 +1,11 @@
 # Aragora Feature Documentation
 
-> **Last Updated:** 2026-02-03
+> **Last reviewed:** 2026-03-06
+> **Snapshot basis:** 2026-02-03
+> Historical phase-by-phase feature chronology. For current state and planning, use [STATUS](STATUS.md), [FEATURE_DISCOVERY](FEATURE_DISCOVERY.md), [FEATURE_GAP_LIST](../FEATURE_GAP_LIST.md), and [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md).
 
 
-This document provides a snapshot of major features and their origins. For live counts and recent updates, see `docs/STATUS.md`.
+This document provides a snapshot of major features and their origins. For live counts and recent updates, see `docs/status/STATUS.md`.
 
 ## Table of Contents
 

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -4,7 +4,7 @@
 
 This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
 
-> **Quick Links**: [STATUS.md](STATUS.md) for implementation status | [ENTERPRISE_FEATURES.md](ENTERPRISE_FEATURES.md) for enterprise details | [API_REFERENCE.md](./api/API_REFERENCE.md) for endpoints
+> **Quick Links**: [STATUS.md](STATUS.md) for implementation status | [ENTERPRISE_FEATURES.md](../ENTERPRISE_FEATURES.md) for enterprise details | [API_REFERENCE.md](../api/API_REFERENCE.md) for endpoints
 
 ---
 
@@ -22,7 +22,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 230+ features | 3,700+ Python modules | 208,000+ tests | 3,000+ API operations
+**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,700+ API operations
 
 ---
 
@@ -32,8 +32,8 @@ This document provides a comprehensive inventory of Aragora's features organized
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Arena** | Stable | Main debate engine orchestrating multi-agent discussions | `aragora/debate/orchestrator.py` | [DEBATE_PHASES.md](./debate/DEBATE_PHASES.md) |
-| **Debate Phases** | Stable | Structured phases (propose, critique, revise, vote) | `aragora/debate/phases/` | [DEBATE_PHASES.md](./debate/DEBATE_PHASES.md) |
+| **Arena** | Stable | Main debate engine orchestrating multi-agent discussions | `aragora/debate/orchestrator.py` | [DEBATE_PHASES.md](../debate/DEBATE_PHASES.md) |
+| **Debate Phases** | Stable | Structured phases (propose, critique, revise, vote) | `aragora/debate/phases/` | [DEBATE_PHASES.md](../debate/DEBATE_PHASES.md) |
 | **Consensus Detection** | Stable | Multi-strategy consensus (majority, unanimous, weighted) | `aragora/debate/consensus.py` | |
 | **Convergence Detection** | Stable | Semantic similarity tracking with ANN backend | `aragora/debate/convergence.py` | |
 | **Team Selection** | Stable | ELO-based agent team composition with calibration | `aragora/debate/team_selector.py` | |
@@ -45,13 +45,13 @@ This document provides a comprehensive inventory of Aragora's features organized
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Trickster** | Stable | Hollow consensus detection (devil's advocate) | `aragora/debate/trickster.py` | [TRICKSTER.md](./debate/TRICKSTER.md) |
+| **Trickster** | Stable | Hollow consensus detection (devil's advocate) | `aragora/debate/trickster.py` | [TRICKSTER.md](../debate/TRICKSTER.md) |
 | **Rhetorical Observer** | Stable | Argument quality analysis and scoring | `aragora/debate/rhetorical_observer.py` | |
 | **Security Barrier** | Stable | Telemetry redaction and content protection | `aragora/debate/security_barrier.py` | |
 | **Calibration Tracker** | Stable | Agent confidence calibration via `enable_calibration` | `aragora/debate/calibration.py` | |
 | **Performance Monitor** | Stable | Debate performance metrics via Arena and AutonomicExecutor | `aragora/debate/performance.py` | |
-| **Graph Debates** | Stable | Graph-structured argument topology | `aragora/debate/topology.py` | [GRAPH_DEBATES.md](./debate/GRAPH_DEBATES.md) |
-| **Matrix Debates** | Stable | Multi-dimensional debate analysis | `aragora/debate/matrix.py` | [MATRIX_DEBATES.md](./debate/MATRIX_DEBATES.md) |
+| **Graph Debates** | Stable | Graph-structured argument topology | `aragora/debate/topology.py` | [GRAPH_DEBATES.md](../debate/GRAPH_DEBATES.md) |
+| **Matrix Debates** | Stable | Multi-dimensional debate analysis | `aragora/debate/matrix.py` | [MATRIX_DEBATES.md](../debate/MATRIX_DEBATES.md) |
 | **Debate Breakpoints** | Stable | Pause/resume debate execution | `aragora/debate/breakpoints.py` | |
 | **Hybrid Debates** | Stable | External + internal agent debates | `aragora/server/handlers/hybrid_debate.py` | |
 
@@ -62,7 +62,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Stable | Real-time debate spectating | `aragora/spectate/` |
+| **Spectate** | Partial | Debate spectating exists, but `/api/v1/spectate/stream` is currently served as an SSE snapshot/stub rather than full live streaming | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
 
 ### Configuration
 
@@ -127,20 +127,20 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Memory Streams** | Stable | Event-based memory updates | `aragora/memory/streams.py` | |
 | **Embeddings** | Stable | Semantic embedding for retrieval (OpenAI, Gemini, Ollama) | `aragora/memory/embeddings.py` | |
 | **Critique Store** | Stable | Critique pattern storage | `aragora/memory/store.py` | |
-| **Progressive Memory Search** | Stable | Staged retrieval (index → timeline → entries) | `aragora/server/handlers/memory/memory.py` | |
+| **Progressive Memory Search** | Partial | Staged retrieval (index → timeline → entries); some timeline and batch flows remain backend-conditional and can return `501` | `aragora/server/handlers/memory/memory.py`, `aragora/server/handlers/memory/memory_progressive.py` | |
 | **Memory Viewer** | Stable | HTML viewer for memory inspection | `aragora/server/handlers/memory/memory.py` | |
 | **Tool Usage Capture** | Optional | Opt-in tool usage capture into FAST tier | `aragora/memory/capture.py` | |
-| **Unified Memory Gateway** | Integrated | Fan-out query across ContinuumMemory, KM, Supermemory, claude-mem via `enable_unified_memory` (150 tests) | `aragora/memory/gateway/` | |
-| **ClaudeMemAdapter** | Integrated | KM adapter wrapping claude-mem MCP connector (one of 45 adapters) | `aragora/knowledge/mound/adapters/claude_mem_adapter.py` | |
+| **Unified Memory Gateway** | Integrated | Fan-out query across ContinuumMemory, KM, Supermemory, claude-mem via `enable_unified_memory`; handler availability still depends on optional unified-memory backends | `aragora/memory/gateway.py`, `aragora/memory/retention_gate.py`, `aragora/memory/dedup.py` | |
+| **ClaudeMemAdapter** | Integrated | KM adapter wrapping claude-mem MCP connector (one of 42 registered adapter specs) | `aragora/knowledge/mound/adapters/claude_mem_adapter.py` | |
 
 ### Unified Memory Gateway Components
 
 | Component | Status | Description | Key Files |
 |-----------|--------|-------------|-----------|
-| **MemoryGateway** | Integrated | Unified fan-out query interface across all memory systems | `aragora/memory/gateway/core.py` |
-| **RetentionGate** | Integrated | Titans/MIRAS surprise-driven retain/demote/forget/consolidate decisions | `aragora/memory/gateway/retention.py` |
-| **CrossSystemDedupEngine** | Integrated | SHA-256 exact + Jaccard near-duplicate detection across memory systems | `aragora/memory/gateway/dedup.py` |
-| **RLMMemoryNavigator** | Integrated | REPL helpers for programmatic cross-system memory exploration | `aragora/memory/gateway/rlm_navigator.py` |
+| **MemoryGateway** | Integrated | Unified fan-out query interface across all memory systems | `aragora/memory/gateway.py` |
+| **RetentionGate** | Integrated | Titans/MIRAS surprise-driven retain/demote/forget/consolidate decisions | `aragora/memory/retention_gate.py` |
+| **CrossSystemDedupEngine** | Integrated | SHA-256 exact + Jaccard near-duplicate detection across memory systems | `aragora/memory/dedup.py` |
+| **RLMMemoryNavigator** | Integrated | REPL helpers for programmatic cross-system memory exploration | `aragora/rlm/memory_navigator.py` |
 
 ### Memory Tiers
 
@@ -168,9 +168,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **RLM Factory** | Stable | RLM context management factory | `aragora/rlm/factory.py` | [RLM_GUIDE.md](./guides/RLM_GUIDE.md) |
+| **RLM Factory** | Stable | RLM context management factory | `aragora/rlm/factory.py` | [RLM_GUIDE.md](../guides/RLM_GUIDE.md) |
 | **RLM Bridge** | Stable | Integration bridge for RLM | `aragora/rlm/bridge.py` | |
-| **RLM Handler** | Stable | Request handling | `aragora/rlm/handler.py` | |
+| **RLM Handler** | Partial | Request handling is available, but context storage is still in-memory by default and some streaming flows are backend-conditional | `aragora/server/handlers/rlm.py` | |
 | **Streaming RLM** | Stable | Progressive context loading (top-down, bottom-up, targeted) | `aragora/rlm/streaming.py` | |
 | **RLM Training** | Stable | Experience replay buffer and reward computation | `aragora/rlm/training/` | |
 | **Cognitive Limiter** | Stable | Context management via `use_rlm_limiter` | `aragora/debate/cognitive_limiter_rlm.py` | |
@@ -183,7 +183,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Core Storage** | Stable | Unified knowledge storage | `aragora/knowledge/mound/core.py` | [KNOWLEDGE_MOUND.md](./knowledge/KNOWLEDGE_MOUND.md) |
+| **Core Storage** | Stable | Unified knowledge storage | `aragora/knowledge/mound/core.py` | [KNOWLEDGE_MOUND.md](../knowledge/KNOWLEDGE_MOUND.md) |
 | **Semantic Store** | Stable | Vector embedding-based search | `aragora/knowledge/mound/semantic.py` | |
 | **Graph Store** | Stable | Relationship and lineage tracking | `aragora/knowledge/mound/graph.py` | |
 | **Domain Taxonomy** | Stable | Hierarchical knowledge organization | `aragora/knowledge/mound/taxonomy.py` | |
@@ -200,7 +200,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | **KM Resilience** | Stable | ResilientPostgresStore with retry, health, cache invalidation | `aragora/knowledge/mound/resilience.py` | |
 | **SLO Alerting** | Stable | Adapter performance monitoring with Prometheus | `aragora/config/performance_slos.py` | |
 
-### Knowledge Adapters (45 Total)
+### Knowledge Adapters (42 Registered Adapter Specs)
 
 | Adapter | Purpose | Key Files |
 |---------|---------|-----------|
@@ -244,7 +244,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Belief Network** | Stable | Claim provenance tracking with cruxes | `aragora/reasoning/belief.py` | [REASONING.md](./workflow/REASONING.md) |
+| **Belief Network** | Stable | Claim provenance tracking with cruxes | `aragora/reasoning/belief.py` | [REASONING.md](../workflow/REASONING.md) |
 | **Provenance Tracking** | Stable | Decision lineage and audit trails | `aragora/reasoning/provenance.py` | |
 | **Claims System** | Stable | Structured claim management | `aragora/reasoning/claims.py` | |
 
@@ -256,11 +256,11 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **OIDC Integration** | Production | OpenID Connect SSO with JWK verification | `aragora/auth/oidc.py` | [SSO_SETUP.md](./enterprise/SSO_SETUP.md) |
+| **OIDC Integration** | Production | OpenID Connect SSO with JWK verification | `aragora/auth/oidc.py` | [SSO_SETUP.md](../enterprise/SSO_SETUP.md) |
 | **SAML Support** | Production | SAML 2.0 enterprise IdP integration | `aragora/auth/saml.py` | |
 | **MFA (TOTP/HOTP)** | Production | Multi-factor via authenticator apps | `aragora/server/middleware/mfa.py` | |
 | **API Key Management** | Production | Scoped keys with rotation and usage tracking | `aragora/server/handlers/auth/` | |
-| **Session Management** | Production | Token versioning, lockout tracking, cleanup | `aragora/server/session_store.py` | [SESSION_MANAGEMENT.md](./enterprise/SESSION_MANAGEMENT.md) |
+| **Session Management** | Production | Token versioning, lockout tracking, cleanup | `aragora/server/session_store.py` | [SESSION_MANAGEMENT.md](../enterprise/SESSION_MANAGEMENT.md) |
 | **SCIM 2.0** | Production | Automated user/group provisioning (Okta, Azure AD, OneLogin) | `aragora/auth/scim/` | |
 | **Account Lockout** | Production | Progressive delays, IP/user tracking | `aragora/auth/lockout.py` | |
 
@@ -288,13 +288,13 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **AES-256-GCM Encryption** | Production | Field-level encryption with key derivation | `aragora/security/encryption.py` | [SECRETS.md](./enterprise/SECRETS.md) |
+| **AES-256-GCM Encryption** | Production | Field-level encryption with key derivation | `aragora/security/encryption.py` | [SECRETS.md](../enterprise/SECRETS.md) |
 | **Cloud KMS** | Production | AWS KMS, Azure Key Vault, GCP Cloud KMS | `aragora/security/kms_provider.py` | |
 | **Key Rotation** | Production | Automatic key rotation with versioning | `aragora/security/key_rotation.py` | |
 | **Encrypted Fields** | Production | OAuth tokens, API keys, secrets auto-encrypted | `aragora/storage/encrypted_fields.py` | |
 | **Anomaly Detection** | Production | Security anomaly detection | `aragora/security/anomaly_detection.py` | |
 | **SSRF Protection** | Production | Server-side request forgery protection | `aragora/security/ssrf_protection.py` | |
-| **Rate Limiting** | Production | Multi-layer (IP, token, endpoint) with Redis backend | `aragora/server/rate_limit.py` | [RATE_LIMITING.md](./api/RATE_LIMITING.md) |
+| **Rate Limiting** | Production | Multi-layer (IP, token, endpoint) with Redis backend | `aragora/server/rate_limit.py` | [RATE_LIMITING.md](../api/RATE_LIMITING.md) |
 | **Circuit Breaker** | Production | Per-provider thresholds, recovery timeout | `aragora/resilience.py` | |
 | **Security Headers** | Production | CSP, HSTS, X-Frame-Options | `aragora/server/middleware/security_headers.py` | |
 
@@ -304,7 +304,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 |---------|--------|-------------|-----------|------|
 | **Audit Trail** | Production | Tamper-evident logging with hash chains | `aragora/audit/` | |
 | **SOC 2 Controls** | Production | SOC 2 Type II compliance controls | `aragora/compliance/soc2.py` | |
-| **GDPR Support** | Production | DSAR workflow, right to erasure, portability | `aragora/privacy/` | [DSAR_WORKFLOW.md](./enterprise/DSAR_WORKFLOW.md) |
+| **GDPR Support** | Production | DSAR workflow, right to erasure, portability | `aragora/privacy/` | [DSAR_WORKFLOW.md](../enterprise/DSAR_WORKFLOW.md) |
 | **Consent Management** | Production | User consent tracking | `aragora/privacy/consent.py` | |
 | **Data Retention** | Production | Configurable retention policies | `aragora/privacy/retention.py` | |
 | **Deletion Coordinator** | Production | Unified GDPR deletion across systems | `aragora/deletion_coordinator.py` | |
@@ -322,7 +322,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files |
 |---------|--------|-------------|-----------|
-| **Setup Wizard** | Stable | Guided onboarding with SSO/RBAC integration | `aragora/onboarding/wizard.py` |
+| **Setup Wizard** | Partial | Guided onboarding with SSO/RBAC integration; provider coverage in live connection tests and disconnect flows remains incomplete | `aragora/onboarding/wizard.py`, `aragora/server/handlers/oauth_wizard.py` |
 
 ### Coordination System
 
@@ -349,9 +349,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Stable | Bot, OAuth, webhooks, evidence collection | `aragora/connectors/chat/slack/` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Stable | Teams, channels, meetings, JWT verification | `aragora/connectors/chat/teams.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |
@@ -445,7 +445,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
 | **Structured Logging** | Stable | JSON logs with correlation IDs, PII redaction | `aragora/observability/logging.py` | |
-| **Alert Runbooks** | Stable | Automated alert responses | `docs/ALERT_RUNBOOKS.md` | [ALERT_RUNBOOKS.md](./deployment/ALERT_RUNBOOKS.md) |
+| **Alert Runbooks** | Stable | Automated alert responses | `docs/deployment/ALERT_RUNBOOKS.md` | [ALERT_RUNBOOKS.md](../deployment/ALERT_RUNBOOKS.md) |
 
 ### Health Monitoring
 
@@ -464,7 +464,7 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Unified Server** | Stable | 3,000+ API operations | `aragora/server/unified_server.py` | [API_REFERENCE.md](./api/API_REFERENCE.md) |
+| **Unified Server** | Stable | 3,000+ API operations | `aragora/server/unified_server.py` | [API_REFERENCE.md](../api/API_REFERENCE.md) |
 | **Handler Registry** | Stable | O(1) route lookup with LRU caching | `aragora/server/handler_registry.py` | |
 | **GraphQL API** | Stable | Schema for debates, agents, memory | `aragora/server/graphql/` | |
 | **WebSocket Streaming** | Stable | 26 stream modules for real-time events | `aragora/server/stream/` | |
@@ -474,8 +474,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | SDK | Status | Namespaces | Key Files |
 |-----|--------|------------|-----------|
-| **Python SDK** | Stable | 184 namespaces | `sdk/python/` |
-| **TypeScript SDK** | Stable | 183 namespaces | `sdk/typescript/` |
+| **Python SDK** | Stable | 186 namespaces | `sdk/python/` |
+| **TypeScript SDK** | Stable | 185 namespaces | `sdk/typescript/` |
 
 ### CLI
 
@@ -483,14 +483,14 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 |---------|--------|-------------|-----------|
 | **CLI Main** | Stable | Command-line interface | `aragora/cli/main.py` |
 | **REPL** | Stable | Interactive shell | `aragora/cli/repl.py` |
-| **Setup Wizard** | Stable | Guided `aragora setup` for self-hosted | `aragora/cli/setup.py` |
+| **Setup Wizard** | Partial | Guided `aragora setup` for self-hosted; some provider test/disconnect flows remain selectively implemented | `aragora/cli/setup.py`, `aragora/server/handlers/oauth_wizard.py` |
 | **Gauntlet CLI** | Stable | Compliance test runner | `aragora/cli/gt.py` |
 
 ### Workflow Engine
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Workflow Engine** | Stable | DAG-based automation | `aragora/workflow/engine.py` | [WORKFLOWS.md](./workflow/WORKFLOWS.md) |
+| **Workflow Engine** | Stable | DAG-based automation | `aragora/workflow/engine.py` | [WORKFLOWS.md](../workflow/WORKFLOWS.md) |
 | **Workflow Nodes** | Stable | Reusable node types | `aragora/workflow/nodes/` | |
 | **Workflow Patterns** | Stable | Hive-mind, map-reduce, review-cycle factories | `aragora/workflow/patterns/` | |
 | **Workflow Templates** | Stable | 50+ pre-built templates across 6 categories | `aragora/workflow/templates/` | |
@@ -511,8 +511,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files |
 |---------|--------|-------------|-----------|
-| **Trust Wedge Core** | Stable | Receipt-gated email actions: Gmail → debate → signed receipt → execute | `aragora/inbox/trust_wedge.py` |
-| **Triage Runner** | Stable | Batch email triage with adversarial debate decisions | `aragora/inbox/triage_runner.py` |
+| **Trust Wedge Core** | Integrated | Receipt-gated Gmail actions are shipped; surrounding channel/setup surfaces still have partial or placeholder-backed edges | `aragora/inbox/trust_wedge.py` |
+| **Triage Runner** | Partial | Batch email triage with adversarial debate decisions; can still fall back to stub debates when engine/agent wiring is unavailable | `aragora/inbox/triage_runner.py` |
 | **Receipt-Gated Executor** | Stable | Only executes actions with previously persisted approved receipts | `aragora/inbox/receipt_gated_executor.py` |
 | **CLI Review Loop** | Stable | Interactive CLI approval for triage decisions | `aragora/inbox/cli_review.py` |
 | **Auto-Approval Policy** | Stable | Narrow auto-approval rules (ARCHIVE/STAR/LABEL/IGNORE only) | `aragora/inbox/auto_approval.py` |
@@ -522,8 +522,8 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Gauntlet Runner** | Stable | Compliance test execution | `aragora/gauntlet/runner.py` | [GAUNTLET.md](./debate/GAUNTLET.md) |
-| **Decision Receipts** | Stable | SHA-256 cryptographic audit trails | `aragora/gauntlet/receipts.py` | |
+| **Gauntlet Runner** | Stable | Compliance test execution | `aragora/gauntlet/runner.py` | [GAUNTLET.md](../debate/GAUNTLET.md) |
+| **Decision Receipts** | Integrated | SHA-256 cryptographic audit trails; anchor verification and export coverage still vary across handler surfaces | `aragora/gauntlet/receipts.py`, `aragora/server/handlers/gauntlet/receipts.py` | |
 | **Findings** | Stable | Compliance findings management | `aragora/gauntlet/findings.py` | |
 | **Gauntlet Defense** | Stable | Attack/defend cycles via `proposer_agent` | `aragora/gauntlet/defense.py` | |
 | **Personas** | Stable | GDPR, SOC2, HIPAA, PCI-DSS, AI Act, NIST CSF | `aragora/gauntlet/personas/` | |
@@ -540,14 +540,14 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **MCP Server** | Stable | Context protocol server | `aragora/mcp/server.py` | [MCP_INTEGRATION.md](./integrations/MCP_INTEGRATION.md) |
-| **MCP Tools** | Stable | Tool definitions | `aragora/mcp/tools.py` | [MCP_ADVANCED.md](./integrations/MCP_ADVANCED.md) |
+| **MCP Server** | Stable | Context protocol server | `aragora/mcp/server.py` | [MCP_INTEGRATION.md](../integrations/MCP_INTEGRATION.md) |
+| **MCP Tools** | Stable | Tool definitions | `aragora/mcp/tools.py` | [MCP_ADVANCED.md](../integrations/MCP_ADVANCED.md) |
 
 ### Agent Marketplace
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Template Registry** | Stable | Agent, debate, workflow templates | `aragora/marketplace/` | [MARKETPLACE.md](./workflow/MARKETPLACE.md) |
+| **Template Registry** | Stable | Agent, debate, workflow templates | `aragora/marketplace/` | [MARKETPLACE.md](../workflow/MARKETPLACE.md) |
 | **Built-in Templates** | Stable | Devil's Advocate, Code Reviewer, Research Analyst | `aragora/marketplace/templates/` | |
 
 ### Skills Marketplace
@@ -664,7 +664,7 @@ Used in: audit pipeline (`aragora/audit/`), bug detection (`aragora/audit/bug_de
 
 | Feature | Status | Description | Key Files | Docs |
 |---------|--------|-------------|-----------|------|
-| **Pulse Ingestor** | Stable | Topic ingestion pipeline | `aragora/pulse/ingestor.py` | [PULSE.md](./resilience/PULSE.md) |
+| **Pulse Ingestor** | Stable | Topic ingestion pipeline | `aragora/pulse/ingestor.py` | [PULSE.md](../resilience/PULSE.md) |
 | **Quality Filtering** | Stable | Clickbait/spam detection | `aragora/pulse/quality.py` | |
 | **Freshness Scoring** | Stable | Configurable decay curves | `aragora/pulse/freshness.py` | |
 | **Source Weighting** | Stable | Credibility scores | `aragora/pulse/weighting.py` | |
@@ -758,16 +758,16 @@ python scripts/self_develop.py --goal "Improve test coverage" --dry-run
 
 ```bash
 # Find all handlers
-grep -r "class.*Handler" aragora/server/handlers/ --include="*.py"
+rg "class.*Handler" aragora/server/handlers/
 
 # Find all adapters
-grep -r "class.*Adapter" aragora/ --include="*.py"
+rg "class.*Adapter" aragora/
 
 # Find all permissions
-grep -r "require_permission" aragora/ --include="*.py"
+rg "require_permission" aragora/
 
 # Find all WebSocket events
-grep -r "event_type=" aragora/ --include="*.py"
+rg "event_type=" aragora/
 ```
 
 ### Key Entry Points
@@ -786,16 +786,16 @@ grep -r "event_type=" aragora/ --include="*.py"
 
 | Document | Purpose |
 |----------|---------|
-| [CLAUDE.md](../CLAUDE.md) | Development guide for AI assistants |
+| [CLAUDE.md](../../CLAUDE.md) | Development guide for AI assistants |
 | [STATUS.md](STATUS.md) | Release status and changelog |
-| [ENTERPRISE_FEATURES.md](ENTERPRISE_FEATURES.md) | Enterprise capability deep-dive |
-| [EXTENDED_README.md](EXTENDED_README.md) | Comprehensive technical reference |
+| [ENTERPRISE_FEATURES.md](../ENTERPRISE_FEATURES.md) | Enterprise capability deep-dive |
+| [EXTENDED_README.md](../EXTENDED_README.md) | Comprehensive technical reference |
 | [COMMERCIAL_OVERVIEW.md](COMMERCIAL_OVERVIEW.md) | Commercial positioning |
-| [API_REFERENCE.md](./api/API_REFERENCE.md) | REST API documentation |
-| [WORKFLOWS.md](./workflow/WORKFLOWS.md) | Workflow engine guide |
-| [GAUNTLET.md](./debate/GAUNTLET.md) | Compliance testing guide |
-| [PULSE.md](./resilience/PULSE.md) | Trending topics guide |
-| [RLM_GUIDE.md](./guides/RLM_GUIDE.md) | Recursive Language Models guide |
+| [API_REFERENCE.md](../api/API_REFERENCE.md) | REST API documentation |
+| [WORKFLOWS.md](../workflow/WORKFLOWS.md) | Workflow engine guide |
+| [GAUNTLET.md](../debate/GAUNTLET.md) | Compliance testing guide |
+| [PULSE.md](../resilience/PULSE.md) | Trending topics guide |
+| [RLM_GUIDE.md](../guides/RLM_GUIDE.md) | Recursive Language Models guide |
 
 ---
 

--- a/docs/status/FEATURE_MATURITY.md
+++ b/docs/status/FEATURE_MATURITY.md
@@ -1,7 +1,8 @@
 # Feature Maturity Matrix
 
-**Last Updated:** January 14, 2026
-**Version:** 1.5.0
+> **Last reviewed:** 2026-03-06
+> **Snapshot basis:** 2026-01-14 / v1.5.0
+> Historical maturity snapshot. It is not the current ship/no-ship source of truth. Use [STATUS](STATUS.md), [FEATURE_GAP_LIST](../FEATURE_GAP_LIST.md), [FEATURE_DISCOVERY](FEATURE_DISCOVERY.md), and [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md) for current release posture.
 
 ---
 

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -2,7 +2,8 @@
 
 *Last updated: March 6, 2026*
 
-> See [README](../README.md) for the five pillars framework. See [Documentation Index](INDEX.md) for the curated technical reference map.
+> See [README](../README.md) for the five pillars framework. See [Documentation Index](../INDEX.md) for the curated technical reference map.
+> For roadmap extraction, doc drift, and partial-feature tracking, see [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md).
 
 ## March 2026 Sprint — Closed-Loop Backbone, Trust Wedge & Infrastructure
 
@@ -44,12 +45,12 @@
 
 ### Codebase Metrics (March 6, 2026)
 - **Python modules**: 3,700+
-- **Tests**: 208,000+ across 5,000+ test files
+- **Tests**: 210,000+ across 5,000+ test files
 - **HTTP handlers**: 700+
-- **KM adapters**: 45
+- **KM adapters**: 42 registered adapter specs
 - **Agent types**: 43
 - **API operations**: 3,000+ across 2,900+ paths
-- **RBAC permissions**: 360+
+- **RBAC permissions**: 420+
 - **Version**: v2.8.0
 
 ---
@@ -85,7 +86,7 @@ Massive production hardening sprint: 205,000+ tests (up from 129,000+), comprehe
 - **Type safety**: Fixed RepositoryCrawler API usage, resolve_db_path imports, float/dict type annotations
 - **CDC password**: Replaced example credential with placeholder
 
-### SDK Expansion (184 Python / 183 TypeScript namespaces)
+### SDK Expansion (186 Python / 185 TypeScript namespaces)
 - **13 new TypeScript namespaces**: agent_dashboard, playground, partner, selection, expenses, github, and more
 - **6 new Python namespaces**: control_plane, partner, selection, expenses, github SDK methods
 - **SDK types regenerated** from updated OpenAPI spec


### PR DESCRIPTION
## Summary
- salvage the documentation-hygiene lane from `codex/preserve-dirty-root-20260306@4e3e8e4ae` into a fresh docs worktree off `origin/main`
- improve discoverability of canonical status/planning docs and add a dedicated documentation hygiene register
- reconcile current-source docs against the codebase, including counts, stale links, stale file paths, and over-strong feature labels
- regenerate capability-matrix artifacts and restore OpenAPI description coverage for `sdk_missing.py`

## Included
- current-source doc updates in `README.md`, `ROADMAP.md`, `docs/README.md`, `docs/INDEX.md`, `docs/CANONICAL_GOALS.md`, `docs/STATUS.md`, `docs/status/STATUS.md`, `docs/status/FEATURE_DISCOVERY.md`, `docs/FEATURE_DISCOVERY.md`, `docs/status/FEATURES.md`, `docs/status/FEATURE_MATURITY.md`, `docs/EU_AI_ACT_COMPLIANCE.md`, `docs/ENTERPRISE_FEATURES.md`, `docs/guides/SME_STARTER_PACK.md`, `docs/knowledge/KNOWLEDGE_MOUND.md`, `docs/status/COMMERCIAL_OVERVIEW.md`, and the regenerated capability matrix docs
- new `docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md`
- OpenAPI description-only updates in `aragora/server/openapi/endpoints/sdk_missing.py` so the documentation audit remains green

## Explicitly excluded
- `docs/COMMERCIAL_OVERVIEW.md` was intentionally left out of this salvage and should be reconciled separately
- `docs/status/NEXT_STEPS_CANONICAL.md` was not ported wholesale because `origin/main` already had a newer canonical version

## Validation
- `python3 scripts/validate_doc_links.py`
- `python3 scripts/reconcile_status.py`
- `python3 scripts/reconcile_status_docs.py --strict`
- `PYTHONPATH=. python3 scripts/check_agent_registry_sync.py`
- `python3 scripts/audit_openapi_docs.py`
- `python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json`
