### PR TITLE
feat(pipeline): require persisted receipts before plan execution

### DIFF
--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -278,6 +278,10 @@ class PlanExecutor:
             plan.metadata.setdefault("org_id", getattr(auth_context, "org_id", None))
             plan.metadata.setdefault("requested_by", getattr(auth_context, "user_id", None))
 
+        from aragora.pipeline.receipt_gate import ensure_plan_receipt, sync_plan_receipt_state
+
+        ensure_plan_receipt(plan)
+
         # Transition to executing
         plan.status = PlanStatus.EXECUTING
         plan.execution_started_at = datetime.now()
@@ -503,6 +507,10 @@ class PlanExecutor:
             logger.debug("Convoy creation failed (non-critical): %s", e)
 
         # Update store with final state
+        sync_plan_receipt_state(
+            plan,
+            on_status=PlanStatus.COMPLETED if outcome.success else PlanStatus.FAILED,
+        )
         store_plan(plan)
 
         return outcome

--- a/aragora/pipeline/plan_store.py
+++ b/aragora/pipeline/plan_store.py
@@ -167,6 +167,13 @@ class PlanStore:
 
     def create(self, plan: DecisionPlan) -> None:
         """Insert a new plan into the store."""
+        try:
+            from aragora.pipeline.receipt_gate import ensure_plan_receipt
+
+            ensure_plan_receipt(plan)
+        except Exception as exc:  # noqa: BLE001 - keep persistence available; execution gate enforces
+            logger.warning("Failed to pre-persist decision receipt for plan %s: %s", plan.id, exc)
+
         now = datetime.now(timezone.utc).isoformat()
         budget_json = json.dumps(plan.budget.to_dict()) if plan.budget else "{}"
         approval_json = json.dumps(plan.approval_record.to_dict()) if plan.approval_record else None
@@ -354,6 +361,19 @@ class PlanStore:
             updated = cursor.rowcount > 0
             if updated:
                 logger.info("Updated plan %s to status %s", plan_id, status.value)
+                if status in (PlanStatus.APPROVED, PlanStatus.REJECTED, PlanStatus.COMPLETED):
+                    try:
+                        from aragora.pipeline.receipt_gate import sync_plan_receipt_state
+
+                        plan = self.get(plan_id)
+                        if plan is not None:
+                            sync_plan_receipt_state(plan, on_status=status)
+                    except Exception as exc:  # noqa: BLE001 - do not mask status update
+                        logger.warning(
+                            "Failed to synchronize decision receipt for plan %s: %s",
+                            plan_id,
+                            exc,
+                        )
             return updated
         finally:
             conn.close()
@@ -423,6 +443,19 @@ class PlanStore:
                     new_status.value,
                     ",".join(expected_values),
                 )
+                if new_status in (PlanStatus.APPROVED, PlanStatus.REJECTED, PlanStatus.COMPLETED):
+                    try:
+                        from aragora.pipeline.receipt_gate import sync_plan_receipt_state
+
+                        plan = self.get(plan_id)
+                        if plan is not None:
+                            sync_plan_receipt_state(plan, on_status=new_status)
+                    except Exception as exc:  # noqa: BLE001 - do not mask status update
+                        logger.warning(
+                            "Failed to synchronize decision receipt for plan %s: %s",
+                            plan_id,
+                            exc,
+                        )
             return updated
         finally:
             conn.close()

