### PR TITLE
fix(ci): restore mainline workflow truthfulness

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: aragora
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: docs-site
@@ -78,7 +78,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: aragora
+    runs-on: ubuntu-latest
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -1,33 +1,27 @@
 name: Deploy to EC2
 
-# Production deployment to 3 EC2 instances behind Cloudflare Load Balancer
-# in us-east-2, using AWS SSM (no SSH keys required).
+# Legacy manual EC2 deployment fallback for production instances.
+# The canonical automatic production lane remains deploy-secure.yml.
 #
-# Instances:
-#   i-0dbd51f74a9a11fcc  (aragora-api-server)  — primary / canary
-#   i-092c2d3b4dafc1f24  (aragora-al2023-1)    — worker
-#   i-0aae2ccd2f68b94d2  (aragora-al2023-2)    — worker
-#
-# Rolling deploy strategy:
-#   1. Deploy to canary (aragora-api-server), verify health
-#   2. Deploy to remaining two instances in parallel, verify health
-#   3. Final external health check via Cloudflare
+# Manual strategy:
+#   1. Discover production instances by tag
+#   2. Verify canary health
+#   3. Optionally validate only (no deploy/rollback commands)
+#   4. Deploy to canary, verify health, then deploy to primary instances
+#   5. Verify external health via Cloudflare
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'aragora/**'
-      - 'deploy/**'
-      - 'requirements.txt'
-      - 'pyproject.toml'
-      - '.github/workflows/deploy-ec2.yml'
   workflow_dispatch:
     inputs:
       skip_tests:
         description: 'Skip test step'
         required: false
-        default: 'false'
+        default: false
+        type: boolean
+      validate_only:
+        description: 'Run discovery and health checks only without deploying or rolling back'
+        required: false
+        default: false
         type: boolean
 
 concurrency:
@@ -35,20 +29,13 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  id-token: write   # Required for OIDC
+  id-token: write
   contents: read
 
 env:
   AWS_REGION: us-east-2
-  # Hardcoded instance IDs — these are long-lived production instances
-  CANARY_INSTANCE: i-0dbd51f74a9a11fcc
-  WORKER_INSTANCES: i-092c2d3b4dafc1f24,i-0aae2ccd2f68b94d2
-  ALL_INSTANCES: i-0dbd51f74a9a11fcc,i-092c2d3b4dafc1f24,i-0aae2ccd2f68b94d2
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Test — quick smoke test before deploying
-  # ---------------------------------------------------------------------------
   test:
     if: ${{ github.event.inputs.skip_tests != 'true' }}
     runs-on: ubuntu-latest
@@ -92,16 +79,124 @@ jobs:
         env:
           PYTHONPATH: .
 
-  # ---------------------------------------------------------------------------
-  # Deploy canary — single instance, verify before continuing
-  # ---------------------------------------------------------------------------
-  deploy-canary:
+  pre-flight:
     needs: test
     if: always() && (needs.test.result == 'success' || needs.test.result == 'skipped')
