### PR TITLE
fix(types): preserve async nomic metric wrappers

### DIFF
--- a/aragora/server/prometheus_nomic.py
+++ b/aragora/server/prometheus_nomic.py
@@ -8,10 +8,13 @@ Provides metrics for Nomic loop phase execution and cycle tracking.
 import logging
 import time
 from functools import wraps
-from typing import Any
-from collections.abc import Callable
+from typing import Any, ParamSpec, TypeVar
+from collections.abc import Awaitable, Callable
 
 logger = logging.getLogger(__name__)
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 from aragora.server.prometheus import (
     PROMETHEUS_AVAILABLE,
@@ -103,7 +106,9 @@ def record_nomic_agent_phase(
         )
 
 
-def timed_nomic_phase(phase: str) -> Callable[[Callable], Callable]:
+def timed_nomic_phase(
+    phase: str,
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
     """Async decorator to time nomic phase execution.
 
     Args:
@@ -118,7 +123,7 @@ def timed_nomic_phase(phase: str) -> Callable[[Callable], Callable]:
             ...
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         @wraps(func)
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             start = time.perf_counter()


### PR DESCRIPTION
## Summary
- type the async nomic metrics decorator with ParamSpec and Awaitable
- preserve async return signatures when wrapping nomic phase functions
- keep the change scoped to aragora/server/prometheus_nomic.py

## Validation
- python -m mypy aragora/server/prometheus_nomic.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/server/prometheus_nomic.py
- pytest -q tests/nomic/test_dev_coordination.py tests/nomic/test_pipeline_bridge.py tests/pipeline/test_execution_wiring.py