### PR TITLE
[codex] docs: add conductor workflow and prompt pack

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,13 @@ This index intentionally links to actively maintained docs with validated paths.
 - [Security Deployment](deployment/SECURITY_DEPLOYMENT.md)
 - [Runbook](deployment/RUNBOOK.md)
 - [Incident Response](deployment/INCIDENT_RESPONSE.md)
+- [Aragora Conductor Workflow](guides/CONDUCTOR_WORKFLOW.md)
+- [Aragora Worker Prompt Pack](guides/WORKER_PROMPT_PACK.md)
+- [Dev Swarm Coordination](architecture/DEV_SWARM_COORDINATION.md)
+
+## Architecture and Planning
+
+- [Conductor Control Plane Implementation Spec](plans/2026-03-07-conductor-control-plane.md)
 
 ## Security and Compliance
 

--- a/docs/guides/CONDUCTOR_WORKFLOW.md
+++ b/docs/guides/CONDUCTOR_WORKFLOW.md
@@ -1,0 +1,175 @@
+# Aragora Conductor Workflow
+
+Use this workflow when one human-facing Codex or Claude session is coordinating multiple bounded workers. The conductor is not a free-roaming implementer. The conductor restores shared state, assigns at most a small number of non-overlapping lanes, and stops as soon as the next decision point is reached.
+
+This guide documents the operating model that matched the repository's recent recovery work:
+
+- one canonical lane per issue
+- one worker per active lane
+- no worker merges
+- no worker touches root
+- no new lane until active lanes reach a PR-or-blocker stop condition
+
+For the lower-level coordination primitives, see [Dev Swarm Coordination](../architecture/DEV_SWARM_COORDINATION.md). For spec-driven swarm runs, see [Supervised Swarm Dogfood Operator Guide](SWARM_DOGFOOD_OPERATOR.md).
+
+## 1. Distinguish Root States Correctly
+
+Do not treat every non-ideal root state as "contaminated." There are three different cases:
+
+- `dirty`: uncommitted file changes exist in root
+- `behind`: root is clean, but local `main` is older than `origin/main`
+- `unsafe for implementation`: root may be clean, but active lanes or overlapping ownership make it a bad implementation base
+
+The correct conductor behavior is:
+
+- if root is `dirty`, stop and report; do not sync or code
+- if root is clean and `behind`, fast-forward it to `origin/main`
+- even when root is clean and current, do not use it as a worker lane; root is the conductor/integrator surface
+
+## 2. Conductor Loop
+
+Run this loop in the single conductor session before any coding:
+
+1. fetch `origin` and inspect repo state
+2. if root is dirty, stop and report
+3. if root is clean and behind, fast-forward root `main` to `origin/main`
+4. inspect open PRs
+5. inspect worktrees
+6. identify active lanes
+7. choose at most two non-overlapping worker assignments
+8. stop assigning once those lanes are in flight
+
+The conductor should emit this summary each cycle:
+
+1. current repo state
+2. active lanes
+3. canonical ownership
+4. next worker assignments
+5. stop condition for each worker
+
+## 3. Minimum Conductor Commands
+
+These are the minimum checks needed to keep state coherent:
+
+```bash
+git fetch origin --prune
+git status -sb
+git worktree list --porcelain
+gh pr list --state open --limit 20 --json number,title,headRefName,baseRefName,url
+```
+
+Useful Aragora-native read surfaces:
+
+```bash
+aragora swarm status --json
+aragora worktree fleet-status --json
+aragora worktree fleet-claims --json
+aragora worktree fleet-queue-list --json
+aragora worktree autopilot status --json
+```
+
+Useful low-level recovery commands when sessions are churny:
+
+```bash
+./scripts/codex_session.sh
+python3 scripts/codex_worktree_autopilot.py ensure --agent codex --base main --reconcile --print-path
+python3 scripts/codex_worktree_autopilot.py maintain --base main --strategy merge --ttl-hours 24
+python3 scripts/codex_worktree_autopilot.py reconcile --all --base main
+python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
+```
+
+## 4. Decision Rule
+
+Only do one of these per conductor cycle:
+
+1. merge an already-green non-overlapping PR
+2. assign one or two bounded worker lanes
+3. clean stale state
+4. stop because ownership is ambiguous
+
+Do not try to merge, assign, clean, and start follow-up work in the same cycle. That is how stale assumptions compound.
+
+## 5. Hot Coordination Files
+
+Treat these paths as serialized coordination surfaces:
+
+- `docs/status/**`
+- `README.md`
+- `ROADMAP.md`
+- `.github/workflows/**`
+- `scripts/reconcile_status_docs.py`
+- `scripts/pre_release_check.py`
+
+Only a dedicated docs/truthfulness lane or integrator lane should touch them. General implementation lanes should not edit them.
+
+## 6. Worker Assignment Contract
+
+A worker assignment must include all of the following:
+
+- exactly one issue or one narrow follow-up
+- explicit allowed paths
+- explicit forbidden paths
+- exact validation commands
+- exact stop condition
+
+The standard stop condition is:
+
+- open one PR and stop, or
+- report one blocker and stop
+
+Workers do not merge, do not widen scope, and do not clean up other lanes.
+
+## 7. Example Conductor Prompt
+
+```text
+You are the Aragora conductor/integrator.
+
+Before any coding:
+1. fetch origin and inspect repo state
+2. if root is dirty, stop and report; do not sync or code
+3. if root is clean and behind, fast-forward root main to origin/main
+4. inspect open PRs
+5. inspect worktrees
+6. identify active lanes
+7. choose at most 2 non-overlapping worker assignments
+8. do not code until ownership is clear
+
+Rules:
+- one canonical lane per issue
+- one worker per lane
+- no worker merges
+- no worker touches root
+- no new lane until current lanes reach PR-or-blocker stop condition
+- if repo state is ambiguous, resolve state first instead of starting work
+
+Output each cycle:
+1. current repo state
+2. active lanes
+3. canonical ownership
+4. next worker assignments
+5. stop condition for each worker
+```
+
+## 8. Why This Replaces "Yes To All In Best Order"
+
+"Yes to all in best order" sounds efficient, but it delegates scheduling and exclusivity to workers that do not share state. The failure mode is predictable:
+
+- duplicate lanes for the same issue
+- workers coding on stale branch assumptions
+- worktrees cleaned up while still useful
+- docs/status hot files edited by unrelated lanes
+- PR churn without canonical ownership
+
+The conductor loop fixes that by restoring one shared truth before allowing more work to start.
+
+## 9. Current Best Next Engineering Sequence
+
+After the merged worktree protection and integrator-view slices, the next control-plane work should usually proceed in this order:
+
+1. file-scope ownership enforcement
+2. canonical PR / supersession protocol
+3. receipt and provenance requirements for every lane
+4. prompt rendering from leases and worker roles
+5. a first-class `aragora swarm conduct` operator command
+
+That order matches the existing codebase shape more cleanly than jumping straight to many-agent autonomy.