+    runs-on: aragora
+    timeout-minutes: 10
+    outputs:
+      validate_only: ${{ steps.mode.outputs.validate_only }}
+      canary_instance: ${{ steps.discover.outputs.canary_instance }}
+      worker_instances: ${{ steps.discover.outputs.worker_instances }}
+      all_instances: ${{ steps.discover.outputs.all_instances }}
+      canary_ok: ${{ steps.canary_health.outputs.canary_ok }}
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_DEPLOY_ROLE_NAME }}
+          role-session-name: deploy-ec2-preflight-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set execution mode
+        id: mode
+        shell: bash
+        run: |
+          if [[ "${{ github.event.inputs.validate_only }}" == 'true' ]]; then
+            echo 'validate_only=true' >> "$GITHUB_OUTPUT"
+            echo 'Running in validate-only mode; deploy and rollback commands will be skipped.'
+          else
+            echo 'validate_only=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Discover production instances
+        id: discover
+        shell: bash
+        run: |
+          CANARY_ID=$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Environment,Values=production" \
+              "Name=tag:Application,Values=aragora" \
+              "Name=tag:Role,Values=canary" \
+              "Name=instance-state-name,Values=running" \
+            --query 'Reservations[0].Instances[0].InstanceId' \
+            --output text 2>/dev/null || true)
+          if [[ "$CANARY_ID" == 'None' ]]; then
+            CANARY_ID=''
+          fi
+          if [[ -z "$CANARY_ID" ]]; then
+            echo '::error::No running canary instance found (tags: Environment=production, Application=aragora, Role=canary)'
+            exit 1
+          fi
+
+          PROD_IDS_RAW=$(aws ec2 describe-instances \
+            --filters \
+              "Name=tag:Environment,Values=production" \
+              "Name=tag:Application,Values=aragora" \
+              "Name=tag:Role,Values=primary" \
+              "Name=instance-state-name,Values=running" \
+            --query 'Reservations[].Instances[].InstanceId' \
+            --output text 2>/dev/null || true)
+          if [[ "$PROD_IDS_RAW" == 'None' ]]; then
+            PROD_IDS_RAW=''
+          fi
+          PROD_IDS=$(printf '%s' "$PROD_IDS_RAW" | tr '\t' ',' | sed 's/^,*//; s/,*$//; s/,,*/,/g')
+          if [[ -z "$PROD_IDS" ]]; then
+            echo '::error::No running primary instances found (tags: Environment=production, Application=aragora, Role=primary)'
+            exit 1
+          fi
+
+          ALL_IDS="$CANARY_ID,$PROD_IDS"
+
+          echo "canary_instance=$CANARY_ID" >> "$GITHUB_OUTPUT"
+          echo "worker_instances=$PROD_IDS" >> "$GITHUB_OUTPUT"
+          echo "all_instances=$ALL_IDS" >> "$GITHUB_OUTPUT"
+          echo "Canary: $CANARY_ID"
+          echo "Primary instances: $PROD_IDS"
+
+      - name: Pre-deploy canary health check
+        id: canary_health
+        shell: bash
+        run: |
+          CANARY_INSTANCE='${{ steps.discover.outputs.canary_instance }}'
+          echo "Verifying canary instance health before deployment..."
+          STATUS=$(aws ec2 describe-instance-status \
+            --instance-ids "$CANARY_INSTANCE" \
+            --query 'InstanceStatuses[0].[InstanceStatus.Status, SystemStatus.Status]' \
+            --output text 2>/dev/null || echo 'unknown unknown')
+          INST_STATUS=$(echo "$STATUS" | awk '{print $1}')
+          SYS_STATUS=$(echo "$STATUS" | awk '{print $2}')
+          if [[ "$INST_STATUS" != 'ok' ]] || [[ "$SYS_STATUS" != 'ok' ]]; then
+            echo "::error::Canary instance $CANARY_INSTANCE health check failed: instance=$INST_STATUS system=$SYS_STATUS"
+            exit 1
+          fi
+          echo 'canary_ok=true' >> "$GITHUB_OUTPUT"
+          echo "Canary instance healthy: instance=$INST_STATUS system=$SYS_STATUS"
+
+      - name: Pre-flight summary
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF_SUMMARY
+          ## EC2 Deployment Pre-flight
+
+          | Parameter | Value |
+          |-----------|-------|
+          | Commit | `${{ github.sha }}` |
+          | Triggered by | ${{ github.actor }} |
+          | Validate only | ${{ steps.mode.outputs.validate_only }} |
+          | Canary instance | `${{ steps.discover.outputs.canary_instance }}` |
+          | Primary instances | `${{ steps.discover.outputs.worker_instances }}` |
+          EOF_SUMMARY
+
+  deploy-canary:
+    needs: pre-flight
+    if: needs.pre-flight.outputs.canary_ok == 'true' && needs.pre-flight.outputs.validate_only != 'true'
     runs-on: aragora
     timeout-minutes: 15
     outputs:
       canary_ok: ${{ steps.health.outputs.canary_ok }}