--- a/aragora/pipeline/receipt_gate.py
+++ b/aragora/pipeline/receipt_gate.py
@@ -1,0 +1,436 @@
+"""Pre-execution receipt gating for DecisionPlan action-taking.
+
+This module makes plan execution fail closed unless there is either:
+- a persisted, signed decision receipt in the expected lifecycle state, or
+- an explicit documented exemption in plan metadata.
+
+The receipt is created before execution, not after, so action-taking can
+verify receipt state before any workflow/hybrid/computer-use path runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+from aragora.gauntlet.receipt_models import DecisionReceipt
+from aragora.gauntlet.receipt_store import (
+    ReceiptState,
+    ReceiptStateError,
+    get_receipt_store,
+)
+from aragora.pipeline.decision_plan.core import PlanStatus
+
+logger = logging.getLogger(__name__)
+
+
+class PlanReceiptGateError(RuntimeError):
+    """Raised when a plan lacks a valid pre-execution decision receipt."""
+
+
+@dataclass
+class PlanReceiptStatus:
+    """Resolved receipt gate state for one plan."""
+
+    receipt_id: str | None
+    state: str
+    signature_valid: bool
+    integrity_valid: bool
+    exempted: bool = False
+
+
+def _metadata(plan: Any) -> dict[str, Any]:
+    metadata = getattr(plan, "metadata", None)
+    if isinstance(metadata, dict):
+        return metadata
+    metadata = {}
+    setattr(plan, "metadata", metadata)
+    return metadata
+
+
+def _receipt_meta(plan: Any) -> dict[str, Any]:
+    metadata = _metadata(plan)
+    receipt_meta = metadata.get("decision_receipt")
+    if isinstance(receipt_meta, dict):
+        return receipt_meta
+    receipt_meta = {}
+    metadata["decision_receipt"] = receipt_meta
+    return receipt_meta
+
+
+def _documented_exemption(plan: Any) -> dict[str, Any] | None:
+    exemption = _metadata(plan).get("receipt_gate_exemption")
+    if not isinstance(exemption, dict):
+        return None
+    reason = str(exemption.get("reason", "") or "").strip()
+    approved_by = str(exemption.get("approved_by", "") or "").strip()
+    if not reason or not approved_by:
+        return None
+    return {
+        "reason": reason,
+        "approved_by": approved_by,
+    }
+
+
+def _expected_receipt_state(plan: Any, *, on_status: PlanStatus | None = None) -> ReceiptState:
+    status = on_status or getattr(plan, "status", PlanStatus.CREATED)
+    if status == PlanStatus.REJECTED:
+        return ReceiptState.EXPIRED
+    if status == PlanStatus.COMPLETED:
+        return ReceiptState.EXECUTED
+
+    requires_human = bool(getattr(plan, "requires_human_approval", False))
+    is_approved = bool(getattr(plan, "is_approved", False))
+    if status == PlanStatus.AWAITING_APPROVAL or (requires_human and not is_approved):
+        return ReceiptState.CREATED
+    return ReceiptState.APPROVED
+
+
+def _list_of_strings(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, (list, tuple, set)):
+        result: list[str] = []
+        for item in value:
+            text = str(item or "").strip()
+            if text:
+                result.append(text)
+        return result
+    return []
+
+
+def _synthetic_debate_result(plan: Any) -> Any:
+    metadata = _metadata(plan)
+    deliberation = metadata.get("deliberation_bundle")
+    if not isinstance(deliberation, dict):
+        deliberation = {}
+
+    gate = metadata.get("execution_gate")
+    if not isinstance(gate, dict):
+        gate = {}
+
+    signed_receipt = gate.get("signed_receipt")
+    if not isinstance(signed_receipt, dict):
+        signed_receipt = {}
+
+    signed_consensus = signed_receipt.get("consensus_proof")
+    if not isinstance(signed_consensus, dict):
+        signed_consensus = {}
+
+    supporting_agents = _list_of_strings(signed_consensus.get("supporting_agents"))
+    dissenting_agents = _list_of_strings(signed_consensus.get("dissenting_agents"))
+    participants = supporting_agents + [
+        agent for agent in dissenting_agents if agent not in supporting_agents
+    ]
+    if not participants:
+        participants = _list_of_strings(metadata.get("decision_participants"))
+
+    dissenting_views = _list_of_strings(deliberation.get("dissenting_views"))
+    if not dissenting_views:
+        dissenting_views = _list_of_strings(signed_receipt.get("dissenting_views"))
+
+    confidence = float(
+        deliberation.get("confidence")
+        or signed_receipt.get("confidence")
+        or metadata.get("decision_confidence")
+        or 0.0
+    )
+    consensus_reached = bool(deliberation.get("consensus_reached"))
+    if not consensus_reached:
+        consensus_reached = bool(signed_consensus.get("reached"))
+
+    return SimpleNamespace(
+        debate_id=str(getattr(plan, "debate_id", "") or getattr(plan, "id", "")),
+        task=str(getattr(plan, "task", "") or ""),
+        final_answer=str(
+            deliberation.get("verdict")
+            or metadata.get("decision_summary")
+            or getattr(plan, "task", "")
+            or ""
+        ),
+        confidence=confidence,
+        consensus_reached=consensus_reached,
+        rounds_used=int(metadata.get("rounds_used") or 1),
+        duration_seconds=float(metadata.get("duration_seconds") or 0.0),
+        consensus_strength=str(
+            deliberation.get("consensus_strength") or signed_consensus.get("method") or "majority"
+        ),
+        participants=participants,
+        dissenting_views=dissenting_views,
+        messages=[],
+        votes=[],
+        winner=None,
+    )
+
+
+def _build_receipt(plan: Any) -> DecisionReceipt:
+    source = getattr(plan, "debate_result", None) or _synthetic_debate_result(plan)
+    receipt = DecisionReceipt.from_debate_result(source)
+
+    metadata = _metadata(plan)
+    gate = metadata.get("execution_gate")
+    if not isinstance(gate, dict):
+        gate = {}
+
+    deliberation = metadata.get("deliberation_bundle")
+    if not isinstance(deliberation, dict):
+        deliberation = {}
+
+    receipt.config_used.update(
+        {
+            "plan_id": getattr(plan, "id", ""),
+            "debate_id": getattr(plan, "debate_id", ""),
+            "approval_mode": getattr(getattr(plan, "approval_mode", None), "value", ""),
+            "execution_gate": gate,
+        }
+    )
+
+    profile = getattr(plan, "implementation_profile", None)
+    if profile is not None and hasattr(profile, "to_dict"):
+        receipt.config_used["implementation_profile"] = profile.to_dict()
+
+    settlement_metadata = dict(receipt.settlement_metadata or {})
+    if deliberation:
+        settlement_metadata["deliberation_bundle"] = deliberation
+    if gate:
+        settlement_metadata["execution_gate"] = gate
+    if settlement_metadata:
+        receipt.settlement_metadata = settlement_metadata
+
+    taint_flags = _list_of_strings(deliberation.get("taint_flags"))
+    if gate.get("context_taint_detected"):
+        taint_flags.append("context_taint_detected")
+    if taint_flags or gate:
+        taint_analysis = {
+            "tainted": bool(taint_flags) or bool(gate.get("context_taint_detected")),
+            "flags": sorted(set(taint_flags)),
+            "provider_diversity": gate.get("provider_diversity"),
+            "model_family_diversity": gate.get("model_family_diversity"),
+            "providers": _list_of_strings(gate.get("providers")),
+            "model_families": _list_of_strings(gate.get("model_families")),
+            "reason_codes": _list_of_strings(gate.get("reason_codes")),
+        }
+        receipt.taint_analysis = taint_analysis
+        receipt.config_used["taint_analysis"] = taint_analysis
+
+    signed_receipt = gate.get("signed_receipt")
+    if (
+        receipt.consensus_proof is not None
+        and isinstance(signed_receipt, dict)
+        and isinstance(signed_receipt.get("consensus_proof"), dict)
+    ):
+        consensus = signed_receipt["consensus_proof"]
+        trust_score = consensus.get("trust_score")
+        if trust_score is not None:
+            try:
+                receipt.consensus_proof.trust_score = float(trust_score)
+            except (TypeError, ValueError):
+                pass
+        tainted_proposals = _list_of_strings(consensus.get("tainted_proposals"))
+        if tainted_proposals:
+            receipt.consensus_proof.tainted_proposals = tainted_proposals
+
+    return receipt
+
+
+def _update_metadata_from_store(
+    plan: Any, *, receipt_id: str, state: ReceiptState, stored: Any
+) -> None:
+    metadata = _metadata(plan)
+    receipt_meta = _receipt_meta(plan)
+    receipt_meta.update(
+        {
+            "receipt_id": receipt_id,
+            "state": state.value,
+            "signature_key_id": getattr(stored, "signature_key_id", None),
+            "signed_at": getattr(stored, "signed_at", None),
+            "signature_algorithm": getattr(stored, "signature_algorithm", None),
+            "exempted": False,
+        }
+    )
+    metadata["decision_receipt_id"] = receipt_id
+
+
+def _mark_exemption_metadata(plan: Any, exemption: dict[str, Any]) -> None:
+    metadata = _metadata(plan)
+    receipt_meta = _receipt_meta(plan)
+    receipt_meta.update(
+        {
+            "receipt_id": None,
+            "state": "EXEMPTED",
+            "exempted": True,
+            "reason": exemption["reason"],
+            "approved_by": exemption["approved_by"],
+        }
+    )
+    metadata["decision_receipt_id"] = None
+
+
+def _validate_existing_receipt(
+    plan: Any,
+    *,
+    require_state: ReceiptState | None,
+) -> PlanReceiptStatus:
+    receipt_meta = _receipt_meta(plan)
+    receipt_id = str(
+        receipt_meta.get("receipt_id") or _metadata(plan).get("decision_receipt_id") or ""
+    ).strip()
+    if not receipt_id:
+        raise PlanReceiptGateError(
+            f"Plan {getattr(plan, 'id', '<unknown>')} has no decision receipt"
+        )
+
+    store = get_receipt_store()
+    stored = store.get(receipt_id)
+    if stored is None:
+        raise PlanReceiptGateError(
+            f"Decision receipt {receipt_id} not found for plan {getattr(plan, 'id', '<unknown>')}"
+        )
+
+    if require_state is not None and stored.state != require_state:
+        raise PlanReceiptGateError(
+            f"Decision receipt {receipt_id} is in state {stored.state.value}, "
+            f"expected {require_state.value}"
+        )
+
+    signature_valid = bool(stored.signature) and store.verify_receipt(receipt_id)
+    if not signature_valid:
+        raise PlanReceiptGateError(f"Decision receipt {receipt_id} failed signature verification")
+
+    integrity_valid = True
+    try:
+        receipt = DecisionReceipt.from_dict(stored.receipt_data)
+        integrity_valid = receipt.verify_integrity()
+    except (TypeError, ValueError, KeyError) as exc:
+        raise PlanReceiptGateError(
+            f"Decision receipt {receipt_id} could not be reconstructed"
+        ) from exc
+
+    if not integrity_valid:
+        raise PlanReceiptGateError(f"Decision receipt {receipt_id} failed integrity verification")
+
+    _update_metadata_from_store(
+        plan,
+        receipt_id=receipt_id,
+        state=stored.state,
+        stored=stored,
+    )
+    return PlanReceiptStatus(
+        receipt_id=receipt_id,
+        state=stored.state.value,
+        signature_valid=signature_valid,
+        integrity_valid=integrity_valid,
+    )
+
+
+def ensure_plan_receipt(
+    plan: Any,
+    *,
+    on_status: PlanStatus | None = None,
+) -> PlanReceiptStatus:
+    """Ensure a plan has a persisted decision receipt in the expected state."""
+    exemption = _documented_exemption(plan)
+    if exemption is not None:
+        _mark_exemption_metadata(plan, exemption)
+        return PlanReceiptStatus(
+            receipt_id=None,
+            state="EXEMPTED",
+            signature_valid=False,
+            integrity_valid=False,
+            exempted=True,
+        )
+
+    require_state = _expected_receipt_state(plan, on_status=on_status)
+    receipt_meta = _receipt_meta(plan)
+    receipt_id = str(
+        receipt_meta.get("receipt_id") or _metadata(plan).get("decision_receipt_id") or ""
+    ).strip()
+
+    if receipt_id:
+        return _validate_existing_receipt(plan, require_state=require_state)
+
+    receipt = _build_receipt(plan)
+    receipt.sign()
+
+    store = get_receipt_store()
+    stored = store.persist(
+        receipt_id=receipt.receipt_id,
+        receipt_data=receipt.to_dict(),
+        signature=receipt.signature,
+        signature_key_id=receipt.signature_key_id,
+        signed_at=receipt.signed_at,
+        signature_algorithm=receipt.signature_algorithm,
+        state=require_state,
+    )
+    _update_metadata_from_store(
+        plan,
+        receipt_id=receipt.receipt_id,
+        state=require_state,
+        stored=stored,
+    )
+    return _validate_existing_receipt(plan, require_state=require_state)
+
+
+def sync_plan_receipt_state(
+    plan: Any,
+    *,
+    on_status: PlanStatus | None = None,
+) -> PlanReceiptStatus | None:
+    """Synchronize persisted receipt lifecycle state with plan lifecycle state."""
+    exemption = _documented_exemption(plan)
+    if exemption is not None:
+        _mark_exemption_metadata(plan, exemption)
+        return PlanReceiptStatus(
+            receipt_id=None,
+            state="EXEMPTED",
+            signature_valid=False,
+            integrity_valid=False,
+            exempted=True,
+        )
+
+    target_state = _expected_receipt_state(plan, on_status=on_status)
+    receipt_meta = _receipt_meta(plan)
+    receipt_id = str(
+        receipt_meta.get("receipt_id") or _metadata(plan).get("decision_receipt_id") or ""
+    ).strip()
+    if receipt_id:
+        status = _validate_existing_receipt(plan, require_state=None)
+    else:
+        status = ensure_plan_receipt(plan, on_status=on_status)
+        if status.exempted or status.receipt_id is None:
+            return status
+
+    store = get_receipt_store()
+    stored = store.get(status.receipt_id)
+    if stored is None:
+        raise PlanReceiptGateError(f"Decision receipt {status.receipt_id} missing during sync")
+
+    if stored.state != target_state:
+        try:
+            stored = store.transition(status.receipt_id, target_state)
+        except ReceiptStateError as exc:
+            raise PlanReceiptGateError(
+                f"Could not transition decision receipt {status.receipt_id} "
+                f"from {stored.state.value} to {target_state.value}"
+            ) from exc
+
+    _update_metadata_from_store(
+        plan,
+        receipt_id=status.receipt_id,
+        state=stored.state,
+        stored=stored,
+    )
+    return _validate_existing_receipt(plan, require_state=target_state)
+
+
+__all__ = [
+    "PlanReceiptGateError",
+    "PlanReceiptStatus",
+    "ensure_plan_receipt",
+    "sync_plan_receipt_state",
+]

--- a/tests/pipeline/test_plan_store.py
+++ b/tests/pipeline/test_plan_store.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     BudgetAllocation,
@@ -31,6 +32,13 @@ def store(tmp_path: Path) -> PlanStore:
     """Create a PlanStore with a temp database."""
     db_path = str(tmp_path / "test_plans.db")
     return PlanStore(db_path=db_path)
+
+
+@pytest.fixture(autouse=True)
+def _reset_receipt_store_fixture() -> None:
+    reset_receipt_store()
+    yield
+    reset_receipt_store()
 
 
 @pytest.fixture
@@ -77,6 +85,22 @@ class TestPlanStoreCreate:
         assert retrieved is not None
         assert retrieved.metadata["priority"] == "high"
         assert len(retrieved.metadata["action_items"]) == 1
+
+    def test_create_persists_pre_execution_receipt(
+        self, store: PlanStore, sample_plan: DecisionPlan
+    ) -> None:
+        store.create(sample_plan)
+        retrieved = store.get(sample_plan.id)
+
+        assert retrieved is not None
+        receipt_meta = retrieved.metadata["decision_receipt"]
+        receipt_id = receipt_meta["receipt_id"]
+        stored = get_receipt_store().get(receipt_id)
+
+        assert receipt_id
+        assert receipt_meta["state"] == ReceiptState.CREATED.value
+        assert stored is not None
+        assert stored.state == ReceiptState.CREATED
 
     def test_create_preserves_max_auto_risk(self, store: PlanStore) -> None:
         plan = DecisionPlan(
@@ -273,6 +297,10 @@ class TestPlanStoreUpdate:
         assert plan.approval_record is not None
         assert plan.approval_record.approved is True
         assert plan.approval_record.approver_id == "user-42"
+        receipt_id = plan.metadata["decision_receipt"]["receipt_id"]
+        stored = get_receipt_store().get(receipt_id)
+        assert stored is not None
+        assert stored.state == ReceiptState.APPROVED
 
     def test_update_status_reject(self, store: PlanStore, sample_plan: DecisionPlan) -> None:
         store.create(sample_plan)
@@ -290,6 +318,25 @@ class TestPlanStoreUpdate:
         assert plan.approval_record is not None
         assert plan.approval_record.approved is False
         assert plan.approval_record.reason == "Too risky"
+        receipt_id = plan.metadata["decision_receipt"]["receipt_id"]
+        stored = get_receipt_store().get(receipt_id)
+        assert stored is not None
+        assert stored.state == ReceiptState.EXPIRED
+
+    def test_update_status_completed_marks_receipt_executed(
+        self, store: PlanStore, sample_plan: DecisionPlan
+    ) -> None:
+        sample_plan.status = PlanStatus.APPROVED
+        store.create(sample_plan)
+        result = store.update_status(sample_plan.id, PlanStatus.COMPLETED)
+
+        assert result is True
+        plan = store.get(sample_plan.id)
+        assert plan is not None
+        receipt_id = plan.metadata["decision_receipt"]["receipt_id"]
+        stored = get_receipt_store().get(receipt_id)
+        assert stored is not None
+        assert stored.state == ReceiptState.EXECUTED
 
     def test_update_nonexistent_returns_false(self, store: PlanStore) -> None:
         result = store.update_status("ghost", PlanStatus.APPROVED)

--- a/tests/pipeline/test_receipt_gate.py
+++ b/tests/pipeline/test_receipt_gate.py
@@ -1,0 +1,148 @@
+"""Tests for pre-execution receipt gating of DecisionPlan actions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
+from aragora.pipeline.decision_plan.core import (
+    ApprovalMode,
+    ApprovalRecord,
+    DecisionPlan,
+    PlanStatus,
+)
+from aragora.pipeline.decision_plan.memory import PlanOutcome
+from aragora.pipeline.executor import PlanExecutor
+from aragora.pipeline.receipt_gate import PlanReceiptGateError, ensure_plan_receipt
+
+
+@pytest.fixture(autouse=True)
+def _reset_receipts() -> None:
+    reset_receipt_store()
+    yield
+    reset_receipt_store()
+
+
+def _plan(
+    *,
+    status: PlanStatus = PlanStatus.APPROVED,
+    approval_mode: ApprovalMode = ApprovalMode.ALWAYS,
+    approval_record: ApprovalRecord | None = None,
+    metadata: dict[str, object] | None = None,
+) -> DecisionPlan:
+    return DecisionPlan(
+        id="dp-receipt-gate",
+        debate_id="debate-receipt-gate",
+        task="Ship the approved workflow changes",
+        status=status,
+        approval_mode=approval_mode,
+        approval_record=approval_record,
+        metadata=metadata or {},
+    )
+
+
+def test_ensure_plan_receipt_supports_documented_exemption() -> None:
+    plan = _plan(
+        metadata={
+            "receipt_gate_exemption": {
+                "reason": "Legacy admin remediation path",
+                "approved_by": "admin-user",
+            }
+        }
+    )
+
+    status = ensure_plan_receipt(plan)
+
+    assert status.exempted is True
+    assert plan.metadata["decision_receipt"]["state"] == "EXEMPTED"
+    assert get_receipt_store().list_receipts() == []
+
+
+def test_existing_tampered_receipt_fails_closed() -> None:
+    plan = _plan(
+        status=PlanStatus.CREATED,
+        approval_mode=ApprovalMode.NEVER,
+        metadata={
+            "execution_gate": {
+                "provider_diversity": 2,
+                "model_family_diversity": 2,
+                "providers": ["openai", "anthropic"],
+                "model_families": ["gpt", "claude"],
+            }
+        },
+    )
+
+    status = ensure_plan_receipt(plan)
+    receipt_id = status.receipt_id
+    assert receipt_id is not None
+
+    store = get_receipt_store()
+    stored = store.get(receipt_id)
+    assert stored is not None
+    stored.signature = "tampered-signature"
+
+    with pytest.raises(PlanReceiptGateError, match="signature verification"):
+        ensure_plan_receipt(plan)
+
+
+@pytest.mark.asyncio
+async def test_executor_verifies_receipt_before_running_actions() -> None:
+    plan = _plan(
+        approval_record=ApprovalRecord(approved=True, approver_id="user-42"),
+        metadata={
+            "execution_gate": {
+                "provider_diversity": 2,
+                "model_family_diversity": 2,
+                "providers": ["openai", "anthropic"],
+                "model_families": ["gpt", "claude"],
+                "context_taint_detected": True,
+                "reason_codes": ["tainted_context_detected"],
+            },
+            "deliberation_bundle": {
+                "confidence": 0.82,
+                "consensus_reached": True,
+                "dissenting_views": ["critic: verify rollback path"],
+                "taint_flags": ["external_unverified"],
+            },
+        },
+    )
+
+    store = get_receipt_store()
+
+    async def _run_workflow_assert_receipt(*args, **kwargs):
+        receipt_id = plan.metadata["decision_receipt"]["receipt_id"]
+        stored = store.get(receipt_id)
+        assert stored is not None
+        assert stored.state == ReceiptState.APPROVED
+        return PlanOutcome(
+            plan_id=plan.id,
+            debate_id=plan.debate_id,
+            task=plan.task,
+            success=True,
+            tasks_completed=1,
+            tasks_total=1,
+            duration_seconds=0.1,
+        )
+
+    executor = PlanExecutor()
+    with (
+        patch.object(
+            PlanExecutor, "_run_workflow", AsyncMock(side_effect=_run_workflow_assert_receipt)
+        ),
+        patch.object(PlanExecutor, "_generate_receipt", AsyncMock(return_value=None)),
+        patch.object(PlanExecutor, "_ingest_to_km", AsyncMock()),
+        patch("aragora.pipeline.executor.record_plan_outcome", AsyncMock()),
+        patch.object(PlanExecutor, "_emit_plan_event"),
+        patch("aragora.workspace.convoy.ConvoyTracker", MagicMock()),
+    ):
+        outcome = await executor.execute(plan, execution_mode="workflow")
+
+    receipt_id = plan.metadata["decision_receipt"]["receipt_id"]
+    stored = store.get(receipt_id)
+    assert outcome.success is True
+    assert stored is not None
+    assert stored.state == ReceiptState.EXECUTED
+    assert stored.receipt_data["config_used"]["taint_analysis"]["tainted"] is True
+    assert stored.receipt_data["config_used"]["execution_gate"]["provider_diversity"] == 2


