### PR TITLE
feat(pipeline): unify canvas execution on decision plans

### DIFF
--- a/aragora/pipeline/canonical_execution.py
+++ b/aragora/pipeline/canonical_execution.py
@@ -1,0 +1,387 @@
+"""Canonical DecisionPlan execution helpers for canvas and pipeline surfaces."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from aragora.core_types import DebateResult
+from aragora.implement.types import ImplementPlan, ImplementTask
+from aragora.pipeline.decision_plan import ApprovalMode, DecisionPlanFactory
+from aragora.pipeline.decision_plan.factory import normalize_execution_mode
+
+logger = logging.getLogger(__name__)
+
+_ACTIONLESS_NODE_TYPES = frozenset({"agent", "label", "note", "group"})
+
+
+def _flatten_node(node: dict[str, Any]) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    data = node.get("data")
+    if isinstance(data, dict):
+        flattened.update(data)
+    for key, value in node.items():
+        if key == "data":
+            continue
+        flattened.setdefault(key, value)
+    return flattened
+
+
+def _flatten_edge(edge: dict[str, Any]) -> dict[str, Any]:
+    flattened: dict[str, Any] = {}
+    data = edge.get("data")
+    if isinstance(data, dict):
+        flattened.update(data)
+    for key, value in edge.items():
+        if key == "data":
+            continue
+        flattened.setdefault(key, value)
+    return flattened
+
+
+def _normalize_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _extract_files(node: dict[str, Any]) -> list[str]:
+    candidates = [
+        node.get("files"),
+        node.get("file_scope"),
+        node.get("paths"),
+        node.get("targets"),
+        node.get("fileHints"),
+        node.get("file_hints"),
+        (node.get("metadata") or {}).get("files") if isinstance(node.get("metadata"), dict) else [],
+    ]
+    files: list[str] = []
+    for candidate in candidates:
+        files.extend(_normalize_string_list(candidate))
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for file_path in files:
+        if file_path not in seen:
+            deduped.append(file_path)
+            seen.add(file_path)
+    return deduped
+
+
+def _derive_complexity(node: dict[str, Any], *, task_type: str) -> str:
+    raw = str(node.get("complexity", "") or "").strip().lower()
+    if raw in {"simple", "moderate", "complex"}:
+        return raw
+    if task_type in {"human", "verification"}:
+        return "simple"
+    if task_type == "computer_use":
+        return "moderate"
+    return "moderate"
+
+
+def _derive_task_shape(node: dict[str, Any]) -> tuple[str | None, list[str]]:
+    raw_type = (
+        node.get("task_type")
+        or node.get("taskType")
+        or node.get("orch_type")
+        or node.get("orchType")
+        or node.get("type")
+        or "agent_task"
+    )
+    orch_type = str(raw_type).strip().lower().replace("-", "_")
+    if node.get("computer_use_actions"):
+        return "computer_use", ["computer_use"]
+    if orch_type in {"human_gate", "manual", "human"}:
+        return "human", ["manual"]
+    if orch_type in {"browser", "ui", "computer_use", "computeruse"}:
+        return "computer_use", ["computer_use", "browser"]
+    if orch_type == "verification":
+        return "verification", ["verification"]
+    if orch_type == "debate":
+        return "analysis", ["debate"]
+    if orch_type in {"parallel_fan", "merge"}:
+        return "coordination", ["coordination"]
+    if orch_type in _ACTIONLESS_NODE_TYPES:
+        return None, []
+    return "implementation", []
+
+
+def _task_description(node: dict[str, Any], *, index: int) -> str:
+    description = (
+        node.get("label")
+        or node.get("name")
+        or node.get("description")
+        or node.get("title")
+        or f"Task {index}"
+    )
+    return str(description).strip() or f"Task {index}"
+
+
+def _task_requires_approval(node: dict[str, Any], *, require_task_approval: bool) -> bool:
+    if require_task_approval:
+        return True
+    orch_type = str(node.get("orch_type") or node.get("orchType") or "").strip().lower()
+    return bool(
+        node.get("requires_approval")
+        or node.get("require_approval")
+        or orch_type in {"human_gate", "manual", "human"}
+    )
+
+
+def _extract_actionable_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    flattened = [_flatten_node(node) for node in nodes if isinstance(node, dict)]
+    actionable = []
+    for node in flattened:
+        task_type, _ = _derive_task_shape(node)
+        if task_type is None:
+            continue
+        actionable.append(node)
+    if actionable:
+        return actionable
+    return [
+        node
+        for node in flattened
+        if str(node.get("type") or "").strip().lower() not in _ACTIONLESS_NODE_TYPES
+    ]
+
+
+def _build_dependency_map(tasks: list[ImplementTask], edges: list[dict[str, Any]]) -> None:
+    task_ids = {task.id for task in tasks}
+    for raw_edge in edges:
+        if not isinstance(raw_edge, dict):
+            continue
+        edge = _flatten_edge(raw_edge)
+        source = edge.get("source") or edge.get("from") or edge.get("from_step")
+        target = edge.get("target") or edge.get("to") or edge.get("to_step")
+        if source not in task_ids or target not in task_ids:
+            continue
+        for task in tasks:
+            if task.id == target and source not in task.dependencies:
+                task.dependencies.append(str(source))
+                break
+
+
+def _build_design_hash(
+    subject_id: str, nodes: list[dict[str, Any]], edges: list[dict[str, Any]]
+) -> str:
+    payload = json.dumps(
+        {
+            "subject_id": subject_id,
+            "nodes": nodes,
+            "edges": edges,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def build_decision_plan_from_orchestration(
+    *,
+    subject_id: str,
+    subject_label: str,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]] | None = None,
+    source_surface: str,
+    metadata: dict[str, Any] | None = None,
+    budget_limit_usd: float | None = None,
+    execution_mode: str | None = "workflow",
+    require_task_approval: bool = False,
+    approval_mode: ApprovalMode = ApprovalMode.NEVER,
+) -> tuple[Any, list[ImplementTask]]:
+    """Build a canonical DecisionPlan from orchestration nodes/edges."""
+    actionable_nodes = _extract_actionable_nodes(nodes)
+    if not actionable_nodes:
+        raise ValueError(f"No actionable orchestration nodes found for {subject_label}")
+
+    tasks: list[ImplementTask] = []
+    for index, node in enumerate(actionable_nodes, start=1):
+        task_type, capabilities = _derive_task_shape(node)
+        task_id = str(node.get("id") or f"task-{index}")
+        tasks.append(
+            ImplementTask(
+                id=task_id,
+                description=_task_description(node, index=index),
+                files=_extract_files(node),
+                complexity=_derive_complexity(node, task_type=task_type or "implementation"),
+                task_type=task_type,
+                capabilities=capabilities,
+                requires_approval=_task_requires_approval(
+                    node,
+                    require_task_approval=require_task_approval,
+                ),
+            )
+        )
+
+    _build_dependency_map(tasks, edges or [])
+
+    task_lines = [f"{i}. {task.description}" for i, task in enumerate(tasks, start=1)]
+    debate_result = DebateResult(
+        debate_id=f"{source_surface}-{uuid.uuid4().hex[:12]}",
+        task=subject_label,
+        final_answer="\n".join(
+            [
+                f"Execution plan for {subject_label}",
+                *task_lines,
+            ]
+        ),
+        confidence=0.72,
+        consensus_reached=True,
+        rounds_used=1,
+        status="completed",
+        participants=[source_surface],
+        metadata={
+            "source_surface": source_surface,
+            "source_id": subject_id,
+            "node_count": len(actionable_nodes),
+        },
+    )
+
+    implement_plan = ImplementPlan(
+        design_hash=_build_design_hash(subject_id, actionable_nodes, edges or []),
+        tasks=tasks,
+    )
+
+    plan_metadata: dict[str, Any] = {
+        "source_surface": source_surface,
+        "source_id": subject_id,
+        "orchestration": {
+            "nodes": actionable_nodes,
+            "edges": edges or [],
+        },
+    }
+    if isinstance(metadata, dict):
+        plan_metadata.update(metadata)
+
+    normalized_mode = normalize_execution_mode(execution_mode) or "workflow"
+    plan = DecisionPlanFactory.from_debate_result(
+        debate_result,
+        budget_limit_usd=budget_limit_usd,
+        approval_mode=approval_mode,
+        metadata=plan_metadata,
+        implement_plan=implement_plan,
+        implementation_profile={"execution_mode": normalized_mode},
+    )
+    return plan, tasks
+
+
+def queue_plan_execution(
+    plan: Any,
+    *,
+    auth_context: Any | None = None,
+    execution_mode: str | None = None,
+) -> dict[str, Any]:
+    """Persist a plan and queue a durable execution record."""
+    from aragora.pipeline.executor import store_plan
+    from aragora.pipeline.plan_store import get_plan_store
+
+    normalized_mode = normalize_execution_mode(execution_mode) or "workflow"
+    execution_id = f"exec-{uuid.uuid4().hex[:12]}"
+    correlation_id = f"corr-{uuid.uuid4().hex[:12]}"
+    store = get_plan_store()
+    store.create(plan)
+    store_plan(plan)
+    store.create_execution_record(
+        execution_id=execution_id,
+        plan_id=plan.id,
+        debate_id=plan.debate_id,
+        correlation_id=correlation_id,
+        status="queued",
+        metadata={
+            "execution_mode": normalized_mode,
+            "scheduled_by": getattr(auth_context, "user_id", None),
+        },
+    )
+    return {
+        "plan_id": plan.id,
+        "execution_id": execution_id,
+        "correlation_id": correlation_id,
+        "execution_mode": normalized_mode,
+        "status": "queued",
+        "scheduled_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def build_decision_receipt_payload(
+    plan: Any,
+    outcome: Any,
+) -> dict[str, Any] | None:
+    """Build and persist a canonical DecisionReceipt payload."""
+    if not getattr(outcome, "receipt_id", None):
+        return None
+
+    try:
+        from aragora.gauntlet.receipt import DecisionReceipt
+
+        receipt = DecisionReceipt.from_plan_outcome(outcome, plan=plan)
+        receipt.receipt_id = outcome.receipt_id
+        try:
+            receipt.sign()
+        except (OSError, RuntimeError, ValueError) as exc:
+            logger.debug("Decision receipt signing skipped: %s", exc)
+        payload = receipt.to_dict() if hasattr(receipt, "to_dict") else None
+        if not isinstance(payload, dict):
+            return None
+        try:
+            from aragora.storage.receipt_store import get_receipt_store
+
+            get_receipt_store().save(payload)
+        except (ImportError, RuntimeError, ValueError, TypeError, AttributeError) as exc:
+            logger.debug("Decision receipt persistence skipped: %s", exc)
+        return payload
+    except (ImportError, RuntimeError, ValueError, TypeError, AttributeError) as exc:
+        logger.debug("Decision receipt payload unavailable: %s", exc)
+        return None
+
+
+async def execute_queued_plan(
+    plan: Any,
+    *,
+    execution_id: str,
+    correlation_id: str,
+    auth_context: Any | None = None,
+    execution_mode: str | None = None,
+) -> tuple[Any, dict[str, Any] | None, dict[str, Any] | None]:
+    """Execute a queued plan through ExecutionBridge and return artifacts."""
+    from aragora.pipeline.execution_bridge import get_execution_bridge
+    from aragora.pipeline.plan_store import get_plan_store
+
+    bridge = get_execution_bridge()
+    normalized_mode = normalize_execution_mode(execution_mode) or "workflow"
+    outcome = await bridge.execute_approved_plan(
+        plan.id,
+        auth_context=auth_context,
+        execution_mode=normalized_mode,
+        execution_id=execution_id,
+        correlation_id=correlation_id,
+    )
+    store = get_plan_store()
+    stored_plan = store.get(plan.id) or plan
+    record = bridge.get_execution_record(execution_id)
+    decision_receipt = build_decision_receipt_payload(stored_plan, outcome)
+    return outcome, record, decision_receipt
+
+
+def schedule_coroutine(coro: Any, *, name: str) -> asyncio.Task[Any] | threading.Thread:
+    """Schedule *coro* on the current event loop or a dedicated thread."""
+    try:
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(coro, name=name)
+        return task
+    except RuntimeError:
+
+        def _runner() -> None:
+            asyncio.run(coro)
+
+        worker = threading.Thread(target=_runner, name=name, daemon=True)
+        worker.start()
+        return worker

--- a/aragora/server/fastapi/routes/canvas_pipeline.py
+++ b/aragora/server/fastapi/routes/canvas_pipeline.py
@@ -825,40 +825,148 @@ async def execute_pipeline(
 ) -> PipelineCreateResponse:
     """Execute a completed pipeline's orchestration stage."""
     data = _get_result_or_404(pipeline_id)
