### PR TITLE
feat: add runner heartbeat freshness for boss routing

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -203,8 +203,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         )
 
         subaction = str(goal or "inspect").strip().lower()
-        if subaction not in {"inspect", "register"}:
-            print("Error: swarm runner action must be 'inspect' or 'register'")
+        if subaction not in {"inspect", "register", "heartbeat"}:
+            print("Error: swarm runner action must be 'inspect', 'register', or 'heartbeat'")
             return
 
         inspection = CodexRunnerInspector().inspect()
@@ -213,6 +213,16 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             payload = (
                 LocalRunnerRegistry()
                 .register(
+                    inspection,
+                    owner_context=owner_context,
+                )
+                .to_dict()
+            )
+        elif subaction == "heartbeat":
+            owner_context = authorization_context_from_env()
+            payload = (
+                LocalRunnerRegistry()
+                .heartbeat(
                     inspection,
                     owner_context=owner_context,
                 )

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -667,6 +667,13 @@ def render_runner_registration_text(payload: dict[str, Any]) -> str:
 
     if payload.get("registered"):
         lines.append(f"registered_at={_text(payload.get('registered_at'))}")
+    freshness_status = _text(payload.get("freshness_status"))
+    if freshness_status:
+        lines.append(
+            "freshness="
+            f"{freshness_status} heartbeat_at={_text(payload.get('heartbeat_at')) or 'none'} "
+            f"stale_after={_text(payload.get('stale_after_seconds')) or 'none'}"
+        )
 
     status_summary = _text(payload.get("status_summary"))
     if status_summary:
@@ -802,11 +809,29 @@ def render_boss_text(payload: dict[str, Any]) -> str:
         selected_runner_ids = [
             _text(item) for item in routing.get("selected_runner_ids", []) if _text(item)
         ]
-        if selected_runner_ids:
+        selected_runners = routing.get("selected_runners", [])
+        selected_runner_parts: list[str] = []
+        if isinstance(selected_runners, list):
+            for item in selected_runners:
+                if not isinstance(item, dict):
+                    continue
+                runner_id = _text(item.get("runner_id"))
+                if not runner_id:
+                    continue
+                freshness = _text(item.get("freshness_status")) or "unknown"
+                selected_runner_parts.append(f"{runner_id}({freshness})")
+        if selected_runner_parts:
+            lines.append("routing: selected_runners=" + ",".join(selected_runner_parts))
+        elif selected_runner_ids:
             lines.append("routing: selected_runners=" + ",".join(selected_runner_ids))
         blocked_reason = _text(routing.get("blocked_reason"))
         if blocked_reason:
             lines.append(f"routing_blocked: {blocked_reason}")
+        rejected_runner_ids = [
+            _text(item) for item in routing.get("rejected_runner_ids", []) if _text(item)
+        ]
+        if rejected_runner_ids:
+            lines.append("routing_rejected: " + ",".join(rejected_runner_ids))
         routing_next = _text(routing.get("next_action"))
         if routing_next:
             lines.append(f"routing_next: {routing_next}")

--- a/aragora/swarm/runner_registry.py
+++ b/aragora/swarm/runner_registry.py
@@ -18,6 +18,7 @@ from aragora.swarm.worker_launcher import LaunchConfig
 
 UTC = timezone.utc
 VERIFIED_AUTH_MODES = {"chatgpt_login", "api_key"}
+DEFAULT_RUNNER_STALE_AFTER_SECONDS = 3600
 
 
 def _utcnow() -> str:
@@ -53,6 +54,9 @@ class CodexRunnerInspection:
     registered: bool = False
     registry_path: str | None = None
     registered_at: str | None = None
+    heartbeat_at: str | None = None
+    freshness_status: str = "unknown"
+    stale_after_seconds: int = DEFAULT_RUNNER_STALE_AFTER_SECONDS
     next_action: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -70,6 +74,9 @@ class CodexRunnerInspection:
             "registered": self.registered,
             "registry_path": self.registry_path,
             "registered_at": self.registered_at,
+            "heartbeat_at": self.heartbeat_at,
+            "freshness_status": self.freshness_status,
+            "stale_after_seconds": self.stale_after_seconds,
             "next_action": self.next_action,
         }
 
@@ -81,6 +88,7 @@ class BossRoutingDecision:
     selected_runners: list[dict[str, Any]] = field(default_factory=list)
     selection_basis: str = ""
     blocked_reason: str | None = None
+    rejected_runner_ids: list[str] = field(default_factory=list)
     next_action: str | None = None
 
     @property
@@ -94,6 +102,7 @@ class BossRoutingDecision:
             "selected_runners": [dict(item) for item in self.selected_runners],
             "selection_basis": self.selection_basis,
             "blocked_reason": self.blocked_reason,
