### PR TITLE
feat: add boss mode supervised swarm

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -26,7 +26,7 @@ from uuid import uuid4
 def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | None]:
     first = getattr(args, "swarm_action_or_goal", None)
     second = getattr(args, "swarm_goal", None)
-    if first in {"run", "status", "reconcile"}:
+    if first in {"run", "boss", "status", "reconcile"}:
         return str(first), second
     return "run", first
 
@@ -54,6 +54,34 @@ def _run_supervised_or_report(awaitable: object) -> object | None:
     except ValueError as exc:
         print(f"Error: {exc}")
         return None
+
+
+def _build_boss_payload(
+    run: dict[str, object],
+    *,
+    repo_root: Path,
+    target_branch: str,
+) -> dict[str, object]:
+    from aragora.swarm.reporter import build_boss_payload, build_integrator_view
+    from aragora.worktree.fleet import FleetCoordinationStore, build_fleet_rows
+
+    worktrees = build_fleet_rows(repo_root, base_branch=target_branch, tail=0)
+    store = FleetCoordinationStore(repo_root)
+    claims = store.list_claims()
+    merge_queue = store.list_merge_queue()
+    coordination = store.status_summary()
+    integrator_view = build_integrator_view(
+        runs=[run],
+        worktrees=worktrees,
+        claims=claims,
+        merge_queue=merge_queue,
+        coordination=coordination,
+    )
+    return build_boss_payload(
+        run=run,
+        integrator_view=integrator_view,
+        coordination=coordination,
+    )
 
 
 def cmd_swarm(args: argparse.Namespace) -> None:
@@ -100,8 +128,13 @@ def cmd_swarm(args: argparse.Namespace) -> None:
     dispatch_only = bool(getattr(args, "dispatch_only", False))
     no_wait = bool(getattr(args, "no_wait", False))
     dispatch_workers = not no_dispatch
+    boss_mode = action == "boss"
     if dispatch_only:
         no_wait = True
+    if boss_mode:
+        dispatch_workers = True
+        no_wait = False
+        concurrency_cap = max(4, concurrency_cap)
 
     # Phase 2: User profile
     profile_str = getattr(args, "profile", "ceo")
@@ -269,10 +302,24 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         )
         if run is None:
             return
+        run_payload = run.to_dict()
+        if boss_mode:
+            boss_payload = _build_boss_payload(
+                run_payload,
+                repo_root=Path.cwd(),
+                target_branch=target_branch,
+            )
+            if as_json:
+                print(json.dumps(boss_payload, indent=2))
+            else:
+                from aragora.swarm.reporter import render_boss_text
+
+                print(render_boss_text(boss_payload))
+            return
         if as_json:
-            print(json.dumps(run.to_dict(), indent=2))
+            print(json.dumps(run_payload, indent=2))
         else:
-            _print_supervisor_run(run.to_dict())
+            _print_supervisor_run(run_payload)
     elif dry_run:
         if skip_interrogation:
             spec = SwarmSpec(
@@ -321,10 +368,24 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         )
         if run is None:
             return
+        run_payload = run.to_dict()
+        if boss_mode:
+            boss_payload = _build_boss_payload(
+                run_payload,
+                repo_root=Path.cwd(),
+                target_branch=target_branch,
+            )
+            if as_json:
+                print(json.dumps(boss_payload, indent=2))
+            else:
+                from aragora.swarm.reporter import render_boss_text
+
+                print(render_boss_text(boss_payload))
+            return
         if as_json:
-            print(json.dumps(run.to_dict(), indent=2))
+            print(json.dumps(run_payload, indent=2))
         else:
