### PR TITLE
Make launch truthfulness blocking

### DIFF
--- a/.github/workflows/integration-gate.yml
+++ b/.github/workflows/integration-gate.yml
@@ -240,36 +240,12 @@ jobs:
           python-version: "3.11"
 
       # ---------------------------------------------------------------
-      # Validate that docs/STATUS.md is parseable and well-formed
+      # Validate status docs against the strict truthfulness reconciler
       # ---------------------------------------------------------------
-      - name: "Validate STATUS.md is parseable"
-        run: |
-          python -c "
-          from pathlib import Path
-          import sys
-
-          status_path = Path('docs/STATUS.md')
-          if not status_path.exists():
-              print('::error::docs/STATUS.md does not exist')
-              sys.exit(1)
-
-          content = status_path.read_text()
-
-          # Check basic structure
-          if not content.strip():
-              print('::error::docs/STATUS.md is empty')
-              sys.exit(1)
-
-          # Check for required sections
-          required_markers = ['# Aragora', 'Summary', '##']
-          found = [m for m in required_markers if m in content]
-          if len(found) < 2:
-              print(f'::warning::docs/STATUS.md may be malformed (found {len(found)}/{len(required_markers)} expected markers)')
-
-          lines = content.splitlines()
-          print(f'docs/STATUS.md: {len(lines)} lines, {len(content)} bytes')
-          print('STATUS.md validation passed')
-          "
+      - name: "Validate release/status truthfulness"
+        run: python scripts/pre_release_check.py --gate status-doc
+        env:
+          PYTHONPATH: .
 
       # ---------------------------------------------------------------
       # Verify version in pyproject.toml matches release tag (if tagged)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -493,11 +493,12 @@ jobs:
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
 
       # ---------------------------------------------------------------
-      # STATUS.md validation: ensure the status doc is parseable
+      # STATUS.md validation: enforce strict release/status truthfulness
       # ---------------------------------------------------------------
-      - name: Validate STATUS.md
-        run: |
-          python scripts/pre_release_check.py --gate status-doc
+      - name: Validate release/status truthfulness
+        run: python scripts/pre_release_check.py --gate status-doc
+        env:
+          PYTHONPATH: .
 
   # ---------------------------------------------------------------------------
   # Integration gate: reusable workflow for integration smoke tests.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,12 +6,12 @@
 
 ## Current Status (March 2026)
 
-Aragora is **98% GA-ready**. The closed-loop backbone (CLB) sprint is now complete (14/14 issues closed). The platform has shipped all core infrastructure and is pending only an external vendor-dependent milestone before public launch.
+Aragora has shipped most of the closed-loop backbone (CLB) infrastructure and completed the 14/14 issue sprint, but launch readiness remains gated by truthfulness, self-host validation, and the remaining tracked launch work below.
 
 **By the numbers:**
 - 208,000+ tests across 5,000+ test files (0 failures on main)
 - 42 Knowledge Mound adapter specs registered (up from 34 in Q4 2025)
-- 3,000+ API operations across 2,900+ paths
+- 3,100+ API operations across 2,600+ paths
 - 15 RBAC resource types, 8 actions, 420+ named permissions
 - SOC 2 controls framework: 98% implemented
 
@@ -29,8 +29,8 @@ Aragora is **98% GA-ready**. The closed-loop backbone (CLB) sprint is now comple
 - PR watch daemon fleet (3 Mac machines, 30 autonomous reviews/hour)
 - Dev swarm coordination layer
 
-**Remaining blockers before GA:**
-- External penetration test (vendor-dependent; scheduling still pending confirmation and remains the only named GA blocker)
+**Remaining tracked launch work:**
+- External penetration test (vendor-dependent; scheduling still pending confirmation)
 
 **EU AI Act enforcement date: August 2, 2026** — the compliance CLI and audit trail infrastructure
 position Aragora as a natural adoption path for enterprises facing this deadline.
@@ -68,7 +68,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 ### Integrations
 - Slack, Discord, Microsoft Teams bots
 - Email-to-debate routing
-- REST API with 3,000+ operations across 2,900+ paths
+- REST API with 3,100+ operations across 2,600+ paths
 - WebSocket real-time API
 - MCP server for Claude Desktop
 
