### PR TITLE
fix(inbox): fail closed unified bulk actions without receipts

### DIFF
--- a/aragora/server/handlers/features/unified_inbox/actions.py
+++ b/aragora/server/handlers/features/unified_inbox/actions.py
@@ -11,6 +11,31 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 VALID_ACTIONS = ["archive", "mark_read", "mark_unread", "star", "delete"]
+RECEIPT_REQUIRED_ACTIONS = frozenset({"archive", "star", "delete"})
+RECEIPT_EXEMPT_ACTIONS = {
+    "mark_read": "read-state sync is explicitly exempt until unified inbox bulk receipts exist",
+    "mark_unread": "read-state sync is explicitly exempt until unified inbox bulk receipts exist",
+}
+
+
+def _receipt_required_result(action: str, message_ids: list[str]) -> dict[str, Any]:
+    """Fail closed when the bulk path lacks receipt verification for a write action."""
+    errors = [
+        {
+            "id": msg_id,
+            "error": (
+                "This action requires a cryptographic decision receipt. "
+                "Unified inbox bulk execution is not receipt-backed for this action."
+            ),
+        }
+        for msg_id in message_ids
+    ]
+    return {
+        "action": action,
+        "success_count": 0,
+        "error_count": len(errors),
+        "errors": errors if errors else None,
+    }
 
 
 async def execute_bulk_action(
@@ -23,6 +48,22 @@ async def execute_bulk_action(
 
     Returns a dict with success_count, error_count, and errors list.
     """
+    if action in RECEIPT_REQUIRED_ACTIONS:
+        logger.info(
+            "Blocking unified inbox bulk action without receipt backing: tenant=%s action=%s count=%s",
+            tenant_id,
+            action,
+            len(message_ids),
+        )
+        return _receipt_required_result(action, message_ids)
+    if action in RECEIPT_EXEMPT_ACTIONS:
+        logger.debug(
+            "Unified inbox bulk action using explicit receipt exemption: tenant=%s action=%s reason=%s",
+            tenant_id,
+            action,
+            RECEIPT_EXEMPT_ACTIONS[action],
+        )
+
     success_count = 0
     errors: list[dict[str, str]] = []
 

--- a/tests/handlers/features/unified_inbox/test_actions.py
+++ b/tests/handlers/features/unified_inbox/test_actions.py
@@ -48,6 +48,15 @@ def _make_store(
     return store
 
 
+def _assert_receipt_required(result: dict[str, Any], action: str, message_ids: list[str]) -> None:
+    assert result["action"] == action
+    assert result["success_count"] == 0
+    assert result["error_count"] == len(message_ids)
+    assert result["errors"] is not None
+    assert [entry["id"] for entry in result["errors"]] == message_ids
+    assert all("cryptographic decision receipt" in entry["error"] for entry in result["errors"])
+
+
 # ---------------------------------------------------------------------------
 # VALID_ACTIONS constant
 # ---------------------------------------------------------------------------
@@ -164,35 +173,31 @@ class TestStar:
     async def test_star_single_message(self):
         store = _make_store()
         result = await execute_bulk_action("t1", ["msg-1"], "star", store)
-        assert result["action"] == "star"
-        assert result["success_count"] == 1
-        assert result["error_count"] == 0
-        store.update_message_flags.assert_awaited_once_with("t1", "msg-1", is_starred=True)
+        _assert_receipt_required(result, "star", ["msg-1"])
+        store.update_message_flags.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_star_multiple_messages(self):
         store = _make_store()
         ids = ["a", "b"]
         result = await execute_bulk_action("t1", ids, "star", store)
-        assert result["success_count"] == 2
-        assert result["error_count"] == 0
+        _assert_receipt_required(result, "star", ids)
+        store.update_message_flags.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_star_not_found(self):
         store = _make_store(update_return=False)
         result = await execute_bulk_action("t1", ["msg-1"], "star", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Message not found"
+        _assert_receipt_required(result, "star", ["msg-1"])
+        store.update_message_flags.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_star_store_raises_type_error(self):
         store = _make_store()
         store.update_message_flags.side_effect = TypeError("nope")
         result = await execute_bulk_action("t1", ["msg-1"], "star", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Action failed"
+        _assert_receipt_required(result, "star", ["msg-1"])
+        store.update_message_flags.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -207,27 +212,23 @@ class TestArchive:
     async def test_archive_single_message(self):
         store = _make_store()
         result = await execute_bulk_action("t1", ["msg-1"], "archive", store)
-        assert result["action"] == "archive"
-        assert result["success_count"] == 1
-        assert result["error_count"] == 0
-        store.delete_message.assert_awaited_once_with("t1", "msg-1")
+        _assert_receipt_required(result, "archive", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_archive_not_found(self):
         store = _make_store(delete_return=False)
         result = await execute_bulk_action("t1", ["msg-1"], "archive", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Message not found"
+        _assert_receipt_required(result, "archive", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_archive_store_raises_key_error(self):
         store = _make_store()
         store.delete_message.side_effect = KeyError("missing")
         result = await execute_bulk_action("t1", ["msg-1"], "archive", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Action failed"
+        _assert_receipt_required(result, "archive", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -242,27 +243,23 @@ class TestDelete:
     async def test_delete_single_message(self):
         store = _make_store()
         result = await execute_bulk_action("t1", ["msg-1"], "delete", store)
-        assert result["action"] == "delete"
-        assert result["success_count"] == 1
-        assert result["error_count"] == 0
-        store.delete_message.assert_awaited_once_with("t1", "msg-1")
+        _assert_receipt_required(result, "delete", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_not_found(self):
         store = _make_store(delete_return=False)
         result = await execute_bulk_action("t1", ["msg-1"], "delete", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Message not found"
+        _assert_receipt_required(result, "delete", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_store_raises_os_error(self):
         store = _make_store()
         store.delete_message.side_effect = OSError("disk full")
         result = await execute_bulk_action("t1", ["msg-1"], "delete", store)
-        assert result["success_count"] == 0
-        assert result["error_count"] == 1
-        assert result["errors"][0]["error"] == "Action failed"
+        _assert_receipt_required(result, "delete", ["msg-1"])
+        store.delete_message.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -298,11 +295,8 @@ class TestMixedAndEdgeCases:
         store = _make_store()
         store.update_message_flags = AsyncMock(side_effect=[True, RuntimeError("boom")])
         result = await execute_bulk_action("t1", ["ok", "fail"], "star", store)
-        # "star" uses update_message_flags
-        assert result["success_count"] == 1
-        assert result["error_count"] == 1
-        assert result["errors"][0]["id"] == "fail"
-        assert result["errors"][0]["error"] == "Action failed"
+        _assert_receipt_required(result, "star", ["ok", "fail"])
+        store.update_message_flags.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_unrecognised_action_counts_as_success(self):
@@ -317,7 +311,8 @@ class TestMixedAndEdgeCases:
     async def test_errors_is_none_when_all_succeed(self):
         store = _make_store()
         result = await execute_bulk_action("t1", ["a", "b", "c"], "delete", store)
-        assert result["errors"] is None
+        assert isinstance(result["errors"], list)
+        assert len(result["errors"]) == 3
 
     @pytest.mark.asyncio
     async def test_errors_is_list_when_failures_exist(self):
@@ -345,7 +340,7 @@ class TestMixedAndEdgeCases:
     async def test_tenant_id_is_forwarded_to_delete(self):
         store = _make_store()
         await execute_bulk_action("tenant-xyz", ["m1"], "archive", store)
-        store.delete_message.assert_awaited_once_with("tenant-xyz", "m1")
+        store.delete_message.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_return_dict_keys(self):
@@ -376,9 +371,9 @@ class TestMixedAndEdgeCases:
 
     @pytest.mark.asyncio
     async def test_delete_and_archive_share_code_path(self):
-        """Both archive and delete call store.delete_message."""
+        """Both archive and delete are blocked pending receipt backing."""
         for action in ("archive", "delete"):
             store = _make_store()
             result = await execute_bulk_action("t1", ["m1"], action, store)
-            assert result["success_count"] == 1
-            store.delete_message.assert_awaited_once_with("t1", "m1")
+            _assert_receipt_required(result, action, ["m1"])
+            store.delete_message.assert_not_awaited()


### PR DESCRIPTION
## Summary
- fail closed for unified inbox bulk `archive`, `star`, and `delete` because that path is not yet receipt-backed
- keep `mark_read` and `mark_unread` as explicit narrow exemptions until bulk receipts exist
- update focused unified inbox bulk-action tests to assert no direct writes occur on blocked actions

## Why
This is a bounded `#812` follow-up tranche. The unified inbox bulk-action path still allowed meaningful mutations without cryptographic decision receipt verification. Until that path is wired to real receipt validation, it should not silently execute write actions.

## Validation
- `pytest -q tests/handlers/features/unified_inbox/test_actions.py tests/inbox/test_receipt_gated_executor.py tests/server/handlers/test_approvals_inbox.py`
