### PR TITLE
fix(swarm): fail closed on under-specified specs

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -48,6 +48,14 @@ def _print_supervisor_run(run: dict[str, object]) -> None:
     print(f"work_orders={len(work_orders)} [{counts_text}]")
 
 
+def _run_supervised_or_report(awaitable: object) -> object | None:
+    try:
+        return asyncio.run(awaitable)
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        return None
+
+
 def cmd_swarm(args: argparse.Namespace) -> None:
     """Handle 'swarm' command."""
     from aragora.swarm import (
@@ -245,7 +253,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         spec = SwarmSpec.from_yaml(spec_path.read_text())
         print(f"\nLoaded spec from {spec_file}")
         print(spec.summary())
-        run = asyncio.run(
+        run = _run_supervised_or_report(
             commander.run_supervised_from_spec(
                 spec,
                 repo_path=Path.cwd(),
@@ -259,6 +267,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 max_ticks=max_ticks,
             )
         )
+        if run is None:
+            return
         if as_json:
             print(json.dumps(run.to_dict(), indent=2))
         else:
@@ -284,19 +294,18 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             Path(save_path).write_text(spec.to_yaml())
             print(f"\nSpec saved to {save_path}")
     elif skip_interrogation:
-        spec = SwarmSpec(
-            id=str(uuid4()),
-            created_at=datetime.now(timezone.utc),
-            raw_goal=goal,
-            refined_goal=goal,
+        spec = SwarmSpec.from_direct_goal(
+            goal,
             budget_limit_usd=budget_limit,
             requires_approval=require_approval,
-            interrogation_turns=0,
             user_expertise="developer",
         )
         print("\nSkipping interrogation (developer mode)")
         print(spec.summary())
-        run = asyncio.run(
+        if not spec.is_dispatch_bounded():
+            print(f"Error: {spec.dispatch_gate_reason()}")
+            return
+        run = _run_supervised_or_report(
             commander.run_supervised_from_spec(
                 spec,
                 repo_path=Path.cwd(),
@@ -310,12 +319,14 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 max_ticks=max_ticks,
             )
         )
+        if run is None:
+            return
         if as_json:
             print(json.dumps(run.to_dict(), indent=2))
         else:
             _print_supervisor_run(run.to_dict())
     else:
-        run = asyncio.run(
+        run = _run_supervised_or_report(
             commander.run_supervised(
                 goal,
                 repo_path=Path.cwd(),
@@ -329,6 +340,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 max_ticks=max_ticks,
             )
         )
+        if run is None:
+            return
         if as_json:
             print(json.dumps(run.to_dict(), indent=2))
         else:

--- a/aragora/swarm/commander.py
+++ b/aragora/swarm/commander.py
@@ -45,6 +45,12 @@ class SwarmCommander:
         self._spec: SwarmSpec | None = None
         self._result: Any = None
 
+    @staticmethod
+    def _require_dispatch_bounded(spec: SwarmSpec) -> None:
+        if spec.is_dispatch_bounded():
+            return
+        raise ValueError(spec.dispatch_gate_reason())
+
     async def run(
         self,
         initial_goal: str,
@@ -232,6 +238,7 @@ class SwarmCommander:
             wait: If True, reconcile until the run reaches a stable stop condition.
         """
         self._spec = spec
+        self._require_dispatch_bounded(spec)
         from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher
 
         launcher = WorkerLauncher(config=LaunchConfig(detach=not wait))

--- a/aragora/swarm/interrogator.py
+++ b/aragora/swarm/interrogator.py
@@ -49,6 +49,11 @@ Produce a JSON object with these fields:
 Respond with ONLY the JSON object, no other text.
 """
 
+FOLLOW_UP_BOUNDING_PROMPT = (
+    "I still need at least one concrete boundary before dispatch. Give me one acceptance "
+    "criterion, one constraint, one file or directory to touch, or one explicit work order."
+)
+
 
 class SwarmInterrogator:
     """Gathers requirements from a non-developer user via conversational Q&A.
@@ -100,6 +105,7 @@ class SwarmInterrogator:
             logger.warning("No Claude CLI available and fallback disabled")
 
         spec = await self._produce_spec(initial_goal, harness)
+        spec = await self._complete_dispatch_bounds(spec, initial_goal, harness, _input, _print)
 
         _print("\n" + "-" * 60)
         _print("SPEC SUMMARY")
@@ -227,6 +233,30 @@ class SwarmInterrogator:
             user_expertise=spec_data.get("user_expertise", "non-developer"),
         )
 
+    async def _complete_dispatch_bounds(
+        self,
+        spec: SwarmSpec,
+        initial_goal: str,
+        harness: Any,
+        _input: Any,
+        _print: Any,
+    ) -> SwarmSpec:
+        """Keep interrogation open briefly when the resulting spec is too vague to dispatch."""
+        while not spec.is_dispatch_bounded():
+            user_turns = len([m for m in self._conversation if m["role"] == "user"])
+            if user_turns >= self.config.max_turns:
+                break
+            _print(f"\n{FOLLOW_UP_BOUNDING_PROMPT}")
+            answer = self._safe_input(_input, "> ")
+            if answer is None or not answer.strip():
+                break
+            self._conversation.append({"role": "assistant", "content": FOLLOW_UP_BOUNDING_PROMPT})
+            self._conversation.append({"role": "user", "content": answer})
+            spec = await self._produce_spec(initial_goal, harness)
+        if not spec.is_dispatch_bounded():
+            _print(f"\nDispatch gate: {spec.dispatch_gate_reason()}\n")
+        return spec
+
     def _parse_json_from_response(self, text: str) -> dict[str, Any] | None:
         """Extract JSON object from LLM response text."""
         # Try direct parse
@@ -286,12 +316,16 @@ class SwarmInterrogator:
             if keyword in lower and track not in hints:
                 hints.append(track)
 
+        acceptance_criteria = SwarmSpec.infer_acceptance_criteria(user_messages[1:])
+        constraints = SwarmSpec.infer_constraints(user_messages[1:])
+        file_scope_hints = SwarmSpec.infer_file_scope_hints(combined)
+
         return {
             "refined_goal": refined_goal,
-            "acceptance_criteria": [],
-            "constraints": [],
+            "acceptance_criteria": acceptance_criteria,
+            "constraints": constraints,
             "track_hints": hints,
-            "file_scope_hints": [],
+            "file_scope_hints": file_scope_hints,
             "estimated_complexity": "medium",
             "requires_approval": False,
         }
@@ -316,6 +350,6 @@ class SwarmInterrogator:
         """Read one input safely, returning None on EOF/non-interactive stdin."""
         try:
             return input_fn(prompt)
-        except EOFError:
+        except (EOFError, StopIteration):
             logger.info("Interrogation input ended early; proceeding with gathered context")
             return None

--- a/aragora/swarm/spec.py
+++ b/aragora/swarm/spec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import uuid
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
@@ -57,6 +58,123 @@ class SwarmSpec:
     # Metadata
     interrogation_turns: int = 0
     user_expertise: str = "non-developer"
+
+    @staticmethod
+    def _nonempty_strings(values: list[str]) -> list[str]:
+        return [str(item).strip() for item in values if str(item).strip()]
+
+    @staticmethod
+    def infer_file_scope_hints(text: str) -> list[str]:
+        """Extract path-like hints from free-form prompt text."""
+        hints: list[str] = []
+        for raw in re.split(r"\s+", text or ""):
+            token = raw.strip().strip("`'\".,;:()[]{}<>")
+            if not token or token.startswith(("http://", "https://")):
+                continue
+            normalized = token.removeprefix("./")
+            if "/" not in normalized:
+                continue
+            normalized = normalized.rstrip("/")
+            if not normalized:
+                continue
+            hints.append(normalized)
+        return list(dict.fromkeys(hints))
+
+    @staticmethod
+    def infer_constraints(messages: list[str]) -> list[str]:
+        """Extract obvious constraints from user language."""
+        markers = (
+            "do not ",
+            "don't ",
+            "must not ",
+            "without ",
+            "leave ",
+            "only touch ",
+            "should not ",
+        )
+        constraints: list[str] = []
+        for message in messages:
+            text = str(message).strip()
+            lower = text.lower()
+            if text and any(marker in lower for marker in markers):
+                constraints.append(text)
+        return list(dict.fromkeys(constraints))
+
+    @staticmethod
+    def infer_acceptance_criteria(messages: list[str]) -> list[str]:
+        """Extract obvious success criteria from user language."""
+        markers = (
+            "done looks like",
+            "done means",
+            "works when",
+            "success is",
+            "should ",
+            "must ",
+            "passes ",
+            "pass when",
+        )
+        criteria: list[str] = []
+        for message in messages:
+            text = str(message).strip()
+            lower = text.lower()
+            if len(text) >= 12 and any(marker in lower for marker in markers):
+                criteria.append(text)
+        return list(dict.fromkeys(criteria))
+
+    @classmethod
+    def from_direct_goal(
+        cls,
+        raw_goal: str,
+        *,
+        budget_limit_usd: float | None,
+        requires_approval: bool,
+        user_expertise: str,
+    ) -> SwarmSpec:
+        """Build a direct spec from a raw goal without conversational interrogation."""
+        return cls(
+            id=str(uuid.uuid4()),
+            created_at=datetime.now(timezone.utc),
+            raw_goal=raw_goal,
+            refined_goal=raw_goal,
+            constraints=cls.infer_constraints([raw_goal]),
+            budget_limit_usd=budget_limit_usd,
+            file_scope_hints=cls.infer_file_scope_hints(raw_goal),
+            requires_approval=requires_approval,
+            interrogation_turns=0,
+            user_expertise=user_expertise,
+        )
+
+    def dispatch_bounds(self) -> dict[str, bool]:
+        """Return which fields make this spec safe enough to dispatch."""
+        return {
+            "acceptance_criteria": bool(self._nonempty_strings(self.acceptance_criteria)),
+            "constraints": bool(self._nonempty_strings(self.constraints)),
+            "file_scope_hints": bool(self._nonempty_strings(self.file_scope_hints)),
+            "work_orders": bool([item for item in self.work_orders if isinstance(item, dict)]),
+        }
+
+    def is_dispatch_bounded(self) -> bool:
+        """Whether the spec has at least one concrete bound for dispatch."""
+        return any(self.dispatch_bounds().values())
+
+    def missing_dispatch_bounds(self) -> list[str]:
+        """Human-readable names for missing dispatch-bounding fields."""
+        labels = {
+            "acceptance_criteria": "acceptance criterion",
+            "constraints": "constraint",
+            "file_scope_hints": "file-scope hint",
+            "work_orders": "explicit work order",
+        }
+        return [labels[key] for key, present in self.dispatch_bounds().items() if not present]
+
+    def dispatch_gate_reason(self) -> str:
+        """Reason why this spec may or may not dispatch."""
+        if self.is_dispatch_bounded():
+            return "dispatch-bounded"
+        return (
+            "Swarm spec is under-specified for dispatch. Add at least one acceptance "
+            "criterion, constraint, file-scope hint, or explicit work order."
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dictionary."""

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -247,11 +247,11 @@ class TestSwarmCommand:
         assert "[DRY RUN] Skipping interrogation" in out
         assert '"raw_goal": "verify dry run"' in out
 
-    def test_cmd_swarm_skip_interrogation_dispatches(self):
+    def test_cmd_swarm_skip_interrogation_dispatches_when_goal_is_already_bounded(self):
         fake_run = MagicMock()
         mock_commander = SimpleNamespace(run_supervised_from_spec=AsyncMock(return_value=fake_run))
         args = argparse.Namespace(
-            swarm_action_or_goal="harden CI",
+            swarm_action_or_goal="Only touch aragora/swarm/spec.py",
             swarm_goal=None,
             spec=None,
             skip_interrogation=True,
@@ -279,6 +279,40 @@ class TestSwarmCommand:
             cmd_swarm(args)
 
         mock_commander.run_supervised_from_spec.assert_awaited_once()
+
+    def test_cmd_swarm_skip_interrogation_fails_closed_for_vague_goal(self, capsys):
+        mock_commander = SimpleNamespace(run_supervised_from_spec=AsyncMock())
+        args = argparse.Namespace(
+            swarm_action_or_goal="make it better",
+            swarm_goal=None,
+            spec=None,
+            skip_interrogation=True,
+            dry_run=False,
+            budget_limit=9.0,
+            require_approval=True,
+            save_spec=None,
+            from_obsidian=None,
+            obsidian_vault=None,
+            no_obsidian_receipts=False,
+            profile="developer",
+            autonomy="propose",
+            max_parallel=20,
+            no_loop=False,
+            target_branch="main",
+            concurrency_cap=8,
+            managed_dir_pattern=".worktrees/{agent}-auto",
+            json=False,
+            run_id=None,
+            status_limit=20,
+            refresh_scaling=False,
+        )
+
+        with patch("aragora.swarm.SwarmCommander", return_value=mock_commander):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert "under-specified for dispatch" in out
+        mock_commander.run_supervised_from_spec.assert_not_called()
 
     @patch("aragora.worktree.fleet.FleetCoordinationStore")
     @patch("aragora.worktree.fleet.build_fleet_rows")

--- a/tests/swarm/test_commander.py
+++ b/tests/swarm/test_commander.py
@@ -76,7 +76,11 @@ class TestSwarmCommanderRunFromSpec:
 
     @pytest.mark.asyncio
     async def test_run_supervised_from_spec_uses_supervisor(self):
-        spec = SwarmSpec(raw_goal="Test goal", refined_goal="Test goal refined")
+        spec = SwarmSpec(
+            raw_goal="Test goal",
+            refined_goal="Test goal refined",
+            file_scope_hints=["aragora/swarm/spec.py"],
+        )
         commander = SwarmCommander()
         fake_run = MagicMock()
         fake_run.run_id = "test-run-id"
@@ -94,7 +98,11 @@ class TestSwarmCommanderRunFromSpec:
 
     @pytest.mark.asyncio
     async def test_run_supervised_from_spec_wait_false_returns_refreshed_run(self):
-        spec = SwarmSpec(raw_goal="Test goal", refined_goal="Test goal refined")
+        spec = SwarmSpec(
+            raw_goal="Test goal",
+            refined_goal="Test goal refined",
+            file_scope_hints=["aragora/swarm/spec.py"],
+        )
         commander = SwarmCommander()
         fake_run = MagicMock()
         fake_run.run_id = "test-run-id"
@@ -202,6 +210,14 @@ class TestSwarmCommanderRunFromSpec:
         mock_sup.dispatch_workers.assert_not_awaited()
         mock_sup.refresh_run.assert_called_once_with(fake_run.run_id)
         mock_reconciler_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_supervised_from_spec_rejects_under_specified_spec(self):
+        commander = SwarmCommander()
+        spec = SwarmSpec(raw_goal="Make it better", refined_goal="Make it better")
+
+        with pytest.raises(ValueError, match="under-specified for dispatch"):
+            await commander.run_supervised_from_spec(spec)
 
 
 class TestSwarmCommanderDryRun:

--- a/tests/swarm/test_interrogator.py
+++ b/tests/swarm/test_interrogator.py
@@ -149,3 +149,24 @@ class TestInterrogatorInputSafety:
 
         assert spec.raw_goal == "Check dry-run plumbing"
         assert spec.refined_goal == "Check dry-run plumbing"
+
+
+class TestInterrogatorDispatchBounds:
+    @pytest.mark.asyncio
+    async def test_interrogator_keeps_asking_until_spec_is_dispatch_bounded(self):
+        answers = iter(["", "", "", "", "", "", "Only touch aragora/swarm/spec.py"])
+        output: list[str] = []
+        interrogator = SwarmInterrogator(
+            config=InterrogatorConfig(fallback_to_fixed_questions=True, max_turns=8)
+        )
+
+        with patch.object(interrogator, "_get_harness", new=AsyncMock(return_value=None)):
+            spec = await interrogator.interrogate(
+                "Make it better",
+                input_fn=lambda _prompt: next(answers),
+                print_fn=lambda msg: output.append(str(msg)),
+            )
+
+        assert spec.is_dispatch_bounded() is True
+        assert "aragora/swarm/spec.py" in spec.file_scope_hints
+        assert any("concrete boundary" in line.lower() for line in output)

--- a/tests/swarm/test_spec.py
+++ b/tests/swarm/test_spec.py
@@ -151,3 +151,28 @@ class TestSwarmSpecSummary:
         spec = SwarmSpec(work_orders=[{"work_order_id": "docs-lane"}])
         summary = spec.summary()
         assert "Explicit work orders: 1" in summary
+
+
+class TestSwarmSpecDispatchBounds:
+    def test_empty_spec_is_not_dispatch_bounded(self):
+        spec = SwarmSpec(raw_goal="Make it better")
+        assert spec.is_dispatch_bounded() is False
+        assert "under-specified" in spec.dispatch_gate_reason()
+
+    def test_acceptance_criterion_makes_spec_dispatch_bounded(self):
+        spec = SwarmSpec(raw_goal="Goal", acceptance_criteria=["Tests pass"])
+        assert spec.is_dispatch_bounded() is True
+
+    def test_file_scope_hint_makes_spec_dispatch_bounded(self):
+        spec = SwarmSpec(raw_goal="Goal", file_scope_hints=["aragora/swarm/spec.py"])
+        assert spec.is_dispatch_bounded() is True
+
+    def test_direct_goal_builder_extracts_path_scope(self):
+        spec = SwarmSpec.from_direct_goal(
+            "Only touch aragora/swarm/spec.py and tests/swarm/test_spec.py",
+            budget_limit_usd=5.0,
+            requires_approval=False,
+            user_expertise="developer",
+        )
+        assert spec.is_dispatch_bounded() is True
+        assert "aragora/swarm/spec.py" in spec.file_scope_hints


### PR DESCRIPTION
Closes #853.

## Summary
- add a read-side bounded-spec gate on `SwarmSpec`
- keep interrogation open with targeted follow-up when the extracted spec is still too vague to dispatch
- fail closed for supervised dispatch and `--skip-interrogation` when the spec still has no concrete bounds
- add focused swarm/CLI regression coverage for the bounded-spec gate

## Validation
- `pytest -q tests/swarm -k 'interrogator or commander or spec'`
- `pytest -q tests/cli/test_swarm_command.py -k 'swarm and (skip or interrogation or spec or dry)'`