--- a/docs/guides/WORKER_PROMPT_PACK.md
+++ b/docs/guides/WORKER_PROMPT_PACK.md
@@ -1,0 +1,197 @@
+# Aragora Worker Prompt Pack
+
+These prompts are the manual operating model until Aragora renders them directly from leases and supervisor state.
+
+Use them as bounded lane contracts. Do not append "yes to all in best order." End with a stop condition instead.
+
+## 1. Standard Worker Prompt
+
+```text
+You are a bounded Aragora worker.
+
+Task:
+- implement exactly one issue or one narrow follow-up lane
+
+Base:
+- start from current origin/main
+- create one fresh disposable worktree
+- do not use root
+- if an overlapping PR or worktree already exists, stop and report
+
+Allowed paths:
+- <explicit files or directories only>
+
+Forbidden paths:
+- docs/status/**
+- README.md
+- ROADMAP.md
+- .github/workflows/**
+- any path owned by another active lane
+- any path outside the allowed list
+
+Do not:
+- merge
+- widen scope
+- touch other worktrees
+- clean up anything you did not create
+- open more than one PR
+
+Required behavior:
+- inspect first
+- form a short plan
+- implement only the bounded task
+- run only focused validation
+- if overlap, drift, or ownership ambiguity appears, stop immediately and report
+
+Final report:
+1. branch
+2. worktree path
+3. files changed
+4. tests/checks run
+5. PR URL or exact blocker
+
+Then stop.
+```
+
+## 2. Reviewer Prompt
+
+```text
+You are the Aragora reviewer.
+
+Task:
+- inspect exactly one PR or one candidate lane
+- no edits unless explicitly told to fix one concrete required-check failure
+
+Do not:
+- open a new branch
+- open a new PR
+- merge
+- widen into implementation
+
+Review for:
+- regressions
+- overlap with active lanes
+- truthfulness drift
+- missing tests
+- fake execution or placeholder behavior
+- receipt-bypass or approval-bypass risk where relevant
+
+Output:
+1. go / no-go
+2. top findings ordered by severity
+3. exact files and lines
+4. missing validation
+5. whether the PR is merge-ready or blocked
+
+Then stop.
+```
+
+## 3. Docs / Status Curator Prompt
+
+```text
+You own docs and status only.
+
+Allowed paths:
+- docs/status/**
+- docs/FEATURE_GAP_LIST.md
+- docs/STATUS.md
+- ROADMAP.md
+- README.md only if explicitly listed for the lane
+
+Forbidden paths:
+- aragora/**
+- tests/**
+- .github/workflows/**
+- runtime scripts unless explicitly listed
+
+Goal:
+- make docs current, mutually consistent, and accurate versus the codebase and issue tracker
+
+Do not:
+- touch code
+- touch workflows
+- merge
+- open more than one PR
+
+Stop after:
+- one docs-only PR, or
+- one blocker report explaining which source of truth conflicts
+```
+
+## 4. Integrator Prompt
+
+```text
+You are the Aragora integrator, not a free-roaming implementer.
+
+Your task:
+- inspect current PRs, issues, and active worktrees
+- choose the single best next integration action
+
+Priority rules:
+1. unblock or merge an already-green non-overlapping PR
+2. if no PR is ready, inspect the highest-priority active lane
+3. only if there is no active owner for the needed work, open one new bounded lane
+
+Do not:
+- start multiple new lanes
+- merge overlapping PRs
+- clean up worktrees you did not verify as stale
+- make broad code changes yourself unless the task is a narrow integration fix
+
+Required output:
+- current active lanes
+- best next action
+- why that action is first
+- exact stop condition
+
+If you merge something, stop after the merge.
+If nothing is merge-ready, stop after assigning or describing the next bounded lane.
+```
+
+## 5. Aragora Hot-File Rule
+
+Treat these as serialized by default:
+
+- `docs/status/**`
+- `README.md`
+- `ROADMAP.md`
+- `.github/workflows/**`
+- `scripts/reconcile_status_docs.py`
+- `scripts/pre_release_check.py`
+
+Do not let normal implementation lanes edit them unless the lane explicitly owns them.
+
+## 6. Lane Ownership Rule
+
+If an issue already has:
+
+- an open PR, or
+- an active worktree, or
+- a clean historical source lane plus a dirty residual lane,
+
+then stop and report before creating another branch. The integrator must designate canonical ownership first.
+
+## 7. One-Line Replacement For "Yes To All In Best Order"
+
+Use this instead:
+
+```text
+Resolve repo state first. Then take exactly one bounded next action from current origin/main. Respect lane ownership. Stop after one PR or one blocker report.
+```
+
+## 8. Good vs Bad Operator Instructions
+
+Good:
+
+- `Take exactly one bounded lane from current origin/main. Allowed paths: ... Do not merge. Stop after one PR or one blocker report.`
+- `Inspect PR #847 only. No edits. Tell me go/no-go and top risks.`
+- `You own docs/status only. Do not touch code or workflows.`
+
+Bad:
+
+- `yes to all in best order`
+- `keep going`
+- `fix whatever seems next`
+- `just merge what looks right`
+
+Those instructions erase ownership and stop conditions, which is exactly what causes duplicate lanes and repo-state drift.