+      deploy_started: ${{ steps.deploy.outputs.deploy_started }}
 
     steps:
       - name: Configure AWS credentials
@@ -111,27 +206,14 @@ jobs:
           role-session-name: deploy-ec2-canary-${{ github.run_id }}
           aws-region: ${{ env.AWS_REGION }}
 
-      - name: Pre-deploy canary health check
-        run: |
-          echo "Verifying canary instance health before deployment..."
-          STATUS=$(aws ec2 describe-instance-status \
-            --instance-ids "$CANARY_INSTANCE" \
-            --query 'InstanceStatuses[0].[InstanceStatus.Status, SystemStatus.Status]' \
-            --output text 2>/dev/null || echo "unknown unknown")
-          INST_STATUS=$(echo "$STATUS" | awk '{print $1}')
-          SYS_STATUS=$(echo "$STATUS" | awk '{print $2}')
-          if [[ "$INST_STATUS" != "ok" ]] || [[ "$SYS_STATUS" != "ok" ]]; then
-            echo "::error::Canary instance $CANARY_INSTANCE health check failed: instance=$INST_STATUS system=$SYS_STATUS"
-            exit 1
-          fi
-          echo "Canary instance healthy: instance=$INST_STATUS system=$SYS_STATUS"
-
       - name: Deploy to canary via SSM
         id: deploy
+        shell: bash
         run: |
+          CANARY_INSTANCE='${{ needs.pre-flight.outputs.canary_instance }}'
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "$CANARY_INSTANCE" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Deploy aragora canary from GitHub Actions run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -147,9 +229,9 @@ jobs:
               "sudo -u ec2-user git reset --hard origin/main",
               "sudo chown -R ec2-user:ec2-user /home/ec2-user/aragora/venv || true",
               "sudo chown -R ec2-user:ec2-user /home/ec2-user/.npm /home/ec2-user/.cache || true",
-              "sudo -u ec2-user bash -c 'cd /home/ec2-user/aragora && source venv/bin/activate && python -m pip install -e . --quiet --no-cache-dir'",
+              "sudo -u ec2-user bash -c '\''cd /home/ec2-user/aragora && source venv/bin/activate && python -m pip install -e . --quiet --no-cache-dir'\''",
               "find /home/ec2-user/aragora/venv/lib/python3.11/site-packages -maxdepth 1 -name \"~*\" -type d -exec rm -rf {} + 2>/dev/null || true",
-              "sudo -u ec2-user bash -c 'cd /home/ec2-user/aragora && source venv/bin/activate && python -c \"from aragora.server.unified_server import UnifiedServer; print(\\\"Import OK\\\")\"'",
+              "sudo -u ec2-user bash -c '\''cd /home/ec2-user/aragora && source venv/bin/activate && python -c \"from aragora.server.unified_server import UnifiedServer; print(\\\"Import OK\\\")\"'\''",
               "sudo systemctl restart aragora",
               "sleep 5",
               "if ! systemctl is-active --quiet aragora; then echo \"=== SERVICE FAILED ===\"; systemctl status aragora --no-pager || true; journalctl -u aragora -n 50 --no-pager || true; exit 1; fi",
@@ -161,16 +243,16 @@ jobs:
             --query 'Command.CommandId' \
             --output text)
 
-          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+          echo 'deploy_started=true' >> "$GITHUB_OUTPUT"
+          echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
           echo "Started canary deployment: $COMMAND_ID"
 
-          # Poll for completion (up to 5 minutes)
           MAX_POLL=60
           CONSECUTIVE_ERRORS=0
           MAX_CONSECUTIVE_ERRORS=5
           BACKOFF=5
 
