### PR TITLE
fix(swarm): escalate waiting_conflict deadlock to needs_human

### DIFF
--- a/aragora/swarm/reconciler.py
+++ b/aragora/swarm/reconciler.py
@@ -96,5 +96,9 @@ class SwarmReconciler:
             return True
         if run.status == "needs_human":
             return True
-        active_statuses = {"queued", "waiting_conflict", "waiting_resource", "leased", "dispatched"}
-        return not (statuses & active_statuses)
+        # Only statuses that represent real forward progress keep the
+        # reconciler alive.  waiting_conflict and waiting_resource are
+        # dead-end blockers — _derive_status escalates them to needs_human
+        # when no forward-progress path remains.
+        forward_progress_statuses = {"queued", "leased", "dispatched"}
+        return not (statuses & forward_progress_statuses)

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1154,6 +1154,13 @@ class SwarmSupervisor:
             return SupervisorRunStatus.NEEDS_HUMAN.value
         if "dispatch_failed" in statuses:
             return SupervisorRunStatus.NEEDS_HUMAN.value
+        # Deadlocked: only waiting_conflict/waiting_resource remain with no
+        # forward-progress statuses (queued/leased/dispatched).  Escalate
+        # instead of polling indefinitely.
+        forward_progress = {"queued", "leased", "dispatched"}
+        non_terminal = statuses - terminal
+        if non_terminal and not (non_terminal & forward_progress):
+            return SupervisorRunStatus.NEEDS_HUMAN.value
         return SupervisorRunStatus.ACTIVE.value
 
     @staticmethod

--- a/tests/swarm/test_reconciler.py
+++ b/tests/swarm/test_reconciler.py
@@ -128,8 +128,10 @@ async def test_watch_run_stops_when_completed() -> None:
     assert reconciler.tick_run.await_count == 2
 
 
-def test_should_not_stop_for_waiting_resource() -> None:
-    run = _run("active", ["waiting_resource"])
+def test_should_not_stop_for_waiting_resource_with_forward_progress() -> None:
+    """waiting_resource alone is a dead-end, but combined with a leased
+    work order the run still has forward progress."""
+    run = _run("active", ["waiting_resource", "leased"])
 
     assert SwarmReconciler._should_stop(run) is False
 
@@ -138,3 +140,32 @@ def test_should_stop_when_only_terminal_work_orders_remain() -> None:
     run = _run("active", ["completed", "merged", "blocked"])
 
     assert SwarmReconciler._should_stop(run) is True
+
+
+def test_should_stop_when_only_waiting_conflict_remains() -> None:
+    """Regression for #883: waiting_conflict with no forward-progress path
+    must cause the reconciler to stop, not poll indefinitely."""
+    run = _run("needs_human", ["completed", "waiting_conflict", "waiting_conflict", "failed"])
+
+    assert SwarmReconciler._should_stop(run) is True
+
+
+def test_should_stop_when_only_waiting_resource_remains() -> None:
+    """waiting_resource alone (no leased/dispatched/queued) is a dead-end."""
+    run = _run("needs_human", ["waiting_resource"])
+
+    assert SwarmReconciler._should_stop(run) is True
+
+
+def test_should_not_stop_when_queued_work_remains() -> None:
+    """queued work orders represent forward progress even if some are
+    waiting_conflict."""
+    run = _run("active", ["waiting_conflict", "queued"])
+
+    assert SwarmReconciler._should_stop(run) is False
+
+
+def test_should_not_stop_when_dispatched_work_remains() -> None:
+    run = _run("active", ["waiting_conflict", "dispatched"])
+
+    assert SwarmReconciler._should_stop(run) is False

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -275,7 +275,9 @@ def test_refresh_run_marks_resource_wait_on_disk_full(
     )
     run = supervisor.start_run(spec=SwarmSpec(raw_goal="Goal", refined_goal="Goal"))
 
