### PR TITLE
fix(ci): repair lint workflow false failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,9 +85,10 @@ jobs:
 
       - name: Verify checkout integrity
         shell: bash
+        working-directory: .
         run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+          if [[ ! -f pyproject.toml ]] || [[ ! -f aragora/live/package.json ]]; then
+            echo "::warning::Frontend checkout incomplete after checkout; attempting recovery"
             git reset --hard || true
             git clean -ffdx || true
             git sparse-checkout disable || true
@@ -100,17 +101,18 @@ jobs:
             fi
             git clean -ffdx || true
           fi
-          if [[ ! -f pyproject.toml ]]; then
+          if [[ ! -f pyproject.toml ]] || [[ ! -f aragora/live/package.json ]]; then
             echo "::warning::Sparse-checkout recovery incomplete; attempting archive restore"
             find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
             if ! git archive "${GITHUB_SHA:-HEAD}" | tar -x; then
               git archive HEAD | tar -x
             fi
           fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+          if [[ ! -f pyproject.toml ]] || [[ ! -f aragora/live/package.json ]]; then
+            echo "::error::Repository checkout is incomplete (missing pyproject.toml or aragora/live/package.json)"
             echo "PWD=$(pwd)"
             ls -la
+            ls -la aragora/live || true
             exit 1
           fi
 
@@ -859,23 +861,7 @@ jobs:
 
       - name: Count TODOs and enforce baseline
         run: |
-          CURRENT=$(python3 - <<'PY'
-          from pathlib import Path
-          import re
-
-          root = Path("aragora")
-          pattern = re.compile(r"^\s*#\s*(TODO|FIXME|HACK|XXX)\b", re.IGNORECASE)
-          count = 0
-          for path in root.rglob("*.py"):
-              try:
-                  for line in path.read_text(encoding="utf-8", errors="ignore").splitlines():
-                      if pattern.search(line):
-                          count += 1
-              except OSError:
-                  pass
-          print(count)
-          PY
-          )
+          CURRENT=$(python3 scripts/todo_audit.py --mode count --root aragora)
           BASELINE=$(cat aragora/.todo_baseline 2>/dev/null || echo 50)
           THRESHOLD=1  # Allow only 1 new TODO (tightened Feb 2026)
 
@@ -888,24 +874,7 @@ jobs:
             echo "::error::Exceeds threshold of $THRESHOLD new TODOs"
             echo ""
             echo "New TODOs found:"
-            python3 - <<'PY'
-            from pathlib import Path
-            import re
-
-            root = Path("aragora")
-            pattern = re.compile(r"^\s*#\s*(TODO|FIXME|HACK|XXX)\b", re.IGNORECASE)
-            shown = 0
-            for path in sorted(root.rglob("*.py")):
-                try:
-                    for idx, line in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
-                        if pattern.search(line):
-                            print(f"{path}:{idx}:{line.strip()}")
-                            shown += 1
-                            if shown >= 20:
-                                raise SystemExit
-                except OSError:
-                    continue
-            PY
+            python3 scripts/todo_audit.py --mode list --root aragora --limit 20
             echo ""
             echo "Please resolve existing TODOs before adding new ones,"
             echo "or update aragora/.todo_baseline if increase is intentional."

--- a/scripts/todo_audit.py
+++ b/scripts/todo_audit.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+MARKER_RE = re.compile(r"^\s*#\s*(TODO|FIXME|HACK|XXX)\b", re.IGNORECASE)
+
+
+def iter_markers(root: Path) -> list[tuple[Path, int, str]]:
+    markers: list[tuple[Path, int, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        try:
+            lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
+        except OSError:
+            continue
+        for idx, line in enumerate(lines, 1):
+            if MARKER_RE.search(line):
+                markers.append((path, idx, line.strip()))
+    return markers
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Count or list Python comment TODO/FIXME/HACK/XXX markers."
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("count", "list"),
+        required=True,
+        help="Whether to print the marker count or matching lines.",
+    )
+    parser.add_argument(
+        "--root",
+        default="aragora",
+        help="Root directory to scan for Python files.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Maximum number of list results to print.",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    markers = iter_markers(Path(args.root))
+    if args.mode == "count":
+        print(len(markers))
+        return 0
+    for path, line_no, content in markers[: args.limit]:
+        print(f"{path}:{line_no}:{content}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_todo_audit.py
+++ b/tests/scripts/test_todo_audit.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.todo_audit import iter_markers, main
+
+
+def test_iter_markers_counts_comment_markers_only(tmp_path: Path) -> None:
+    root = tmp_path / "aragora"
+    root.mkdir()
+    (root / "one.py").write_text(
+        "# TODO: keep me\ntext = 'TODO in string should not count'\n  # FIXME later\n",
+        encoding="utf-8",
+    )
+    (root / "two.py").write_text(
+        "def noop():\n    return '# HACK in string should not count'\n# XXX final marker\n",
+        encoding="utf-8",
+    )
+    (root / "notes.txt").write_text("# TODO in txt should not count\n", encoding="utf-8")
+
+    markers = iter_markers(root)
+
+    assert [(path.name, line_no, content) for path, line_no, content in markers] == [
+        ("one.py", 1, "# TODO: keep me"),
+        ("one.py", 3, "# FIXME later"),
+        ("two.py", 3, "# XXX final marker"),
+    ]
+
+
+def test_main_list_respects_limit(tmp_path: Path, capsys: object, monkeypatch: object) -> None:
+    root = tmp_path / "aragora"
+    root.mkdir()
+    (root / "a.py").write_text("# TODO first\n", encoding="utf-8")
+    (root / "b.py").write_text("# FIXME second\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["todo_audit.py", "--mode", "list", "--root", str(root), "--limit", "1"],
+    )
+
+    assert main() == 0
+    captured = capsys.readouterr()
+    lines = [line for line in captured.out.splitlines() if line]
+    assert len(lines) == 1
+    assert lines[0].endswith(":1:# TODO first")


### PR DESCRIPTION
## Summary
- repair frontend-lint checkout verification so it validates the repo root and frontend package path correctly
- move TODO marker counting into a repo script to avoid shell heredoc parsing failures in GitHub Actions
- keep this PR scoped to workflow false failures so the remaining core mypy debt is isolated as the next lane

## Testing
- pytest -q tests/scripts/test_todo_audit.py
- python3 scripts/todo_audit.py --mode count --root aragora
- python3 - <<'PY'
  import yaml, pathlib
  with pathlib.Path('.github/workflows/lint.yml').open() as f:
      yaml.safe_load(f)
  print('YAML_OK')
  PY
- python3 scripts/check_workflow_pip_install_policy.py