-          for i in $(seq 1 $MAX_POLL); do
+          for i in $(seq 1 "$MAX_POLL"); do
             STATUS=$(aws ssm get-command-invocation \
               --command-id "$COMMAND_ID" \
               --instance-id "$CANARY_INSTANCE" \
@@ -182,11 +264,11 @@ jobs:
               CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
               echo "::warning::SSM API error (attempt $i, errors: $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS)"
               if [[ $CONSECUTIVE_ERRORS -ge $MAX_CONSECUTIVE_ERRORS ]]; then
-                echo "::error::Too many consecutive SSM API errors, aborting"
+                echo '::error::Too many consecutive SSM API errors, aborting'
                 exit 1
               fi
               BACKOFF=$((BACKOFF * 2 > 30 ? 30 : BACKOFF * 2))
-              sleep $BACKOFF
+              sleep "$BACKOFF"
               continue
             fi
 
@@ -195,25 +277,25 @@ jobs:
 
             case "$STATUS" in
               Success)
-                echo "Canary deployment succeeded"
-                echo "deploy_success=true" >> $GITHUB_OUTPUT
+                echo 'Canary deployment succeeded'
+                echo 'deploy_success=true' >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
               Failed|Cancelled|TimedOut)
                 echo "::error::Canary deployment failed (status: $STATUS)"
-                echo "=== Stdout ==="
+                echo '=== Stdout ==='
                 aws ssm get-command-invocation \
                   --command-id "$COMMAND_ID" \
                   --instance-id "$CANARY_INSTANCE" \
                   --query 'StandardOutputContent' \
                   --output text || true
-                echo "=== Stderr ==="
+                echo '=== Stderr ==='
                 aws ssm get-command-invocation \
                   --command-id "$COMMAND_ID" \
                   --instance-id "$CANARY_INSTANCE" \
                   --query 'StandardErrorContent' \
                   --output text || true
-                echo "deploy_success=false" >> $GITHUB_OUTPUT
+                echo 'deploy_success=false' >> "$GITHUB_OUTPUT"
                 exit 1
                 ;;
               *)
@@ -223,17 +305,19 @@ jobs:
             esac
           done
 
-          echo "::error::Canary deployment timed out waiting for SSM"
-          echo "deploy_success=false" >> $GITHUB_OUTPUT
+          echo '::error::Canary deployment timed out waiting for SSM'
+          echo 'deploy_success=false' >> "$GITHUB_OUTPUT"
           exit 1
 
       - name: Verify canary health via SSM
         id: health
         if: steps.deploy.outputs.deploy_success == 'true'
+        shell: bash
         run: |
+          CANARY_INSTANCE='${{ needs.pre-flight.outputs.canary_instance }}'
           HEALTH_CMD_ID=$(aws ssm send-command \
             --instance-ids "$CANARY_INSTANCE" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Canary health check from run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -248,16 +332,16 @@ jobs:
             --output text)
 
           MAX_POLL=20
-          for i in $(seq 1 $MAX_POLL); do
+          for i in $(seq 1 "$MAX_POLL"); do
             STATUS=$(aws ssm get-command-invocation \
               --command-id "$HEALTH_CMD_ID" \
               --instance-id "$CANARY_INSTANCE" \
               --query 'Status' \
-              --output text 2>/dev/null || echo "Pending")
+              --output text 2>/dev/null || echo 'Pending')
             case "$STATUS" in
               Success)
-                echo "Canary health check passed"
-                echo "canary_ok=true" >> $GITHUB_OUTPUT
+                echo 'Canary health check passed'
+                echo 'canary_ok=true' >> "$GITHUB_OUTPUT"
                 exit 0
                 ;;
               Failed|TimedOut|Cancelled)
@@ -267,7 +351,7 @@ jobs:
                   --instance-id "$CANARY_INSTANCE" \
                   --query 'StandardErrorContent' \
                   --output text || true
-                echo "canary_ok=false" >> $GITHUB_OUTPUT
+                echo 'canary_ok=false' >> "$GITHUB_OUTPUT"
                 exit 1
                 ;;
               *)
@@ -276,17 +360,19 @@ jobs:
             esac
           done
 
-          echo "::error::Canary health check timed out"
-          echo "canary_ok=false" >> $GITHUB_OUTPUT
+          echo '::error::Canary health check timed out'
+          echo 'canary_ok=false' >> "$GITHUB_OUTPUT"
           exit 1
 
       - name: Rollback canary on failure
