### PR TITLE
fix(inbox): route shared inbox receipt execution through trust wedge

### DIFF
--- a/aragora/server/handlers/features/unified_inbox/handler.py
+++ b/aragora/server/handlers/features/unified_inbox/handler.py
@@ -440,6 +440,7 @@ class UnifiedInboxHandler(BaseHandler):
             body = await self._get_json_body(request)
             message_ids = body.get("message_ids", [])
             action = body.get("action", "")
+            receipt_id = str(body.get("receipt_id", "") or "").strip()
 
             if not message_ids:
                 return error_response("No message IDs provided", 400)
@@ -449,12 +450,116 @@ class UnifiedInboxHandler(BaseHandler):
                     f"Invalid action. Must be one of: {', '.join(VALID_ACTIONS)}", 400
                 )
 
+            if receipt_id:
+                wedge_result = await self._handle_receipt_backed_bulk_action(
+                    tenant_id, message_ids, action, receipt_id
+                )
+                if wedge_result is not None:
+                    return wedge_result
+
             result = await execute_bulk_action(tenant_id, message_ids, action, self._store)
             return success_response(result)
 
         except (KeyError, ValueError, TypeError) as e:
             logger.exception("Error executing bulk action: %s", e)
             return error_response("Bulk action failed", 500)
+
+    async def _handle_receipt_backed_bulk_action(
+        self,
+        tenant_id: str,
+        message_ids: list[str],
+        action: str,
+        receipt_id: str,
+    ) -> HandlerResult | None:
+        """Execute the narrow receipt-backed single-message bulk path.
+
+        Unified inbox bulk actions are still mostly non-receipt-backed. This
+        helper only consolidates the exact archive/star single-message execution
+        path onto the inbox trust wedge.
+        """
+        if action not in {"archive", "star"}:
+            return error_response(
+                (
+                    "Receipt-backed inbox bulk actions currently support "
+                    "single-message archive and star only."
+                ),
+                400,
+            )
+        if len(message_ids) != 1:
+            return error_response(
+                "Receipt-backed inbox bulk actions currently support exactly one message_id.",
+                400,
+            )
+
+        from aragora.inbox import InboxWedgeAction, ReceiptState, get_inbox_trust_wedge_service
+
+        message_id = message_ids[0]
+        record = await self._store.get_message(tenant_id, message_id)
+        if not record:
+            return error_response("Message not found", 404)
+
+        message = record_to_message(record)
+        if message.provider is not EmailProvider.GMAIL:
+            return error_response(
+                "Inbox trust wedge currently supports Gmail unified inbox messages only",
+                400,
+            )
+        if not message.account_id:
+            return error_response("Message missing connected account ID", 400)
+
+        provider_message_id = message.external_id or message.id
+        if not provider_message_id:
+            return error_response("Message missing provider message ID", 400)
+
+        expected_action = InboxWedgeAction.ARCHIVE if action == "archive" else InboxWedgeAction.STAR
+        wedge_service = get_inbox_trust_wedge_service()
+        validation = wedge_service.validate_receipt(receipt_id, require_state=ReceiptState.APPROVED)
+        if not validation.valid or validation.envelope is None:
+            return error_response(validation.error or "receipt validation failed", 400)
+
+        envelope = validation.envelope
+        if envelope.intent.provider != message.provider.value:
+            return error_response("receipt provider mismatch", 400)
+        if envelope.intent.user_id != message.account_id:
+            return error_response("receipt user mismatch", 400)
+        if envelope.intent.message_id != provider_message_id:
+            return error_response("receipt message mismatch", 400)
+        if envelope.intent.action is not expected_action:
+            return error_response("receipt action mismatch", 400)
+
+        try:
+            execution_result = await wedge_service.execute_receipt(receipt_id)
+        except ValueError as exc:
+            return error_response(str(exc), 400)
+        except (
+            AttributeError,
+            RuntimeError,
+            OSError,
+            ConnectionError,
+            TypeError,
+            KeyError,
+        ):
+            logger.exception("Error executing unified inbox trust wedge receipt")
+            return error_response("Receipt execution failed", 500)
+
+        updated = wedge_service.store.get_receipt(receipt_id) or envelope
+        return success_response(
+            {
+                "action": action,
+                "success_count": 1,
+                "error_count": 0,
+                "errors": None,
+                "source_message_id": message.id,
+                "provider_message_id": provider_message_id,
+                "receipt": updated.receipt.to_dict(),
+                "intent": updated.intent.to_dict(),
+                "decision": updated.decision.to_dict(),
+                "provider_route": updated.provider_route,
+                "debate_id": updated.debate_id,
+                "executed": True,
+                "execution_result": execution_result.to_dict(),
+            }
+        )
 
     # =========================================================================
     # Stats & Trends

