### PR TITLE
fix(types): type introspection snapshot serialization

### DIFF
--- a/aragora/introspection/types.py
+++ b/aragora/introspection/types.py
@@ -6,6 +6,7 @@ that gets injected into debate prompts.
 """
 
 from dataclasses import dataclass, field
+from typing import Any
 
 
 @dataclass
@@ -141,7 +142,7 @@ class IntrospectionSnapshot:
 
         return "; ".join(directives[:2])  # Max 2 directives to stay concise
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """Serialize snapshot to dictionary."""
         return {
             "agent_name": self.agent_name,


### PR DESCRIPTION
## Summary
- add the missing typed dict return for introspection snapshot serialization
- keep runtime behavior unchanged while satisfying strict mypy

## Testing
- python3 -m mypy aragora/introspection/types.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/introspection/types.py
- pytest -q tests/introspection/test_types.py tests/introspection/test_api.py tests/introspection/test_cache.py tests/introspection/test_evolution_bridge.py -k "IntrospectionSnapshot or to_dict or proposal_acceptance_rate or calibration_label"