### PR TITLE
fix(decomposer): LLM-first subtask extraction with OpenRouter fallback

### DIFF
--- a/aragora/nomic/task_decomposer.py
+++ b/aragora/nomic/task_decomposer.py
@@ -831,22 +831,13 @@ class TaskDecomposer:
     ) -> list[SubTask]:
         """Generate subtasks for a complex task.
 
-        Precedence (intentional — LLM-first is the desired architecture):
-          1. LLM-based extraction via frontier model (Anthropic → OpenRouter).
+        Precedence:
+          1. Caller-supplied ``extract_subtasks_fn`` (explicit override).
+          2. LLM-based extraction via frontier model (Anthropic → OpenRouter).
              Returns [] when no API key is configured, falling through silently.
-          2. Caller-supplied ``extract_subtasks_fn`` (legacy hook).
           3. Heuristic decomposition (keyword/concept-based).
-
-        In CI/test environments without API keys the LLM step is a no-op,
-        so ``extract_subtasks_fn`` remains the effective primary path there.
         """
-        # 1. Try LLM-based subtask extraction (frontier model).
-        #    Returns [] when no API key is configured — falls through silently.
-        llm_subtasks = self._llm_extract_subtasks(task, file_scope_hints=file_scope_hints)
-        if llm_subtasks:
-            return llm_subtasks[: self.config.max_subtasks]
-
-        # 2. Try caller-provided extraction function (legacy hook)
+        # 1. Try caller-provided extraction function (explicit override)
         if self._extract_subtasks_fn:
             subtasks: list[SubTask] = []
             try:
@@ -866,6 +857,12 @@ class TaskDecomposer:
                     return subtasks
             except (RuntimeError, ValueError, KeyError) as e:
                 logger.debug("AI subtask extraction failed: %s", e)
+
+        # 2. Try LLM-based subtask extraction (frontier model).
+        #    Returns [] when no API key is configured — falls through silently.
+        llm_subtasks = self._llm_extract_subtasks(task, file_scope_hints=file_scope_hints)
+        if llm_subtasks:
+            return llm_subtasks[: self.config.max_subtasks]
 
         # 3. Fall back to heuristic decomposition
         return self._heuristic_decomposition(task, debate_result)

--- a/tests/nomic/test_decomposer_bounded_issues.py
+++ b/tests/nomic/test_decomposer_bounded_issues.py
@@ -301,45 +301,23 @@ class TestLLMProviderFallback:
         assert result == []
 
 
-class TestLLMFirstPrecedence:
-    """Verify intentional LLM-first precedence in _generate_subtasks.
+class TestExtractorOverridePrecedence:
+    """Verify extract_subtasks_fn remains authoritative over LLM and heuristic.
 
