### PR TITLE
feat(playground): real debates everywhere on current main

### DIFF
--- a/aragora/cli/demo.py
+++ b/aragora/cli/demo.py
@@ -1,13 +1,15 @@
 """
 CLI demo command -- run a self-contained adversarial debate in one command.
 
-No API keys required.  Uses StyledMockAgent from the aragora-debate package
-to simulate a realistic multi-perspective debate with real-time output.
+When API keys are available, uses real LLM models for a genuine multi-agent
+debate.  Falls back to mock agents when no keys are present or --offline is
+passed.
 
 Usage:
-    aragora demo                          # Default: microservices debate
+    aragora demo                          # Real debate (if API keys set)
     aragora demo --topic "Should we use Kubernetes?"
     aragora demo --list                   # Show available demos
+    aragora demo --offline                # Force offline mock agents
     aragora demo --server                 # Start offline server and open browser
 """
 
@@ -15,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
 import time
 from pathlib import Path
@@ -488,6 +491,178 @@ def _run_server_demo() -> None:
 
 
 # ---------------------------------------------------------------------------
+# API key detection and real-model support
+# ---------------------------------------------------------------------------
+
+
+def _has_any_api_key() -> bool:
+    """Check if any LLM API key is available."""
+    return bool(
+        os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+    )
+
+
+def _run_real_demo(topic: str, receipt_path: str | None = None) -> None:
+    """Run a real 1-round debate via available API keys with budget cap."""
+    print()
+    print("=" * 64)
+    print("  ARAGORA DEMO — Real AI Debate")
+    print("=" * 64)
+    print()
+    print(f"  Topic: {topic}")
+    print("  Using real AI models via API...")
+    print()
+
+    try:
+        from aragora.server.handlers.playground import start_playground_debate
+
+        start_time = time.monotonic()
+        result = start_playground_debate(
+            question=topic,
+            agent_count=3,
+            max_rounds=1,
+            timeout=30,
+        )
+        elapsed = time.monotonic() - start_time
+
+        # Print results
+        print(f"  Status: {result.get('status', 'completed')}")
+        print(f"  Duration: {elapsed:.1f}s")
+        print(f"  Consensus: {result.get('consensus_reached', False)}")
+        print(f"  Confidence: {result.get('confidence', 0):.0%}")
+        print()
+
+        participants = result.get("participants", [])
+        if participants:
+            print(f"  Participants: {', '.join(str(p) for p in participants)}")
+            print()
+
+        proposals = result.get("proposals", {})
+        if isinstance(proposals, dict):
+            for agent_name, text in proposals.items():
+                print(f"  [{agent_name}]")
+                for line in _wrap(str(text)[:300], width=58):
+                    print(f"    {line}")
+                print()
+
+        final = result.get("final_answer", "")
+        if final:
+            print("  CONCLUSION:")
+            print("  " + "-" * 40)
+            for line in _wrap(str(final), width=58):
+                print(f"    {line}")
+            print()
+
+        if receipt_path:
+            saved = _save_live_demo_receipt(result, topic, elapsed, receipt_path)
+            print(f"  Receipt saved to: {saved}")
+            print()
+
+        print("=" * 64)
+        print()
+
+    except Exception as exc:
+        print(f"  Debate failed: {exc}")
+        print("  Try 'aragora demo --offline' for an offline demo.")
+        print()
+
+
+def _build_live_receipt_data(
+    result: dict[str, Any],
+    topic: str,
+    elapsed: float,
+) -> dict[str, Any]:
+    """Build receipt payload from the live playground debate response."""
+    consensus_reached = bool(result.get("consensus_reached", False))
+    supporting_agents = list(result.get("participants") or []) if consensus_reached else []
+    return {
+        "receipt_id": "",
+        "question": topic,
+        "verdict": result.get("verdict") or ("consensus" if consensus_reached else "no_consensus"),
+        "confidence": result.get("confidence", 0.0),
+        "agents": list(result.get("participants") or []),
+        "rounds": result.get("rounds_used", 0),
+        "summary": result.get("final_answer", ""),
+        "dissent": list(result.get("dissenting_views") or []),
+        "dissenting_views": list(result.get("dissenting_views") or []),
+        "consensus_proof": {
+            "reached": consensus_reached,
+            "method": result.get("verdict") or "playground-live",
+            "confidence": result.get("confidence", 0.0),
+            "supporting_agents": supporting_agents,
+            "dissenting_agents": [],
+        },
+        "artifact_hash": "",
+        "signature_algorithm": "",
+        "elapsed_seconds": elapsed,
+        "mode": "demo (live)",
+        "proposals": result.get("proposals", {}),
+    }
+
+
+def _save_live_demo_receipt(
+    result: dict[str, Any],
+    topic: str,
+    elapsed: float,
+    output_path: str,
+) -> str:
+    """Save a receipt for the live playground-backed demo path."""
+    import json
+
+    receipt_data = _build_live_receipt_data(result, topic, elapsed)
+    path = Path(output_path)
+
+    if path.suffix.lower() in (".html", ".htm"):
+        from aragora.cli.receipt_formatter import receipt_to_html
+
+        path.write_text(receipt_to_html(receipt_data))
+    elif path.suffix.lower() == ".md":
+        from aragora.cli.receipt_formatter import receipt_to_markdown
+
+        path.write_text(receipt_to_markdown(receipt_data))
+    else:
+        path.write_text(json.dumps(receipt_data, indent=2, default=str))
+
+    return str(path)
+
+
+def _run_mock_demo(args: argparse.Namespace) -> None:
+    """Run the offline mock demo using aragora-debate package or builtin."""
+    if not HAS_ARAGORA_DEBATE:
+        print()
+        print("  Running in offline mode (no aragora-debate package).")
+        print("  Set OPENROUTER_API_KEY for real AI debates.")
+        print()
+        # Simple inline mock output
+        topic = getattr(args, "topic", None) or DEMO_TASKS.get(
+            getattr(args, "name", None) or _DEFAULT_DEMO, {}
+        ).get("topic", "Should we adopt microservices?")
+        print(f"  Topic: {topic}")
+        print("  [Mock] Analyst: Considers multiple perspectives...")
+        print("  [Mock] Critic: Identifies potential issues...")
+        print("  [Mock] Synthesizer: Finds common ground...")
+        print()
+        print("  Verdict: CONSENSUS REACHED (mock)")
+        print("  Confidence: 75%")
+        print()
+        return
+
+    # Use existing aragora-debate based logic
+    receipt_path = getattr(args, "receipt", None)
+    custom_topic = getattr(args, "topic", None)
+    if custom_topic:
+        result, elapsed = asyncio.run(_run_demo_debate(custom_topic))
+        if receipt_path:
+            _save_demo_receipt(result, elapsed, receipt_path)
+        return
+
+    demo_name = getattr(args, "name", None) or _DEFAULT_DEMO
+    run_demo(demo_name, receipt_path=receipt_path)
+
+
+# ---------------------------------------------------------------------------
 # CLI entry points
 # ---------------------------------------------------------------------------
 
@@ -519,11 +694,6 @@ def run_demo(
 
 def main(args: argparse.Namespace) -> None:
     """Handle 'demo' command."""
-    if not HAS_ARAGORA_DEBATE:
-        print("Error: aragora-debate package is not installed.")
-        print("Install it with: pip install aragora-debate")
-        sys.exit(1)
-
     # --list flag
     if getattr(args, "list_demos", False):
         print("\nAvailable demos:")
@@ -538,20 +708,28 @@ def main(args: argparse.Namespace) -> None:
         _run_server_demo()
         return
 
-    receipt_path = getattr(args, "receipt", None)
+    # Determine topic
+    topic = getattr(args, "topic", None)
+    if not topic:
+        demo_name = getattr(args, "name", None) or _DEFAULT_DEMO
+        topic = DEMO_TASKS.get(demo_name, {}).get(
+            "topic", "Should we adopt microservices or keep our monolith?"
+        )
 
-    # Custom topic via --topic
-    custom_topic = getattr(args, "topic", None)
-    if custom_topic:
-        result, elapsed = asyncio.run(_run_demo_debate(custom_topic))
-        if receipt_path:
-            saved = _save_demo_receipt(result, elapsed, receipt_path)
-            print(f"\n  Receipt saved to: {saved}")
+    # --offline flag: always use mock
+    if getattr(args, "offline", False):
+        _run_mock_demo(args)
         return
 
-    # Named demo (or default)
-    demo_name = getattr(args, "name", None) or _DEFAULT_DEMO
-    run_demo(demo_name, receipt_path=receipt_path)
+    receipt_path = getattr(args, "receipt", None)
+
+    # Real debate if API keys available
+    if _has_any_api_key():
+        _run_real_demo(topic, receipt_path=receipt_path)
+    else:
+        print("\n  No API keys found. Running offline demo.")
+        print("  Set OPENROUTER_API_KEY for real AI debates.\n")
+        _run_mock_demo(args)
 
 
 if __name__ == "__main__":
@@ -577,5 +755,10 @@ if __name__ == "__main__":
         "--server",
         action="store_true",
         help="Start server in offline demo mode",
+    )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Force offline mode with mock agents (no API keys used)",
     )
     main(parser.parse_args())

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -682,6 +682,11 @@ Examples:
         "-r",
         help="Save decision receipt to file (.json, .html, or .md)",
     )
+    demo_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Force offline mode with mock agents (no API keys used)",
+    )
     demo_parser.set_defaults(func=_lazy("aragora.cli.commands.delegated", "cmd_demo"))
 
 

