### PR TITLE
Make self-host readiness truthful and PR-gated

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -43,6 +43,7 @@ jobs:
               '.github/workflows/sdk-parity.yml',
               '.github/workflows/sdk-test.yml',
               '.github/workflows/openapi.yml',
+              '.github/workflows/self-host-readiness.yml',
               '.github/workflows/required-check-priority.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
@@ -51,6 +52,7 @@ jobs:
               'SDK Parity Check',
               'SDK Tests',
               'OpenAPI Spec',
+              'Self-Host Readiness',
             ]);
 
             const requiredContexts = new Set();

--- a/.github/workflows/self-host-readiness.yml
+++ b/.github/workflows/self-host-readiness.yml
@@ -1,0 +1,91 @@
+name: Self-Host Readiness
+
+on:
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: self-host-readiness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  self-host-compose-smoke:
+    name: Self-Host Compose Smoke
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify checkout integrity
+        shell: bash
+        run: |
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
+            git sparse-checkout disable || true
+            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
+            git reset --hard FETCH_HEAD
+            git clean -ffd || true
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::warning::Standard recovery failed; attempting archive restore"
+            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
+          fi
+          if [[ ! -f pyproject.toml ]]; then
+            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
+            echo "PWD=$(pwd)"
+            ls -la
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pyyaml
+
+      - name: Validate production compose + env example
+        run: python scripts/check_self_host_compose.py
+
+      - name: Prepare CI production env file
+        run: |
+          cp .env.production.example .env.production.ci
+          cat >> .env.production.ci <<'EOF'
+          DOMAIN=localhost
+          ACME_EMAIL=ci@example.com
+          ANTHROPIC_API_KEY=ci-anthropic-key
+          OPENAI_API_KEY=ci-openai-key
+          POSTGRES_PASSWORD=aragora-ci-postgres-password-0123456789
+          ARAGORA_API_TOKEN=aragora-ci-api-token-0123456789abcdef
+          ARAGORA_JWT_SECRET=aragora-ci-jwt-secret-0123456789abcdef
+          ARAGORA_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          GRAFANA_ADMIN_PASSWORD=aragora-ci-grafana-password
+          ARAGORA_ALLOWED_ORIGINS=http://localhost
+          ARAGORA_RATE_LIMIT_BACKEND=redis
+          ARAGORA_REDIS_MODE=sentinel
+          ARAGORA_REDIS_SENTINEL_HOSTS=sentinel-1:26379,sentinel-2:26379,sentinel-3:26379
+          ARAGORA_REDIS_SENTINEL_MASTER=mymaster
+          ARAGORA_STRICT_DEPLOYMENT=true
+          ARAGORA_SECRETS_STRICT=false
+          ARAGORA_REPLICAS=1
+          ARAGORA_MAX_CONCURRENT_DEBATES=2
+          TRAEFIK_DASHBOARD_USERS=admin:ci
+          EOF
+
+      - name: Runtime compose smoke validation
+        run: |
+          python scripts/check_self_host_runtime.py \
+            --env-file .env.production.ci \
+            --service-timeout 360 \
+            --api-timeout 240

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -31,7 +31,17 @@ The server is now available at `http://localhost:8080`.
 | **Simple** | `docker-compose.simple.yml` | SQLite | Evaluation, small teams |
 | **Standard** | `docker-compose.yml` | PostgreSQL + Redis | Production use |
 | **SME** | `docker-compose.sme.yml` | PostgreSQL + Redis + Grafana | SMBs with monitoring |
-| **Production** | `docker-compose.production.yml` | PostgreSQL + Redis Sentinel + Traefik | Enterprise HA |
+| **Production** | `docker-compose.production.yml` | PostgreSQL + Redis Sentinel + Traefik | Single-host production-style stack |
+
+## Production Compose Semantics
+
+`docker compose -f docker-compose.production.yml` is the documented single-host production path. It gives you Traefik ingress, PostgreSQL, Redis Sentinel, workers, and observability on one machine.
+
+Important differences from real orchestrators:
+
+- The production compose file exposes Aragora through Traefik on ports `80/443`. It does not publish the app container's `8080` port directly to the host.
+- `deploy.replicas`, rolling-update, and rollback directives in the compose file are swarm-oriented metadata. Plain `docker compose` ignores those replica/orchestration settings.
+- For actual multi-node replicas, rolling updates, or orchestrated HA, use Kubernetes or Docker Swarm. Treat the compose production file as a single-host production-style stack, not a cluster manager.
 
 ## Standard Deployment (PostgreSQL + Redis)
 