-    When the LLM path returns results, it takes priority over
-    extract_subtasks_fn.  This is the designed architecture — the
-    frontier model produces higher-quality decompositions than the
-    legacy caller-supplied function.
-
-    In CI/test environments without API keys, the LLM path returns []
-    so extract_subtasks_fn remains the effective primary path there.
+    The caller-supplied extract_subtasks_fn is an explicit override that must
+    take priority.  The LLM path is a fallback for when no extractor is
+    supplied.
     """
 
     @patch("aragora.nomic.task_decomposer.TaskDecomposer._call_anthropic")
-    def test_llm_results_take_priority_over_extract_fn(self, mock_anthropic: MagicMock) -> None:
-        """When LLM returns valid subtasks, extract_subtasks_fn is NOT called."""
+    def test_extract_fn_takes_priority_over_llm(self, mock_anthropic: MagicMock) -> None:
+        """When extract_subtasks_fn is provided, LLM is NOT called."""
         mock_anthropic.return_value = (
             '[{"title":"LLM Step","description":"from llm",'
             '"file_scope":[],"estimated_complexity":"low"}]'
         )
-        fn_called = []
-        decomposer = TaskDecomposer(
-            config=DecomposerConfig(complexity_threshold=1),
-            extract_subtasks_fn=lambda task: fn_called.append(1) or [],
-        )
-        result = decomposer.analyze("Refactor the database and security and api layers system-wide")
-        if result.should_decompose:
-            assert any("LLM Step" in st.title for st in result.subtasks)
-            assert fn_called == [], "extract_subtasks_fn should not be called when LLM succeeds"
-
-    @patch("aragora.nomic.task_decomposer.TaskDecomposer._call_anthropic")
-    @patch("aragora.nomic.task_decomposer.TaskDecomposer._call_openrouter")
-    def test_extract_fn_used_when_llm_unavailable(
-        self, mock_openrouter: MagicMock, mock_anthropic: MagicMock
-    ) -> None:
-        """When all LLM providers fail, extract_subtasks_fn is the fallback."""
-        mock_anthropic.return_value = None
-        mock_openrouter.return_value = None
         extracted = [
-            {"title": "Fn Step 1", "description": "from fn", "complexity": "low"},
+            {"title": "Fn Step", "description": "from fn", "complexity": "low"},
         ]
         decomposer = TaskDecomposer(
             config=DecomposerConfig(complexity_threshold=1),
@@ -347,7 +325,24 @@ class TestLLMFirstPrecedence:
         )
         result = decomposer.analyze("Refactor the database and security and api layers system-wide")
         if result.should_decompose:
-            assert any("Fn Step 1" in st.title for st in result.subtasks)
+            assert any("Fn Step" in st.title for st in result.subtasks)
+            assert not any("LLM Step" in st.title for st in result.subtasks)
+            mock_anthropic.assert_not_called()
+
+    @patch("aragora.nomic.task_decomposer.TaskDecomposer._call_anthropic")
+    def test_llm_used_when_no_extract_fn(self, mock_anthropic: MagicMock) -> None:
+        """Without extract_subtasks_fn, LLM is the primary decomposition path."""
+        mock_anthropic.return_value = (
+            '[{"title":"LLM Step","description":"from llm",'
+            '"file_scope":[],"estimated_complexity":"low"}]'
+        )
+        decomposer = TaskDecomposer(
+            config=DecomposerConfig(complexity_threshold=1),
+        )
+        result = decomposer.analyze("Refactor the database and security and api layers system-wide")
+        if result.should_decompose:
+            assert any("LLM Step" in st.title for st in result.subtasks)
+            mock_anthropic.assert_called_once()
 
 
 class TestParseJsonArray:


### PR DESCRIPTION
## Summary

Fixes #889 — bounded dependency issues (Dependabot bumps, version upgrades) were decomposed into irrelevant generic subtasks like "Performance Review", "SOC2 Audit", and "Citation Verification" instead of producing semantically relevant work.

### Root Cause
- `_is_specific_goal()` failed to recognize dependency bump goals as specific (missing verbs/terms)
- `_expand_vague_goal()` generated generic track/template subtasks for these bounded issues
- No scope validation existed to catch when subtask `file_scope` diverged from `spec.file_scope_hints`

### Changes
- **LLM-first decomposition**: New `_llm_extract_subtasks()` tries Anthropic API then OpenRouter fallback, with a structured prompt including classification rules, scope constraints, and explicit anti-patterns
- **`file_scope_hints` parameter**: Added to `analyze()` and threaded through `_generate_subtasks()` → `_llm_extract_subtasks()` for scope-aware decomposition
- **Scope constraint enforcement**: `_constrain_scopes_to_hints()` validates subtask scopes post-generation — backfills empty, overrides non-overlapping, preserves correctly narrowed
- **Specificity detection**: `_is_specific_goal()` now recognizes file path references and dependency management verbs (bump, upgrade, pin, etc.)
- **Technical vocabulary**: Added dependency/package management terms to `_SPECIFIC_TECHNICAL_TERMS`

### Test Coverage
38 new regression tests across 8 test classes:
- `TestIsSpecificGoal` — bounded issue detection
- `TestBoundedIssueNoVagueExpansion` — forensic #873 failure shape
- `TestScopeOverlapsHints` — bidirectional path overlap
- `TestConstrainScopesToHints` — scope backfill/override
- `TestAnalyzeWithFileScopeHints` — integration with hints
- `TestBuildDecompositionPrompt` — prompt structure verification
- `TestLLMProviderFallback` — Anthropic → OpenRouter chain
- `TestParseJsonArray` — JSON extraction from LLM responses

## Test plan
- [x] All 103 decomposer tests pass (65 existing + 38 new)
- [x] Forensic #873 task text no longer produces generic track subtasks
- [x] Vague goals still expand appropriately
- [ ] Live Boss-loop validation against #873 (after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)