+    data_dict = data.to_dict() if hasattr(data, "to_dict") else data
+    if not isinstance(data_dict, dict):
+        raise HTTPException(status_code=500, detail="Pipeline execution failed")
+
+    stage_status = data_dict.get("stage_status", {})
+    incomplete = [
+        stage
+        for stage in ("ideas", "goals", "actions", "orchestration")
+        if stage_status.get(stage) != "complete"
+    ]
+    orch = data_dict.get("orchestration", {}) if isinstance(data_dict, dict) else {}
+    orch_nodes = orch.get("nodes", []) if isinstance(orch, dict) else []
+    agent_tasks = [
+        node
+        for node in orch_nodes
+        if isinstance(node, dict) and node.get("data", {}).get("orch_type") == "agent_task"
+    ]
+
+    if body.sandbox:
+        logger.debug(
+            "Canvas pipeline execute requested sandbox mode for %s; canonical workflow runtime ignores the legacy sandbox flag",
+            pipeline_id,
+        )
+    if body.use_hardened_orchestrator:
+        logger.debug(
+            "Canvas pipeline execute requested hardened orchestrator for %s; routing through canonical DecisionPlan runtime instead",
+            pipeline_id,
+        )
+
+    if body.sandbox:
+        logger.debug("Sandbox execution flag ignored for canonical runtime on %s", pipeline_id)
+
+    if incomplete:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Cannot execute: stages not complete: {', '.join(incomplete)}",
+        )
+
+    execution_state = data_dict.get("execution", {})
+    if isinstance(execution_state, dict) and execution_state.get("status") in {
+        "queued",
+        "running",
+        "executing",
+    }:
+        raise HTTPException(status_code=409, detail="Pipeline is already executing")
 
     try:
-        if body.use_hardened_orchestrator:
-            from aragora.nomic.hardened_orchestrator import HardenedOrchestrator
+        from aragora.pipeline.canonical_execution import (
+            build_decision_plan_from_orchestration,
+            execute_queued_plan,
+            queue_plan_execution,
+        )
 