-        if: failure()
+        if: failure() && needs.pre-flight.outputs.canary_instance != '' && steps.deploy.outputs.deploy_started == 'true'
+        shell: bash
         run: |
-          echo "::warning::Rolling back canary instance..."
+          CANARY_INSTANCE='${{ needs.pre-flight.outputs.canary_instance }}'
+          echo '::warning::Rolling back canary instance...'
           aws ssm send-command \
             --instance-ids "$CANARY_INSTANCE" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Rollback canary from run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -302,14 +388,11 @@ jobs:
               "echo \"Canary rollback complete\""
             ]' \
             --timeout-seconds 120
-          echo "Rollback command sent to canary"
+          echo 'Rollback command sent to canary'
 
-  # ---------------------------------------------------------------------------
-  # Deploy workers — remaining 2 instances in parallel, after canary verified
-  # ---------------------------------------------------------------------------
   deploy-workers:
-    needs: deploy-canary
-    if: needs.deploy-canary.outputs.canary_ok == 'true'
+    needs: [pre-flight, deploy-canary]
+    if: needs.pre-flight.outputs.validate_only != 'true' && needs.pre-flight.outputs.worker_instances != '' && needs.deploy-canary.outputs.canary_ok == 'true'
     runs-on: aragora
     timeout-minutes: 15
 
@@ -322,31 +405,35 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Pre-deploy worker health check
+        shell: bash
         run: |
-          echo "Verifying worker instances health before deployment..."
-          IFS=',' read -ra IDS <<< "$WORKER_INSTANCES"
+          IDS_CSV='${{ needs.pre-flight.outputs.worker_instances }}'
+          echo 'Verifying worker instances health before deployment...'
+          IFS=',' read -ra IDS <<< "$IDS_CSV"
           for INST_ID in "${IDS[@]}"; do
             STATUS=$(aws ec2 describe-instance-status \
               --instance-ids "$INST_ID" \
               --query 'InstanceStatuses[0].[InstanceStatus.Status, SystemStatus.Status]' \
-              --output text 2>/dev/null || echo "unknown unknown")
+              --output text 2>/dev/null || echo 'unknown unknown')
             INST_STATUS=$(echo "$STATUS" | awk '{print $1}')
             SYS_STATUS=$(echo "$STATUS" | awk '{print $2}')
-            if [[ "$INST_STATUS" != "ok" ]] || [[ "$SYS_STATUS" != "ok" ]]; then
+            if [[ "$INST_STATUS" != 'ok' ]] || [[ "$SYS_STATUS" != 'ok' ]]; then
               echo "::error::Worker $INST_ID health check failed: instance=$INST_STATUS system=$SYS_STATUS"
               exit 1
             fi
             echo "Worker $INST_ID: instance=$INST_STATUS system=$SYS_STATUS"
           done
-          echo "All worker instances healthy"
+          echo 'All worker instances healthy'
 
       - name: Deploy to workers via SSM (parallel)
         id: deploy
+        shell: bash
         run: |
