### PR TITLE
feat(swarm): classify clean-exit/no-deliverable worker outcomes (#908)

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -335,9 +335,10 @@ class BossIterationStatus:
     next_actions: list[str]
     elapsed_seconds: float = 0.0
     error: str | None = None
+    worker_outcome: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "iteration": self.iteration,
             "run_id": self.run_id,
             "timestamp": self.timestamp,
@@ -350,6 +351,9 @@ class BossIterationStatus:
             "elapsed_seconds": self.elapsed_seconds,
             "error": self.error,
         }
+        if self.worker_outcome is not None:
+            d["worker_outcome"] = self.worker_outcome
+        return d
 
 
 @dataclass
@@ -422,6 +426,20 @@ class BossLoopConfig:
 # ---------------------------------------------------------------------------
 # Boss Loop
 # ---------------------------------------------------------------------------
+
+
+def _extract_worker_outcome(run_dict: dict[str, Any]) -> str | None:
+    """Extract the primary worker_outcome from a run's work orders.
+
+    Returns the first non-empty ``worker_outcome`` found, or ``None``.
+    """
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        outcome = str(wo.get("worker_outcome", "")).strip()
+        if outcome:
+            return outcome
+    return None
 
 
 def _extract_deliverable(run_dict: dict[str, Any]) -> dict[str, Any] | None:
@@ -671,6 +689,7 @@ class BossLoop:
         worker_result = await self._dispatch_issue(selected, freshness)
 
         elapsed = time.monotonic() - iter_start
+        outcome = worker_result.get("worker_outcome")
 
         if worker_result.get("status") == "completed":
             self._completed_issues.append(issue_dict)
@@ -686,6 +705,7 @@ class BossLoop:
                 needs_human_reasons=[],
                 next_actions=["Proceeding to next issue."],
                 elapsed_seconds=elapsed,
+                worker_outcome=outcome,
             )
 
         if worker_result.get("status") == "needs_human":
@@ -701,6 +721,7 @@ class BossLoop:
                 needs_human_reasons=worker_result.get("reasons", ["Worker requires human input."]),
                 next_actions=["Review the worker output and decide next steps."],
                 elapsed_seconds=elapsed,
+                worker_outcome=outcome,
             )
 
         # Worker failed
@@ -725,6 +746,7 @@ class BossLoop:
                 ],
                 elapsed_seconds=elapsed,
                 error=worker_result.get("error"),
+                worker_outcome=outcome,
             )
 
         return BossIterationStatus(
@@ -743,6 +765,7 @@ class BossLoop:
             ],
             elapsed_seconds=elapsed,
             error=worker_result.get("error"),