@@ -86,7 +86,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 - [x] Usage dashboard with spend analytics
 
 ### Track 2: Developer Platform
-- [x] OpenAPI 3.1 specification (3,000+ operations)
+- [x] OpenAPI 3.1 specification (3,100+ operations)
 - [x] TypeScript SDK feature parity with Python
 - [x] SDK code generation pipeline
 - [ ] Interactive API explorer at docs.aragora.ai/api
@@ -100,7 +100,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 - [x] Helm chart for Kubernetes
 
 ### Enterprise Readiness (Ongoing)
-- [ ] Complete third-party penetration testing (vendor-dependent scheduling remains the only named GA blocker)
+- [ ] Complete third-party penetration testing (vendor-dependent scheduling still pending)
 - [ ] Deploy public status page at status.aragora.ai
 - [x] Implement quarterly disaster recovery drills (BackupScheduler with DR integration)
 - [x] Finalize data classification policy (runtime enforcement, CI PII gate, evidence bundles)

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -17,7 +17,7 @@ All aragoradocs should cite these values. Update monthly.
 | Lines of code | 1,490,000 | LOC count |
 | Automated tests | 210,000+ | repo-wide `def test_` count |
 | Test files | 5,000+ | `tests/` file count |
-| API operations | 3,700+ across 2,900+ paths | OpenAPI spec |
+| API operations | 3,100+ across 2,600+ paths | OpenAPI spec |
 | WebSocket event types | 270+ | stream event inventory |
 | SDK namespaces | 186 Python / 185 TypeScript | SDK package |
 | Knowledge Mound adapters | 42 registered adapter specs | adapter factory registry |
@@ -26,8 +26,8 @@ All aragoradocs should cite these values. Update monthly.
 | Workflow templates | 50+ across 6 categories | template registry |
 | Debate modules | 210+ | debate/ directory |
 | Handler modules | 580+ | handlers/ directory |
-| Connector count | 151 production | connectors/STATUS.md |
-| GA readiness | 98% (1 blocker: external pentest) | GA_CHECKLIST.md |
+| Connector count | 149 production + 2 stub | connectors/STATUS.md |
+| GA readiness | Pre-GA; remaining launch work is tracked in GA_CHECKLIST.md | GA_CHECKLIST.md |
 | SOC 2 readiness | 98% | compliance assessment |
 | Mypy type errors | 0 | CI typecheck |
 | Pricing tiers | Free ($0) / Pro ($49/seat/mo) / Enterprise (custom) | -- |

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -24,7 +24,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,700+ API operations
+**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,100+ API operations across 2,600+ paths
 
 ---
 

--- a/docs/GA_CHECKLIST.md
+++ b/docs/GA_CHECKLIST.md
@@ -52,7 +52,7 @@ This checklist tracks all items required before declaring Aragora self-hosted GA
 
 ## API & SDK
 
-- [x] **REST API** - 3,000+ operations across 2,900+ paths
+- [x] **REST API** - 3,100+ operations across 2,600+ paths
 - [x] **WebSocket streaming** - 190+ event types
 - [x] **Python SDK** - `aragora-sdk` with full API parity
 - [x] **TypeScript SDK** - `@aragora/sdk` with 136/136 namespaces
@@ -119,4 +119,4 @@ This checklist tracks all items required before declaring Aragora self-hosted GA
 | Documentation | 5/5 | 100% |
 | **Total** | **58/59** | **98%** |
 
-**Only blocker: External penetration test.** Everything else is GA-ready.
+**Current unmet checklist item:** External penetration test. Release truthfulness and self-host evidence gates are tracked separately in the status/roadmap docs.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -49,7 +49,7 @@
 - **HTTP handlers**: 700+
 - **KM adapters**: 42 registered adapter specs
 - **Agent types**: 43
-- **API operations**: 3,000+ across 2,900+ paths
+- **API operations**: 3,100+ across 2,600+ paths
 - **RBAC permissions**: 420+
 - **Version**: v2.8.0
 
