### PR TITLE
fix(swarm): stage unstaged worker diffs before exit-141 salvage commit

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -229,7 +229,15 @@ class WorkerLauncher:
             worker.diff = await self._collect_diff(worker.worktree_path)
 
             _exit_ok = worker.exit_code == 0 or worker.exit_code in _SALVAGEABLE_EXIT_CODES
-            if self.config.auto_commit and worker.diff and _exit_ok:
+            # For salvageable non-zero exits (e.g. SIGPIPE 141), the worker
+            # may have valid unstaged changes that ``git diff HEAD`` missed
+            # (timeout, binary-only files, etc.).  Fall back to
+            # ``git status --porcelain`` so the salvage commit is not skipped.
+            _has_changes = bool(worker.diff) or (
+                worker.exit_code in _SALVAGEABLE_EXIT_CODES
+                and await self._has_working_tree_changes(worker.worktree_path)
+            )
+            if self.config.auto_commit and _has_changes and _exit_ok:
                 await self._auto_commit(worker)
 
             worker.head_sha = await self._git_output(worker.worktree_path, "rev-parse", "HEAD")
@@ -496,6 +504,24 @@ class WorkerLauncher:
             return ""
 
     @classmethod
+    async def _has_working_tree_changes(cls, worktree_path: str) -> bool:
+        """Check for real (non-artifact) working-tree changes via git status.
+
+        This is a robust fallback for ``_collect_diff`` which relies on
+        ``git diff HEAD`` — that command can return empty on timeout, error,
+        or when only binary files changed.  ``git status --porcelain`` is
+        cheaper and more reliable for a yes/no dirty-tree check.
+        """
+        status = await cls._git_output(worktree_path, "status", "--porcelain")
+        for line in status.splitlines():
+            if len(line) < 4:
+                continue
+            path = line[3:].strip()
+            if path and path not in SESSION_ARTIFACTS:
+                return True
+        return False
+
+    @classmethod
     async def _collect_diff(cls, worktree_path: str) -> str:
         return await cls._git_output(worktree_path, "diff", "HEAD")
 
@@ -585,7 +611,15 @@ class WorkerLauncher:
             worker.diff = await cls._collect_diff(worktree_path)
 
             _exit_ok = worker.exit_code == 0 or worker.exit_code in _SALVAGEABLE_EXIT_CODES
-            if auto_commit and worker.diff and _exit_ok:
+            # For salvageable non-zero exits (e.g. SIGPIPE 141), the worker
+            # may have valid unstaged changes that ``git diff HEAD`` missed
+            # (timeout, binary-only files, etc.).  Fall back to
+            # ``git status --porcelain`` so the salvage commit is not skipped.
+            _has_changes = bool(worker.diff) or (
+                worker.exit_code in _SALVAGEABLE_EXIT_CODES
+                and await cls._has_working_tree_changes(worktree_path)
+            )
+            if auto_commit and _has_changes and _exit_ok:
                 await cls._auto_commit(worker)
 
             worker.head_sha = await cls._git_output(worktree_path, "rev-parse", "HEAD")
@@ -685,7 +719,15 @@ class WorkerLauncher:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(add_proc.communicate(), timeout=10)
+            _, add_stderr = await asyncio.wait_for(add_proc.communicate(), timeout=10)
+            if add_proc.returncode != 0:
+                logger.warning(
+                    "git add -A failed for %s (rc=%s): %s",
+                    worker.work_order_id,
+                    add_proc.returncode,
+                    (add_stderr or b"").decode(errors="replace").strip(),
+                )
+                return
 
             # Unstage session artifacts — ignore errors if files are not staged
             for artifact in SESSION_ARTIFACTS:
@@ -701,6 +743,25 @@ class WorkerLauncher:
                 )
                 await asyncio.wait_for(reset_proc.communicate(), timeout=5)
 
