### PR TITLE
fix(types): type validation entity regex patterns

### DIFF
--- a/aragora/server/validation/entities.py
+++ b/aragora/server/validation/entities.py
@@ -32,7 +32,7 @@ SAFE_SESSION_ID_PATTERN = re.compile(r"^[a-zA-Z0-9_-]{8,64}$")
 def validate_path_segment(
     value: str,
     name: str,
-    pattern: re.Pattern | None = None,
+    pattern: re.Pattern[str] | None = None,
 ) -> tuple[bool, str | None]:
     """Validate a path segment against a pattern.
 


### PR DESCRIPTION
## Summary
- add the missing regex pattern type parameter in server validation entities
- keep the validator surface unchanged while satisfying strict mypy

## Testing
- python3 -m mypy aragora/server/validation/entities.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/server/validation/entities.py
- pytest -q tests/security/test_input_fuzzing.py tests/security/test_path_traversal.py tests/test_audio_security.py tests/test_handlers_debates_batch.py