### PR TITLE
fix(swarm): stop on terminal worker state

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -473,7 +473,9 @@ class SwarmSupervisor:
                 )
                 if scope_violations:
                     self._mark_scope_violation(item, scope_violations)
+                    self._release_terminal_lease(item)
                     await self._kill_worker(item)
+                    changed = True
 
                 continue
 
@@ -489,6 +491,7 @@ class SwarmSupervisor:
                         item,
                         "worker process exited without receipt or exit marker",
                     )
+                self._release_terminal_lease(item)
                 changed = True
                 continue
 
@@ -505,6 +508,7 @@ class SwarmSupervisor:
                     self._mark_scope_violation(item, timeout_violations, extra_reason=reason)
                 else:
                     self._mark_needs_human(item, reason)
+                self._release_terminal_lease(item)
                 changed = True
 
         if not finished and not changed:
@@ -764,6 +768,7 @@ class SwarmSupervisor:
                         "violations": list(exc.violations),
                         "changed_paths": list(result.changed_paths),
                     }
+                    self._release_terminal_lease(item)
                     item["exit_code"] = result.exit_code
                     return
                 item["receipt_id"] = receipt.receipt_id
@@ -781,6 +786,15 @@ class SwarmSupervisor:
         item["exit_code"] = result.exit_code
         if result.stderr.strip():
             item["blockers"] = [result.stderr.strip()]
+
+    def _release_terminal_lease(self, item: dict[str, Any]) -> None:
+        lease_id = str(item.get("lease_id", "")).strip()
+        if not lease_id:
+            return
+        try:
+            self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
+        except KeyError:
+            return
 
     def _requeue_after_dispatch_error(self, item: dict[str, Any], exc: Exception) -> bool:
         message = str(exc).strip()

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -7,6 +7,7 @@ reusing the managed-session wrapper so worktree locks/logs stay coherent.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from dataclasses import dataclass, field
@@ -531,7 +532,10 @@ class WorkerLauncher:
         Returns None if the worker is still running (PID alive).
         Returns a WorkerProcess with collected results if finished.
         """
-        if pid is not None and cls._is_pid_running(pid):
+        session_meta = cls._read_session_meta(worktree_path)
+        session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
+
+        if session_exit_code is None and pid is not None and cls._is_pid_running(pid):
             return None
 
         worker = WorkerProcess(
@@ -545,8 +549,8 @@ class WorkerLauncher:
 
         worker.stdout = cls._read_log_file(worktree_path, "stdout")
         worker.stderr = cls._read_log_file(worktree_path, "stderr")
-        worker.exit_code = 0
-        worker.completed_at = datetime.now(UTC).isoformat()
+        worker.exit_code = 0 if session_exit_code is None else session_exit_code
+        worker.completed_at = session_completed_at or datetime.now(UTC).isoformat()
         worker.diff = await cls._collect_diff(worktree_path)
 
         if auto_commit and worker.diff:
@@ -571,6 +575,27 @@ class WorkerLauncher:
             len(worker.changed_paths),
         )
         return worker
+
+    @staticmethod
+    def _read_session_meta(worktree_path: str) -> dict[str, Any]:
+        meta_path = Path(worktree_path) / ".codex_session_meta.json"
+        try:
+            payload = json.loads(meta_path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _terminal_session_result(session_meta: dict[str, Any]) -> tuple[int | None, str | None]:
+        ended_at = str(session_meta.get("ended_at", "")).strip()
+        if not ended_at:
+            return None, None
+        raw_exit_code = session_meta.get("exit_code")
+        try:
+            exit_code = int(raw_exit_code)
+        except (TypeError, ValueError):
+            return None, None
+        return exit_code, ended_at
 
     @staticmethod
     def _is_pid_running(pid: int) -> bool:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -544,8 +544,84 @@ async def test_collect_results_marks_scope_violation_needs_human(
     assert wo["scope_violation"]["violations"][0]["type"] == "out_of_scope"
 
     summary = store.status_summary()
-    assert summary["counts"]["scope_violations"] == 1
-    assert summary["counts"]["active_leases"] == 1
+    assert summary["counts"]["scope_violations"] == 0
+    assert summary["counts"]["active_leases"] == 0
+
+
+@pytest.mark.asyncio
+async def test_collect_finished_results_uses_terminal_session_meta_even_when_pid_looks_alive(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    initial_head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+    (repo / "README.md").write_text("wrong work\n", encoding="utf-8")
+    _run(repo, "git", "add", "README.md")
+    _run(repo, "git", "commit", "-m", "wrong work")
+    (repo / ".codex_session_meta.json").write_text(
+        ('{\n  "ended_at": "2026-03-09T13:33:17Z",\n  "exit_code": 0\n}\n'),
+        encoding="utf-8",
+    )
+
+    lease = store.claim_lease(
+        task_id="citation-lane",
+        title="Citation lane",
+        owner_agent="codex",
+        owner_session_id="scope-session",
+        branch="main",
+        worktree_path=str(repo),
+        claimed_paths=["docs/citations.md"],
+    )
+    run_record = store.create_supervisor_run(
+        goal="detect terminal session meta",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "detect terminal session meta"},
+        work_orders=[
+            {
+                "work_order_id": "wo-session-meta",
+                "status": "dispatched",
+                "worktree_path": str(repo),
+                "branch": "main",
+                "target_agent": "codex",
+                "owner_session_id": "scope-session",
+                "lease_id": lease.lease_id,
+                "pid": 96969,
+                "initial_head": initial_head,
+                "review_status": "pending",
+                "file_scope": ["docs/citations.md"],
+            }
+        ],
+        status="active",
+    )
+
+    mock_launcher = MagicMock(spec=WorkerLauncher)
+    mock_launcher.collect_finished = AsyncMock(return_value=[])
+    mock_launcher.snapshot_progress = AsyncMock()
+    mock_launcher.config = SimpleNamespace(auto_commit=False, no_progress_timeout_seconds=120.0)
+
+    supervisor = SwarmSupervisor(repo_root=repo, store=store, launcher=mock_launcher)
+
+    with patch.object(WorkerLauncher, "_is_pid_running", return_value=True):
+        completed = await supervisor.collect_finished_results(run_record["run_id"])
+
+    assert len(completed) == 1
+    assert completed[0].exit_code == 0
+    mock_launcher.snapshot_progress.assert_not_awaited()
+
+    updated = store.get_supervisor_run(run_record["run_id"])
+    assert updated is not None
+    assert updated["status"] == "completed"
+    work_order = updated["work_orders"][0]
+    assert work_order["status"] == "scope_violation"
+    assert work_order["review_status"] == "changes_requested"
+    violation_paths = {
+        item["path"] for item in work_order["scope_violation"]["violations"] if "path" in item
+    }
+    assert "README.md" in violation_paths
+
+    summary = store.status_summary()
+    assert summary["counts"]["active_leases"] == 0
+    assert summary["counts"]["scope_violations"] == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- detect detached worker completion from terminal `.codex_session_meta.json` even when stale PID liveness still looks active
- release leases when dispatched workers reach terminal scope-violation or needs-human states so the supervisor stops truthfully
- add regression coverage for the preserved #873-style terminal-artifact failure mode

## Testing
- pytest -q /Users/armand/Development/aragora/tests/swarm/test_supervisor.py /Users/armand/Development/aragora/tests/swarm/test_commander.py /Users/armand/Development/aragora/tests/swarm/test_reconciler.py /Users/armand/Development/aragora/tests/cli/test_swarm_command.py

Closes #877