--- a/tests/handlers/features/unified_inbox/test_handler.py
+++ b/tests/handlers/features/unified_inbox/test_handler.py
@@ -25,6 +25,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aragora.inbox import InboxWedgeAction
 
 
 # ---------------------------------------------------------------------------
@@ -1117,6 +1118,101 @@ class TestBulkAction:
             )
             result = await handler.handle_request(req, "/api/v1/inbox/bulk-action", "POST")
             assert _status(result) == 200
+
+    @pytest.mark.asyncio
+    async def test_bulk_action_archive_executes_receipt_backed_single_message(
+        self, handler, mock_store
+    ):
+        mock_store.get_message.return_value = _message_record("msg-1")
+        mock_service = MagicMock()
+        mock_envelope = MagicMock()
+        mock_envelope.intent.provider = "gmail"
+        mock_envelope.intent.user_id = "acct-1"
+        mock_envelope.intent.message_id = "ext-123"
+        mock_envelope.intent.action = InboxWedgeAction.ARCHIVE
+        mock_envelope.intent.to_dict.return_value = {
+            "provider": "gmail",
+            "user_id": "acct-1",
+            "message_id": "ext-123",
+            "action": "archive",
+        }
+        mock_envelope.decision.to_dict.return_value = {
+            "final_action": "archive",
+            "confidence": 0.93,
+        }
+        mock_envelope.receipt.to_dict.return_value = {
+            "receipt_id": "receipt-1",
+            "state": "executed",
+        }
+        mock_envelope.provider_route = "direct"
+        mock_envelope.debate_id = "debate-1"
+        mock_service.validate_receipt.return_value = MagicMock(
+            valid=True,
+            envelope=mock_envelope,
+            error=None,
+        )
+        mock_service.execute_receipt = AsyncMock(
+            return_value=MagicMock(to_dict=MagicMock(return_value={"archived": True}))
+        )
+        mock_service.store.get_receipt.return_value = mock_envelope
+
+        with patch(
+            "aragora.server.handlers.features.unified_inbox.handler.execute_bulk_action",
+            new_callable=AsyncMock,
+        ) as mock_bulk:
+            with patch(
+                "aragora.inbox.get_inbox_trust_wedge_service",
+                return_value=mock_service,
+            ):
+                req = _req(
+                    method="POST",
+                    path="/api/v1/inbox/bulk-action",
+                    body={
+                        "message_ids": ["msg-1"],
+                        "action": "archive",
+                        "receipt_id": "receipt-1",
+                    },
+                )
+                result = await handler.handle_request(req, "/api/v1/inbox/bulk-action", "POST")
+
+        assert _status(result) == 200
+        body = _body(result)
+        assert body["success"] is True
+        assert body["data"]["executed"] is True
+        assert body["data"]["receipt"]["receipt_id"] == "receipt-1"
+        assert body["data"]["provider_message_id"] == "ext-123"
+        mock_service.execute_receipt.assert_awaited_once_with("receipt-1")
+        mock_bulk.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_bulk_action_receipt_rejects_multiple_message_ids(self, handler, mock_store):
+        req = _req(
+            method="POST",
+            path="/api/v1/inbox/bulk-action",
+            body={
+                "message_ids": ["msg-1", "msg-2"],
+                "action": "archive",
+                "receipt_id": "receipt-1",
+            },
+        )
+        result = await handler.handle_request(req, "/api/v1/inbox/bulk-action", "POST")
+        assert _status(result) == 400
+        assert "exactly one message_id" in _body(result)["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_bulk_action_receipt_rejects_unsupported_action(self, handler, mock_store):
+        req = _req(
+            method="POST",
+            path="/api/v1/inbox/bulk-action",
+            body={
+                "message_ids": ["msg-1"],
+                "action": "mark_read",
+                "receipt_id": "receipt-1",
+            },
+        )
+        result = await handler.handle_request(req, "/api/v1/inbox/bulk-action", "POST")
+        assert _status(result) == 400
+        assert "archive and star only" in _body(result)["error"].lower()
 
     @pytest.mark.asyncio
     async def test_bulk_action_no_message_ids(self, handler, mock_store):


### PR DESCRIPTION
Closes #817\n\n## Summary\n- route unified inbox single-message archive/star execution through the inbox trust wedge when a receipt_id is supplied\n- fail closed for unsupported receipt-backed bulk usage instead of silently falling back\n- keep the existing bulk path unchanged for non-receipt-backed actions\n\n## Validation\n- pytest -q tests/handlers/features/unified_inbox/test_handler.py tests/handlers/features/unified_inbox/test_actions.py