-          IFS=',' read -ra IDS <<< "$WORKER_INSTANCES"
+          IDS_CSV='${{ needs.pre-flight.outputs.worker_instances }}'
+          IFS=',' read -ra IDS <<< "$IDS_CSV"
           COMMAND_ID=$(aws ssm send-command \
             --instance-ids "${IDS[@]}" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Deploy aragora workers from GitHub Actions run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -362,9 +449,9 @@ jobs:
               "sudo -u ec2-user git reset --hard origin/main",
               "sudo chown -R ec2-user:ec2-user /home/ec2-user/aragora/venv || true",
               "sudo chown -R ec2-user:ec2-user /home/ec2-user/.npm /home/ec2-user/.cache || true",
-              "sudo -u ec2-user bash -c 'cd /home/ec2-user/aragora && source venv/bin/activate && python -m pip install -e . --quiet --no-cache-dir'",
+              "sudo -u ec2-user bash -c '\''cd /home/ec2-user/aragora && source venv/bin/activate && python -m pip install -e . --quiet --no-cache-dir'\''",
               "find /home/ec2-user/aragora/venv/lib/python3.11/site-packages -maxdepth 1 -name \"~*\" -type d -exec rm -rf {} + 2>/dev/null || true",
-              "sudo -u ec2-user bash -c 'cd /home/ec2-user/aragora && source venv/bin/activate && python -c \"from aragora.server.unified_server import UnifiedServer; print(\\\"Import OK\\\")\"'",
+              "sudo -u ec2-user bash -c '\''cd /home/ec2-user/aragora && source venv/bin/activate && python -c \"from aragora.server.unified_server import UnifiedServer; print(\\\"Import OK\\\")\"'\''",
               "sudo systemctl restart aragora",
               "sleep 5",
               "if ! systemctl is-active --quiet aragora; then echo \"=== SERVICE FAILED ===\"; systemctl status aragora --no-pager || true; journalctl -u aragora -n 50 --no-pager || true; exit 1; fi",
@@ -376,19 +463,19 @@ jobs:
             --query 'Command.CommandId' \
             --output text)
 
-          echo "command_id=$COMMAND_ID" >> $GITHUB_OUTPUT
+          echo 'deploy_started=true' >> "$GITHUB_OUTPUT"
+          echo "command_id=$COMMAND_ID" >> "$GITHUB_OUTPUT"
           echo "Started worker deployment: $COMMAND_ID"
 
-          # Poll for completion on both instances (up to 5 minutes)
           MAX_POLL=60
           CONSECUTIVE_ERRORS=0
           MAX_CONSECUTIVE_ERRORS=5
           BACKOFF=5
 
-          for i in $(seq 1 $MAX_POLL); do
+          for i in $(seq 1 "$MAX_POLL"); do
             POLL_ERROR=false
             ALL_DONE=true
-            FAILED_IDS=""
+            FAILED_IDS=''
 
             for INST_ID in "${IDS[@]}"; do
               STATUS=$(aws ssm get-command-invocation \
@@ -415,15 +502,15 @@ jobs:
               esac
             done
 
-            if [[ "$POLL_ERROR" == "true" ]]; then
+            if [[ "$POLL_ERROR" == 'true' ]]; then
               CONSECUTIVE_ERRORS=$((CONSECUTIVE_ERRORS + 1))
               echo "::warning::SSM API error (attempt $i, errors: $CONSECUTIVE_ERRORS/$MAX_CONSECUTIVE_ERRORS)"
               if [[ $CONSECUTIVE_ERRORS -ge $MAX_CONSECUTIVE_ERRORS ]]; then
-                echo "::error::Too many consecutive SSM API errors, aborting"
+                echo '::error::Too many consecutive SSM API errors, aborting'
                 exit 1
               fi
               BACKOFF=$((BACKOFF * 2 > 30 ? 30 : BACKOFF * 2))
-              sleep $BACKOFF
+              sleep "$BACKOFF"
               continue
             fi
 
@@ -448,8 +535,8 @@ jobs:
               exit 1
             fi
 
-            if [[ "$ALL_DONE" == "true" ]]; then
-              echo "Worker deployment succeeded on all instances"
+            if [[ "$ALL_DONE" == 'true' ]]; then
+              echo 'Worker deployment succeeded on all instances'
               exit 0
             fi
 
@@ -457,16 +544,18 @@ jobs:
             sleep 5
           done
 
-          echo "::error::Worker deployment timed out"
+          echo '::error::Worker deployment timed out'
           exit 1
 
       - name: Verify all workers healthy via SSM
         id: health
+        shell: bash
         run: |
-          IFS=',' read -ra IDS <<< "$WORKER_INSTANCES"
+          IDS_CSV='${{ needs.pre-flight.outputs.worker_instances }}'
+          IFS=',' read -ra IDS <<< "$IDS_CSV"
           HEALTH_CMD_ID=$(aws ssm send-command \
             --instance-ids "${IDS[@]}" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Worker health check from run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -481,7 +570,7 @@ jobs:
             --output text)
 
           MAX_POLL=20
-          for i in $(seq 1 $MAX_POLL); do
+          for i in $(seq 1 "$MAX_POLL"); do
             ALL_DONE=true
             ALL_OK=true
             for INST_ID in "${IDS[@]}"; do
@@ -489,7 +578,7 @@ jobs:
                 --command-id "$HEALTH_CMD_ID" \
                 --instance-id "$INST_ID" \
                 --query 'Status' \
-                --output text 2>/dev/null || echo "Pending")
+                --output text 2>/dev/null || echo 'Pending')
               case "$STATUS" in
                 Success)
                   ;;
