### PR TITLE
fix(types): annotate knowledge adapter helpers

### DIFF
--- a/aragora/rlm/knowledge_adapter.py
+++ b/aragora/rlm/knowledge_adapter.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from .types import AbstractionLevel, AbstractionNode, RLMContext
 
 logger = logging.getLogger(__name__)
+NodeRecord = dict[str, Any]
+ReplHelper = Callable[..., Awaitable[Any]]
 
 
 class KnowledgeMoundAdapter:
@@ -77,7 +79,7 @@ class KnowledgeMoundAdapter:
         )
 
         # Group nodes by type for hierarchical representation
-        nodes_by_type: dict[str, list] = {}
+        nodes_by_type: dict[str, list[Any]] = {}
         for node in nodes:
             node_type = getattr(node, "node_type", "unknown")
             nodes_by_type.setdefault(node_type, []).append(node)
@@ -107,14 +109,14 @@ class KnowledgeMoundAdapter:
 
         return context
 
-    def get_repl_helpers(self) -> dict[str, Callable]:
+    def get_repl_helpers(self) -> dict[str, ReplHelper]:
         """
         Get helper functions for REPL access to Knowledge Mound.
 
         Returns dict of functions that can be injected into REPL namespace.
         """
 
-        async def search_mound(query: str, limit: int = 10) -> list[dict]:
+        async def search_mound(query: str, limit: int = 10) -> list[NodeRecord]:
             nodes = await self.mound.query_semantic(query, limit=limit)
             return [
                 {
@@ -126,7 +128,7 @@ class KnowledgeMoundAdapter:
                 for n in nodes
             ]
 
-        async def get_mound_node(node_id: str) -> dict | None:
+        async def get_mound_node(node_id: str) -> NodeRecord | None:
             node = await self.mound.get_node(node_id)
             if not node:
                 return None


### PR DESCRIPTION
## Summary
- add explicit typing for grouped Knowledge Mound nodes
- type REPL helper callables and helper result records
- clear the knowledge-adapter-specific Core Module Type Safety errors

## Testing
- python -m mypy aragora/rlm/knowledge_adapter.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/rlm/knowledge_adapter.py
- pytest -q tests/handlers/features/test_rlm.py tests/rlm/test_rlm_integration.py