### PR TITLE
fix(ci): salvage deploy-ec2 canary fallback and revert rate limiting

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -87,6 +87,7 @@ jobs:
     outputs:
       validate_only: ${{ steps.mode.outputs.validate_only }}
       canary_instance: ${{ steps.discover.outputs.canary_instance }}
+      has_canary: ${{ steps.discover.outputs.has_canary }}
       worker_instances: ${{ steps.discover.outputs.worker_instances }}
       all_instances: ${{ steps.discover.outputs.all_instances }}
       canary_ok: ${{ steps.canary_health.outputs.canary_ok }}
@@ -126,8 +127,10 @@ jobs:
             CANARY_ID=''
           fi
           if [[ -z "$CANARY_ID" ]]; then
-            echo '::error::No running canary instance found (tags: Environment=production, Application=aragora, Role=canary)'
-            exit 1
+            echo '::warning::No running canary instance found; canary deployment will be skipped'
+            echo "has_canary=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_canary=true" >> "$GITHUB_OUTPUT"
           fi
 
           PROD_IDS_RAW=$(aws ec2 describe-instances \
@@ -147,16 +150,21 @@ jobs:
             exit 1
           fi
 
-          ALL_IDS="$CANARY_ID,$PROD_IDS"
+          if [[ -n "$CANARY_ID" ]]; then
+            ALL_IDS="$CANARY_ID,$PROD_IDS"
+          else
+            ALL_IDS="$PROD_IDS"
+          fi
 
           echo "canary_instance=$CANARY_ID" >> "$GITHUB_OUTPUT"
           echo "worker_instances=$PROD_IDS" >> "$GITHUB_OUTPUT"
           echo "all_instances=$ALL_IDS" >> "$GITHUB_OUTPUT"
-          echo "Canary: $CANARY_ID"
+          echo "Canary: ${CANARY_ID:-none}"
           echo "Primary instances: $PROD_IDS"
 
       - name: Pre-deploy canary health check
         id: canary_health
+        if: steps.discover.outputs.has_canary == 'true'
         shell: bash
         run: |
           CANARY_INSTANCE='${{ steps.discover.outputs.canary_instance }}'
@@ -191,7 +199,7 @@ jobs:
 
   deploy-canary:
     needs: pre-flight
-    if: needs.pre-flight.outputs.canary_ok == 'true' && needs.pre-flight.outputs.validate_only != 'true'
+    if: needs.pre-flight.outputs.has_canary == 'true' && needs.pre-flight.outputs.canary_ok == 'true' && needs.pre-flight.outputs.validate_only != 'true'
     runs-on: aragora
     timeout-minutes: 15
     outputs:
@@ -365,7 +373,7 @@ jobs:
           exit 1
 
       - name: Rollback canary on failure
-        if: failure() && needs.pre-flight.outputs.canary_instance != '' && steps.deploy.outputs.deploy_started == 'true'
+        if: failure() && needs.pre-flight.outputs.has_canary == 'true' && steps.deploy.outputs.deploy_started == 'true'
         shell: bash
         run: |
           CANARY_INSTANCE='${{ needs.pre-flight.outputs.canary_instance }}'
@@ -392,7 +400,12 @@ jobs:
 
   deploy-workers:
     needs: [pre-flight, deploy-canary]
-    if: needs.pre-flight.outputs.validate_only != 'true' && needs.pre-flight.outputs.worker_instances != '' && needs.deploy-canary.outputs.canary_ok == 'true'
+    if: |
+      always() &&
+      needs.pre-flight.result == 'success' &&
+      needs.pre-flight.outputs.validate_only != 'true' &&
+      needs.pre-flight.outputs.worker_instances != '' &&
+      (needs.deploy-canary.outputs.canary_ok == 'true' || needs.deploy-canary.result == 'skipped')
     runs-on: aragora
     timeout-minutes: 15
 
@@ -648,7 +661,12 @@ jobs:
 
   verify:
     needs: [pre-flight, deploy-canary, deploy-workers]
-    if: needs.pre-flight.outputs.validate_only != 'true' && needs.deploy-canary.outputs.canary_ok == 'true' && (needs.deploy-workers.result == 'success' || needs.deploy-workers.result == 'skipped')
+    if: |
+      always() &&
+      needs.pre-flight.result == 'success' &&
+      needs.pre-flight.outputs.validate_only != 'true' &&
+      (needs.deploy-canary.outputs.canary_ok == 'true' || needs.deploy-canary.result == 'skipped') &&
+      (needs.deploy-workers.result == 'success' || needs.deploy-workers.result == 'skipped')
     runs-on: aragora
     timeout-minutes: 5
 

--- a/aragora/debate/consensus.py
+++ b/aragora/debate/consensus.py
@@ -38,7 +38,7 @@ class Evidence:
     supports_claim: bool  # True if supports, False if refutes
     strength: float  # 0-1
     timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -267,7 +267,7 @@ class ConsensusProof:
     # Metadata
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
     rounds_to_consensus: int = 0
-    metadata: dict = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
 
     # Cached checksum (computed on first access, excluded from repr/compare)
     _cached_checksum: str | None = field(default=None, repr=False, compare=False)
@@ -278,7 +278,7 @@ class ConsensusProof:
         if self._cached_checksum is not None:
             return self._cached_checksum
 
-        def enum_dict_factory(data: list) -> dict:
+        def enum_dict_factory(data: list[tuple[str, Any]]) -> dict[str, Any]:
             """Convert Enum values to their string values for JSON serialization."""
             return {k: v.value if isinstance(v, Enum) else v for k, v in data}
 
@@ -430,10 +430,10 @@ class ConsensusProof:
 
         return correlation
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
 
-        def enum_dict_factory(data: list) -> dict:
+        def enum_dict_factory(data: list[tuple[str, Any]]) -> dict[str, Any]:
             """Convert Enum values to their string values for JSON serialization."""
             return {k: v.value if isinstance(v, Enum) else v for k, v in data}
 
@@ -747,7 +747,7 @@ class ConsensusBuilder:
                 )
 
         # Build claims-by-author index for O(1) lookup (optimization)
