### PR TITLE
fix(triage): stabilize worktree state and action extraction

### DIFF
--- a/aragora/debate/scenarios.py
+++ b/aragora/debate/scenarios.py
@@ -419,7 +419,15 @@ class ScenarioComparator:
 
         results = matrix_result.results
         if not results:
-            return {"error": "No results to analyze"}
+            return {
+                "error": "No results to analyze",
+                "outcome_category": OutcomeCategory.INCONCLUSIVE.value,
+                "total_scenarios": 0,
+                "avg_similarity": 0.0,
+                "universal_conclusions": [],
+                "conditional_patterns": {},
+                "comparisons": [],
+            }
 
         # Compare all pairs
         comparisons = []

--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -44,7 +44,7 @@ _DECISION_LINE_PATTERNS = [
     re.compile(
         r"(?im)^\s*(?:#+\s*)?"
         r"(?:proposal|recommended action|recommendation|action|final action)\s*:\s*"
-        r"(archive|star|label|ignore)\b"
+        r"(?:\*\*|__)?(archive|star|label|ignore)(?:\*\*|__)?\b"
     ),
 ]
 

--- a/aragora/persistence/db_config.py
+++ b/aragora/persistence/db_config.py
@@ -44,6 +44,50 @@ from enum import Enum
 from pathlib import Path
 
 
+def _find_repo_root(start: Path) -> Path | None:
+    """Return the nearest parent that contains a Git marker."""
+    current = start.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _read_worktree_gitdir(repo_root: Path) -> Path | None:
+    """Resolve the per-worktree gitdir target when running in a linked worktree."""
+    git_marker = repo_root / ".git"
+    if not git_marker.is_file():
+        return None
+
+    try:
+        raw = git_marker.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+    prefix = "gitdir:"
+    if not raw.startswith(prefix):
+        return None
+
+    gitdir = Path(raw[len(prefix) :].strip())
+    if not gitdir.is_absolute():
+        gitdir = (repo_root / gitdir).resolve()
+    return gitdir.resolve()
+
+
+def _linked_worktree_data_dir(start: Path | None = None) -> Path | None:
+    """Return a stable runtime data dir for a linked worktree, if applicable."""
+    repo_root = _find_repo_root(start or Path.cwd())
+    if repo_root is None:
+        return None
+
+    gitdir = _read_worktree_gitdir(repo_root)
+    if gitdir is None or gitdir.parent.name != "worktrees":
+        return None
+
+    common_git_dir = gitdir.parent.parent
+    return common_git_dir / "aragora" / "data" / gitdir.name
+
+
 class DatabaseType(Enum):
     """Enumeration of all database types in Aragora."""
 
@@ -99,6 +143,10 @@ def get_default_data_dir() -> Path:
     env_dir = os.environ.get("ARAGORA_DATA_DIR") or os.environ.get("ARAGORA_NOMIC_DIR")
     if env_dir:
         return Path(env_dir)
+
+    worktree_data_dir = _linked_worktree_data_dir()
+    if worktree_data_dir is not None:
+        return worktree_data_dir
 
     # Prefer existing .nomic/ for backwards compatibility, otherwise use data/
     nomic_dir = Path(".nomic")