--- a/docs/plans/2026-03-07-conductor-control-plane.md
+++ b/docs/plans/2026-03-07-conductor-control-plane.md
@@ -1,0 +1,204 @@
+# 2026-03-07 Conductor Control Plane Implementation Spec
+
+## Summary
+
+Aragora already has most of the substrate for multi-agent development:
+
+- supervisor-backed swarm runs
+- worker launches in isolated worktrees
+- worktree autopilot and cleanup
+- lease-like coordination state
+- completion receipts and integration decisions
+- an initial integrator-facing status view
+
+What is still missing is the hierarchy that lets one human-facing session act as a conductor instead of manually copy-pasting instructions across multiple worker sessions.
+
+The goal of this plan is to make Aragora itself manage the pattern that was manually used to recover the repository:
+
+- one conductor/integrator session
+- one implementer/planner layer that turns goals into bounded lanes
+- multiple workers launched from leases
+- one merge authority
+
+## Current Shipped Base
+
+As of `cd2985adf` on `main`, the control-plane baseline already includes:
+
+- worktree/session protection and cleanup hardening
+  - `scripts/codex_worktree_autopilot.py`
+  - `aragora/worktree/autopilot.py`
+- integrator-facing status summary surfaces
+  - `aragora/swarm/reporter.py`
+  - `aragora/cli/commands/swarm.py`
+  - `aragora/cli/commands/worktree.py`
+  - `aragora/server/handlers/control_plane/coordination.py`
+- supervisor-backed swarm execution
+  - `aragora/swarm/supervisor.py`
+  - `aragora/swarm/reconciler.py`
+  - `aragora/swarm/worker_launcher.py`
+- richer coordination semantics
+  - `aragora/nomic/dev_coordination.py`
+- merge/integration worker
+  - `aragora/worktree/integration_worker.py`
+
+This means the next tranche should extend the current codebase, not create a second orchestration system.
+
+## Problem To Solve
+
+The manual operator pattern still lives outside Aragora:
+
+- the user inspects repo state manually
+- the user designates canonical lanes manually
+- the user copies bounded prompts to worker sessions manually
+- the user decides when workers must stop manually
+- the user tracks receipts and merge readiness manually
+
+That is workable for a few agents, but not for 10 or 20.
+
+## Target Operating Model
+
+### Roles
+
+1. `Conductor`
+- single human-facing Codex or Claude session
+- restores shared state
+- chooses at most a small number of bounded next actions
+- never free-roams as a worker by default
+
+2. `Implementer`
+- translates one approved issue or goal into bounded work orders
+- owns file-scope definition, tests, and stop conditions
+
+3. `Worker`
+- edits only leased scope
+- emits a completion receipt
+- cannot merge
+
+4. `Integrator`
+- the only role allowed to merge, supersede, or discard lanes
+
+### Conductor Cycle
+
+The conductor cycle should become a first-class command:
+
+1. inspect repo state
+2. sync clean root to `origin/main`
+3. inspect open PRs and worktrees
+4. canonicalize ownership
+5. choose at most two non-overlapping worker assignments
+6. stop assigning until those lanes hit PR-or-blocker stop conditions
+
+## Proposed Deliverables
+
+### 1. Prompt Rendering From Leases
+
+Add role-aware prompt rendering to the coordination layer.
+
+Input:
+- `WorkLease`
+- `allowed_globs`
+- `expected_tests`
+- role (`worker`, `reviewer`, `integrator`)
+- stop condition
+
+Output:
+- bounded worker prompt
+- reviewer prompt
+- integrator prompt
+
+Likely insertion points:
+- `aragora/nomic/dev_coordination.py`
+- `aragora/swarm/supervisor.py`
+- `aragora/swarm/spec.py`
+
+### 2. First-Class Conductor Command
+
+Add a top-level operator command, conceptually:
+
+```bash
+aragora swarm conduct
+```
+
+Minimum responsibilities:
+- inspect root cleanliness / behind state
+- inspect open PRs
+- inspect worktrees and leases
+- render canonical lane view
+- suggest the one next conductor action
+
+Likely insertion points:
+- `aragora/cli/commands/swarm.py`
+- `aragora/swarm/reporter.py`
+- `aragora/server/handlers/control_plane/coordination.py`
+
+### 3. Lane Canonicalization and Supersession
+
+Add explicit support for:
+- one canonical lane per issue
+- duplicate-lane detection
+- superseded lane status
+- stop-new-lane-on-active-owner behavior
+
+This should reuse existing coordination artifacts rather than redesign storage in the first tranche.
+
+Likely insertion points:
+- `aragora/nomic/dev_coordination.py`
+- `aragora/worktree/fleet.py`
+- `aragora/swarm/reporter.py`
+
+### 4. Stop-Condition Enforcement
+
+Every launched worker lane should be required to terminate at:
+- one PR, or
+- one blocker report
+
+Not an open-ended continuation loop.
+
+Likely insertion points:
+- `aragora/swarm/worker_launcher.py`
+- `aragora/swarm/reconciler.py`
+- `aragora/nomic/dev_coordination.py`
+
+## Scope Boundaries
+
+This tranche should not attempt:
+
+- a full visual mission-control UI
+- 10+ agent autonomous scaling
+- deep schema redesign of coordination storage
+- broad model-routing redesign
+- a second orchestration stack parallel to the current supervisor/fleet model
+
+Those can come later. The goal here is to remove manual copy-paste and ambiguous ownership first.
+
+## Suggested Issue Order
+
+The next control-plane sequence should be:
+
+1. file-scope ownership enforcement
+2. canonical PR / supersession protocol
+3. receipts and provenance requirements for every lane
+4. prompt rendering from leases
+5. first-class conductor command
+
+That order assumes the worktree protection and integrator-view slices are already landed.
+
+## Acceptance Criteria
+
+This plan is successful when all of the following are true:
+
+1. A conductor session can inspect repo state and receive a canonical lane summary without manual shell archaeology.
+2. A worker prompt can be generated directly from lease data.
+3. An issue with an active owner cannot silently spawn another competing lane.
+4. Every worker lane ends at one PR or one blocker.
+5. The integrator view can show canonical lane, receipt presence, stale heartbeat status, and merge readiness in one place.
+
+## Suggested First PR Scope
+
+The most reasonable first implementation PR after the already-merged protection/view work is:
+
+- add role-aware prompt rendering from `WorkLease`
+- expose rendered prompts through CLI / API read surfaces
+- no automatic worker launch changes in that first PR
+
+That is small enough to validate the operating model without touching every coordination path at once.


### PR DESCRIPTION
## Summary
Adds the first explicit conductor/operator documentation for Aragora's multi-agent development workflow.

This PR packages the operating model that was used to recover the repository into repo-local documentation so the coordination rules stop living only in chat transcripts.

## What changed
- added a conductor workflow guide covering root-state handling, canonical lane selection, hot coordination files, and the one-action-per-cycle rule
- added a reusable worker prompt pack for bounded worker, reviewer, docs curator, and integrator lanes
- added a conductor control-plane implementation spec describing how to wire this operating model into Aragora's existing swarm and coordination code
- linked the new docs from the main docs index

## Why this matters
Recent multi-agent sessions exposed that the main failure mode is not model capability but coordination drift: duplicate lanes, stale ownership, unsafe cleanup assumptions, and too much manual copy-paste between conductor and workers.

These docs make the current safe operating model explicit and tie it to the code that already exists in:
- `aragora/swarm/*`
- `aragora/nomic/dev_coordination.py`
- `aragora/worktree/*`
- the CLI/control-plane read surfaces

## Validation
- `python3 scripts/validate_doc_links.py`
- `python3 scripts/reconcile_status_docs.py --strict`

The strict reconciliation still reports the pre-existing truthful warning about 2 stub connectors, but the run passes.