@@ -401,9 +401,9 @@ All 18 items from the 8-agent comprehensive assessment have been addressed (see 
 - `aragora/memory/continuum/crud.py` - Added async wrappers for all blocking SQLite operations
 - `aragora/server/openapi/endpoints/__init__.py` - Registered OpenClaw endpoints
 
-### GA Readiness Verification Audit (February 3, 2026)
+### Launch Readiness Verification Audit (February 3, 2026)
 
-Independent verification of production readiness found the project is **98% GA-ready** (up from 95% after resolving SDK parity, slash commands, and decision receipts gaps). Key findings:
+Independent verification found substantial launch-ready infrastructure, but Aragora remains pre-GA until the remaining launch work and release-truthfulness gates are closed. Key findings:
 
 | Area | Previous Estimate | Verified Status |
 |------|-------------------|-----------------|
@@ -414,7 +414,7 @@ Independent verification of production readiness found the project is **98% GA-r
 | Self-Hosted Deployment | Missing production setup | Docker Compose + .env.example comprehensive (193 + 125 lines) |
 | Knowledge Handler Tests | Partial | 97 tests passing (whitespace validation fix applied) |
 
-**Remaining GA Gaps (genuine):**
+**Remaining launch-readiness gaps tracked at the time:**
 - External penetration test (requires third-party vendor)
 - ~~TypeScript SDK parity at ~70% (target: 95%)~~ → **RESOLVED**: 99.3% parity (136/136 namespaces matched)
 - ~~Slack/Teams OAuth wizard and slash commands~~ → **RESOLVED**: 7+ slash commands per platform fully implemented
@@ -2816,7 +2816,7 @@ The nomic loop (`scripts/nomic_loop.py`) implements a 6-phase self-improvement c
 - `on_meta_analyzed`, `on_elo_recorded`, `on_claims_extracted`, `on_belief_network_built`
 
 The codebase is **feature-rich with improving exposure**:
-- 3,000+ API operations across 2,900+ paths, 580+ HTTP handler modules
+- 3,100+ API operations across 2,600+ paths, 580+ HTTP handler modules
 - Many sophisticated features now surfaced via new APIs
 - WebSocket-first architecture for real-time, REST for data access
 

--- a/docs/connectors/STATUS.md
+++ b/docs/connectors/STATUS.md
@@ -4,9 +4,9 @@ Last updated: 2026-02-23
 
 ## Summary
 
-- **Production**: 151 connectors
+- **Production**: 149 connectors
 - **Beta**: 0 connectors
-- **Stub**: 0 connectors
+- **Stub**: 2 connectors
 
 ## Status Criteria
 
@@ -271,8 +271,8 @@ Top-level evidence connectors extend `BaseConnector` and provide `search()`/`fet
 | Connector | Status | Features | Tests |
 |-----------|--------|----------|-------|
 | DocuSign (`legal/docusign.py`) | Production | OAuth 2.0/JWT, envelopes, templates, status tracking, retry with backoff | Yes |
-| LexisNexis (`legal/lexis.py`) | Production | Licensed content proxy, query sanitization, retry with backoff, circuit breaker | Yes |
-| Westlaw (`legal/westlaw.py`) | Production | Licensed content proxy, query sanitization, retry with backoff, circuit breaker | Yes |
+| LexisNexis (`legal/lexis.py`) | Stub | Placeholder for licensed proxy integration; query sanitization, retry with backoff, circuit breaker scaffolding | Yes |
+| Westlaw (`legal/westlaw.py`) | Stub | Placeholder for licensed proxy integration; query sanitization, retry with backoff, circuit breaker scaffolding | Yes |
 
 ### Low-Code
 
@@ -384,8 +384,8 @@ Integration connectors post debate results to external platforms and handle bidi
 
 ## Notes
 
-- **Stub connectors**: None remain. All former stubs (SendGrid, Twilio, Instagram, Trello) have been promoted to Production with real API calls, search, fetch, health checks, rate limiting, and circuit breaker integration.
+- **Stub connectors**: 2 licensed legal placeholders remain: LexisNexis and Westlaw. Both expose configuration and resilience scaffolding, but they are still documented as stubs until the licensed integrations are fully wired.
 - **Beta connectors**: None remain. All 18 former Beta connectors have been promoted to Production with circuit breaker patterns, retry with exponential backoff, and query sanitization where applicable. Promotion was achieved via two patterns: (1) BaseConnector subclasses use inherited `_request_with_retry`, (2) standalone connectors use `ProductionConnectorMixin` (`aragora/connectors/production_mixin.py`). Device connectors (Alexa, Google Home) already had circuit breaker and retry via `DeviceConnector` base class. EHR adapters (Epic, Cerner) gained retry/circuit breaker through the updated `EHRAdapter._request` method. Amazon gained production status through its `EnterpriseConnector` base class.
 - **Production connectors** include robust error handling, circuit breakers, rate limiting, caching, and/or retry with exponential backoff.
 - The **enterprise connectors** (`enterprise/`) all extend `EnterpriseConnector` with incremental sync, pagination safety caps (`_MAX_PAGES`), and standardized `SyncItem` output.
-- The **LexisNexis** and **Westlaw** connectors implement configurable proxy endpoints with query sanitization, retry with backoff, and circuit breaker patterns.
+- The **LexisNexis** and **Westlaw** connectors currently provide placeholder-backed licensed proxy scaffolding with query sanitization, retry with backoff, and circuit breaker patterns.

--- a/docs/status/COMMERCIAL_OVERVIEW.md
+++ b/docs/status/COMMERCIAL_OVERVIEW.md
@@ -106,7 +106,7 @@ Aragora is built on five architectural commitments that together produce somethi
 
 ## Commercial Readiness Assessment
 
-### Overall: 98% Production Ready
+### Overall: Strong pre-GA foundation
 
 | Category | Score | Status | Notes |
 |----------|-------|--------|-------|
@@ -118,7 +118,7 @@ Aragora is built on five architectural commitments that together produce somethi
 | Documentation | 95% | Ready | API docs, runbooks, compliance guides |
 | Compliance & Governance | 98% | Ready | RBAC v2 with 420+ permissions, 7 roles, role hierarchy |
 | SDK & Integrations | 98% | Ready | 186 Python / 185 TypeScript namespaces |
-| **OVERALL** | **98%** | **GA Ready** | Enterprise-grade features integrated, 0 mypy errors |
+| **OVERALL** | **Pre-GA** | **Substantial foundation** | Enterprise-grade features integrated; launch truthfulness and remaining readiness work still open |
 
 ### Deployment Readiness
 

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -22,7 +22,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,700+ API operations
+**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,100+ API operations across 2,600+ paths
 
 ---
 

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -49,7 +49,7 @@
 - **HTTP handlers**: 700+
 - **KM adapters**: 42 registered adapter specs
 - **Agent types**: 43
-- **API operations**: 3,000+ across 2,900+ paths
+- **API operations**: 3,100+ across 2,600+ paths
 - **RBAC permissions**: 420+
 - **Version**: v2.8.0
 
@@ -401,9 +401,9 @@ All 18 items from the 8-agent comprehensive assessment have been addressed (see 
 - `aragora/memory/continuum/crud.py` - Added async wrappers for all blocking SQLite operations
 - `aragora/server/openapi/endpoints/__init__.py` - Registered OpenClaw endpoints
 
-### GA Readiness Verification Audit (February 3, 2026)
+### Launch Readiness Verification Audit (February 3, 2026)
 
-Independent verification of production readiness found the project is **98% GA-ready** (up from 95% after resolving SDK parity, slash commands, and decision receipts gaps). Key findings:
+Independent verification found substantial launch-ready infrastructure, but Aragora remains pre-GA until the remaining launch work and release-truthfulness gates are closed. Key findings:
 
 | Area | Previous Estimate | Verified Status |
 |------|-------------------|-----------------|
@@ -414,7 +414,7 @@ Independent verification of production readiness found the project is **98% GA-r
 | Self-Hosted Deployment | Missing production setup | Docker Compose + .env.example comprehensive (193 + 125 lines) |
 | Knowledge Handler Tests | Partial | 97 tests passing (whitespace validation fix applied) |
 
-**Remaining GA Gaps (genuine):**
+**Remaining launch-readiness gaps tracked at the time:**
 - External penetration test (requires third-party vendor)
 - ~~TypeScript SDK parity at ~70% (target: 95%)~~ → **RESOLVED**: 99.3% parity (136/136 namespaces matched)
 - ~~Slack/Teams OAuth wizard and slash commands~~ → **RESOLVED**: 7+ slash commands per platform fully implemented
@@ -2816,7 +2816,7 @@ The nomic loop (`scripts/nomic_loop.py`) implements a 6-phase self-improvement c
 - `on_meta_analyzed`, `on_elo_recorded`, `on_claims_extracted`, `on_belief_network_built`
 
 The codebase is **feature-rich with improving exposure**:
-- 3,000+ API operations across 2,900+ paths, 580+ HTTP handler modules
+- 3,100+ API operations across 2,600+ paths, 580+ HTTP handler modules
 - Many sophisticated features now surfaced via new APIs
 - WebSocket-first architecture for real-time, REST for data access
 

--- a/scripts/generate_capability_matrix.py
+++ b/scripts/generate_capability_matrix.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 
 from capability_gap_report import build_report
@@ -51,6 +52,9 @@ def _count_cli_commands(repo_root: Path) -> int:
     calls in `aragora/cli/parser.py`.
     """
     try:
+        repo_root_str = str(repo_root)
+        if repo_root_str not in sys.path:
+            sys.path.insert(0, repo_root_str)
         from aragora.cli.parser import build_parser
 
         parser = build_parser()

--- a/scripts/pre_release_check.py
+++ b/scripts/pre_release_check.py
@@ -567,7 +567,7 @@ def gate_version_tag() -> bool:
 
 
 def gate_status_doc() -> bool:
-    """Validate that docs/STATUS.md exists and is parseable."""
+    """Validate that release/status docs pass the strict truthfulness checks."""
     status_path = PROJECT_ROOT / "docs" / "STATUS.md"
 
     if not status_path.exists():
@@ -591,7 +591,27 @@ def gate_status_doc() -> bool:
     if not has_sections:
         return _gate("status_doc", False, "docs/STATUS.md has no sections (## headings)")
 
-    return _gate("status_doc", True, f"{len(lines)} lines, well-formed")
+    env = os.environ.copy()
+    env.setdefault("PYTHONPATH", ".")
+    try:
+        result = subprocess.run(
+            [sys.executable, "scripts/reconcile_status_docs.py", "--strict"],
+            capture_output=True,
+            text=True,
+            cwd=PROJECT_ROOT,
+            env=env,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired:
+        return _gate("status_doc", False, "truthfulness reconciliation timed out after 120s")
+    except OSError as exc:
+        return _gate("status_doc", False, f"could not run truthfulness reconciliation: {exc}")
+
+    if result.returncode != 0:
+        detail = (result.stdout + result.stderr).strip() or "truthfulness reconciliation failed"
+        return _gate("status_doc", False, detail)
+
+    return _gate("status_doc", True, f"{len(lines)} lines, strict reconciliation passed")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reconcile_status_docs.py
+++ b/scripts/reconcile_status_docs.py
@@ -32,6 +32,52 @@ STATUS_DIR = REPO_ROOT / "docs" / "status" / "STATUS.md"
 ROADMAP = REPO_ROOT / "ROADMAP.md"
 CONNECTOR_STATUS = REPO_ROOT / "docs" / "connectors" / "STATUS.md"
 EXECUTION_PROGRAM = REPO_ROOT / "docs" / "status" / "EXECUTION_PROGRAM_2026Q2_Q4.md"
+CANONICAL_GOALS = REPO_ROOT / "docs" / "CANONICAL_GOALS.md"
+FEATURE_DISCOVERY = REPO_ROOT / "docs" / "FEATURE_DISCOVERY.md"
+FEATURE_DISCOVERY_STATUS = REPO_ROOT / "docs" / "status" / "FEATURE_DISCOVERY.md"
+COMMERCIAL_OVERVIEW_STATUS = REPO_ROOT / "docs" / "status" / "COMMERCIAL_OVERVIEW.md"
+OPENAPI_GENERATED = REPO_ROOT / "docs" / "api" / "openapi_generated.json"
+CONNECTOR_ROOT = REPO_ROOT / "aragora" / "connectors"
+
+API_METRIC_DOCS = [
+    (CANONICAL_GOALS, "CANONICAL_GOALS.md"),
+    (FEATURE_DISCOVERY, "FEATURE_DISCOVERY.md"),
+    (FEATURE_DISCOVERY_STATUS, "status/FEATURE_DISCOVERY.md"),
+    (GA_CHECKLIST, "GA_CHECKLIST.md"),
+    (STATUS_DOC, "STATUS.md"),
+    (STATUS_DIR, "status/STATUS.md"),
+    (ROADMAP, "ROADMAP.md"),
+]
+
+LAUNCH_READINESS_DOCS = [
+    (CANONICAL_GOALS, "CANONICAL_GOALS.md"),
+    (STATUS_DOC, "STATUS.md"),
+    (STATUS_DIR, "status/STATUS.md"),
+    (ROADMAP, "ROADMAP.md"),
+    (COMMERCIAL_OVERVIEW_STATUS, "status/COMMERCIAL_OVERVIEW.md"),
+]
+
+API_CLAIM_PATTERNS = [
+    re.compile(
+        r"(?P<ops>\d[\d,]*)\+\s+API operations(?:\s+across\s+(?P<paths>\d[\d,]*)\+\s+paths)?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"(?P<ops>\d[\d,]*)\+\s+operations\s+across\s+(?P<paths>\d[\d,]*)\+\s+paths",
+        re.IGNORECASE,
+    ),
+]
+
+LAUNCH_READINESS_PATTERNS = [
+    re.compile(r"98%\s+GA-ready", re.IGNORECASE),
+    re.compile(r"98%\s*\(1 blocker:\s*external pentest\)", re.IGNORECASE),
+    re.compile(r"98%\s+Production Ready", re.IGNORECASE),
+    re.compile(r"only named GA blocker", re.IGNORECASE),
+    re.compile(
+        r"pending only an external vendor-dependent milestone before public launch", re.IGNORECASE
+    ),
+    re.compile(r"\|\s*\*\*OVERALL\*\*\s*\|\s*\*\*98%\*\*\s*\|\s*\*\*GA Ready\*\*", re.IGNORECASE),
+]
 
 
 def _file_age_days(path: Path) -> int | None:
@@ -218,6 +264,167 @@ def _check_connector_status() -> list[dict]:
     return findings
 
 
+def _extract_openapi_counts() -> tuple[int, int] | None:
+    """Return (paths, operations) from the generated OpenAPI spec."""
+    if not OPENAPI_GENERATED.exists():
+        return None
+
+    try:
+        spec = json.loads(OPENAPI_GENERATED.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    paths = spec.get("paths", {})
+    operations = 0
+    valid_methods = {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+    for path_item in paths.values():
+        if isinstance(path_item, dict):
+            operations += sum(1 for method in path_item if method.lower() in valid_methods)
+    return len(paths), operations
+
+
+def _check_api_metric_claims() -> list[dict]:
+    """Fail when launch/status docs overstate OpenAPI path or operation counts."""
+    findings = []
+    counts = _extract_openapi_counts()
+    if counts is None:
+        findings.append(
+            {
+                "severity": "warning",
+                "source": "docs/api/openapi_generated.json",
+                "message": "Could not load generated OpenAPI counts for reconciliation",
+            }
+        )
+        return findings
+
+    actual_paths, actual_operations = counts
+
+    for path, label in API_METRIC_DOCS:
+        if not path.exists():
+            continue
+
+        content = path.read_text(encoding="utf-8", errors="replace")
+        seen_spans: set[tuple[int, int]] = set()
+
+        for pattern in API_CLAIM_PATTERNS:
+            for match in pattern.finditer(content):
+                span = match.span()
+                if span in seen_spans:
+                    continue
+                seen_spans.add(span)
+
+                ops_floor = int(match.group("ops").replace(",", ""))
+                paths_group = match.groupdict().get("paths")
+                paths_floor = int(paths_group.replace(",", "")) if paths_group else None
+
+                if ops_floor > actual_operations or (
+                    paths_floor is not None and paths_floor > actual_paths
+                ):
+                    excerpt = " ".join(match.group(0).split())
+                    findings.append(
+                        {
+                            "severity": "critical",
+                            "source": label,
+                            "message": (
+                                f"OpenAPI claim '{excerpt}' exceeds generated counts "
+                                f"(actual: {actual_operations} operations across {actual_paths} paths)"
+                            ),
+                        }
+                    )
+
+    findings.append(
+        {
+            "severity": "info",
+            "source": "docs/api/openapi_generated.json",
+            "message": f"Generated OpenAPI counts: {actual_operations} operations across {actual_paths} paths",
+        }
+    )
+    return findings
+
+
+def _find_explicit_placeholder_connectors() -> list[Path]:
+    """Return connector files that explicitly declare themselves placeholders."""
+    placeholder_files: list[Path] = []
+    if not CONNECTOR_ROOT.exists():
+        return placeholder_files
+
+    marker = re.compile(r"\bthis connector is a placeholder\b", re.IGNORECASE)
+    for path in CONNECTOR_ROOT.rglob("*.py"):
+        try:
+            content = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if marker.search(content):
+            placeholder_files.append(path)
+    return sorted(placeholder_files)
+
+
+def _check_connector_placeholder_drift() -> list[dict]:
+    """Cross-check explicit placeholder connectors against connector status docs."""
+    findings = []
+    if not CONNECTOR_STATUS.exists():
+        return findings
+
+    placeholder_files = _find_explicit_placeholder_connectors()
+    if not placeholder_files:
+        return findings
+
+    content = CONNECTOR_STATUS.read_text(encoding="utf-8", errors="replace")
+    stub_match = re.search(r"(?im)^\s*-\s*\*\*Stub\*\*:\s*(\d+)\s+connectors", content)
+    documented_stub_count = int(stub_match.group(1)) if stub_match else 0
+
+    if documented_stub_count < len(placeholder_files):
+        findings.append(
+            {
+                "severity": "critical",
+                "source": "connectors/STATUS.md",
+                "message": (
+                    f"Connector status documents {documented_stub_count} stub connectors, but "
+                    f"{len(placeholder_files)} explicit placeholder connectors exist in code: "
+                    + ", ".join(str(p.relative_to(CONNECTOR_ROOT)) for p in placeholder_files)
+                ),
+            }
+        )
+
+    for path in placeholder_files:
+        rel = str(path.relative_to(CONNECTOR_ROOT))
+        if re.search(rf"\(`{re.escape(rel)}`\)\s*\|\s*Production\s*\|", content):
+            findings.append(
+                {
+                    "severity": "critical",
+                    "source": "connectors/STATUS.md",
+                    "message": f"Connector `{rel}` is listed as Production but explicitly declares itself a placeholder",
+                }
+            )
+
+    return findings
+
+
+def _check_launch_readiness_claims() -> list[dict]:
+    """Block overconfident GA-readiness messaging in monitored docs."""
+    findings = []
+    for path, label in LAUNCH_READINESS_DOCS:
+        if not path.exists():
+            continue
+        content = path.read_text(encoding="utf-8", errors="replace")
+        for pattern in LAUNCH_READINESS_PATTERNS:
+            match = pattern.search(content)
+            if not match:
+                continue
+            findings.append(
+                {
+                    "severity": "critical",
+                    "source": label,
+                    "message": (
+                        f"Launch-readiness claim '{match.group(0)}' is not allowed in current-source docs. "
+                        "Use evidence-backed wording instead of single-blocker / percentage-ready messaging."
+                    ),
+                }
+            )
+            break
+    return findings
+
+
 def _check_staleness() -> list[dict]:
     """Check all status docs for staleness."""
     findings = []
@@ -253,6 +460,9 @@ def reconcile(strict: bool = False) -> dict:
     findings.extend(_check_capability_matrix_freshness())
     findings.extend(_check_ga_checklist())
     findings.extend(_check_connector_status())
+    findings.extend(_check_api_metric_claims())
+    findings.extend(_check_connector_placeholder_drift())
+    findings.extend(_check_launch_readiness_claims())
     findings.extend(_check_staleness())
 
     critical = [f for f in findings if f["severity"] == "critical"]


### PR DESCRIPTION
## Summary
- make release and integration status-doc gates enforce strict truthfulness reconciliation
- add blocking checks for overstated OpenAPI metrics, placeholder connector drift, and unsupported GA-ready messaging
- reconcile the affected roadmap/status docs and make capability-matrix generation deterministic across CI environments

## Validation
- python3 -m py_compile scripts/pre_release_check.py scripts/reconcile_status_docs.py scripts/generate_capability_matrix.py
- python3 scripts/check_capability_matrix_sync.py
- python3 scripts/reconcile_status_docs.py --strict
- python3 scripts/pre_release_check.py --gate status-doc

Closes #807