+            worker_outcome=outcome,
         )
 
     async def _dispatch_issue(
@@ -801,12 +824,14 @@ class BossLoop:
 
             run_dict = run.to_dict()
             status = str(run_dict.get("status", "")).strip()
+            outcome = _extract_worker_outcome(run_dict)
 
             if status == "completed":
                 deliverable = _extract_deliverable(run_dict)
                 if deliverable is None:
                     return {
                         "status": "needs_human",
+                        "worker_outcome": outcome or "clean_exit_no_effect",
                         "reasons": [
                             "Run reported completed but produced no concrete deliverable "
                             "(no pushed branch, no PR, no committed artifact). "
@@ -814,7 +839,12 @@ class BossLoop:
                         ],
                         "run": run_dict,
                     }
-                return {"status": "completed", "deliverable": deliverable, "run": run_dict}
+                return {
+                    "status": "completed",
+                    "worker_outcome": outcome,
+                    "deliverable": deliverable,
+                    "run": run_dict,
+                }
             if status == "needs_human":
                 reasons: list[str] = []
                 for wo in run_dict.get("work_orders", []):
@@ -826,11 +856,16 @@ class BossLoop:
                             reasons.append(str(err))
                 return {
                     "status": "needs_human",
+                    "worker_outcome": outcome,
                     "reasons": reasons or ["Worker reached needs_human state."],
                     "run": run_dict,
                 }
 
-            return {"status": "failed", "error": f"Run ended with status: {status}"}
+            return {
+                "status": "failed",
+                "worker_outcome": outcome,
+                "error": f"Run ended with status: {status}",
+            }
 
         except ValueError as exc:
             return {"status": "failed", "error": str(exc)}

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -58,6 +58,22 @@ class SupervisorRunStatus(str, Enum):
     COMPLETED = "completed"
 
 
+class WorkerOutcome(str, Enum):
+    """Fine-grained classification of how a dispatched worker completed or failed.
+
+    This is additional metadata alongside the work-order ``status`` field,
+    providing richer signal for model-matrix benchmarking and outcome analysis.
+    """
+
+    COMPLETED = "completed"
+    TIMEOUT_NO_PROGRESS = "timeout_no_progress"
+    TIMEOUT_WITH_SALVAGE = "timeout_with_salvage"
+    CRASH = "crash"
+    CRASH_WITH_SALVAGE = "crash_with_salvage"
+    CLEAN_EXIT_NO_EFFECT = "clean_exit_no_effect"
+    SCOPE_VIOLATION = "scope_violation"
+
+
 @dataclass(slots=True)
 class SwarmApprovalPolicy:
     """Explicit human-gating policy for supervised swarm runs."""
@@ -504,6 +520,7 @@ class SwarmSupervisor:
                     logger.debug("Exit result collection failed for %s", woid, exc_info=True)
 
                 if exit_result is not None and exit_result.commit_shas:
+                    item["worker_outcome"] = WorkerOutcome.CRASH_WITH_SALVAGE.value
                     finished.append(exit_result)
                     finished_ids.add(woid)
                 else:
@@ -516,8 +533,10 @@ class SwarmSupervisor:
                     exit_violations = self._check_file_scope_violations(item, collected_paths)
                     if exit_violations:
                         self._mark_scope_violation(item, exit_violations)
+                        item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                     else:
                         self._mark_needs_human(item, reason)
+                        item["worker_outcome"] = WorkerOutcome.CRASH.value
                     self._release_terminal_lease(item)
                 changed = True
                 continue
@@ -553,6 +572,7 @@ class SwarmSupervisor:
                 if timeout_result is not None and timeout_result.commit_shas:
                     # Worker produced a concrete deliverable before timing out.
                     # Surface it through the normal result path.
+                    item["worker_outcome"] = WorkerOutcome.TIMEOUT_WITH_SALVAGE.value
                     finished.append(timeout_result)
                     finished_ids.add(woid)
                 else:
@@ -566,8 +586,10 @@ class SwarmSupervisor:
                     timeout_violations = self._check_file_scope_violations(item, collected_paths)
                     if timeout_violations:
                         self._mark_scope_violation(item, timeout_violations, extra_reason=reason)
+                        item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                     else:
                         self._mark_needs_human(item, reason)
+                        item["worker_outcome"] = WorkerOutcome.TIMEOUT_NO_PROGRESS.value
                     self._release_terminal_lease(item)
                 changed = True
 
@@ -825,6 +847,8 @@ class SwarmSupervisor:
         scope_violations = self._check_file_scope_violations(item, clean_paths)
         if scope_violations:
             self._mark_scope_violation(item, scope_violations)
+            if "worker_outcome" not in item:
+                item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
             lease_id = str(item.get("lease_id", "")).strip()
             if lease_id:
                 self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
@@ -843,9 +867,18 @@ class SwarmSupervisor:
                     item,
                     "worker produced only session artifacts, no real deliverables",
                 )
+                if "worker_outcome" not in item:
+                    item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
                 self._release_terminal_lease(item)
                 item["exit_code"] = result.exit_code
                 return
+
+            # Classify outcome before completion recording
+            if "worker_outcome" not in item:
+                if clean_paths or result.commit_shas:
+                    item["worker_outcome"] = WorkerOutcome.COMPLETED.value
+                else:
+                    item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
 
             receipt_id = str(item.get("receipt_id", "")).strip()
             if lease_id and not receipt_id:
@@ -874,6 +907,8 @@ class SwarmSupervisor:
                         "violations": list(exc.violations),
                         "changed_paths": clean_paths,
                     }
+                    if "worker_outcome" not in item:
+                        item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                     self._release_terminal_lease(item)
                     item["exit_code"] = result.exit_code
                     return
@@ -892,6 +927,13 @@ class SwarmSupervisor:
         item["exit_code"] = result.exit_code
         if result.stderr.strip():
             item["blockers"] = [result.stderr.strip()]