+            # Verify something is actually staged before committing
+            diff_index_proc = await asyncio.create_subprocess_exec(
+                "git",
+                "diff",
+                "--cached",
+                "--quiet",
+                cwd=worker.worktree_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await asyncio.wait_for(diff_index_proc.communicate(), timeout=5)
+            if diff_index_proc.returncode == 0:
+                # returncode 0 means no staged changes — nothing to commit
+                logger.info(
+                    "No staged changes for %s after git add — skipping commit",
+                    worker.work_order_id,
+                )
+                return
+
             if worker.exit_code is not None and worker.exit_code != 0:
                 msg = (
                     f"fix(swarm): salvage {worker.agent} work for "
@@ -713,11 +774,17 @@ class WorkerLauncher:
                 "commit",
                 "-m",
                 msg,
-                "--allow-empty",
                 cwd=worker.worktree_path,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
-            await asyncio.wait_for(commit_proc.communicate(), timeout=10)
+            _, commit_stderr = await asyncio.wait_for(commit_proc.communicate(), timeout=10)
+            if commit_proc.returncode != 0:
+                logger.warning(
+                    "git commit failed for %s (rc=%s): %s",
+                    worker.work_order_id,
+                    commit_proc.returncode,
+                    (commit_stderr or b"").decode(errors="replace").strip(),
+                )
         except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
             logger.warning("Auto-commit failed for %s: %s", worker.work_order_id, exc)

--- a/tests/swarm/test_exit141_salvage.py
+++ b/tests/swarm/test_exit141_salvage.py
@@ -1,0 +1,345 @@
+"""Regression tests for exit-141 salvage staging (#901).
+
+Covers the bug where a worker exits with SIGPIPE (141) leaving valid but
+unstaged changes in the worktree.  The salvage path must stage those
+changes and produce a concrete commit-backed deliverable.
+
+The fix adds a ``_has_working_tree_changes`` fallback so the salvage
+condition is satisfied even when ``git diff HEAD`` returns empty (timeout,
+error, binary-only files).  ``_auto_commit`` now also verifies return
+codes and checks for staged changes before committing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.swarm.worker_launcher import (
+    _SALVAGEABLE_EXIT_CODES,
+    LaunchConfig,
+    WorkerLauncher,
+    WorkerProcess,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _head(repo: Path) -> str:
+    return _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """Minimal git repo with one initial commit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", "initial")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Core: salvageable 141 with unstaged work -> concrete deliverable
+# ---------------------------------------------------------------------------
+
+
+class TestSalvageableExit141WithUnstagedWork:
+    """Exit 141 with valid unstaged changes must produce a commit."""
+
+    @pytest.mark.asyncio
+    async def test_wait_path_stages_and_commits(self, repo: Path) -> None:
+        """The wait() path must stage unstaged changes for exit 141."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+        # Changes are in the working tree but NOT staged
+        assert "README.md" in _run(repo, "git", "status", "--porcelain").stdout
+
+        launcher = WorkerLauncher(config=LaunchConfig())
+        worker = WorkerProcess(
+            work_order_id="wo-141",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=141,
+            initial_head=initial_head,
+        )
+        launcher._workers["wo-141"] = worker
+
+        # Simulate process already completed — skip real subprocess
+        with patch.object(launcher, "_processes", {"wo-141": _FakeFinishedProc(141)}):
+            result = await launcher.wait("wo-141")
+
+        assert result.exit_code == 141
+        assert result.commit_shas, "Expected at least one salvage commit"
+        assert result.head_sha != initial_head
+        assert _head(repo) != initial_head, "HEAD must advance after salvage commit"
+
+    @pytest.mark.asyncio
+    async def test_detached_path_stages_and_commits(self, repo: Path) -> None:
+        """collect_detached_result must stage unstaged changes for exit 141."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+        assert "README.md" in _run(repo, "git", "status", "--porcelain").stdout
+
+        # Simulate session meta indicating exit 141
+        import json
+
+        meta = {
+            "pid": 99999,
+            "session_id": "test",
+            "agent": "codex",
+            "started_at": "2026-03-10T05:00:00Z",
+            "ended_at": "2026-03-10T05:01:00Z",
+            "exit_code": 141,
+        }
+        (repo / ".codex_session_meta.json").write_text(json.dumps(meta) + "\n", encoding="utf-8")
+
+        result = await WorkerLauncher.collect_detached_result(
+            work_order_id="wo-141",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            pid=None,
+            initial_head=initial_head,
+            auto_commit=True,
+        )
+
+        assert result is not None
+        assert result.exit_code == 141
+        assert result.commit_shas, "Expected at least one salvage commit"
+        assert result.head_sha != initial_head
+
+    @pytest.mark.asyncio
+    async def test_salvage_when_diff_returns_empty(self, repo: Path) -> None:
+        """Salvage must work even when _collect_diff returns empty (fallback)."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+
+        launcher = WorkerLauncher(config=LaunchConfig())
+        worker = WorkerProcess(
+            work_order_id="wo-141-nodiff",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=141,
+            initial_head=initial_head,
+        )
+        launcher._workers["wo-141-nodiff"] = worker
+
+        # Force _collect_diff to return empty, simulating timeout/error
+        with (
+            patch.object(launcher, "_processes", {"wo-141-nodiff": _FakeFinishedProc(141)}),
+            patch.object(WorkerLauncher, "_collect_diff", new_callable=AsyncMock, return_value=""),
+        ):
+            result = await launcher.wait("wo-141-nodiff")
+
+        assert result.commit_shas, "Fallback should still produce a salvage commit"
+        assert _head(repo) != initial_head
+
+
+# ---------------------------------------------------------------------------
+# Guard: non-salvageable non-zero exit -> no deliverable
+# ---------------------------------------------------------------------------
+
+
+class TestNonSalvageableExitNoDeliverable:
+    """Non-salvageable non-zero exits must NOT produce commits."""
+
+    @pytest.mark.asyncio
+    async def test_exit_1_no_commit(self, repo: Path) -> None:
+        """Exit code 1 is not salvageable — changes must stay uncommitted."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("bad work\n", encoding="utf-8")
+
+        launcher = WorkerLauncher(config=LaunchConfig())
+        worker = WorkerProcess(
+            work_order_id="wo-fail",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=1,
+            initial_head=initial_head,
+        )
+        launcher._workers["wo-fail"] = worker
+
+        with patch.object(launcher, "_processes", {"wo-fail": _FakeFinishedProc(1)}):
+            result = await launcher.wait("wo-fail")
+
+        assert result.exit_code == 1
+        assert not result.commit_shas, "Non-salvageable exit must not produce commits"
+        assert _head(repo) == initial_head
+
+    @pytest.mark.asyncio
+    async def test_exit_2_detached_no_commit(self, repo: Path) -> None:
+        """Exit code 2 via detached path must not produce commits."""
+        import json
+
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("bad work\n", encoding="utf-8")
+
+        meta = {
+            "pid": 99999,
+            "ended_at": "2026-03-10T05:01:00Z",
+            "exit_code": 2,
+        }
+        (repo / ".codex_session_meta.json").write_text(json.dumps(meta) + "\n", encoding="utf-8")
+
+        result = await WorkerLauncher.collect_detached_result(
+            work_order_id="wo-fail-detached",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            pid=None,
+            initial_head=initial_head,
+            auto_commit=True,
+        )
+
+        assert result is not None
+        assert result.exit_code == 2
+        assert not result.commit_shas
+        assert _head(repo) == initial_head
+
+
+# ---------------------------------------------------------------------------
+# Guard: dirty worktree only does not count unless salvage produces deliverable
+# ---------------------------------------------------------------------------
+
+
+class TestDirtyWorktreeRequiresSalvageDeliverable:
+    """Dirty worktree alone is not a deliverable — salvage must create a commit."""
+
+    @pytest.mark.asyncio
+    async def test_dirty_tree_exit_0_produces_commit(self, repo: Path) -> None:
+        """Clean exit with dirty tree should auto-commit (normal path)."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("clean exit work\n", encoding="utf-8")
+
+        launcher = WorkerLauncher(config=LaunchConfig())
+        worker = WorkerProcess(
+            work_order_id="wo-clean",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            initial_head=initial_head,
+        )
+        launcher._workers["wo-clean"] = worker
+
+        with patch.object(launcher, "_processes", {"wo-clean": _FakeFinishedProc(0)}):
+            result = await launcher.wait("wo-clean")
+
+        assert result.commit_shas, "Exit 0 with dirty tree should produce commit"
+
+    @pytest.mark.asyncio
+    async def test_dirty_tree_no_auto_commit_flag(self, repo: Path) -> None:
+        """With auto_commit=False, dirty tree produces no commit (no deliverable)."""
+        initial_head = _head(repo)
+        (repo / "README.md").write_text("work\n", encoding="utf-8")
+
+        launcher = WorkerLauncher(config=LaunchConfig(auto_commit=False))
+        worker = WorkerProcess(
+            work_order_id="wo-noac",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            initial_head=initial_head,
+        )
+        launcher._workers["wo-noac"] = worker
+
+        with patch.object(launcher, "_processes", {"wo-noac": _FakeFinishedProc(0)}):
+            result = await launcher.wait("wo-noac")
+
+        assert not result.commit_shas, "auto_commit=False must not create commits"
+        assert _head(repo) == initial_head
+
+
+# ---------------------------------------------------------------------------
+# Unit: _has_working_tree_changes
+# ---------------------------------------------------------------------------
+
+
+class TestHasWorkingTreeChanges:
+    """Unit tests for the fallback dirty-tree detector."""
+
+    @pytest.mark.asyncio
+    async def test_clean_repo(self, repo: Path) -> None:
+        assert not await WorkerLauncher._has_working_tree_changes(str(repo))
+
+    @pytest.mark.asyncio
+    async def test_modified_file(self, repo: Path) -> None:
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+        assert await WorkerLauncher._has_working_tree_changes(str(repo))
+
+    @pytest.mark.asyncio
+    async def test_only_session_artifacts(self, repo: Path) -> None:
+        """Session artifacts alone should not count as real changes."""
+        (repo / ".codex_session_meta.json").write_text("{}\n", encoding="utf-8")
+        (repo / ".codex_session.log").write_text("log\n", encoding="utf-8")
+        (repo / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        assert not await WorkerLauncher._has_working_tree_changes(str(repo))
+
+    @pytest.mark.asyncio
+    async def test_real_changes_plus_artifacts(self, repo: Path) -> None:
+        """Real changes should be detected even when artifacts are present."""
+        (repo / ".codex_session_meta.json").write_text("{}\n", encoding="utf-8")
+        (repo / "README.md").write_text("changed\n", encoding="utf-8")
+        assert await WorkerLauncher._has_working_tree_changes(str(repo))
+
+
+# ---------------------------------------------------------------------------
+# Unit: _SALVAGEABLE_EXIT_CODES
+# ---------------------------------------------------------------------------
+
+
+class TestSalvageableExitCodes:
+    """Verify the set of salvageable exit codes."""
+
+    def test_141_is_salvageable(self) -> None:
+        assert 141 in _SALVAGEABLE_EXIT_CODES
+
+    def test_0_is_not_salvageable(self) -> None:
+        assert 0 not in _SALVAGEABLE_EXIT_CODES
+
+    def test_1_is_not_salvageable(self) -> None:
+        assert 1 not in _SALVAGEABLE_EXIT_CODES
+
+    def test_minus1_is_not_salvageable(self) -> None:
+        assert -1 not in _SALVAGEABLE_EXIT_CODES
+
+
+# ---------------------------------------------------------------------------
+# Fake process for wait() tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeFinishedProc:
+    """Minimal asyncio.subprocess.Process stand-in that is already finished."""
+
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+        self.pid = 99999
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+    async def wait(self) -> int:
+        return self.returncode
+
+    def kill(self) -> None:
+        pass

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -55,6 +55,10 @@ def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
 
 
+def _head(repo: Path) -> str:
+    return _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+
 # ---------------------------------------------------------------------------
 # SESSION_ARTIFACTS constant
 # ---------------------------------------------------------------------------
@@ -359,8 +363,9 @@ class TestAutoCommitSessionArtifactPrevention:
         assert "work.txt" in committed_files
         assert ".codex_session.log" not in committed_files
 
-    def test_auto_commit_only_artifacts_produces_empty_commit(self, repo: Path) -> None:
-        """If only session artifacts exist, auto-commit produces an allow-empty commit."""
+    def test_auto_commit_only_artifacts_skips_commit(self, repo: Path) -> None:
+        """If only session artifacts exist, auto-commit skips (no commit created)."""
+        initial_head = _head(repo)
         (repo / ".codex_session_meta.json").write_text('{"pid": 2}', encoding="utf-8")
 
         worker = WorkerProcess(
@@ -372,10 +377,8 @@ class TestAutoCommitSessionArtifactPrevention:
 
         asyncio.run(WorkerLauncher._auto_commit(worker))
 
-        # The commit should have no file changes (empty commit via --allow-empty)
-        result = _run(repo, "git", "diff", "--name-only", "HEAD~1", "HEAD")
-        committed_files = [f for f in result.stdout.strip().splitlines() if f]
-        assert len(committed_files) == 0
+        # HEAD should not advance — no real changes to commit
+        assert _head(repo) == initial_head
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #901.

- The salvage path for SIGPIPE (exit 141) workers was gated on `git diff HEAD` returning non-empty output. When that command timed out or returned empty (binary-only changes, large diffs), `_auto_commit` was never called and valid worker output remained uncommitted — observed in live boss-loop run `boss-86f745f2c851`.
- Adds `_has_working_tree_changes()` fallback using `git status --porcelain` to detect dirty-tree state for salvageable exit codes, ensuring the salvage commit is not skipped when `git diff HEAD` fails.
- Hardens `_auto_commit` with return-code checking on `git add` and `git commit`, a `git diff --cached --quiet` pre-commit gate (replacing `--allow-empty` which could create empty commits), and structured warning logs on failure.

## Changes

| File | Change |
|------|--------|
| `aragora/swarm/worker_launcher.py` | Add `_has_working_tree_changes()`, modify salvage condition in `wait()` and `collect_detached_result()`, harden `_auto_commit` |
| `tests/swarm/test_exit141_salvage.py` | 15 focused regression tests: exit-141 salvage with unstaged work, diff-empty fallback, non-salvageable guards, dirty-tree semantics, `_has_working_tree_changes` unit tests |
| `tests/swarm/test_session_artifact_prevention.py` | Update `test_auto_commit_only_artifacts_*` to match new behavior (skip commit instead of empty commit) |

## Test plan

- [x] `pytest tests/swarm/test_exit141_salvage.py` — 15/15 pass
- [x] `pytest tests/swarm/test_boss_loop.py tests/swarm/test_supervisor.py tests/swarm/test_session_artifact_prevention.py tests/swarm/test_exit141_salvage.py` — 93/93 pass
- [x] `pytest tests/swarm/test_timeout_cleanup.py tests/swarm/test_session_artifact_cleanup_guaranteed.py` — 16/16 pass
- [x] Pre-commit hooks pass (ruff lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)