-        claims_by_author: dict[str, list] = {}
+        claims_by_author: dict[str, list[Any]] = {}
         for claim in builder.claims:
             if claim.author not in claims_by_author:
                 claims_by_author[claim.author] = []

--- a/aragora/gauntlet/result.py
+++ b/aragora/gauntlet/result.py
@@ -63,7 +63,7 @@ class Vulnerability:
         """Calculate risk score from exploitability and impact."""
         return self.exploitability * self.impact
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "id": self.id,
             "title": self.title,
@@ -98,7 +98,7 @@ class AttackSummary:
     robustness_score: float = 1.0
     coverage_score: float = 0.0
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "total_attacks": self.total_attacks,
             "successful_attacks": self.successful_attacks,
@@ -121,7 +121,7 @@ class ProbeSummary:
     vulnerability_rate: float = 0.0
     elo_penalty: float = 0.0
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "probes_run": self.probes_run,
             "vulnerabilities_found": self.vulnerabilities_found,
@@ -141,7 +141,7 @@ class ScenarioSummary:
     universal_conclusions: list[str] = field(default_factory=list)
     conditional_patterns: dict[str, list[str]] = field(default_factory=dict)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "scenarios_run": self.scenarios_run,
             "outcome_category": self.outcome_category,
@@ -319,7 +319,7 @@ class GauntletResult:
             "estimated_effort": effort,
         }
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "gauntlet_id": self.gauntlet_id,
             "input_hash": self.input_hash,

--- a/aragora/gauntlet/types.py
+++ b/aragora/gauntlet/types.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
+from typing import Any
 
 
 class InputType(Enum):
@@ -158,7 +159,7 @@ class BaseFinding:
         """Get numeric severity value (0-1)."""
         return self.severity.numeric_value
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
         return {
             "id": self.id,
@@ -209,7 +210,7 @@ class RiskSummary:
         else:
             self.info += 1
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
         return {
             "critical": self.critical,

--- a/scripts/auto_revert_main_required_failures.py
+++ b/scripts/auto_revert_main_required_failures.py
@@ -270,6 +270,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
+def _recent_revert_exists(repo_path: Path, minutes: int = 10) -> bool:
+    """Check if a revert commit was made in the last *minutes* minutes."""
+    result = _run(
+        ["git", "log", f"--since={minutes} minutes ago", "--grep=Revert", "--oneline"],
+        cwd=repo_path,
+    )
+    if result.returncode != 0:
+        return False
+    return bool(result.stdout.strip())
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     if not args.repo:
@@ -333,8 +344,22 @@ def main(argv: list[str] | None = None) -> int:
         if args.dry_run:
             return 0
 
+        repo_path = Path(args.repo_path).resolve()
+        if _recent_revert_exists(repo_path):
+            print(
+                json.dumps(
+                    {
+                        "action": "skip",
+                        "reason": "rate_limited_recent_revert",
+                        "target_sha": target_sha,
+                        "detail": "A revert was performed in the last 10 minutes; skipping to prevent flap loop",
+                    }
+                )
+            )
+            return 0
+
         ok, message = perform_revert(
-            Path(args.repo_path).resolve(),
+            repo_path,
             target_sha=target_sha,
             base_branch=args.base,
         )


### PR DESCRIPTION
## Summary
- salvage the remaining actionable CI fixes from `#766` onto a fresh `origin/main` base after `#763` and `#764` landed
- make `deploy-ec2.yml` tolerate missing canary instances by skipping canary-specific phases instead of hard-failing preflight
- add a 10-minute rate limit to `scripts/auto_revert_main_required_failures.py` to reduce revert flap loops
- carry the small type-annotation fixes in `aragora/debate/consensus.py`, `aragora/gauntlet/result.py`, and `aragora/gauntlet/types.py`

## Explicitly excluded
- `deploy-secure.yml` safe.directory changes are already merged via `#763`
- EU AI Act collateral and pentest docs from `#766` are not included here

## Validation
- `python3 -m pytest tests/scripts/test_auto_revert_main_required_failures.py -q`
- `python3 - <<'PY' ... yaml.safe_load(Path('.github/workflows/deploy-ec2.yml').read_text()) ... PY`
- `python3 scripts/check_workflow_pip_install_policy.py`

## Notes
- the type-fix files are also covered by required CI `typecheck`