### PR TITLE
Implement #810 prompt specification to DecisionPlan bridge

### DIFF
--- a/aragora/pipeline/decision_plan/factory.py
+++ b/aragora/pipeline/decision_plan/factory.py
@@ -7,6 +7,7 @@ Stability: STABLE
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -171,24 +172,12 @@ class DecisionPlanFactory:
                     else fail_closed_spec_validation
                 ),
             )
-            merged_metadata["spec_bundle"] = {
-                "title": spec_bundle.title,
-                "problem_statement": spec_bundle.problem_statement,
-                "objectives": spec_bundle.objectives,
-                "constraints": spec_bundle.constraints,
-                "acceptance_criteria": spec_bundle.acceptance_criteria,
-                "verification_plan": spec_bundle.verification_plan,
-                "rollback_plan": spec_bundle.rollback_plan,
-                "owner_file_scopes": spec_bundle.owner_file_scopes,
-                "open_questions": spec_bundle.open_questions,
-                "confidence": spec_bundle.confidence,
-                "source_kind": spec_bundle.source_kind,
-                "taint_flags": spec_bundle.taint_flags,
-            }
-            if spec_bundle.missing_required_fields:
-                merged_metadata["spec_bundle_missing_fields"] = list(
-                    spec_bundle.missing_required_fields
-                )
+            DecisionPlanFactory._attach_spec_metadata(
+                merged_metadata,
+                spec_bundle=spec_bundle,
+                specification=specification,
+                validation_result=validation_result,
+            )
 
         plan = DecisionPlan(
             debate_id=result.debate_id,
@@ -228,6 +217,85 @@ class DecisionPlanFactory:
         return plan
 
     @staticmethod
+    def from_specification(
+        specification: Any,
+        *,
+        debate_id: str | None = None,
+        task: str | None = None,
+        budget_limit_usd: float | None = None,
+        approval_mode: ApprovalMode = ApprovalMode.RISK_BASED,
+        max_auto_risk: RiskLevel = RiskLevel.LOW,
+        metadata: dict[str, Any] | None = None,
+        implementation_profile: ImplementationProfile | dict[str, Any] | None = None,
+        validation_result: ValidationResult | Any | None = None,
+        fail_closed_spec_validation: bool = True,
+    ) -> DecisionPlan:
+        """Create a DecisionPlan directly from a prompt-engine specification."""
+        spec_bundle = DecisionPlanFactory.validate_execution_grade_specification(
+            specification,
+            validation_result=validation_result,
+            fail_closed=fail_closed_spec_validation,
+        )
+
+        merged_metadata: dict[str, Any] = {}
+        if isinstance(metadata, dict):
+            merged_metadata.update(metadata)
+        DecisionPlanFactory._attach_spec_metadata(
+            merged_metadata,
+            spec_bundle=spec_bundle,
+            specification=specification,
+            validation_result=validation_result,
+        )
+
+        profile = DecisionPlanFactory._resolve_implementation_profile(
+            implementation_profile=implementation_profile,
+            metadata=merged_metadata,
+        )
+        DecisionPlanFactory._attach_profile_metadata(merged_metadata, profile)
+
+        serialized_spec = DecisionPlanFactory._serialize_specification(specification)
+        resolved_debate_id = DecisionPlanFactory._resolve_spec_debate_id(
+            specification,
+            override=debate_id,
+            serialized_spec=serialized_spec,
+        )
+        resolved_task = (
+            str(task or "").strip()
+            or str(getattr(specification, "title", "")).strip()
+            or str(getattr(specification, "problem_statement", "")).strip()
+            or "Prompt-engine specification"
+        )
+
+        plan = DecisionPlan(
+            debate_id=resolved_debate_id,
+            task=resolved_task,
+            approval_mode=approval_mode,
+            max_auto_risk=max_auto_risk,
+            metadata=merged_metadata,
+            implementation_profile=profile,
+        )
+        plan.budget = BudgetAllocation(limit_usd=budget_limit_usd)
+        plan.risk_register = DecisionPlanFactory._build_risk_register_from_specification(
+            specification,
+            debate_id=resolved_debate_id,
+            spec_bundle=spec_bundle,
+            validation_result=validation_result,
+        )
+        plan.verification_plan = DecisionPlanFactory._build_verification_plan_from_specification(
+            specification,
+            debate_id=resolved_debate_id,
+            spec_bundle=spec_bundle,
+        )
+        plan.implement_plan = DecisionPlanFactory._build_implement_plan_from_specification(
+            specification,
+            spec_bundle=spec_bundle,
+        )
+        plan.status = (
+            PlanStatus.AWAITING_APPROVAL if plan.requires_human_approval else PlanStatus.APPROVED
+        )
+        return plan
+
+    @staticmethod
     def validate_execution_grade_specification(
         specification: Any,
         *,
@@ -244,6 +312,357 @@ class DecisionPlanFactory:
             missing = ", ".join(bundle.missing_required_fields)
             raise ValueError(f"Specification is not execution-grade: missing {missing}")
         return bundle
+
+    @staticmethod
+    def _attach_spec_metadata(
+        metadata: dict[str, Any],
+        *,
+        spec_bundle: SpecBundle,
+        specification: Any | None = None,
+        validation_result: ValidationResult | Any | None = None,
+    ) -> None:
+        metadata["spec_bundle"] = spec_bundle.to_dict()
+        if spec_bundle.missing_required_fields:
+            metadata["spec_bundle_missing_fields"] = list(spec_bundle.missing_required_fields)
+        else:
+            metadata.pop("spec_bundle_missing_fields", None)
+
+        artifact_payload: dict[str, Any] = {"spec_bundle": spec_bundle.to_dict()}
+        serialized_spec = DecisionPlanFactory._serialize_specification(specification)
+        if serialized_spec:
+            artifact_payload["specification"] = serialized_spec
+        serialized_validation = DecisionPlanFactory._serialize_validation_result(validation_result)
+        if serialized_validation is not None:
+            artifact_payload["validation"] = serialized_validation
+        if artifact_payload:
+            metadata["prompt_spec_artifacts"] = artifact_payload
+
+    @staticmethod
+    def _resolve_implementation_profile(
+        *,
+        implementation_profile: ImplementationProfile | dict[str, Any] | None,
+        metadata: dict[str, Any],
+    ) -> ImplementationProfile | None:
+        profile: ImplementationProfile | None = None
+        if isinstance(implementation_profile, ImplementationProfile):
+            profile = implementation_profile
+            profile.execution_mode = normalize_execution_mode(profile.execution_mode)
+        elif isinstance(implementation_profile, dict):
+            profile_payload = dict(implementation_profile)
+            profile_payload["execution_mode"] = normalize_execution_mode(
+                profile_payload.get("execution_mode")
+            )
+            profile = ImplementationProfile.from_dict(profile_payload)
+        else:
+            impl_payload = metadata.get("implementation_profile") or metadata.get("implementation")
+            if isinstance(impl_payload, dict):
+                impl_payload = dict(impl_payload)
+                impl_payload["execution_mode"] = normalize_execution_mode(
+                    impl_payload.get("execution_mode")
+                )
+                profile = ImplementationProfile.from_dict(impl_payload)
+        return profile
+
+    @staticmethod
+    def _attach_profile_metadata(
+        metadata: dict[str, Any],
+        profile: ImplementationProfile | None,
+    ) -> None:
+        if profile is None:
+            return
+        metadata.setdefault("implementation_profile", profile.to_dict())
+        if profile.channel_targets and "channel_targets" not in metadata:
+            metadata["channel_targets"] = profile.channel_targets
+        if profile.thread_id and "thread_id" not in metadata:
+            metadata["thread_id"] = profile.thread_id
+        if profile.thread_id_by_platform and "thread_id_by_platform" not in metadata:
+            metadata["thread_id_by_platform"] = profile.thread_id_by_platform
+
+    @staticmethod
+    def _serialize_specification(specification: Any | None) -> dict[str, Any]:
+        if specification is None:
+            return {}
+
+        payload: dict[str, Any] = {}
+        if hasattr(specification, "to_dict"):
+            raw = specification.to_dict()
+            if isinstance(raw, dict):
+                payload.update(raw)
+        elif isinstance(specification, dict):
+            payload.update(specification)
+
+        file_changes: list[dict[str, Any]] = []
+        for item in getattr(specification, "file_changes", []) or payload.get("file_changes", []):
+            if isinstance(item, dict):
+                file_changes.append(dict(item))
+                continue
+            file_changes.append(
+                {
+                    "path": getattr(item, "path", ""),
+                    "action": getattr(item, "action", ""),
+                    "description": getattr(item, "description", ""),
+                    "estimated_lines": getattr(item, "estimated_lines", 0),
+                }
+            )
+        if file_changes:
+            payload["file_changes"] = file_changes
+
+        risks: list[dict[str, Any]] = []
+        for item in getattr(specification, "risks", []) or payload.get("risks", []):
+            if isinstance(item, dict):
+                risks.append(dict(item))
+                continue
+            if hasattr(item, "to_dict"):
+                risks.append(item.to_dict())
+        if risks:
+            payload["risks"] = risks
+
+        dependencies = getattr(specification, "dependencies", None)
+        if dependencies:
+            payload["dependencies"] = list(dependencies)
+        return payload
+
+    @staticmethod
+    def _serialize_validation_result(
+        validation_result: ValidationResult | Any | None,
+    ) -> dict[str, Any] | None:
+        if validation_result is None:
+            return None
+        if hasattr(validation_result, "to_dict"):
+            raw = validation_result.to_dict()
+            if isinstance(raw, dict):
+                return raw
+        if isinstance(validation_result, dict):
+            return dict(validation_result)
+        return {
+            "passed": getattr(validation_result, "passed", None),
+            "overall_confidence": getattr(validation_result, "overall_confidence", None),
+        }
+
+    @staticmethod
+    def _resolve_spec_debate_id(
+        specification: Any,
+        *,
+        override: str | None,
+        serialized_spec: dict[str, Any] | None = None,
+    ) -> str:
+        explicit = str(override or "").strip()
+        if explicit:
+            return explicit
+        provenance = getattr(specification, "provenance", None)
+        provenance_debate_id = str(getattr(provenance, "debate_id", "") or "").strip()
+        if provenance_debate_id:
+            return provenance_debate_id
+        prompt_hash = str(getattr(provenance, "prompt_hash", "") or "").strip()
+        if prompt_hash:
+            return f"prompt-spec-{prompt_hash[:12]}"
+        serialized = serialized_spec or DecisionPlanFactory._serialize_specification(specification)
+        digest = hashlib.sha256(
+            json.dumps(
+                serialized or {"title": getattr(specification, "title", "")}, sort_keys=True
+            ).encode()
+        ).hexdigest()
+        return f"prompt-spec-{digest[:12]}"
+
+    @staticmethod
+    def _build_risk_register_from_specification(
+        specification: Any,
+        *,
+        debate_id: str,
+        spec_bundle: SpecBundle,
+        validation_result: ValidationResult | Any | None = None,
+    ) -> RiskRegister:
+        register = RiskRegister(debate_id=debate_id)
+        confidence = float(
+            getattr(
+                validation_result, "overall_confidence", getattr(specification, "confidence", 0.0)
+            )
+            or spec_bundle.confidence
+            or 0.0
+        )
+        if confidence < 0.7:
+            register.add_risk(
+                Risk(
+                    id=f"risk-confidence-{debate_id[:8]}",
+                    title="Low specification confidence",
+                    description=(
+                        f"Specification confidence is {confidence:.0%}; execution may require "
+                        "manual review or refinement."
+                    ),
+                    level=RiskLevel.MEDIUM if confidence >= 0.5 else RiskLevel.HIGH,
+                    category=RiskCategory.UNKNOWN,
+                    source="specification_confidence",
+                    impact=0.6,
+                    likelihood=max(0.1, 1.0 - confidence),
+                )
+            )
+
+        if getattr(validation_result, "passed", None) is False:
+            register.add_risk(
+                Risk(
+                    id=f"risk-validation-{debate_id[:8]}",
+                    title="Specification validation failed",
+                    description="Execution-grade validation did not pass for this specification.",
+                    level=RiskLevel.HIGH,
+                    category=RiskCategory.TECHNICAL,
+                    source="spec_validation",
+                    impact=0.8,
+                    likelihood=0.7,
+                )
+            )
+
+        for idx, item in enumerate(getattr(specification, "risks", []) or [], start=1):
+            if isinstance(item, dict):
+                description = str(item.get("description", "")).strip()
+                mitigation = str(item.get("mitigation", "")).strip()
+                likelihood_raw = item.get("likelihood")
+                impact_raw = item.get("impact")
+            else:
+                description = str(getattr(item, "description", "")).strip()
+                mitigation = str(getattr(item, "mitigation", "")).strip()
+                likelihood_raw = getattr(item, "likelihood", None)
+                impact_raw = getattr(item, "impact", None)
+
+            likelihood = _coerce_probability(likelihood_raw)
+            impact = _coerce_probability(impact_raw)
+            level = _coerce_risk_level(max(likelihood, impact))
+            register.add_risk(
+                Risk(
+                    id=f"risk-spec-{idx}",
+                    title=description[:80] or f"Specification risk {idx}",
+                    description=description or f"Risk {idx} from specification",
+                    level=level,
+                    category=_categorize_issue(description or mitigation or "technical risk"),
+                    source="prompt_specification",
+                    impact=impact,
+                    likelihood=likelihood,
+                    mitigation=mitigation,
+                )
+            )
+        return register
+
+    @staticmethod
+    def _build_verification_plan_from_specification(
+        specification: Any,
+        *,
+        debate_id: str,
+        spec_bundle: SpecBundle,
+    ) -> VerificationPlan:
+        plan = VerificationPlan(
+            debate_id=debate_id,
+            title=f"Verify: {spec_bundle.title}",
+            description=f"Verification plan generated from specification {spec_bundle.title}",
+            critical_paths=list(spec_bundle.owner_file_scopes),
+        )
+        for idx, criterion in enumerate(spec_bundle.acceptance_criteria, start=1):
+            plan.add_test(
+                VerificationCase(
+                    id=f"acceptance-{idx}",
+                    title=f"Acceptance: {criterion[:60]}",
+                    description=f"Confirm specification acceptance criterion: {criterion}",
+                    test_type=VerificationType.INTEGRATION,
+                    priority=CasePriority.P1,
+                    steps=[
+                        "Apply the implementation change",
+                        "Run the intended workflow or API path",
+                        f"Verify the outcome matches: {criterion}",
+                    ],
+                    expected_result=criterion,
+                    automated=True,
+                )
+            )
+
+        plan.add_test(
+            VerificationCase(
+                id="smoke-1",
+                title="Smoke test: Prompt-spec execution path",
+                description="Confirm the generated implementation is reachable and healthy.",
+                test_type=VerificationType.E2E,
+                priority=CasePriority.P0,
+                steps=["Execute the primary happy path", "Verify the service remains healthy"],
+                expected_result="Primary flow succeeds without regression",
+            )
+        )
+        plan.add_test(
+            VerificationCase(
+                id="regression-1",
+                title="Regression: Existing behavior still works",
+                description="Run the relevant regression checks for the touched file scopes.",
+                test_type=VerificationType.REGRESSION,
+                priority=CasePriority.P1,
+                steps=["Run targeted regression checks", "Verify existing workflows still pass"],
+                expected_result="No regression introduced",
+            )
+        )
+        return plan
+
+    @staticmethod
+    def _build_implement_plan_from_specification(
+        specification: Any,
+        *,
+        spec_bundle: SpecBundle,
+    ) -> ImplementPlan:
+        serialized_spec = DecisionPlanFactory._serialize_specification(specification)
+        design_hash = hashlib.sha256(
+            json.dumps(serialized_spec, sort_keys=True).encode()
+        ).hexdigest()
+        tasks: list[ImplementTask] = []
+        previous_task_id: str | None = None
+
+        for idx, item in enumerate(getattr(specification, "file_changes", []) or [], start=1):
+            if isinstance(item, dict):
+                path = str(item.get("path", "")).strip()
+                action = str(item.get("action", "")).strip()
+                description = str(item.get("description", "")).strip()
+                estimated_lines = int(item.get("estimated_lines", 0) or 0)
+            else:
+                path = str(getattr(item, "path", "") or "").strip()
+                action = str(getattr(item, "action", "") or "").strip()
+                description = str(getattr(item, "description", "") or "").strip()
+                estimated_lines = int(getattr(item, "estimated_lines", 0) or 0)
+            task_id = f"task-{idx}"
+            tasks.append(
+                ImplementTask(
+                    id=task_id,
+                    description=description or f"{action or 'modify'} {path or 'target file'}",
+                    files=[path] if path else [],
+                    complexity=_complexity_for_estimated_lines(estimated_lines),
+                    dependencies=[previous_task_id] if previous_task_id else [],
+                )
+            )
+            previous_task_id = task_id
+
+        if not tasks:
+            for idx, step in enumerate(
+                getattr(specification, "implementation_plan", []) or [], start=1
+            ):
+                text = str(step).strip()
+                if not text:
+                    continue
+                task_id = f"task-{idx}"
+                tasks.append(
+                    ImplementTask(
+                        id=task_id,
+                        description=text,
+                        files=list(spec_bundle.owner_file_scopes),
+                        complexity="moderate",
+                        dependencies=[previous_task_id] if previous_task_id else [],
+                    )
+                )
+                previous_task_id = task_id
+
+        if not tasks:
+            tasks.append(
+                ImplementTask(
+                    id="task-1",
+                    description=f"Implement specification: {spec_bundle.title}",
+                    files=list(spec_bundle.owner_file_scopes),
+                    complexity="moderate",
+                    dependencies=[],
+                )
+            )
+
+        return ImplementPlan(design_hash=design_hash, tasks=tasks)
 
     @staticmethod
     def from_implement_plan(
@@ -796,3 +1215,40 @@ def _categorize_issue(issue: str) -> RiskCategory:
     if any(k in lower for k in ["compat", "version", "depend", "integrat", "migrat"]):
         return RiskCategory.COMPATIBILITY
     return RiskCategory.TECHNICAL
+
+
+def _coerce_probability(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if numeric > 1.0:
+            numeric = numeric / 10.0
+        return max(0.0, min(1.0, numeric))
+    text = str(value or "").strip().lower()
+    mapping = {
+        "low": 0.3,
+        "medium": 0.5,
+        "med": 0.5,
+        "moderate": 0.5,
+        "high": 0.75,
+        "critical": 0.95,
+    }
+    return mapping.get(text, 0.5)
+
+
+def _coerce_risk_level(value: Any) -> RiskLevel:
+    numeric = _coerce_probability(value)
+    if numeric >= 0.9:
+        return RiskLevel.CRITICAL
+    if numeric >= 0.7:
+        return RiskLevel.HIGH
+    if numeric >= 0.45:
+        return RiskLevel.MEDIUM
+    return RiskLevel.LOW
+
+
+def _complexity_for_estimated_lines(estimated_lines: int) -> str:
+    if estimated_lines >= 200:
+        return "complex"
+    if estimated_lines >= 50:
+        return "moderate"
+    return "simple"

--- a/aragora/pipeline/execution_bridge.py
+++ b/aragora/pipeline/execution_bridge.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 import uuid
@@ -284,18 +285,19 @@ class ExecutionBridge:
             loop.create_task(_run())
             logger.info("Scheduled background execution for plan %s", plan_id)
         except RuntimeError:
-            logger.warning(
-                "No running event loop; cannot schedule background execution for plan %s",
-                plan_id,
+
+            def _run_in_thread() -> None:
+                asyncio.run(_run())
+
+            worker = threading.Thread(
+                target=_run_in_thread,
+                name=f"plan-exec-{plan_id[:8]}",
+                daemon=True,
             )
-            self.plan_store.update_execution_record(
-                record_execution_id,
-                status="canceled",
-                error={
-                    "type": "RuntimeError",
-                    "message": "No running event loop available for background execution",
-                    "at": datetime.now(timezone.utc).isoformat(),
-                },
+            worker.start()
+            logger.info(
+                "Scheduled background execution for plan %s via dedicated thread",
+                plan_id,
             )
 
 

--- a/aragora/pipeline/plan_store.py
+++ b/aragora/pipeline/plan_store.py
@@ -32,7 +32,9 @@ from aragora.pipeline.decision_plan.core import (
     ImplementationProfile,
     PlanStatus,
 )
-from aragora.pipeline.risk_register import RiskLevel
+from aragora.pipeline.risk_register import RiskLevel, RiskRegister
+from aragora.pipeline.verification_plan import VerificationPlan
+from aragora.implement.types import ImplementPlan
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +95,9 @@ class PlanStore:
                     budget_json TEXT,
                     approval_record_json TEXT,
                     implementation_profile_json TEXT,
+                    risk_register_json TEXT,
+                    verification_plan_json TEXT,
+                    implement_plan_json TEXT,
                     metadata_json TEXT,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL,
@@ -146,6 +151,12 @@ class PlanStore:
                 )
             if "implementation_profile_json" not in columns:
                 conn.execute("ALTER TABLE plans ADD COLUMN implementation_profile_json TEXT")
+            if "risk_register_json" not in columns:
+                conn.execute("ALTER TABLE plans ADD COLUMN risk_register_json TEXT")
+            if "verification_plan_json" not in columns:
+                conn.execute("ALTER TABLE plans ADD COLUMN verification_plan_json TEXT")
+            if "implement_plan_json" not in columns:
+                conn.execute("ALTER TABLE plans ADD COLUMN implement_plan_json TEXT")
             conn.commit()
         finally:
             conn.close()
@@ -164,6 +175,15 @@ class PlanStore:
             if plan.implementation_profile
             else None
         )
+        risk_register_json = (
+            json.dumps(plan.risk_register.to_dict()) if plan.risk_register else None
+        )
+        verification_plan_json = (
+            json.dumps(plan.verification_plan.to_dict()) if plan.verification_plan else None
+        )
+        implement_plan_json = (
+            json.dumps(plan.implement_plan.to_dict()) if plan.implement_plan else None
+        )
         metadata_json = json.dumps(plan.metadata) if plan.metadata else "{}"
 
         conn = self._connect()
@@ -175,8 +195,9 @@ class PlanStore:
                     max_auto_risk,
                     approved_by, rejection_reason, budget_json,
                     approval_record_json, implementation_profile_json,
+                    risk_register_json, verification_plan_json, implement_plan_json,
                     metadata_json, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     plan.id,
@@ -192,6 +213,9 @@ class PlanStore:
                     budget_json,
                     approval_json,
                     implementation_profile_json,
+                    risk_register_json,
+                    verification_plan_json,
+                    implement_plan_json,
                     metadata_json,
                     plan.created_at.isoformat(),
                     now,
@@ -652,6 +676,28 @@ class PlanStore:
                 )
 
         metadata = json.loads(row["metadata_json"] or "{}")
+        risk_register = None
+        if "risk_register_json" in row_keys and row["risk_register_json"]:
+            try:
+                risk_register = RiskRegister.from_dict(json.loads(row["risk_register_json"]))
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                logger.warning("invalid risk_register_json for plan %s: %s", row["id"], exc)
+
+        verification_plan = None
+        if "verification_plan_json" in row_keys and row["verification_plan_json"]:
+            try:
+                verification_plan = VerificationPlan.from_dict(
+                    json.loads(row["verification_plan_json"])
+                )
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                logger.warning("invalid verification_plan_json for plan %s: %s", row["id"], exc)
+
+        implement_plan = None
+        if "implement_plan_json" in row_keys and row["implement_plan_json"]:
+            try:
+                implement_plan = ImplementPlan.from_dict(json.loads(row["implement_plan_json"]))
+            except (TypeError, ValueError, json.JSONDecodeError) as exc:
+                logger.warning("invalid implement_plan_json for plan %s: %s", row["id"], exc)
 
         max_auto_risk_raw = (
             row["max_auto_risk"] if "max_auto_risk" in row_keys else RiskLevel.LOW.value
@@ -672,6 +718,9 @@ class PlanStore:
             max_auto_risk=max_auto_risk,
             budget=budget,
             approval_record=approval_record,
+            risk_register=risk_register,
+            verification_plan=verification_plan,
+            implement_plan=implement_plan,
             metadata=metadata,
             implementation_profile=implementation_profile,
             created_at=created_at,

--- a/aragora/pipeline/risk_register.py
+++ b/aragora/pipeline/risk_register.py
@@ -110,6 +110,36 @@ class Risk:
             result["related_plan_ids"] = self.related_plan_ids
         return result
 
+    @classmethod
+    def from_dict(cls, data: dict) -> Risk:
+        """Deserialize a Risk from a dictionary payload."""
+        try:
+            level = RiskLevel(data.get("level", RiskLevel.LOW.value))
+        except ValueError:
+            level = RiskLevel.LOW
+        try:
+            category = RiskCategory(data.get("category", RiskCategory.UNKNOWN.value))
+        except ValueError:
+            category = RiskCategory.UNKNOWN
+        return cls(
+            id=data.get("id", ""),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            level=level,
+            category=category,
+            source=data.get("source", ""),
+            impact=float(data.get("impact", 0.5) or 0.5),
+            likelihood=float(data.get("likelihood", 0.5) or 0.5),
+            mitigation=data.get("mitigation", ""),
+            mitigation_status=data.get("mitigation_status", "proposed"),
+            related_critique_ids=list(data.get("related_critique_ids", []) or []),
+            related_claim_ids=list(data.get("related_claim_ids", []) or []),
+            historical_occurrences=int(data.get("historical_occurrences", 0) or 0),
+            historical_success_rate=data.get("historical_success_rate"),
+            related_plan_ids=list(data.get("related_plan_ids", []) or []),
+            created_at=data.get("created_at", datetime.now().isoformat()),
+        )
+
 
 @dataclass
 class RiskRegister:
@@ -235,6 +265,18 @@ class RiskRegister:
                 "critical_support": self.critical_support_threshold,
             },
         }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> RiskRegister:
+        """Deserialize a RiskRegister from a dictionary payload."""
+        thresholds = data.get("thresholds", {}) or {}
+        return cls(
+            debate_id=data.get("debate_id", ""),
+            risks=[Risk.from_dict(item) for item in data.get("risks", []) or []],
+            created_at=data.get("created_at", datetime.now().isoformat()),
+            low_support_threshold=float(thresholds.get("low_support", 0.5) or 0.5),
+            critical_support_threshold=float(thresholds.get("critical_support", 0.7) or 0.7),
+        )
 
 
 class RiskAnalyzer:

--- a/aragora/pipeline/verification_plan.py
+++ b/aragora/pipeline/verification_plan.py
@@ -109,6 +109,32 @@ class VerificationCase:
             "implemented": self.implemented,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict) -> VerificationCase:
+        """Deserialize a VerificationCase from a dictionary payload."""
+        try:
+            test_type = VerificationType(data.get("test_type", VerificationType.UNIT.value))
+        except ValueError:
+            test_type = VerificationType.UNIT
+        try:
+            priority = CasePriority(data.get("priority", CasePriority.P2.value))
+        except ValueError:
+            priority = CasePriority.P2
+        return cls(
+            id=data.get("id", ""),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            test_type=test_type,
+            priority=priority,
+            preconditions=list(data.get("preconditions", []) or []),
+            steps=list(data.get("steps", []) or []),
+            expected_result=data.get("expected_result", ""),
+            related_claim_ids=list(data.get("related_claim_ids", []) or []),
+            related_critique_ids=list(data.get("related_critique_ids", []) or []),
+            automated=bool(data.get("automated", False)),
+            implemented=bool(data.get("implemented", False)),
+        )
+
 
 @dataclass
 class VerificationPlan:
@@ -237,6 +263,21 @@ class VerificationPlan:
             "critical_paths": self.critical_paths,
             "created_at": self.created_at,
         }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> VerificationPlan:
+        """Deserialize a VerificationPlan from a dictionary payload."""
+        return cls(
+            debate_id=data.get("debate_id", ""),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            test_cases=[
+                VerificationCase.from_dict(item) for item in data.get("test_cases", []) or []
+            ],
+            created_at=data.get("created_at", datetime.now().isoformat()),
+            target_coverage=float(data.get("target_coverage", 0.8) or 0.8),
+            critical_paths=list(data.get("critical_paths", []) or []),
+        )
 
 
 class VerificationPlanGenerator:

--- a/aragora/server/handlers/prompt_engine/handler.py
+++ b/aragora/server/handlers/prompt_engine/handler.py
@@ -110,6 +110,90 @@ class PromptEngineHandler(SecureHandler):
     # Endpoint handlers
     # ------------------------------------------------------------------
 
+    def _normalize_decision_plan_request(
+        self,
+        handler: Any,
+        data: dict[str, Any],
+    ) -> tuple[dict[str, Any] | None, HandlerResult | None]:
+        plan_data = data.get("decision_plan")
+        if plan_data is None:
+            return None, None
+        if not isinstance(plan_data, dict):
+            return None, error_response("decision_plan must be an object", 400)
+
+        create_requested = bool(plan_data.get("create"))
+        schedule_requested = bool(plan_data.get("schedule_execution"))
+        if schedule_requested and not create_requested:
+            return None, error_response(
+                "decision_plan.schedule_execution requires decision_plan.create", 400
+            )
+        if not create_requested:
+            return None, None
+
+        from aragora.pipeline.decision_plan import ApprovalMode
+        from aragora.pipeline.risk_register import RiskLevel
+
+        approval_mode_raw = str(plan_data.get("approval_mode", ApprovalMode.RISK_BASED.value))
+        try:
+            approval_mode = ApprovalMode(approval_mode_raw)
+        except ValueError:
+            return None, error_response(
+                f"Invalid decision_plan.approval_mode: {approval_mode_raw}",
+                400,
+            )
+
+        max_auto_risk_raw = str(plan_data.get("max_auto_risk", RiskLevel.LOW.value))
+        try:
+            max_auto_risk = RiskLevel(max_auto_risk_raw)
+        except ValueError:
+            return None, error_response(
+                f"Invalid decision_plan.max_auto_risk: {max_auto_risk_raw}",
+                400,
+            )
+
+        budget_limit_usd = plan_data.get("budget_limit_usd")
+        if budget_limit_usd is not None:
+            try:
+                budget_limit_usd = float(budget_limit_usd)
+            except (TypeError, ValueError):
+                return None, error_response("decision_plan.budget_limit_usd must be numeric", 400)
+
+        metadata = plan_data.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            return None, error_response("decision_plan.metadata must be an object", 400)
+
+        implementation_profile = plan_data.get("implementation_profile") or plan_data.get(
+            "implementation"
+        )
+        if implementation_profile is not None and not isinstance(implementation_profile, dict):
+            return None, error_response(
+                "decision_plan.implementation_profile must be an object",
+                400,
+            )
+
+        _, perm_err = self.require_permission_or_error(handler, "plans:write")
+        if perm_err:
+            return None, perm_err
+        if schedule_requested:
+            _, perm_err = self.require_permission_or_error(handler, "plans:approve")
+            if perm_err:
+                return None, perm_err
+
+        return (
+            {
+                "create": True,
+                "schedule_execution": schedule_requested,
+                "approval_mode": approval_mode,
+                "max_auto_risk": max_auto_risk,
+                "budget_limit_usd": budget_limit_usd,
+                "debate_id": str(plan_data.get("debate_id", "") or "").strip() or None,
+                "task": str(plan_data.get("task", "") or "").strip() or None,
+                "metadata": metadata,
+                "implementation_profile": implementation_profile,
+            },
+            None,
+        )
+
     def _handle_run(self, handler: Any) -> HandlerResult:
         """Run the full prompt-to-specification pipeline."""
         import asyncio
