### PR TITLE
fix(types): annotate task brief post-init

### DIFF
--- a/aragora/task_brief.py
+++ b/aragora/task_brief.py
@@ -42,7 +42,7 @@ class TaskBriefV1:
     assumptions: list[str] = field(default_factory=list)
     requires_user_confirmation: bool = False
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Perform validation after the object is initialized."""
         if not self.goal or not self.goal.strip():
             raise ValueError("The 'goal' field cannot be empty.")


### PR DESCRIPTION
## Summary
- add the missing return annotation to TaskBriefV1.__post_init__
- keep task brief validation behavior unchanged while satisfying strict mypy

## Testing
- python3 -m mypy aragora/task_brief.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/task_brief.py aragora/topic_handler.py
- python3 - <<'PY'
from aragora.topic_handler import handle_ambiguous_task
brief = handle_ambiguous_task("build a planner")
assert brief.goal.startswith("Design a software architecture for:")
assert brief.requires_user_confirmation is True
assert brief.confidence == 0.4
print("task_brief_smoke=ok")
PY