### PR TITLE
fix(deps): bump langgraph 1.0.9 → 1.0.10 (GHSA-g48c-2wqr-h844)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2950,7 +2950,7 @@ wheels = [
 
 [[package]]
 name = "langgraph"
-version = "1.0.9"
+version = "1.0.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "langchain-core" },
@@ -2960,9 +2960,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/63/69373a6721f30026ffa462a62084b11ed4bb5a201d1672366e13a89532f3/langgraph-1.0.9.tar.gz", hash = "sha256:feac2729faba7d3c325bef76f240d7d7f66b02d2cbf4fdb1ed7d0cc83f963651", size = 502800, upload-time = "2026-02-19T18:19:45.228Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/92/14df6fefba28c10caf1cb05aa5b8c7bf005838fe32a86d903b6c7cc4018d/langgraph-1.0.10.tar.gz", hash = "sha256:73bd10ee14a8020f31ef07e9cd4c1a70c35cc07b9c2b9cd637509a10d9d51e29", size = 511644, upload-time = "2026-02-27T21:04:38.743Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/a2/562a6c2430085c2c29b23c1e1d12233bf41a64e9a9832eda7573af3666cf/langgraph-1.0.9-py3-none-any.whl", hash = "sha256:bce0d1f3e9a20434215a2a818395a58aedfc11c87bd6b52706c0db5c05ec44ec", size = 158150, upload-time = "2026-02-19T18:19:43.913Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/60/260e0c04620a37ba8916b712766c341cc5fc685dabc6948c899494bbc2ae/langgraph-1.0.10-py3-none-any.whl", hash = "sha256:7c298bef4f6ea292fcf9824d6088fe41a6727e2904ad6066f240c4095af12247", size = 160920, upload-time = "2026-02-27T21:04:35.932Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps langgraph from 1.0.9 to 1.0.10 in `uv.lock` to resolve [GHSA-g48c-2wqr-h844](https://github.com/advisories/GHSA-g48c-2wqr-h844)
- Targeted lockfile edit — only the langgraph entry changed (version, sdist hash, wheel hash)
- Dependencies identical between 1.0.9 and 1.0.10; stays within langchain constraint `>=1.0.8,<1.1.0`
- Validated with `uv lock --check` (463 packages resolved, no conflicts)

## Test plan
- [x] `uv lock --check` passes (lockfile consistent with pyproject.toml)
- [ ] CI passes (no code changes, only lockfile)
- [ ] Dependabot alert auto-closes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)