### PR TITLE
fix(swarm): increase boss-loop dispatch and no-progress timeouts

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -751,7 +751,7 @@ class BossLoop:
                 dispatch=True,
                 wait=True,
                 interval_seconds=5.0,
-                max_ticks=60,
+                max_ticks=360,
             )
 
             run_dict = run.to_dict()

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -73,7 +73,7 @@ class LaunchConfig:
     claude_path: str = "claude"
     codex_path: str = "codex"
     timeout_seconds: float = 600.0
-    no_progress_timeout_seconds: float = 120.0
+    no_progress_timeout_seconds: float = 720.0
     claude_model: str | None = None
     codex_model: str | None = None
     auto_commit: bool = True


### PR DESCRIPTION
## Summary
- Increases `no_progress_timeout_seconds` from 120s to 720s in `worker_launcher.py`
- Increases `max_ticks` in boss_loop dispatch from 60 to 360 in `boss_loop.py`
- First live Boss-loop dispatch test showed both timeouts were too tight for tasks involving npm install/build cycles (~2-5 minutes)

## Context
During the first live Boss-loop test against issue #872:
- **Run 1** (120s no-progress timeout): Worker was killed before producing any git diffs — it was running `npm install` which takes time
- **Run 2** (720s no-progress, 300s commander wait): Commander wait (`max_ticks=60 × 5s = 300s`) expired while the worker was still active
- **Run 3** (720s no-progress, 1800s commander wait): Worker completed successfully in 132 seconds

## Test plan
- [x] `pytest tests/swarm/test_boss_loop.py` — 40/40 passed
- [x] Pre-commit hooks passed (ruff, ruff format, gitleaks)
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)