### PR TITLE
fix(swarm): campaign status reports blocked when deps are unreachable

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -1238,6 +1238,41 @@ def _compute_stop_reason(manifest: CampaignManifest) -> str:
     }
     if statuses and statuses.issubset(blocked_like | {CampaignProjectStatus.COMPLETED.value}):
         return CampaignStopReason.CAMPAIGN_BLOCKED.value
+    # Check for unreachable pending projects: if every non-terminal project
+    # has at least one dependency in a terminal-but-not-completed state, the
+    # campaign is effectively blocked even though raw statuses include pending.
+    terminal_not_completed = blocked_like
+    active_statuses = {
+        CampaignProjectStatus.ACTIVE.value,
+        CampaignProjectStatus.DELIVERED.value,
+    }
+    if not statuses & active_statuses:
+        project_status_map = {p.project_id: p.status for p in manifest.projects}
+        reachable = [
+            p
+            for p in manifest.projects
+            if p.status
+            in {
+                CampaignProjectStatus.PENDING.value,
+                CampaignProjectStatus.READY.value,
+                CampaignProjectStatus.NEEDS_REVISION.value,
+            }
+        ]
+        if reachable and all(
+            any(
+                project_status_map.get(d.project_id) in terminal_not_completed
+                for d in p.dependencies
+            )
+            for p in reachable
+            if p.dependencies
+        ):
+            # Every remaining non-terminal project with dependencies has at least
+            # one dependency that will never complete.  If there are also no
+            # dependency-free pending projects that could still make progress,
+            # the campaign is blocked.
+            dependency_free = [p for p in reachable if not p.dependencies]
+            if not dependency_free:
+                return CampaignStopReason.CAMPAIGN_BLOCKED.value
     return CampaignStopReason.STILL_RUNNING.value
 
 

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -19,7 +19,9 @@ from aragora.swarm.campaign import (
     CampaignReviewGate,
     CampaignReviewStatus,
     CampaignRunOutcome,
+    CampaignStopReason,
     CampaignExecutor,
+    _compute_stop_reason,
     load_campaign_manifest,
     save_campaign_manifest,
 )
@@ -375,6 +377,138 @@ class TestCampaignExecutor:
         executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
         with pytest.raises(ValueError):
             executor.status()
+
+
+class TestComputeStopReason:
+    """Dogfood finding F2: status and run must agree on blocked state."""
+
+    def test_unreachable_pending_projects_are_campaign_blocked(self) -> None:
+        """Pending projects whose deps are skipped/failed are unreachable."""
+        manifest = CampaignManifest(
+            campaign_id="campaign-unreachable",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Head project",
+                    spec=_bounded_spec("Head project"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.SKIPPED.value,
+                ),
+                CampaignProject(
+                    project_id="proj-002",
+                    title="Downstream",
+                    spec=_bounded_spec("Downstream", ["docs/CLI_REFERENCE.md"]),
+                    file_scope_hints=["docs/CLI_REFERENCE.md"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.PENDING.value,
+                    dependencies=[CampaignDependency(project_id="proj-001", reason="sequential")],
+                ),
+            ],
+        )
+        assert _compute_stop_reason(manifest) == CampaignStopReason.CAMPAIGN_BLOCKED.value
+
+    def test_reachable_pending_projects_are_still_running(self) -> None:
+        """Pending projects with no deps or all-completed deps are reachable."""
+        manifest = CampaignManifest(
+            campaign_id="campaign-reachable",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Completed head",
+                    spec=_bounded_spec("Completed head"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.COMPLETED.value,
+                ),
+                CampaignProject(
+                    project_id="proj-002",
+                    title="Ready downstream",
+                    spec=_bounded_spec("Ready downstream", ["docs/CLI_REFERENCE.md"]),
+                    file_scope_hints=["docs/CLI_REFERENCE.md"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.PENDING.value,
+                    dependencies=[CampaignDependency(project_id="proj-001", reason="sequential")],
+                ),
+            ],
+        )
+        assert _compute_stop_reason(manifest) == CampaignStopReason.STILL_RUNNING.value
+
+    def test_mixed_skipped_and_independent_pending_is_still_running(self) -> None:
+        """A dependency-free pending project keeps the campaign alive."""
+        manifest = CampaignManifest(
+            campaign_id="campaign-mixed",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Skipped head",
+                    spec=_bounded_spec("Skipped head"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.SKIPPED.value,
+                ),
+                CampaignProject(
+                    project_id="proj-002",
+                    title="Independent project",
+                    spec=_bounded_spec("Independent project", ["docs/FAQ.md"]),
+                    file_scope_hints=["docs/FAQ.md"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.PENDING.value,
+                    dependencies=[],
+                ),
+            ],
+        )
+        assert _compute_stop_reason(manifest) == CampaignStopReason.STILL_RUNNING.value
+
+    def test_status_agrees_with_run_on_unreachable_blocked(self, tmp_path: Path) -> None:
+        """End-to-end: executor.status() must report campaign_blocked for unreachable projects."""
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-status-blocked",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Skipped head",
+                    spec=_bounded_spec("Skipped head"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.SKIPPED.value,
+                ),
+                CampaignProject(
+                    project_id="proj-002",
+                    title="Unreachable downstream",
+                    spec=_bounded_spec("Unreachable downstream", ["docs/CLI_REFERENCE.md"]),
+                    file_scope_hints=["docs/CLI_REFERENCE.md"],
+                    acceptance_criteria=["pass"],
+                    constraints=["scope"],
+                    status=CampaignProjectStatus.PENDING.value,
+                    dependencies=[CampaignDependency(project_id="proj-001", reason="sequential")],
+                ),
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+        status = executor.status()
+        assert status["stop_reason"] == CampaignStopReason.CAMPAIGN_BLOCKED.value
 
 
 class TestCampaignCLI:


### PR DESCRIPTION
## Summary

- Fix `_compute_stop_reason` to detect unreachable pending projects whose dependencies are in terminal non-completed states (skipped/failed/blocked)
- `campaign status` and `campaign run` now agree on `campaign_blocked` for this state

Dogfood finding F2 from PR #914: after proj-001 was skipped, proj-002/003 (which depend on it) remained `pending` but could never become ready. `campaign run` correctly returned `campaign_blocked`, but `campaign status` returned `still_running` because raw statuses `{skipped, pending}` didn't match the blocked_like check.

## Changes

**`aragora/swarm/campaign.py`**: Added reachability check in `_compute_stop_reason` — after existing blocked_like test, checks if every remaining non-terminal project with dependencies has at least one unreachable dependency. Dependency-free pending projects still keep the campaign alive.

**`tests/swarm/test_campaign.py`**: 4 new tests in `TestComputeStopReason`:
- Unreachable pending projects → `campaign_blocked`
- Reachable pending projects (completed deps) → `still_running`
- Mixed skipped + independent pending → `still_running`
- End-to-end via `executor.status()` → `campaign_blocked`

## Test plan

- [x] `python -m pytest -q tests/swarm/test_campaign.py` — 23/23 pass
- [x] Full swarm suite — 377 pass, 17 pre-existing failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)