-            orchestrator = HardenedOrchestrator()
-            execute_fn = getattr(
-                orchestrator, "execute", getattr(orchestrator, "execute_goal", None)
-            )
-            if execute_fn is None:
-                raise AttributeError("HardenedOrchestrator has no execute method")
-            exec_result = await execute_fn(data)
-            if hasattr(exec_result, "to_dict"):
-                return PipelineCreateResponse(
-                    pipeline_id=pipeline_id,
-                    stage_status={"orchestration": "complete"},
-                    stages_completed=1,
-                    result=exec_result.to_dict(),
+        plan, tasks = build_decision_plan_from_orchestration(
+            subject_id=pipeline_id,
+            subject_label=data_dict.get("name") or f"Pipeline {pipeline_id}",
+            nodes=orch_nodes,
+            edges=orch.get("edges", []) if isinstance(orch, dict) else [],
+            source_surface="fastapi_canvas_pipeline",
+            metadata={"pipeline_id": pipeline_id},
+            execution_mode="workflow",
+        )
+        launch = queue_plan_execution(plan, auth_context=auth, execution_mode="workflow")
+        data_dict["execution"] = {
+            **launch,
+            "runtime": "decision_plan",
+            "status": "queued",
+            "tasks_total": len(tasks),
+            "agent_tasks": len(agent_tasks),
+            "total_orchestration_nodes": len(orch_nodes),
+        }
+        _get_store().save(pipeline_id, data_dict)
+
+        async def _execute() -> None:
+            try:
+                data_dict["execution"]["status"] = "running"
+                _get_store().save(pipeline_id, data_dict)
+                outcome, record, decision_receipt = await execute_queued_plan(
+                    plan,
+                    execution_id=launch["execution_id"],
+                    correlation_id=launch["correlation_id"],
+                    auth_context=auth,
+                    execution_mode=launch["execution_mode"],
                 )
-        # Standard execution
-        from aragora.pipeline.idea_to_execution import IdeaToExecutionPipeline
+                receipt_bundle: dict[str, Any] = {
+                    "receipt_id": getattr(outcome, "receipt_id", None),
+                    "pipeline_id": pipeline_id,
+                    "plan_id": plan.id,
+                    "execution_id": launch["execution_id"],
+                    "correlation_id": launch["correlation_id"],
+                    "decision_receipt": decision_receipt,
+                }
+                try:
+                    from aragora.pipeline.receipt_generator import generate_pipeline_receipt
 
-        pipeline = IdeaToExecutionPipeline()
-        execute_fn = getattr(pipeline, "execute", None)
-        result = execute_fn(data, sandbox=body.sandbox) if execute_fn is not None else data
-        if hasattr(result, "pipeline_id"):
-            _store_result(result)
-            return _summarize_result(result)
+                    receipt_bundle["pipeline_receipt"] = await generate_pipeline_receipt(
+                        pipeline_id,
+                        {
+                            **(record or {}),
+                            "execution_id": launch["execution_id"],
+                            "correlation_id": launch["correlation_id"],
+                            "status": "completed" if outcome.success else "failed",
+                        },
+                    )
+                except (ImportError, RuntimeError, ValueError, TypeError, OSError) as exc:
+                    logger.debug("Pipeline provenance receipt generation skipped: %s", exc)
+
+                data_dict["execution"] = {
+                    **data_dict.get("execution", {}),
+                    "status": "completed" if outcome.success else "failed",
+                    "record": record,
+                    "outcome": outcome.to_dict(),
+                    "receipt_id": getattr(outcome, "receipt_id", None),
+                }
+                data_dict["receipt"] = receipt_bundle
+                _get_store().save(pipeline_id, data_dict)
+            except Exception as exc:  # noqa: BLE001 - background task must persist terminal failure
+                logger.error("Pipeline execute failed: %s", exc)
+                data_dict["execution"] = {
+                    **data_dict.get("execution", {}),
+                    "status": "failed",
+                    "error": str(exc),
+                }
+                _get_store().save(pipeline_id, data_dict)
+
+        asyncio.create_task(_execute())
 
         return PipelineCreateResponse(
             pipeline_id=pipeline_id,
-            stage_status={"orchestration": "complete"},
-            stages_completed=1,
-            result=result if isinstance(result, dict) else None,
+            stage_status=data_dict.get("stage_status", {}),
+            stages_completed=sum(
+                1 for value in data_dict.get("stage_status", {}).values() if value == "complete"
+            ),
+            result={
+                "status": "executing",
+                "runtime": "decision_plan",
+                "plan_id": plan.id,
+                "execution_id": launch["execution_id"],
+                "correlation_id": launch["correlation_id"],
+                "agent_tasks": len(agent_tasks),
+                "total_orchestration_nodes": len(orch_nodes),
+            },
         )
 
     except NotFoundError:
@@ -1097,13 +1205,19 @@ async def get_pipeline_graph(
 async def get_pipeline_receipt(pipeline_id: str) -> PipelineReceiptResponse:
     """Get the DecisionReceipt for a pipeline."""
     data = _get_result_or_404(pipeline_id)
+    data_dict = (
+        data.to_dict() if hasattr(data, "to_dict") else (data if isinstance(data, dict) else {})
+    )
+    if isinstance(data_dict, dict) and isinstance(data_dict.get("receipt"), dict):
+        return PipelineReceiptResponse(
+            pipeline_id=pipeline_id,
+            receipt=data_dict.get("receipt"),
+            has_receipt=True,
+        )
 
     try:
         from aragora.pipeline.receipt_generator import generate_pipeline_receipt
 
-        data_dict = (
-            data.to_dict() if hasattr(data, "to_dict") else (data if isinstance(data, dict) else {})
-        )
         receipt = await generate_pipeline_receipt(pipeline_id, data_dict)
         receipt_dict = receipt.to_dict() if hasattr(receipt, "to_dict") else receipt
         return PipelineReceiptResponse(

--- a/aragora/server/handlers/canvas_pipeline.py
+++ b/aragora/server/handlers/canvas_pipeline.py
@@ -32,6 +32,7 @@ import logging
 import re
 import time
 import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from aragora.server.handlers.base import HandlerResult, error_response, handle_errors, json_response
@@ -50,8 +51,8 @@ _DEBATE_TO_PIPELINE = re.compile(r"^/api/v1/debates/([a-zA-Z0-9_-]+)/to-pipeline
 
 # Live PipelineResult objects for advance_stage() (cannot be persisted)
 _pipeline_objects: dict[str, Any] = {}
-# Async pipeline tasks (cannot be persisted)
-_pipeline_tasks: dict[str, asyncio.Task[Any]] = {}
+# Async pipeline tasks / worker threads (cannot be persisted)
+_pipeline_tasks: dict[str, Any] = {}
 
 
 def _spectate_pipeline(event_type: str, pipeline_id: str, data: dict[str, Any]) -> None:
@@ -1892,8 +1893,6 @@ class CanvasPipelineHandler:
         Body:
             dry_run: bool (default False) — Preview execution plan without running
         """
-        import uuid as _uuid
-
         store = _get_store()
         existing = store.get(pipeline_id)
         if not existing:
@@ -1917,13 +1916,11 @@ class CanvasPipelineHandler:
             if isinstance(n, dict) and n.get("data", {}).get("orch_type") == "agent_task"
         ]
 
-        execution_id = f"exec-{_uuid.uuid4().hex[:8]}"
-
         if dry_run:
             return json_response(
                 {
                     "pipeline_id": pipeline_id,
-                    "execution_id": execution_id,
+                    "runtime": "decision_plan",
                     "status": "dry_run",
                     "stages_complete": [
                         s
@@ -1941,6 +1938,14 @@ class CanvasPipelineHandler:
                 f"Cannot execute: stages not complete: {', '.join(incomplete)}",
                 400,
             )
+
+        execution_state = existing.get("execution", {})
+        if isinstance(execution_state, dict) and execution_state.get("status") in {
+            "queued",
+            "running",
+            "executing",
+        }:
+            return error_response("Pipeline is already executing", 409)
 
         # Set up stream emitter for real-time progress
         emitter = None
@@ -1979,7 +1984,35 @@ class CanvasPipelineHandler:
         except (ImportError, RuntimeError, TypeError, ValueError) as exc:
             logger.debug("Canvas-to-workflow sync skipped: %s", exc)
 
-        # Start async execution
+        from aragora.pipeline.canonical_execution import (
+            build_decision_plan_from_orchestration,
+            execute_queued_plan,
+            queue_plan_execution,
+        )
+
+        plan, tasks = build_decision_plan_from_orchestration(
+            subject_id=pipeline_id,
+            subject_label=existing.get("name") or f"Pipeline {pipeline_id}",
+            nodes=orch_nodes,
+            edges=orch_data.get("edges", []) if isinstance(orch_data, dict) else [],
+            source_surface="canvas_pipeline",
+            metadata={
+                "pipeline_id": pipeline_id,
+                "synced_workflow": existing.get("synced_workflow"),
+            },
+            execution_mode="workflow",
+        )
+        launch = queue_plan_execution(plan, execution_mode="workflow")
+        existing["execution"] = {
+            **launch,
+            "runtime": "decision_plan",
+            "status": "queued",
+            "tasks_total": len(tasks),
+            "agent_tasks": len(agent_tasks),
+            "total_orchestration_nodes": len(orch_nodes),
+        }
+        store.save(pipeline_id, existing)
+
         async def _execute() -> None:
             try:
                 if emitter:
@@ -1987,71 +2020,90 @@ class CanvasPipelineHandler:
                         pipeline_id,
                         "execution",
                         {
-                            "execution_id": execution_id,
+                            "execution_id": launch["execution_id"],
+                            "plan_id": plan.id,
                             "agent_tasks": len(agent_tasks),
                         },
                     )
 
-                # Execute each agent task in sequence
-                _agent_names = ["Analyst", "Implementer", "Reviewer", "Architect"]
-                task_results = []
-                for i, task_node in enumerate(agent_tasks):
-                    task_data = task_node.get("data", {})
-                    task_label = task_data.get("label", f"Task {i + 1}")
-                    agent_name = task_data.get("agent", _agent_names[i % len(_agent_names)])
+                existing["execution"]["status"] = "running"
+                store.save(pipeline_id, existing)
 
-                    if emitter:
-                        await emitter.emit_step_progress(
-                            pipeline_id,
-                            f"[{agent_name}] {task_label}",
-                            i / max(len(agent_tasks), 1),
-                        )
+                outcome, record, decision_receipt = await execute_queued_plan(
+                    plan,
+                    execution_id=launch["execution_id"],
+                    correlation_id=launch["correlation_id"],
+                    execution_mode=launch["execution_mode"],
+                )
 
-                    # Brief delay to allow WebSocket clients to see progress
-                    await asyncio.sleep(0.3)
-
-                    task_results.append(
-                        {
-                            "task": task_label,
-                            "agent": agent_name,
-                            "status": "completed",
-                        }
-                    )
-
-                # Update pipeline status in store
-                existing["execution"] = {
-                    "execution_id": execution_id,
-                    "status": "completed",
-                    "tasks_executed": len(agent_tasks),
-                    "task_results": task_results,
+                receipt_bundle: dict[str, Any] = {
+                    "receipt_id": getattr(outcome, "receipt_id", None),
+                    "pipeline_id": pipeline_id,
+                    "plan_id": plan.id,
+                    "execution_id": launch["execution_id"],
+                    "correlation_id": launch["correlation_id"],
+                    "decision_receipt": decision_receipt,
                 }
+                try:
+                    from aragora.pipeline.receipt_generator import generate_pipeline_receipt
+
+                    receipt_bundle["pipeline_receipt"] = await generate_pipeline_receipt(
+                        pipeline_id,
+                        {
+                            **(record or {}),
+                            "execution_id": launch["execution_id"],
+                            "correlation_id": launch["correlation_id"],
+                            "status": "completed" if outcome.success else "failed",
+                            "started_at": existing["execution"].get("scheduled_at"),
+                            "completed_at": datetime.now(timezone.utc).isoformat(),
+                        },
+                    )
+                except (ImportError, RuntimeError, ValueError, TypeError, OSError) as exc:
+                    logger.debug("Pipeline provenance receipt generation skipped: %s", exc)
+
+                existing["execution"] = {
+                    **existing.get("execution", {}),
+                    "status": "completed" if outcome.success else "failed",
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "record": record,
+                    "outcome": outcome.to_dict(),
+                    "receipt_id": getattr(outcome, "receipt_id", None),
+                }
+                existing["receipt"] = receipt_bundle
                 store.save(pipeline_id, existing)
 
                 if emitter:
-                    await emitter.emit_completed(pipeline_id, existing.get("receipt"))
-            except (ImportError, ValueError, TypeError, OSError) as exc:
+                    await emitter.emit_completed(pipeline_id, receipt_bundle)
+            except Exception as exc:  # noqa: BLE001 - background execution must update state before surfacing
                 logger.error("Pipeline execution failed: %s", exc)
+                existing["execution"] = {
+                    **existing.get("execution", {}),
+                    "status": "failed",
+                    "completed_at": datetime.now(timezone.utc).isoformat(),
+                    "error": str(exc),
+                }
+                store.save(pipeline_id, existing)
                 if emitter:
-                    await emitter.emit_failed(pipeline_id, "Execution failed")
+                    await emitter.emit_failed(pipeline_id, str(exc))
 
         task = asyncio.create_task(_execute())
         task.add_done_callback(
-            lambda t: logger.error(
-                "Pipeline execute task failed: %s",
-                t.exception(),
-            )
+            lambda t: logger.error("Pipeline execute task failed: %s", t.exception())
             if not t.cancelled() and t.exception()
             else None
         )
-        _pipeline_tasks[execution_id] = task
+        _pipeline_tasks[launch["execution_id"]] = task
 
         return json_response(
             {
                 "pipeline_id": pipeline_id,
-                "execution_id": execution_id,
+                "execution_id": launch["execution_id"],
+                "plan_id": plan.id,
+                "correlation_id": launch["correlation_id"],
                 "status": "executing",
                 "agent_tasks": len(agent_tasks),
                 "total_orchestration_nodes": len(orch_nodes),
+                "runtime": "decision_plan",
             },
             202,
         )

--- a/aragora/server/handlers/orchestration_canvas.py
+++ b/aragora/server/handlers/orchestration_canvas.py
@@ -564,17 +564,83 @@ class OrchestrationCanvasHandler(SecureHandler):
                 nodes = [n.to_dict() for n in canvas.nodes.values()]
                 edges = [e.to_dict() for e in canvas.edges.values()]
 
-            execution_id = f"exec-{uuid.uuid4().hex[:8]}"
+            from aragora.pipeline.canonical_execution import (
+                build_decision_plan_from_orchestration,
+                execute_queued_plan,
+                queue_plan_execution,
+                schedule_coroutine,
+            )
+
+            plan, tasks = build_decision_plan_from_orchestration(
+                subject_id=canvas_id,
+                subject_label=canvas_meta.get("name") or f"Orchestration canvas {canvas_id}",
+                nodes=nodes,
+                edges=edges,
+                source_surface="orchestration_canvas",
+                metadata={
+                    "canvas_id": canvas_id,
+                    "canvas_metadata": canvas_meta.get("metadata", {}),
+                },
+                execution_mode="workflow",
+            )
+            launch = queue_plan_execution(plan, auth_context=context, execution_mode="workflow")
+
+            metadata = dict(canvas_meta.get("metadata", {}) or {})
+            metadata["execution"] = {
+                **launch,
+                "runtime": "decision_plan",
+                "status": "queued",
+                "tasks_total": len(tasks),
+                "nodes_count": len(nodes),
+                "edges_count": len(edges),
+            }
+            store.update_canvas(canvas_id=canvas_id, metadata=metadata)
+
+            async def _execute() -> None:
+                try:
+                    outcome, record, decision_receipt = await execute_queued_plan(
+                        plan,
+                        execution_id=launch["execution_id"],
+                        correlation_id=launch["correlation_id"],
+                        auth_context=context,
+                        execution_mode=launch["execution_mode"],
+                    )
+                    updated_metadata = dict(store.load_canvas(canvas_id).get("metadata", {}) or {})
+                    updated_metadata["execution"] = {
+                        **updated_metadata.get("execution", {}),
+                        "status": "completed" if outcome.success else "failed",
+                        "record": record,
+                        "outcome": outcome.to_dict(),
+                        "receipt": decision_receipt,
+                    }
+                    store.update_canvas(canvas_id=canvas_id, metadata=updated_metadata)
+                except Exception as exc:  # noqa: BLE001 - persist terminal failure state
+                    logger.error("Failed to execute orchestration canvas %s: %s", canvas_id, exc)
+                    updated_metadata = dict(store.load_canvas(canvas_id).get("metadata", {}) or {})
+                    updated_metadata["execution"] = {
+                        **updated_metadata.get("execution", {}),
+                        "status": "failed",
+                        "error": str(exc),
+                    }
+                    store.update_canvas(canvas_id=canvas_id, metadata=updated_metadata)
+
+            schedule_coroutine(
+                _execute(),
+                name=f"orch-plan-exec-{canvas_id[:8]}",
+            )
 
             return json_response(
                 {
-                    "execution_id": execution_id,
+                    "execution_id": launch["execution_id"],
+                    "plan_id": plan.id,
+                    "correlation_id": launch["correlation_id"],
                     "canvas_id": canvas_id,
                     "stage": "orchestration",
                     "nodes_count": len(nodes),
                     "edges_count": len(edges),
                     "metadata": canvas_meta.get("metadata", {}),
                     "status": "queued",
+                    "runtime": "decision_plan",
                 },
                 status=201,
             )

--- a/aragora/server/handlers/pipeline/execute.py
+++ b/aragora/server/handlers/pipeline/execute.py
@@ -137,7 +137,54 @@ class PipelineExecuteHandler(BaseHandler):
                 {"description": g.description, "track": g.track.value, "priority": g.priority}
                 for g in goals
             ]
+            _executions[pipeline_id]["runtime"] = "decision_plan"
             return json_response(_executions[pipeline_id])
+
+        if use_hardened:
+            logger.debug(
+                "Pipeline execute requested hardened orchestrator for %s; routing through canonical DecisionPlan runtime instead",
+                pipeline_id,
+            )
+
+        from aragora.pipeline.canonical_execution import (
+            build_decision_plan_from_orchestration,
+            queue_plan_execution,
+        )
+
+        synthetic_nodes = [
+            {
+                "id": f"goal-{index}",
+                "label": goal.description,
+                "data": {
+                    "orch_type": "human_gate" if require_approval else "agent_task",
+                    "track": getattr(goal.track, "value", str(getattr(goal, "track", "core"))),
+                },
+            }
+            for index, goal in enumerate(goals, start=1)
+        ]
+        plan, tasks = build_decision_plan_from_orchestration(
+            subject_id=pipeline_id,
+            subject_label=f"Pipeline {pipeline_id}",
+            nodes=synthetic_nodes,
+            edges=[],
+            source_surface="pipeline_execute",
+            metadata={"pipeline_id": pipeline_id},
+            budget_limit_usd=budget_limit,
+            execution_mode="workflow",
+            require_task_approval=require_approval,
+        )
+        launch = queue_plan_execution(plan, execution_mode="workflow")
+        _executions[pipeline_id].update(
+            {
+                "status": "started",
+                "runtime": "decision_plan",
+                "plan_id": plan.id,
+                "execution_id": launch["execution_id"],
+                "correlation_id": launch["correlation_id"],
+                "record_status": launch["status"],
+                "tasks_total": len(tasks),
+            }
+        )
 
         # Start background execution
         task = asyncio.create_task(
@@ -148,7 +195,15 @@ class PipelineExecuteHandler(BaseHandler):
         _execution_tasks[pipeline_id] = task
 
         return json_response(
-            {"pipeline_id": pipeline_id, "cycle_id": cycle_id, "status": "started"},
+            {
+                "pipeline_id": pipeline_id,
+                "cycle_id": cycle_id,
+                "status": "started",
+                "runtime": "decision_plan",
+                "plan_id": plan.id,
+                "execution_id": launch["execution_id"],
+                "correlation_id": launch["correlation_id"],
+            },
             status=202,
         )
 
@@ -221,101 +276,120 @@ class PipelineExecuteHandler(BaseHandler):
         require_approval: bool,
         use_hardened: bool = False,
     ) -> None:
-        """Execute pipeline goals via SelfImprovePipeline or HardenedOrchestrator."""
+        """Execute pipeline goals via the canonical DecisionPlan runtime."""
         # Wire WebSocket emitter for real-time progress
         emitter = _get_emitter()
-
-        # Route through HardenedOrchestrator for full safety-gated execution
-        if use_hardened:
-            await self._execute_via_hardened(
-                pipeline_id, cycle_id, goals, budget_limit, require_approval, emitter
-            )
-            return
-
+        execution_state = _executions.get(pipeline_id, {})
         try:
-            from aragora.nomic.self_improve import SelfImproveConfig, SelfImprovePipeline
+            from aragora.pipeline.canonical_execution import (
+                build_decision_plan_from_orchestration,
+                execute_queued_plan,
+                queue_plan_execution,
+            )
+            from aragora.pipeline.plan_store import get_plan_store
+
+            plan = None
+            plan_id = execution_state.get("plan_id")
+            execution_id = execution_state.get("execution_id")
+            correlation_id = execution_state.get("correlation_id")
+            if not plan_id or not execution_id or not correlation_id:
+                synthetic_nodes = [
+                    {
+                        "id": f"goal-{index}",
+                        "label": getattr(goal, "description", f"Goal {index}"),
+                        "data": {
+                            "orch_type": "human_gate" if require_approval else "agent_task",
+                        },
+                    }
+                    for index, goal in enumerate(goals, start=1)
+                ]
+                plan, _tasks = build_decision_plan_from_orchestration(
+                    subject_id=pipeline_id,
+                    subject_label=f"Pipeline {pipeline_id}",
+                    nodes=synthetic_nodes,
+                    edges=[],
+                    source_surface="pipeline_execute",
+                    metadata={"pipeline_id": pipeline_id},
+                    budget_limit_usd=budget_limit,
+                    execution_mode="workflow",
+                    require_task_approval=require_approval,
+                )
+                launch = queue_plan_execution(plan, execution_mode="workflow")
+                execution_state.update(
+                    {
+                        "runtime": "decision_plan",
+                        "plan_id": plan.id,
+                        "execution_id": launch["execution_id"],
+                        "correlation_id": launch["correlation_id"],
+                        "record_status": launch["status"],
+                    }
+                )
+                plan_id = launch["plan_id"]
+                execution_id = launch["execution_id"]
+                correlation_id = launch["correlation_id"]
+
+            store = get_plan_store()
+            plan = store.get(str(plan_id)) or plan
+            if plan is None:
+                raise ValueError(f"Plan not found: {plan_id}")
 
             if emitter:
                 await emitter.emit_started(
                     pipeline_id,
                     {
                         "cycle_id": cycle_id,
+                        "plan_id": plan_id,
+                        "execution_id": execution_id,
                         "goal_count": len(goals),
                     },
                 )
 
-            # Build combined goal description from all orchestration nodes
-            combined_goal = "; ".join(g.description for g in goals[:10])
-
-            # Create progress callback that bridges to WebSocket events
-            event_callback = emitter.as_event_callback(pipeline_id) if emitter else None
-
-            def progress_callback(event: str, data: dict[str, Any]) -> None:
-                # Update in-memory execution state from progress events
-                if event == "stage_started":
-                    _executions[pipeline_id]["current_stage"] = data.get("stage", "")
-                elif event == "step_progress":
-                    _executions[pipeline_id]["progress"] = data.get("progress", 0)
-                # Forward to WebSocket emitter
-                if event_callback:
-                    event_callback(event, data)
-
-            config = SelfImproveConfig(
-                budget_limit_usd=budget_limit or 10.0,
-                require_approval=require_approval,
-                autonomous=not require_approval,
-                max_goals=len(goals),
-                progress_callback=progress_callback,
+            _executions[pipeline_id]["status"] = "running"
+            outcome, record, decision_receipt = await execute_queued_plan(
+                plan,
+                execution_id=str(execution_id),
+                correlation_id=str(correlation_id),
+                execution_mode="workflow",
             )
-            pipeline = SelfImprovePipeline(config=config)
-            result = await pipeline.run(combined_goal)
+            receipt_bundle: dict[str, Any] = decision_receipt or {}
+            try:
+                from aragora.pipeline.receipt_generator import generate_pipeline_receipt
 
+                receipt_bundle = {
+                    **receipt_bundle,
+                    "pipeline_receipt": await generate_pipeline_receipt(
+                        pipeline_id,
+                        {
+                            **(record or {}),
+                            "execution_id": execution_id,
+                            "correlation_id": correlation_id,
+                            "status": "completed" if outcome.success else "failed",
+                        },
+                    ),
+                }
+            except (ImportError, RuntimeError, ValueError, TypeError, OSError) as exc:
+                logger.debug("Pipeline provenance receipt generation skipped: %s", exc)
             _executions[pipeline_id].update(
                 {
-                    "status": "completed" if result.subtasks_completed > 0 else "failed",
+                    "status": "completed" if outcome.success else "failed",
                     "completed_at": datetime.now(timezone.utc).isoformat(),
-                    "total_subtasks": result.subtasks_total,
-                    "completed_subtasks": result.subtasks_completed,
-                    "failed_subtasks": result.subtasks_failed,
+                    "total_subtasks": outcome.tasks_total,
+                    "completed_subtasks": outcome.tasks_completed,
+                    "failed_subtasks": max(0, outcome.tasks_total - outcome.tasks_completed),
+                    "record": record,
+                    "outcome": outcome.to_dict(),
+                    "receipt": receipt_bundle or decision_receipt,
                 }
             )
 
             if emitter:
-                final_status = _executions[pipeline_id]["status"]
-                if final_status == "completed":
+                if outcome.success:
                     await emitter.emit_completed(pipeline_id, _executions[pipeline_id])
                 else:
-                    await emitter.emit_failed(pipeline_id, "No subtasks completed")
-
-            # Create convoy linking pipeline artifacts (best-effort)
-            try:
-                from aragora.workspace.convoy import ConvoyTracker
-
-                convoy_id = f"convoy-{uuid.uuid4().hex[:12]}"
-                tracker = ConvoyTracker()
-                convoy = await tracker.create_convoy(
-                    workspace_id=pipeline_id,
-                    rig_id=pipeline_id,
-                    name=f"Pipeline execution: {combined_goal[:80]}",
-                    bead_ids=[f"pipeline:{pipeline_id}", f"cycle:{cycle_id}"],
-                    convoy_id=convoy_id,
-                    metadata={
-                        "pipeline_id": pipeline_id,
-                        "cycle_id": cycle_id,
-                        "status": _executions[pipeline_id].get("status", "unknown"),
-                    },
-                )
-                _executions[pipeline_id]["convoy_id"] = convoy.convoy_id
-            except (ImportError, RuntimeError, ValueError, OSError, TypeError, AttributeError) as e:
-                logger.debug("Convoy creation skipped: %s", type(e).__name__)
-
-            # Generate provenance receipt
-            try:
-                from aragora.pipeline.receipt_generator import generate_pipeline_receipt
-
-                await generate_pipeline_receipt(pipeline_id, _executions[pipeline_id])
-            except (ImportError, RuntimeError, ValueError, OSError) as e:
-                logger.debug("Receipt generation skipped: %s", type(e).__name__)
+                    await emitter.emit_failed(
+                        pipeline_id,
+                        outcome.error or "Pipeline execution failed",
+                    )
 
         except asyncio.CancelledError:
             _executions[pipeline_id].update(
@@ -326,28 +400,17 @@ class PipelineExecuteHandler(BaseHandler):
             )
             if emitter:
                 await emitter.emit_failed(pipeline_id, "Pipeline cancelled")
-        except ImportError:
-            logger.debug("SelfImprovePipeline not available")
+        except Exception as e:  # noqa: BLE001 - background execution must preserve error state
+            logger.error("Pipeline execution failed: %s", e)
             _executions[pipeline_id].update(
                 {
                     "status": "failed",
-                    "error": "Self-improvement pipeline not available",
+                    "error": str(e),
                     "completed_at": datetime.now(timezone.utc).isoformat(),
                 }
             )
             if emitter:
-                await emitter.emit_failed(pipeline_id, "Self-improvement pipeline not available")
-        except (RuntimeError, ValueError, TypeError, OSError) as e:
-            logger.error("Pipeline execution failed: %s", type(e).__name__)
-            _executions[pipeline_id].update(
-                {
-                    "status": "failed",
-                    "error": "Pipeline execution failed",
-                    "completed_at": datetime.now(timezone.utc).isoformat(),
-                }
-            )
-            if emitter:
-                await emitter.emit_failed(pipeline_id, "Pipeline execution failed")
+                await emitter.emit_failed(pipeline_id, str(e))
         finally:
             _execution_tasks.pop(pipeline_id, None)
 

--- a/aragora/storage/pipeline_store.py
+++ b/aragora/storage/pipeline_store.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from aragora.storage.base_store import SQLiteStore
 from aragora.storage.schema import SchemaManager
+from aragora.storage.schema import safe_add_column
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ class PipelineResultStore(SQLiteStore):
     """Persistent storage for idea-to-execution pipeline results."""
 
     SCHEMA_NAME = "pipeline_results"
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
 
     INITIAL_SCHEMA = """
         CREATE TABLE IF NOT EXISTS pipeline_results (
@@ -37,6 +38,7 @@ class PipelineResultStore(SQLiteStore):
             provenance_count INTEGER DEFAULT 0,
             integrity_hash TEXT,
             receipt_json TEXT,
+            execution_json TEXT,
             duration REAL DEFAULT 0.0,
             created_at REAL NOT NULL,
             updated_at REAL NOT NULL
@@ -49,7 +51,17 @@ class PipelineResultStore(SQLiteStore):
 
     def register_migrations(self, manager: SchemaManager) -> None:
         """Register schema migrations."""
-        pass
+        manager.register_migration(
+            from_version=1,
+            to_version=2,
+            function=lambda conn: safe_add_column(
+                conn,
+                "pipeline_results",
+                "execution_json",
+                "TEXT",
+            ),
+            description="Persist canonical execution metadata",
+        )
 
     def save(self, pipeline_id: str, result_dict: dict[str, Any]) -> None:
         """Save or update a pipeline result.
@@ -79,8 +91,8 @@ class PipelineResultStore(SQLiteStore):
                     id, status, stage_status_json,
                     ideas_json, goals_json, actions_json, orchestration_json,
                     transitions_json, provenance_count, integrity_hash,
-                    receipt_json, duration, created_at, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    receipt_json, execution_json, duration, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     status = excluded.status,
                     stage_status_json = excluded.stage_status_json,
@@ -92,6 +104,7 @@ class PipelineResultStore(SQLiteStore):
                     provenance_count = excluded.provenance_count,
                     integrity_hash = excluded.integrity_hash,
                     receipt_json = excluded.receipt_json,
+                    execution_json = excluded.execution_json,
                     duration = excluded.duration,
                     updated_at = excluded.updated_at
                 """,
@@ -109,6 +122,9 @@ class PipelineResultStore(SQLiteStore):
                     result_dict.get("provenance_count", 0),
                     result_dict.get("integrity_hash", ""),
                     json.dumps(result_dict.get("receipt")) if result_dict.get("receipt") else None,
+                    json.dumps(result_dict.get("execution"))
+                    if result_dict.get("execution")
+                    else None,
                     result_dict.get("duration", 0.0),
                     now,
                     now,
@@ -251,6 +267,9 @@ def _deserialize_row(row: dict[str, Any]) -> dict[str, Any]:
     receipt_json = row.get("receipt_json")
     if receipt_json:
         result["receipt"] = _parse_json(receipt_json)
+    execution_json = row.get("execution_json")
+    if execution_json:
+        result["execution"] = _parse_json(execution_json)
     return result
 
 

--- a/tests/handlers/pipeline/test_execute.py
+++ b/tests/handlers/pipeline/test_execute.py
@@ -120,6 +120,51 @@ def _mock_orch_nodes(count: int = 2) -> list[dict[str, Any]]:
     return nodes
 
 
+def _mock_plan(plan_id: str = "plan-123") -> MagicMock:
+    plan = MagicMock()
+    plan.id = plan_id
+    return plan
+
+
+def _mock_launch(
+    plan_id: str = "plan-123",
+    execution_id: str = "exec-123",
+    correlation_id: str = "corr-123",
+) -> dict[str, Any]:
+    return {
+        "plan_id": plan_id,
+        "execution_id": execution_id,
+        "correlation_id": correlation_id,
+        "execution_mode": "workflow",
+        "status": "queued",
+    }
+
+
+def _mock_outcome(
+    *,
+    success: bool = True,
+    tasks_total: int = 1,
+    tasks_completed: int | None = None,
+    receipt_id: str = "rcpt-123",
+    error: str | None = None,
+) -> MagicMock:
+    completed = tasks_completed if tasks_completed is not None else tasks_total
+    outcome = MagicMock()
+    outcome.success = success
+    outcome.tasks_total = tasks_total
+    outcome.tasks_completed = completed
+    outcome.error = error
+    outcome.receipt_id = receipt_id
+    outcome.to_dict.return_value = {
+        "success": success,
+        "tasks_total": tasks_total,
+        "tasks_completed": completed,
+        "error": error,
+        "receipt_id": receipt_id,
+    }
+    return outcome
+
+
 # ---------------------------------------------------------------------------
 # Route Registration and can_handle
 # ---------------------------------------------------------------------------
@@ -367,12 +412,21 @@ class TestPostExecution:
         orch_nodes = _mock_orch_nodes(3)
 
         with patch.object(h, "_load_orchestration_nodes", return_value=orch_nodes):
-            with patch.object(h, "_execute_pipeline", new_callable=AsyncMock):
-                await h.handle_post("/api/v1/pipeline/pipe-123/execute", {}, http)
+            with patch(
+                "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+                return_value=(_mock_plan(), [MagicMock(), MagicMock(), MagicMock()]),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.queue_plan_execution",
+                    return_value=_mock_launch(),
+                ):
+                    with patch.object(h, "_execute_pipeline", new_callable=AsyncMock):
+                        await h.handle_post("/api/v1/pipeline/pipe-123/execute", {}, http)
 
         assert "pipe-123" in _executions
         assert _executions["pipe-123"]["goal_count"] == 3
         assert _executions["pipe-123"]["status"] == "started"
+        assert _executions["pipe-123"]["runtime"] == "decision_plan"
 
     @pytest.mark.asyncio
     async def test_start_execution_empty_id_segment(self):
@@ -806,23 +860,32 @@ class TestExecutePipeline:
     async def test_execution_success(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 3
-        mock_result.subtasks_total = 3
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1"), MagicMock(description="Goal 2")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock(), MagicMock(), MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True, tasks_total=3, tasks_completed=3),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, 10.0, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, 10.0, False)
 
         assert _executions["pipe-123"]["status"] == "completed"
         assert _executions["pipe-123"]["total_subtasks"] == 3
@@ -833,23 +896,32 @@ class TestExecutePipeline:
     async def test_execution_failure_zero_subtasks(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 0
-        mock_result.subtasks_total = 3
-        mock_result.subtasks_failed = 3
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock(), MagicMock(), MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=False, tasks_total=3, tasks_completed=0),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
 
@@ -857,14 +929,21 @@ class TestExecutePipeline:
     async def test_execution_cancelled(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=asyncio.CancelledError())
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=asyncio.CancelledError()),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "cancelled"
         assert "completed_at" in _executions["pipe-123"]
@@ -873,10 +952,12 @@ class TestExecutePipeline:
     async def test_execution_import_error(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch.dict("sys.modules", {"aragora.nomic.self_improve": None}):
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            side_effect=ImportError("canonical runtime not available"),
+        ):
             await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
@@ -886,30 +967,44 @@ class TestExecutePipeline:
     async def test_execution_runtime_error(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=RuntimeError("Boom"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=RuntimeError("Boom")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
-        assert _executions["pipe-123"]["error"] == "Pipeline execution failed"
+        assert _executions["pipe-123"]["error"] == "Boom"
 
     @pytest.mark.asyncio
     async def test_execution_value_error(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=ValueError("Bad value"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=ValueError("Bad value")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
 
@@ -917,14 +1012,21 @@ class TestExecutePipeline:
     async def test_execution_type_error(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=TypeError("Type mismatch"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=TypeError("Type mismatch")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
 
@@ -932,14 +1034,21 @@ class TestExecutePipeline:
     async def test_execution_os_error(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=OSError("Disk full"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=OSError("Disk full")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
 
@@ -948,23 +1057,31 @@ class TestExecutePipeline:
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
         _execution_tasks["pipe-123"] = MagicMock()
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ):
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert "pipe-123" not in _execution_tasks
 
@@ -973,14 +1090,21 @@ class TestExecutePipeline:
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
         _execution_tasks["pipe-123"] = MagicMock()
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=RuntimeError("Boom"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=RuntimeError("Boom")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert "pipe-123" not in _execution_tasks
 
@@ -989,21 +1113,23 @@ class TestExecutePipeline:
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
         _execution_tasks["pipe-123"] = MagicMock()
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=asyncio.CancelledError())
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=asyncio.CancelledError()),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert "pipe-123" not in _execution_tasks
-
-
-# ---------------------------------------------------------------------------
-# Receipt Generation
-# ---------------------------------------------------------------------------
 
 
 class TestReceiptGeneration:
@@ -1011,250 +1137,200 @@ class TestReceiptGeneration:
     async def test_receipt_generated_on_success(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
-                ) as mock_receipt:
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
+                ):
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         mock_receipt.assert_awaited_once()
-        call_args = mock_receipt.call_args[0]
-        assert call_args[0] == "pipe-123"
+        assert mock_receipt.call_args[0][0] == "pipe-123"
 
     @pytest.mark.asyncio
     async def test_receipt_import_error_does_not_fail(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    side_effect=ImportError("receipt gen unavailable"),
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    # Should NOT raise
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        side_effect=ImportError("receipt gen unavailable"),
+                    ):
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
-        # Execution should still complete
         assert _executions["pipe-123"]["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_receipt_runtime_error_does_not_fail(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    side_effect=RuntimeError("receipt gen failed"),
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        side_effect=RuntimeError("receipt gen failed"),
+                    ):
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "completed"
 
 
-# ---------------------------------------------------------------------------
-# SelfImproveConfig Construction
-# ---------------------------------------------------------------------------
-
-
-class TestSelfImproveConfig:
+class TestCanonicalBootstrap:
     @pytest.mark.asyncio
-    async def test_config_default_budget(self):
+    async def test_budget_is_forwarded_to_plan_builder(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig") as MockConfig:
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ) as mock_build:
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, 50.0, False)
 
-        # Default budget is 10.0 when None
-        MockConfig.assert_called_once()
-        call_kwargs = MockConfig.call_args[1]
-        assert call_kwargs["budget_limit_usd"] == 10.0
+        assert mock_build.call_args.kwargs["budget_limit_usd"] == 50.0
 
     @pytest.mark.asyncio
-    async def test_config_custom_budget(self):
+    async def test_require_approval_is_forwarded_to_plan_builder(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="Goal 1")]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig") as MockConfig:
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ) as mock_build:
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, 50.0, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, True)
 
-        call_kwargs = MockConfig.call_args[1]
-        assert call_kwargs["budget_limit_usd"] == 50.0
+        assert mock_build.call_args.kwargs["require_task_approval"] is True
 
     @pytest.mark.asyncio
-    async def test_config_require_approval(self):
+    async def test_bootstrap_creates_one_synthetic_node_per_goal(self):
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
-        goals = [MagicMock(description="Goal 1")]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig") as MockConfig:
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
-                with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
-                ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, True)
-
-        call_kwargs = MockConfig.call_args[1]
-        assert call_kwargs["require_approval"] is True
-        assert call_kwargs["autonomous"] is False
-
-    @pytest.mark.asyncio
-    async def test_config_autonomous_when_no_approval(self):
-        h = _make_handler()
-        _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
-        goals = [MagicMock(description="Goal 1")]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig") as MockConfig:
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
-                with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
-                ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
-
-        call_kwargs = MockConfig.call_args[1]
-        assert call_kwargs["require_approval"] is False
-        assert call_kwargs["autonomous"] is True
-
-    @pytest.mark.asyncio
-    async def test_config_max_goals(self):
-        h = _make_handler()
-        _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description=f"Goal {i}") for i in range(5)]
 
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig") as MockConfig:
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock() for _ in range(5)]),
+        ) as mock_build:
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True, tasks_total=5, tasks_completed=5),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
-        call_kwargs = MockConfig.call_args[1]
-        assert call_kwargs["max_goals"] == 5
-
-
-# ---------------------------------------------------------------------------
-# Combined Goal Description
-# ---------------------------------------------------------------------------
-
-
-class TestCombinedGoalDescription:
-    @pytest.mark.asyncio
-    async def test_combined_goal_limited_to_10(self):
-        h = _make_handler()
-        _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
-
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 1
-        mock_result.subtasks_total = 1
-        mock_result.subtasks_failed = 0
-
-        # Create 15 goals but only first 10 should be in combined description
-        goals = [MagicMock(description=f"Goal {i}") for i in range(15)]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
-                with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
-                ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
-
-        # Verify that pipeline.run was called with combined goal
-        run_call = mock_instance.run.call_args
-        combined = run_call[0][0]
-        # Should have exactly 10 items separated by "; "
-        parts = combined.split("; ")
-        assert len(parts) == 10
+        assert len(mock_build.call_args.kwargs["nodes"]) == 5
 
 
 # ---------------------------------------------------------------------------
