### PR TITLE
fix(ci): avoid apt bootstrap in production monitoring

### DIFF
--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -60,7 +60,14 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: aragora/live
-        run: npx playwright install --with-deps chromium
+        shell: bash
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            npx playwright install --with-deps chromium
+          else
+            echo "::notice::apt-get unavailable on runner; installing Chromium without OS package bootstrap"
+            npx playwright install chromium
+          fi
 
       - name: Run production smoke tests
         working-directory: aragora/live
@@ -133,7 +140,14 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: aragora/live
-        run: npx playwright install --with-deps chromium
+        shell: bash
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            npx playwright install --with-deps chromium
+          else
+            echo "::notice::apt-get unavailable on runner; installing Chromium without OS package bootstrap"
+            npx playwright install chromium
+          fi
 
       - name: Run auth flow tests
         working-directory: aragora/live
@@ -213,7 +227,14 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: aragora/live
-        run: npx playwright install --with-deps chromium
+        shell: bash
+        run: |
+          if command -v apt-get >/dev/null 2>&1; then
+            npx playwright install --with-deps chromium
+          else
+            echo "::notice::apt-get unavailable on runner; installing Chromium without OS package bootstrap"
+            npx playwright install chromium
+          fi
 
       - name: Run full production test suite
         working-directory: aragora/live


### PR DESCRIPTION
## Summary
- make `production-monitor.yml` install Playwright browser dependencies conditionally based on runner capabilities
- keep `--with-deps` on runners that have `apt-get`
- fall back to `npx playwright install chromium` on self-hosted runners without `apt-get`

## Why
`Production Monitoring` on `main` failed in `Install Playwright browsers` because the self-hosted Linux runner attempted `npx playwright install --with-deps chromium`, and Playwright tried to call `apt-get`, which is not available on that runner image.

## Scope
This PR intentionally fixes only `production-monitor.yml`, which is the workflow that actually failed. It does not broaden into other Playwright workflows.

## Validation
- YAML parse of `.github/workflows/production-monitor.yml`
- `python3 scripts/check_workflow_pip_install_policy.py`
- local runner capability check confirmed the fallback path is selected when `apt-get` is unavailable