-    assert run.status == "active"
+    # waiting_resource with no forward-progress path escalates to needs_human
+    # (fixes #883 deadlock where dead-end statuses kept the run active).
+    assert run.status == "needs_human"
     work_order = run.work_orders[0]
     assert work_order["status"] == "waiting_resource"
     assert "No space left on device" in work_order["resource_error"]

--- a/tests/swarm/test_waiting_conflict_deadlock.py
+++ b/tests/swarm/test_waiting_conflict_deadlock.py
@@ -1,0 +1,151 @@
+"""Regression tests for waiting_conflict deadlock (issue #883).
+
+Covers the bug where a Boss-loop run with only waiting_conflict-blocked
+work orders remained active until manual kill because:
+1. _derive_status treated waiting_conflict as active (not needs_human)
+2. _should_stop kept the reconciler alive for waiting_conflict
+
+Forensic evidence from the second pure live run against #873:
+- run_id: e60a6aaf-f2a
+- final statuses: completed(1), waiting_conflict(2), failed(1)
+- no forward progress possible, killed after ~28 minutes
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.reconciler import SwarmReconciler, SwarmReconcilerConfig
+from aragora.swarm.supervisor import SupervisorRun, SwarmApprovalPolicy, SwarmSupervisor
+from aragora.swarm.spec import SwarmSpec
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _run(status: str, work_order_statuses: list[str], *, run_id: str = "run-e60a") -> SupervisorRun:
+    return SupervisorRun(
+        run_id=run_id,
+        goal="Bump @eslint/eslintrc from 3.2.0 to 3.3.0 in /aragora/live",
+        target_branch="main",
+        status=status,
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy=SwarmApprovalPolicy(),
+        spec=SwarmSpec(raw_goal="bump eslintrc"),
+        work_orders=[
+            {"work_order_id": f"wo-{idx}", "status": s}
+            for idx, s in enumerate(work_order_statuses, start=1)
+        ],
+    )
+
+
+class TestDeriveStatusDeadlock:
+    """Verify _derive_status escalates dead-end runs to needs_human."""
+
+    def test_waiting_conflict_only_escalates(self) -> None:
+        work_orders = [
+            {"status": "waiting_conflict"},
+            {"status": "waiting_conflict"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "needs_human"
+
+    def test_forensic_873_shape_escalates(self) -> None:
+        """Exact statuses from the failed run: completed + 2x waiting_conflict + failed."""
+        work_orders = [
+            {"status": "completed"},
+            {"status": "waiting_conflict"},
+            {"status": "waiting_conflict"},
+            {"status": "failed"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "needs_human"
+
+    def test_waiting_resource_only_escalates(self) -> None:
+        work_orders = [{"status": "waiting_resource"}]
+        assert SwarmSupervisor._derive_status(work_orders) == "needs_human"
+
+    def test_mixed_waiting_and_terminal_escalates(self) -> None:
+        work_orders = [
+            {"status": "completed"},
+            {"status": "merged"},
+            {"status": "waiting_conflict"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "needs_human"
+
+    def test_waiting_conflict_with_queued_stays_active(self) -> None:
+        """A queued work order can still make progress — don't escalate."""
+        work_orders = [
+            {"status": "waiting_conflict"},
+            {"status": "queued"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "active"
+
+    def test_waiting_conflict_with_leased_stays_active(self) -> None:
+        work_orders = [
+            {"status": "waiting_conflict"},
+            {"status": "leased"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "active"
+
+    def test_waiting_conflict_with_dispatched_stays_active(self) -> None:
+        work_orders = [
+            {"status": "waiting_conflict"},
+            {"status": "dispatched"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "active"
+
+    def test_all_terminal_still_completed(self) -> None:
+        """Ensure terminal-only runs still resolve to completed (not needs_human)."""
+        work_orders = [
+            {"status": "completed"},
+            {"status": "merged"},
+            {"status": "failed"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "completed"
+
+    def test_needs_human_still_takes_precedence(self) -> None:
+        work_orders = [
+            {"status": "needs_human"},
+            {"status": "waiting_conflict"},
+        ]
+        assert SwarmSupervisor._derive_status(work_orders) == "needs_human"
+
+
+class TestReconcilerStopForensic873:
+    """Verify the reconciler stops for the exact #873 failure shape."""
+
+    def test_reconciler_stops_on_forensic_shape(self) -> None:
+        run = _run("needs_human", ["completed", "waiting_conflict", "waiting_conflict", "failed"])
+        assert SwarmReconciler._should_stop(run) is True
+
+    @pytest.mark.asyncio
+    async def test_watch_run_terminates_on_deadlock(self) -> None:
+        """watch_run must terminate (not poll forever) when only
+        waiting_conflict work orders remain."""
+        # First tick: still active with a leased worker
+        active = _run("active", ["leased", "waiting_conflict"])
+        # Second tick: leased worker completed, only waiting_conflict left
+        deadlocked = _run(
+            "needs_human", ["completed", "waiting_conflict", "waiting_conflict", "failed"]
+        )
+
+        reconciler = SwarmReconciler(supervisor=MagicMock())
+        reconciler.tick_run = AsyncMock(side_effect=[active, deadlocked])
+
+        result = await reconciler.watch_run("run-e60a", interval_seconds=0.01, max_ticks=10)
+
+        assert result.status == "needs_human"
+        # Must have stopped after 2 ticks, not hit max_ticks=10
+        assert reconciler.tick_run.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_watch_run_continues_with_forward_progress(self) -> None:
+        """Ensure watch_run still polls when real forward progress exists."""
+        tick1 = _run("active", ["leased", "waiting_conflict"])
+        tick2 = _run("active", ["dispatched", "waiting_conflict"])
+        tick3 = _run("completed", ["completed", "completed"])
+
+        reconciler = SwarmReconciler(supervisor=MagicMock())
+        reconciler.tick_run = AsyncMock(side_effect=[tick1, tick2, tick3])
+
+        result = await reconciler.watch_run("run-e60a", interval_seconds=0.01, max_ticks=10)
+
+        assert result.status == "completed"
+        assert reconciler.tick_run.await_count == 3


### PR DESCRIPTION
Fixes #883

## Summary

- **`_derive_status`** now detects dead-end runs where the only non-terminal statuses are `waiting_conflict` or `waiting_resource` with no forward-progress path (`queued`/`leased`/`dispatched`), and escalates to `needs_human` instead of staying `active` forever
- **`_should_stop`** in the reconciler only considers `queued`/`leased`/`dispatched` as forward-progress statuses — `waiting_conflict` and `waiting_resource` alone no longer keep the reconciler polling

## Root Cause

In the second live Boss-loop test (run `e60a6aaf`), work order statuses ended as `completed(1), waiting_conflict(2), failed(1)`. No forward progress was possible, but:
1. `_derive_status` fell through to `return "active"` because `waiting_conflict` wasn't in terminal or needs_human checks
2. `_should_stop` returned `False` because `waiting_conflict` was in `active_statuses`

The reconciler polled for 28 minutes until manual kill.

## Test plan

- [x] 12 new regression tests in `test_waiting_conflict_deadlock.py`:
  - `_derive_status` escalates for waiting_conflict-only, forensic #873 shape, waiting_resource-only, mixed waiting+terminal
  - `_derive_status` stays active when queued/leased/dispatched remain
  - Reconciler stops on forensic shape, terminates watch_run on deadlock, continues with forward progress
- [x] Updated `test_reconciler.py`: 5 new stop-condition tests, 1 updated for new behavior
- [x] Updated `test_supervisor.py`: resource-wait test expects `needs_human` (correct escalation)
- [x] All 95 tests pass across `test_reconciler.py`, `test_supervisor.py`, `test_commander.py`, `test_swarm_command.py`, `test_waiting_conflict_deadlock.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)