@@ -121,6 +205,10 @@ class PromptEngineHandler(SecureHandler):
         prompt = data.get("prompt", "").strip()
         if not prompt:
             return error_response("prompt is required", 400)
+
+        plan_request, plan_error = self._normalize_decision_plan_request(handler, data)
+        if plan_error:
+            return plan_error
 
         conductor = self._make_conductor(data)
         context = data.get("context")
@@ -134,18 +222,76 @@ class PromptEngineHandler(SecureHandler):
         validation = validator.validate_heuristic(result.specification)
         spec_bundle = SpecBundle.from_prompt_spec(result.specification, validation=validation)
 
-        return json_response(
-            {
-                "specification": result.specification.to_dict(),
-                "spec_bundle": spec_bundle.to_dict(),
-                "intent": result.intent.to_dict(),
-                "questions": [q.to_dict() for q in result.questions],
-                "research": result.research.to_dict() if result.research else None,
-                "auto_approved": result.auto_approved,
-                "stages_completed": result.stages_completed,
-                "validation": validation.to_dict(),
+        payload = {
+            "specification": result.specification.to_dict(),
+            "spec_bundle": spec_bundle.to_dict(),
+            "intent": result.intent.to_dict(),
+            "questions": [q.to_dict() for q in result.questions],
+            "research": result.research.to_dict() if result.research else None,
+            "auto_approved": result.auto_approved,
+            "stages_completed": result.stages_completed,
+            "validation": validation.to_dict(),
+        }
+
+        if not plan_request:
+            return json_response(payload)
+
+        from aragora.pipeline.decision_plan import DecisionPlanFactory
+        from aragora.pipeline.executor import store_plan
+        from aragora.pipeline.execution_bridge import get_execution_bridge
+        from aragora.pipeline.plan_store import get_plan_store
+
+        try:
+            plan = DecisionPlanFactory.from_specification(
+                result.specification,
+                debate_id=plan_request["debate_id"],
+                task=plan_request["task"],
+                budget_limit_usd=plan_request["budget_limit_usd"],
+                approval_mode=plan_request["approval_mode"],
+                max_auto_risk=plan_request["max_auto_risk"],
+                metadata=plan_request["metadata"],
+                implementation_profile=plan_request["implementation_profile"],
+                validation_result=validation,
+                fail_closed_spec_validation=True,
+            )
+        except ValueError as exc:
+            payload["decision_plan_error"] = {
+                "message": str(exc),
+                "missing_required_fields": list(spec_bundle.missing_required_fields),
             }
-        )
+            return json_response(payload, status=422)
+
+        store = get_plan_store()
+        store.create(plan)
+        store_plan(plan)
+        payload["decision_plan"] = plan.to_dict()
+
+        if plan_request["schedule_execution"]:
+            if plan.requires_human_approval and not plan.is_approved:
+                payload["execution"] = {
+                    "status": "pending_approval",
+                    "plan_id": plan.id,
+                    "requires_human_approval": True,
+                }
+            else:
+                bridge = get_execution_bridge()
+                execution_mode = (
+                    plan.implementation_profile.execution_mode
+                    if plan.implementation_profile
+                    else None
+                )
+                bridge.schedule_execution(plan.id, execution_mode=execution_mode)
+                record = next(iter(bridge.list_execution_records(plan_id=plan.id, limit=1)), None)
+                execution_payload: dict[str, Any] = {
+                    "status": "scheduled",
+                    "plan_id": plan.id,
+                    "execution_mode": execution_mode or "default",
+                }
+                if record:
+                    execution_payload["record"] = record
+                payload["execution"] = execution_payload
+
+        return json_response(payload)
 
     def _handle_decompose(self, handler: Any) -> HandlerResult:
         """Decompose a vague prompt into structured intent."""

--- a/tests/pipeline/test_decision_plan.py
+++ b/tests/pipeline/test_decision_plan.py
@@ -31,7 +31,7 @@ from aragora.pipeline.decision_plan import (
 )
 from aragora.pipeline.risk_register import RiskLevel
 from aragora.prompt_engine.spec_validator import ValidationResult, ValidatorRole
-from aragora.prompt_engine.types import RiskItem, Specification, SpecFile
+from aragora.prompt_engine.types import RiskItem, SpecFile, SpecProvenance, Specification
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +261,68 @@ class TestDecisionPlanFactory:
 
         assert plan.metadata["spec_bundle"]["title"] == "Execution-grade spec"
         assert "spec_bundle_missing_fields" not in plan.metadata
+        assert plan.metadata["spec_bundle"]["is_execution_grade"] is True
+
+    def test_from_specification_creates_runnable_plan_and_preserves_provenance(self):
+        spec = Specification(
+            title="Execution-grade spec",
+            problem_statement="Problem",
+            proposed_solution="Ship the change",
+            success_criteria=["Criterion"],
+            file_changes=[
+                SpecFile(path="aragora/pipeline/example.py", action="modify", description="Change")
+            ],
+            risks=[
+                RiskItem(
+                    description="Regression risk",
+                    likelihood="medium",
+                    impact="medium",
+                    mitigation="Use staged rollback",
+                )
+            ],
+            provenance=SpecProvenance(
+                original_prompt="Build the execution bridge",
+                debate_id="prompt-debate-123",
+                prompt_hash="abc123def4567890",
+            ),
+            provenance_chain=[{"stage": "specify", "id": "stage-1"}],
+        )
+        spec.constraints = ["Keep existing API contract stable"]
+        validation = ValidationResult(
+            role_results={ValidatorRole.DEVILS_ADVOCATE: {"passed": True, "confidence": 0.9}},
+            overall_confidence=0.92,
+            passed=True,
+        )
+
+        plan = DecisionPlanFactory.from_specification(
+            spec,
+            approval_mode=ApprovalMode.NEVER,
+            validation_result=validation,
+        )
+
+        assert plan.debate_id == "prompt-debate-123"
+        assert plan.status == PlanStatus.APPROVED
+        assert plan.implement_plan is not None
+        assert len(plan.implement_plan.tasks) == 1
+        assert plan.verification_plan is not None
+        assert len(plan.verification_plan.test_cases) >= 3
+        assert plan.metadata["spec_bundle"]["provenance_refs"][0]["original_prompt"] == (
+            "Build the execution bridge"
+        )
+        assert plan.metadata["prompt_spec_artifacts"]["specification"]["file_changes"][0][
+            "path"
+        ] == ("aragora/pipeline/example.py")
+
+    def test_from_specification_fails_closed_on_missing_execution_fields(self):
+        spec = Specification(
+            title="Incomplete spec",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            success_criteria=["Criterion"],
+        )
+
+        with pytest.raises(ValueError, match="execution-grade"):
+            DecisionPlanFactory.from_specification(spec)
 
     def test_from_debate_result_stores_deliberation_bundle_in_metadata(self):
         result = _make_result(

--- a/tests/pipeline/test_execution_bridge.py
+++ b/tests/pipeline/test_execution_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime
 from pathlib import Path
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -347,6 +348,31 @@ class TestExecutionBridgeSchedule:
         # Should not raise - errors are logged
         bridge.schedule_execution(approved_plan.id)
         await asyncio.sleep(0.1)
+
+    def test_schedule_execution_falls_back_to_thread_without_running_loop(
+        self, bridge: ExecutionBridge, store: PlanStore, approved_plan: DecisionPlan
+    ) -> None:
+        store.create(approved_plan)
+        started: dict[str, bool] = {}
+
+        class ImmediateThread:
+            def __init__(self, target, name=None, daemon=None):
+                self._target = target
+                started["daemon"] = bool(daemon)
+
+            def start(self):
+                started["started"] = True
+                self._target()
+
+        with patch.object(threading, "Thread", ImmediateThread):
+            bridge.schedule_execution(approved_plan.id)
+
+        assert started["started"] is True
+        assert started["daemon"] is True
+        bridge.executor.execute.assert_called_once()
+        records = bridge.list_execution_records(plan_id=approved_plan.id)
+        assert len(records) == 1
+        assert records[0]["status"] == "succeeded"
 
 
 class TestExecutionBridgeSingleton:

--- a/tests/pipeline/test_plan_store.py
+++ b/tests/pipeline/test_plan_store.py
@@ -15,8 +15,15 @@ from aragora.pipeline.decision_plan.core import (
     ImplementationProfile,
     PlanStatus,
 )
-from aragora.pipeline.risk_register import RiskLevel
+from aragora.pipeline.risk_register import Risk, RiskCategory, RiskLevel, RiskRegister
 from aragora.pipeline.plan_store import PlanStore
+from aragora.pipeline.verification_plan import (
+    CasePriority,
+    VerificationCase,
+    VerificationPlan,
+    VerificationType,
+)
+from aragora.implement.types import ImplementPlan, ImplementTask
 
 
 @pytest.fixture
@@ -108,6 +115,61 @@ class TestPlanStoreCreate:
             "slack": "abc",
             "teams": "xyz",
         }
+
+    def test_create_preserves_plan_artifacts(self, store: PlanStore) -> None:
+        plan = DecisionPlan(
+            id="dp-artifacts-roundtrip",
+            debate_id="debate-artifacts",
+            task="Artifact persistence test",
+            risk_register=RiskRegister(
+                debate_id="debate-artifacts",
+                risks=[
+                    Risk(
+                        id="risk-1",
+                        title="Regression risk",
+                        description="Regression risk",
+                        level=RiskLevel.MEDIUM,
+                        category=RiskCategory.TECHNICAL,
+                        source="test",
+                    )
+                ],
+            ),
+            verification_plan=VerificationPlan(
+                debate_id="debate-artifacts",
+                title="Verify artifacts",
+                description="Artifact verification plan",
+                test_cases=[
+                    VerificationCase(
+                        id="case-1",
+                        title="Verify something",
+                        description="Confirm artifact persistence",
+                        test_type=VerificationType.INTEGRATION,
+                        priority=CasePriority.P1,
+                    )
+                ],
+            ),
+            implement_plan=ImplementPlan(
+                design_hash="abc123",
+                tasks=[
+                    ImplementTask(
+                        id="task-1",
+                        description="Modify file",
+                        files=["aragora/pipeline/example.py"],
+                        complexity="moderate",
+                    )
+                ],
+            ),
+        )
+        store.create(plan)
+        retrieved = store.get(plan.id)
+
+        assert retrieved is not None
+        assert retrieved.risk_register is not None
+        assert retrieved.risk_register.risks[0].title == "Regression risk"
+        assert retrieved.verification_plan is not None
+        assert retrieved.verification_plan.test_cases[0].title == "Verify something"
+        assert retrieved.implement_plan is not None
+        assert retrieved.implement_plan.tasks[0].files == ["aragora/pipeline/example.py"]
 
     def test_get_nonexistent_returns_none(self, store: PlanStore) -> None:
         assert store.get("does-not-exist") is None

--- a/tests/server/handlers/test_prompt_engine_handler.py
+++ b/tests/server/handlers/test_prompt_engine_handler.py
@@ -9,6 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.pipeline.decision_plan import ApprovalMode, PlanStatus
+from aragora.prompt_engine.spec_validator import ValidationResult
+from aragora.prompt_engine.types import RiskItem, SpecFile, Specification
 from aragora.server.handlers.prompt_engine.handler import PromptEngineHandler
 
 
@@ -285,6 +288,147 @@ class TestRunPipeline:
         assert "spec_bundle" in parsed["data"]
         assert parsed["data"]["validation"]["passed"] is True
         assert "stages_completed" in parsed["data"]
+
+    @patch("aragora.pipeline.executor.store_plan")
+    @patch("aragora.pipeline.plan_store.get_plan_store")
+    @patch("aragora.pipeline.execution_bridge.get_execution_bridge")
+    @patch("aragora.prompt_engine.SpecValidator")
+    @patch("aragora.prompt_engine.PromptConductor")
+    @patch("aragora.prompt_engine.ConductorConfig")
+    def test_run_can_create_and_schedule_decision_plan(
+        self,
+        mock_config_cls: MagicMock,
+        mock_conductor_cls: MagicMock,
+        mock_validator_cls: MagicMock,
+        mock_get_execution_bridge: MagicMock,
+        mock_get_plan_store: MagicMock,
+        mock_store_plan: MagicMock,
+        handler: PromptEngineHandler,
+    ) -> None:
+        spec = Specification(
+            title="Runnable spec",
+            problem_statement="Problem",
+            proposed_solution="Ship the change",
+            success_criteria=["Criterion"],
+            file_changes=[
+                SpecFile(path="aragora/server/example.py", action="modify", description="Patch")
+            ],
+            risks=[
+                RiskItem(
+                    description="Regression risk",
+                    likelihood="medium",
+                    impact="medium",
+                    mitigation="Rollback quickly",
+                )
+            ],
+            confidence=0.95,
+        )
+        spec.constraints = ["Preserve API contract"]
+        mock_intent = MagicMock()
+        mock_intent.to_dict.return_value = {"raw_prompt": "test", "intent_type": "feature"}
+        mock_result = MagicMock(
+            specification=spec,
+            intent=mock_intent,
+            questions=[],
+            research=None,
+            auto_approved=False,
+            stages_completed=["decompose", "specify"],
+        )
+        mock_conductor_cls.return_value.run = AsyncMock(return_value=mock_result)
+
+        validation = ValidationResult(
+            role_results={},
+            passed=True,
+            overall_confidence=0.95,
+        )
+        mock_validator_cls.return_value.validate_heuristic.return_value = validation
+        mock_config_cls.return_value = MagicMock()
+        mock_config_cls.from_profile.return_value = MagicMock()
+        mock_get_execution_bridge.return_value.list_execution_records.return_value = [
+            {"execution_id": "exec-123", "status": "queued"}
+        ]
+        handler.require_permission_or_error = MagicMock(return_value=(MagicMock(), None))
+
+        req = _make_handler_request(
+            {
+                "prompt": "Build something",
+                "decision_plan": {
+                    "create": True,
+                    "schedule_execution": True,
+                    "approval_mode": ApprovalMode.NEVER.value,
+                    "implementation_profile": {"execution_mode": "workflow"},
+                },
+            }
+        )
+        req.path = "/api/prompt-engine/run"
+
+        result = handler.handle_POST(req)
+        parsed = _parse(result)
+
+        assert parsed["status"] == 200
+        assert parsed["data"]["decision_plan"]["status"] == PlanStatus.APPROVED.value
+        assert parsed["data"]["execution"]["status"] == "scheduled"
+        mock_get_plan_store.return_value.create.assert_called_once()
+        mock_store_plan.assert_called_once()
+        mock_get_execution_bridge.return_value.schedule_execution.assert_called_once()
+
+    @patch("aragora.pipeline.plan_store.get_plan_store")
+    @patch("aragora.prompt_engine.SpecValidator")
+    @patch("aragora.prompt_engine.PromptConductor")
+    @patch("aragora.prompt_engine.ConductorConfig")
+    def test_run_returns_422_when_decision_plan_spec_is_not_execution_grade(
+        self,
+        mock_config_cls: MagicMock,
+        mock_conductor_cls: MagicMock,
+        mock_validator_cls: MagicMock,
+        mock_get_plan_store: MagicMock,
+        handler: PromptEngineHandler,
+    ) -> None:
+        spec = Specification(
+            title="Incomplete spec",
+            problem_statement="Problem",
+            proposed_solution="Ship the change",
+            success_criteria=["Criterion"],
+        )
+        mock_intent = MagicMock()
+        mock_intent.to_dict.return_value = {"raw_prompt": "test", "intent_type": "feature"}
+        mock_result = MagicMock(
+            specification=spec,
+            intent=mock_intent,
+            questions=[],
+            research=None,
+            auto_approved=False,
+            stages_completed=["decompose", "specify"],
+        )
+        mock_conductor_cls.return_value.run = AsyncMock(return_value=mock_result)
+
+        validation = ValidationResult(
+            role_results={},
+            passed=False,
+            overall_confidence=0.2,
+        )
+        mock_validator_cls.return_value.validate_heuristic.return_value = validation
+        mock_config_cls.return_value = MagicMock()
+        mock_config_cls.from_profile.return_value = MagicMock()
+        handler.require_permission_or_error = MagicMock(return_value=(MagicMock(), None))
+
+        req = _make_handler_request(
+            {
+                "prompt": "Build something",
+                "decision_plan": {"create": True},
+            }
+        )
+        req.path = "/api/prompt-engine/run"
+
+        result = handler.handle_POST(req)
+        parsed = _parse(result)
+
+        assert parsed["status"] == 422
+        assert "decision_plan_error" in parsed["data"]
+        assert (
+            "owner_file_scopes" in parsed["data"]["decision_plan_error"]["missing_required_fields"]
+        )
+        mock_get_plan_store.return_value.create.assert_not_called()
 
     def test_unknown_endpoint_returns_404(self, handler: PromptEngineHandler) -> None:
         req = _make_handler_request({"prompt": "test"})


### PR DESCRIPTION
## Summary
- add `DecisionPlanFactory.from_specification(...)` for execution-grade prompt-engine specs
- persist plan artifacts needed for `ExecutionBridge` execution after `PlanStore` reload
- wire `POST /api/prompt-engine/run` to optionally create and schedule a DecisionPlan with fail-closed validation

## Validation
- `pytest -q tests/pipeline/test_decision_plan.py tests/pipeline/test_plan_store.py tests/pipeline/test_execution_bridge.py tests/server/handlers/test_prompt_engine_handler.py`

## Notes
- sync handler scheduling now falls back to a dedicated background thread when no event loop is running
- prompt/spec/validation provenance is attached to plan metadata for downstream receipt linkage
- streaming prompt-engine/UI integration remains a follow-up lane; this PR keeps scope on the REST execution bridge described in #810

Closes #810