### PR TITLE
fix(readiness): salvage OpenRouter fallback truthfulness

### DIFF
--- a/aragora/nomic/preflight.py
+++ b/aragora/nomic/preflight.py
@@ -212,7 +212,7 @@ class PreflightHealthCheck:
                 name="api_keys",
                 status=CheckStatus.FAILED,
                 message="No API keys found. Set at least one of: "
-                "ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY",
+                "ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, OPENROUTER_API_KEY",
                 latency_ms=latency,
             )
 

--- a/aragora/server/handlers/readiness_check.py
+++ b/aragora/server/handlers/readiness_check.py
@@ -35,23 +35,25 @@ logger = logging.getLogger(__name__)
 # Provider configuration
 # ---------------------------------------------------------------------------
 
-# (env_var, default_model) – default_model is the value we report when the
+# (env_vars, default_model) – default_model is the value we report when the
 # key is present.  We intentionally do NOT import agent modules here to keep
 # the handler lightweight and free of heavy dependencies.
-_PROVIDER_CONFIG: dict[str, tuple[str, str]] = {
-    "anthropic": ("ANTHROPIC_API_KEY", "claude-opus-4-5-20251101"),
-    "openai": ("OPENAI_API_KEY", "gpt-5.3"),
-    "openrouter": ("OPENROUTER_API_KEY", "deepseek/deepseek-chat-v3-0324"),
-    "mistral": ("MISTRAL_API_KEY", "mistral-large-2512"),
-    "gemini": ("GEMINI_API_KEY", "gemini-2.5-pro"),
-    "xai": ("XAI_API_KEY", "grok-4-latest"),
+_PROVIDER_CONFIG: dict[str, tuple[tuple[str, ...], str]] = {
+    "anthropic": (("ANTHROPIC_API_KEY",), "claude-opus-4-6"),
+    "openai": (("OPENAI_API_KEY",), "gpt-5.3"),
+    "openrouter": (("OPENROUTER_API_KEY",), "deepseek/deepseek-chat"),
+    "mistral": (("MISTRAL_API_KEY",), "mistral-large-2512"),
+    "gemini": (("GEMINI_API_KEY", "GOOGLE_API_KEY"), "gemini-3.1-pro-preview"),
+    "xai": (("XAI_API_KEY", "GROK_API_KEY"), "grok-4-latest"),
 }
 
-# A debate requires *at least one* of these providers.
-_REQUIRED_PROVIDERS = {"anthropic", "openai"}
+# A debate requires at least one of these core providers. OpenRouter counts as
+# core because direct API agents can degrade to it when primary provider keys
+# are unfunded or exhausted.
+_REQUIRED_PROVIDERS = {"anthropic", "openai", "openrouter"}
 
 # The rest are optional (nice-to-have for heterogeneous consensus).
-_OPTIONAL_PROVIDERS = {"openrouter", "mistral", "gemini", "xai"}
+_OPTIONAL_PROVIDERS = {"mistral", "gemini", "xai"}
 
 # ---------------------------------------------------------------------------
 # Feature detection helpers
@@ -60,12 +62,23 @@ _OPTIONAL_PROVIDERS = {"openrouter", "mistral", "gemini", "xai"}
 
 def _check_provider(name: str) -> dict[str, Any]:
     """Return availability info for a single AI provider."""
-    env_var, default_model = _PROVIDER_CONFIG[name]
-    key = os.environ.get(env_var)
-    available = key is not None and len(key) > 10
+    env_vars, default_model = _PROVIDER_CONFIG[name]
+    configured_var = next(
+        (
+            env_var
+            for env_var in env_vars
+            if (key := os.environ.get(env_var)) is not None and len(key) > 10
+        ),
+        None,
+    )
+    available = configured_var is not None
     if available:
         return {"available": True, "model": default_model}
-    return {"available": False, "reason": f"{env_var} not set"}
+    if len(env_vars) == 1:
+        env_hint = env_vars[0]
+    else:
+        env_hint = " or ".join(env_vars)
+    return {"available": False, "reason": f"{env_hint} not set"}
 
 
 def _detect_storage() -> dict[str, Any]:
@@ -151,20 +164,19 @@ class ReadinessCheckHandler(BaseHandler):
             providers[name] = _check_provider(name)
 
         # -- Missing keys --
+        any_required_available = any(providers[name]["available"] for name in _REQUIRED_PROVIDERS)
+
         missing_required: list[str] = []
-        for name in _REQUIRED_PROVIDERS:
-            if not providers[name]["available"]:
-                env_var = _PROVIDER_CONFIG[name][0]
-                missing_required.append(env_var)
+        if not any_required_available:
+            for name in _REQUIRED_PROVIDERS:
+                missing_required.extend(_PROVIDER_CONFIG[name][0])
 
         missing_optional: list[str] = []
         for name in _OPTIONAL_PROVIDERS:
             if not providers[name]["available"]:
-                env_var = _PROVIDER_CONFIG[name][0]
-                missing_optional.append(env_var)
+                missing_optional.extend(_PROVIDER_CONFIG[name][0])
 
-        # ready_to_debate = at least one required provider is configured
-        any_required_available = any(providers[name]["available"] for name in _REQUIRED_PROVIDERS)
+        # ready_to_debate = at least one core provider is configured
         ready_to_debate = any_required_available
 
         # -- Storage --

--- a/aragora/server/openapi/endpoints/system.py
+++ b/aragora/server/openapi/endpoints/system.py
@@ -720,7 +720,7 @@ SYSTEM_ENDPOINTS = {
 call it before any credentials are set up.
 
 **Response includes:**
-- `ready_to_debate` -- boolean indicating if at least one required provider is configured
+- `ready_to_debate` -- boolean indicating if at least one core provider is configured
 - Per-provider availability (anthropic, openai, openrouter, mistral, gemini, xai)
 - Missing required and optional API key names
 - Storage backend type and status
@@ -733,7 +733,7 @@ call it before any credentials are set up.
                         "properties": {
                             "ready_to_debate": {
                                 "type": "boolean",
-                                "description": "True if at least one required AI provider is configured",
+                                "description": "True if at least one core AI provider is configured",
                             },
                             "providers": {
                                 "type": "object",
@@ -801,7 +801,7 @@ call it before any credentials are set up.
                             "providers": {
                                 "anthropic": {
                                     "available": True,
-                                    "model": "claude-opus-4-5-20251101",
+                                    "model": "claude-opus-4-6",
                                 },
                                 "openai": {"available": True, "model": "gpt-5.3"},
                                 "openrouter": {
@@ -812,14 +812,21 @@ call it before any credentials are set up.
                                     "available": False,
                                     "reason": "MISTRAL_API_KEY not set",
                                 },
-                                "gemini": {"available": False, "reason": "GEMINI_API_KEY not set"},
-                                "xai": {"available": False, "reason": "XAI_API_KEY not set"},
+                                "gemini": {
+                                    "available": False,
+                                    "reason": "GEMINI_API_KEY or GOOGLE_API_KEY not set",
+                                },
+                                "xai": {
+                                    "available": False,
+                                    "reason": "XAI_API_KEY or GROK_API_KEY not set",
+                                },
                             },
                             "missing_required": [],
                             "missing_optional": [
                                 "GEMINI_API_KEY",
+                                "GOOGLE_API_KEY",
+                                "GROK_API_KEY",
                                 "MISTRAL_API_KEY",
-                                "OPENROUTER_API_KEY",
                                 "XAI_API_KEY",
                             ],
                             "storage": {"type": "sqlite", "status": "connected"},

--- a/aragora/server/startup/validation.py
+++ b/aragora/server/startup/validation.py
@@ -33,6 +33,19 @@ def _get_config_value(name: str) -> str | None:
         return None
 
 
+def _openrouter_fallback_configured() -> bool:
+    """Return True when OpenRouter fallback is available for direct API agents."""
+    if not _get_config_value("OPENROUTER_API_KEY"):
+        return False
+
+    try:
+        from aragora.agents.fallback import get_default_fallback_enabled
+
+        return get_default_fallback_enabled()
+    except (ImportError, AttributeError, RuntimeError, OSError, ValueError):
+        return True
+
+
 def check_connector_dependencies() -> list[str]:
     """Check if connector dependencies are available.
 
@@ -158,18 +171,36 @@ def check_agent_credentials(default_agents: str | None = None) -> list[str]:
                 "Set via env or AWS Secrets Manager (ARAGORA_USE_SECRETS_MANAGER=1)."
             )
 
+    fallback_available = _openrouter_fallback_configured()
+
     # Direct API providers
-    if "openai-api" in agent_names and not _get_config_value("OPENAI_API_KEY"):
+    if "openai-api" in agent_names and not (
+        _get_config_value("OPENAI_API_KEY") or fallback_available
+    ):
         warnings.append("OPENAI_API_KEY missing for openai-api agent (env or Secrets Manager).")
-    if "anthropic-api" in agent_names and not _get_config_value("ANTHROPIC_API_KEY"):
+    if "anthropic-api" in agent_names and not (
+        _get_config_value("ANTHROPIC_API_KEY") or fallback_available
+    ):
         warnings.append(
             "ANTHROPIC_API_KEY missing for anthropic-api agent (env or Secrets Manager)."
         )
-    if "gemini" in agent_names and not _get_config_value("GEMINI_API_KEY"):
-        warnings.append("GEMINI_API_KEY missing for gemini agent (env or Secrets Manager).")
-    if "grok" in agent_names and not _get_config_value("XAI_API_KEY"):
-        warnings.append("XAI_API_KEY missing for grok agent (env or Secrets Manager).")
-    if "mistral-api" in agent_names and not _get_config_value("MISTRAL_API_KEY"):
+    if "gemini" in agent_names and not (
+        _get_config_value("GEMINI_API_KEY")
+        or _get_config_value("GOOGLE_API_KEY")
+        or fallback_available
+    ):
+        warnings.append(
+            "GEMINI_API_KEY or GOOGLE_API_KEY missing for gemini agent (env or Secrets Manager)."
+        )
+    if "grok" in agent_names and not (
+        _get_config_value("XAI_API_KEY") or _get_config_value("GROK_API_KEY") or fallback_available
+    ):
+        warnings.append(
+            "XAI_API_KEY or GROK_API_KEY missing for grok agent (env or Secrets Manager)."
+        )
+    if "mistral-api" in agent_names and not (
+        _get_config_value("MISTRAL_API_KEY") or fallback_available
+    ):
         warnings.append("MISTRAL_API_KEY missing for mistral-api agent (env or Secrets Manager).")
 
     return warnings

--- a/tests/handlers/test_readiness_check.py
+++ b/tests/handlers/test_readiness_check.py
@@ -64,7 +64,9 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "OPENROUTER_API_KEY",
         "MISTRAL_API_KEY",
         "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
         "XAI_API_KEY",
+        "GROK_API_KEY",
         "DATABASE_URL",
         "ARAGORA_POSTGRES_DSN",
         "SUPABASE_POSTGRES_DSN",
@@ -234,6 +236,19 @@ class TestReadyToDebate:
         assert body["ready_to_debate"] is True
         assert body["missing_required"] == []
 
+    def test_ready_when_only_openrouter_set(
+        self,
+        handler: ReadinessCheckHandler,
+        mock_http_handler: MagicMock,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-XXXXXXXXXXXX")
+        result = handler.handle("/api/v1/readiness", {}, mock_http_handler)
+        body = parse_body(result)
+        assert body["ready_to_debate"] is True
+        assert body["missing_required"] == []
+
     def test_not_ready_when_no_required_providers(
         self,
         handler: ReadinessCheckHandler,
@@ -251,7 +266,6 @@ class TestReadyToDebate:
         clean_env: None,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-XXXXXXXXXXXX")
         monkeypatch.setenv("MISTRAL_API_KEY", "XXXXXXXXXXXXXXXXXXXX")
         result = handler.handle("/api/v1/readiness", {}, mock_http_handler)
         body = parse_body(result)
@@ -290,6 +304,7 @@ class TestMissingKeys:
         body = parse_body(result)
         assert "ANTHROPIC_API_KEY" in body["missing_required"]
         assert "OPENAI_API_KEY" in body["missing_required"]
+        assert "OPENROUTER_API_KEY" in body["missing_required"]
 
     def test_optional_missing_when_clean(
         self,
@@ -299,10 +314,11 @@ class TestMissingKeys:
     ) -> None:
         result = handler.handle("/api/v1/readiness", {}, mock_http_handler)
         body = parse_body(result)
-        assert "OPENROUTER_API_KEY" in body["missing_optional"]
         assert "MISTRAL_API_KEY" in body["missing_optional"]
         assert "GEMINI_API_KEY" in body["missing_optional"]
+        assert "GOOGLE_API_KEY" in body["missing_optional"]
         assert "XAI_API_KEY" in body["missing_optional"]
+        assert "GROK_API_KEY" in body["missing_optional"]
 
     def test_missing_required_sorted(
         self,
@@ -346,7 +362,7 @@ class TestMissingKeys:
         monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-XXXXXXXXXXXX")
         result = handler.handle("/api/v1/readiness", {}, mock_http_handler)
         body = parse_body(result)
-        assert "OPENROUTER_API_KEY" not in body["missing_optional"]
+        assert "OPENROUTER_API_KEY" not in body["missing_required"]
 
 
 # ============================================================================
@@ -384,6 +400,26 @@ class TestProviderDetails:
         for name in _PROVIDER_CONFIG:
             result = _check_provider(name)
             assert "available" in result
+
+    def test_gemini_google_api_key_counts_as_available(
+        self,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GOOGLE_API_KEY", "AIza-test-key-12345")
+        result = _check_provider("gemini")
+        assert result["available"] is True
+        assert result["model"] == "gemini-3.1-pro-preview"
+
+    def test_xai_grok_api_key_alias_counts_as_available(
+        self,
+        clean_env: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GROK_API_KEY", "xai-test-key-12345")
+        result = _check_provider("xai")
+        assert result["available"] is True
+        assert result["model"] == "grok-4-latest"
 
 
 # ============================================================================

--- a/tests/server/startup/test_validation.py
+++ b/tests/server/startup/test_validation.py
@@ -16,6 +16,11 @@ from aragora.server.startup.validation import (
 )
 
 
+def _env_only(name: str) -> str | None:
+    """Restrict startup validation tests to the patched environment only."""
+    return os.environ.get(name)
+
+
 # ---------------------------------------------------------------------------
 # _get_config_value tests
 # ---------------------------------------------------------------------------
@@ -137,46 +142,131 @@ class TestCheckAgentCredentials:
             },
             clear=True,
         ):
-            with patch("aragora.config.settings.get_settings") as mock_settings:
+            with (
+                patch("aragora.config.settings.get_settings") as mock_settings,
+                patch(
+                    "aragora.server.startup.validation._get_config_value",
+                    side_effect=_env_only,
+                ),
+            ):
                 mock_settings.return_value.agent.default_agents = "openai-api,anthropic-api"
                 warnings = check_agent_credentials()
                 assert warnings == []
 
     def test_warning_missing_openai_key(self):
         with patch.dict("os.environ", {}, clear=True):
-            with patch("aragora.config.settings.get_settings") as mock_settings:
+            with (
+                patch("aragora.config.settings.get_settings") as mock_settings,
+                patch(
+                    "aragora.server.startup.validation._get_config_value",
+                    side_effect=_env_only,
+                ),
+            ):
                 mock_settings.return_value.agent.default_agents = "openai-api"
                 warnings = check_agent_credentials()
                 assert any("OPENAI_API_KEY" in w for w in warnings)
 
     def test_warning_missing_anthropic_key(self):
         with patch.dict("os.environ", {}, clear=True):
-            with patch("aragora.config.settings.get_settings") as mock_settings:
+            with (
+                patch("aragora.config.settings.get_settings") as mock_settings,
+                patch(
+                    "aragora.server.startup.validation._get_config_value",
+                    side_effect=_env_only,
+                ),
+            ):
                 mock_settings.return_value.agent.default_agents = "anthropic-api"
                 warnings = check_agent_credentials()
                 assert any("ANTHROPIC_API_KEY" in w for w in warnings)
 
     def test_warning_missing_openrouter_key(self):
         with patch.dict("os.environ", {}, clear=True):
-            with patch("aragora.config.settings.get_settings") as mock_settings:
+            with (
+                patch("aragora.config.settings.get_settings") as mock_settings,
+                patch(
+                    "aragora.server.startup.validation._get_config_value",
+                    side_effect=_env_only,
+                ),
+            ):
                 mock_settings.return_value.agent.default_agents = "deepseek,qwen"
                 warnings = check_agent_credentials()
                 assert any("OPENROUTER_API_KEY" in w for w in warnings)
 
     def test_custom_agents_override(self):
         with patch.dict("os.environ", {"GEMINI_API_KEY": "test"}, clear=True):
-            warnings = check_agent_credentials(default_agents="gemini")
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="gemini")
             assert warnings == []
 
     def test_warning_missing_gemini_key(self):
         with patch.dict("os.environ", {}, clear=True):
-            warnings = check_agent_credentials(default_agents="gemini")
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="gemini")
             assert any("GEMINI_API_KEY" in w for w in warnings)
 
     def test_warning_missing_grok_key(self):
         with patch.dict("os.environ", {}, clear=True):
-            warnings = check_agent_credentials(default_agents="grok")
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="grok")
             assert any("XAI_API_KEY" in w for w in warnings)
+
+    def test_openrouter_fallback_satisfies_direct_agents(self):
+        with patch.dict(
+            "os.environ",
+            {"OPENROUTER_API_KEY": "or-test-key-12345"},
+            clear=True,
+        ):
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(
+                    default_agents="openai-api,anthropic-api,gemini,grok,mistral-api"
+                )
+            assert warnings == []
+
+    def test_openrouter_fallback_can_be_disabled(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "OPENROUTER_API_KEY": "or-test-key-12345",
+                "ARAGORA_OPENROUTER_FALLBACK_ENABLED": "false",
+            },
+            clear=True,
+        ):
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="openai-api")
+            assert any("OPENAI_API_KEY" in w for w in warnings)
+
+    def test_google_api_key_satisfies_gemini(self):
+        with patch.dict("os.environ", {"GOOGLE_API_KEY": "google-test-key-12345"}, clear=True):
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="gemini")
+            assert warnings == []
+
+    def test_grok_api_key_alias_satisfies_grok(self):
+        with patch.dict("os.environ", {"GROK_API_KEY": "grok-test-key-12345"}, clear=True):
+            with patch(
+                "aragora.server.startup.validation._get_config_value",
+                side_effect=_env_only,
+            ):
+                warnings = check_agent_credentials(default_agents="grok")
+            assert warnings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_nomic_preflight.py
+++ b/tests/test_nomic_preflight.py
@@ -195,6 +195,7 @@ class TestPreflightHealthCheckAPIKeys:
 
         assert result.status == CheckStatus.FAILED
         assert "No API keys found" in result.message
+        assert "OPENROUTER_API_KEY" in result.message
 
     @pytest.mark.asyncio
     async def test_single_api_key_warns(self, check, monkeypatch):


### PR DESCRIPTION
## Summary
- salvage the positive readiness/startup truthfulness slice from \
- treat OpenRouter fallback as a valid core path for readiness and startup validation
- recognize GOOGLE_API_KEY and GROK_API_KEY aliases in readiness/status reporting
- update startup validation and OpenAPI docs/tests to match the current runtime fallback semantics

## Included
- \
- \
- \
- \
- focused readiness/startup tests

## Explicitly excluded
- regressive OpenAI model-map changes
- UI changes from the stash
- minimal-mode/comment-only churn with no positive net effect

## Validation
- \........................................................................ [ 60%]
..........................s.s..................                          [100%]
117 passed, 2 skipped in 4.37s
- \All checks passed!
