### PR TITLE
fix(types): type debate adapter helper returns

### DIFF
--- a/aragora/rlm/debate_adapter.py
+++ b/aragora/rlm/debate_adapter.py
@@ -315,12 +315,12 @@ class DebateContextAdapter:
             consensus = debate_result.final_answer
 
         # Build helper functions
-        def get_round(n: int) -> dict | None:
+        def get_round(n: int) -> dict[str, Any] | None:
             if 0 < n <= len(rounds):
                 return rounds[n - 1]
             return None
 
-        def get_critiques_for(agent: str) -> list[dict]:
+        def get_critiques_for(agent: str) -> list[dict[str, Any]]:
             return [c for c in critiques if c["target"] == agent]
 
         def get_proposals_by(agent: str) -> list[str]:


### PR DESCRIPTION
## Summary
- type the debate adapter round lookup helper explicitly
- type critique helper return records explicitly
- keep the change scoped to aragora/rlm/debate_adapter.py

## Validation
- python -m mypy aragora/rlm/debate_adapter.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/rlm/debate_adapter.py
- pytest -q tests/knowledge/mound/adapters/test_debate_adapter.py tests/rlm/test_debate_helpers.py