-            _print_supervisor_run(run.to_dict())
+            _print_supervisor_run(run_payload)
     else:
         run = _run_supervised_or_report(
             commander.run_supervised(
@@ -342,7 +403,21 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         )
         if run is None:
             return
+        run_payload = run.to_dict()
+        if boss_mode:
+            boss_payload = _build_boss_payload(
+                run_payload,
+                repo_root=Path.cwd(),
+                target_branch=target_branch,
+            )
+            if as_json:
+                print(json.dumps(boss_payload, indent=2))
+            else:
+                from aragora.swarm.reporter import render_boss_text
+
+                print(render_boss_text(boss_payload))
+            return
         if as_json:
-            print(json.dumps(run.to_dict(), indent=2))
+            print(json.dumps(run_payload, indent=2))
         else:
-            _print_supervisor_run(run.to_dict())
+            _print_supervisor_run(run_payload)

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -639,6 +639,145 @@ def build_integrator_view(
     }
 
 
+def _work_order_status_counts(work_orders: list[dict[str, Any]] | None) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in work_orders or []:
+        if not isinstance(item, dict):
+            continue
+        status = _text(item.get("status")) or "unknown"
+        counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def build_boss_payload(
+    *,
+    run: dict[str, Any],
+    integrator_view: dict[str, Any] | None = None,
+    coordination: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable boss-facing payload for supervised swarm runs."""
+    integrator_view = integrator_view if isinstance(integrator_view, dict) else {}
+    coordination = coordination if isinstance(coordination, dict) else {}
+    work_orders = [dict(item) for item in run.get("work_orders", []) if isinstance(item, dict)]
+    lanes_from_integrator = [
+        dict(item) for item in integrator_view.get("lanes", []) if isinstance(item, dict)
+    ]
+    lane_by_work_order = {
+        _text(item.get("work_order_id")): item
+        for item in lanes_from_integrator
+        if _text(item.get("work_order_id"))
+    }
+
+    lane_summaries: list[dict[str, Any]] = []
+    needs_human: list[dict[str, Any]] = []
+    for item in work_orders:
+        work_order_id = _text(item.get("work_order_id"))
+        lane = lane_by_work_order.get(work_order_id, {})
+        lane_summary = {
+            "work_order_id": work_order_id or None,
+            "title": _first_text(item.get("title"), lane.get("title")) or None,
+            "status": _first_text(item.get("status"), lane.get("status"), "unknown"),
+            "target_agent": _first_text(item.get("target_agent"), lane.get("owner_agent")) or None,
+            "branch": _first_text(item.get("branch"), lane.get("branch")) or None,
+            "worktree_path": _first_text(item.get("worktree_path"), lane.get("worktree_path"))
+            or None,
+            "lease_id": _first_text(item.get("lease_id"), lane.get("lease_id")) or None,
+            "receipt_id": _extract_receipt_id(item, lane) or None,
+            "review_status": _first_text(item.get("review_status")) or None,
+            "next_action": _first_text(lane.get("next_action")) or None,
+        }
+        lane_summaries.append(lane_summary)
+
+        escalation_reasons = [_text(reason) for reason in lane.get("blockers", []) if _text(reason)]
+        for key in ("dispatch_error", "resource_error"):
+            reason = _text(item.get(key))
+            if reason:
+                escalation_reasons.append(reason)
+        if lane_summary["status"] == "needs_human" or escalation_reasons:
+            needs_human.append(
+                {
+                    "work_order_id": lane_summary["work_order_id"],
+                    "title": lane_summary["title"],
+                    "reasons": sorted(set(escalation_reasons)),
+                }
+            )
+
+    return {
+        "mode": "boss",
+        "run_id": _text(run.get("run_id")),
+        "status": _text(run.get("status")),
+        "goal": _text(run.get("goal")),
+        "target_branch": _text(run.get("target_branch")),
+        "work_order_counts": _work_order_status_counts(work_orders),
+        "lanes": lane_summaries,
+        "integrator_next_actions": [
+            _text(item) for item in integrator_view.get("next_actions", []) if _text(item)
+        ],
+        "needs_human": needs_human,
+        "coordination_counts": coordination.get("counts", {}),
+        "integrator_summary": integrator_view.get("summary", {}),
+    }
+
+
+def render_boss_text(payload: dict[str, Any]) -> str:
+    """Render a concise boss-facing supervised swarm summary."""
+    counts = payload.get("work_order_counts", {})
+    counts_text = (
+        ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        if isinstance(counts, dict) and counts
+        else "none"
+    )
+    lines = [
+        f"run_id={_text(payload.get('run_id'))}",
+        f"status={_text(payload.get('status'))} target_branch={_text(payload.get('target_branch'))}",
+        f"goal={_text(payload.get('goal'))}",
+        f"work_orders=[{counts_text}]",
+    ]
+
+    lanes = payload.get("lanes", [])
+    if isinstance(lanes, list):
+        for lane in lanes[:6]:
+            if not isinstance(lane, dict):
+                continue
+            parts = [
+                _text(lane.get("work_order_id")) or "lane",
+                _text(lane.get("status")) or "unknown",
+            ]
+            branch = _text(lane.get("branch"))
+            if branch:
+                parts.append(f"branch={branch}")
+            worktree_path = _text(lane.get("worktree_path"))
+            if worktree_path:
+                parts.append(f"worktree={worktree_path}")
+            receipt_id = _text(lane.get("receipt_id"))
+            if receipt_id:
+                parts.append(f"receipt={receipt_id}")
+            lines.append("lane: " + " ".join(parts))
+
+    next_actions = payload.get("integrator_next_actions", [])
+    if isinstance(next_actions, list):
+        for item in next_actions[:3]:
+            text = _text(item)
+            if text:
+                lines.append(f"next: {text}")
+
+    needs_human = payload.get("needs_human", [])
+    if isinstance(needs_human, list):
+        for item in needs_human[:3]:
+            if not isinstance(item, dict):
+                continue
+            reasons = [_text(reason) for reason in item.get("reasons", []) if _text(reason)]
+            if not reasons:
+                continue
+            lines.append(
+                "needs_human: "
+                f"{_first_text(item.get('title'), item.get('work_order_id'), 'lane')} -> "
+                + "; ".join(reasons)
+            )
+
+    return "\n".join(lines)
+
+
 @dataclass
 class SwarmReport:
     """Plain-English report of swarm execution for non-developer users."""

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -711,6 +711,7 @@ class SwarmSupervisor:
                         "worker completion violated file-scope ownership; narrow or split the lane",
                     )
                     item["review_status"] = "changes_requested"
+                    item["receipt_id"] = None
                     item["scope_violation"] = {
                         "violations": list(exc.violations),
                         "changed_paths": list(result.changed_paths),

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -380,10 +380,17 @@ class WorkerLauncher:
     def _build_prompt(work_order: dict[str, Any]) -> str:
         """Build the task prompt from a work order dict."""
         parts: list[str] = []
+        metadata = work_order.get("metadata", {})
 
         title = str(work_order.get("title", "")).strip()
         if title:
             parts.append(f"# Task: {title}")
+
+        parts.append(
+            "You are one Aragora-managed CLI worker lane inside a supervised swarm run. "
+            "Do only the bounded work for this lane and leave coordination, integration, "
+            "and human escalation to the boss lane."
+        )
 
         description = str(work_order.get("description", "")).strip()
         if description:
@@ -392,14 +399,13 @@ class WorkerLauncher:
         file_scope = work_order.get("file_scope", [])
         if file_scope:
             scope_list = ", ".join(str(f) for f in file_scope)
-            parts.append(f"Files in scope: {scope_list}")
+            parts.append(f"Bounded scope:\n  - Only touch: {scope_list}")
 
         expected_tests = work_order.get("expected_tests", [])
         if expected_tests:
             tests_text = "\n".join(f"  - {t}" for t in expected_tests)
-            parts.append(f"Run these tests to verify:\n{tests_text}")
+            parts.append(f"Expected validation:\n{tests_text}")
 
-        metadata = work_order.get("metadata", {})
         acceptance = metadata.get("acceptance_criteria", [])
         if acceptance:
             criteria_text = "\n".join(f"  - {c}" for c in acceptance)
@@ -410,12 +416,29 @@ class WorkerLauncher:
             constraints_text = "\n".join(f"  - {c}" for c in constraints)
             parts.append(f"Constraints:\n{constraints_text}")
 
+        approval_required = bool(work_order.get("approval_required", False))
+        if approval_required:
+            parts.append(
+                "Decision boundary:\n"
+                "  - If you hit a real ambiguity, approval boundary, or blocker, stop cleanly and "
+                "report the exact reason instead of widening scope."
+            )
+
+        lease_id = str(work_order.get("lease_id", "")).strip()
+        if lease_id:
+            parts.append(
+                "Receipt expectation:\n"
+                f"  - Lease id: {lease_id}\n"
+                "  - Aragora will record the completion receipt after a successful exit from this lane."
+            )
+
         parts.append(
-            "IMPORTANT: After completing the task, you MUST:\n"
-            "1. Run the tests listed above to verify your changes work correctly.\n"
-            "2. Stage all changed files with `git add -A`.\n"
-            '3. Commit with a descriptive message using `git commit -m "..."`. '
-            "Do NOT skip the commit step."
+            "Stop condition:\n"
+            "  - Finish the bounded lane or stop at a real blocker.\n"
+            "  - Run the expected validation commands when possible, or state exactly why they could not run.\n"
+            "  - Stage all changed files with `git add -A`.\n"
+            '  - Commit with a descriptive message using `git commit -m "..."` before exiting.\n'
+            "  - Exit with a truthful final state; do not claim integration or approval work is done unless it happened in this lane."
         )
 
         return "\n\n".join(parts)

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -279,6 +279,10 @@ class TestSwarmCommand:
             cmd_swarm(args)
 
         mock_commander.run_supervised_from_spec.assert_awaited_once()
+        call = mock_commander.run_supervised_from_spec.await_args
+        assert call.kwargs["max_concurrency"] == 8
+        assert call.kwargs["dispatch"] is True
+        assert call.kwargs["wait"] is True
 
     def test_cmd_swarm_skip_interrogation_fails_closed_for_vague_goal(self, capsys):
         mock_commander = SimpleNamespace(run_supervised_from_spec=AsyncMock())
@@ -492,6 +496,150 @@ class TestSwarmCommand:
         out = capsys.readouterr().out
         assert '"run_id": "run-123"' in out
         assert '"status": "active"' in out
+
+    def test_cmd_swarm_boss_mode_forces_supervised_defaults_and_prints_text(self, capsys):
+        fake_run = _fake_supervisor_run(
+            run_id="boss-run-1",
+            status="needs_human",
+            work_orders=[
+                {
+                    "work_order_id": "lane-a",
+                    "title": "Lane A",
+                    "status": "needs_human",
+                    "branch": "codex/lane-a",
+                    "worktree_path": "/tmp/repo/.worktrees/lane-a",
+                    "target_agent": "codex",
+                    "lease_id": "lease-a",
+                    "receipt_id": "receipt-a",
+                    "dispatch_error": "waiting for human choice",
+                }
+            ],
+        )
+        mock_commander = SimpleNamespace(run_supervised=AsyncMock(return_value=fake_run))
+        args = _swarm_args(
+            swarm_action_or_goal="boss",
+            swarm_goal="Split vague operator request into supervised lanes",
+            concurrency_cap=1,
+        )
+
+        with (
+            patch("aragora.swarm.SwarmCommander", return_value=mock_commander),
+            patch("aragora.cli.commands.swarm._build_boss_payload") as build_payload,
+        ):
+            build_payload.return_value = {
+                "mode": "boss",
+                "run_id": "boss-run-1",
+                "status": "needs_human",
+                "goal": "Split vague operator request into supervised lanes",
+                "target_branch": "main",
+                "work_order_counts": {"needs_human": 1},
+                "lanes": [
+                    {
+                        "work_order_id": "lane-a",
+                        "status": "needs_human",
+                        "branch": "codex/lane-a",
+                        "worktree_path": "/tmp/repo/.worktrees/lane-a",
+                        "receipt_id": "receipt-a",
+                    }
+                ],
+                "integrator_next_actions": ["Review lane-a and decide whether to narrow scope."],
+                "needs_human": [
+                    {
+                        "work_order_id": "lane-a",
+                        "title": "Lane A",
+                        "reasons": ["waiting for human choice"],
+                    }
+                ],
+            }
+            cmd_swarm(args)
+
+        call = mock_commander.run_supervised.await_args
+        assert call.args[0] == "Split vague operator request into supervised lanes"
+        assert call.kwargs["max_concurrency"] == 4
+        assert call.kwargs["dispatch"] is True
+        assert call.kwargs["wait"] is True
+        out = capsys.readouterr().out
+        assert "run_id=boss-run-1" in out
+        assert "work_orders=[needs_human=1]" in out
+        assert "next: Review lane-a and decide whether to narrow scope." in out
+        assert "needs_human: Lane A -> waiting for human choice" in out
+
+    def test_cmd_swarm_boss_mode_json_with_spec_emits_boss_payload(self, tmp_path: Path, capsys):
+        spec_path = tmp_path / "swarm-spec.yaml"
+        spec = SwarmSpec(
+            raw_goal="Run boss mode from spec",
+            refined_goal="Run boss mode from spec",
+            work_orders=[
+                {
+                    "work_order_id": "lane-b",
+                    "title": "Lane B",
+                    "file_scope": ["aragora/swarm/reporter.py"],
+                    "expected_tests": ["python -m pytest tests/swarm/test_commander.py -q"],
+                    "target_agent": "claude",
+                }
+            ],
+        )
+        spec_path.write_text(spec.to_yaml())
+        fake_run = _fake_supervisor_run(
+            run_id="boss-run-2",
+            status="active",
+            work_orders=[
+                {
+                    "work_order_id": "lane-b",
+                    "title": "Lane B",
+                    "status": "leased",
+                    "branch": "codex/lane-b",
+                    "worktree_path": "/tmp/repo/.worktrees/lane-b",
+                    "target_agent": "claude",
+                }
+            ],
+        )
+        mock_commander = SimpleNamespace(run_supervised_from_spec=AsyncMock(return_value=fake_run))
+        args = _swarm_args(
+            swarm_action_or_goal="boss",
+            spec=str(spec_path),
+            json=True,
+            concurrency_cap=2,
+        )
+
+        with (
+            patch("aragora.swarm.SwarmCommander", return_value=mock_commander),
+            patch("aragora.cli.commands.swarm._build_boss_payload") as build_payload,
+        ):
+            build_payload.return_value = {
+                "mode": "boss",
+                "run_id": "boss-run-2",
+                "status": "active",
+                "goal": "Run boss mode from spec",
+                "target_branch": "main",
+                "work_order_counts": {"leased": 1},
+                "lanes": [
+                    {
+                        "work_order_id": "lane-b",
+                        "status": "leased",
+                        "branch": "codex/lane-b",
+                        "worktree_path": "/tmp/repo/.worktrees/lane-b",
+                        "lease_id": "lease-b",
+                        "receipt_id": None,
+                        "next_action": "Wait for worker completion.",
+                    }
+                ],
+                "integrator_next_actions": ["Wait for worker completion."],
+                "needs_human": [],
+                "coordination_counts": {"active_leases": 1},
+                "integrator_summary": {"review_lanes": 0},
+            }
+            cmd_swarm(args)
+
+        call = mock_commander.run_supervised_from_spec.await_args
+        assert call.kwargs["max_concurrency"] == 4
+        assert call.kwargs["dispatch"] is True
+        assert call.kwargs["wait"] is True
+        out = capsys.readouterr().out
+        assert '"mode": "boss"' in out
+        assert '"run_id": "boss-run-2"' in out
+        assert '"integrator_next_actions": [' in out
+        assert '"coordination_counts": {' in out
 
     def test_cmd_swarm_reconcile_watch_uses_watch_run(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -14,6 +14,7 @@ from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposition
 from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.supervisor import SwarmSupervisor
+from aragora.swarm.worker_launcher import WorkerLauncher
 from aragora.worktree.lifecycle import ManagedWorktreeSession
 
 
@@ -338,7 +339,7 @@ def test_start_run_prefers_explicit_spec_work_orders(
 # ---------- dispatch_workers / collect_results tests ----------
 
 from unittest.mock import AsyncMock, patch
-from aragora.swarm.worker_launcher import WorkerLauncher, WorkerProcess
+from aragora.swarm.worker_launcher import WorkerProcess
 
 UTC = timezone.utc
 
@@ -843,3 +844,30 @@ async def test_collect_finished_results_marks_no_progress_timeout_needs_human(
     work_order = updated["work_orders"][0]
     assert work_order["status"] == "needs_human"
     assert "no-progress timeout" in work_order["dispatch_error"]
+
+
+def test_worker_prompt_includes_boss_lane_contract() -> None:
+    prompt = WorkerLauncher._build_prompt(
+        {
+            "title": "Implement boss-facing reporter output",
+            "description": "Emit stable coordinator output for one lane.",
+            "file_scope": ["aragora/swarm/reporter.py", "tests/swarm/test_supervisor.py"],
+            "expected_tests": ["python -m pytest tests/swarm/test_supervisor.py -q"],
+            "approval_required": True,
+            "lease_id": "lease-123",
+            "metadata": {
+                "acceptance_criteria": ["Output includes run_id and next actions"],
+                "constraints": ["Do not widen beyond the swarm package"],
+            },
+        }
+    )
+
+    assert "Aragora-managed CLI worker lane" in prompt
+    assert "Bounded scope:" in prompt
+    assert "Expected validation:" in prompt
+    assert "Acceptance criteria:" in prompt
+    assert "Constraints:" in prompt
+    assert "Decision boundary:" in prompt
+    assert "Receipt expectation:" in prompt
+    assert "Lease id: lease-123" in prompt
+    assert "Stop condition:" in prompt


### PR DESCRIPTION
## Summary
- add a boss-mode front door on top of the existing supervised swarm path
- emit stable boss-facing text/json status with run, lane, receipt, and next-action summaries
- strengthen the CLI worker prompt contract and cover the new behavior with focused tests

## Validation
- pytest -q tests/cli/test_swarm_command.py tests/swarm/test_commander.py tests/swarm/test_supervisor.py tests/swarm/test_reconciler.py
- fixture-backed boss-mode command invocation proving run_id, status summary, next actions, and JSON boss payload output