### PR TITLE
feat(coordination): add integrator view for active swarm lanes

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -63,6 +63,12 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         InterrogatorConfig,
         UserProfile,
     )
+    from aragora.swarm.reporter import build_integrator_view
+    from aragora.worktree.fleet import (
+        FleetCoordinationStore,
+        build_fleet_rows,
+        resolve_repo_root,
+    )
 
     action, goal = _resolve_swarm_action_goal(args)
     spec_file = getattr(args, "spec", None)
@@ -115,11 +121,24 @@ def cmd_swarm(args: argparse.Namespace) -> None:
     autonomy_level = autonomy_map.get(autonomy_str, AutonomyLevel.PROPOSE_APPROVE)
 
     if action == "status":
-        supervisor = SwarmSupervisor(repo_root=Path.cwd())
+        repo_root = resolve_repo_root(Path.cwd())
+        supervisor = SwarmSupervisor(repo_root=repo_root)
         payload = supervisor.status_summary(
             run_id=run_id,
             limit=int(getattr(args, "status_limit", 20)),
             refresh_scaling=refresh_scaling,
+        )
+        base_branch = str(getattr(args, "target_branch", "main") or "main")
+        worktrees = build_fleet_rows(repo_root, base_branch=base_branch, tail=0)
+        store = FleetCoordinationStore(repo_root)
+        claims = store.list_claims()
+        merge_queue = store.list_merge_queue()
+        payload["integrator_view"] = build_integrator_view(
+            runs=payload.get("runs", []),
+            worktrees=worktrees,
+            claims=claims,
+            merge_queue=merge_queue,
+            coordination=payload.get("coordination", {}),
         )
         if as_json:
             print(json.dumps(payload, indent=2))
@@ -132,6 +151,21 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     completed=payload["counts"].get("completed_work_orders", 0),
                 )
             )
+            integrator_summary = payload["integrator_view"].get("summary", {})
+            print(
+                "integrator ready={ready} review={review} blocked={blocked} stale={stale} "
+                "collisions={collisions} missing_receipts={missing} superseded={superseded}".format(
+                    ready=integrator_summary.get("ready_lanes", 0),
+                    review=integrator_summary.get("review_lanes", 0),
+                    blocked=integrator_summary.get("blocked_lanes", 0),
+                    stale=integrator_summary.get("stale_heartbeat_lanes", 0),
+                    collisions=integrator_summary.get("collision_lanes", 0),
+                    missing=integrator_summary.get("missing_receipt_lanes", 0),
+                    superseded=integrator_summary.get("superseded_lanes", 0),
+                )
+            )
+            for action_text in payload["integrator_view"].get("next_actions", [])[:3]:
+                print(f"next: {action_text}")
             for run in payload.get("runs", []):
                 if isinstance(run, dict):
                     print("---")