+            "rejected_runner_ids": list(self.rejected_runner_ids),
             "next_action": self.next_action,
         }
 
@@ -114,6 +123,7 @@ class CodexRunnerInspector:
         codex_path = shutil.which(self.config.codex_path)
         runner_id = self._runner_id(codex_path)
         owner = owner_binding_from_env(self.env)
+        stale_after_seconds = self._stale_after_seconds()
 
         if not codex_path:
             return CodexRunnerInspection(
@@ -127,6 +137,8 @@ class CodexRunnerInspector:
                 status_summary=None,
                 capabilities=self._capabilities(False, None),
                 owner_binding=owner,
+                freshness_status="unavailable",
+                stale_after_seconds=stale_after_seconds,
                 next_action="Install the Codex CLI or add `codex` to PATH before registering this runner.",
             )
 
@@ -162,6 +174,8 @@ class CodexRunnerInspector:
                 status_summary=None,
                 capabilities=self._capabilities(False, None),
                 owner_binding=owner,
+                freshness_status="unavailable",
+                stale_after_seconds=stale_after_seconds,
                 next_action="The local `codex` binary exists but did not respond truthfully; fix the CLI installation before registering this runner.",
             )
 
@@ -180,6 +194,8 @@ class CodexRunnerInspector:
             status_summary=self._first_line(login_text) or None,
             capabilities=self._capabilities(True, help_text),
             owner_binding=owner,