--- a/aragora/server/handlers/base.py
+++ b/aragora/server/handlers/base.py
@@ -1100,6 +1100,9 @@ class BaseHandler:
     def read_json_body(self, handler: Any, max_size: int | None = None) -> dict[str, Any] | None:
         """Read and parse JSON body from request handler.
 
+        Handles missing Content-Length (e.g. Cloudflare HTTP/2 proxying)
+        and Transfer-Encoding: chunked.
+
         Args:
             handler: The HTTP request handler with headers and rfile
             max_size: Maximum body size to accept (default: MAX_BODY_SIZE)
@@ -1110,12 +1113,25 @@ class BaseHandler:
         max_size = max_size or self.MAX_BODY_SIZE
         try:
             content_length = int(handler.headers.get("Content-Length", 0))
-            if content_length <= 0:
-                return {}
+            is_chunked = "chunked" in (handler.headers.get("Transfer-Encoding", "") or "").lower()
+
             if content_length > max_size:
                 return None  # Body too large
-            body = handler.rfile.read(content_length)
-            return json.loads(body) if body else {}
+
+            if content_length > 0:
+                body = handler.rfile.read(content_length)
+            elif is_chunked or content_length == 0:
+                # Missing or zero Content-Length: read available data up to max_size.
+                # This handles Cloudflare HTTP/2 -> HTTP/1.1 proxy scenarios.
+                body = handler.rfile.read(max_size)
+            else:
+                return {}
+
+            if not body:
+                return {}
+            if len(body) > max_size:
+                return None  # Body too large after read
+            return json.loads(body)
         except (json.JSONDecodeError, ValueError, TypeError):
             return None
 

--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -51,6 +51,16 @@ _PLAYGROUND_RATE_WINDOW = 60.0  # seconds
 _LIVE_RATE_LIMIT = 1  # 1 live debate per window per IP
 _LIVE_RATE_WINDOW = 600.0  # 10 minutes
 
+# OpenRouter model diversity for playground debates.
+# Each agent gets a different model architecture for genuine adversarial diversity.
+OPENROUTER_PLAYGROUND_MODELS: list[tuple[str, str]] = [
+    ("analyst", "anthropic/claude-sonnet-4"),
+    ("critic", "openai/gpt-4o"),
+    ("synthesizer", "google/gemini-2.0-flash-001"),
+    ("contrarian", "mistralai/mistral-large-latest"),
+    ("auditor", "deepseek/deepseek-chat"),
+]
+
 # IP -> list of timestamps
 _request_timestamps: dict[str, list[float]] = {}
 _live_request_timestamps: dict[str, list[float]] = {}
@@ -247,6 +257,43 @@ def _build_mock_critiques(
         "contrarian": ["Steel-man the opposing position before dismissing it"],
     }
     return {"issues": issues, "suggestions": suggestions}
+
+
+def _normalize_public_debate_payload(data: dict[str, Any]) -> dict[str, Any]:
+    """Normalize debate payloads to the public handler contract."""
+    critiques = data.get("critiques")
+    if not isinstance(critiques, list):
+        return data
+
+    normalized_critiques: list[dict[str, Any]] = []
+    for critique in critiques:
+        if not isinstance(critique, dict):
+            continue
+
+        target_agent = critique.get("target_agent") or critique.get("target") or ""
+        issues = critique.get("issues")
+        content = str(critique.get("content") or "").strip()
+        if not isinstance(issues, list):
+            issues = [content] if content else []
+
+        suggestions = critique.get("suggestions")
+        if not isinstance(suggestions, list):
+            suggestions = []
+
+        severity = critique.get("severity")
+        if not isinstance(severity, (int, float)):
+            severity = 0.5 if issues else 0.0
+
+        normalized = dict(critique)
+        normalized.pop("target", None)
+        normalized["target_agent"] = target_agent
+        normalized["issues"] = issues
+        normalized["suggestions"] = suggestions
+        normalized["severity"] = severity
+        normalized_critiques.append(normalized)
+
+    data["critiques"] = normalized_critiques
+    return data
 
 
 # Keep static versions for backward compat
@@ -1641,25 +1688,7 @@ class PlaygroundHandler(BaseHandler):
         if path != "/api/v1/playground/debate":
             return None
 
-        # Rate limiting
-        client_ip = "unknown"
-        if handler and hasattr(handler, "client_address"):
-            addr = handler.client_address
-            if isinstance(addr, (list, tuple)) and len(addr) >= 1:
-                client_ip = str(addr[0])
-
-        allowed, retry_after = _check_rate_limit(client_ip)
-        if not allowed:
-            return json_response(
-                {
-                    "error": "Rate limit exceeded. Please try again later.",
-                    "code": "rate_limit_exceeded",
-                    "retry_after": retry_after,
-                },
-                status=429,
-            )
-
-        # Parse body
+        # Parse body early so we can check cache before rate limiting
         body = self.read_json_body(handler) if handler else {}
         if body is None:
             body = {}
@@ -1680,14 +1709,11 @@ class PlaygroundHandler(BaseHandler):
         mode = str(body.get("mode", "") or "").strip() or "consult"
 
         # Source: "oracle" for Oracle page, "landing" for main site, etc.
+        # Controls prompt flavour — Oracle uses tentacle language, landing uses neutral.
         source = str(body.get("source", "") or "").strip() or "oracle"
 
         # Session ID for follow-up conversation memory
         session_id = str(body.get("session_id", "") or "").strip() or None
-
-        # Source: "oracle" for Oracle page, "landing" for main site, etc.
-        # Controls prompt flavour — Oracle uses tentacle language, landing uses neutral.
-        source = str(body.get("source", "") or "").strip() or "oracle"
 
         try:
             rounds = int(body.get("rounds", _DEFAULT_ROUNDS))
@@ -1701,6 +1727,50 @@ class PlaygroundHandler(BaseHandler):
             agent_count = _DEFAULT_AGENTS
         agent_count = max(_MIN_AGENTS, min(agent_count, _MAX_AGENTS))
 
+        # --- Content-addressed cache lookup (before rate limiting) ---
+        cache_key: str | None = None
+        model_ids: list[str] = []
+        try:
+            from aragora.storage.debate_store import get_debate_store, normalize_cache_key
+
+            agent_tags = _get_available_live_agents(agent_count)
+            model_ids = [
+                tag.split(":", 1)[1] if tag.startswith("openrouter:") else tag for tag in agent_tags
+            ]
+            effective_topic = question or topic
+            cache_key = normalize_cache_key(effective_topic, model_ids, rounds)
+
+            store = get_debate_store()
+            cached = store.get_by_cache_key(cache_key)
+            if cached is not None:
+                cached = _normalize_public_debate_payload(cached)
+                cached["cached"] = True
+                cached["cached_at"] = time.time()
+                logger.info("Cache hit for debate key %.12s…", cache_key)
+                return json_response(cached)
+        except (ImportError, RuntimeError, OSError, ValueError):
+            logger.debug("Cache lookup unavailable, proceeding to debate", exc_info=True)
+        except Exception:  # noqa: BLE001
+            logger.debug("Cache lookup failed, proceeding to debate", exc_info=True)
+
+        # Rate limiting (skipped on cache hit above)
+        client_ip = "unknown"
+        if handler and hasattr(handler, "client_address"):
+            addr = handler.client_address
+            if isinstance(addr, (list, tuple)) and len(addr) >= 1:
+                client_ip = str(addr[0])
+
+        allowed, retry_after = _check_rate_limit(client_ip)
+        if not allowed:
+            return json_response(
+                {
+                    "error": "Rate limit exceeded. Please try again later.",
+                    "code": "rate_limit_exceeded",
+                    "retry_after": retry_after,
+                },
+                status=429,
+            )
+
         return self._run_debate(
             topic,
             rounds,
@@ -1709,6 +1779,8 @@ class PlaygroundHandler(BaseHandler):
             mode=mode,
             session_id=session_id,
             source=source,
+            cache_key=cache_key,
+            model_ids=model_ids,
         )
 
     def _run_debate(
@@ -1720,7 +1792,13 @@ class PlaygroundHandler(BaseHandler):
         mode: str = "consult",
         session_id: str | None = None,
         source: str = "oracle",
+        cache_key: str | None = None,
+        model_ids: list[str] | None = None,
     ) -> HandlerResult:
+        _cache_kw: dict[str, Any] = {}
+        if cache_key is not None:
+            _cache_kw = {"cache_key": cache_key, "model_ids": model_ids or [], "rounds": rounds}
+
         if question:
             if source == "oracle":
                 # Oracle mode: try single-agent Oracle response first
@@ -1732,6 +1810,7 @@ class PlaygroundHandler(BaseHandler):
                         json_response(oracle_result),
                         topic,
                         source,
+                        **_cache_kw,
                     )
                 logger.info(
                     "Oracle LLM call failed — returning placeholder instead of irrelevant mock"
@@ -1763,6 +1842,7 @@ class PlaygroundHandler(BaseHandler):
                     ),
                     topic,
                     source,
+                    **_cache_kw,
                 )
             else:
                 # Non-Oracle source (landing, playground, etc.): try multi-perspective tentacles
@@ -1776,40 +1856,38 @@ class PlaygroundHandler(BaseHandler):
                     summary_depth="none",  # no essay context for non-Oracle sources
                 )
                 if tentacle_result:
-                    return self._persist_and_respond(json_response(tentacle_result), topic, source)
-                logger.info("Multi-perspective call failed — falling through to mock debate")
-                # Fall through to mock debate below (no Oracle placeholder for landing)
-        else:
-            # Normal playground: try aragora-debate package
-            try:
-                result = self._run_debate_with_package(
-                    topic, rounds, agent_count, question=question
-                )
-                return self._persist_and_respond(result, topic, source)
-            except ImportError:
-                logger.info("aragora-debate not installed, using inline mock debate")
-            except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError):
-                logger.exception("aragora-debate failed, falling back to inline mock")
+                    return self._persist_and_respond(
+                        json_response(tentacle_result), topic, source, **_cache_kw
+                    )
+                logger.info("Multi-perspective call failed — trying live debate")
 
-        # Last resort: inline mock debate (question-aware when question provided)
+        # Run a real live debate (no mock fallback)
         try:
-            mock_result = _run_inline_mock_debate(topic, rounds, agent_count, question=question)
-            return self._persist_and_respond(
-                json_response(mock_result),
-                topic,
-                source,
+            live_result = self._run_live_debate(question or topic, rounds, agent_count)
+            return self._persist_and_respond(live_result, topic, source, **_cache_kw)
+        except (TimeoutError, ValueError, RuntimeError, OSError) as exc:
+            logger.warning("Live debate failed: %s", exc)
+            return error_response(
+                "Debate temporarily unavailable. Please try again in a moment.",
+                503,
             )
-        except (RuntimeError, ValueError, TypeError, KeyError, AttributeError, OSError):
-            logger.exception("Inline mock debate failed")
-            return error_response("Debate failed unexpectedly", 500)
 
     @staticmethod
     def _persist_and_respond(
         handler_result: HandlerResult,
         topic: str,
         source: str,
+        *,
+        cache_key: str | None = None,
+        model_ids: list[str] | None = None,
+        rounds: int | None = None,
     ) -> HandlerResult:
-        """Persist the debate result and inject share_url into the response."""
+        """Persist the debate result and inject share_url into the response.
+
+        When *cache_key*, *model_ids*, and *rounds* are provided the method
+        also writes a cache index entry so that future identical requests
+        can be served from cache.
+        """
         try:
             from aragora.storage.debate_store import get_debate_store
 
@@ -1818,7 +1896,7 @@ class PlaygroundHandler(BaseHandler):
             if not body_bytes:
                 return handler_result
 
-            data = json.loads(body_bytes.decode("utf-8"))
+            data = _normalize_public_debate_payload(json.loads(body_bytes.decode("utf-8")))
             debate_id = data.get("id", "")
             if debate_id:
                 # Inject share fields and source into data BEFORE persisting
@@ -1829,6 +1907,27 @@ class PlaygroundHandler(BaseHandler):
                 try:
                     store = get_debate_store()
                     store.save(debate_id, topic, data, source=source)
+
+                    # Save cache index so this debate can be found by content hash
+                    if cache_key and model_ids is not None and rounds is not None:
+                        try:
+                            normalized_topic = re.sub(
+                                r"\s+",
+                                " ",
+                                (data.get("topic", topic) or topic).strip().lower(),
+                            )
+                            store.save_cache_index(
+                                cache_key=cache_key,
+                                debate_id=debate_id,
+                                topic_normalized=normalized_topic,
+                                model_ids="|".join(sorted(model_ids)),
+                                rounds=rounds,
+                            )
+                            logger.debug("Saved cache index %.12s… → %s", cache_key, debate_id)
+                        except (RuntimeError, OSError):
+                            logger.debug("Cache index save failed", exc_info=True)
+                        except Exception:  # noqa: BLE001
+                            logger.debug("Cache index save failed unexpectedly", exc_info=True)
                 except (ImportError, RuntimeError, OSError):
                     logger.debug("Debate store unavailable, debate not persisted", exc_info=True)
                 except Exception:  # noqa: BLE001
@@ -2213,37 +2312,64 @@ _live_semaphore = asyncio.Semaphore(_LIVE_MAX_CONCURRENT)
 
 
 def _get_available_live_agents(count: int) -> list[str]:
-    """Pick agent providers that have API keys configured.
+    """Pick agent providers for playground debates.
 
-    With fallback enabled by default, agents whose primary key is
-    missing can still operate via OpenRouter.  We therefore include
-    providers that *either* have a primary key *or* can fall back.
+    Prefers primary API keys when available. Falls back to OpenRouter
+    with diverse models when primary keys are missing. Raises ValueError
+    if not even OPENROUTER_API_KEY is available.
     """
     has_openrouter = bool(_get_api_key("OPENROUTER_API_KEY"))
 
