### PR TITLE
fix(ci): stabilize production smoke and stale-run GC

### DIFF
--- a/.github/workflows/pr-stale-run-gc.yml
+++ b/.github/workflows/pr-stale-run-gc.yml
@@ -40,6 +40,29 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::Standard recovery failed; attempting archive restore"
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
+          fi
+          if [[ ! -f pyproject.toml ]] || [[ ! -f .github/actions/setup-python-safe/action.yml ]]; then
+            echo "::error::Repository checkout is incomplete (missing pyproject.toml or .github/actions/setup-python-safe/action.yml)"
+            echo "PWD=$(pwd)"
+            ls -la
+            ls -la .github/actions || true
+            exit 1
+          fi
+
       - name: Set up Python
         uses: ./.github/actions/setup-python-safe
         with:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -27,18 +27,20 @@ jobs:
         env:
           API_URL: ${{ vars.PRODUCTION_API_URL || 'https://api.aragora.ai' }}
 
-      - name: Check playground endpoint
+      - name: Check playground status endpoint
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            --max-time 15 \
-            -X POST \
-            -H "Content-Type: application/json" \
-            -d '{"topic":"health check","rounds":1,"agents":2,"source":"ci"}' \
-            "${API_URL}/api/v1/playground/debate" || echo "000")
-          echo "Playground status: $STATUS"
-          # 200 or 429 (rate limited) are both "alive" signals
-          if [ "$STATUS" != "200" ] && [ "$STATUS" != "429" ]; then
-            echo "::error::Playground endpoint failed (status=$STATUS)"
+          STATUS=$(curl -sS -o /tmp/playground-status.json -w "%{http_code}" \
+            --max-time 10 \
+            "${API_URL}/api/v1/playground/status" || echo "000")
+          echo "Playground status endpoint: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "::error::Playground status endpoint failed (status=$STATUS)"
+            [ -f /tmp/playground-status.json ] && cat /tmp/playground-status.json
+            exit 1
+          fi
+          if ! grep -q '"status"[[:space:]]*:[[:space:]]*"ok"' /tmp/playground-status.json; then
+            echo "::error::Playground status payload missing expected ok marker"
+            cat /tmp/playground-status.json
             exit 1
           fi
         env:


### PR DESCRIPTION
## Summary
- switch production smoke from a real playground debate POST to the lightweight playground status endpoint
- add checkout-integrity recovery to stale-run GC before it calls the local setup-python-safe action

## Validation
- python YAML parse of both workflow files
- python3 scripts/check_workflow_pip_install_policy.py