@@ -1475,22 +1551,31 @@ class TestExecutionStateTransitions:
         h = _make_handler()
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
 
-        mock_result = MagicMock()
-        mock_result.subtasks_completed = 2
-        mock_result.subtasks_total = 2
-        mock_result.subtasks_failed = 0
-
         goals = [MagicMock(description="G1")]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(return_value=mock_result)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
                 with patch(
-                    "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
-                    new_callable=AsyncMock,
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(
+                        return_value=(
+                            _mock_outcome(success=True, tasks_total=2, tasks_completed=2),
+                            {"execution_id": "exec-123"},
+                            {"receipt_id": "rcpt-123"},
+                        )
+                    ),
                 ):
-                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+                    with patch(
+                        "aragora.pipeline.receipt_generator.generate_pipeline_receipt",
+                        new_callable=AsyncMock,
+                    ) as mock_receipt:
+                        mock_receipt.return_value = {"receipt_id": "pipe-rcpt"}
+                        await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "completed"
         assert "completed_at" in _executions["pipe-123"]
@@ -1501,16 +1586,23 @@ class TestExecutionStateTransitions:
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
 
         goals = [MagicMock(description="G1")]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=RuntimeError("Oops"))
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=RuntimeError("Oops")),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "failed"
         assert "completed_at" in _executions["pipe-123"]