+            freshness_status=self._inspection_freshness(available=True, auth_mode=auth_mode),
+            stale_after_seconds=stale_after_seconds,
             next_action=self._next_action(
                 available=True,
                 auth_mode=auth_mode,
@@ -205,6 +221,21 @@ class CodexRunnerInspector:
         if "api key" in lowered and "logged in" in lowered:
             return "api_key"
         return "unknown"
+
+    def _stale_after_seconds(self) -> int:
+        return _env_flag_int(
+            self.env,
+            "ARAGORA_RUNNER_STALE_AFTER_SECONDS",
+            DEFAULT_RUNNER_STALE_AFTER_SECONDS,
+        )
+
+    @staticmethod
+    def _inspection_freshness(*, available: bool, auth_mode: str) -> str:
+        if not available:
+            return "unavailable"
+        if auth_mode not in VERIFIED_AUTH_MODES:
+            return "unknown"
+        return "fresh"
 
     @staticmethod
     def _first_line(text: str) -> str:
@@ -297,11 +328,14 @@ class LocalRunnerRegistry:
 
         records = self._load()
         now = _utcnow()
+        freshness_status = self._freshness_for_inspection(inspection)
         entry = {
             **inspection.to_dict(),
             "owner_binding": owner_binding_from_context(owner_context),
             "registered": True,
             "registered_at": now,
+            "heartbeat_at": now,
+            "freshness_status": freshness_status,
             "updated_at": now,
         }
         records["registrations"] = [
@@ -316,9 +350,75 @@ class LocalRunnerRegistry:
         inspection.registered = True
         inspection.registry_path = registry_path
         inspection.registered_at = now
+        inspection.heartbeat_at = now
+        inspection.freshness_status = freshness_status
         inspection.next_action = (
             "Runner registered. Future Boss-mode routing can target this owner-bound Codex runner."
         )
+        return inspection
+
+    def heartbeat(
+        self,
+        inspection: CodexRunnerInspection,
+        *,
+        owner_context: AuthorizationContext | None,
+    ) -> CodexRunnerInspection:
+        registry_path = str(self.path)
+        inspection.registry_path = registry_path
+        if owner_context is None:
+            inspection.registered = False
+            inspection.next_action = (
+                "Set `ARAGORA_USER_ID` and `ARAGORA_WORKSPACE_ID` before refreshing a runner "
+                "heartbeat for Boss-mode routing."
+            )
+            return inspection
+
+        records = self._load()
+        registrations = [
+            dict(item) for item in records.get("registrations", []) if isinstance(item, dict)
+        ]
+        existing = next(
+            (
+                item
+                for item in registrations
+                if item.get("runner_id") == inspection.runner_id
+                and self._is_owner_compatible(item, owner_context=owner_context)
+            ),
+            None,
+        )
+        if existing is None:
+            inspection.registered = False
+            inspection.next_action = (
+                "Register this Codex runner for the current Aragora user/workspace context before "
+                "refreshing its heartbeat."
+            )
+            return inspection
+
+        now = _utcnow()
+        freshness_status = self._freshness_for_inspection(inspection)
+        owner_binding = owner_binding_from_context(owner_context)
+        updated_entry = {
+            **existing,
+            **inspection.to_dict(),
+            "registered": True,
+            "owner_binding": owner_binding,
+            "registered_at": existing.get("registered_at"),
+            "heartbeat_at": now,
+            "freshness_status": freshness_status,
+            "updated_at": now,
+        }
+        records["registrations"] = [
+            updated_entry if item.get("runner_id") == inspection.runner_id else item
+            for item in registrations
+        ]
+        self._save(records)
+
+        inspection.owner_binding = owner_binding
+        inspection.registered = True
+        inspection.registered_at = _text(existing.get("registered_at")) or None
+        inspection.heartbeat_at = now
+        inspection.freshness_status = freshness_status
+        inspection.next_action = self._heartbeat_next_action(freshness_status)
         return inspection
 
     def list_registrations(self) -> list[dict[str, Any]]:
@@ -333,8 +433,9 @@ class LocalRunnerRegistry:
     ) -> BossRoutingDecision:
         owner_binding = owner_binding_from_context(owner_context)
         selection_basis = (
-            "registered=true, availability=available, auth_mode in {chatgpt_login, api_key}, "
-            "owner_binding user/workspace compatible with current Aragora context"
+            "registered=true, freshness_status=fresh, availability=available, auth_mode in "
+            "{chatgpt_login, api_key}, owner_binding user/workspace compatible with current "
+            "Aragora context"
         )
         if owner_context is None or not _text(owner_context.user_id):
             return BossRoutingDecision(
@@ -348,13 +449,30 @@ class LocalRunnerRegistry:
             )
 
         eligible: list[dict[str, Any]] = []
+        rejected_runner_ids: list[str] = []
+        saw_compatible_nonfresh = False
         for runner in self.list_registrations():
+            if self._is_owner_compatible(runner, owner_context=owner_context):
+                if (
+                    _text(runner.get("runner_type")) == "codex"
+                    and bool(runner.get("registered"))
+                    and self._freshness_status(runner) != "fresh"
+                ):
+                    saw_compatible_nonfresh = True
             if not self._is_runner_eligible(runner, owner_context=owner_context):
+                runner_id = _text(runner.get("runner_id"))
+                if runner_id:
+                    rejected_runner_ids.append(runner_id)
                 continue
             eligible.append(
                 {
                     "runner_id": _text(runner.get("runner_id")),
                     "auth_mode": _text(runner.get("auth_mode")),
+                    "freshness_status": self._freshness_status(runner),
+                    "heartbeat_at": _text(runner.get("heartbeat_at")) or None,
+                    "stale_after_seconds": int(
+                        runner.get("stale_after_seconds") or DEFAULT_RUNNER_STALE_AFTER_SECONDS
+                    ),
                     "owner_binding": dict(runner.get("owner_binding") or {}),
                     "capabilities": dict(runner.get("capabilities") or {}),
                 }
@@ -364,9 +482,17 @@ class LocalRunnerRegistry:
             return BossRoutingDecision(
                 owner_binding=owner_binding,
                 selection_basis=selection_basis,
-                blocked_reason="no_eligible_registered_runners",
+                blocked_reason=(
+                    "no_fresh_registered_runners"
+                    if saw_compatible_nonfresh
+                    else "no_eligible_registered_runners"
+                ),
+                rejected_runner_ids=sorted(set(rejected_runner_ids)),
                 next_action=(
-                    "Register an available Codex runner for this exact Aragora user/workspace "
+                    "Refresh the heartbeat for an available registered Codex runner in this exact "
+                    "Aragora user/workspace context before running Boss mode."
+                    if saw_compatible_nonfresh
+                    else "Register an available Codex runner for this exact Aragora user/workspace "
                     "context before running Boss mode."
                 ),
             )
@@ -376,11 +502,12 @@ class LocalRunnerRegistry:
             selected_runner_ids=[item["runner_id"] for item in eligible],
             selected_runners=eligible,
             selection_basis=selection_basis,
+            rejected_runner_ids=sorted(set(rejected_runner_ids)),
             next_action="Boss mode will route only through the selected registered Codex runner set.",
         )
 
-    @staticmethod
     def _is_runner_eligible(
+        self,
         runner: dict[str, Any],
         *,
         owner_context: AuthorizationContext,
@@ -395,7 +522,18 @@ class LocalRunnerRegistry:
             return False
         if _text(runner.get("auth_mode")) not in VERIFIED_AUTH_MODES:
             return False
+        if self._freshness_status(runner) != "fresh":
+            return False
+        if not self._is_owner_compatible(runner, owner_context=owner_context):
+            return False
+        return True
 
+    @staticmethod
+    def _is_owner_compatible(
+        runner: dict[str, Any],
+        *,
+        owner_context: AuthorizationContext,
+    ) -> bool:
         owner_binding = dict(runner.get("owner_binding") or {})
         if _text(owner_binding.get("user_id")) != _text(owner_context.user_id):
             return False
@@ -411,6 +549,61 @@ class LocalRunnerRegistry:
             return False
 
         return True
+
+    @staticmethod
+    def _freshness_for_inspection(inspection: CodexRunnerInspection) -> str:
+        if not inspection.available:
+            return "unavailable"
+        if inspection.auth_mode not in VERIFIED_AUTH_MODES:
+            return "unknown"
+        return "fresh"
+
+    def _freshness_status(self, runner: dict[str, Any]) -> str:
+        if _text(runner.get("availability")) != "available" or not bool(
+            runner.get("available", True)
+        ):
+            return "unavailable"
+        if _text(runner.get("auth_mode")) not in VERIFIED_AUTH_MODES:
+            return "unknown"
+
+        heartbeat_at = _text(runner.get("heartbeat_at"))
+        if not heartbeat_at:
+            return "stale"
+        heartbeat_dt = self._parse_timestamp(heartbeat_at)
+        if heartbeat_dt is None:
+            return "unknown"
+
+        stale_after_seconds = int(
+            runner.get("stale_after_seconds") or DEFAULT_RUNNER_STALE_AFTER_SECONDS
+        )
+        age_seconds = max(0.0, (datetime.now(UTC) - heartbeat_dt).total_seconds())
+        if age_seconds > stale_after_seconds:
+            return "stale"
+        return "fresh"
+
+    @staticmethod
+    def _heartbeat_next_action(freshness_status: str) -> str:
+        if freshness_status == "fresh":
+            return (
+                "Runner heartbeat refreshed. Boss mode can route work to this runner while the "
+                "heartbeat remains fresh."
+            )
+        if freshness_status == "unavailable":
+            return (
+                "Runner heartbeat recorded an unavailable Codex runner. Restore the local CLI "
+                "before relying on Boss-mode routing."
+            )
+        return (
+            "Runner heartbeat recorded a non-fresh state. Confirm local Codex availability and auth "
+            "before relying on Boss-mode routing."
+        )
+
+    @staticmethod
+    def _parse_timestamp(value: str) -> datetime | None:
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
 
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -171,6 +171,9 @@ class TestSwarmCommand:
                 "auth_mode": "chatgpt_login",
                 "availability": "available",
                 "available": True,
+                "freshness_status": "fresh",
+                "heartbeat_at": "2026-03-09T12:00:00+00:00",
+                "stale_after_seconds": 3600,
                 "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
                 "capabilities": {"max_parallel_lanes": 1},
                 "next_action": "Runner is eligible for Boss-mode routing.",
@@ -186,6 +189,7 @@ class TestSwarmCommand:
         assert '"auth_mode": "chatgpt_login"' in out
         assert '"availability": "available"' in out
         assert '"action": "inspect"' in out
+        assert '"freshness_status": "fresh"' in out
 
     def test_cmd_swarm_runner_register_rejects_unknown_auth(self, capsys):
         args = _swarm_args(
@@ -198,6 +202,9 @@ class TestSwarmCommand:
                 "runner_type": "codex",
                 "auth_mode": "unknown",
                 "availability": "available",
+                "freshness_status": "unknown",
+                "heartbeat_at": None,
+                "stale_after_seconds": 3600,
                 "owner_binding": {"user_id": None, "workspace_id": None},
                 "capabilities": {
                     "supports_exec": True,
@@ -215,6 +222,9 @@ class TestSwarmCommand:
                 "availability": "available",
                 "registered": False,
                 "registry_path": "/tmp/swarm-runners.json",
+                "freshness_status": "unknown",
+                "heartbeat_at": None,
+                "stale_after_seconds": 3600,
                 "owner_binding": {"user_id": None, "workspace_id": None},
                 "capabilities": {
                     "supports_exec": True,
@@ -239,8 +249,62 @@ class TestSwarmCommand:
         assert "runner_id=codex-runner-123" in out
         assert "availability=available auth_mode=unknown" in out
         assert "owner=unbound workspace=none" in out
+        assert "freshness=unknown heartbeat_at=none stale_after=3600" in out
         assert "registered_at=" not in out
         assert "next: Registration blocked: Codex auth mode is unknown." in out
+
+    def test_cmd_swarm_runner_heartbeat_emits_freshness(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="runner",
+            swarm_goal="heartbeat",
+            json=True,
+        )
+        inspection = SimpleNamespace(
+            to_dict=lambda: {
+                "runner_id": "codex-runner-123",
+                "runner_type": "codex",
+                "auth_mode": "chatgpt_login",
+                "availability": "available",
+                "available": True,
+                "freshness_status": "fresh",
+                "heartbeat_at": "2026-03-09T12:05:00+00:00",
+                "stale_after_seconds": 3600,
+                "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                "capabilities": {"supports_exec": True, "max_parallel_lanes": 2},
+                "next_action": "Runner heartbeat refreshed.",
+            }
+        )
+        heartbeated = SimpleNamespace(
+            to_dict=lambda: {
+                "runner_id": "codex-runner-123",
+                "runner_type": "codex",
+                "auth_mode": "chatgpt_login",
+                "availability": "available",
+                "available": True,
+                "registered": True,
+                "freshness_status": "fresh",
+                "heartbeat_at": "2026-03-09T12:05:00+00:00",
+                "stale_after_seconds": 3600,
+                "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                "capabilities": {"supports_exec": True, "max_parallel_lanes": 2},
+                "next_action": "Runner heartbeat refreshed.",
+            }
+        )
+
+        with (
+            patch("aragora.swarm.runner_registry.CodexRunnerInspector") as inspector_cls,
+            patch("aragora.swarm.runner_registry.authorization_context_from_env") as auth_ctx,
+            patch("aragora.swarm.runner_registry.LocalRunnerRegistry") as registry_cls,
+        ):
+            inspector_cls.return_value.inspect.return_value = inspection
+            auth_ctx.return_value = object()
+            registry_cls.return_value.heartbeat.return_value = heartbeated
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"action": "heartbeat"' in out
+        assert '"freshness_status": "fresh"' in out
+        assert '"heartbeat_at": "2026-03-09T12:05:00+00:00"' in out
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(
@@ -624,9 +688,10 @@ class TestSwarmCommand:
             resolve_routing.return_value = {
                 "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
                 "selected_runner_ids": ["codex-runner-1"],
-                "selected_runners": [{"runner_id": "codex-runner-1"}],
+                "selected_runners": [{"runner_id": "codex-runner-1", "freshness_status": "fresh"}],
                 "selection_basis": "registered=true",
                 "blocked_reason": None,
+                "rejected_runner_ids": [],
                 "next_action": "Boss mode will route only through the selected registered Codex runner set.",
             }
             build_payload.return_value = {
@@ -638,7 +703,11 @@ class TestSwarmCommand:
                 "work_order_counts": {"needs_human": 1},
                 "routing": {
                     "selected_runner_ids": ["codex-runner-1"],
+                    "selected_runners": [
+                        {"runner_id": "codex-runner-1", "freshness_status": "fresh"}
+                    ],
                     "blocked_reason": None,
+                    "rejected_runner_ids": [],
                     "next_action": "Boss mode will route only through the selected registered Codex runner set.",
                 },
                 "lanes": [
@@ -669,7 +738,7 @@ class TestSwarmCommand:
         out = capsys.readouterr().out
         assert "run_id=boss-run-1" in out
         assert "work_orders=[needs_human=1]" in out
-        assert "routing: selected_runners=codex-runner-1" in out
+        assert "routing: selected_runners=codex-runner-1(fresh)" in out
         assert "next: Review lane-a and decide whether to narrow scope." in out
         assert "needs_human: Lane A -> waiting for human choice" in out
 
@@ -719,9 +788,10 @@ class TestSwarmCommand:
             resolve_routing.return_value = {
                 "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
                 "selected_runner_ids": ["codex-runner-1"],
-                "selected_runners": [{"runner_id": "codex-runner-1"}],
+                "selected_runners": [{"runner_id": "codex-runner-1", "freshness_status": "fresh"}],
                 "selection_basis": "registered=true",
                 "blocked_reason": None,
+                "rejected_runner_ids": [],
                 "next_action": "Boss mode will route only through the selected registered Codex runner set.",
             }
             build_payload.return_value = {
@@ -733,7 +803,11 @@ class TestSwarmCommand:
                 "work_order_counts": {"leased": 1},
                 "routing": {
                     "selected_runner_ids": ["codex-runner-1"],
+                    "selected_runners": [
+                        {"runner_id": "codex-runner-1", "freshness_status": "fresh"}
+                    ],
                     "blocked_reason": None,
+                    "rejected_runner_ids": [],
                     "next_action": "Boss mode will route only through the selected registered Codex runner set.",
                 },
                 "lanes": [
@@ -783,6 +857,7 @@ class TestSwarmCommand:
                 "selected_runners": [],
                 "selection_basis": "registered=true",
                 "blocked_reason": "missing_owner_context",
+                "rejected_runner_ids": [],
                 "next_action": "Set `ARAGORA_USER_ID` and `ARAGORA_WORKSPACE_ID` before running Boss mode.",
             }
             cmd_swarm(args)
@@ -792,6 +867,34 @@ class TestSwarmCommand:
         assert '"status": "blocked"' in out
         assert '"blocked_reason": "missing_owner_context"' in out
         assert '"selected_runner_ids": []' in out
+
+    def test_cmd_swarm_boss_mode_blocks_when_only_stale_runners_exist(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="boss",
+            swarm_goal="Split vague operator request into supervised lanes",
+            json=True,
+        )
+        mock_commander = SimpleNamespace(run_supervised=AsyncMock())
+
+        with (
+            patch("aragora.swarm.SwarmCommander", return_value=mock_commander),
+            patch("aragora.cli.commands.swarm._resolve_boss_routing") as resolve_routing,
+        ):
+            resolve_routing.return_value = {
+                "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                "selected_runner_ids": [],
+                "selected_runners": [],
+                "selection_basis": "registered=true freshness_status=fresh",
+                "blocked_reason": "no_fresh_registered_runners",
+                "rejected_runner_ids": ["codex-runner-stale"],
+                "next_action": "Refresh the heartbeat for an available registered Codex runner.",
+            }
+            cmd_swarm(args)
+
+        mock_commander.run_supervised.assert_not_called()
+        out = capsys.readouterr().out
+        assert '"blocked_reason": "no_fresh_registered_runners"' in out
+        assert '"rejected_runner_ids": [' in out
 
     def test_cmd_swarm_reconcile_watch_uses_watch_run(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_runner_registry.py
+++ b/tests/swarm/test_runner_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 import json
 from pathlib import Path
 
@@ -11,6 +12,8 @@ from aragora.swarm.runner_registry import (
     authorization_context_from_env,
 )
 
+UTC = timezone.utc
+
 
 class TestCodexRunnerInspector:
     def test_codex_unavailable(self, monkeypatch):
@@ -20,6 +23,7 @@ class TestCodexRunnerInspector:
         assert inspection.available is False
         assert inspection.availability == "unavailable"
         assert inspection.auth_mode == "unavailable"
+        assert inspection.freshness_status == "unavailable"
         assert "Install the Codex CLI" in str(inspection.next_action)
 
     def test_api_key_runner_detected_from_login_status(self, monkeypatch):
@@ -45,6 +49,7 @@ class TestCodexRunnerInspector:
 
         assert inspection.available is True
         assert inspection.auth_mode == "api_key"
+        assert inspection.freshness_status == "fresh"
         assert inspection.capabilities["supports_exec"] is True
         assert inspection.capabilities["supports_review"] is True
 
@@ -69,6 +74,7 @@ class TestCodexRunnerInspector:
 
         assert inspection.auth_mode == "chatgpt_login"
         assert inspection.available is True
+        assert inspection.freshness_status == "fresh"
 
     def test_ambiguous_state_returns_unknown(self, monkeypatch):
         monkeypatch.setattr(
@@ -86,6 +92,7 @@ class TestCodexRunnerInspector:
         inspection = CodexRunnerInspector(env={}).inspect()
 
         assert inspection.auth_mode == "unknown"
+        assert inspection.freshness_status == "unknown"
         assert "Confirm the local Codex CLI login state" in str(inspection.next_action)
 
     def test_openai_api_key_env_alone_does_not_prove_api_key_auth(self, monkeypatch):
@@ -108,10 +115,11 @@ class TestCodexRunnerInspector:
         inspection = CodexRunnerInspector(env={"OPENAI_API_KEY": "sk-test"}).inspect()
 
         assert inspection.auth_mode == "unknown"
+        assert inspection.freshness_status == "unknown"
 
 
 class TestLocalRunnerRegistry:
-    def test_registration_persists_owner_binding_and_payload_shape(self, tmp_path: Path) -> None:
+    def test_registration_persists_owner_binding_and_freshness(self, tmp_path: Path) -> None:
         registry_path = tmp_path / "swarm-runners.json"
         registry = LocalRunnerRegistry(path=registry_path)
         owner_context = authorization_context_from_env(
@@ -132,6 +140,7 @@ class TestLocalRunnerRegistry:
             status_summary="Logged in using ChatGPT",
             capabilities={"supports_exec": True, "supports_review": True, "max_parallel_lanes": 2},
             owner_binding={},
+            freshness_status="fresh",
         )
 
         registered = registry.register(inspection, owner_context=owner_context)
@@ -139,33 +148,16 @@ class TestLocalRunnerRegistry:
         assert registered.registered is True
         assert registered.owner_binding["user_id"] == "user-123"
         assert registered.owner_binding["workspace_id"] == "ws-456"
+        assert registered.freshness_status == "fresh"
+        assert registered.heartbeat_at is not None
         assert registry_path.exists()
 
         stored = json.loads(registry_path.read_text(encoding="utf-8"))
         assert stored["registrations"][0]["runner_id"] == "codex-runner-123"
         assert stored["registrations"][0]["auth_mode"] == "chatgpt_login"
         assert stored["registrations"][0]["owner_binding"]["org_id"] == "org-789"
-
-    def test_registration_without_owner_context_fails_closed(self, tmp_path: Path) -> None:
-        registry = LocalRunnerRegistry(path=tmp_path / "swarm-runners.json")
-        inspection = CodexRunnerInspection(
-            runner_id="codex-runner-123",
-            runner_type="codex",
-            availability="available",
-            available=True,
-            auth_mode="unknown",
-            codex_path="/usr/local/bin/codex",
-            version=None,
-            status_summary=None,
-            capabilities={},
-            owner_binding={},
-        )
-
-        registered = registry.register(inspection, owner_context=None)
-
-        assert registered.registered is False
-        assert registered.registry_path is not None
-        assert "Registration blocked: Codex auth mode is unknown" in str(registered.next_action)
+        assert stored["registrations"][0]["freshness_status"] == "fresh"
+        assert stored["registrations"][0]["heartbeat_at"]
 
     def test_registration_of_unknown_auth_runner_fails_closed(self, tmp_path: Path) -> None:
         registry = LocalRunnerRegistry(path=tmp_path / "swarm-runners.json")
@@ -186,6 +178,7 @@ class TestLocalRunnerRegistry:
             status_summary="Authentication status unavailable",
             capabilities={"supports_exec": True},
             owner_binding={},
+            freshness_status="unknown",
         )
 
         registered = registry.register(inspection, owner_context=owner_context)
@@ -196,7 +189,88 @@ class TestLocalRunnerRegistry:
         assert "Registration blocked: Codex auth mode is unknown" in str(registered.next_action)
         assert not (tmp_path / "swarm-runners.json").exists()
 
-    def test_resolve_boss_routing_selects_eligible_runner(self, tmp_path: Path) -> None:
+    def test_heartbeat_refreshes_registered_runner(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "swarm-runners.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "codex-runner-1",
+                            "runner_type": "codex",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "chatgpt_login",
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "registered_at": "2026-03-09T00:00:00+00:00",
+                            "heartbeat_at": "2026-03-09T00:00:00+00:00",
+                            "freshness_status": "stale",
+                            "stale_after_seconds": 3600,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        registry = LocalRunnerRegistry(path=registry_path)
+        owner_context = authorization_context_from_env(
+            {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
+        )
+        inspection = CodexRunnerInspection(
+            runner_id="codex-runner-1",
+            runner_type="codex",
+            availability="available",
+            available=True,
+            auth_mode="chatgpt_login",
+            codex_path="/usr/local/bin/codex",
+            version="codex 1.2.3",
+            status_summary="Logged in using ChatGPT",
+            capabilities={"supports_exec": True},
+            owner_binding={},
+            freshness_status="fresh",
+        )
+
+        heartbeated = registry.heartbeat(inspection, owner_context=owner_context)
+
+        assert heartbeated.registered is True
+        assert heartbeated.freshness_status == "fresh"
+        assert heartbeated.heartbeat_at is not None
+        stored = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert stored["registrations"][0]["freshness_status"] == "fresh"
+        assert stored["registrations"][0]["heartbeat_at"]
+
+    def test_missing_heartbeat_is_treated_as_stale(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "swarm-runners.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "codex-runner-1",
+                            "runner_type": "codex",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "chatgpt_login",
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        decision = LocalRunnerRegistry(path=registry_path).resolve_boss_routing(
+            owner_context=authorization_context_from_env(
+                {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
+            )
+        )
+
+        assert decision.is_blocked is True
+        assert decision.blocked_reason == "no_fresh_registered_runners"
+
+    def test_resolve_boss_routing_selects_fresh_runner(self, tmp_path: Path) -> None:
+        fresh_heartbeat = (datetime.now(UTC) - timedelta(minutes=5)).isoformat()
         registry_path = tmp_path / "swarm-runners.json"
         registry_path.write_text(
             json.dumps(
@@ -211,6 +285,8 @@ class TestLocalRunnerRegistry:
                             "auth_mode": "chatgpt_login",
                             "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
                             "capabilities": {"max_parallel_lanes": 2},
+                            "heartbeat_at": fresh_heartbeat,
+                            "stale_after_seconds": 3600,
                         }
                     ]
                 }
@@ -225,6 +301,40 @@ class TestLocalRunnerRegistry:
 
         assert decision.is_blocked is False
         assert decision.selected_runner_ids == ["codex-runner-1"]
+        assert decision.selected_runners[0]["freshness_status"] == "fresh"
+
+    def test_resolve_boss_routing_rejects_stale_runner(self, tmp_path: Path) -> None:
+        stale_heartbeat = (datetime.now(UTC) - timedelta(hours=3)).isoformat()
+        registry_path = tmp_path / "swarm-runners.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "codex-runner-stale",
+                            "runner_type": "codex",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "chatgpt_login",
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "heartbeat_at": stale_heartbeat,
+                            "stale_after_seconds": 3600,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        decision = LocalRunnerRegistry(path=registry_path).resolve_boss_routing(
+            owner_context=authorization_context_from_env(
+                {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
+            )
+        )
+
+        assert decision.is_blocked is True
+        assert decision.blocked_reason == "no_fresh_registered_runners"
+        assert "codex-runner-stale" in decision.rejected_runner_ids
 
     def test_resolve_boss_routing_rejects_wrong_workspace(self, tmp_path: Path) -> None:
         registry_path = tmp_path / "swarm-runners.json"
@@ -240,6 +350,8 @@ class TestLocalRunnerRegistry:
                             "available": True,
                             "auth_mode": "chatgpt_login",
                             "owner_binding": {"user_id": "user-123", "workspace_id": "ws-other"},
+                            "heartbeat_at": datetime.now(UTC).isoformat(),
+                            "stale_after_seconds": 3600,
                         }
                     ]
                 }
@@ -255,55 +367,6 @@ class TestLocalRunnerRegistry:
         assert decision.is_blocked is True
         assert decision.blocked_reason == "no_eligible_registered_runners"
 
-    def test_resolve_boss_routing_rejects_unregistered_unknown_and_unavailable(
-        self, tmp_path: Path
-    ) -> None:
-        registry_path = tmp_path / "swarm-runners.json"
-        registry_path.write_text(
-            json.dumps(
-                {
-                    "registrations": [
-                        {
-                            "runner_id": "codex-runner-unregistered",
-                            "runner_type": "codex",
-                            "registered": False,
-                            "availability": "available",
-                            "available": True,
-                            "auth_mode": "chatgpt_login",
-                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
-                        },
-                        {
-                            "runner_id": "codex-runner-unknown",
-                            "runner_type": "codex",
-                            "registered": True,
-                            "availability": "available",
-                            "available": True,
-                            "auth_mode": "unknown",
-                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
-                        },
-                        {
-                            "runner_id": "codex-runner-down",
-                            "runner_type": "codex",
-                            "registered": True,
-                            "availability": "unavailable",
-                            "available": False,
-                            "auth_mode": "chatgpt_login",
-                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
-                        },
-                    ]
-                }
-            ),
-            encoding="utf-8",
-        )
-        decision = LocalRunnerRegistry(path=registry_path).resolve_boss_routing(
-            owner_context=authorization_context_from_env(
-                {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
-            )
-        )
-
-        assert decision.is_blocked is True
-        assert decision.selected_runner_ids == []
-
     def test_resolve_boss_routing_blocks_without_owner_context(self, tmp_path: Path) -> None:
         decision = LocalRunnerRegistry(path=tmp_path / "swarm-runners.json").resolve_boss_routing(
             owner_context=None
@@ -312,8 +375,9 @@ class TestLocalRunnerRegistry:
         assert decision == BossRoutingDecision(
             owner_binding={"user_id": None, "workspace_id": None, "org_id": None},
             selection_basis=(
-                "registered=true, availability=available, auth_mode in {chatgpt_login, api_key}, "
-                "owner_binding user/workspace compatible with current Aragora context"
+                "registered=true, freshness_status=fresh, availability=available, auth_mode in "
+                "{chatgpt_login, api_key}, owner_binding user/workspace compatible with current "
+                "Aragora context"
             ),
             blocked_reason="missing_owner_context",
             next_action=(


### PR DESCRIPTION
## Summary
- extend local Codex runner registrations with heartbeat and freshness metadata
- add a `swarm runner heartbeat` path and fail Boss routing closed when only stale runners exist
- surface freshness details in runner output and Boss routing payloads with focused coverage

## Validation
- pytest -q /Users/armand/Development/aragora-worktrees/runner-heartbeat-freshness-20260309/tests/cli/test_swarm_command.py /Users/armand/Development/aragora-worktrees/runner-heartbeat-freshness-20260309/tests/swarm/test_runner_registry.py
- fixture-backed Boss invocation proving a fresh eligible registered runner is selected and emitted in the JSON routing payload