### PR TITLE
fix(types): annotate hierarchy cache dicts

### DIFF
--- a/aragora/rlm/hierarchy_cache.py
+++ b/aragora/rlm/hierarchy_cache.py
@@ -190,7 +190,7 @@ class RLMHierarchyCache:
             except (RuntimeError, ValueError, ConnectionError, TimeoutError, OSError) as e:
                 logger.debug("[RLMHierarchyCache] Mound storage failed: %s", e)
 
-    def _serialize_compression(self, compression: CompressionResult) -> dict:
+    def _serialize_compression(self, compression: CompressionResult) -> dict[str, Any]:
         """Serialize compression result for storage."""
         # Serialize key topics and level summaries
         level_data = {}
@@ -214,7 +214,7 @@ class RLMHierarchyCache:
             "levels": level_data,
         }
 
-    def _deserialize_compression(self, data: dict) -> CompressionResult | None:
+    def _deserialize_compression(self, data: dict[str, Any]) -> CompressionResult | None:
         """Deserialize compression result from storage."""
         try:
             # Rebuild context
@@ -279,7 +279,7 @@ class RLMHierarchyCache:
             return None
 
     @property
-    def stats(self) -> dict:
+    def stats(self) -> dict[str, int | float]:
         """Get cache statistics."""
         total = self._cache_hits + self._cache_misses
         return {


### PR DESCRIPTION
## Summary
- add explicit dict typing for serialized hierarchy cache payloads
- type the deserialize input and cache stats surface
- clear the hierarchy-cache-specific Core Module Type Safety failures

## Testing
- python -m mypy aragora/rlm/hierarchy_cache.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/rlm/hierarchy_cache.py
- pytest -q tests/debate/test_cross_pollination.py tests/debate/test_hierarchy_team_selector_integration.py