-        assert _executions["pipe-123"]["error"] == "Pipeline execution failed"
+        assert _executions["pipe-123"]["error"] == "Oops"
 
     @pytest.mark.asyncio
     async def test_state_from_started_to_cancelled(self):
@@ -1518,12 +1610,19 @@ class TestExecutionStateTransitions:
         _executions["pipe-123"] = {"pipeline_id": "pipe-123", "status": "started"}
 
         goals = [MagicMock(description="G1")]
-
-        with patch("aragora.nomic.self_improve.SelfImprovePipeline") as MockPipeline:
-            with patch("aragora.nomic.self_improve.SelfImproveConfig"):
-                mock_instance = MockPipeline.return_value
-                mock_instance.run = AsyncMock(side_effect=asyncio.CancelledError())
-                await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
+        with patch(
+            "aragora.pipeline.canonical_execution.build_decision_plan_from_orchestration",
+            return_value=(_mock_plan(), [MagicMock()]),
+        ):
+            with patch(
+                "aragora.pipeline.canonical_execution.queue_plan_execution",
+                return_value=_mock_launch(),
+            ):
+                with patch(
+                    "aragora.pipeline.canonical_execution.execute_queued_plan",
+                    new=AsyncMock(side_effect=asyncio.CancelledError()),
+                ):
+                    await h._execute_pipeline("pipe-123", "cycle-1", goals, None, False)
 
         assert _executions["pipe-123"]["status"] == "cancelled"
         assert "completed_at" in _executions["pipe-123"]

