### PR TITLE
fix(types): clear remaining core module blockers

### DIFF
--- a/aragora/cli/main.py
+++ b/aragora/cli/main.py
@@ -106,7 +106,7 @@ _LAZY_REEXPORTS: dict[str, tuple[str, str]] = {
 }
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> object:
     if name in _LAZY_REEXPORTS:
         module_path, attr_name = _LAZY_REEXPORTS[name]
         import importlib

--- a/aragora/debate/phases/feedback_evolution.py
+++ b/aragora/debate/phases/feedback_evolution.py
@@ -145,15 +145,18 @@ class EvolutionFeedback:
         if not result or not result.votes:
             return False
 
-        winner = getattr(result, "winner", None)
-        if not winner:
+        winner_obj = getattr(result, "winner", None)
+        if not isinstance(winner_obj, str) or not winner_obj:
             return False
 
         for vote in result.votes:
             if vote.agent == agent.name:
                 # Check if the agent's choice matches the winner
-                canonical = ctx.choice_mapping.get(vote.choice, vote.choice)
-                return canonical == winner
+                choice_key = vote.choice if isinstance(vote.choice, str) else str(vote.choice)
+                canonical_obj = ctx.choice_mapping.get(choice_key, choice_key)
+                if not isinstance(canonical_obj, str):
+                    canonical_obj = str(canonical_obj)
+                return canonical_obj == winner_obj
 
         return False
 

--- a/aragora/explainability/decision.py
+++ b/aragora/explainability/decision.py
@@ -213,7 +213,7 @@ class Decision:
     # Metadata
     metadata: dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if not self.decision_id:
             self.decision_id = self._generate_id()
 

--- a/aragora/resilience/retry.py
+++ b/aragora/resilience/retry.py
@@ -587,7 +587,7 @@ def calculate_backoff_delay(
         delay = random.random() * delay  # noqa: S311 -- retry jitter
     # NONE: no jitter applied
 
-    return max(0, delay)
+    return float(max(0.0, delay))
 
 
 def _fibonacci(n: int) -> int:


### PR DESCRIPTION
## Summary
- add the missing return annotations in cli.main and explainability decision surfaces
- remove Any leaks in retry delay calculation and feedback evolution winner matching
- clear the remaining failures from the required core-module mypy gate

## Validation
- timeout 60 python3 -m mypy aragora/cli/main.py aragora/explainability/decision.py aragora/resilience/retry.py aragora/debate/phases/feedback_evolution.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m ruff check aragora/cli/main.py aragora/explainability/decision.py aragora/resilience/retry.py aragora/debate/phases/feedback_evolution.py
- pytest -q tests/pipeline/test_autonomy.py tests/test_resilience.py tests/test_resilience_async.py -k "retry or Autonomy or backoff"
- timeout 180 python3 -m mypy aragora/ranking/elo.py aragora/server/stream/servers.py aragora/server/handlers/training.py aragora/cli/main.py aragora/config/secrets.py aragora/storage/repository.py aragora/debate/orchestrator.py aragora/memory/continuum/__init__.py aragora/debate/consensus.py aragora/resilience/__init__.py aragora/reasoning/belief.py aragora/debate/team_selector.py aragora/debate/prompt_builder.py aragora/knowledge/types.py aragora/agents/types.py aragora/rbac/models.py aragora/rbac/defaults/__init__.py aragora/server/prometheus_nomic.py aragora/server/prometheus_control_plane.py aragora/server/prometheus_rlm.py aragora/debate/phases/feedback_elo.py aragora/debate/phases/feedback_persona.py aragora/debate/phases/feedback_evolution.py aragora/rlm/debate_adapter.py aragora/rlm/knowledge_adapter.py aragora/rlm/hierarchy_cache.py aragora/rlm/types.py aragora/policy/engine.py aragora/policy/risk.py aragora/policy/tools.py aragora/connectors/chat/models.py aragora/connectors/chat/base/__init__.py aragora/connectors/chat/telegram.py aragora/connectors/chat/whatsapp.py aragora/connectors/chat/slack/__init__.py aragora/connectors/chat/discord.py aragora/gauntlet/runner.py aragora/gauntlet/receipt.py aragora/gauntlet/result.py aragora/gauntlet/types.py aragora/gauntlet/heatmap.py aragora/workflow/engine.py aragora/workflow/engine_v2.py aragora/explainability/builder.py aragora/explainability/decision.py aragora/backup/manager.py aragora/resilience/circuit_breaker.py aragora/resilience/retry.py aragora/resilience/timeout.py --config-file pyproject.toml --no-error-summary --follow-imports=silent