### PR TITLE
feat(swarm): support explicit spec work orders

### DIFF
--- a/aragora/swarm/spec.py
+++ b/aragora/swarm/spec.py
@@ -35,6 +35,7 @@ class SwarmSpec:
     # Hints for decomposition
     track_hints: list[str] = field(default_factory=list)
     file_scope_hints: list[str] = field(default_factory=list)
+    work_orders: list[dict[str, Any]] = field(default_factory=list)
 
     # Risk assessment
     estimated_complexity: str = "medium"
@@ -69,6 +70,10 @@ class SwarmSpec:
         data = dict(data)
         if isinstance(data.get("created_at"), str):
             data["created_at"] = datetime.fromisoformat(data["created_at"])
+        if "work_orders" in data and isinstance(data["work_orders"], list):
+            data["work_orders"] = [
+                dict(item) for item in data["work_orders"] if isinstance(item, dict)
+            ]
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
     def to_json(self, indent: int = 2) -> str:
@@ -117,4 +122,6 @@ class SwarmSpec:
             lines.append(f"Tracks: {', '.join(self.track_hints)}")
         if self.file_scope_hints:
             lines.append(f"File scope: {', '.join(self.file_scope_hints[:5])}")
+        if self.work_orders:
+            lines.append(f"Explicit work orders: {len(self.work_orders)}")
         return "\n".join(lines)

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -486,6 +486,10 @@ class SwarmSupervisor:
         return finished
 
     def _build_supervised_work_orders(self, spec: SwarmSpec) -> list[BoundedWorkOrder]:
+        explicit = self._explicit_work_orders_from_spec(spec)
+        if explicit:
+            return explicit
+
         goal = spec.refined_goal or spec.raw_goal
         decomposition = self.decomposer.analyze(self._task_prompt(spec))
         subtasks = list(decomposition.subtasks)
@@ -515,6 +519,104 @@ class SwarmSupervisor:
                 "acceptance_criteria": list(spec.acceptance_criteria),
                 "constraints": list(spec.constraints),
             }