+    # Try primary providers first
     candidates: list[str] = []
     if _get_api_key("ANTHROPIC_API_KEY"):
         candidates.append("anthropic-api")
-    if _get_api_key("OPENAI_API_KEY") or has_openrouter:
+    if _get_api_key("OPENAI_API_KEY"):
         candidates.append("openai-api")
-    if has_openrouter:
-        candidates.append("openrouter")
-    if _get_api_key("MISTRAL_API_KEY") or has_openrouter:
+    if _get_api_key("MISTRAL_API_KEY"):
         candidates.append("mistral-api")
 
-    # De-duplicate while preserving order
-    seen: set[str] = set()
-    unique: list[str] = []
-    for c in candidates:
-        if c not in seen:
-            seen.add(c)
-            unique.append(c)
-    candidates = unique
+    # If we have enough primary agents, use them
+    if len(candidates) >= count:
+        return candidates[:count]
 
-    # Pad to requested count by repeating
+    # Fill remaining slots with OpenRouter models for diversity
+    if has_openrouter:
+        for _role, model in OPENROUTER_PLAYGROUND_MODELS:
+            if len(candidates) >= count:
+                break
+            tag = f"openrouter:{model}"
+            if tag not in candidates:
+                candidates.append(tag)
+        while len(candidates) < count and candidates:
+            candidates.append(candidates[0])
+        return candidates[:count]
+
+    if not candidates:
+        raise ValueError(
+            "No API keys configured. Set OPENROUTER_API_KEY for universal access "
+            "to multiple LLM providers, or set individual provider keys."
+        )
+
     while len(candidates) < count and candidates:
         candidates.append(candidates[0])
     return candidates[:count]
