### PR TITLE
fix(swarm): eliminate shell-trap race that recreates session artifacts

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -634,6 +634,20 @@ class WorkerLauncher:
                 head_sha=worker.head_sha,
             )
         finally:
+            # Wait for the worker process (including its shell EXIT trap) to
+            # fully terminate before removing artifacts.  Without this wait
+            # the codex_session.sh trap can recreate .codex_session_meta.json
+            # and append to .codex_session.log after Python-side cleanup (#902).
+            _cleanup_pid = pid
+            if _cleanup_pid is None:
+                raw_pid = session_meta.get("pid")
+                if raw_pid is not None:
+                    try:
+                        _cleanup_pid = int(raw_pid)
+                    except (TypeError, ValueError):
+                        pass
+            if _cleanup_pid is not None:
+                await cls._wait_for_pid_exit(_cleanup_pid)
             cls._cleanup_session_artifacts(worktree_path)
 
         logger.info(
@@ -695,6 +709,22 @@ class WorkerLauncher:
             return False
         except OSError:
             return False
+
+    @classmethod
+    async def _wait_for_pid_exit(cls, pid: int, timeout: float = 5.0) -> None:
+        """Wait for a process to fully terminate, including trap handlers.
+
+        The shell wrapper ``codex_session.sh`` uses an EXIT trap that rewrites
+        session artifacts.  After sending SIGTERM the trap handler may still be
+        running when Python-side cleanup fires.  Polling until the PID is gone
+        ensures the trap has completed before we delete those files.
+        """
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            if not cls._is_pid_running(pid):
+                return
+            await asyncio.sleep(0.1)
+        logger.debug("PID %d still alive after %.1fs wait — proceeding with cleanup", pid, timeout)
 
     @staticmethod
     def _read_log_file(worktree_path: str, stream: str) -> str:

--- a/tests/swarm/test_shell_trap_artifact_race.py
+++ b/tests/swarm/test_shell_trap_artifact_race.py
@@ -1,0 +1,310 @@
+"""Regression tests for shell-trap session artifact recreation race (#902).
+
+Covers the bug where the ``codex_session.sh`` EXIT trap handler rewrites
+``.codex_session_meta.json`` and appends to ``.codex_session.log`` after
+Python-side ``_cleanup_session_artifacts`` has already deleted them.
+
+The fix adds ``_wait_for_pid_exit`` in ``collect_detached_result``'s
+finally block, ensuring the shell process (and its trap) has fully
+terminated before artifact deletion.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.swarm.worker_launcher import (
+    SESSION_ARTIFACTS,
+    WorkerLauncher,
+    WorkerProcess,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _head(repo: Path) -> str:
+    return _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+
+def _create_session_artifacts(
+    repo: Path,
+    *,
+    pid: int = 99999,
+    ended_at: str = "2026-03-10T05:01:00Z",
+    exit_code: int = 0,
+) -> None:
+    """Plant session artifacts simulating a terminated worker."""
+    meta: dict[str, Any] = {
+        "pid": pid,
+        "session_id": "test-race",
+        "agent": "codex",
+        "started_at": "2026-03-10T05:00:00Z",
+        "ended_at": ended_at,
+        "exit_code": exit_code,
+    }
+    (repo / ".codex_session_meta.json").write_text(json.dumps(meta) + "\n", encoding="utf-8")
+    (repo / ".codex_session.log").write_text("log data\n", encoding="utf-8")
+    (repo / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", "initial")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Core: artifacts cleaned after detached result collection
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactsCleanedAfterDetachedCollection:
+    """After collect_detached_result, all session artifacts must be gone."""
+
+    @pytest.mark.asyncio
+    async def test_meta_and_log_cleaned(self, repo: Path) -> None:
+        """Both .codex_session_meta.json and .codex_session.log must be removed."""
+        _create_session_artifacts(repo)
+        assert (repo / ".codex_session_meta.json").exists()
+        assert (repo / ".codex_session.log").exists()
+
+        result = await WorkerLauncher.collect_detached_result(
+            work_order_id="wo-race",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            pid=None,
+            initial_head=_head(repo),
+            auto_commit=True,
+        )
+
+        assert result is not None
+        assert not (repo / ".codex_session_meta.json").exists()
+        assert not (repo / ".codex_session.log").exists()
+        assert not (repo / ".codex_session_active").exists()
+
+    @pytest.mark.asyncio
+    async def test_real_changes_preserved(self, repo: Path) -> None:
+        """Real worktree changes must survive artifact cleanup."""
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+        _run(repo, "git", "add", "README.md")
+        _run(repo, "git", "commit", "-m", "worker change")
+        new_head = _head(repo)
+
+        _create_session_artifacts(repo)
+        initial_head = _run(repo, "git", "rev-parse", "HEAD~1").stdout.strip()
+
+        result = await WorkerLauncher.collect_detached_result(
+            work_order_id="wo-preserve",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            pid=None,
+            initial_head=initial_head,
+            auto_commit=True,
+        )
+
+        assert result is not None
+        assert result.commit_shas == [new_head]
+        assert "README.md" in result.changed_paths
+        # Artifacts cleaned, real content intact
+        assert not (repo / ".codex_session_meta.json").exists()
+        assert (repo / "README.md").read_text(encoding="utf-8") == "updated\n"
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_pid_exit
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForPidExit:
+    """Unit tests for _wait_for_pid_exit."""
+
+    @pytest.mark.asyncio
+    async def test_returns_immediately_for_dead_pid(self) -> None:
+        """Should return instantly when PID does not exist."""
+        # PID 2**30 is extremely unlikely to exist
+        await WorkerLauncher._wait_for_pid_exit(2**30, timeout=1.0)
+
+    @pytest.mark.asyncio
+    async def test_waits_for_process_to_exit(self) -> None:
+        """Should wait until a running process terminates."""
+        # Spawn a short-lived subprocess
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(0.3)",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        pid = proc.pid
+        assert pid is not None
+
+        # Process should still be running
+        assert WorkerLauncher._is_pid_running(pid)
+
+        # Wait should block until it exits
+        await WorkerLauncher._wait_for_pid_exit(pid, timeout=5.0)
+
+        # After wait returns, process should be gone
+        # (need to reap the zombie first)
+        await proc.wait()
+        assert not WorkerLauncher._is_pid_running(pid)
+
+    @pytest.mark.asyncio
+    async def test_timeout_does_not_raise(self) -> None:
+        """Should not raise even if timeout expires (graceful degradation)."""
+        # Spawn a long-lived process
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(30)",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            # Very short timeout — should return without error
+            await WorkerLauncher._wait_for_pid_exit(proc.pid, timeout=0.2)
+        finally:
+            proc.kill()
+            await proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Race simulation: shell trap recreates artifacts after cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestShellTrapRaceEliminated:
+    """Simulate the race where a trap handler rewrites artifacts after cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_wait_prevents_recreation(self, repo: Path) -> None:
+        """When PID wait completes before cleanup, artifacts stay deleted.
+
+        Simulates the race by spawning a subprocess that recreates
+        artifacts after a delay, then verifying that _wait_for_pid_exit
+        blocks until the subprocess is done.
+        """
+        _create_session_artifacts(repo)
+
+        # Spawn a helper that simulates the shell trap: sleeps briefly,
+        # then rewrites session meta.  This mimics codex_session.sh's
+        # EXIT trap running concurrently with Python cleanup.
+        trap_script = textwrap.dedent(f"""\
+            import json, time
+            from pathlib import Path
+            time.sleep(0.3)
+            meta = {{"pid": 0, "ended_at": "2026-03-10T05:01:00Z", "exit_code": 0}}
+            Path("{repo / ".codex_session_meta.json"}").write_text(
+                json.dumps(meta) + "\\n", encoding="utf-8"
+            )
+        """)
+        trap_proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            trap_script,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+
+        # Wait for the trap simulator to finish, then clean up
+        await WorkerLauncher._wait_for_pid_exit(trap_proc.pid, timeout=5.0)
+        await trap_proc.wait()
+
+        # The trap has rewritten the meta file
+        assert (repo / ".codex_session_meta.json").exists()
+
+        # NOW clean up — since the trap is done, files stay deleted
+        WorkerLauncher._cleanup_session_artifacts(str(repo))
+
+        assert not (repo / ".codex_session_meta.json").exists()
+        assert not (repo / ".codex_session.log").exists()
+        assert not (repo / ".codex_session_active").exists()
+
+    @pytest.mark.asyncio
+    async def test_collect_detached_uses_meta_pid(self, repo: Path) -> None:
+        """collect_detached_result uses session_meta PID when pid param is None."""
+        # Spawn a short-lived process whose PID we'll embed in session meta
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(0.2)",
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        real_pid = proc.pid
+
+        _create_session_artifacts(repo, pid=real_pid)
+        initial_head = _head(repo)
+
+        # Call with pid=None — should fall back to session_meta["pid"]
+        with patch.object(
+            WorkerLauncher,
+            "_wait_for_pid_exit",
+            new_callable=AsyncMock,
+        ) as mock_wait:
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-meta-pid",
+                agent="codex",
+                worktree_path=str(repo),
+                branch="main",
+                pid=None,
+                initial_head=initial_head,
+                auto_commit=True,
+            )
+
+        # _wait_for_pid_exit should have been called with the meta PID
+        mock_wait.assert_awaited_once_with(real_pid)
+
+        # Cleanup subprocess
+        await proc.wait()
+
+    @pytest.mark.asyncio
+    async def test_pid_param_takes_precedence(self, repo: Path) -> None:
+        """When pid param is provided, it takes precedence over session_meta."""
+        _create_session_artifacts(repo, pid=11111)
+        initial_head = _head(repo)
+
+        with patch.object(
+            WorkerLauncher,
+            "_wait_for_pid_exit",
+            new_callable=AsyncMock,
+        ) as mock_wait:
+            # The PID 22222 won't be found running, so collect proceeds
+            with patch.object(WorkerLauncher, "_is_pid_running", return_value=False):
+                result = await WorkerLauncher.collect_detached_result(
+                    work_order_id="wo-pid-prio",
+                    agent="codex",
+                    worktree_path=str(repo),
+                    branch="main",
+                    pid=22222,
+                    initial_head=initial_head,
+                    auto_commit=True,
+                )
+
+        # Should use the pid parameter (22222), not session_meta pid (11111)
+        mock_wait.assert_awaited_once_with(22222)