--- a/tests/config/test_db_path_resolution.py
+++ b/tests/config/test_db_path_resolution.py
@@ -17,6 +17,41 @@ def _reload_for_data_dir(tmp_path, monkeypatch):
     return legacy, schema
 
 
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(cwd, "git", *args)
+
+
+def _make_git_repo_with_linked_worktree(tmp_path: Path) -> tuple[Path, Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+
+    linked = tmp_path / "linked-worktree"
+    _git(repo, "worktree", "add", "-b", "feature/test", str(linked), "main")
+
+    common_dir = _git(repo, "rev-parse", "--git-common-dir").stdout.strip()
+    common_dir_path = Path(common_dir)
+    if not common_dir_path.is_absolute():
+        common_dir_path = (repo / common_dir_path).resolve()
+
+    return repo, linked, common_dir_path
+
+
 def test_resolve_db_path_uses_data_dir(tmp_path, monkeypatch):
     legacy, _schema = _reload_for_data_dir(tmp_path, monkeypatch)
     resolved = Path(legacy.resolve_db_path("example.db"))
@@ -87,6 +122,19 @@ def test_get_nomic_dir_prefers_nomic_over_data(tmp_path, monkeypatch):
     assert db_config.get_nomic_dir() == Path(".nomic")
 
 
+def test_get_nomic_dir_uses_git_common_dir_for_linked_worktree(tmp_path, monkeypatch):
+    _repo, linked, common_dir = _make_git_repo_with_linked_worktree(tmp_path)
+
+    monkeypatch.delenv("ARAGORA_DATA_DIR", raising=False)
+    monkeypatch.delenv("ARAGORA_NOMIC_DIR", raising=False)
+    monkeypatch.chdir(linked)
+
+    import aragora.persistence.db_config as db_config
+
+    db_config = importlib.reload(db_config)
+    assert db_config.get_nomic_dir() == common_dir / "aragora" / "data" / linked.name
+
+
 def test_resolve_db_path_absolute_passthrough():
     """Absolute paths should be returned as-is."""
     import aragora.config.legacy as legacy
@@ -107,6 +155,20 @@ def test_resolve_db_path_file_uri_passthrough():
     import aragora.config.legacy as legacy
 
     assert legacy.resolve_db_path("file:test?mode=memory").startswith("file:")
+
+
+def test_resolve_db_path_uses_git_common_dir_for_linked_worktree(tmp_path, monkeypatch):
+    _repo, linked, common_dir = _make_git_repo_with_linked_worktree(tmp_path)
+
+    monkeypatch.delenv("ARAGORA_DATA_DIR", raising=False)
+    monkeypatch.delenv("ARAGORA_NOMIC_DIR", raising=False)
+    monkeypatch.chdir(linked)
+
+    import aragora.config.legacy as legacy
+
+    legacy = importlib.reload(legacy)
+    resolved = Path(legacy.resolve_db_path("example.db"))
+    assert resolved == common_dir / "aragora" / "data" / linked.name / "example.db"
 
 
 def test_guard_repo_clean_scan_paths():

--- a/tests/debate/test_scenarios.py
+++ b/tests/debate/test_scenarios.py
@@ -959,7 +959,10 @@ class TestScenarioComparator:
 
         analysis = comparator.analyze_matrix(matrix_result)
 
-        assert analysis == {"error": "No results to analyze"}
+        assert analysis["error"] == "No results to analyze"
+        assert analysis["outcome_category"] == "inconclusive"
+        assert analysis["total_scenarios"] == 0
+        assert analysis["universal_conclusions"] == []
 
     def test_analyze_matrix_consistent_outcomes(self):
         """Test analyzing matrix with consistent outcomes."""
@@ -1623,19 +1626,19 @@ class TestEdgeCases:
 
     @pytest.mark.asyncio
     async def test_runner_empty_matrix(self):
-        """Test running with empty matrix raises KeyError due to empty analysis."""
+        """Test running with empty matrix falls back to inconclusive analysis."""
         mock_func = AsyncMock()
         runner = MatrixDebateRunner(mock_func, max_parallel=1)
 
         matrix = ScenarioMatrix()  # Empty matrix
 
-        # With empty results, analyze_matrix returns {"error": "No results to analyze"}
-        # which doesn't have 'outcome_category', causing a KeyError in run_matrix
-        with pytest.raises(KeyError):
-            await runner.run_matrix("Empty matrix test", matrix)
+        result = await runner.run_matrix("Empty matrix test", matrix)
 
         # The debate function should never have been called
         assert mock_func.call_count == 0
+        assert result.outcome_category == OutcomeCategory.INCONCLUSIVE
+        assert result.results == []
+        assert "Scenarios Analyzed**: 0" in result.summary
 
     def test_scenario_special_characters_in_replacements(self):
         """Test context replacements with special characters."""

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -293,6 +293,43 @@ async def test_structured_proposal_header_takes_priority_over_other_action_menti
 
 
 @pytest.mark.asyncio
+async def test_emphasized_action_header_preserves_archive_under_manual_review():
+    gmail = _DummyGmail()
+    wedge_service = SimpleNamespace()
+    wedge_service.execute_receipt = AsyncMock()
+    wedge_service.create_receipt = MagicMock(
+        side_effect=lambda intent, decision, auto_approve=False: _make_envelope(
+            decision,
+            receipt_id="receipt-emphasized",
+            state=ReceiptState.APPROVED if auto_approve else ReceiptState.CREATED,
+        )
+    )
+
+    runner = InboxTriageRunner(gmail_connector=gmail, wedge_service=wedge_service)
+    runner._run_debate = AsyncMock(
+        return_value=DebateResult(
+            debate_id="debate-emphasized",
+            final_answer=(
+                "## ACTION: **ARCHIVE**\n\n"
+                "Alternatives considered: ignore, star, or label depending on follow-up needs."
+            ),
+            confidence=0.5,
+            consensus_reached=False,
+        )
+    )
+
+    decisions = await runner.run_triage(batch_size=1, auto_approve=True)
+
+    decision = decisions[0]
+    assert wedge_service.create_receipt.call_args.kwargs["auto_approve"] is False
+    assert decision.final_action == InboxWedgeAction.ARCHIVE
+    assert decision.blocked_by_policy is True
+    assert "No consensus reached" in decision.dissent_summary
+    assert "fell back to ignore" not in decision.dissent_summary
+    wedge_service.execute_receipt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_word_form_action_parsing_preserves_archive():
     gmail = _DummyGmail()
     wedge_service = SimpleNamespace()


### PR DESCRIPTION
## Summary
- move default SQLite state for linked worktrees under the git common-dir so disposable worktrees do not lose debate/checkpoint databases when the worktree disappears
- accept emphasized markdown action headers like `## ACTION: **ARCHIVE**` in inbox triage extraction
- make empty scenario matrices truthful and non-fatal instead of crashing founder triage on missing `outcome_category`

## Included
- `aragora/persistence/db_config.py`
- `aragora/inbox/triage_runner.py`
- `aragora/debate/scenarios.py`
- focused regression tests for path resolution, triage action extraction, and empty matrix handling

## Validation
- `python3 -m pytest -q tests/config/test_db_path_resolution.py tests/storage/test_factory.py tests/inbox/test_triage_runner.py tests/inbox/test_cli_review.py tests/debate/test_scenarios.py`
- `python3 -m ruff check aragora/persistence/db_config.py aragora/inbox/triage_runner.py aragora/debate/scenarios.py tests/config/test_db_path_resolution.py tests/inbox/test_triage_runner.py tests/debate/test_scenarios.py`