### PR DESCRIPTION
Advances #812.

## What Changed
- added a central `receipt_gate` helper for `DecisionPlan` execution
- require a persisted signed decision receipt or a documented exemption before `PlanExecutor` runs any actions
- pre-persist receipts in `PlanStore.create()` and synchronize receipt lifecycle state on approve/reject/complete transitions
- carry execution-gate, taint, and deliberation metadata into the persisted pre-execution receipt payload
- added focused tests for plan-store lifecycle sync, fail-closed tamper detection, documented exemptions, and executor pre-checks

## Validation
- `python3 -m py_compile aragora/pipeline/receipt_gate.py aragora/pipeline/plan_store.py aragora/pipeline/executor.py tests/pipeline/test_plan_store.py tests/pipeline/test_receipt_gate.py`
- `pytest -q tests/pipeline/test_plan_store.py tests/pipeline/test_receipt_gate.py`
- `pytest -q tests/pipeline/test_execution_bridge.py tests/e2e/test_decision_action_smoke.py tests/e2e/test_decision_pipeline.py -k 'execute or receipt or decision_action'`
- `pytest -q tests/handlers/pipeline/test_execute.py -k 'execute or receipt'`
- `pytest -q tests/pipeline/test_plan_api.py tests/server/handlers/test_plans.py -k 'execute or approve or reject or receipt'`
- `pytest -q tests/server/handlers/decisions/test_pipeline.py tests/pipeline/test_gold_path.py -k 'execute or approve or PlanExecutor or receipt'`

## Scope Notes
This PR hardens `DecisionPlan` execution and plan lifecycle surfaces only. It does not claim to close the broader receipt-bypass inventory across inbox bulk actions, Gmail thread mutations, OpenClaw action endpoints, DAG execution, or MCP bridges; those remain explicit follow-up work under `#812`.