--- a/aragora/cli/commands/worktree.py
+++ b/aragora/cli/commands/worktree.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from aragora.swarm.reporter import build_integrator_view
 from aragora.worktree import (
     AutopilotRequest,
     FleetIntegrationWorker,
@@ -459,6 +460,12 @@ def _cmd_worktree_fleet_status(
         session_id = str(row.get("session_id", ""))
         row["claimed_paths"] = sorted(claims_by_session.get(session_id, []))
         row["queued_branches"] = sorted(queue_by_session.get(session_id, []))
+    integrator_view = build_integrator_view(
+        worktrees=rows,
+        claims=claims,
+        merge_queue=queue,
+        coordination=coordination_summary,
+    )
 
     if getattr(args, "json", False):
         payload = {
@@ -469,6 +476,7 @@ def _cmd_worktree_fleet_status(
             "claims": claims,
             "merge_queue": queue,
             "coordination": coordination_summary,
+            "integrator_view": integrator_view,
         }
         print(json.dumps(payload, indent=2))
         return
@@ -484,6 +492,19 @@ def _cmd_worktree_fleet_status(
             f"fleet_claims={counts.get('fleet_claims', 0)} "
             f"fleet_queue={counts.get('fleet_merge_queue', 0)}"
         )
+    integrator_summary = integrator_view.get("summary", {})
+    print(
+        "Integrator: "
+        f"ready={integrator_summary.get('ready_lanes', 0)} "
+        f"review={integrator_summary.get('review_lanes', 0)} "
+        f"blocked={integrator_summary.get('blocked_lanes', 0)} "
+        f"stale={integrator_summary.get('stale_heartbeat_lanes', 0)} "
+        f"collisions={integrator_summary.get('collision_lanes', 0)} "
+        f"missing_receipts={integrator_summary.get('missing_receipt_lanes', 0)} "
+        f"superseded={integrator_summary.get('superseded_lanes', 0)}"
+    )
+    for action in integrator_view.get("next_actions", [])[:3]:
+        print(f"  next: {action}")
     if not rows:
         return
 
@@ -505,6 +526,26 @@ def _cmd_worktree_fleet_status(
         print(f"  dirty_files: {row['dirty_files']} ahead/behind({base_branch}): {ahead_behind}")
         print(f"  orchestrator: {row.get('orchestration_pattern') or 'generic'}")
         print(f"  last_activity: {row.get('last_activity') or 'n/a'}")
+        lane = next(
+            (
+                item
+                for item in integrator_view.get("lanes", [])
+                if item.get("owner_session_id") == row.get("session_id")
+                and item.get("worktree_path") == row.get("path")
+            ),
+            None,
+        )
+        if isinstance(lane, dict):
+            print(
+                f"  lease_health: {lane.get('lease_health', 'idle')} "
+                f"merge_readiness: {lane.get('merge_readiness', 'unknown')}"
+            )
+            if lane.get("collisions"):
+                print(f"  collisions: {', '.join(lane['collisions'])}")
+            if lane.get("missing_receipt"):
+                print("  receipt: missing")
+            elif lane.get("receipt_id"):
+                print(f"  receipt: {lane['receipt_id']}")
         claimed_paths = row.get("claimed_paths")
         if isinstance(claimed_paths, list) and claimed_paths:
             print(f"  claimed_paths({len(claimed_paths)}): {', '.join(claimed_paths[:8])}")

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -28,6 +28,7 @@ from aragora.server.handlers.utils.decorators import (
     handle_errors,
     require_permission,
 )
+from aragora.swarm.reporter import build_integrator_view
 from aragora.worktree.fleet import (
     FleetCoordinationStore,
     build_fleet_rows,
@@ -687,6 +688,18 @@ class CoordinationHandlerMixin:
             limit=max(1, min(limit, 100)),
             refresh_scaling=bool(query_params.get("refresh", False)),
         )
+        base_branch = str(query_params.get("base", "main"))
+        rows = build_fleet_rows(repo_root, base_branch=base_branch, tail=0)
+        store = self._fleet_store(repo_root)
+        claims = store.list_claims()
+        queue = store.list_merge_queue()
+        payload["integrator_view"] = build_integrator_view(
+            runs=payload.get("runs", []),
+            worktrees=rows,
+            claims=claims,
+            merge_queue=queue,
+            coordination=payload.get("coordination", {}),
+        )
         return json_response(payload)
 
     @api_endpoint(
@@ -732,6 +745,12 @@ class CoordinationHandlerMixin:
             session_id = str(row.get("session_id", ""))
             row["claimed_paths"] = sorted(claims_by_session.get(session_id, []))
             row["queued_branches"] = sorted(queue_by_session.get(session_id, []))
+        integrator_view = build_integrator_view(
+            worktrees=rows,
+            claims=claims,
+            merge_queue=queue,
+            coordination=coordination_summary,
+        )
         return json_response(
             {
                 "repo_root": str(repo_root),
@@ -741,6 +760,7 @@ class CoordinationHandlerMixin:
                 "claims": claims,
                 "merge_queue": queue,
                 "coordination": coordination_summary,
+                "integrator_view": integrator_view,
                 "total": len(rows),
             }
         )

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
+from datetime import UTC, datetime
 import logging
 from dataclasses import dataclass, field
 from typing import Any
@@ -12,6 +14,590 @@ from aragora.harnesses.base import AnalysisType
 from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
+
+_STALE_LANE_AFTER_SECONDS = 15 * 60
+
+
+def _parse_iso_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _age_seconds(value: Any, *, now: datetime) -> float | None:
+    parsed = _parse_iso_timestamp(value)
+    if parsed is None:
+        return None
+    return max(0.0, (now - parsed).total_seconds())
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _metadata(item: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        return {}
+    data = item.get("metadata")
+    return data if isinstance(data, dict) else {}
+
+
+def _first_text(*values: Any) -> str:
+    for value in values:
+        text = _text(value)
+        if text:
+            return text
+    return ""
+
+
+def _extract_receipt_id(*sources: dict[str, Any] | None) -> str:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in ("receipt_id", "decision_receipt_id", "last_receipt_id"):
+            text = _text(source.get(key))
+            if text:
+                return text
+        meta = _metadata(source)
+        for key in ("receipt_id", "decision_receipt_id", "last_receipt_id"):
+            text = _text(meta.get(key))
+            if text:
+                return text
+    return ""
+
+
+def _extract_pr_link(*sources: dict[str, Any] | None) -> dict[str, Any] | None:
+    url = ""
+    number: int | None = None
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        meta = _metadata(source)
+        for candidate in (
+            source.get("pr_url"),
+            source.get("pull_request_url"),
+            meta.get("pr_url"),
+            meta.get("pull_request_url"),
+        ):
+            text = _text(candidate)
+            if text and not url:
+                url = text
+        for candidate in (
+            source.get("pr_number"),
+            source.get("pull_request_number"),
+            meta.get("pr_number"),
+            meta.get("pull_request_number"),
+        ):
+            if isinstance(candidate, int):
+                number = candidate
+                break
+            text = _text(candidate)
+            if text.isdigit():
+                number = int(text)
+                break
+        if url or number is not None:
+            break
+    if not url and number is None:
+        return None
+    return {"url": url or None, "number": number}
+
+
+def _explicit_missing_receipt(*sources: dict[str, Any] | None) -> bool:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for error_field in ("dispatch_error", "error"):
+            lowered = _text(source.get(error_field)).lower()
+            if "without receipt" in lowered or "missing receipt" in lowered:
+                return True
+        meta = _metadata(source)
+        lowered = _text(meta.get("error")).lower()
+        if "without receipt" in lowered or "missing receipt" in lowered:
+            return True
+    return False
+
+
+def _is_superseded(*sources: dict[str, Any] | None) -> bool:
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if _text(source.get("status")).lower() == "superseded":
+            return True
+        meta = _metadata(source)
+        if _text(meta.get("superseded_by")) or _text(meta.get("supersedes")):
+            return True
+    return False
+
+
+def _merge_queue_status(queue_item: dict[str, Any] | None) -> str:
+    if not isinstance(queue_item, dict):
+        return ""
+    return _text(queue_item.get("status")).lower()
+
+
+def _receipt_expected(status: str, queue_status: str) -> bool:
+    if queue_status in {"validating", "integrating", "needs_human", "merged", "failed"}:
+        return True
+    return status in {"completed", "needs_human", "merged"}
+
+
+def _merge_readiness(
+    *,
+    status: str,
+    queue_status: str,
+    stale_heartbeat: bool,
+    missing_receipt: bool,
+    superseded: bool,
+    collisions: list[str],
+) -> str:
+    if superseded:
+        return "superseded"
+    if collisions or stale_heartbeat or missing_receipt or queue_status in {"blocked", "failed"}:
+        return "blocked"
+    if queue_status == "merged":
+        return "merged"
+    if queue_status in {"validating", "integrating"}:
+        return queue_status
+    if queue_status == "needs_human":
+        return "review"
+    if status in {"completed", "needs_human"}:
+        return "ready"
+    if status in {"leased", "dispatched", "queued", "active"}:
+        return "in_progress"
+    return status or queue_status or "unknown"
+
+
+def _next_action(
+    *,
+    readiness: str,
+    stale_heartbeat: bool,
+    missing_receipt: bool,
+    superseded: bool,
+    collisions: list[str],
+    queue_status: str,
+) -> str:
+    if superseded:
+        return "Close or archive the superseded lane."
+    if collisions:
+        return "Resolve the branch or file-scope collision before integrating."
+    if stale_heartbeat:
+        return "Inspect the stale lane and decide whether to salvage or reassign it."
+    if missing_receipt:
+        return "Attach or regenerate the completion receipt before integration."
+    if queue_status == "needs_human":
+        return "Review the validated lane and decide whether it should merge."
+    if readiness == "ready":
+        return "Queue or validate this lane for merge."
+    if readiness == "merged":
+        return "No action needed; the lane is already merged."
+    return "Monitor the lane or reconcile it if progress stalls."
+
+
+def build_integrator_view(
+    *,
+    runs: list[dict[str, Any]] | None = None,
+    worktrees: list[dict[str, Any]] | None = None,
+    claims: list[dict[str, Any]] | None = None,
+    merge_queue: list[dict[str, Any]] | None = None,
+    coordination: dict[str, Any] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Normalize coordination state into an integrator-facing lane view."""
+    runs = [item for item in (runs or []) if isinstance(item, dict)]
+    worktrees = [item for item in (worktrees or []) if isinstance(item, dict)]
+    claims = [item for item in (claims or []) if isinstance(item, dict)]
+    merge_queue = [item for item in (merge_queue or []) if isinstance(item, dict)]
+    coordination = coordination if isinstance(coordination, dict) else {}
+    now = now or datetime.now(UTC)
+
+    worktrees_by_branch: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    worktrees_by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    worktrees_by_session: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in worktrees:
+        branch = _text(row.get("branch"))
+        if branch:
+            worktrees_by_branch[branch].append(row)
+        path = _text(row.get("path"))
+        if path:
+            worktrees_by_path[path].append(row)
+        session_id = _text(row.get("session_id"))
+        if session_id:
+            worktrees_by_session[session_id].append(row)
+
+    claims_by_session: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    sessions_by_path: dict[str, set[str]] = defaultdict(set)
+    for claim in claims:
+        session_id = _text(claim.get("session_id"))
+        path = _text(claim.get("path"))
+        if session_id:
+            claims_by_session[session_id].append(claim)
+        if session_id and path:
+            sessions_by_path[path].add(session_id)
+
+    worktree_branch_counts: dict[str, int] = defaultdict(int)
+    work_order_branch_counts: dict[str, int] = defaultdict(int)
+    queue_branch_counts: dict[str, int] = defaultdict(int)
+    for branch, rows_for_branch in worktrees_by_branch.items():
+        worktree_branch_counts[branch] += len(rows_for_branch)
+    for run in runs:
+        for work_order in run.get("work_orders", []):
+            if not isinstance(work_order, dict):
+                continue
+            branch = _text(work_order.get("branch"))
+            if branch:
+                work_order_branch_counts[branch] += 1
+
+    queue_by_branch: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    queue_by_session: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in merge_queue:
+        branch = _text(item.get("branch"))
+        session_id = _text(item.get("session_id"))
+        if branch:
+            queue_by_branch[branch].append(item)
+            queue_branch_counts[branch] += 1
+        if session_id:
+            queue_by_session[session_id].append(item)
+
+    lanes: list[dict[str, Any]] = []
+    seen_worktree_keys: set[tuple[str, str]] = set()
+    seen_queue_keys: set[tuple[str, str, str]] = set()
+
+    def build_lane(
+        *,
+        source: str,
+        run: dict[str, Any] | None = None,
+        work_order: dict[str, Any] | None = None,
+        worktree_row: dict[str, Any] | None = None,
+        queue_item: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        work_order = work_order or {}
+        worktree_row = worktree_row or {}
+        queue_item = queue_item or {}
+        run = run or {}
+        work_order_meta = _metadata(work_order)
+        queue_meta = _metadata(queue_item)
+        inferred_status = ""
+        if bool(worktree_row.get("has_lock")) and bool(worktree_row.get("pid_alive")):
+            inferred_status = "active"
+        elif bool(worktree_row.get("has_lock")):
+            inferred_status = "needs_human"
+        status = _first_text(
+            work_order.get("status"), worktree_row.get("status"), inferred_status, "unknown"
+        ).lower()
+        branch = _first_text(
+            work_order.get("branch"), worktree_row.get("branch"), queue_item.get("branch")
+        )
+        worktree_path = _first_text(
+            work_order.get("worktree_path"),
+            worktree_row.get("path"),
+            queue_meta.get("integration_workspace_path"),
+        )
+        session_id = _first_text(
+            work_order_meta.get("owner_session_id"),
+            worktree_row.get("session_id"),
+            queue_item.get("session_id"),
+        )
+        owner_agent = _first_text(
+            work_order.get("target_agent"),
+            work_order_meta.get("owner_agent"),
+            worktree_row.get("agent"),
+        )
+        receipt_id = _extract_receipt_id(work_order, queue_item)
+        queue_status = _merge_queue_status(queue_item)
+        branch_collision = bool(
+            branch
+            and (
+                worktree_branch_counts.get(branch, 0) > 1
+                or work_order_branch_counts.get(branch, 0) > 1
+                or queue_branch_counts.get(branch, 0) > 1
+            )
+        )
+
+        claimed_paths = sorted(
+            {
+                _text(claim.get("path"))
+                for claim in claims_by_session.get(session_id, [])
+                if _text(claim.get("path"))
+            }
+        )
+        file_scope = [_text(path) for path in work_order.get("file_scope", []) if _text(path)]
+        collision_reasons: list[str] = []
+        if branch_collision:
+            collision_reasons.append(f"branch:{branch}")
+        for path in claimed_paths or file_scope:
+            owners = sessions_by_path.get(path, set())
+            if len(owners) > 1:
+                collision_reasons.append(f"path:{path}")
+        collision_reasons = sorted(set(collision_reasons))
+
+        heartbeat_source = _first_text(
+            work_order.get("last_progress_at"),
+            work_order.get("last_observed_at"),
+            work_order.get("dispatched_at"),
+            worktree_row.get("last_activity"),
+            queue_item.get("updated_at"),
+        )
+        heartbeat_age_seconds = _age_seconds(heartbeat_source, now=now)
+        stale_heartbeat = bool(
+            (
+                work_order
+                and status in {"leased", "dispatched", "active"}
+                and heartbeat_age_seconds is not None
+                and heartbeat_age_seconds >= _STALE_LANE_AFTER_SECONDS
+            )
+            or (bool(worktree_row.get("has_lock")) and not bool(worktree_row.get("pid_alive")))
+        )
+
+        superseded = _is_superseded(work_order, queue_item)
+        missing_receipt = _explicit_missing_receipt(work_order, queue_item) or (
+            _receipt_expected(status, queue_status) and not receipt_id
+        )
+        if status in {"queued", "leased", "dispatched"} and queue_status in {"", "queued"}:
+            missing_receipt = (
+                False if not _explicit_missing_receipt(work_order, queue_item) else True
+            )
+
+        lease_id = _first_text(work_order.get("lease_id"), work_order_meta.get("lease_id"))
+        lease_health = "idle"
+        if lease_id:
+            lease_health = "stale" if stale_heartbeat else "healthy"
+        elif status in {"leased", "dispatched"}:
+            lease_health = "missing"
+        elif bool(worktree_row.get("has_lock")):
+            lease_health = "stale" if stale_heartbeat else "healthy"
+
+        readiness = _merge_readiness(
+            status=status,
+            queue_status=queue_status,
+            stale_heartbeat=stale_heartbeat,
+            missing_receipt=missing_receipt,
+            superseded=superseded,
+            collisions=collision_reasons,
+        )
+
+        title = _first_text(
+            work_order.get("title"),
+            work_order.get("description"),
+            queue_item.get("title"),
+            run.get("goal"),
+            branch,
+            session_id,
+            "lane",
+        )
+        pr = _extract_pr_link(work_order, queue_item)
+        blockers = sorted(
+            {
+                *[_text(item) for item in work_order.get("blockers", []) if _text(item)],
+                *collision_reasons,
+            }
+        )
+        if stale_heartbeat:
+            blockers.append("stale_heartbeat")
+        if missing_receipt:
+            blockers.append("missing_receipt")
+        if superseded:
+            blockers.append("superseded")
+        blockers = sorted(set(blockers))
+
+        lane_id = _first_text(
+            work_order.get("work_order_id"),
+            queue_item.get("id"),
+            branch,
+            session_id,
+            worktree_path,
+            title,
+        )
+        return {
+            "lane_id": lane_id,
+            "source": source,
+            "run_id": _text(run.get("run_id")),
+            "work_order_id": _text(work_order.get("work_order_id")),
+            "title": title,
+            "status": status,
+            "owner_agent": owner_agent or None,
+            "owner_session_id": session_id or None,
+            "branch": branch or None,
+            "worktree_path": worktree_path or None,
+            "lease_id": lease_id or None,
+            "lease_health": lease_health,
+            "heartbeat_at": heartbeat_source or None,
+            "heartbeat_age_seconds": round(heartbeat_age_seconds, 1)
+            if heartbeat_age_seconds is not None
+            else None,
+            "stale_heartbeat": stale_heartbeat,
+            "claimed_paths": claimed_paths,
+            "file_scope": file_scope,
+            "queue_item_id": _text(queue_item.get("id")) or None,
+            "merge_queue_status": queue_status or None,
+            "receipt_id": receipt_id or None,
+            "missing_receipt": missing_receipt,
+            "superseded": superseded,
+            "collisions": collision_reasons,
+            "pr": pr,
+            "merge_readiness": readiness,
+            "blockers": blockers,
+            "next_action": _next_action(
+                readiness=readiness,
+                stale_heartbeat=stale_heartbeat,
+                missing_receipt=missing_receipt,
+                superseded=superseded,
+                collisions=collision_reasons,
+                queue_status=queue_status,
+            ),
+        }
+
+    for run in runs:
+        for work_order in run.get("work_orders", []):
+            if not isinstance(work_order, dict):
+                continue
+            branch = _text(work_order.get("branch"))
+            worktree_path = _text(work_order.get("worktree_path"))
+            matched_row = None
+            if branch and worktrees_by_branch.get(branch):
+                matched_row = worktrees_by_branch[branch][0]
+            elif worktree_path and worktrees_by_path.get(worktree_path):
+                matched_row = worktrees_by_path[worktree_path][0]
+            queue_item = queue_by_branch.get(branch, [None])[0] if branch else None
+            if matched_row:
+                seen_worktree_keys.add(
+                    (_text(matched_row.get("session_id")), _text(matched_row.get("branch")))
+                )
+            if isinstance(queue_item, dict):
+                seen_queue_keys.add(
+                    (
+                        _text(queue_item.get("id")),
+                        _text(queue_item.get("branch")),
+                        _text(queue_item.get("session_id")),
+                    )
+                )
+            lanes.append(
+                build_lane(
+                    source="swarm",
+                    run=run,
+                    work_order=work_order,
+                    worktree_row=matched_row,
+                    queue_item=queue_item if isinstance(queue_item, dict) else None,
+                )
+            )
+
+    for row in worktrees:
+        key = (_text(row.get("session_id")), _text(row.get("branch")))
+        if key in seen_worktree_keys:
+            continue
+        branch = _text(row.get("branch"))
+        queue_item = queue_by_branch.get(branch, [None])[0] if branch else None
+        if isinstance(queue_item, dict):
+            seen_queue_keys.add(
+                (
+                    _text(queue_item.get("id")),
+                    _text(queue_item.get("branch")),
+                    _text(queue_item.get("session_id")),
+                )
+            )
+        lanes.append(
+            build_lane(
+                source="fleet",
+                worktree_row=row,
+                queue_item=queue_item if isinstance(queue_item, dict) else None,
+            )
+        )
+
+    for item in merge_queue:
+        queue_key = (
+            _text(item.get("id")),
+            _text(item.get("branch")),
+            _text(item.get("session_id")),
+        )
+        if queue_key in seen_queue_keys:
+            continue
+        session_id = _text(item.get("session_id"))
+        matched_row = worktrees_by_session.get(session_id, [None])[0] if session_id else None
+        lanes.append(
+            build_lane(
+                source="merge_queue",
+                worktree_row=matched_row if isinstance(matched_row, dict) else None,
+                queue_item=item,
+            )
+        )
+
+    def lane_sort_key(item: dict[str, Any]) -> tuple[int, str, str]:
+        readiness = _text(item.get("merge_readiness"))
+        priority = {
+            "blocked": 0,
+            "review": 1,
+            "ready": 2,
+            "in_progress": 3,
+            "validating": 4,
+            "integrating": 5,
+            "merged": 6,
+            "superseded": 7,
+        }.get(readiness, 8)
+        return (priority, _text(item.get("branch")), _text(item.get("lane_id")))
+
+    lanes.sort(key=lane_sort_key)
+
+    alerts = {
+        "collisions": [],
+        "stale_heartbeats": [],
+        "superseded_lanes": [],
+        "missing_receipts": [],
+        "merge_ready": [],
+    }
+    for lane in lanes:
+        ref = {
+            "lane_id": lane["lane_id"],
+            "branch": lane["branch"],
+            "owner_session_id": lane["owner_session_id"],
+            "title": lane["title"],
+        }
+        if lane["collisions"]:
+            alerts["collisions"].append({**ref, "reasons": lane["collisions"]})
+        if lane["stale_heartbeat"]:
+            alerts["stale_heartbeats"].append(ref)
+        if lane["superseded"]:
+            alerts["superseded_lanes"].append(ref)
+        if lane["missing_receipt"]:
+            alerts["missing_receipts"].append(ref)
+        if lane["merge_readiness"] == "ready":
+            alerts["merge_ready"].append(ref)
+
+    next_actions: list[str] = []
+    for lane in lanes:
+        action = _text(lane.get("next_action"))
+        if not action:
+            continue
+        summary = f"{lane['title']}: {action}"
+        if summary not in next_actions:
+            next_actions.append(summary)
+        if len(next_actions) >= 5:
+            break
+
+    summary = {
+        "total_lanes": len(lanes),
+        "ready_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "ready"),
+        "blocked_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "blocked"),
+        "review_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "review"),
+        "in_progress_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "in_progress"),
+        "collision_lanes": len(alerts["collisions"]),
+        "stale_heartbeat_lanes": len(alerts["stale_heartbeats"]),
+        "superseded_lanes": len(alerts["superseded_lanes"]),
+        "missing_receipt_lanes": len(alerts["missing_receipts"]),
+        "merge_ready_lanes": len(alerts["merge_ready"]),
+        "coordination_counts": coordination.get("counts", {}),
+    }
+    return {
+        "summary": summary,
+        "next_actions": next_actions,
+        "alerts": alerts,
+        "lanes": lanes,
+    }
 
 
 @dataclass

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -280,7 +280,38 @@ class TestSwarmCommand:
 
         mock_commander.run_supervised_from_spec.assert_awaited_once()
 
-    def test_cmd_swarm_status_uses_supervisor(self, capsys):
+    @patch("aragora.worktree.fleet.FleetCoordinationStore")
+    @patch("aragora.worktree.fleet.build_fleet_rows")
+    @patch("aragora.worktree.fleet.resolve_repo_root")
+    def test_cmd_swarm_status_uses_supervisor(
+        self, mock_resolve_root, mock_build_rows, mock_store_cls, capsys
+    ):
+        mock_resolve_root.return_value = Path("/tmp/repo")
+        mock_build_rows.return_value = [
+            {
+                "session_id": "sess-a",
+                "path": "/tmp/repo/.worktrees/a",
+                "branch": "codex/docs-lane",
+                "has_lock": True,
+                "pid_alive": True,
+                "agent": "codex",
+                "last_activity": "2026-03-07T00:00:00+00:00",
+            }
+        ]
+        store = MagicMock()
+        store.list_claims.return_value = [
+            {"session_id": "sess-a", "path": "aragora/swarm/reporter.py"}
+        ]
+        store.list_merge_queue.return_value = [
+            {
+                "id": "mq-1",
+                "branch": "codex/docs-lane",
+                "session_id": "sess-a",
+                "status": "needs_human",
+                "metadata": {"receipt_id": "rcpt-123"},
+            }
+        ]
+        mock_store_cls.return_value = store
         args = argparse.Namespace(
             swarm_action_or_goal="status",
             swarm_goal=None,
@@ -308,18 +339,42 @@ class TestSwarmCommand:
 
         with patch("aragora.swarm.SwarmSupervisor") as supervisor_cls:
             supervisor_cls.return_value.status_summary.return_value = {
-                "runs": [],
+                "runs": [
+                    {
+                        "run_id": "run-1",
+                        "status": "active",
+                        "target_branch": "main",
+                        "goal": "dogfood",
+                        "work_orders": [
+                            {
+                                "work_order_id": "docs-lane",
+                                "title": "Write operator guide",
+                                "status": "completed",
+                                "branch": "codex/docs-lane",
+                                "worktree_path": "/tmp/repo/.worktrees/a",
+                                "target_agent": "codex",
+                                "last_progress_at": "2026-03-07T00:00:00+00:00",
+                            }
+                        ],
+                    }
+                ],
                 "counts": {
                     "runs": 1,
-                    "queued_work_orders": 2,
-                    "leased_work_orders": 1,
-                    "completed_work_orders": 0,
+                    "queued_work_orders": 0,
+                    "leased_work_orders": 0,
+                    "completed_work_orders": 1,
                 },
+                "coordination": {"counts": {"active_leases": 1}},
             }
             cmd_swarm(args)
 
         out = capsys.readouterr().out
-        assert "runs=1 queued=2 leased=1 completed=0" in out
+        assert "runs=1 queued=0 leased=0 completed=1" in out
+        assert "integrator ready=0 review=1 blocked=0" in out
+        assert (
+            "next: Write operator guide: Review the validated lane and decide whether it should merge."
+            in out
+        )
 
     def test_cmd_swarm_reconcile_uses_reconciler(self, capsys):
         args = _swarm_args(

--- a/tests/cli/test_worktree_command.py
+++ b/tests/cli/test_worktree_command.py
@@ -262,9 +262,11 @@ class TestWorktreeAutopilot:
 class TestWorktreeFleetStatus:
     @patch("aragora.cli.commands.worktree.FleetCoordinationStore")
     @patch("aragora.cli.commands.worktree.build_fleet_rows")
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore.status_summary")
     def test_fleet_status_prints_tail_and_metadata(
-        self, mock_rows, mock_store_cls, capsys, tmp_path: Path
+        self, mock_status_summary, mock_rows, mock_store_cls, capsys, tmp_path: Path
     ):
+        mock_status_summary.return_value = {"counts": {"active_leases": 1}}
         mock_rows.return_value = [
             {
                 "session_id": "session-a",
@@ -300,8 +302,13 @@ class TestWorktreeFleetStatus:
 
         out = capsys.readouterr().out
         assert "[active] codex/test-session" in out
+        assert (
+            "Integrator: ready=0 review=0 blocked=0 stale=0 collisions=0 missing_receipts=0 superseded=0"
+            in out
+        )
         assert "dirty_files: 2 ahead/behind(main): +1/-0" in out
         assert "orchestrator: crewai" in out
+        assert "lease_health: healthy merge_readiness: in_progress" in out
         assert "claimed_paths(1): aragora/a.py" in out
         assert "log_tail(last 2 lines):" in out
         assert "line-2" in out
@@ -309,7 +316,11 @@ class TestWorktreeFleetStatus:
 
     @patch("aragora.cli.commands.worktree.FleetCoordinationStore")
     @patch("aragora.cli.commands.worktree.build_fleet_rows")
-    def test_fleet_status_json_output(self, mock_rows, mock_store_cls, capsys, tmp_path: Path):
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore.status_summary")
+    def test_fleet_status_json_output(
+        self, mock_status_summary, mock_rows, mock_store_cls, capsys, tmp_path: Path
+    ):
+        mock_status_summary.return_value = {"counts": {"active_leases": 0}}
         mock_rows.return_value = [
             {
                 "session_id": "session-z",
@@ -347,6 +358,7 @@ class TestWorktreeFleetStatus:
         assert payload["worktrees"][0]["session_id"] == "session-z"
         assert payload["claims"] == []
         assert payload["merge_queue"] == []
+        assert payload["integrator_view"]["summary"]["total_lanes"] == 1
 
 
 class TestWorktreeFleetOwnership:

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -668,23 +668,81 @@ class TestRouteDispatch:
         result = handler.handle("/api/v1/coordination/fleet/status", {}, mock_http_handler)
         assert result is not None
         assert result.status_code == 200
+        data = json.loads(result.body)
+        assert data["integrator_view"]["summary"]["total_lanes"] == 0
 
+    @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
+    @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
     @patch("aragora.swarm.SwarmSupervisor")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
     def test_get_coordination_swarm_status(
         self,
         mock_resolve,
         mock_supervisor_cls,
+        mock_build_rows,
+        mock_store_cls,
         handler: ControlPlaneHandler,
     ):
         mock_resolve.return_value = Path("/tmp/repo")
+        mock_build_rows.return_value = [
+            {
+                "session_id": "sess-a",
+                "path": "/tmp/repo/.worktrees/docs",
+                "branch": "codex/docs-lane",
+                "has_lock": True,
+                "pid_alive": False,
+                "agent": "codex",
+                "last_activity": "2026-03-06T00:00:00+00:00",
+            }
+        ]
+        store = MagicMock()
+        store.list_claims.return_value = [
+            {"session_id": "sess-a", "path": "aragora/swarm/reporter.py"},
+            {"session_id": "sess-b", "path": "aragora/swarm/reporter.py"},
+        ]
+        store.list_merge_queue.return_value = [
+            {
+                "id": "mq-1",
+                "branch": "codex/docs-lane",
+                "session_id": "sess-a",
+                "status": "needs_human",
+                "metadata": {},
+            }
+        ]
+        mock_store_cls.return_value = store
         mock_supervisor_cls.return_value.status_summary.return_value = {
-            "runs": [],
+            "runs": [
+                {
+                    "run_id": "run-1",
+                    "status": "active",
+                    "goal": "dogfood",
+                    "work_orders": [
+                        {
+                            "work_order_id": "docs-lane",
+                            "title": "Write operator guide",
+                            "status": "needs_human",
+                            "branch": "codex/docs-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/docs",
+                            "target_agent": "codex",
+                            "last_progress_at": "2026-03-06T00:00:00+00:00",
+                            "dispatch_error": "worker exited without receipt or exit marker",
+                        }
+                    ],
+                }
+            ],
             "counts": {"runs": 0},
             "coordination": {},
         }
         result = handler._handle_swarm_status({})
         assert result.status_code == 200
+        data = json.loads(result.body)
+        summary = data["integrator_view"]["summary"]
+        assert summary["blocked_lanes"] == 1
+        assert summary["stale_heartbeat_lanes"] == 1
+        assert summary["missing_receipt_lanes"] == 1
+        assert data["integrator_view"]["alerts"]["collisions"][0]["reasons"] == [
+            "path:aragora/swarm/reporter.py"
+        ]
 
     @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")


### PR DESCRIPTION
## Summary
- add a read-only integrator view that normalizes swarm runs, worktrees, claims, queue state, receipts, and merge readiness
- expose the integrator view through `aragora swarm status`, `aragora worktree fleet-status`, and the coordination status handlers
- cover stale heartbeats, missing receipts, collisions, and review-ready lanes in focused CLI/handler tests

## Validation
- pytest -q tests/cli/test_worktree_command.py tests/cli/test_swarm_command.py tests/handlers/control_plane/test_coordination.py

Refs #843