+        return work_orders
+
+    def _explicit_work_orders_from_spec(self, spec: SwarmSpec) -> list[BoundedWorkOrder]:
+        if not spec.work_orders:
+            return []
+
+        work_orders: list[BoundedWorkOrder] = []
+        pipeline_id_by_work_order: dict[str, str] = {}
+        normalized_payloads = [
+            dict(payload) for payload in spec.work_orders if isinstance(payload, dict)
+        ]
+        explicit_ids: list[str] = []
+
+        for index, payload in enumerate(normalized_payloads, start=1):
+            work_order_id = str(payload.get("work_order_id", "")).strip() or f"work-{index}"
+            explicit_ids.append(work_order_id)
+            pipeline_id_by_work_order[work_order_id] = (
+                str(payload.get("pipeline_task_id", "")).strip() or f"task-{index}"
+            )
+
+        for index, payload in enumerate(normalized_payloads, start=1):
+            work_order_id = explicit_ids[index - 1]
+            pipeline_task_id = pipeline_id_by_work_order[work_order_id]
+            target_agent = str(payload.get("target_agent", "")).strip()
+            reviewer_agent = str(payload.get("reviewer_agent", "")).strip()
+            if not target_agent:
+                target_agent = "codex" if (index - 1) % 2 == 0 else "claude"
+            if not reviewer_agent:
+                reviewer_agent = "claude" if target_agent == "codex" else "codex"
+
+            success_criteria = dict(payload.get("success_criteria") or {})
+            expected_tests = [
+                str(item).strip() for item in payload.get("expected_tests", []) if str(item).strip()
+            ]
+            if expected_tests and "tests" not in success_criteria:
+                success_criteria["tests"] = list(expected_tests)
+
+            estimated_complexity = (
+                str(payload.get("estimated_complexity", "medium")).strip() or "medium"
+            )
+            risk_level = str(payload.get("risk_level", "")).strip() or self._risk_level_for_scope(
+                [str(item) for item in payload.get("file_scope", []) if str(item).strip()]
+            )
+
+            dependency_ids = [
+                str(dep).strip() for dep in payload.get("dependency_ids", []) if str(dep).strip()
+            ]
+            if not dependency_ids:
+                dependency_ids = [
+                    pipeline_id_by_work_order.get(str(dep).strip(), str(dep).strip())
+                    for dep in payload.get("dependencies", [])
+                    if str(dep).strip()
+                ]
+
+            work_orders.append(
+                BoundedWorkOrder(
+                    work_order_id=work_order_id,
+                    pipeline_task_id=pipeline_task_id,
+                    title=str(payload.get("title", "")).strip() or work_order_id,
+                    description=str(payload.get("description", "")).strip()
+                    or str(payload.get("title", "")).strip()
+                    or spec.refined_goal
+                    or spec.raw_goal,
+                    file_scope=[
+                        str(item).strip()
+                        for item in payload.get("file_scope", [])
+                        if str(item).strip()
+                    ],
+                    dependency_ids=dependency_ids,
+                    success_criteria=success_criteria,
+                    expected_tests=expected_tests,
+                    estimated_complexity=estimated_complexity,
+                    risk_level=risk_level,
+                    target_agent=target_agent,
+                    reviewer_agent=reviewer_agent,
+                    approval_required=bool(payload.get("approval_required", False)),
+                    metadata={
+                        **dict(payload.get("metadata") or {}),
+                        "source": "explicit_spec_work_order",
+                    },
+                )
+            )
+
+        for item in work_orders:
+            item.expected_tests = self._default_tests(item, spec)
+            item.risk_level = str(item.risk_level).strip() or self._risk_level_for_scope(
+                item.file_scope
+            )
+            item.approval_required = item.approval_required or item.risk_level in {
+                "critical",
+                "review",
+            }
+            item.metadata = {
+                **dict(item.metadata),
+                "acceptance_criteria": list(spec.acceptance_criteria),
+                "constraints": list(spec.constraints),
+            }
+
         return work_orders
 
     def _lease_work_order(

--- a/docs/guides/SWARM_DOGFOOD_OPERATOR.md
+++ b/docs/guides/SWARM_DOGFOOD_OPERATOR.md
@@ -1,0 +1,144 @@
+# Supervised Swarm Dogfood Operator Guide
+
+Use this runbook for the first spec-driven supervised swarm run in a local Aragora checkout. Keep work-order file scopes disjoint, use explicit expected tests, and let the reconcile loop move work instead of doing manual worktree surgery.
+
+## 1. Create the spec
+
+You can generate the initial envelope from the CLI:
+
+```bash
+python -m aragora.cli.main swarm \
+  "Ship the first supervised swarm dogfood run" \
+  --skip-interrogation \
+  --dry-run \
+  --save-spec /tmp/swarm-dogfood.yaml
+```
+
+Then edit the spec so each work order owns a narrow `file_scope` and concrete `expected_tests`.
+
+```yaml
+raw_goal: Ship the first supervised swarm dogfood run
+refined_goal: Ship the first supervised swarm dogfood run
+work_orders:
+  - work_order_id: docs-lane
+    title: Write operator guide
+    description: Add the first supervised runbook.
+    file_scope:
+      - docs/guides/SWARM_DOGFOOD_OPERATOR.md
+    expected_tests: []
+    target_agent: codex
+    reviewer_agent: claude
+    risk_level: info
+  - work_order_id: swarm-tests
+    title: Cover spec and reconcile flow
+    description: Add CLI and commander regression coverage.
+    file_scope:
+      - tests/cli/test_swarm_command.py
+      - tests/swarm/test_commander.py
+    expected_tests:
+      - python -m pytest tests/cli/test_swarm_command.py tests/swarm/test_commander.py -q
+    target_agent: claude
+    reviewer_agent: codex
+    risk_level: review
+  - work_order_id: integration-tests
+    title: Cover reconcile and integration queue flow
+    description: Add reconciler and queue regression coverage.
+    file_scope:
+      - tests/swarm/test_reconciler.py
+      - tests/worktree/test_integration_worker.py
+    expected_tests:
+      - python -m pytest tests/swarm/test_reconciler.py tests/worktree/test_integration_worker.py -q
+    target_agent: codex
+    reviewer_agent: claude
+    risk_level: review
+```
+
+## 2. Provision the run without dispatching workers
+
+Use `--no-dispatch` when you want to confirm the run shape before any worker sessions start:
+
+```bash
+python -m aragora.cli.main swarm --spec /tmp/swarm-dogfood.yaml --no-dispatch --json
+```
+
+Record the returned `run_id`. This should create the supervisor run and lease available work orders without launching workers.
+
+## 3. Dispatch and reconcile
+
+Use the reconcile loop as the operator control plane:
+
+```bash
+python -m aragora.cli.main swarm reconcile \
+  --run-id <run_id> \
+  --watch \
+  --interval-seconds 2 \
+  --json
+```
+
+Useful variants:
+
+```bash
+python -m aragora.cli.main swarm --spec /tmp/swarm-dogfood.yaml --dispatch-only --json
+python -m aragora.cli.main swarm status --run-id <run_id> --json
+python -m aragora.cli.main swarm reconcile --run-id <run_id>
+python -m aragora.cli.main swarm reconcile --all-runs
+```
+
+- `--dispatch-only` launches workers and returns immediately.
+- `--no-dispatch` provisions supervisor state without launching workers.
+- `reconcile --watch` is the operator-friendly path for topping up work, collecting finished workers, and syncing pending integration work.
+
+## 4. Inspect the integration queue
+
+Use the fleet merge queue as the integration surface:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-list
+python -m aragora.cli.main worktree fleet-queue-list --status needs_human
+python -m aragora.cli.main worktree fleet-queue-list --status blocked
+```
+
+Expected queue metadata for dogfood runs includes:
+
+- `receipt_id`
+- `changed_paths`
+- `tests_run`
+- `confidence`
+
+Typical queue states:
+
+- `queued`: ready for validation
+- `needs_human`: validated or blocked by an explicit gate
+- `blocked`: merge conflict or validation failure
+- `merged`: integrated successfully
+
+## 5. Validate or execute the next integration item
+
+Validation only:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-process-next \
+  --worker-session-id integrator-1 \
+  --json
+```
+
+Validate and merge:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-process-next \
+  --worker-session-id integrator-1 \
+  --execute \
+  --json
+```
+
+Use validation first on the first dogfood run. Execute only after the queue item shows the expected files, tests, and conflict metadata.
+
+## 6. When the run needs help
+
+Check these fields before intervening:
+
+- `dispatch_error` or `resource_error` on the swarm run
+- `reconciler_conflicts` on the queue item
+- `merge_error` or `merge_conflicts` on the integration outcome
+
+For the first supervised dogfood run, prefer fixing the narrow blocking issue and re-running the reconciler instead of broad manual cleanup.

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.cli.commands.swarm import cmd_swarm
+from aragora.swarm.spec import SwarmSpec
 
 
 class _FakeSpec:
@@ -16,6 +17,59 @@ class _FakeSpec:
 
     def to_yaml(self) -> str:
         return self._yaml_text
+
+
+def _swarm_args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "swarm_action_or_goal": "run",
+        "swarm_goal": None,
+        "spec": None,
+        "skip_interrogation": False,
+        "dry_run": False,
+        "budget_limit": 9.0,
+        "require_approval": False,
+        "save_spec": None,
+        "from_obsidian": None,
+        "obsidian_vault": None,
+        "no_obsidian_receipts": False,
+        "profile": "developer",
+        "autonomy": "propose",
+        "max_parallel": 20,
+        "no_loop": False,
+        "target_branch": "main",
+        "concurrency_cap": 8,
+        "managed_dir_pattern": ".worktrees/{agent}-auto",
+        "json": False,
+        "run_id": None,
+        "status_limit": 20,
+        "refresh_scaling": False,
+        "no_dispatch": False,
+        "watch": False,
+        "interval_seconds": 5.0,
+        "max_ticks": None,
+        "all_runs": False,
+        "dispatch_only": False,
+        "no_wait": False,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def _fake_supervisor_run(
+    *,
+    run_id: str = "run-123",
+    status: str = "active",
+    work_orders: list[dict[str, object]] | None = None,
+) -> MagicMock:
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "run_id": run_id,
+        "status": status,
+        "target_branch": "main",
+        "goal": "goal",
+        "work_orders": work_orders or [],
+    }
+    return fake_run
 
 
 class TestSwarmParser:
@@ -77,6 +131,20 @@ class TestSwarmParser:
         assert args.run_id == "run-123"
         assert args.watch is True
         assert args.interval_seconds == 1.5
+
+    def test_swarm_parser_accepts_spec_dispatch_options(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["swarm", "--spec", "swarm-spec.yaml", "--dispatch-only", "--no-wait", "--json"]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal is None
+        assert args.spec == "swarm-spec.yaml"
+        assert args.dispatch_only is True
+        assert args.no_wait is True
+        assert args.json is True
 
 
 class TestSwarmCommand:
@@ -254,44 +322,12 @@ class TestSwarmCommand:
         assert "runs=1 queued=2 leased=1 completed=0" in out
 
     def test_cmd_swarm_reconcile_uses_reconciler(self, capsys):
-        args = argparse.Namespace(
+        args = _swarm_args(
             swarm_action_or_goal="reconcile",
-            swarm_goal=None,
-            spec=None,
-            skip_interrogation=False,
-            dry_run=False,
-            budget_limit=9.0,
-            require_approval=True,
-            save_spec=None,
-            from_obsidian=None,
-            obsidian_vault=None,
-            no_obsidian_receipts=False,
-            profile="developer",
-            autonomy="propose",
-            max_parallel=20,
-            no_loop=False,
-            target_branch="main",
-            concurrency_cap=8,
-            managed_dir_pattern=".worktrees/{agent}-auto",
-            json=False,
             run_id="run-123",
-            status_limit=20,
-            refresh_scaling=False,
-            no_dispatch=False,
-            watch=False,
-            interval_seconds=5.0,
-            max_ticks=None,
-            all_runs=False,
         )
 
-        fake_run = MagicMock()
-        fake_run.to_dict.return_value = {
-            "run_id": "run-123",
-            "status": "active",
-            "target_branch": "main",
-            "goal": "goal",
-            "work_orders": [],
-        }
+        fake_run = _fake_supervisor_run()
 
         with patch("aragora.swarm.SwarmReconciler") as reconciler_cls:
             reconciler_cls.return_value.tick_run = AsyncMock(return_value=fake_run)
@@ -299,3 +335,98 @@ class TestSwarmCommand:
 
         out = capsys.readouterr().out
         assert "run_id=run-123" in out
+
+    def test_cmd_swarm_spec_no_dispatch_preserves_explicit_work_orders(self, tmp_path: Path):
+        spec_path = tmp_path / "swarm-spec.yaml"
+        spec = SwarmSpec(
+            raw_goal="Dogfood the supervised swarm",
+            refined_goal="Dogfood the supervised swarm",
+            work_orders=[
+                {
+                    "work_order_id": "docs-lane",
+                    "title": "Add operator guide",
+                    "file_scope": ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"],
+                    "expected_tests": [],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                }
+            ],
+        )
+        spec_path.write_text(spec.to_yaml())
+        mock_commander = SimpleNamespace(
+            run_supervised_from_spec=AsyncMock(return_value=_fake_supervisor_run())
+        )
+        args = _swarm_args(spec=str(spec_path), no_dispatch=True)
+
+        with patch("aragora.swarm.SwarmCommander", return_value=mock_commander):
+            cmd_swarm(args)
+
+        mock_commander.run_supervised_from_spec.assert_awaited_once()
+        call = mock_commander.run_supervised_from_spec.await_args
+        passed_spec = call.args[0]
+        assert passed_spec.work_orders[0]["work_order_id"] == "docs-lane"
+        assert passed_spec.work_orders[0]["file_scope"] == ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"]
+        assert call.kwargs["dispatch"] is False
+        assert call.kwargs["wait"] is True
+
+    def test_cmd_swarm_spec_dispatch_only_runs_fire_and_forget(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        spec_path = tmp_path / "swarm-spec.yaml"
+        spec = SwarmSpec(
+            raw_goal="Dogfood the supervised swarm",
+            refined_goal="Dogfood the supervised swarm",
+            work_orders=[
+                {
+                    "work_order_id": "tests-lane",
+                    "title": "Add regressions",
+                    "file_scope": ["tests/swarm/test_commander.py"],
+                    "expected_tests": ["python -m pytest tests/swarm/test_commander.py -q"],
+                    "target_agent": "claude",
+                    "reviewer_agent": "codex",
+                }
+            ],
+        )
+        spec_path.write_text(spec.to_yaml())
+        fake_run = _fake_supervisor_run(
+            work_orders=[{"work_order_id": "tests-lane", "status": "dispatched"}]
+        )
+        mock_commander = SimpleNamespace(run_supervised_from_spec=AsyncMock(return_value=fake_run))
+        args = _swarm_args(spec=str(spec_path), dispatch_only=True, json=True)
+
+        with patch("aragora.swarm.SwarmCommander", return_value=mock_commander):
+            cmd_swarm(args)
+
+        call = mock_commander.run_supervised_from_spec.await_args
+        assert call.kwargs["dispatch"] is True
+        assert call.kwargs["wait"] is False
+        out = capsys.readouterr().out
+        assert '"run_id": "run-123"' in out
+        assert '"status": "active"' in out
+
+    def test_cmd_swarm_reconcile_watch_uses_watch_run(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="reconcile",
+            run_id="run-123",
+            watch=True,
+            interval_seconds=1.5,
+            max_ticks=4,
+        )
+        fake_run = _fake_supervisor_run(
+            work_orders=[{"work_order_id": "tests-lane", "status": "completed"}]
+        )
+
+        with patch("aragora.swarm.SwarmReconciler") as reconciler_cls:
+            reconciler = reconciler_cls.return_value
+            reconciler.watch_run = AsyncMock(return_value=fake_run)
+            reconciler.tick_run = AsyncMock()
+            cmd_swarm(args)
+
+        reconciler.watch_run.assert_awaited_once_with(
+            "run-123",
+            interval_seconds=1.5,
+            max_ticks=4,
+        )
+        reconciler.tick_run.assert_not_called()
+        out = capsys.readouterr().out
+        assert "work_orders=1 [completed=1]" in out

--- a/tests/swarm/test_commander.py
+++ b/tests/swarm/test_commander.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -90,6 +91,117 @@ class TestSwarmCommanderRunFromSpec:
         mock_sup.start_run.assert_called_once()
         mock_sup.dispatch_workers.assert_called_once_with(fake_run.run_id)
         mock_sup.refresh_run.assert_called_once_with(fake_run.run_id)
+
+    @pytest.mark.asyncio
+    async def test_run_supervised_from_spec_wait_false_returns_refreshed_run(self):
+        spec = SwarmSpec(raw_goal="Test goal", refined_goal="Test goal refined")
+        commander = SwarmCommander()
+        fake_run = MagicMock()
+        fake_run.run_id = "test-run-id"
+        refreshed_run = MagicMock()
+        refreshed_run.run_id = fake_run.run_id
+
+        with (
+            patch("aragora.swarm.commander.SwarmSupervisor") as mock_supervisor_cls,
+            patch("aragora.swarm.commander.SwarmReconciler") as mock_reconciler_cls,
+        ):
+            mock_sup = mock_supervisor_cls.return_value
+            mock_sup.start_run.return_value = fake_run
+            mock_sup.dispatch_workers = AsyncMock(return_value=[MagicMock()])
+            mock_sup.refresh_run.return_value = refreshed_run
+
+            result = await commander.run_supervised_from_spec(spec, wait=False)
+
+        assert result is refreshed_run
+        mock_sup.dispatch_workers.assert_awaited_once_with(fake_run.run_id)
+        mock_sup.refresh_run.assert_called_once_with(fake_run.run_id)
+        mock_reconciler_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_supervised_from_spec_watches_when_workers_launch(self):
+        spec = SwarmSpec(
+            raw_goal="Dogfood the swarm with explicit work orders",
+            refined_goal="Dogfood the swarm with explicit work orders",
+            work_orders=[
+                {
+                    "work_order_id": "docs-lane",
+                    "title": "Write operator guide",
+                    "file_scope": ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"],
+                    "expected_tests": [],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                }
+            ],
+        )
+        commander = SwarmCommander()
+        fake_run = MagicMock()
+        fake_run.run_id = "test-run-id"
+        watched_run = MagicMock()
+        watched_run.run_id = fake_run.run_id
+
+        with (
+            patch("aragora.swarm.commander.SwarmSupervisor") as mock_supervisor_cls,
+            patch("aragora.swarm.commander.SwarmReconciler") as mock_reconciler_cls,
+        ):
+            mock_sup = mock_supervisor_cls.return_value
+            mock_sup.start_run.return_value = fake_run
+            mock_sup.dispatch_workers = AsyncMock(return_value=[MagicMock()])
+            mock_reconciler_cls.return_value.watch_run = AsyncMock(return_value=watched_run)
+
+            result = await commander.run_supervised_from_spec(
+                spec,
+                interval_seconds=1.5,
+                max_ticks=4,
+            )
+
+        assert result is watched_run
+        assert mock_sup.start_run.call_args.kwargs["spec"] is spec
+        mock_sup.dispatch_workers.assert_awaited_once_with(fake_run.run_id)
+        mock_reconciler_cls.assert_called_once_with(supervisor=mock_sup)
+        mock_reconciler_cls.return_value.watch_run.assert_awaited_once_with(
+            fake_run.run_id,
+            interval_seconds=1.5,
+            max_ticks=4,
+        )
+
+    @pytest.mark.asyncio
+    async def test_run_supervised_from_spec_no_dispatch_skips_launcher(self):
+        spec = SwarmSpec(
+            raw_goal="Dogfood the swarm with explicit work orders",
+            refined_goal="Dogfood the swarm with explicit work orders",
+            work_orders=[
+                {
+                    "work_order_id": "tests-lane",
+                    "title": "Add regression coverage",
+                    "file_scope": ["tests/swarm/test_commander.py"],
+                    "expected_tests": ["python -m pytest tests/swarm/test_commander.py -q"],
+                    "target_agent": "claude",
+                    "reviewer_agent": "codex",
+                }
+            ],
+        )
+        commander = SwarmCommander()
+        fake_run = MagicMock()
+        fake_run.run_id = "test-run-id"
+        refreshed_run = MagicMock()
+        refreshed_run.run_id = fake_run.run_id
+
+        with (
+            patch("aragora.swarm.commander.SwarmSupervisor") as mock_supervisor_cls,
+            patch("aragora.swarm.commander.SwarmReconciler") as mock_reconciler_cls,
+        ):
+            mock_sup = mock_supervisor_cls.return_value
+            mock_sup.start_run.return_value = fake_run
+            mock_sup.dispatch_workers = AsyncMock()
+            mock_sup.refresh_run.return_value = refreshed_run
+
+            result = await commander.run_supervised_from_spec(spec, dispatch=False)
+
+        assert result is refreshed_run
+        assert mock_sup.start_run.call_args.kwargs["spec"].work_orders == spec.work_orders
+        mock_sup.dispatch_workers.assert_not_awaited()
+        mock_sup.refresh_run.assert_called_once_with(fake_run.run_id)
+        mock_reconciler_cls.assert_not_called()
 
 
 class TestSwarmCommanderDryRun:

--- a/tests/swarm/test_reconciler.py
+++ b/tests/swarm/test_reconciler.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 
-from aragora.swarm.reconciler import SwarmReconciler
+from aragora.swarm.reconciler import SwarmReconciler, SwarmReconcilerConfig
 from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.supervisor import SupervisorRun, SwarmApprovalPolicy
 
 
-def _run(status: str, work_order_statuses: list[str]) -> SupervisorRun:
+def _run(status: str, work_order_statuses: list[str], *, run_id: str = "run-123") -> SupervisorRun:
     return SupervisorRun(
-        run_id="run-123",
+        run_id=run_id,
         goal="goal",
         target_branch="main",
         status=status,
@@ -47,6 +47,74 @@ async def test_tick_run_dispatches_collects_and_syncs_queue() -> None:
 
 
 @pytest.mark.asyncio
+async def test_tick_run_redispatches_after_finished_workers_free_capacity() -> None:
+    supervisor = MagicMock()
+    supervisor.refresh_run.side_effect = [
+        _run("active", ["leased"]),
+        _run("active", ["completed", "leased"]),
+    ]
+    supervisor.dispatch_workers = AsyncMock(side_effect=[[], []])
+    supervisor.collect_finished_results = AsyncMock(return_value=[MagicMock(work_order_id="wo-1")])
+    supervisor.store.sync_pending_work_queue = AsyncMock(return_value={"created": 1})
+    supervisor.store.get_supervisor_run.return_value = _run(
+        "active", ["completed", "dispatched"]
+    ).to_dict()
+
+    reconciler = SwarmReconciler(supervisor=supervisor)
+    result = await reconciler.tick_run("run-123")
+
+    assert result.run_id == "run-123"
+    assert supervisor.refresh_run.call_args_list == [call("run-123"), call("run-123")]
+    assert supervisor.dispatch_workers.await_args_list == [call("run-123"), call("run-123")]
+    supervisor.collect_finished_results.assert_awaited_once_with("run-123")
+
+
+@pytest.mark.asyncio
+async def test_tick_run_can_skip_pending_queue_sync() -> None:
+    supervisor = MagicMock()
+    supervisor.refresh_run.side_effect = [_run("active", ["leased"])]
+    supervisor.dispatch_workers = AsyncMock(return_value=[])
+    supervisor.collect_finished_results = AsyncMock(return_value=[])
+    supervisor.store.sync_pending_work_queue = AsyncMock(return_value={"created": 0})
+    supervisor.store.get_supervisor_run.return_value = _run("active", ["dispatched"]).to_dict()
+
+    reconciler = SwarmReconciler(
+        supervisor=supervisor,
+        config=SwarmReconcilerConfig(sync_pending_queue=False),
+    )
+    await reconciler.tick_run("run-123")
+
+    supervisor.store.sync_pending_work_queue.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tick_open_runs_only_advances_named_runs() -> None:
+    supervisor = MagicMock()
+    supervisor.status_summary.return_value = {
+        "runs": [
+            {"run_id": "run-123"},
+            {"run_id": ""},
+            {"status": "active"},
+            "invalid",
+            {"run_id": "run-456"},
+        ]
+    }
+    reconciler = SwarmReconciler(supervisor=supervisor)
+    reconciler.tick_run = AsyncMock(
+        side_effect=[
+            _run("active", ["dispatched"], run_id="run-123"),
+            _run("needs_human", ["blocked"], run_id="run-456"),
+        ]
+    )
+
+    runs = await reconciler.tick_open_runs(limit=7)
+
+    assert [run.run_id for run in runs] == ["run-123", "run-456"]
+    supervisor.status_summary.assert_called_once_with(limit=7, refresh_scaling=False)
+    assert reconciler.tick_run.await_args_list == [call("run-123"), call("run-456")]
+
+
+@pytest.mark.asyncio
 async def test_watch_run_stops_when_completed() -> None:
     active = _run("active", ["dispatched"])
     completed = _run("completed", ["merged"])
@@ -64,3 +132,9 @@ def test_should_not_stop_for_waiting_resource() -> None:
     run = _run("active", ["waiting_resource"])
 
     assert SwarmReconciler._should_stop(run) is False
+
+
+def test_should_stop_when_only_terminal_work_orders_remain() -> None:
+    run = _run("active", ["completed", "merged", "blocked"])
+
+    assert SwarmReconciler._should_stop(run) is True

--- a/tests/swarm/test_spec.py
+++ b/tests/swarm/test_spec.py
@@ -25,6 +25,7 @@ class TestSwarmSpecCreation:
         assert spec.constraints == []
         assert spec.track_hints == []
         assert spec.file_scope_hints == []
+        assert spec.work_orders == []
 
     def test_creation_with_values(self):
         spec = SwarmSpec(
@@ -34,6 +35,7 @@ class TestSwarmSpecCreation:
             constraints=["Don't modify the API"],
             budget_limit_usd=10.0,
             track_hints=["sme", "core"],
+            work_orders=[{"work_order_id": "wo-1", "title": "lane"}],
             estimated_complexity="high",
             requires_approval=True,
             user_expertise="developer",
@@ -43,6 +45,7 @@ class TestSwarmSpecCreation:
         assert len(spec.acceptance_criteria) == 1
         assert spec.budget_limit_usd == 10.0
         assert spec.track_hints == ["sme", "core"]
+        assert spec.work_orders == [{"work_order_id": "wo-1", "title": "lane"}]
         assert spec.estimated_complexity == "high"
         assert spec.requires_approval is True
 
@@ -58,6 +61,14 @@ class TestSwarmSpecSerialization:
             constraints=["No breaking changes"],
             budget_limit_usd=7.50,
             track_hints=["qa"],
+            work_orders=[
+                {
+                    "work_order_id": "docs-lane",
+                    "title": "Write operator guide",
+                    "file_scope": ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"],
+                    "expected_tests": [],
+                }
+            ],
         )
         data = spec.to_dict()
         restored = SwarmSpec.from_dict(data)
@@ -68,6 +79,7 @@ class TestSwarmSpecSerialization:
         assert restored.constraints == spec.constraints
         assert restored.budget_limit_usd == spec.budget_limit_usd
         assert restored.track_hints == spec.track_hints
+        assert restored.work_orders == spec.work_orders
         assert restored.id == spec.id
 
     def test_to_json_and_back(self):
@@ -134,3 +146,8 @@ class TestSwarmSpecSummary:
         summary = spec.summary()
         assert "qa" in summary
         assert "core" in summary
+
+    def test_summary_includes_explicit_work_order_count(self):
+        spec = SwarmSpec(work_orders=[{"work_order_id": "docs-lane"}])
+        summary = spec.summary()
+        assert "Explicit work orders: 1" in summary

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -280,6 +280,61 @@ def test_refresh_run_marks_resource_wait_on_disk_full(
     assert "No space left on device" in work_order["resource_error"]
 
 
+def test_start_run_prefers_explicit_spec_work_orders(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    session_path = repo / "wt-explicit"
+    session_path.mkdir()
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-explicit",
+        agent="codex",
+        branch="codex/swarm-explicit",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    decomposer = MagicMock()
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+    spec = SwarmSpec(
+        raw_goal="Dogfood the supervised swarm",
+        refined_goal="Dogfood the supervised swarm",
+        acceptance_criteria=["python -m pytest tests/swarm/test_commander.py -q"],
+        work_orders=[
+            {
+                "work_order_id": "docs-lane",
+                "title": "Write operator guide",
+                "description": "Add the operator guide.",
+                "file_scope": ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"],
+                "expected_tests": [],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {"lane": "docs"},
+            }
+        ],
+    )
+
+    run = supervisor.start_run(spec=spec, max_concurrency=1)
+
+    decomposer.analyze.assert_not_called()
+    assert run.status == "active"
+    assert len(run.work_orders) == 1
+    work_order = run.work_orders[0]
+    assert work_order["work_order_id"] == "docs-lane"
+    assert work_order["target_agent"] == "codex"
+    assert work_order["reviewer_agent"] == "claude"
+    assert work_order["file_scope"] == ["docs/guides/SWARM_DOGFOOD_OPERATOR.md"]
+    assert work_order["metadata"]["lane"] == "docs"
+    assert work_order["metadata"]["source"] == "explicit_spec_work_order"
+
+
 # ---------- dispatch_workers / collect_results tests ----------
 
 from unittest.mock import AsyncMock, patch

--- a/tests/worktree/test_integration_worker.py
+++ b/tests/worktree/test_integration_worker.py
@@ -165,6 +165,68 @@ async def test_process_next_validates_without_execute(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_process_next_preserves_dogfood_receipt_metadata_during_validation(
+    tmp_path: Path,
+) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    queued = store.enqueue_merge(
+        session_id="session-a",
+        branch="codex/dogfood",
+        priority=60,
+        metadata={
+            "receipt_id": "receipt-123",
+            "tests_run": ["python -m pytest tests/swarm/test_reconciler.py -q"],
+            "changed_paths": ["tests/swarm/test_reconciler.py"],
+            "confidence": 0.91,
+        },
+    )
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        return_value=MergeResult(
+            source_branch="codex/dogfood",
+            target_branch="main",
+            success=True,
+        )
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = [
+        "tests/swarm/test_reconciler.py",
+        "tests/worktree/test_integration_worker.py",
+    ]
+    reconciler.get_commits_ahead.return_value = 2
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    outcome = await worker.process_next(worker_session_id="integrator-1")
+
+    assert outcome.action == "validated"
+    assert outcome.queue_status == "needs_human"
+    assert outcome.queue_item_id == queued["item"]["id"]
+    assert outcome.metadata["receipt_id"] == "receipt-123"
+    assert outcome.metadata["tests_run"] == ["python -m pytest tests/swarm/test_reconciler.py -q"]
+    assert outcome.metadata["changed_paths"] == ["tests/swarm/test_reconciler.py"]
+    assert outcome.metadata["confidence"] == 0.91
+    assert outcome.metadata["worker_session_id"] == "integrator-1"
+    assert outcome.metadata["validated_by"] == "integrator-1"
+    assert outcome.metadata["changed_files"] == [
+        "tests/swarm/test_reconciler.py",
+        "tests/worktree/test_integration_worker.py",
+    ]
+    assert outcome.metadata["commits_ahead"] == 2
+    assert outcome.metadata["dry_run_success"] is True
+    assert outcome.metadata["dry_run_conflicts"] == []
+    assert outcome.metadata["reconciler_conflicts"] == []
+    assert outcome.metadata["validated_only"] is True
+    assert outcome.metadata["integration_workspace_path"] == str(tmp_path)
+
+
+@pytest.mark.asyncio
 async def test_process_next_executes_merge_successfully(tmp_path: Path) -> None:
     store = FleetCoordinationStore(tmp_path)
     store.enqueue_merge(
@@ -245,6 +307,52 @@ async def test_process_next_marks_execution_conflicts_blocked(tmp_path: Path) ->
     assert outcome.queue_status == "blocked"
     assert outcome.conflicts == ["aragora/x.py"]
     assert store.list_merge_queue()[0]["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_process_next_marks_non_conflict_execution_errors_failed(tmp_path: Path) -> None:
+    store = FleetCoordinationStore(tmp_path)
+    store.enqueue_merge(
+        session_id="session-a",
+        branch="codex/ready",
+        priority=60,
+        metadata={"receipt_id": "receipt-456"},
+    )
+    branch_coordinator = MagicMock()
+    branch_coordinator.safe_merge = AsyncMock(
+        side_effect=[
+            MergeResult(source_branch="codex/ready", target_branch="main", success=True),
+            MergeResult(
+                source_branch="codex/ready",
+                target_branch="main",
+                success=False,
+                error="remote rejected update",
+            ),
+        ]
+    )
+    reconciler = MagicMock()
+    reconciler.get_changed_files.return_value = ["aragora/x.py"]
+    reconciler.get_commits_ahead.return_value = 3
+    reconciler.detect_conflicts.return_value = []
+
+    worker = FleetIntegrationWorker(
+        repo_path=tmp_path,
+        fleet_store=store,
+        branch_coordinator=branch_coordinator,
+        reconciler=reconciler,
+    )
+
+    with patch("aragora.nomic.dev_coordination.DevCoordinationStore") as store_cls:
+        outcome = await worker.process_next(worker_session_id="integrator-1", execute=True)
+
+    assert outcome.action == "failed"
+    assert outcome.queue_status == "failed"
+    assert outcome.error == "remote rejected update"
+    assert outcome.conflicts == []
+    assert store.list_merge_queue()[0]["status"] == "failed"
+    assert store.list_merge_queue()[0]["metadata"]["merge_error"] == "remote rejected update"
+    assert store.list_merge_queue()[0]["metadata"]["merge_conflicts"] == []
+    store_cls.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- salvage the remaining useful swarm dogfood lane from the dirty runtime cluster into a fresh `origin/main` worktree
- preserve explicit `work_orders` in `SwarmSpec` and honor them in the supervisor instead of always re-decomposing
- add a durable operator guide for the spec-driven swarm dogfood flow
- extend the focused swarm CLI/commander/reconciler/integration tests around explicit spec orders and dogfood metadata

## Included
- `aragora/swarm/spec.py`
- `aragora/swarm/supervisor.py`
- `docs/guides/SWARM_DOGFOOD_OPERATOR.md`
- focused tests in:
  - `tests/swarm/test_spec.py`
  - `tests/swarm/test_supervisor.py`
  - `tests/swarm/test_commander.py`
  - `tests/cli/test_swarm_command.py`
  - `tests/swarm/test_reconciler.py`
  - `tests/worktree/test_integration_worker.py`

## Why this salvage matters
The dirty swarm-dogfood worktrees were pointing at a real contract gap: the CLI already supported `--spec`, `--no-dispatch`, and `--dispatch-only`, but `SwarmSpec` dropped explicit `work_orders` and the supervisor always decomposed from scratch. This PR lands that missing contract instead of porting stale runtime patches.

## Validation
- `python -m ruff check aragora/swarm/spec.py aragora/swarm/supervisor.py tests/swarm/test_spec.py tests/swarm/test_supervisor.py tests/cli/test_swarm_command.py tests/swarm/test_commander.py tests/swarm/test_reconciler.py tests/worktree/test_integration_worker.py`
- `python -m pytest tests/swarm/test_spec.py tests/swarm/test_supervisor.py tests/cli/test_swarm_command.py tests/swarm/test_commander.py tests/swarm/test_reconciler.py tests/worktree/test_integration_worker.py -q`