+        if "worker_outcome" not in item:
+            if result.exit_code == -1:
+                item["worker_outcome"] = WorkerOutcome.TIMEOUT_NO_PROGRESS.value
+            elif result.commit_shas:
+                item["worker_outcome"] = WorkerOutcome.CRASH_WITH_SALVAGE.value
+            else:
+                item["worker_outcome"] = WorkerOutcome.CRASH.value
 
     def _release_terminal_lease(self, item: dict[str, Any]) -> None:
         lease_id = str(item.get("lease_id", "")).strip()

--- a/tests/swarm/test_worker_outcome_classification.py
+++ b/tests/swarm/test_worker_outcome_classification.py
@@ -1,0 +1,591 @@
+"""Tests for WorkerOutcome classification (#908).
+
+Verifies that the supervisor sets ``worker_outcome`` on work-order items
+for each distinct terminal state: completed, clean_exit_no_effect, crash,
+crash_with_salvage, timeout_no_progress, timeout_with_salvage,
+scope_violation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.nomic.dev_coordination import DevCoordinationStore
+from aragora.swarm.supervisor import SwarmSupervisor, WorkerOutcome
+from aragora.swarm.worker_launcher import (
+    LaunchConfig,
+    WorkerLauncher,
+    WorkerProcess,
+)
+
+UTC = timezone.utc
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", "initial")
+    _run(repo, "git", "remote", "add", "origin", str(repo))
+    _run(repo, "git", "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+@pytest.fixture()
+def store(repo: Path) -> DevCoordinationStore:
+    return DevCoordinationStore(repo_root=repo)
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _head(repo: Path) -> str:
+    return _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+
+def _make_supervisor(repo: Path, store: DevCoordinationStore) -> SwarmSupervisor:
+    config = LaunchConfig(no_progress_timeout_seconds=1.0)
+    launcher = WorkerLauncher(config=config)
+    return SwarmSupervisor(repo_root=repo, store=store, launcher=launcher)
+
+
+def _make_dispatched_item(
+    repo: Path,
+    *,
+    work_order_id: str = "wo-outcome",
+    initial_head: str | None = None,
+) -> dict[str, Any]:
+    head = initial_head or _head(repo)
+    dispatched_at = datetime(2020, 1, 1, tzinfo=UTC).isoformat()
+    return {
+        "work_order_id": work_order_id,
+        "status": "dispatched",
+        "target_agent": "codex",
+        "worktree_path": str(repo),
+        "branch": "main",
+        "initial_head": head,
+        "lease_id": "",
+        "file_scope": [],
+        "pid": 99999,
+        "dispatched_at": dispatched_at,
+        "last_progress_at": dispatched_at,
+        "changed_paths": [],
+    }
+
+
+def _create_run(store: DevCoordinationStore, item: dict[str, Any]) -> str:
+    record = store.create_supervisor_run(
+        goal="test outcome",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "test outcome"},
+        work_orders=[item],
+    )
+    return record["run_id"]
+
+
+def _mock_kill_worker(item: dict[str, Any]) -> None:
+    item.pop("pid", None)
+
+
+# ---------------------------------------------------------------------------
+# COMPLETED: exit 0 with real deliverable
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCompleted:
+    @pytest.mark.asyncio
+    async def test_exit_0_with_commits_is_completed(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+        _run(repo, "git", "add", "README.md")
+        _run(repo, "git", "commit", "-m", "worker change")
+        new_head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=["README.md"],
+            commit_shas=[new_head],
+            head_sha=new_head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.COMPLETED.value
+
+
+# ---------------------------------------------------------------------------
+# CLEAN_EXIT_NO_EFFECT: exit 0, zero commits, zero changed paths
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCleanExitNoEffect:
+    @pytest.mark.asyncio
+    async def test_exit_0_no_changes_is_clean_exit_no_effect(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
+
+    @pytest.mark.asyncio
+    async def test_exit_0_only_session_artifacts_is_clean_exit_no_effect(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        """Worker produced only session artifacts (stripped to empty)."""
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=[".codex_session_meta.json", ".codex_session.log"],
+            commit_shas=["abc123"],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
+        assert wo["status"] == "needs_human"
+
+
+# ---------------------------------------------------------------------------
+# CRASH: non-zero exit, no salvage
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCrash:
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_no_commits_is_crash(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=1,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CRASH.value
+        assert wo["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# CRASH_WITH_SALVAGE: pid_alive=False fallback with commit_shas
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCrashWithSalvage:
+    @pytest.mark.asyncio
+    async def test_pid_dead_with_salvage_is_crash_with_salvage(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        (repo / "README.md").write_text("salvaged\n", encoding="utf-8")
+        _run(repo, "git", "add", "README.md")
+        _run(repo, "git", "commit", "-m", "salvaged work")
+        new_head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        salvaged = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=141,
+            changed_paths=["README.md"],
+            commit_shas=[new_head],
+            head_sha=new_head,
+        )
+
+        with (
+            patch.object(
+                supervisor.launcher,
+                "collect_finished",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(
+                WorkerLauncher,
+                "collect_detached_result",
+                new_callable=AsyncMock,
+                side_effect=[None, salvaged],
+            ),
+            patch.object(
+                supervisor.launcher,
+                "snapshot_progress",
+                new_callable=AsyncMock,
+                return_value={"pid_alive": False},
+            ),
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CRASH_WITH_SALVAGE.value
+
+
+# ---------------------------------------------------------------------------
+# CRASH (via pid_alive=False fallback, no salvage)
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeCrashViaPidFallback:
+    @pytest.mark.asyncio
+    async def test_pid_dead_no_salvage_is_crash(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        item = _make_dispatched_item(repo)
+        run_id = _create_run(store, item)
+
+        no_deliverable = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=141,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=_head(repo),
+        )
+
+        with (
+            patch.object(
+                supervisor.launcher,
+                "collect_finished",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(
+                WorkerLauncher,
+                "collect_detached_result",
+                new_callable=AsyncMock,
+                side_effect=[None, no_deliverable],
+            ),
+            patch.object(
+                supervisor.launcher,
+                "snapshot_progress",
+                new_callable=AsyncMock,
+                return_value={"pid_alive": False},
+            ),
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CRASH.value
+        assert wo["status"] == "needs_human"
+
+
+# ---------------------------------------------------------------------------
+# TIMEOUT_NO_PROGRESS: no-progress timeout, no salvage
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeTimeoutNoProgress:
+    @pytest.mark.asyncio
+    async def test_timeout_no_salvage_is_timeout_no_progress(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        item = _make_dispatched_item(repo)
+        run_id = _create_run(store, item)
+
+        no_deliverable = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=_head(repo),
+        )
+
+        with (
+            patch.object(
+                supervisor.launcher,
+                "collect_finished",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(supervisor, "_exceeded_no_progress_timeout", return_value=True),
+            patch.object(
+                supervisor, "_kill_worker", new_callable=AsyncMock, side_effect=_mock_kill_worker
+            ),
+            patch.object(
+                WorkerLauncher,
+                "collect_detached_result",
+                new_callable=AsyncMock,
+                side_effect=[None, no_deliverable],
+            ),
+            patch.object(
+                supervisor.launcher,
+                "snapshot_progress",
+                new_callable=AsyncMock,
+                return_value={"pid_alive": True},
+            ),
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.TIMEOUT_NO_PROGRESS.value
+        assert wo["status"] == "needs_human"
+
+
+# ---------------------------------------------------------------------------
+# TIMEOUT_WITH_SALVAGE: no-progress timeout, but salvageable commits
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeTimeoutWithSalvage:
+    @pytest.mark.asyncio
+    async def test_timeout_with_salvage_is_timeout_with_salvage(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        (repo / "README.md").write_text("timeout salvage\n", encoding="utf-8")
+        _run(repo, "git", "add", "README.md")
+        _run(repo, "git", "commit", "-m", "partial work")
+        new_head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        salvaged = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=["README.md"],
+            commit_shas=[new_head],
+            head_sha=new_head,
+        )
+
+        with (
+            patch.object(
+                supervisor.launcher,
+                "collect_finished",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch.object(supervisor, "_exceeded_no_progress_timeout", return_value=True),
+            patch.object(
+                supervisor, "_kill_worker", new_callable=AsyncMock, side_effect=_mock_kill_worker
+            ),
+            patch.object(
+                WorkerLauncher,
+                "collect_detached_result",
+                new_callable=AsyncMock,
+                side_effect=[None, salvaged],
+            ),
+            patch.object(
+                supervisor.launcher,
+                "snapshot_progress",
+                new_callable=AsyncMock,
+                return_value={"pid_alive": True},
+            ),
+        ):
+            results = await supervisor.collect_finished_results(run_id)
+
+        assert len(results) == 1
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.TIMEOUT_WITH_SALVAGE.value
+
+
+# ---------------------------------------------------------------------------
+# SCOPE_VIOLATION: worker touched out-of-scope files
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeScopeViolation:
+    @pytest.mark.asyncio
+    async def test_scope_violation_is_scope_violation(
+        self, repo: Path, store: DevCoordinationStore
+    ) -> None:
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+        item = _make_dispatched_item(repo, initial_head=head)
+        item["file_scope"] = ["aragora/live/**"]
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=["aragora/server/main.py"],
+            commit_shas=[head],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.SCOPE_VIOLATION.value
+        assert wo["status"] == "scope_violation"
+
+
+# ---------------------------------------------------------------------------
+# Boss loop: worker_outcome surfaces in iteration status
+# ---------------------------------------------------------------------------
+
+
+class TestBossLoopOutcomeSurface:
+    def test_extract_worker_outcome_from_run_dict(self) -> None:
+        from aragora.swarm.boss_loop import _extract_worker_outcome
+
+        run_dict: dict[str, Any] = {
+            "work_orders": [
+                {"worker_outcome": "clean_exit_no_effect", "status": "completed"},
+            ]
+        }
+        assert _extract_worker_outcome(run_dict) == "clean_exit_no_effect"
+
+    def test_extract_worker_outcome_none_when_missing(self) -> None:
+        from aragora.swarm.boss_loop import _extract_worker_outcome
+
+        run_dict: dict[str, Any] = {"work_orders": [{"status": "completed"}]}
+        assert _extract_worker_outcome(run_dict) is None
+
+    def test_iteration_status_includes_worker_outcome(self) -> None:
+        from aragora.swarm.boss_loop import BossIterationStatus
+
+        status = BossIterationStatus(
+            iteration=1,
+            run_id="test",
+            timestamp="2026-01-01T00:00:00Z",
+            runner_freshness={},
+            selected_issue=None,
+            worker_status="needs_human",
+            stop_reason="needs_human",
+            needs_human_reasons=["test"],
+            next_actions=[],
+            worker_outcome="clean_exit_no_effect",
+        )
+        d = status.to_dict()
+        assert d["worker_outcome"] == "clean_exit_no_effect"
+
+    def test_iteration_status_omits_worker_outcome_when_none(self) -> None:
+        from aragora.swarm.boss_loop import BossIterationStatus
+
+        status = BossIterationStatus(
+            iteration=1,
+            run_id="test",
+            timestamp="2026-01-01T00:00:00Z",
+            runner_freshness={},
+            selected_issue=None,
+            worker_status="idle",
+            stop_reason=None,
+            needs_human_reasons=[],
+            next_actions=[],
+        )
+        d = status.to_dict()
+        assert "worker_outcome" not in d


### PR DESCRIPTION
## Summary

- Adds `WorkerOutcome` enum with 7 distinct outcome classes to `supervisor.py`
- Sets `worker_outcome` on work-order items at each classification point in the reconciliation loop and `_apply_worker_result`
- Surfaces `worker_outcome` in boss-loop `BossIterationStatus` JSON output via new `_extract_worker_outcome` helper
- Pre-tagging from timeout and pid_alive fallback blocks is preserved (outcome only set if not already present)

Closes #908

## Outcome classes

| Outcome | When |
|---------|------|
| `completed` | Exit 0 with real changed paths or commits |
| `clean_exit_no_effect` | Exit 0, zero commits, zero real changes (Run #4 scenario) |
| `crash` | Non-zero exit, no salvageable commits |
| `crash_with_salvage` | PID dead but salvageable commits recovered |
| `timeout_no_progress` | No-progress timeout, no salvage |
| `timeout_with_salvage` | No-progress timeout, but salvageable commits recovered |
| `scope_violation` | Worker touched out-of-scope files |

## Test plan

- [x] 13 regression tests in `test_worker_outcome_classification.py`
  - Each of the 7 outcome classes has at least one test
  - Boss-loop surface tests for extraction helper and iteration status serialization
- [x] Full validation suite: 102 tests passing (`test_boss_loop`, `test_supervisor`, `test_session_artifact_prevention`, `test_worker_outcome_classification`, `test_pid_alive_fallback`, `test_timeout_cleanup`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)