@@ -502,23 +591,23 @@ jobs:
               esac
             done
 
-            if [[ "$ALL_DONE" == "true" ]]; then
+            if [[ "$ALL_DONE" == 'true' ]]; then
               break
             fi
             sleep 5
           done
 
-          if [[ "$ALL_OK" == "true" && "$ALL_DONE" == "true" ]]; then
-            echo "All worker health checks passed"
+          if [[ "$ALL_OK" == 'true' && "$ALL_DONE" == 'true' ]]; then
+            echo 'All worker health checks passed'
           else
-            echo "::error::Worker health check failed on one or more instances"
+            echo '::error::Worker health check failed on one or more instances'
             for INST_ID in "${IDS[@]}"; do
               INST_STATUS=$(aws ssm get-command-invocation \
                 --command-id "$HEALTH_CMD_ID" \
                 --instance-id "$INST_ID" \
                 --query 'Status' \
-                --output text 2>/dev/null || echo "Unknown")
-              if [[ "$INST_STATUS" != "Success" ]]; then
+                --output text 2>/dev/null || echo 'Unknown')
+              if [[ "$INST_STATUS" != 'Success' ]]; then
                 echo "=== Health failure on $INST_ID (status: $INST_STATUS) ==="
                 aws ssm get-command-invocation \
                   --command-id "$HEALTH_CMD_ID" \
@@ -531,13 +620,15 @@ jobs:
           fi
 
       - name: Rollback workers on failure
-        if: failure()
+        if: failure() && steps.deploy.outputs.deploy_started == 'true'
+        shell: bash
         run: |
-          echo "::warning::Rolling back worker instances..."
-          IFS=',' read -ra IDS <<< "$WORKER_INSTANCES"
+          IDS_CSV='${{ needs.pre-flight.outputs.worker_instances }}'
+          IFS=',' read -ra IDS <<< "$IDS_CSV"
+          echo '::warning::Rolling back worker instances...'
           aws ssm send-command \
             --instance-ids "${IDS[@]}" \
-            --document-name "AWS-RunShellScript" \
+            --document-name 'AWS-RunShellScript' \
             --comment "Rollback workers from run ${{ github.run_id }}" \
             --parameters 'commands=[
               "set -e",
@@ -553,22 +644,21 @@ jobs:
               "echo \"Worker rollback complete\""
             ]' \
             --timeout-seconds 120
-          echo "Rollback command sent to workers"
+          echo 'Rollback command sent to workers'
 
-  # ---------------------------------------------------------------------------
-  # Final verification — external health check via Cloudflare
-  # ---------------------------------------------------------------------------
   verify:
-    needs: [deploy-canary, deploy-workers]
+    needs: [pre-flight, deploy-canary, deploy-workers]
+    if: needs.pre-flight.outputs.validate_only != 'true' && needs.deploy-canary.outputs.canary_ok == 'true' && (needs.deploy-workers.result == 'success' || needs.deploy-workers.result == 'skipped')
     runs-on: aragora
     timeout-minutes: 5
 
     steps:
       - name: Verify external health via Cloudflare
+        shell: bash
         run: |
-          echo "Checking external access via https://api.aragora.ai/api/health ..."
+          echo 'Checking external access via https://api.aragora.ai/api/health ...'
           for i in $(seq 1 12); do
