### PR TITLE
Canonicalize active backlog issue tracking

### DIFF
--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -1,6 +1,7 @@
 # Aragora Feature Gap List
 
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
+> Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md) and the linked GitHub issues. This file remains the capability and productization backlog truth.
 > Last updated: March 2026
 
 ## How to Read This List
@@ -18,7 +19,7 @@
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| External penetration test | Vendor outreach in progress | Kickoff target: Mar 3, 2026. Only remaining external blocker. |
+| External penetration test | Vendor outreach in progress | Kickoff target: Mar 3, 2026. Tracked in [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), and [#509](https://github.com/synaptent/aragora/issues/509). Kept warm, not the main product lane. |
 | Debate output quality | **VALIDATED — moved to Completed** | Run 012 (Mar 5): composite 8.38-9.39/10. Diverse benchmark (10 domains): 100% pass, avg composite 0.938. |
 
 ---
@@ -27,9 +28,9 @@
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Agent-first beta via REST API | **Fleet deployed (12 runners)** | `aragora openclaw watch` polls repos, runs multi-agent review, posts findings. 3 Hetzner + 6 EC2 + 3 local Macs. PR watch daemon on Mac Studio via launchd. |
+| Agent-first beta via REST API | **Fleet deployed (12 runners)** | `aragora openclaw watch` polls repos, runs multi-agent review, posts findings. 3 Hetzner + 6 EC2 + 3 local Macs. PR watch daemon on Mac Studio via launchd. Shared operator productization is tracked in [#817](https://github.com/synaptent/aragora/issues/817) and [#819](https://github.com/synaptent/aragora/issues/819). |
 | GitHub Actions pre-merge gate | **Workflow created** | `aragora-review-gate.yml` manual-only (workflow_dispatch). Re-enable pull_request trigger when ready. |
-| Public demo at aragora.ai/demo | **Live and verified** | `/demo` (standalone debate), `/demo/pipeline` (pipeline demo), `/demo/instant` (debate replay). All return 200. Landing page CTA wired. |
+| Public demo at aragora.ai/demo | **Live and verified** | `/demo` (standalone debate), `/demo/pipeline` (pipeline demo), `/demo/instant` (debate replay). All return 200. Landing page CTA wired. Productization is tracked in [#818](https://github.com/synaptent/aragora/issues/818). |
 | EU AI Act compliance package | **Substantially complete (90/100)** | Art. 9/10/11/12/13/14/15/43/49 bundle coverage and customer playbook appendix are shipped. Remaining work is packaging polish, regulator-ready validation, and launch collateral hardening. **Deadline: Aug 2, 2026.** |
 | First 2 enterprise pilot engagements | Not started | Closed partnerships — target fintech + healthcare |
 | Developer onboarding <10 min | **Working (2-5 min)** | `aragora quickstart --demo` (zero-config), `aragora review --demo`, Docker quickstart all verified working. Needs cold-start user testing. |
@@ -41,12 +42,12 @@
 | Feature | Status | Notes |
 |---------|--------|-------|
 | Semantic convergence (full embedding) | **VALIDATED — moved to Completed** | PR #723 migrated 5 similarity modules from difflib to embedding-based. Remaining difflib usage is exclusively for text diff display, not similarity. |
-| ERC-8004 on-chain deployment | Contracts written | Solidity contracts exist; not deployed to any mainnet. Needs chain endpoint config + gas management. |
-| OpenClaw end-to-end demo | **Core loop shipped** | PR #727: CodeImplementationTask, SpecExtractor, ComputerUseActionBundle, receipt linkage. Production validation with live agents remaining. |
+| ERC-8004 on-chain deployment | Contracts written | Solidity contracts exist; not deployed to any mainnet. Needs chain endpoint config + gas management. Tracked in [#816](https://github.com/synaptent/aragora/issues/816). |
+| OpenClaw end-to-end demo | **Core loop shipped** | PR #727: CodeImplementationTask, SpecExtractor, ComputerUseActionBundle, receipt linkage. Production validation with live agents remaining. Tracked in [#814](https://github.com/synaptent/aragora/issues/814). |
 | Decision-Integrity UI Workbench | **~90% done** | `(app)/decision-integrity/page.tsx` (910 lines), `(app)/leaderboard/page.tsx`, `(app)/knowledge/page.tsx` (1042 lines) all ship. Remaining: Canvas GUI 8-stage visual DAG (moved to P4). |
 | SOC 2 Type II audit engagement | Scope doc ready | 60+ controls implemented (98%); pentest scope doc v3.1.0 finalized; vendor shortlisted (NCC, Bishop Fox, Trail of Bits, Cure53). Blocker: vendor selection + engagement. |
-| Smart provider routing | **Phase 1 shipped** | PR #724: Pareto optimizer, 8-model pricing database, ProviderRouter. Runtime integration with Arena agent selection remaining. |
-| Enterprise Communication Hub (#293) | **Epic closed** | PR #726: template persistence, router event wiring, E2E tests. Delivery log, retry queue, circuit breakers, event telemetry, user preference UI, Active Triage dashboard, TriageRulesPanel all shipped. Remaining: inbox→debate trigger wiring end-to-end validation. |
+| Smart provider routing | **Phase 1 shipped** | PR #724: Pareto optimizer, 8-model pricing database, ProviderRouter. Runtime integration with Arena agent selection remaining. Tracked in [#813](https://github.com/synaptent/aragora/issues/813). |
+| Enterprise Communication Hub (#293) | **Epic closed** | PR #726: template persistence, router event wiring, E2E tests. Delivery log, retry queue, circuit breakers, event telemetry, user preference UI, Active Triage dashboard, TriageRulesPanel all shipped. Remaining: inbox→debate trigger wiring end-to-end validation, tracked in [#817](https://github.com/synaptent/aragora/issues/817). |
 
 ---
 
@@ -59,7 +60,7 @@
 | Skills Marketplace pilot | Scaffolding | SkillRegistry + SkillMarketplace code exists; no public marketplace endpoint. |
 | On-premise deployment productization | Partial | Docker Compose + Helm chart exist; on-prem installer/wizard not built. |
 | International expansion / EU data residency | Not started | Data residency controls needed for EU enterprise buyers. |
-| 10+ agent coordinated debates | Scaffolding | Current practical limit: 2-6 agents. Coordination infrastructure exists; scale testing needed. |
+| 10+ agent coordinated debates | Scaffolding | Current practical limit: 2-6 agents. Coordination infrastructure exists; scale testing needed. Tracked in [#815](https://github.com/synaptent/aragora/issues/815). |
 | Compute escrow mechanism | Not started | Settlement stakes via crypto compute escrow. Design in docs/plans/. |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ organizational knowledge and channels**.
 |----------|-------------|
 | [STATUS](./status/STATUS.md) | Current shipped state and recent delivery summary |
 | [NEXT_STEPS_CANONICAL](./status/NEXT_STEPS_CANONICAL.md) | Single source of truth for execution priorities |
+| [ACTIVE_EXECUTION_ISSUES](./status/ACTIVE_EXECUTION_ISSUES.md) | Live GitHub issue map for the execution program |
 | [EXECUTION_NEXT_6_WEEKS_2026-03-05](./status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md) | Active short-horizon plan |
 | [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](./status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md) | Running roadmap, drift, and feature-gap register |
 

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,0 +1,75 @@
+# Active Execution Issues
+
+Last updated: 2026-03-07
+
+This document links Aragora's current execution program to the live GitHub issue tracker.
+
+- Docs explain thesis, roadmap, and capability posture.
+- GitHub issues track active execution status, owners, priorities, and acceptance criteria.
+- Use [NEXT_STEPS_CANONICAL](NEXT_STEPS_CANONICAL.md) for execution order and this file for the live issue map.
+
+## Current Execution Order
+
+1. Truthfulness and backlog canonicalization
+2. Decision Integrity Kernel unification
+3. Sequential surface productization
+4. Assurance closeout kept warm, not the main product lane
+
+## Truthfulness And Backlog Canonicalization
+
+Epic: [#804](https://github.com/synaptent/aragora/issues/804)
+
+Current tranche: [#809](https://github.com/synaptent/aragora/issues/809)
+
+Recently completed:
+- [#807](https://github.com/synaptent/aragora/issues/807) `CLOSED` - Make launch truthfulness blocking
+- [#808](https://github.com/synaptent/aragora/issues/808) `CLOSED` - Make self-host readiness truthful and PR-gated
+
+| Issue | State | Priority | Owner | Milestone | Scope |
+|------|-------|----------|-------|-----------|-------|
+| [#807](https://github.com/synaptent/aragora/issues/807) | Closed | `priority:critical` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Make launch truthfulness blocking |
+| [#808](https://github.com/synaptent/aragora/issues/808) | Closed | `priority:high` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Make self-host readiness truthful and PR-gated |
+| [#809](https://github.com/synaptent/aragora/issues/809) | Open | `priority:high` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Canonicalize the active backlog into GitHub issues |
+
+## Decision Integrity Kernel Unification
+
+Epic: [#805](https://github.com/synaptent/aragora/issues/805)
+
+| Issue | State | Priority | Owner | Milestone | Scope |
+|------|-------|----------|-------|-----------|-------|
+| [#810](https://github.com/synaptent/aragora/issues/810) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Add prompt -> specification -> DecisionPlan bridge |
+| [#811](https://github.com/synaptent/aragora/issues/811) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Collapse prompt/canvas/pipeline to one canonical execution runtime |
+| [#812](https://github.com/synaptent/aragora/issues/812) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Require cryptographic decision receipts before all action-taking |
+| [#813](https://github.com/synaptent/aragora/issues/813) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Integrate ProviderRouter into runtime agent selection |
+| [#814](https://github.com/synaptent/aragora/issues/814) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Make OpenClaw action dispatch real |
+| [#815](https://github.com/synaptent/aragora/issues/815) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Scale adversarial orchestration to 10+ agents |
+| [#816](https://github.com/synaptent/aragora/issues/816) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Deploy ERC-8004 identity and settlement integration |
+
+## Sequential Surface Productization
+
+Epic: [#806](https://github.com/synaptent/aragora/issues/806)
+
+| Issue | State | Priority | Owner | Milestone | Scope |
+|------|-------|----------|-------|-----------|-------|
+| [#817](https://github.com/synaptent/aragora/issues/817) | Open | `priority:high` | `owner:team-integrations` | `2026-M2 Surface Productization` | Consolidate inbox and shared inbox onto the trust wedge |
+| [#818](https://github.com/synaptent/aragora/issues/818) | Open | `priority:high` | `owner:team-integrations` | `2026-M2 Surface Productization` | Turn the public demo into a live proof surface |
+| [#819](https://github.com/synaptent/aragora/issues/819) | Open | `priority:high` | `owner:team-integrations` | `2026-M2 Surface Productization` | Make the integrations UI trustworthy and non-demo by default |
+| [#820](https://github.com/synaptent/aragora/issues/820) | Open | `priority:medium` | `owner:team-integrations` | `2026-M2 Surface Productization` | Productize Wave 2 surfaces: SME onboarding, spectate, and conditional public endpoints |
+
+## Assurance And GTM Issues Kept Warm
+
+These remain open and real, but they are not the primary product lane while the decision kernel and proof surfaces are still being unified.
+
+| Issue | State | Priority | Owner | Milestone | Scope |
+|------|-------|----------|-------|-----------|-------|
+| [#273](https://github.com/synaptent/aragora/issues/273) | Open | `priority:critical` | `owner:team-risk` | `2026-M2 Channel and FinOps` | Enterprise Assurance Closure epic |
+| [#274](https://github.com/synaptent/aragora/issues/274) | Open | `priority:critical` | `owner:team-risk` | `2026-M2 Channel and FinOps` | Execute external penetration test and remediate findings |
+| [#509](https://github.com/synaptent/aragora/issues/509) | Open | `priority:critical` | `owner:team-risk` | `none` | Pentest vendor selection and scope sign-off |
+
+## Operating Rule
+
+When the execution program changes:
+
+1. update the GitHub issues first
+2. update [NEXT_STEPS_CANONICAL](NEXT_STEPS_CANONICAL.md)
+3. update this issue map and any linked summary docs

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -1,8 +1,10 @@
 # Documentation Hygiene And Gap Register
 
-Last updated: 2026-03-06
+Last updated: 2026-03-07
 
 This register is the working record for documentation cleanup, roadmap extraction, and code-vs-doc drift found during the March 2026 hygiene pass.
+
+The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXECUTION_ISSUES.md) and the linked GitHub issues. Current-source docs should point there for execution status instead of carrying standalone operational backlog.
 
 ## Scope
 
@@ -19,6 +21,7 @@ This register is the working record for documentation cleanup, roadmap extractio
 - Regenerated `docs/CAPABILITY_MATRIX.md` and `docs-site/docs/contributing/capability-matrix.md` from the YAML source of truth.
 - Added discoverability links for status, roadmap, gap, and hygiene docs from the main indexes.
 - Marked legacy snapshot docs as non-canonical where they were being presented as live status.
+- Canonicalized the current execution program into GitHub issues and added `docs/status/ACTIVE_EXECUTION_ISSUES.md` as the issue map for epics `#804`-`#806`, execution lanes `#807`-`#820`, and assurance issues `#273`, `#274`, `#509`.
 
 ## Validation Snapshot
 
@@ -47,7 +50,7 @@ This register is the working record for documentation cleanup, roadmap extractio
 ### Current Focus (March 2026)
 
 - Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
-- Canonical execution priorities are operational hardening, registry/doc drift control, SDK/version alignment, self-host readiness, and pentest closure in `docs/status/NEXT_STEPS_CANONICAL.md`.
+- Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization (`#804`, `#807`-`#809`), Decision Integrity Kernel unification (`#805`, `#810`-`#816`), and sequential surface productization (`#806`, `#817`-`#820`) in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
 - The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in `docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
 
 ### Near-Term Goals (Q2 2026)
@@ -96,3 +99,4 @@ This register is the working record for documentation cleanup, roadmap extractio
 - Historical, pricing, investor, and outreach collateral still contains stale counts in places and was not bulk-rewritten in this pass.
 - Duplicate current-status surfaces still exist for compatibility and should eventually be consolidated into pointer docs once inbound links are audited.
 - A follow-up sweep should normalize current SDK, RBAC, and adapter counts across commercial and enterprise collateral.
+- Future execution-lane changes should update the GitHub issues first, then refresh `ACTIVE_EXECUTION_ISSUES.md` and the linked planning summaries.

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -5,86 +5,56 @@ Last updated: 2026-03-07
 This is the single source of truth for short-horizon execution priorities.
 `docs/CANONICAL_GOALS.md` defines what Aragora is and why.
 `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md` defines the long-range architecture and moat.
-`docs/FEATURE_GAP_LIST.md` is the current delivery/backlog truth.
+`docs/FEATURE_GAP_LIST.md` is the current capability/backlog truth.
+`ACTIVE_EXECUTION_ISSUES.md` links this execution order to the live GitHub issue backlog.
 This file defines execution order.
 
 ## Current Reality
 
-- The product thesis is intact: Aragora is building a decision-integrity platform, not just a debate engine.
-- The repo has shipped major backbone, compliance, swarm, and OpenClaw milestones, but `main` still has operational truthfulness gaps in CI/CD and deployment.
-- Short-horizon work should optimize for launch credibility: what is claimed in roadmap/status docs must match what actually works on `main`.
+- The full vision remains the goal; the near-term requirement is sequencing, not scope reduction.
+- The moat is the receipt-gated decision kernel: prompt/spec/debate/consensus/cryptographic receipt/policy-gated action.
+- GitHub issues now carry active execution status, owners, and acceptance criteria. Docs should summarize context and order, not act as the only operational backlog.
+- Truthfulness hardening is already underway on `main`: [#807](https://github.com/synaptent/aragora/issues/807) and [#808](https://github.com/synaptent/aragora/issues/808) are complete, and [#809](https://github.com/synaptent/aragora/issues/809) is the current backlog-canonicalization tranche.
+- Surface area should be productized sequentially, not hidden or allowed to drift.
 
 ## Execution Order
 
-### 1) Mainline CI/CD and Release Truthfulness
-- Owner: Platform + DevOps
-- Goal: `main` should be a trustworthy signal of ship readiness, not a mixture of real regressions and policy/tooling false positives.
+### 1) Truthfulness And Backlog Canonicalization
+- Tracking: [#804](https://github.com/synaptent/aragora/issues/804), [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809)
+- Goal: `main` and current-source docs should stay truthful, and the active backlog should live in GitHub instead of only in Markdown.
 - Acceptance:
-  - `Branch Discipline` no longer flags merged-PR commits on `main` as direct pushes.
-  - `Deploy Documentation` succeeds on the current runner image or uses a portable archive path that does not require missing host tools.
-  - `Deploy to EC2` handles unhealthy or invalid canary instance state explicitly and does not fail rollback because the target instance is unusable.
-  - `Main Required Checks Auto Revert` stops flapping on the same underlying failures.
-- Evidence today:
-  - `Branch Discipline` failed on `739ab5e`, `b441b2d`, and `ea402d2` even though they are merged-history commits.
-  - `Deploy Documentation` failed because `gtar` is not present on the runner.
-  - `Deploy to EC2` failed because canary instance `i-0dbd51f74a9a11fcc` was not in a valid state.
+  - Launch/readiness claims match what works on `main`.
+  - Self-host/readiness docs and gates are evidence-backed.
+  - Current execution lanes are tracked in GitHub with owners, priorities, and acceptance criteria.
+  - Canonical planning docs link to the issue map instead of carrying operational status alone.
 
-### 2) GTM Proof Closeout
-- Owner: Product + Compliance + GTM
-- Goal: convert the "98% GA-ready" narrative into evidence-backed launch readiness.
-- Acceptance:
-  - EU AI Act customer playbook and appendix are complete and externally usable.
-  - External pentest engagement is underway with tracked remediation ownership.
-  - SOC 2 Type II audit engagement is initiated.
-  - At least two real pilot lanes are actively being converted, not just named in docs.
-- Source of truth:
-  - `docs/FEATURE_GAP_LIST.md` P0-P2
-  - `ROADMAP.md` Q2 2026 priorities
+### 2) Decision Integrity Kernel Unification
+- Tracking: [#805](https://github.com/synaptent/aragora/issues/805), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816)
+- Goal: unify `prompt -> specification -> adversarial debate -> consensus/dissent -> cryptographic decision receipt -> policy gate -> execution` as one canonical runtime.
+- Why now:
+  - This is the architectural center of Aragora's differentiation.
+  - Provider routing, OpenClaw, 10+ agent scale, and ERC-8004 only matter if they plug into the same receipt-gated kernel.
 
-### 3) Agent-First Beta and Public Demo Productization
-- Owner: Product + Runtime
-- Goal: make the shipped beta and demo surfaces reliable enough for external users, not just internal dogfood.
-- Acceptance:
-  - Public demo paths remain stable and are verified from the external surface.
-  - Agent-first beta workflows (`aragora review`, REST/API, fleet runner path) have a documented and validated customer/operator path.
-  - Inbox/comms surfaces are validated end-to-end from intake to debate to action/receipt where claimed.
-  - GitHub review gate strategy is explicit: either intentionally manual-only or re-enabled for pre-merge use.
+### 3) Sequential Surface Productization
+- Tracking: [#806](https://github.com/synaptent/aragora/issues/806), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+- Goal: productize every exposed surface in waves, starting from the inbox trust wedge and public proof surfaces.
+- Rules:
+  - The wedge proves the kernel; it does not replace the whole vision.
+  - Keep partial surfaces visible, but label and harden them honestly.
+  - Prefer one surface wave at a time over broad parallel productization.
 
-### 4) Prompt-to-Execution Golden Path
-- Owner: Pipeline + Decision Integrity
-- Goal: deliver the differentiated core loop from vague intent to executable, verified outcome.
+### 4) Assurance And GTM Closeout (Kept Warm, Not Main Product Lane)
+- Tracking: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
+- Goal: keep enterprise assurance truthfulness real without turning pentest/GTM work into the primary execution lane before the core kernel is unified.
 - Acceptance:
-  - Duplicate-create planning defects are handled deterministically rather than by prompt wording alone.
-  - Prompt/spec/debate/execution handoff is reliable enough for a founder or operator to use without manual archaeology.
-  - The highest-value path is coherent across CLI, API, and UI surfaces.
-  - Receipt/provenance output remains clear when the system executes, fails, or blocks.
-- Why this is core:
-  - This is the wedge described in `docs/CANONICAL_GOALS.md` Pillar 3 and in `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md`.
-
-### 5) Swarm and Worktree Operating Discipline
-- Owner: Platform + Runtime
-- Goal: keep multi-agent velocity without reintroducing integration churn.
-- Acceptance:
-  - Managed worktree maintenance respects all supported session lock types.
-  - One merge lane exists for merge-eligible work; cleanup/reconciliation does not race live sessions.
-  - Valuable work is preserved before cleanup of stale worktrees, branches, or stashes.
-  - Session/worktree state is observable enough that humans can tell what is active, stale, merged, or abandoned.
-- Recent progress:
-  - PR #751 fixed maintainer detection of Claude and Nomic session locks.
-
-### 6) Strategic Moat Hardening
-- Owner: Research + Platform
-- Goal: close the gap between shipped scaffolding and the long-term differentiated moat.
-- Acceptance:
-  - Arena/provider routing is integrated, not just shipped as standalone optimization logic.
-  - OpenClaw execution is validated in real production-like loops.
-  - Security roadmap items with highest leverage stay visible: trust-tier taint propagation, signed context manifests, and external verification gates.
-  - The repo continues converging on the full decision-integrity platform rather than fragmenting into unrelated surfaces.
+  - Open assurance work remains visible, owned, and sequenced.
+  - Docs do not overclaim GA or launch readiness while these items remain open.
 
 ## Operating Rules
-- `docs/FEATURE_GAP_LIST.md` is the delivery truth; `ROADMAP.md` and other summaries must reconcile to it.
+- GitHub issues are the live execution backlog; docs summarize context, order, and capability posture.
+- `ACTIVE_EXECUTION_ISSUES.md` must stay aligned with the current issue set.
+- `docs/FEATURE_GAP_LIST.md` is the capability/backlog truth for planned and partial features; execution status lives in GitHub.
+- `ROADMAP.md` and other summary docs must reconcile to `NEXT_STEPS_CANONICAL.md`, `docs/FEATURE_GAP_LIST.md`, and the issue map.
 - No document should claim "only one blocker remains" unless `main` CI/CD and deployment signals support that claim.
-- One merge lane for operational fixes; avoid parallel merge-eligible churn.
-- Preserve value before deletion: every stash/worktree/branch should map to a destination commit, PR, or explicit discard decision.
-- Required checks must always emit a terminal status.
-- If priorities change, update this file first, then update linked summaries.
+- Productize exposed surface area sequentially; do not broaden active implementation lanes faster than the kernel can support.
+- If priorities change, update the GitHub issues first, then update this file and the linked summaries.

--- a/scripts/reconcile_status_docs.py
+++ b/scripts/reconcile_status_docs.py
@@ -29,15 +29,52 @@ CAPABILITY_YAML = REPO_ROOT / "aragora" / "capability_surfaces.yaml"
 GA_CHECKLIST = REPO_ROOT / "docs" / "GA_CHECKLIST.md"
 STATUS_DOC = REPO_ROOT / "docs" / "STATUS.md"
 STATUS_DIR = REPO_ROOT / "docs" / "status" / "STATUS.md"
+DOCS_README = REPO_ROOT / "docs" / "README.md"
 ROADMAP = REPO_ROOT / "ROADMAP.md"
 CONNECTOR_STATUS = REPO_ROOT / "docs" / "connectors" / "STATUS.md"
 EXECUTION_PROGRAM = REPO_ROOT / "docs" / "status" / "EXECUTION_PROGRAM_2026Q2_Q4.md"
+NEXT_STEPS_CANONICAL = REPO_ROOT / "docs" / "status" / "NEXT_STEPS_CANONICAL.md"
+FEATURE_GAP_LIST = REPO_ROOT / "docs" / "FEATURE_GAP_LIST.md"
+DOCUMENTATION_HYGIENE_REGISTER = (
+    REPO_ROOT / "docs" / "status" / "DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md"
+)
+ACTIVE_EXECUTION_ISSUES = REPO_ROOT / "docs" / "status" / "ACTIVE_EXECUTION_ISSUES.md"
 CANONICAL_GOALS = REPO_ROOT / "docs" / "CANONICAL_GOALS.md"
 FEATURE_DISCOVERY = REPO_ROOT / "docs" / "FEATURE_DISCOVERY.md"
 FEATURE_DISCOVERY_STATUS = REPO_ROOT / "docs" / "status" / "FEATURE_DISCOVERY.md"
 COMMERCIAL_OVERVIEW_STATUS = REPO_ROOT / "docs" / "status" / "COMMERCIAL_OVERVIEW.md"
 OPENAPI_GENERATED = REPO_ROOT / "docs" / "api" / "openapi_generated.json"
 CONNECTOR_ROOT = REPO_ROOT / "aragora" / "connectors"
+
+EXECUTION_TRACKING_DOCS = [
+    (DOCS_README, "README.md"),
+    (NEXT_STEPS_CANONICAL, "status/NEXT_STEPS_CANONICAL.md"),
+    (FEATURE_GAP_LIST, "FEATURE_GAP_LIST.md"),
+    (DOCUMENTATION_HYGIENE_REGISTER, "status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md"),
+]
+
+REQUIRED_EXECUTION_ISSUES = [
+    273,
+    274,
+    509,
+    804,
+    805,
+    806,
+    807,
+    808,
+    809,
+    810,
+    811,
+    812,
+    813,
+    814,
+    815,
+    816,
+    817,
+    818,
+    819,
+    820,
+]
 
 API_METRIC_DOCS = [
     (CANONICAL_GOALS, "CANONICAL_GOALS.md"),
@@ -454,6 +491,80 @@ def _check_staleness() -> list[dict]:
     return findings
 
 
+def _check_execution_issue_tracking() -> list[dict]:
+    """Ensure canonical execution docs point to the live GitHub backlog."""
+    findings = []
+
+    if not ACTIVE_EXECUTION_ISSUES.exists():
+        findings.append(
+            {
+                "severity": "critical",
+                "source": "status/ACTIVE_EXECUTION_ISSUES.md",
+                "message": "Active execution issue map is missing",
+            }
+        )
+        return findings
+
+    issue_map_content = ACTIVE_EXECUTION_ISSUES.read_text(encoding="utf-8", errors="replace")
+    missing_issue_links = [
+        issue for issue in REQUIRED_EXECUTION_ISSUES if f"/issues/{issue}" not in issue_map_content
+    ]
+    if missing_issue_links:
+        findings.append(
+            {
+                "severity": "critical",
+                "source": "status/ACTIVE_EXECUTION_ISSUES.md",
+                "message": (
+                    "Execution issue map is missing required GitHub issue links: "
+                    + ", ".join(f"#{issue}" for issue in missing_issue_links)
+                ),
+            }
+        )
+
+    for path, label in EXECUTION_TRACKING_DOCS:
+        if not path.exists():
+            findings.append(
+                {
+                    "severity": "warning",
+                    "source": label,
+                    "message": "Execution tracking doc is missing",
+                }
+            )
+            continue
+
+        content = path.read_text(encoding="utf-8", errors="replace")
+        if "ACTIVE_EXECUTION_ISSUES.md" not in content:
+            findings.append(
+                {
+                    "severity": "critical",
+                    "source": label,
+                    "message": "Doc does not link to status/ACTIVE_EXECUTION_ISSUES.md",
+                }
+            )
+
+    if NEXT_STEPS_CANONICAL.exists():
+        next_steps_content = NEXT_STEPS_CANONICAL.read_text(encoding="utf-8", errors="replace")
+        for issue in (804, 805, 806):
+            if f"/issues/{issue}" not in next_steps_content:
+                findings.append(
+                    {
+                        "severity": "critical",
+                        "source": "status/NEXT_STEPS_CANONICAL.md",
+                        "message": f"Canonical execution order is missing epic issue link #{issue}",
+                    }
+                )
+
+    findings.append(
+        {
+            "severity": "info",
+            "source": "status/ACTIVE_EXECUTION_ISSUES.md",
+            "message": f"Execution issue map links {len(REQUIRED_EXECUTION_ISSUES)} required issues",
+        }
+    )
+
+    return findings
+
+
 def reconcile(strict: bool = False) -> dict:
     """Run all reconciliation checks and return report."""
     findings = []
@@ -464,6 +575,7 @@ def reconcile(strict: bool = False) -> dict:
     findings.extend(_check_connector_placeholder_drift())
     findings.extend(_check_launch_readiness_claims())
     findings.extend(_check_staleness())
+    findings.extend(_check_execution_issue_tracking())
 
     critical = [f for f in findings if f["severity"] == "critical"]
     warnings = [f for f in findings if f["severity"] == "warning"]


### PR DESCRIPTION
Closes #809

## Summary
- add a canonical `ACTIVE_EXECUTION_ISSUES.md` map that links the live execution program to GitHub
- update the canonical planning/backlog docs to point at the GitHub issue backlog instead of carrying execution status alone
- extend `scripts/reconcile_status_docs.py` so the issue-map linkage becomes a blocking documentation truthfulness check

## Validation
- `python3 -m py_compile scripts/reconcile_status_docs.py`
- `python3 scripts/validate_doc_links.py`
- `python3 scripts/reconcile_status.py`
- `python3 scripts/reconcile_status_docs.py --strict`
- `python3 scripts/pre_release_check.py --gate status-doc`