@@ -69,6 +79,17 @@ This starts three containers: `aragora` (API server), `db` (PostgreSQL 15), and 
 | `GEMINI_API_KEY` | Google Gemini |
 | `XAI_API_KEY` | xAI Grok |
 
+### Production Ingress & Monitoring
+
+These variables are required by `docker-compose.production.yml`:
+
+| Variable | Description |
+|----------|-------------|
+| `DOMAIN` | Public hostname Traefik routes for Aragora |
+| `ACME_EMAIL` | Let's Encrypt contact email for certificate issuance |
+| `GRAFANA_ADMIN_PASSWORD` | Grafana admin password for the bundled monitoring stack |
+| `TRAEFIK_DASHBOARD_USERS` | Optional htpasswd entry for the Traefik dashboard |
+
 ### Server Configuration
 
 | Variable | Default | Description |
@@ -99,14 +120,18 @@ This starts three containers: `aragora` (API server), `db` (PostgreSQL 15), and 
 
 ## Persistent Data
 
-All compose files mount a named volume for persistent data:
+All compose files mount named volumes for persistent data:
 
 | Volume | Container Path | Contents |
 |--------|---------------|----------|
 | `aragora-data` | `/app/data` | SQLite databases, ELO ratings, debate history |
 | `aragora-data/.aragora_beads` | `/app/data/.aragora_beads` | Bead and convoy store |
-| `postgres-data` | `/var/lib/postgresql/data` | PostgreSQL data (Standard+ tiers) |
-| `redis-data` | `/data` | Redis append-only file (Standard+ tiers) |
+| `postgres-data` | `/var/lib/postgresql/data` | PostgreSQL data |
+| `redis-data` | `/data` | Standalone Redis data (`docker-compose.yml` / `docker-compose.sme.yml`) |
+| `redis-master-data` | `/data` | Production compose Redis master data |
+| `redis-replica-1-data` | `/data` | Production compose Redis replica 1 data |
+| `redis-replica-2-data` | `/data` | Production compose Redis replica 2 data |
+| `sentinel-1-data` / `sentinel-2-data` / `sentinel-3-data` | `/data` | Production compose Redis Sentinel state |
 
 To back up your data:
 
@@ -114,9 +139,15 @@ To back up your data:
 # SQLite tier
 docker cp aragora:/app/data ./backup-data
 
-# PostgreSQL tier
-docker exec aragora-db pg_dump -U aragora aragora > backup.sql
+# Standard / SME PostgreSQL tiers
+docker compose exec db pg_dump -U aragora aragora > backup.sql
+
+# Production compose PostgreSQL tier
+docker compose -f docker-compose.production.yml --env-file .env.production \
+  exec postgres pg_dump -U aragora aragora > backup.sql
 ```
+
+For the production compose stack, back up the Redis master/replica/sentinel volumes separately if you need Redis state preservation in addition to PostgreSQL.
 
 ## Health Checks
 
@@ -140,15 +171,30 @@ python scripts/check_self_host_compose.py
 # 2) Start the production stack
 docker compose -f docker-compose.production.yml --env-file .env.production up -d
 
-# 3) Verify service health
+# 3) Verify app container health
 docker compose -f docker-compose.production.yml --env-file .env.production ps
-curl -fsS http://localhost:8080/healthz
-curl -fsS http://localhost:8080/readyz
+docker compose -f docker-compose.production.yml --env-file .env.production exec aragora curl -fsS http://localhost:8080/healthz
+docker compose -f docker-compose.production.yml --env-file .env.production exec aragora curl -fsS http://localhost:8080/readyz
 
-# 4) Verify authenticated API access
-curl -fsS \
+# 4) Verify ingress routing on the host
+curl -k --resolve "${DOMAIN}:443:127.0.0.1" \
+  https://${DOMAIN}/healthz
+```
+
+## Production Ingress Verification
+
+Use ingress URLs for host-level checks. The production compose stack is fronted by Traefik, so `localhost:8080` is only valid from inside the app container.
+
+```bash
+# Lightweight smoke check for an already-running deployment
+python scripts/smoke_self_host_runtime.py \
+  --base-url "https://${DOMAIN}" \
+  --api-token "${ARAGORA_API_TOKEN}"
+
+# Authenticated API access through ingress on the deployment host
+curl -k --resolve "${DOMAIN}:443:127.0.0.1" \
   -H "Authorization: Bearer ${ARAGORA_API_TOKEN}" \
-  http://localhost:8080/api/v1/debates
+  https://${DOMAIN}/api/v1/debates
 ```
 
 For CI and clean-machine validation, run:
@@ -170,7 +216,7 @@ docker compose -f docker-compose.production.yml --env-file .env.production logs 
 ```bash
 # Restart only the API layer (safe first action)
 docker compose -f docker-compose.production.yml --env-file .env.production restart aragora
-curl -fsS http://localhost:8080/readyz
+docker compose -f docker-compose.production.yml --env-file .env.production exec aragora curl -fsS http://localhost:8080/readyz
 ```
 
 ```bash
@@ -183,7 +229,7 @@ docker compose -f docker-compose.production.yml --env-file .env.production logs 
 # Database connection incident recovery
 docker compose -f docker-compose.production.yml --env-file .env.production restart postgres
 docker compose -f docker-compose.production.yml --env-file .env.production logs --tail=120 postgres
-curl -fsS http://localhost:8080/readyz
+docker compose -f docker-compose.production.yml --env-file .env.production exec aragora curl -fsS http://localhost:8080/readyz
 ```
 
 If recovery fails, capture diagnostics before teardown:
@@ -260,7 +306,7 @@ sudo chown -R 1000:1000 ./data
               +--------------+--------------+
               |                             |
      +--------v---------+        +---------v--------+
-     |  Aragora Server  |        |  Aragora Server  |  (replicas in production)
+     |  Aragora Server  |        |  Aragora Server  |  (Swarm/Kubernetes only)
      |  :8080 (HTTP)    |        |  :8080 (HTTP)    |
      |  :8765 (WS)      |        |  :8765 (WS)      |
      +--------+---------+        +---------+--------+