### PR DESCRIPTION
## Summary

Fixes #902.

- The `codex_session.sh` EXIT trap rewrites `.codex_session_meta.json` and appends to `.codex_session.log` during its cleanup sequence. When the supervisor kills a worker and immediately calls `collect_detached_result` (with `pid=None` after `_kill_worker` pops it), Python-side `_cleanup_session_artifacts` runs before the shell trap finishes — the trap then recreates the deleted artifacts.
- Observed in live boss-loop run `boss-86f745f2c851`: `.codex_session_meta.json` (4701 bytes with `ended_at`/`exit_code`) and `.codex_session.log` (194416 bytes) leaked despite #896 try/finally fix. `.codex_session_active` was correctly cleaned (the shell trap removes it but does not recreate it).
- Fix: add `_wait_for_pid_exit()` that polls until the worker PID is gone before deleting artifacts. The PID is recovered from `session_meta["pid"]` when the `pid` parameter is `None` (popped by `_kill_worker`). This ensures the shell EXIT trap has fully completed before cleanup fires.

## Changes

| File | Change |
|------|--------|
| `aragora/swarm/worker_launcher.py` | Add `_wait_for_pid_exit()`, modify `collect_detached_result` finally block to wait before cleanup |
| `tests/swarm/test_shell_trap_artifact_race.py` | 8 regression tests: artifact cleanup, real-change preservation, PID wait unit tests, race simulation, meta-PID fallback, pid-param precedence |

## Test plan

- [x] `pytest tests/swarm/test_shell_trap_artifact_race.py` — 8/8 pass
- [x] `pytest tests/swarm/test_session_artifact_prevention.py tests/swarm/test_boss_loop.py tests/swarm/test_shell_trap_artifact_race.py` — 71/71 pass
- [x] `pytest tests/swarm/test_supervisor.py tests/swarm/test_timeout_cleanup.py tests/swarm/test_session_artifact_cleanup_guaranteed.py tests/swarm/test_exit141_salvage.py` — 46/46 pass
- [x] Pre-commit hooks pass (ruff lint + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)