### PR TITLE
fix(types): type workflow engine sets

### DIFF
--- a/aragora/workflow/engine.py
+++ b/aragora/workflow/engine.py
@@ -107,7 +107,7 @@ class WorkflowEngine:
 
         # Timeout tracking for progressive warnings
         self._timeout_warning_thresholds = [0.5, 0.8, 0.9]  # Warn at 50%, 80%, 90%
-        self._timeout_warnings_issued: set = set()
+        self._timeout_warnings_issued: set[float] = set()
 
     def _register_default_step_types(self) -> None:
         """Register built-in step types."""
@@ -1023,7 +1023,7 @@ class WorkflowEngine:
         workflow_id: str,
         definition_id: str,
         current_step: str,
-        completed_steps: set,
+        completed_steps: set[str],
         context: WorkflowContext,
     ) -> WorkflowCheckpoint:
         """Create a checkpoint of current workflow state."""


### PR DESCRIPTION
## Summary
- type timeout warning thresholds as floats
- type completed step sets explicitly in workflow checkpoints
- keep the change scoped to aragora/workflow/engine.py

## Validation
- python -m mypy aragora/workflow/engine.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/workflow/engine.py
- pytest -q tests/workflow/test_engine.py -k 'timeout_progress_check or no_warning_when_no_timeout or create_checkpoint or checkpoint_to_dict' tests/workflow/test_engine_comprehensive.py -k 'warning_at_50_percent or warning_at_80_percent or warning_at_90_percent or warning_only_issued_once_per_threshold or no_warning_with_zero_timeout or no_warning_with_negative_timeout'