+
+
+def _resolve_playground_agents(agent_tags: list[str]) -> str:
+    """Convert playground agent tags to comma-separated string for DebateFactory.
+
+    Tags like 'openrouter:anthropic/claude-sonnet-4' become 'openrouter/anthropic/claude-sonnet-4'.
+    Tags like 'anthropic-api' pass through unchanged.
+    """
+    resolved = []
+    for tag in agent_tags:
+        if tag.startswith("openrouter:"):
+            model = tag.split(":", 1)[1]
+            resolved.append(f"openrouter/{model}")
+        else:
+            resolved.append(tag)
+    return ",".join(resolved)
 
 
 def start_playground_debate(
@@ -2277,7 +2403,7 @@ def start_playground_debate(
     if len(agents) < 2:
         raise ValueError("At least 2 agent providers with API keys are required")
 
-    agents_str = ",".join(agents)
+    agents_str = _resolve_playground_agents(agents)
 
     def _run() -> dict[str, Any]:
         try:

--- a/aragora/storage/debate_store.py
+++ b/aragora/storage/debate_store.py
@@ -6,8 +6,10 @@ and supporting retrieval via GET /api/v1/playground/debate/{id}.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import re
 import time
 from typing import Any
 
@@ -16,6 +18,14 @@ from aragora.storage.base_store import SQLiteStore
 logger = logging.getLogger(__name__)
 
 _DEFAULT_TTL_DAYS = 30
+
+
+def normalize_cache_key(topic: str, model_ids: list[str], rounds: int) -> str:
+    """Compute a content-addressed cache key for a debate configuration."""
+    normalized_topic = re.sub(r"\s+", " ", topic.strip().lower())
+    sorted_models = "|".join(sorted(model_ids))
+    raw = f"{normalized_topic}|{sorted_models}|{rounds}"
+    return hashlib.sha256(raw.encode()).hexdigest()
 
 
 class DebateResultStore(SQLiteStore):
@@ -37,6 +47,17 @@ class DebateResultStore(SQLiteStore):
             ON debate_results(created_at DESC);
         CREATE INDEX IF NOT EXISTS idx_debate_results_expires
             ON debate_results(expires_at);
+        CREATE TABLE IF NOT EXISTS debate_cache_index (
+            cache_key TEXT PRIMARY KEY,
+            debate_id TEXT NOT NULL,
+            topic_normalized TEXT NOT NULL,
+            model_ids TEXT NOT NULL,
+            rounds INTEGER NOT NULL,
+            created_at REAL NOT NULL,
+            hit_count INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_cache_created
+            ON debate_cache_index(created_at);
     """
 
     def save(
@@ -107,6 +128,64 @@ class DebateResultStore(SQLiteStore):
             }
             for r in rows
         ]
+
+    def save_cache_index(
+        self,
+        cache_key: str,
+        debate_id: str,
+        topic_normalized: str,
+        model_ids: str,
+        rounds: int,
+    ) -> None:
+        """Save a cache index entry mapping a content hash to a debate ID."""
+        now = time.time()
+        with self.connection() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO debate_cache_index
+                    (cache_key, debate_id, topic_normalized, model_ids, rounds, created_at, hit_count)
+                VALUES (?, ?, ?, ?, ?, ?, 0)
+                """,
+                (cache_key, debate_id, topic_normalized, model_ids, rounds, now),
+            )
+
+    def get_by_cache_key(self, cache_key: str) -> dict[str, Any] | None:
+        """Look up a cached debate result by content-addressed key.
+
+        Returns the debate result dict if the cache entry exists and the
+        underlying debate has not expired.  On a cache miss (no index row
+        or expired debate), returns None and cleans up any orphaned index row.
+        On a hit, increments hit_count.
+        """
+        with self.connection() as conn:
+            row = conn.execute(
+                "SELECT debate_id FROM debate_cache_index WHERE cache_key = ?",
+                (cache_key,),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        debate_id = row[0]
+        result = self.get(debate_id)
+
+        if result is None:
+            # Underlying debate expired or missing — clean up orphaned index row
+            with self.connection() as conn:
+                conn.execute(
+                    "DELETE FROM debate_cache_index WHERE cache_key = ?",
+                    (cache_key,),
+                )
+            return None
+
+        # Cache hit — increment counter
+        with self.connection() as conn:
+            conn.execute(
+                "UPDATE debate_cache_index SET hit_count = hit_count + 1 WHERE cache_key = ?",
+                (cache_key,),
+            )
+
+        return result
 
     def cleanup_expired(self) -> int:
         """Delete expired entries. Returns count of deleted rows."""

--- a/tests/cli/test_demo_real.py
+++ b/tests/cli/test_demo_real.py
@@ -1,0 +1,165 @@
+"""Tests for CLI demo with real model support."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+def test_demo_prefers_real_debate_when_openrouter_key_set():
+    """When OPENROUTER_API_KEY is available, demo should run a real debate."""
+    from aragora.cli.demo import main
+
+    args = argparse.Namespace(
+        name=None,
+        topic="Should we use Rust?",
+        list_demos=False,
+        server=False,
+        receipt=None,
+        offline=False,
+    )
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+        with patch("aragora.cli.demo._run_real_demo") as mock_real:
+            mock_real.return_value = None
+            main(args)
+            mock_real.assert_called_once_with("Should we use Rust?", receipt_path=None)
+
+
+def test_demo_passes_receipt_path_to_real_debate():
+    """Real demo path preserves --receipt instead of dropping it."""
+    from aragora.cli.demo import main
+
+    args = argparse.Namespace(
+        name=None,
+        topic="Should we use Rust?",
+        list_demos=False,
+        server=False,
+        receipt="receipt.md",
+        offline=False,
+    )
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+        with patch("aragora.cli.demo._run_real_demo") as mock_real:
+            mock_real.return_value = None
+            main(args)
+            mock_real.assert_called_once_with("Should we use Rust?", receipt_path="receipt.md")
+
+
+def test_demo_offline_flag_uses_mock():
+    """--offline flag should always use mock, even with API keys."""
+    from aragora.cli.demo import main
+
+    args = argparse.Namespace(
+        name=None,
+        topic="test",
+        list_demos=False,
+        server=False,
+        receipt=None,
+        offline=True,
+    )
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "test-key"}):
+        with patch("aragora.cli.demo._run_mock_demo") as mock_fn:
+            mock_fn.return_value = None
+            main(args)
+            mock_fn.assert_called_once()
+
+
+def test_demo_no_keys_falls_back_to_mock():
+    """Without any API keys, fall back to mock with a message."""
+    from aragora.cli.demo import main
+
+    args = argparse.Namespace(
+        name=None,
+        topic="test",
+        list_demos=False,
+        server=False,
+        receipt=None,
+        offline=False,
+    )
+
+    with patch("aragora.cli.demo._has_any_api_key", return_value=False):
+        with patch("aragora.cli.demo._run_mock_demo") as mock_fn:
+            mock_fn.return_value = None
+            main(args)
+            mock_fn.assert_called_once()
+
+
+def test_has_any_api_key_returns_true_for_openrouter():
+    """_has_any_api_key should detect OPENROUTER_API_KEY."""
+    from aragora.cli.demo import _has_any_api_key
+
+    with patch.dict("os.environ", {"OPENROUTER_API_KEY": "sk-or-test"}, clear=False):
+        assert _has_any_api_key() is True
+
+
+def test_has_any_api_key_returns_true_for_anthropic():
+    """_has_any_api_key should detect ANTHROPIC_API_KEY."""
+    from aragora.cli.demo import _has_any_api_key
+
+    with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-test"}, clear=False):
+        assert _has_any_api_key() is True
+
+
+def test_has_any_api_key_returns_false_when_empty():
+    """_has_any_api_key should return False when no keys are set."""
+    from aragora.cli.demo import _has_any_api_key
+
+    env = {
+        "OPENROUTER_API_KEY": "",
+        "ANTHROPIC_API_KEY": "",
+        "OPENAI_API_KEY": "",
+    }
+    with patch.dict("os.environ", env, clear=False):
+        assert _has_any_api_key() is False
+
+
+def test_demo_list_still_works():
+    """--list flag should still list demos regardless of API key state."""
+    from aragora.cli.demo import main
+
+    args = argparse.Namespace(
+        name=None,
+        topic=None,
+        list_demos=True,
+        server=False,
+        receipt=None,
+        offline=False,
+    )
+
+    # Should not raise, and should not try to run any debate
+    with patch("aragora.cli.demo._run_real_demo") as mock_real:
+        with patch("aragora.cli.demo._run_mock_demo") as mock_mock:
+            main(args)
+            mock_real.assert_not_called()
+            mock_mock.assert_not_called()
+
+
+def test_run_real_demo_calls_playground(capsys):
+    """_run_real_demo should call start_playground_debate."""
+    from aragora.cli.demo import _run_real_demo
+
+    mock_result = {
+        "status": "completed",
+        "consensus_reached": True,
+        "confidence": 0.85,
+        "participants": ["analyst", "critic", "synthesizer"],
+        "proposals": {"analyst": "We should use Rust for safety."},
+        "final_answer": "Rust offers memory safety benefits.",
+    }
+
+    # Patch at the source module — _run_real_demo does a lazy import from there
+    with patch(
+        "aragora.server.handlers.playground.start_playground_debate",
+        return_value=mock_result,
+    ):
+        _run_real_demo("Should we use Rust?")
+
+    captured = capsys.readouterr()
+    assert "Real AI Debate" in captured.out
+    assert "Should we use Rust?" in captured.out
+    assert "completed" in captured.out
+    assert "85%" in captured.out

--- a/tests/server/handlers/test_base_handler.py
+++ b/tests/server/handlers/test_base_handler.py
@@ -491,6 +491,7 @@ class TestBaseHandlerJsonParsing:
         handler = BaseHandler({})
         mock_http = MagicMock()
         mock_http.headers = {"Content-Length": "0"}
+        mock_http.rfile = BytesIO(b"")
 
         result = handler.read_json_body(mock_http)
         assert result == {}

--- a/tests/server/handlers/test_playground.py
+++ b/tests/server/handlers/test_playground.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import io
 import json
 import time
+import uuid
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -34,12 +35,61 @@ from aragora.server.handlers.playground import (
 # ===========================================================================
 
 
+def _make_live_debate_response(topic: str = "test", agent_count: int = 3):
+    """Build a mock HandlerResult mimicking _run_live_debate output."""
+    from aragora.server.handlers.base import json_response as _jr
+
+    participants = [f"agent-{i}" for i in range(agent_count)]
+    return _jr(
+        {
+            "id": f"playground_{uuid.uuid4().hex[:8]}",
+            "topic": topic,
+            "status": "completed",
+            "rounds_used": 1,
+            "consensus_reached": True,
+            "confidence": 0.82,
+            "verdict": "consensus",
+            "duration_seconds": 1.5,
+            "participants": participants,
+            "proposals": {p: f"Position from {p}" for p in participants},
+            "critiques": [
+                {"agent": participants[0], "target": participants[1], "content": "Disagree"}
+            ],
+            "votes": [
+                {"agent": p, "choice": participants[0], "confidence": 0.8} for p in participants
+            ],
+            "dissenting_views": [],
+            "final_answer": "The group reached consensus.",
+            "is_live": True,
+            "receipt": {"id": "r1", "hash": "abc123"},
+            "receipt_hash": "abc123",
+            "receipt_preview": {},
+            "upgrade_cta": {},
+        }
+    )
+
+
 @pytest.fixture(autouse=True)
 def clean_rate_limits():
     """Reset rate limit state before each test."""
     _reset_rate_limits()
     yield
     _reset_rate_limits()
+
+
+@pytest.fixture(autouse=True)
+def mock_live_debate():
+    """Patch _run_live_debate so tests don't need real API keys.
+
+    Tests that need to verify live debate behavior can override this
+    by patching _run_live_debate explicitly in the test body.
+    """
+
+    def _side_effect(self, topic, rounds, agent_count):
+        return _make_live_debate_response(topic, agent_count)
+
+    with patch.object(PlaygroundHandler, "_run_live_debate", _side_effect):
+        yield
 
 
 @pytest.fixture
@@ -343,8 +393,14 @@ class TestRateLimiting:
         allowed, _ = _check_rate_limit("192.168.1.4")
         assert allowed is True
 
-    def test_rate_limit_returns_429(self, handler, mock_http_handler):
-        """Handler returns 429 when rate limit is exceeded."""
+    @patch("aragora.storage.debate_store.DebateResultStore.get_by_cache_key", return_value=None)
+    def test_rate_limit_returns_429(self, _mock_cache, handler, mock_http_handler):
+        """Handler returns 429 when rate limit is exceeded.
+
+        Cache is patched to always miss so that every request goes through
+        the rate limiter (cached results intentionally bypass rate limiting).
+        Live debate is already mocked via the autouse mock_live_debate fixture.
+        """
         client_ip = "10.99.99.99"
 
         for _ in range(_PLAYGROUND_RATE_LIMIT):
@@ -377,35 +433,14 @@ class TestRateLimiting:
 
 
 class TestGracefulDegradation:
-    def test_missing_aragora_debate_uses_inline_fallback(self, handler, mock_http_handler):
-        """When aragora-debate is not installed, falls back to inline mock."""
-        h = mock_http_handler({})
-
-        with patch.dict(
-            "sys.modules",
-            {
-                "aragora_debate.styled_mock": None,
-                "aragora_debate.arena": None,
-                "aragora_debate.types": None,
-            },
+    def test_no_live_debate_returns_503(self, handler, mock_http_handler):
+        """When live debate is unavailable, returns 503 instead of mock."""
+        with patch.object(
+            handler,
+            "_run_live_debate",
+            side_effect=RuntimeError("Live debate unavailable"),
         ):
-            # Force the import to fail by patching builtins.__import__
-            original_import = (
-                __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
-            )
-
-            def failing_import(name, *args, **kwargs):
-                if name.startswith("aragora_debate"):
-                    raise ImportError(f"No module named '{name}'")
-                return original_import(name, *args, **kwargs)
-
-            with patch("builtins.__import__", side_effect=failing_import):
-                result = handler._run_debate("test", 1, 2)
-                data, status = _parse_result(result)
-                # Falls back to inline mock instead of returning 503
-                assert status == 200
-                assert "proposals" in data
-                assert "critiques" in data
-                assert "votes" in data
-                assert "receipt" in data
-                assert data["topic"] == "test"
+            result = handler._run_debate("test", 1, 2)
+            data, status = _parse_result(result)
+            assert status == 503
+            assert "unavailable" in data.get("error", "").lower()

--- a/tests/server/handlers/test_playground_cache.py
+++ b/tests/server/handlers/test_playground_cache.py
@@ -1,0 +1,327 @@
+"""Tests for content-addressed debate caching in the playground handler.
+
+Covers:
+- Cache hit returns cached result without running a debate
+- Cache key normalization is consistent for playground topics
+- Cache miss proceeds to debate execution
+- Persist saves cache index after debate completion
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.server.handlers.base import HandlerResult, json_response
+from aragora.storage.debate_store import normalize_cache_key
+
+
+@pytest.fixture()
+def _fake_debate_store(tmp_path, monkeypatch):
+    """Set up a real DebateResultStore backed by a temp directory."""
+    monkeypatch.setenv("ARAGORA_DATA_DIR", str(tmp_path))
+    import aragora.storage.debate_store as mod
+
+    monkeypatch.setattr(mod, "_store", None)
+
+
+@pytest.fixture()
+def handler(_fake_debate_store):
+    from aragora.server.handlers.playground import PlaygroundHandler
+
+    return PlaygroundHandler()
+
+
+def _make_handler_mock(body: dict | None = None) -> MagicMock:
+    """Create a mock HTTP handler with client_address and rfile for body reading."""
+    mock = MagicMock()
+    mock.client_address = ("127.0.0.1", 12345)
+
+    if body is not None:
+        raw = json.dumps(body).encode("utf-8")
+        mock.headers = {"Content-Length": str(len(raw)), "Content-Type": "application/json"}
+        mock.rfile.read.return_value = raw
+    else:
+        mock.headers = {"Content-Length": "2", "Content-Type": "application/json"}
+        mock.rfile.read.return_value = b"{}"
+
+    return mock
+
+
+class TestCacheHitReturnsCachedResult:
+    """When get_by_cache_key returns a result, the handler should return it
+    without running a debate."""
+
+    def test_cache_hit_returns_cached_result(self, handler):
+        """A cached debate is returned immediately without debate execution."""
+        from aragora.storage.debate_store import get_debate_store
+
+        store = get_debate_store()
+
+        # Pre-populate a debate result in the store
+        debate_id = "cachedebate00001"
+        cached_data = {
+            "id": debate_id,
+            "topic": "Should we cache debates?",
+            "status": "completed",
+            "verdict": "yes",
+            "rounds_used": 2,
+        }
+        store.save(debate_id, "Should we cache debates?", cached_data)
+
+        # Create a cache index entry for this topic/model/rounds combo
+        model_ids = ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.0-flash-001"]
+        cache_key = normalize_cache_key("Should we cache debates?", model_ids, 2)
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id=debate_id,
+            topic_normalized="should we cache debates?",
+            model_ids="|".join(sorted(model_ids)),
+            rounds=2,
+        )
+
+        # Mock _get_available_live_agents to return tags matching our model_ids
+        agent_tags = [f"openrouter:{m}" for m in model_ids]
+
+        body = {"topic": "Should we cache debates?", "rounds": 2, "agents": 3}
+        mock_handler = _make_handler_mock(body)
+
+        with (
+            patch(
+                "aragora.server.handlers.playground._get_available_live_agents",
+                return_value=agent_tags,
+            ),
+            patch(
+                "aragora.server.handlers.playground._try_oracle_response",
+                side_effect=AssertionError("Should not be called on cache hit"),
+            ),
+            patch(
+                "aragora.server.handlers.playground._try_oracle_tentacles",
+                side_effect=AssertionError("Should not be called on cache hit"),
+            ),
+            patch(
+                "aragora.server.handlers.playground._run_inline_mock_debate",
+                side_effect=AssertionError("Should not be called on cache hit"),
+            ),
+        ):
+            result = handler.handle_post(
+                "/api/v1/playground/debate",
+                {},
+                mock_handler,
+            )
+
+        assert result is not None
+        assert result.status_code == 200
+        body_out = json.loads(result.body.decode("utf-8"))
+        assert body_out["cached"] is True
+        assert "cached_at" in body_out
+        assert body_out["id"] == debate_id
+
+    def test_cache_hit_skips_rate_limiting(self, handler):
+        """Cached results should be returned even if rate limit would block."""
+        from aragora.storage.debate_store import get_debate_store
+
+        store = get_debate_store()
+
+        debate_id = "ratelimitbypass1"
+        cached_data = {
+            "id": debate_id,
+            "topic": "Rate limit test",
+            "status": "completed",
+        }
+        store.save(debate_id, "Rate limit test", cached_data)
+
+        model_ids = ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.0-flash-001"]
+        cache_key = normalize_cache_key("Rate limit test", model_ids, 2)
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id=debate_id,
+            topic_normalized="rate limit test",
+            model_ids="|".join(sorted(model_ids)),
+            rounds=2,
+        )
+
+        agent_tags = [f"openrouter:{m}" for m in model_ids]
+        body = {"topic": "Rate limit test", "rounds": 2, "agents": 3}
+        mock_handler = _make_handler_mock(body)
+
+        with (
+            patch(
+                "aragora.server.handlers.playground._get_available_live_agents",
+                return_value=agent_tags,
+            ),
+            patch(
+                "aragora.server.handlers.playground._check_rate_limit",
+                return_value=(False, 60.0),  # Rate limited!
+            ),
+        ):
+            result = handler.handle_post(
+                "/api/v1/playground/debate",
+                {},
+                mock_handler,
+            )
+
+        # Should still succeed despite rate limit because cache hit bypasses it
+        assert result is not None
+        assert result.status_code == 200
+        body_out = json.loads(result.body.decode("utf-8"))
+        assert body_out["cached"] is True
+
+
+class TestCacheKeyNormalizationForPlayground:
+    """Verify that topic normalization is consistent with playground inputs."""
+
+    def test_topic_with_extra_whitespace(self):
+        key1 = normalize_cache_key("  Should we   cache debates?  ", ["model-a"], 2)
+        key2 = normalize_cache_key("should we cache debates?", ["model-a"], 2)
+        assert key1 == key2
+
+    def test_topic_case_insensitive(self):
+        key1 = normalize_cache_key("SHOULD WE CACHE", ["model-a"], 2)
+        key2 = normalize_cache_key("should we cache", ["model-a"], 2)
+        assert key1 == key2
+
+    def test_openrouter_prefix_stripped_for_model_ids(self):
+        """The handler strips 'openrouter:' prefix before computing cache key.
+        Models with and without the prefix should match after stripping."""
+        # These are the model IDs that the handler computes
+        model_ids = ["anthropic/claude-sonnet-4", "openai/gpt-4o"]
+        key = normalize_cache_key("test topic", model_ids, 2)
+
+        # Should be a valid SHA-256 hex string
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+
+class TestCacheMissProceedsToDebate:
+    """When the cache has no matching entry, the normal debate flow should run."""
+
+    def test_cache_miss_proceeds_to_debate(self, handler):
+        """On cache miss, the handler falls through to live debate execution."""
+        agent_tags = [
+            "openrouter:anthropic/claude-sonnet-4",
+            "openrouter:openai/gpt-4o",
+            "openrouter:google/gemini-2.0-flash-001",
+        ]
+
+        mock_live_response = json_response(
+            {
+                "id": "newdebate0000001",
+                "topic": "A brand new topic",
+                "status": "completed",
+                "verdict": "interesting",
+                "rounds_used": 2,
+                "consensus_reached": True,
+                "confidence": 0.8,
+                "duration_seconds": 1.0,
+                "participants": ["analyst", "critic", "synthesizer"],
+                "proposals": {},
+                "critiques": [],
+                "votes": [],
+                "dissenting_views": [],
+                "final_answer": "Done.",
+                "is_live": True,
+                "receipt_preview": {},
+                "upgrade_cta": {},
+            }
+        )
+
+        body = {"topic": "A brand new topic", "rounds": 2, "agents": 3}
+        mock_handler = _make_handler_mock(body)
+
+        with (
+            patch(
+                "aragora.server.handlers.playground._get_available_live_agents",
+                return_value=agent_tags,
+            ),
+            patch.object(
+                handler,
+                "_run_live_debate",
+                return_value=mock_live_response,
+            ),
+        ):
+            result = handler.handle_post(
+                "/api/v1/playground/debate",
+                {},
+                mock_handler,
+            )
+
+        assert result is not None
+        assert result.status_code == 200
+        body_out = json.loads(result.body.decode("utf-8"))
+        # Should NOT have cached flag since this was a cache miss
+        assert body_out.get("cached") is not True
+
+
+class TestPersistSavesCacheIndex:
+    """After a debate completes, the cache index should be saved."""
+
+    def test_persist_saves_cache_index(self, handler):
+        """After a debate, _persist_and_respond saves the cache index entry."""
+        from aragora.storage.debate_store import get_debate_store
+
+        debate_data = {
+            "id": "indexed_debate001",
+            "topic": "Cache index test",
+            "verdict": "approved",
+        }
+        original = json_response(debate_data)
+
+        model_ids = ["anthropic/claude-sonnet-4", "openai/gpt-4o"]
+        cache_key = normalize_cache_key("Cache index test", model_ids, 2)
+
+        handler._persist_and_respond(
+            original,
+            "Cache index test",
+            "playground",
+            cache_key=cache_key,
+            model_ids=model_ids,
+            rounds=2,
+        )
+
+        # Verify the cache index was saved
+        store = get_debate_store()
+        cached = store.get_by_cache_key(cache_key)
+        assert cached is not None
+        assert cached["id"] == "indexed_debate001"
+
+    def test_persist_without_cache_params_still_works(self, handler):
+        """When cache_key is not provided, persist works as before (no index saved)."""
+        debate_data = {
+            "id": "no_cache_debate01",
+            "topic": "No cache params",
+            "verdict": "fine",
+        }
+        original = json_response(debate_data)
+
+        # Call without cache params — should not raise
+        result = handler._persist_and_respond(original, "No cache params", "playground")
+        assert result.status_code == 200
+
+    def test_cache_index_error_does_not_crash_persist(self, handler):
+        """If saving the cache index fails, the debate result is still returned."""
+        debate_data = {
+            "id": "resilient_debate1",
+            "topic": "Resilience test",
+            "verdict": "ok",
+        }
+        original = json_response(debate_data)
+
+        with patch(
+            "aragora.storage.debate_store.DebateResultStore.save_cache_index",
+            side_effect=RuntimeError("DB locked"),
+        ):
+            result = handler._persist_and_respond(
+                original,
+                "Resilience test",
+                "playground",
+                cache_key="fake_key",
+                model_ids=["m1"],
+                rounds=2,
+            )
+
+        assert result.status_code == 200
+        body = json.loads(result.body.decode("utf-8"))
+        assert body["id"] == "resilient_debate1"

--- a/tests/server/handlers/test_playground_e2e_cache.py
+++ b/tests/server/handlers/test_playground_e2e_cache.py
@@ -1,0 +1,146 @@
+"""Integration test: playground debate caching end-to-end."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.storage.debate_store import DebateResultStore, normalize_cache_key
+
+
+@pytest.fixture()
+def store(tmp_path):
+    return DebateResultStore(str(tmp_path / "e2e_debates.db"))
+
+
+def test_same_topic_returns_cached_after_first_run(store):
+    """First call stores result; second call returns cached."""
+    topic = "Should we use Rust?"
+    models = ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.0-flash-001"]
+    rounds = 2
+
+    debate_result = {
+        "id": "first_run_abc",
+        "topic": topic,
+        "status": "completed",
+        "consensus_reached": True,
+        "confidence": 0.85,
+        "participants": ["analyst", "critic", "synthesizer"],
+        "proposals": {"analyst": "Use Rust for perf-critical paths"},
+        "final_answer": "Conditional yes",
+    }
+
+    cache_key = normalize_cache_key(topic, models, rounds)
+
+    # Simulate first debate: save result + cache index
+    store.save("first_run_abc", topic, debate_result)
+    store.save_cache_index(
+        cache_key, "first_run_abc", topic.lower(), "|".join(sorted(models)), rounds
+    )
+
+    # Second lookup should return cached
+    cached = store.get_by_cache_key(cache_key)
+    assert cached is not None
+    assert cached["id"] == "first_run_abc"
+    assert cached["status"] == "completed"
+    assert cached["consensus_reached"] is True
+
+
+def test_different_topic_is_cache_miss(store):
+    """Different topics produce different cache keys."""
+    topic1 = "Should we use Rust?"
+    topic2 = "Should we use Go?"
+    models = ["model-a"]
+
+    key1 = normalize_cache_key(topic1, models, 1)
+    key2 = normalize_cache_key(topic2, models, 1)
+
+    store.save("debate1", topic1, {"id": "debate1", "topic": topic1})
+    store.save_cache_index(key1, "debate1", topic1.lower(), "model-a", 1)
+
+    assert store.get_by_cache_key(key1) is not None
+    assert store.get_by_cache_key(key2) is None
+
+
+def test_different_models_is_cache_miss(store):
+    """Same topic with different models is a different cache key."""
+    topic = "Should we use Rust?"
+    models_a = ["model-a", "model-b"]
+    models_b = ["model-a", "model-c"]
+
+    key_a = normalize_cache_key(topic, models_a, 1)
+    key_b = normalize_cache_key(topic, models_b, 1)
+
+    store.save("d1", topic, {"id": "d1"})
+    store.save_cache_index(key_a, "d1", topic.lower(), "|".join(sorted(models_a)), 1)
+
+    assert store.get_by_cache_key(key_a) is not None
+    assert store.get_by_cache_key(key_b) is None
+
+
+def test_different_rounds_is_cache_miss(store):
+    """Same topic and models but different rounds is a different key."""
+    topic = "topic"
+    models = ["model-a"]
+
+    key1 = normalize_cache_key(topic, models, 1)
+    key2 = normalize_cache_key(topic, models, 2)
+
+    store.save("d1", topic, {"id": "d1"})
+    store.save_cache_index(key1, "d1", topic.lower(), "model-a", 1)
+
+    assert store.get_by_cache_key(key1) is not None
+    assert store.get_by_cache_key(key2) is None
+
+
+def test_cache_survives_whitespace_and_case_variation(store):
+    """Cache hit even with different whitespace/casing on topic."""
+    topic_original = "Should We Use Rust?"
+    topic_variant = "  should   we   use   rust?  "
+    models = ["m-a", "m-b"]
+    rounds = 1
+
+    key_original = normalize_cache_key(topic_original, models, rounds)
+    key_variant = normalize_cache_key(topic_variant, models, rounds)
+    assert key_original == key_variant
+
+    store.save("d1", topic_original, {"id": "d1", "topic": topic_original})
+    store.save_cache_index(
+        key_original, "d1", "should we use rust?", "|".join(sorted(models)), rounds
+    )
+
+    cached = store.get_by_cache_key(key_variant)
+    assert cached is not None
+    assert cached["id"] == "d1"
+
+
+def test_expired_debate_is_cache_miss(store):
+    """Expired debate results should not be returned from cache."""
+    topic = "expired topic"
+    models = ["m"]
+    key = normalize_cache_key(topic, models, 1)
+
+    store.save("exp1", topic, {"id": "exp1"}, ttl_days=0)  # expires immediately
+    store.save_cache_index(key, "exp1", topic, "m", 1)
+
+    # Should be None because the underlying debate expired
+    assert store.get_by_cache_key(key) is None
+
+
+def test_hit_count_increments(store):
+    """Multiple cache hits increment the counter."""
+    topic = "counting"
+    models = ["m"]
+    key = normalize_cache_key(topic, models, 1)
+
+    store.save("c1", topic, {"id": "c1"})
+    store.save_cache_index(key, "c1", topic, "m", 1)
+
+    for _ in range(5):
+        store.get_by_cache_key(key)
+
+    with store.connection() as conn:
+        row = conn.execute(
+            "SELECT hit_count FROM debate_cache_index WHERE cache_key = ?",
+            (key,),
+        ).fetchone()
+    assert row[0] == 5

--- a/tests/server/handlers/test_playground_openrouter_agents.py
+++ b/tests/server/handlers/test_playground_openrouter_agents.py
@@ -1,0 +1,227 @@
+"""Tests for OpenRouter universal fallback in playground agent selection.
+
+Covers:
+- Only OPENROUTER_API_KEY set -> returns 3+ diverse agents via OpenRouter models
+- All primary keys set -> returns primary providers
+- No keys at all -> raises ValueError mentioning OPENROUTER_API_KEY
+- Mix of primary + OpenRouter -> primary first, OpenRouter fills remaining
+- _resolve_playground_agents converts tags correctly
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from aragora.server.handlers.playground import (
+    OPENROUTER_PLAYGROUND_MODELS,
+    _get_available_live_agents,
+    _resolve_playground_agents,
+)
+
+
+def _make_key_lookup(keys: dict[str, str | None]):
+    """Return a side_effect function for _get_api_key that uses the given dict."""
+
+    def _lookup(name: str) -> str | None:
+        return keys.get(name)
+
+    return _lookup
+
+
+# ---------------------------------------------------------------------------
+# _get_available_live_agents
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableLiveAgentsOpenRouterOnly:
+    """When only OPENROUTER_API_KEY is set."""
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_returns_diverse_openrouter_agents(self, mock_key):
+        mock_key.side_effect = _make_key_lookup({"OPENROUTER_API_KEY": "or-key"})
+        agents = _get_available_live_agents(3)
+
+        assert len(agents) == 3
+        assert all(a.startswith("openrouter:") for a in agents)
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_agents_use_different_models(self, mock_key):
+        mock_key.side_effect = _make_key_lookup({"OPENROUTER_API_KEY": "or-key"})
+        agents = _get_available_live_agents(3)
+
+        models = [a.split(":", 1)[1] for a in agents]
+        assert len(set(models)) == 3, "All 3 agents should use different models"
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_can_provide_up_to_five(self, mock_key):
+        mock_key.side_effect = _make_key_lookup({"OPENROUTER_API_KEY": "or-key"})
+        agents = _get_available_live_agents(5)
+
+        assert len(agents) == 5
+        models = [a.split(":", 1)[1] for a in agents]
+        assert len(set(models)) == 5, "All 5 agents should use different models"
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_models_match_constant(self, mock_key):
+        mock_key.side_effect = _make_key_lookup({"OPENROUTER_API_KEY": "or-key"})
+        agents = _get_available_live_agents(5)
+
+        expected_models = [model for _role, model in OPENROUTER_PLAYGROUND_MODELS]
+        actual_models = [a.split(":", 1)[1] for a in agents]
+        assert actual_models == expected_models
+
+
+class TestGetAvailableLiveAgentsAllPrimary:
+    """When all primary API keys are set."""
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_returns_primary_providers(self, mock_key):
+        mock_key.side_effect = _make_key_lookup(
+            {
+                "ANTHROPIC_API_KEY": "ant-key",
+                "OPENAI_API_KEY": "oai-key",
+                "MISTRAL_API_KEY": "mis-key",
+                "OPENROUTER_API_KEY": "or-key",
+            }
+        )
+        agents = _get_available_live_agents(3)
+
+        assert agents == ["anthropic-api", "openai-api", "mistral-api"]
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_no_openrouter_tags_when_primary_sufficient(self, mock_key):
+        mock_key.side_effect = _make_key_lookup(
+            {
+                "ANTHROPIC_API_KEY": "ant-key",
+                "OPENAI_API_KEY": "oai-key",
+                "MISTRAL_API_KEY": "mis-key",
+            }
+        )
+        agents = _get_available_live_agents(3)
+
+        assert not any(a.startswith("openrouter:") for a in agents)
+
+
+class TestGetAvailableLiveAgentsNoKeys:
+    """When no API keys are set at all."""
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_raises_value_error(self, mock_key):
+        mock_key.return_value = None
+        with pytest.raises(ValueError, match="OPENROUTER_API_KEY"):
+            _get_available_live_agents(3)
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_error_message_mentions_universal_access(self, mock_key):
+        mock_key.return_value = None
+        with pytest.raises(ValueError, match="universal access"):
+            _get_available_live_agents(3)
+
+
+class TestGetAvailableLiveAgentsMixed:
+    """When some primary keys + OpenRouter are available."""
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_primary_first_then_openrouter(self, mock_key):
+        mock_key.side_effect = _make_key_lookup(
+            {
+                "ANTHROPIC_API_KEY": "ant-key",
+                "OPENROUTER_API_KEY": "or-key",
+            }
+        )
+        agents = _get_available_live_agents(3)
+
+        assert len(agents) == 3
+        assert agents[0] == "anthropic-api"
+        assert agents[1].startswith("openrouter:")
+        assert agents[2].startswith("openrouter:")
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_openrouter_fills_remaining_with_diverse_models(self, mock_key):
+        mock_key.side_effect = _make_key_lookup(
+            {
+                "OPENAI_API_KEY": "oai-key",
+                "OPENROUTER_API_KEY": "or-key",
+            }
+        )
+        agents = _get_available_live_agents(4)
+
+        assert len(agents) == 4
+        assert agents[0] == "openai-api"
+        or_agents = [a for a in agents if a.startswith("openrouter:")]
+        assert len(or_agents) == 3
+        or_models = [a.split(":", 1)[1] for a in or_agents]
+        assert len(set(or_models)) == 3, "OpenRouter slots should use different models"
+
+    @patch("aragora.server.handlers.playground._get_api_key")
+    def test_single_primary_padded_without_openrouter(self, mock_key):
+        """One primary key, no OpenRouter -> pads by repeating."""
+        mock_key.side_effect = _make_key_lookup(
+            {
+                "ANTHROPIC_API_KEY": "ant-key",
+            }
+        )
+        agents = _get_available_live_agents(3)
+
+        assert len(agents) == 3
+        assert all(a == "anthropic-api" for a in agents)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_playground_agents
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePlaygroundAgents:
+    """Verify tag-to-string conversion for DebateFactory."""
+
+    def test_openrouter_tags_converted(self):
+        tags = [
+            "openrouter:anthropic/claude-sonnet-4",
+            "openrouter:openai/gpt-4o",
+            "openrouter:google/gemini-2.0-flash-001",
+        ]
+        result = _resolve_playground_agents(tags)
+        expected = (
+            "openrouter/anthropic/claude-sonnet-4,"
+            "openrouter/openai/gpt-4o,"
+            "openrouter/google/gemini-2.0-flash-001"
+        )
+        assert result == expected
+
+    def test_primary_tags_pass_through(self):
+        tags = ["anthropic-api", "openai-api", "mistral-api"]
+        result = _resolve_playground_agents(tags)
+        assert result == "anthropic-api,openai-api,mistral-api"
+
+    def test_mixed_tags(self):
+        tags = ["anthropic-api", "openrouter:openai/gpt-4o", "openrouter:deepseek/deepseek-chat"]
+        result = _resolve_playground_agents(tags)
+        assert result == "anthropic-api,openrouter/openai/gpt-4o,openrouter/deepseek/deepseek-chat"
+
+    def test_empty_list(self):
+        assert _resolve_playground_agents([]) == ""
+
+
+# ---------------------------------------------------------------------------
+# OPENROUTER_PLAYGROUND_MODELS constant
+# ---------------------------------------------------------------------------
+
+
+class TestOpenRouterPlaygroundModels:
+    """Verify the constant has expected structure."""
+
+    def test_has_at_least_three_models(self):
+        assert len(OPENROUTER_PLAYGROUND_MODELS) >= 3
+
+    def test_each_entry_is_role_model_tuple(self):
+        for role, model in OPENROUTER_PLAYGROUND_MODELS:
+            assert isinstance(role, str)
+            assert isinstance(model, str)
+            assert "/" in model, f"Model {model} should contain provider/name format"
+
+    def test_all_models_unique(self):
+        models = [model for _role, model in OPENROUTER_PLAYGROUND_MODELS]
+        assert len(models) == len(set(models)), "All models should be unique"

--- a/tests/server/handlers/test_playground_share_token.py
+++ b/tests/server/handlers/test_playground_share_token.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +17,38 @@ def _clean_rate_limits():
     _reset_rate_limits()
     yield
     _reset_rate_limits()
+
+
+@pytest.fixture(autouse=True)
+def _mock_live_debate():
+    """Patch _run_live_debate so tests don't need real API keys."""
+
+    def _side_effect(self, topic, rounds, agent_count):
+        participants = [f"agent-{i}" for i in range(agent_count)]
+        return json_response(
+            {
+                "id": f"playground_{uuid.uuid4().hex[:8]}",
+                "topic": topic,
+                "status": "completed",
+                "rounds_used": 1,
+                "consensus_reached": True,
+                "confidence": 0.82,
+                "verdict": "consensus",
+                "duration_seconds": 1.5,
+                "participants": participants,
+                "proposals": {p: f"Position from {p}" for p in participants},
+                "critiques": [],
+                "votes": [],
+                "dissenting_views": [],
+                "final_answer": "Consensus reached.",
+                "is_live": True,
+                "receipt_preview": {},
+                "upgrade_cta": {},
+            }
+        )
+
+    with patch.object(PlaygroundHandler, "_run_live_debate", _side_effect):
+        yield
 
 
 @pytest.fixture()

--- a/tests/server/handlers/test_read_json_body_chunked.py
+++ b/tests/server/handlers/test_read_json_body_chunked.py
@@ -1,0 +1,126 @@
+"""Tests for read_json_body handling missing Content-Length and chunked encoding.
+
+Covers Cloudflare HTTP/2 -> HTTP/1.1 proxy scenarios where Content-Length
+may be absent or zero even though the request body contains data.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture()
+def handler_base():
+    """Create a minimal BaseHandler instance for testing."""
+    from aragora.server.handlers.base import BaseHandler
+
+    return BaseHandler(server_context={})
+
+
+def _make_handler(body: bytes, headers: dict[str, str]) -> SimpleNamespace:
+    """Build a fake HTTP handler with rfile and headers."""
+    return SimpleNamespace(
+        rfile=io.BytesIO(body),
+        headers=headers,
+    )
+
+
+class TestReadJsonBodyChunked:
+    """Test read_json_body with various Content-Length / Transfer-Encoding scenarios."""
+
+    def test_normal_content_length(self, handler_base):
+        """Normal case: Content-Length present and correct -> parses JSON."""
+        payload = {"username": "alice", "password": "secret"}
+        body = json.dumps(payload).encode()
+        handler = _make_handler(body, {"Content-Length": str(len(body))})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == payload
+
+    def test_missing_content_length(self, handler_base):
+        """Missing Content-Length: body exists but CL absent -> should still parse."""
+        payload = {"email": "bob@example.com"}
+        body = json.dumps(payload).encode()
+        # No Content-Length header at all
+        handler = _make_handler(body, {})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == payload
+
+    def test_content_length_zero_but_body_exists(self, handler_base):
+        """Cloudflare scenario: CL=0 but body has data -> should still parse."""
+        payload = {"action": "register", "name": "Charlie"}
+        body = json.dumps(payload).encode()
+        handler = _make_handler(body, {"Content-Length": "0"})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == payload
+
+    def test_transfer_encoding_chunked(self, handler_base):
+        """Transfer-Encoding: chunked -> should read and parse body."""
+        payload = {"stream": True, "data": [1, 2, 3]}
+        body = json.dumps(payload).encode()
+        handler = _make_handler(
+            body,
+            {"Transfer-Encoding": "chunked", "Content-Length": "0"},
+        )
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == payload
+
+    def test_empty_body_with_cl_zero(self, handler_base):
+        """Empty body with CL=0 -> returns empty dict."""
+        handler = _make_handler(b"", {"Content-Length": "0"})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == {}
+
+    def test_empty_body_no_headers(self, handler_base):
+        """Truly empty body with no Content-Length -> returns empty dict."""
+        handler = _make_handler(b"", {})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result == {}
+
+    def test_invalid_json(self, handler_base):
+        """Invalid JSON body -> returns None."""
+        body = b"not valid json {{"
+        handler = _make_handler(body, {"Content-Length": str(len(body))})
+
+        result = handler_base.read_json_body(handler)
+
+        assert result is None
+
+    def test_body_exceeds_max_size(self, handler_base):
+        """Body larger than max_size -> returns None."""
+        payload = {"big": "x" * 200}
+        body = json.dumps(payload).encode()
+        handler = _make_handler(body, {"Content-Length": str(len(body))})
+
+        result = handler_base.read_json_body(handler, max_size=50)
+
+        assert result is None
+
+    def test_chunked_body_exceeds_max_size(self, handler_base):
+        """Chunked body that exceeds max_size after read -> returns None."""
+        payload = {"big": "x" * 200}
+        body = json.dumps(payload).encode()
+        handler = _make_handler(
+            body,
+            {"Transfer-Encoding": "chunked"},
+        )
+
+        result = handler_base.read_json_body(handler, max_size=50)
+
+        # Should return None because the read body exceeds max_size
+        assert result is None

--- a/tests/storage/test_debate_cache_index.py
+++ b/tests/storage/test_debate_cache_index.py
@@ -1,0 +1,159 @@
+"""Tests for content-addressed debate cache index."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from aragora.storage.debate_store import DebateResultStore, normalize_cache_key
+
+
+@pytest.fixture()
+def store(tmp_path, monkeypatch):
+    """Create a fresh DebateResultStore backed by a temp directory."""
+    monkeypatch.setenv("ARAGORA_DATA_DIR", str(tmp_path))
+    return DebateResultStore("test_debate_cache.db")
+
+
+class TestNormalizeCacheKey:
+    def test_strips_and_lowercases(self):
+        key1 = normalize_cache_key("  Hello World  ", ["model-a"], 3)
+        key2 = normalize_cache_key("hello world", ["model-a"], 3)
+        assert key1 == key2
+
+    def test_collapses_whitespace(self):
+        key1 = normalize_cache_key("hello   world", ["model-a"], 3)
+        key2 = normalize_cache_key("hello world", ["model-a"], 3)
+        assert key1 == key2
+
+    def test_different_topics_differ(self):
+        key1 = normalize_cache_key("topic one", ["model-a"], 3)
+        key2 = normalize_cache_key("topic two", ["model-a"], 3)
+        assert key1 != key2
+
+    def test_different_models_differ(self):
+        key1 = normalize_cache_key("topic", ["model-a"], 3)
+        key2 = normalize_cache_key("topic", ["model-b"], 3)
+        assert key1 != key2
+
+    def test_different_rounds_differ(self):
+        key1 = normalize_cache_key("topic", ["model-a"], 3)
+        key2 = normalize_cache_key("topic", ["model-a"], 5)
+        assert key1 != key2
+
+    def test_model_order_does_not_matter(self):
+        key1 = normalize_cache_key("topic", ["model-b", "model-a"], 3)
+        key2 = normalize_cache_key("topic", ["model-a", "model-b"], 3)
+        assert key1 == key2
+
+    def test_returns_hex_string(self):
+        key = normalize_cache_key("topic", ["model-a"], 3)
+        assert isinstance(key, str)
+        # SHA-256 hex digest is 64 characters
+        assert len(key) == 64
+        assert all(c in "0123456789abcdef" for c in key)
+
+
+class TestCacheIndex:
+    def test_save_and_get_round_trip(self, store):
+        result = {"topic": "Cache test", "rounds": [{"round": 1}], "id": "d1"}
+        store.save("d1", "Cache test", result)
+
+        cache_key = normalize_cache_key("Cache test", ["model-a", "model-b"], 3)
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id="d1",
+            topic_normalized="cache test",
+            model_ids="model-a|model-b",
+            rounds=3,
+        )
+
+        cached = store.get_by_cache_key(cache_key)
+        assert cached is not None
+        assert cached["topic"] == "Cache test"
+        assert cached["id"] == "d1"
+
+    def test_get_by_cache_key_returns_none_on_miss(self, store):
+        result = store.get_by_cache_key("nonexistent_key_abc123")
+        assert result is None
+
+    def test_expired_debate_returns_cache_miss(self, store):
+        result = {"topic": "Expiring", "id": "exp1"}
+        store.save("exp1", "Expiring", result, ttl_days=0)
+
+        cache_key = normalize_cache_key("Expiring", ["model-a"], 3)
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id="exp1",
+            topic_normalized="expiring",
+            model_ids="model-a",
+            rounds=3,
+        )
+
+        time.sleep(0.01)
+        cached = store.get_by_cache_key(cache_key)
+        assert cached is None
+
+        # Orphaned index row should be cleaned up
+        with store.connection() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM debate_cache_index WHERE cache_key = ?",
+                (cache_key,),
+            ).fetchone()
+        assert row is None
+
+    def test_hit_count_increments(self, store):
+        result = {"topic": "Hits", "id": "h1"}
+        store.save("h1", "Hits", result)
+
+        cache_key = normalize_cache_key("Hits", ["model-a"], 3)
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id="h1",
+            topic_normalized="hits",
+            model_ids="model-a",
+            rounds=3,
+        )
+
+        # First access
+        store.get_by_cache_key(cache_key)
+        # Second access
+        store.get_by_cache_key(cache_key)
+        # Third access
+        store.get_by_cache_key(cache_key)
+
+        with store.connection() as conn:
+            row = conn.execute(
+                "SELECT hit_count FROM debate_cache_index WHERE cache_key = ?",
+                (cache_key,),
+            ).fetchone()
+        assert row is not None
+        assert row[0] == 3
+
+    def test_save_cache_index_replaces_existing(self, store):
+        result1 = {"topic": "V1", "id": "v1"}
+        result2 = {"topic": "V2", "id": "v2"}
+        store.save("v1", "V1", result1)
+        store.save("v2", "V2", result2)
+
+        cache_key = normalize_cache_key("Same topic", ["model-a"], 3)
+
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id="v1",
+            topic_normalized="same topic",
+            model_ids="model-a",
+            rounds=3,
+        )
+        store.save_cache_index(
+            cache_key=cache_key,
+            debate_id="v2",
+            topic_normalized="same topic",
+            model_ids="model-a",
+            rounds=3,
+        )
+
+        cached = store.get_by_cache_key(cache_key)
+        assert cached is not None
+        assert cached["id"] == "v2"