-            RESPONSE=$(curl -sf "https://api.aragora.ai/api/health" 2>/dev/null || echo "")
+            RESPONSE=$(curl -sf 'https://api.aragora.ai/api/health' 2>/dev/null || echo '')
             if echo "$RESPONSE" | grep -q '"status"'; then
               echo "External health check passed on attempt $i"
               echo "$RESPONSE"
@@ -577,7 +667,7 @@ jobs:
             echo "Waiting for Cloudflare propagation... attempt $i/12"
             sleep 5
           done
-          echo "::warning::External health check via Cloudflare failed after 60s"
+          echo '::warning::External health check via Cloudflare failed after 60s'
           exit 1
 
       - name: Deployment summary
@@ -588,17 +678,38 @@ jobs:
           DEPLOY_REF: ${{ github.ref_name }}
           CANARY_RESULT: ${{ needs.deploy-canary.result }}
           WORKERS_RESULT: ${{ needs.deploy-workers.result }}
+          CANARY_INSTANCE: ${{ needs.pre-flight.outputs.canary_instance }}
+          WORKER_INSTANCES: ${{ needs.pre-flight.outputs.worker_instances }}
+        shell: bash
         run: |
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF_SUMMARY
           ## EC2 Deployment Summary
 
-          **Commit:** \`${DEPLOY_SHA}\`
+          **Commit:** `${DEPLOY_SHA}`
           **Triggered by:** ${DEPLOY_ACTOR}
           **Branch:** ${DEPLOY_REF}
 
-          | Instance | Role | Status |
-          |----------|------|--------|
-          | i-0dbd51f74a9a11fcc | Canary (aragora-api-server) | ${CANARY_RESULT} |
-          | i-092c2d3b4dafc1f24 | Worker (aragora-al2023-1) | ${WORKERS_RESULT} |
-          | i-0aae2ccd2f68b94d2 | Worker (aragora-al2023-2) | ${WORKERS_RESULT} |
-          EOF
+          | Target | Role | Status |
+          |--------|------|--------|
+          | ${CANARY_INSTANCE} | Canary | ${CANARY_RESULT} |
+          | ${WORKER_INSTANCES} | Primary | ${WORKERS_RESULT} |
+          EOF_SUMMARY
+
+  validate-only-summary:
+    needs: pre-flight
+    if: needs.pre-flight.outputs.validate_only == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validation summary
+        shell: bash
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF_SUMMARY
+          ## EC2 Validation Summary
+
+          Discovery and health checks completed without running deploy or rollback commands.
+
+          | Target | Value |
+          |--------|-------|
+          | Canary instance | `${{ needs.pre-flight.outputs.canary_instance }}` |
+          | Primary instances | `${{ needs.pre-flight.outputs.worker_instances }}` |
+          EOF_SUMMARY

--- a/.github/workflows/main-required-checks-auto-revert.yml
+++ b/.github/workflows/main-required-checks-auto-revert.yml
@@ -42,6 +42,29 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::Standard recovery failed; attempting archive restore"
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
+          fi
+          if [[ ! -f pyproject.toml ]] || [[ ! -f scripts/auto_revert_main_required_failures.py ]]; then
+            echo "::error::Repository checkout is incomplete (missing pyproject.toml or scripts/auto_revert_main_required_failures.py)"
+            echo "PWD=$(pwd)"
+            ls -la
+            ls -la scripts || true
+            exit 1
+          fi
+
       - name: Evaluate and revert failed required checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- move documentation deploy jobs to `ubuntu-latest` to avoid self-hosted `gtar` failures
- add checkout-integrity recovery to main required-checks auto-revert before invoking the Python script
- retire stale push-to-main behavior in `deploy-ec2.yml` and switch it to manual tag-discovered deploy/validate mode

## Validation
- `pytest -q tests/scripts/test_auto_revert_main_required_failures.py`
- `python3 scripts/check_workflow_pip_install_policy.py`
- YAML parse for the three edited workflows