### PR TITLE
fix(inbox): speed up triage debate agent selection

### DIFF
--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -166,6 +166,50 @@ def _normalize_debate_outcome(debate_result: Any) -> _NormalizedDebateOutcome:
     )
 
 
+def _create_triage_agents() -> list[Any]:
+    """Create the smallest useful remote debate for inbox triage."""
+    import os
+
+    from aragora.agents.base import create_agent
+
+    agents: list[Any] = []
+
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        try:
+            agents.append(
+                create_agent(
+                    "anthropic-api",
+                    name="triage-proposer",
+                    role="proposer",
+                    model="claude-haiku-4-5-20251001",
+                )
+            )
+        except (ImportError, RuntimeError, ValueError, OSError):
+            logger.debug("Anthropic triage proposer unavailable", exc_info=True)
+
+    if os.environ.get("OPENROUTER_API_KEY"):
+        try:
+            agents.append(
+                create_agent(
+                    "openrouter",
+                    name="triage-critic",
+                    role="critic",
+                    model="deepseek/deepseek-chat",
+                )
+            )
+        except (ImportError, RuntimeError, ValueError, OSError):
+            logger.debug("OpenRouter triage critic unavailable", exc_info=True)
+
+    if len(agents) < 2 and os.environ.get("OPENAI_API_KEY"):
+        role = "critic" if agents else "proposer"
+        try:
+            agents.append(create_agent("openai-api", name=f"triage-{role}", role=role))
+        except (ImportError, RuntimeError, ValueError, OSError):
+            logger.debug("OpenAI triage fallback unavailable", exc_info=True)
+
+    return agents
+
+
 class InboxTriageRunner:
     """Orchestrates the full inbox triage flow.
 
@@ -361,7 +405,6 @@ class InboxTriageRunner:
         )
 
         try:
-            from aragora.agents.registry import AgentRegistry
             from aragora.core import Environment
             from aragora.debate.orchestrator import Arena
             from aragora.debate.protocol import DebateProtocol
@@ -369,21 +412,12 @@ class InboxTriageRunner:
             env = Environment(task=question)
             protocol = DebateProtocol(rounds=2, consensus="majority")
 
-            agent_configs = [
-                ("anthropic-api", "proposer"),
-                ("openai-api", "critic"),
-                ("grok", "synthesizer"),
-            ]
-            agents = []
-            for model_type, role in agent_configs:
-                try:
-                    agent = AgentRegistry.create(model_type, name=f"triage-{role}", role=role)
-                    agents.append(agent)
-                except (ImportError, KeyError, RuntimeError, ValueError, OSError) as exc:
-                    logger.debug("Skipping agent %s: %s", model_type, exc)
+            agents = _create_triage_agents()
 
             if len(agents) < 2:
-                logger.warning("%d/3 agents available (need 2); using stub debate", len(agents))
+                logger.warning(
+                    "%d triage agents available (need 2); using stub debate", len(agents)
+                )
                 return {
                     "final_answer": "ignore",
                     "confidence": 0.0,

--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -174,10 +174,12 @@ class ActionIntent:
         return _sha256_text("\n".join(part for part in parts if part))
 
     def to_dict(self) -> dict[str, Any]:
+        action = self.action
+        action_str = action.value if isinstance(action, Enum) else str(action)
         return {
             "provider": self.provider,
             "message_id": self.message_id,
-            "action": self.action.value,
+            "action": action_str,
             "content_hash": self.content_hash,
             "synthesized_rationale": self.synthesized_rationale,
             "confidence": self.confidence,

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from aragora.core import DebateResult
-from aragora.inbox.triage_runner import InboxTriageRunner
+from aragora.inbox.triage_runner import InboxTriageRunner, _create_triage_agents
 from aragora.inbox.trust_wedge import (
     InboxWedgeAction,
     ReceiptState,
@@ -383,7 +383,7 @@ async def test_triage_message_falls_back_to_body_when_body_text_missing():
 
 
 @pytest.mark.asyncio
-async def test_run_debate_uses_agent_registry_and_explicit_action_prompt(monkeypatch):
+async def test_run_debate_uses_fast_agent_subset_and_explicit_action_prompt(monkeypatch):
     created_agents: list[object] = []
     captured_tasks: list[str] = []
 
@@ -395,18 +395,20 @@ async def test_run_debate_uses_agent_registry_and_explicit_action_prompt(monkeyp
         async def run(self):
             return {"final_answer": "archive", "confidence": 0.9}
 
-    def _create_agent(model_type, name="", role="proposer"):
-        return SimpleNamespace(name=name, role=role, model_type=model_type)
-
     def _environment(*, task):
         return SimpleNamespace(task=task)
 
-    import aragora.agents.registry as reg_mod
     import aragora.core as core_mod
     import aragora.debate.orchestrator as orch_mod
     import aragora.debate.protocol as proto_mod
 
-    monkeypatch.setattr(reg_mod.AgentRegistry, "create", staticmethod(_create_agent))
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner._create_triage_agents",
+        lambda: [
+            SimpleNamespace(name="triage-proposer", role="proposer", model_type="anthropic-api"),
+            SimpleNamespace(name="triage-critic", role="critic", model_type="openrouter"),
+        ],
+    )
     monkeypatch.setattr(core_mod, "Environment", _environment)
     monkeypatch.setattr(proto_mod, "DebateProtocol", lambda **kwargs: SimpleNamespace(**kwargs))
     monkeypatch.setattr(orch_mod, "Arena", _Arena)
@@ -422,7 +424,7 @@ async def test_run_debate_uses_agent_registry_and_explicit_action_prompt(monkeyp
     )
 
     assert result["final_answer"] == "archive"
-    assert len(created_agents) == 3
+    assert len(created_agents) == 2
     assert len(captured_tasks) == 1
     assert "From: sender@example.com" in captured_tasks[0]
     assert "MUST begin with the action word" in captured_tasks[0]
@@ -430,21 +432,16 @@ async def test_run_debate_uses_agent_registry_and_explicit_action_prompt(monkeyp
 
 @pytest.mark.asyncio
 async def test_run_debate_falls_back_to_stub_when_fewer_than_two_agents(monkeypatch):
-    created = 0
-
-    def _create_agent(model_type, name="", role="proposer"):
-        nonlocal created
-        created += 1
-        if created == 1:
-            return SimpleNamespace(name=name, role=role, model_type=model_type)
-        raise RuntimeError("missing credentials")
-
-    import aragora.agents.registry as reg_mod
     import aragora.core as core_mod
     import aragora.debate.orchestrator as orch_mod
     import aragora.debate.protocol as proto_mod
 
-    monkeypatch.setattr(reg_mod.AgentRegistry, "create", staticmethod(_create_agent))
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner._create_triage_agents",
+        lambda: [
+            SimpleNamespace(name="triage-proposer", role="proposer", model_type="anthropic-api")
+        ],
+    )
     monkeypatch.setattr(core_mod, "Environment", lambda **kwargs: SimpleNamespace(**kwargs))
     monkeypatch.setattr(proto_mod, "DebateProtocol", lambda **kwargs: SimpleNamespace(**kwargs))
     monkeypatch.setattr(orch_mod, "Arena", MagicMock())
@@ -461,3 +458,57 @@ async def test_run_debate_falls_back_to_stub_when_fewer_than_two_agents(monkeypa
 
     assert result["final_answer"] == "ignore"
     assert result["confidence"] == 0.0
+
+
+def test_create_triage_agents_prefers_fast_pair(monkeypatch):
+    calls: list[tuple[str, str, str | None]] = []
+
+    def fake_create_agent(
+        model_type: str,
+        name: str | None = None,
+        role: str = "proposer",
+        model: str | None = None,
+        **_: object,
+    ):
+        calls.append((model_type, role, model))
+        return {"model_type": model_type, "name": name, "role": role, "model": model}
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setattr("aragora.agents.base.create_agent", fake_create_agent)
+
+    agents = _create_triage_agents()
+
+    assert len(agents) == 2
+    assert calls == [
+        ("anthropic-api", "proposer", "claude-haiku-4-5-20251001"),
+        ("openrouter", "critic", "deepseek/deepseek-chat"),
+    ]
+
+
+def test_create_triage_agents_falls_back_to_openai_when_needed(monkeypatch):
+    calls: list[tuple[str, str, str | None]] = []
+
+    def fake_create_agent(
+        model_type: str,
+        name: str | None = None,
+        role: str = "proposer",
+        model: str | None = None,
+        **_: object,
+    ):
+        calls.append((model_type, role, model))
+        return {"model_type": model_type, "name": name, "role": role, "model": model}
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic")
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.setattr("aragora.agents.base.create_agent", fake_create_agent)
+
+    agents = _create_triage_agents()
+
+    assert len(agents) == 2
+    assert calls == [
+        ("anthropic-api", "proposer", "claude-haiku-4-5-20251001"),
+        ("openai-api", "critic", None),
+    ]

--- a/tests/inbox/test_trust_wedge.py
+++ b/tests/inbox/test_trust_wedge.py
@@ -207,6 +207,24 @@ def test_auto_approval_stays_narrow(wedge):
     assert blocked_archive.receipt.state == ReceiptState.CREATED
 
 
+def test_action_intent_to_dict_tolerates_string_action():
+    intent = ActionIntent(
+        provider="gmail",
+        user_id="user-1",
+        message_id="msg-1",
+        action="archive",
+        content_hash=ActionIntent.compute_content_hash("subject", "body"),
+        synthesized_rationale="Debated rationale",
+        confidence=0.91,
+        provider_route="openrouter-fallback",
+        debate_id="debate-123",
+    )
+
+    payload = intent.to_dict()
+
+    assert payload["action"] == "archive"
+
+
 @pytest.mark.asyncio
 async def test_label_action_uses_real_label_path(wedge):
     _, service, connector = wedge


### PR DESCRIPTION
## Summary
- use a smaller, cheaper remote agent set for inbox triage debates
- fall back to OpenAI only when the preferred Anthropic/OpenRouter pair is unavailable
- harden ActionIntent serialization when older callers pass string actions

## Validation
- python -m ruff check aragora/inbox/triage_runner.py aragora/inbox/trust_wedge.py tests/inbox/test_triage_runner.py tests/inbox/test_trust_wedge.py
- pytest -q tests/inbox/test_triage_runner.py tests/inbox/test_trust_wedge.py tests/cli/test_triage_command.py