--- a/tests/storage/test_pipeline_store.py
+++ b/tests/storage/test_pipeline_store.py
@@ -26,6 +26,7 @@ def _make_result(
     provenance_count: int = 0,
     integrity_hash: str = "",
     receipt: dict | None = None,
+    execution: dict | None = None,
     duration: float = 0.0,
 ) -> dict:
     return {
@@ -38,6 +39,7 @@ def _make_result(
         "provenance_count": provenance_count,
         "integrity_hash": integrity_hash,
         "receipt": receipt,
+        "execution": execution,
         "duration": duration,
     }
 
@@ -95,6 +97,18 @@ class TestSave:
 
         retrieved = store.get("pipe-1")
         assert retrieved["receipt"] == receipt
+
+    def test_save_preserves_execution(self, store):
+        execution = {
+            "plan_id": "plan-123",
+            "execution_id": "exec-123",
+            "correlation_id": "corr-123",
+            "status": "running",
+        }
+        store.save("pipe-1", _make_result(execution=execution))
+
+        retrieved = store.get("pipe-1")
+        assert retrieved["execution"] == execution
 
     def test_save_preserves_transitions(self, store):
         transitions = [{"from": "ideas", "to": "goals", "timestamp": 1234.5}]


### PR DESCRIPTION
## Summary
- route legacy canvas, FastAPI canvas, orchestration canvas, and legacy pipeline execute endpoints through the canonical `DecisionPlan` + `ExecutionBridge` runtime
- persist canonical execution metadata (`plan_id`, `execution_id`, `correlation_id`, status/outcome) on pipeline records and surface stored receipts before legacy regeneration
- add a shared orchestration-to-plan adapter and update focused execution tests for the new runtime contract

## Validation
- `python3 -m py_compile aragora/pipeline/canonical_execution.py aragora/storage/pipeline_store.py aragora/server/handlers/canvas_pipeline.py aragora/server/fastapi/routes/canvas_pipeline.py aragora/server/handlers/pipeline/execute.py aragora/server/handlers/orchestration_canvas.py tests/handlers/pipeline/test_execute.py`
- `pytest -q tests/handlers/pipeline/test_execute.py`
- `pytest -q tests/storage/test_pipeline_store.py tests/handlers/test_canvas_pipeline.py tests/server/fastapi/test_canvas_pipeline_routes.py tests/handlers/orchestration/test_handler.py -k 'execute or receipt or pipeline or canvas'`

Closes #811