--- a/scripts/check_self_host_compose.py
+++ b/scripts/check_self_host_compose.py
@@ -62,6 +62,12 @@ SENTINEL_REQUIRED_ARAGORA_ENV_KEYS = {
 }
 
 RUNBOOK_MARKER_ALIASES = {
+    "Production Compose Semantics": ("Production Compose Semantics",),
+    "Production Ingress Verification": (
+        "Production Ingress Verification",
+        "Startup and Readiness Verification",
+        "Verify Installation",
+    ),
     "Startup and Readiness Verification": (
         "Startup and Readiness Verification",
         "Verify Installation",

--- a/scripts/check_self_host_runtime.py
+++ b/scripts/check_self_host_runtime.py
@@ -3,8 +3,8 @@
 Runtime validation for self-host production compose stack.
 
 This script boots the production compose core services, waits for healthy state,
-checks HTTP health/readiness probes, and verifies basic authenticated debate API
-reachability.
+checks explicit liveness/readiness probes, and verifies debate endpoint
+reachability plus auth-gate behavior.
 """
 
 from __future__ import annotations
@@ -32,8 +32,8 @@ DEFAULT_CORE_SERVICES = [
     "aragora",
 ]
 
-LIVENESS_PATH_CANDIDATES = ["/healthz", "/api/v1/health", "/api/health", "/health"]
-READINESS_PATH_CANDIDATES = ["/readyz", "/api/v1/health", "/api/health", "/healthz"]
+LIVENESS_PATH_CANDIDATES = ["/healthz"]
+READINESS_PATH_CANDIDATES = ["/readyz"]
 
 
 class RuntimeCheckError(RuntimeError):
@@ -396,15 +396,17 @@ def _wait_for_any_http_200(base_url: str, paths: list[str], timeout_seconds: int
 
 
 def _check_api_flow(base_url: str, api_token: str) -> None:
+    """Verify debate endpoints are reachable and auth is behaving coherently."""
     list_url = urllib.parse.urljoin(base_url, "/api/v1/debates?limit=1&offset=0")
     status, body = _http_request(list_url, token=api_token)
     if status == 200:
-        print("[ok] authenticated GET /api/v1/debates returned 200")
+        print("[ok] GET /api/v1/debates returned 200")
     elif status in {401, 403}:
         # In hardened deployments ARAGORA_API_TOKEN may be a server secret rather
         # than a user credential (JWT/API key). Treat auth-gated responses as a
-        # valid runtime signal and continue.
-        print(f"[warn] GET /api/v1/debates returned {status}; auth gate is enforced")
+        # valid route-protection signal and stop here rather than overstating the
+        # check as authenticated end-user success.
+        print(f"[ok] GET /api/v1/debates returned {status}; auth gate is enforced")
         return
     else:
         raise RuntimeCheckError(
@@ -491,7 +493,7 @@ def main() -> int:
 
         runtime_base_url = _resolve_runtime_base_url(base_cmd, args.base_url)
 
-        print("[step] waiting for HTTP health endpoints")
+        print("[step] waiting for explicit HTTP liveness/readiness endpoints")
         health_path = _wait_for_any_http_200(
             runtime_base_url,
             LIVENESS_PATH_CANDIDATES,
@@ -505,7 +507,7 @@ def main() -> int:
         )
         print(f"[ok] readiness endpoint: {readiness_path}")
 
-        print("[step] validating authenticated API flow")
+        print("[step] validating debate endpoint reachability")
         _check_api_flow(runtime_base_url, api_token=api_token)
 
         print("Self-host runtime validation passed")

--- a/scripts/smoke_self_host_runtime.py
+++ b/scripts/smoke_self_host_runtime.py
@@ -90,28 +90,45 @@ def _fetch(
         return -1, None, str(exc)
 
 
+def _status_value(data: dict[str, Any] | None) -> str:
+    if not isinstance(data, dict):
+        return ""
+    status = data.get("status", "")
+    if not isinstance(status, str):
+        return ""
+    return status.strip().lower()
+
+
+def _body_value(raw: str) -> str:
+    return raw.strip().lower()
+
+
 # ---------------------------------------------------------------------------
 # Individual checks
 # ---------------------------------------------------------------------------
 
 
-def check_liveness(base_url: str, token: str | None) -> bool:
+def check_liveness(base_url: str, token: str | None, timeout: int) -> bool:
     """GET /healthz -> expect 200 with status 'ok'."""
     url = f"{base_url}/healthz"
-    status, data, raw = _fetch(url, token)
+    status, data, raw = _fetch(url, token, timeout)
     if status == -1:
         return _check("/healthz (liveness)", False, f"connection failed: {raw}")
     if status != 200:
         return _check("/healthz (liveness)", False, f"HTTP {status}")
-    if data and data.get("status") == "ok":
-        return _check("/healthz (liveness)", True, "status=ok")
-    return _check("/healthz (liveness)", True, f"HTTP 200 (body: {raw[:80]})")
+    normalized_status = _status_value(data)
+    if normalized_status in {"ok", "healthy"}:
+        return _check("/healthz (liveness)", True, f"status={normalized_status}")
+    normalized_body = _body_value(raw)
+    if normalized_body in {"ok", "healthy"}:
+        return _check("/healthz (liveness)", True, f"body={normalized_body}")
+    return _check("/healthz (liveness)", False, f"unexpected body: {raw[:80]}")
 
 
-def check_readiness(base_url: str, token: str | None) -> bool:
+def check_readiness(base_url: str, token: str | None, timeout: int) -> bool:
     """GET /readyz -> expect 200 with status 'ready'."""
     url = f"{base_url}/readyz"
-    status, data, raw = _fetch(url, token)
+    status, data, raw = _fetch(url, token, timeout)
     if status == -1:
         return _check("/readyz (readiness)", False, f"connection failed: {raw}")
     if status == 503 and data:
@@ -119,43 +136,56 @@ def check_readiness(base_url: str, token: str | None) -> bool:
         return _check("/readyz (readiness)", False, f"HTTP 503: {reason}")
     if status != 200:
         return _check("/readyz (readiness)", False, f"HTTP {status}")
-    ready_status = data.get("status", "") if data else ""
-    return _check("/readyz (readiness)", True, f"status={ready_status}")
+    normalized_status = _status_value(data)
+    if normalized_status in {"ready", "ok"}:
+        return _check("/readyz (readiness)", True, f"status={normalized_status}")
+    normalized_body = _body_value(raw)
+    if normalized_body in {"ready", "ok"}:
+        return _check("/readyz (readiness)", True, f"body={normalized_body}")
+    return _check("/readyz (readiness)", False, f"unexpected body: {raw[:80]}")
 
 
-def check_health_api(base_url: str, token: str | None) -> bool:
+def check_health_api(base_url: str, token: str | None, timeout: int) -> bool:
     """GET /api/v1/health -> expect 200 with JSON body."""
     url = f"{base_url}/api/v1/health"
-    status, data, raw = _fetch(url, token)
+    status, data, raw = _fetch(url, token, timeout)
     if status == -1:
         return _check("/api/v1/health", False, f"connection failed: {raw}")
     if status != 200:
         return _check("/api/v1/health", False, f"HTTP {status}")
     if data is None:
         return _check("/api/v1/health", False, "response is not valid JSON")
-    health_status = data.get("status", "unknown")
+    health_status = _status_value(data)
+    if not health_status:
+        return _check("/api/v1/health", False, "missing status field")
     return _check("/api/v1/health", True, f"status={health_status}")
 
 
-def check_openapi(base_url: str, token: str | None) -> bool:
+def check_openapi(base_url: str, token: str | None, timeout: int) -> bool:
     """GET /api/v1/openapi.json -> expect 200 with valid JSON."""
     url = f"{base_url}/api/v1/openapi.json"
-    status, data, raw = _fetch(url, token)
+    status, data, raw = _fetch(url, token, timeout)
     if status == -1:
         return _check("/api/v1/openapi.json", False, f"connection failed: {raw}")
     if status != 200:
         return _check("/api/v1/openapi.json", False, f"HTTP {status}")
     if data is None:
         return _check("/api/v1/openapi.json", False, "response is not valid JSON")
-    # Verify it looks like an OpenAPI spec
-    has_openapi_field = "openapi" in data or "swagger" in data or "paths" in data
-    return _check("/api/v1/openapi.json", has_openapi_field or True, "valid JSON returned")
+    if not isinstance(data, dict):
+        return _check("/api/v1/openapi.json", False, "response is not a JSON object")
+    spec_version = data.get("openapi") or data.get("swagger")
+    paths = data.get("paths")
+    if not isinstance(spec_version, str):
+        return _check("/api/v1/openapi.json", False, "missing openapi/swagger version field")
+    if not isinstance(paths, dict) or not paths:
+        return _check("/api/v1/openapi.json", False, "missing or empty paths object")
+    return _check("/api/v1/openapi.json", True, f"openapi={spec_version}")
 
 
-def check_build_info(base_url: str, token: str | None) -> bool:
+def check_build_info(base_url: str, token: str | None, timeout: int) -> bool:
     """GET /health/build -> expect 200 with JSON body."""
     url = f"{base_url}/health/build"
-    status, data, raw = _fetch(url, token)
+    status, data, raw = _fetch(url, token, timeout)
     if status == -1:
         return _check("/health/build", False, f"connection failed: {raw}")
     if status != 200:
@@ -209,11 +239,11 @@ def main() -> int:
     _log("")
 
     # Run checks
-    check_liveness(base, token)
-    check_readiness(base, token)
-    check_health_api(base, token)
-    check_openapi(base, token)
-    check_build_info(base, token)
+    check_liveness(base, token, args.timeout)
+    check_readiness(base, token, args.timeout)
+    check_health_api(base, token, args.timeout)
+    check_openapi(base, token, args.timeout)
+    check_build_info(base, token, args.timeout)
 
     # Summary
     passed = sum(1 for _, ok, _ in _results if ok)

--- a/tests/scripts/test_check_self_host_compose.py
+++ b/tests/scripts/test_check_self_host_compose.py
@@ -91,7 +91,9 @@ services:
         "\n".join(
             [
                 "# Self Hosting",
+                "## Production Compose Semantics",
                 "## Startup and Readiness Verification",
+                "## Production Ingress Verification",
                 "## Health Checks",
                 "## Failure Recovery Playbook",
             ]
@@ -152,6 +154,7 @@ services:
         "\n".join(
             [
                 "# Self Hosting",
+                "## Production Compose Semantics",
                 "## Verify Installation",
                 "## Troubleshooting",
             ]
@@ -200,7 +203,7 @@ services:
 
 def test_fails_when_runbook_markers_missing(tmp_path: Path):
     compose, env, runbook = _write_valid_fixture(tmp_path)
-    runbook.write_text("# Self Hosting\n## Health Checks\n")
+    runbook.write_text("# Self Hosting\n## Production Compose Semantics\n## Health Checks\n")
 
     result = _run("--compose", str(compose), "--env-example", str(env), "--runbook", str(runbook))
     assert result.returncode == 1

--- a/tests/scripts/test_check_self_host_runtime.py
+++ b/tests/scripts/test_check_self_host_runtime.py
@@ -116,11 +116,11 @@ def test_validate_runtime_env_file_accepts_valid_values(tmp_path: Path) -> None:
     assert warnings == []
 
 
-def test_readiness_candidates_include_healthz_fallback() -> None:
+def test_readiness_candidates_require_readyz() -> None:
     module = _load_script_module()
 
-    assert module.READINESS_PATH_CANDIDATES[-1] == "/healthz"
-    assert "/readyz" in module.READINESS_PATH_CANDIDATES
+    assert module.READINESS_PATH_CANDIDATES == ["/readyz"]
+    assert module.LIVENESS_PATH_CANDIDATES == ["/healthz"]
 
 
 def test_resolve_runtime_base_url_uses_container_ip_when_no_host_port() -> None:

--- a/tests/scripts/test_smoke_self_host_runtime.py
+++ b/tests/scripts/test_smoke_self_host_runtime.py
@@ -1,0 +1,53 @@
+"""Tests for scripts/smoke_self_host_runtime.py."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import patch
+
+
+def _load_script_module() -> ModuleType:
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "smoke_self_host_runtime.py"
+    spec = importlib.util.spec_from_file_location("smoke_self_host_runtime", script_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Unable to load smoke_self_host_runtime.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_openapi_fails_on_generic_json() -> None:
+    module = _load_script_module()
+
+    with patch.object(
+        module, "_fetch", return_value=(200, {"hello": "world"}, '{"hello":"world"}')
+    ):
+        assert module.check_openapi("http://localhost:8000", None, 5) is False
+
+
+def test_check_openapi_passes_on_valid_spec() -> None:
+    module = _load_script_module()
+
+    payload = {"openapi": "3.1.0", "paths": {"/healthz": {"get": {}}}}
+    with patch.object(module, "_fetch", return_value=(200, payload, '{"openapi":"3.1.0"}')):
+        assert module.check_openapi("http://localhost:8000", None, 5) is True
+
+
+def test_check_readiness_fails_on_http_200_not_ready_status() -> None:
+    module = _load_script_module()
+
+    with patch.object(
+        module, "_fetch", return_value=(200, {"status": "starting"}, '{"status":"starting"}')
+    ):
+        assert module.check_readiness("http://localhost:8000", None, 5) is False
+
+
+def test_check_health_api_requires_status_field() -> None:
+    module = _load_script_module()
+
+    with patch.object(
+        module, "_fetch", return_value=(200, {"uptime_seconds": 12}, '{"uptime_seconds":12}')
+    ):
+        assert module.check_health_api("http://localhost:8000", None, 5) is False


### PR DESCRIPTION
## Summary
- add a pull-request self-host compose smoke workflow and protect it from required-check cancellation
- tighten self-host runtime/smoke validation so broken readiness and bogus OpenAPI responses fail correctly
- reconcile SELF_HOSTING.md with actual production-compose semantics, ingress path, and production volume/env requirements

## Validation
- python3 -m py_compile scripts/smoke_self_host_runtime.py scripts/check_self_host_runtime.py scripts/check_self_host_compose.py
- python3 scripts/check_self_host_compose.py
- pytest -q tests/scripts/test_check_self_host_compose.py tests/scripts/test_check_self_host_runtime.py tests/scripts/test_smoke_self_host_runtime.py

Closes #808