### PR DESCRIPTION
## Summary
- rebuild the real-debates playground lane on top of current `main`
- add content-addressed debate caching and chunked JSON body support
- preserve live demo receipt output and normalize critique payloads to the public handler contract

## Validation
- `python -m ruff check aragora/cli/demo.py aragora/cli/parser.py aragora/server/handlers/base.py aragora/server/handlers/playground.py aragora/storage/debate_store.py tests/cli/test_demo_real.py tests/server/handlers/test_base_handler.py tests/server/handlers/test_playground.py tests/server/handlers/test_playground_cache.py tests/server/handlers/test_playground_e2e_cache.py tests/server/handlers/test_playground_openrouter_agents.py tests/server/handlers/test_playground_share_token.py tests/server/handlers/test_read_json_body_chunked.py tests/storage/test_debate_cache_index.py`
- `pytest -q tests/cli/test_demo_real.py tests/server/handlers/test_playground.py tests/server/handlers/test_playground_cache.py tests/server/handlers/test_playground_e2e_cache.py tests/server/handlers/test_playground_openrouter_agents.py tests/server/handlers/test_playground_share_token.py tests/server/handlers/test_read_json_body_chunked.py tests/storage/test_debate_cache_index.py`
- `pytest -q tests/server/handlers/test_base_handler.py tests/server/handlers/test_playground_persistence.py`

Supersedes #762.