### PR TITLE
docs: refresh current execution truth and hygiene register

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Aragora treats each model as an **unreliable witness** and uses structured debat
 | **Decision Receipts** | Cryptographic audit trails with evidence chains, dissent tracking, and confidence calibration |
 | **Gauntlet Mode** | Red-team stress-tests for specs, policies, and architectures using adversarial personas |
 | **Calibrated Trust** | ELO rankings and Brier scores track which models are actually reliable on which domains |
-| **Institutional Memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (<!-- adpt-count -->45<!-- /adpt-count --> adapters) |
+| **Institutional Memory** | Decisions persist across sessions with 4-tier memory and Knowledge Mound (<!-- adpt-count -->42<!-- /adpt-count --> adapters) |
 | **Channel Delivery** | Results route to Slack, Teams, Discord, Telegram, WhatsApp, email, or voice |
 
 ---

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -19,25 +19,28 @@ This document links Aragora's current execution program to the live GitHub issue
 
 Epic: [#804](https://github.com/synaptent/aragora/issues/804)
 
-Current tranche: [#809](https://github.com/synaptent/aragora/issues/809)
+Tranche status: complete on `main` through [#809](https://github.com/synaptent/aragora/issues/809)
 
 Recently completed:
 - [#807](https://github.com/synaptent/aragora/issues/807) `CLOSED` - Make launch truthfulness blocking
 - [#808](https://github.com/synaptent/aragora/issues/808) `CLOSED` - Make self-host readiness truthful and PR-gated
+- [#809](https://github.com/synaptent/aragora/issues/809) `CLOSED` - Canonicalize the active backlog into GitHub issues
 
 | Issue | State | Priority | Owner | Milestone | Scope |
 |------|-------|----------|-------|-----------|-------|
 | [#807](https://github.com/synaptent/aragora/issues/807) | Closed | `priority:critical` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Make launch truthfulness blocking |
 | [#808](https://github.com/synaptent/aragora/issues/808) | Closed | `priority:high` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Make self-host readiness truthful and PR-gated |
-| [#809](https://github.com/synaptent/aragora/issues/809) | Open | `priority:high` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Canonicalize the active backlog into GitHub issues |
+| [#809](https://github.com/synaptent/aragora/issues/809) | Closed | `priority:high` | `owner:team-platform` | `2026-M1 Truthfulness + Decision Integrity Core` | Canonicalize the active backlog into GitHub issues |
 
 ## Decision Integrity Kernel Unification
 
 Epic: [#805](https://github.com/synaptent/aragora/issues/805)
 
+Current tranche: [#811](https://github.com/synaptent/aragora/issues/811) and [#812](https://github.com/synaptent/aragora/issues/812) after [#810](https://github.com/synaptent/aragora/issues/810) landed on `main`
+
 | Issue | State | Priority | Owner | Milestone | Scope |
 |------|-------|----------|-------|-----------|-------|
-| [#810](https://github.com/synaptent/aragora/issues/810) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Add prompt -> specification -> DecisionPlan bridge |
+| [#810](https://github.com/synaptent/aragora/issues/810) | Closed | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Add prompt -> specification -> DecisionPlan bridge |
 | [#811](https://github.com/synaptent/aragora/issues/811) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Collapse prompt/canvas/pipeline to one canonical execution runtime |
 | [#812](https://github.com/synaptent/aragora/issues/812) | Open | `priority:high` | `owner:team-core` | `2026-M1 Truthfulness + Decision Integrity Core` | Require cryptographic decision receipts before all action-taking |
 | [#813](https://github.com/synaptent/aragora/issues/813) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Integrate ProviderRouter into runtime agent selection |
@@ -65,6 +68,14 @@ These remain open and real, but they are not the primary product lane while the 
 | [#273](https://github.com/synaptent/aragora/issues/273) | Open | `priority:critical` | `owner:team-risk` | `2026-M2 Channel and FinOps` | Enterprise Assurance Closure epic |
 | [#274](https://github.com/synaptent/aragora/issues/274) | Open | `priority:critical` | `owner:team-risk` | `2026-M2 Channel and FinOps` | Execute external penetration test and remediate findings |
 | [#509](https://github.com/synaptent/aragora/issues/509) | Open | `priority:critical` | `owner:team-risk` | `none` | Pentest vendor selection and scope sign-off |
+
+## Operational Incidents
+
+Operational incidents are not part of the planned execution epics, but they can preempt them when `main` is degraded.
+
+| Issue | State | Priority | Scope |
+|------|-------|----------|-------|
+| [#829](https://github.com/synaptent/aragora/issues/829) | Open | `outage` | Service outage detected on 2026-03-07 |
 
 ## Operating Rule
 

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -22,6 +22,8 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - Added discoverability links for status, roadmap, gap, and hygiene docs from the main indexes.
 - Marked legacy snapshot docs as non-canonical where they were being presented as live status.
 - Canonicalized the current execution program into GitHub issues and added `docs/status/ACTIVE_EXECUTION_ISSUES.md` as the issue map for epics `#804`-`#806`, execution lanes `#807`-`#820`, and assurance issues `#273`, `#274`, `#509`.
+- Updated the issue map and canonical execution summary after `#809` and `#810` landed so current-source docs reflect the active `#811` / `#812` kernel tranche.
+- Corrected the root README's Knowledge Mound adapter count from `45` to the current verified `42`.
 
 ## Validation Snapshot
 
@@ -35,10 +37,10 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 
 - Version: `2.8.0`
 - Python modules under `aragora/`: `3,803`
-- Tests: `210,071`
-- Test files under `tests/`: `5,057`
-- OpenAPI paths: `2,981`
-- OpenAPI operations: `3,740`
+- Tests (`def test_` across repo): `210,215`
+- Test files under `tests/`: `5,069`
+- OpenAPI paths (generated spec): `2,666`
+- OpenAPI operations (generated spec): `3,155`
 - SDK namespaces: `186` Python / `185` TypeScript
 - Registered agent types: `43`
 - Allowlisted agent types: `34`
@@ -50,7 +52,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 ### Current Focus (March 2026)
 
 - Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
-- Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization (`#804`, `#807`-`#809`), Decision Integrity Kernel unification (`#805`, `#810`-`#816`), and sequential surface productization (`#806`, `#817`-`#820`) in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
+- Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization is complete on `main` through `#809`, the first kernel bridge tranche `#810` is complete, and the active M1 kernel work is now `#811` and `#812` in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
 - The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in `docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
 
 ### Near-Term Goals (Q2 2026)
@@ -79,6 +81,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - `aragora/server/handlers/features/documents_batch.py` returns placeholder chunk retrieval output pending vector-store integration.
 - `aragora/server/handlers/features/connectors.py` still carries `coming_soon` / stubbed connector flows (`gdrive` and related enterprise sync/test paths).
 - `aragora/server/handlers/computer_use_handler.py` does not implement the full action/policy detail surface advertised by the OpenAPI computer-use endpoints.
+- Self-host compose smoke can still fail because `/readyz` returns `503` when `system.health.read` is denied in the composed runtime, even while `/healthz` succeeds. The gating/docs work is landed, but the runtime permission model still needs follow-through.
 - FastAPI receipts currently expose `json`/`markdown`/`sarif`, while legacy handlers still own `html`/`pdf` exports.
 - Receipt delivery is only wired for `slack`, `teams`, `email`, and `discord`, not the broader connector/channel footprint implied elsewhere in the docs.
 - Unified and progressive memory handlers remain backend-conditional and still return `501` when optional backends or methods are unavailable.

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -14,7 +14,8 @@ This file defines execution order.
 - The full vision remains the goal; the near-term requirement is sequencing, not scope reduction.
 - The moat is the receipt-gated decision kernel: prompt/spec/debate/consensus/cryptographic receipt/policy-gated action.
 - GitHub issues now carry active execution status, owners, and acceptance criteria. Docs should summarize context and order, not act as the only operational backlog.
-- Truthfulness hardening is already underway on `main`: [#807](https://github.com/synaptent/aragora/issues/807) and [#808](https://github.com/synaptent/aragora/issues/808) are complete, and [#809](https://github.com/synaptent/aragora/issues/809) is the current backlog-canonicalization tranche.
+- Truthfulness and backlog canonicalization are complete on `main` through [#809](https://github.com/synaptent/aragora/issues/809), and the first Decision Integrity Kernel bridge tranche [#810](https://github.com/synaptent/aragora/issues/810) is also complete.
+- The current M1 kernel focus is [#811](https://github.com/synaptent/aragora/issues/811) followed by [#812](https://github.com/synaptent/aragora/issues/812).
 - Surface area should be productized sequentially, not hidden or allowed to drift.
 
 ## Execution Order
@@ -22,6 +23,7 @@ This file defines execution order.
 ### 1) Truthfulness And Backlog Canonicalization
 - Tracking: [#804](https://github.com/synaptent/aragora/issues/804), [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809)
 - Goal: `main` and current-source docs should stay truthful, and the active backlog should live in GitHub instead of only in Markdown.
+- Current status: complete on `main`; keep the gates blocking and maintain the issue map/doc linkage.
 - Acceptance:
   - Launch/readiness claims match what works on `main`.
   - Self-host/readiness docs and gates are evidence-backed.
@@ -31,6 +33,7 @@ This file defines execution order.
 ### 2) Decision Integrity Kernel Unification
 - Tracking: [#805](https://github.com/synaptent/aragora/issues/805), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816)
 - Goal: unify `prompt -> specification -> adversarial debate -> consensus/dissent -> cryptographic decision receipt -> policy gate -> execution` as one canonical runtime.
+- Current tranche: [#811](https://github.com/synaptent/aragora/issues/811) and [#812](https://github.com/synaptent/aragora/issues/812) after [#810](https://github.com/synaptent/aragora/issues/810) landed on `main`.
 - Why now:
   - This is the architectural center of Aragora's differentiation.
   - Provider routing, OpenClaw, 10+ agent scale, and ERC-8004 only matter if they plug into the same receipt-gated kernel.
@@ -49,6 +52,10 @@ This file defines execution order.
 - Acceptance:
   - Open assurance work remains visible, owned, and sequenced.
   - Docs do not overclaim GA or launch readiness while these items remain open.
+
+### Operational Incidents (Interrupt-Driven)
+- Tracking: [#829](https://github.com/synaptent/aragora/issues/829) and any future incident tickets
+- Rule: incidents can preempt the planned order, but they do not replace the canonical program; once mitigated, execution returns to the issue order above.
 
 ## Operating Rules
 - GitHub issues are the live execution backlog; docs summarize context, order, and capability posture.


### PR DESCRIPTION
## Summary
- update current-source status docs after #809 and #810 landed so the active execution tranche points at #811 / #812
- correct the root README's current Knowledge Mound adapter count from 45 to the verified 42
- refresh the documentation hygiene register with current verified metrics and one newly verified self-host robustness gap
- add a small operational-incident note so the issue map reflects the live outage ticket without reshaping the canonical roadmap

## Included
- `README.md`
- `docs/status/ACTIVE_EXECUTION_ISSUES.md`
- `docs/status/NEXT_STEPS_CANONICAL.md`
- `docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md`

## Explicitly Excluded
- broad collateral rewrites where many files still say `45 adapters`
- code changes for the self-host `/readyz` permission issue
- any edits in the other Codex worktrees

## Validation
- `python3 scripts/validate_doc_links.py`
- `python3 scripts/reconcile_status.py`
- `python3 scripts/reconcile_status_docs.py --strict`
- `PYTHONPATH=. python3 scripts/check_agent_registry_sync.py`
- `python3 scripts/audit_openapi_docs.py`
