### PR TITLE
fix(swarm): worker no-deliverable hardening

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -335,9 +335,10 @@ class BossIterationStatus:
     next_actions: list[str]
     elapsed_seconds: float = 0.0
     error: str | None = None
+    worker_outcome: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result: dict[str, Any] = {
             "iteration": self.iteration,
             "run_id": self.run_id,
             "timestamp": self.timestamp,
@@ -350,6 +351,9 @@ class BossIterationStatus:
             "elapsed_seconds": self.elapsed_seconds,
             "error": self.error,
         }
+        if self.worker_outcome is not None:
+            result["worker_outcome"] = self.worker_outcome
+        return result
 
 
 @dataclass
@@ -587,6 +591,20 @@ def _extract_deliverable(run_dict: dict[str, Any]) -> dict[str, Any] | None:
                 "work_order_id": wo.get("work_order_id"),
             }
 
+    return None
+
+
+def _extract_worker_outcome(run_dict: dict[str, Any]) -> str | None:
+    """Extract the first non-empty ``worker_outcome`` from a completed run.
+
+    Returns None if no work order carries a ``worker_outcome`` field.
+    """
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        outcome = str(wo.get("worker_outcome", "")).strip()
+        if outcome:
+            return outcome
     return None
 
 

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -58,6 +58,23 @@ class SupervisorRunStatus(str, Enum):
     COMPLETED = "completed"
 
 
+class WorkerOutcome(str, Enum):
+    """Structured classification of a worker's terminal state.
+
+    Set on each work-order item as ``worker_outcome`` so operators and
+    higher-level orchestrators (campaign, boss loop) can distinguish between
+    fundamentally different failure modes without parsing free-text fields.
+    """
+
+    COMPLETED = "completed"
+    CLEAN_EXIT_NO_EFFECT = "clean_exit_no_effect"
+    CRASH = "crash"
+    CRASH_WITH_SALVAGE = "crash_with_salvage"
+    TIMEOUT_NO_PROGRESS = "timeout_no_progress"
+    TIMEOUT_WITH_SALVAGE = "timeout_with_salvage"
+    SCOPE_VIOLATION = "scope_violation"
+
+
 @dataclass(slots=True)
 class SwarmApprovalPolicy:
     """Explicit human-gating policy for supervised swarm runs."""
@@ -488,6 +505,7 @@ class SwarmSupervisor:
                 scope_violations = self._check_file_scope_violations(item, progress_paths)
                 if scope_violations:
                     self._mark_scope_violation(item, scope_violations)
+                    item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                     self._release_terminal_lease(item)
                     await self._kill_worker(item)
                     changed = True
@@ -501,11 +519,39 @@ class SwarmSupervisor:
                 )
                 if exit_violations:
                     self._mark_scope_violation(item, exit_violations)
+                    item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                 else:
+                    # Attempt detached result collection — worker may have
+                    # committed successfully before dying without an exit marker.
+                    detached_result: WorkerProcess | None = None
+                    try:
+                        detached_result = await WorkerLauncher.collect_detached_result(
+                            work_order_id=woid,
+                            agent=str(item.get("target_agent", "codex")),
+                            worktree_path=worktree_path,
+                            branch=str(item.get("branch", "main")),
+                            pid=item.get("pid"),
+                            initial_head=str(item.get("initial_head", "")),
+                            auto_commit=self.launcher.config.auto_commit,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "Detached result collection failed for %s", woid, exc_info=True
+                        )
+
+                    if detached_result is not None and detached_result.commit_shas:
+                        finished.append(detached_result)
+                        finished_ids.add(woid)
+                        item["worker_outcome"] = WorkerOutcome.CRASH_WITH_SALVAGE.value
+                        self._release_terminal_lease(item)
+                        changed = True
+                        continue
+
                     self._mark_needs_human(
                         item,
                         "worker process exited without receipt or exit marker",
                     )
+                    item["worker_outcome"] = WorkerOutcome.CRASH.value
                 self._release_terminal_lease(item)
                 changed = True
                 continue
@@ -543,6 +589,7 @@ class SwarmSupervisor:
                     # Surface it through the normal result path.
                     finished.append(timeout_result)
                     finished_ids.add(woid)
+                    item["worker_outcome"] = WorkerOutcome.TIMEOUT_WITH_SALVAGE.value
                 else:
                     # No deliverable — check scope violations and mark blocked.
                     collected_paths = self._strip_session_artifacts(
@@ -554,8 +601,10 @@ class SwarmSupervisor:
                     timeout_violations = self._check_file_scope_violations(item, collected_paths)
                     if timeout_violations:
                         self._mark_scope_violation(item, timeout_violations, extra_reason=reason)
+                        item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
                     else:
                         self._mark_needs_human(item, reason)
+                        item["worker_outcome"] = WorkerOutcome.TIMEOUT_NO_PROGRESS.value
                     self._release_terminal_lease(item)
                 changed = True
 
@@ -809,10 +858,16 @@ class SwarmSupervisor:
         item["head_sha"] = result.head_sha
         item.pop("pid", None)
 
+        # Preserve worker_outcome if already set by detached/timeout collection
+        # paths — those have more specific context (e.g. timeout_with_salvage).
+        _pre_outcome = str(item.get("worker_outcome", "")).strip()
+
         # Fail closed: check file-scope before accepting any result as successful
         scope_violations = self._check_file_scope_violations(item, clean_paths)
         if scope_violations:
             self._mark_scope_violation(item, scope_violations)
+            if not _pre_outcome:
+                item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
             lease_id = str(item.get("lease_id", "")).strip()
             if lease_id:
                 self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
@@ -831,9 +886,26 @@ class SwarmSupervisor:
                     item,
                     "worker produced only session artifacts, no real deliverables",
                 )
+                if not _pre_outcome:
+                    item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
                 self._release_terminal_lease(item)
                 item["exit_code"] = result.exit_code
                 return
+
+            # Clean exit with zero changes of any kind
+            if not clean_paths and not result.commit_shas:
+                if not _pre_outcome:
+                    item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
+                logger.warning(
+                    "Worker %s exited 0 with no commits and no changed paths — "
+                    "clean_exit_no_effect (branch=%s, initial_head=%s, head_sha=%s)",
+                    item.get("work_order_id"),
+                    item.get("branch"),
+                    result.initial_head,
+                    result.head_sha,
+                )
+            elif not _pre_outcome:
+                item["worker_outcome"] = WorkerOutcome.COMPLETED.value
 
             receipt_id = str(item.get("receipt_id", "")).strip()
             if lease_id and not receipt_id:
@@ -870,6 +942,13 @@ class SwarmSupervisor:
             item["status"] = "completed"
             item["review_status"] = "pending_heterogeneous_review"
             return
+
+        # Non-zero exit: classify as crash (with or without salvage)
+        if not _pre_outcome:
+            if result.commit_shas and clean_paths:
+                item["worker_outcome"] = WorkerOutcome.CRASH_WITH_SALVAGE.value
+            else:
+                item["worker_outcome"] = WorkerOutcome.CRASH.value
 
         if self._requeue_after_worker_failure(item, result):
             return

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -481,6 +481,9 @@ class WorkerLauncher:
             "  - Stage only the files you intentionally changed with `git add <file> ...`.\n"
             "  - Do NOT use `git add -A` or `git add .` — session metadata files must not be committed.\n"
             '  - Commit with a descriptive message using `git commit -m "..."` before exiting.\n'
+            "  - After committing, push your branch: `git push origin HEAD`.\n"
+            "  - If `git push` fails (e.g. no remote, permission error), that is acceptable — "
+            "the harness will attempt to push for you.\n"
             "  - Exit with a truthful final state; do not claim integration or approval work is done unless it happened in this lane."
         )
 
@@ -816,5 +819,47 @@ class WorkerLauncher:
                     commit_proc.returncode,
                     (commit_stderr or b"").decode(errors="replace").strip(),
                 )
+                return
+
+            # Push the branch so the deliverable is visible upstream.
+            # Best-effort: if push fails (no remote, auth, etc.) the local
+            # commit is still collected by _collect_commit_shas.
+            await WorkerLauncher._auto_push(worker)
         except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
             logger.warning("Auto-commit failed for %s: %s", worker.work_order_id, exc)
+
+    @staticmethod
+    async def _auto_push(worker: WorkerProcess) -> None:
+        """Best-effort push of the worker branch to origin.
+
+        Called after auto-commit to ensure the deliverable is available for
+        review and PR creation.  If push fails the local commit is still
+        collected — the deliverable gate accepts branch+commit_shas from
+        the local worktree.
+        """
+        try:
+            push_proc = await asyncio.create_subprocess_exec(
+                "git",
+                "push",
+                "origin",
+                "HEAD",
+                cwd=worker.worktree_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, push_stderr = await asyncio.wait_for(push_proc.communicate(), timeout=30)
+            if push_proc.returncode != 0:
+                logger.info(
+                    "Auto-push failed for %s (rc=%s): %s — local commit preserved",
+                    worker.work_order_id,
+                    push_proc.returncode,
+                    (push_stderr or b"").decode(errors="replace").strip()[:200],
+                )
+            else:
+                logger.info("Auto-pushed branch for %s", worker.work_order_id)
+        except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
+            logger.info(
+                "Auto-push skipped for %s: %s — local commit preserved",
+                worker.work_order_id,
+                exc,
+            )

--- a/tests/swarm/test_worker_no_deliverable.py
+++ b/tests/swarm/test_worker_no_deliverable.py
@@ -1,0 +1,480 @@
+"""Regression tests for worker no-deliverable hardening.
+
+Reproduces the exact failure shape from dogfood runs #1 and #2: workers
+dispatch and exit cleanly but produce no concrete deliverable (no pushed
+branch, no PR, no committed artifact).
+
+Root cause: worker prompt did not instruct push; auto_commit committed
+locally but never pushed; _extract_deliverable gate requires branch +
+commit_shas (which local commits satisfy) but higher-level orchestrators
+need the pushed artifact for review/PR creation.
+
+Fix: (1) worker prompt now instructs git push, (2) _auto_commit now
+pushes after committing, (3) WorkerOutcome enum provides structured
+classification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.swarm.boss_loop import (
+    _classify_terminal_run_outcome,
+    _extract_deliverable,
+    _extract_worker_outcome,
+)
+from aragora.swarm.worker_launcher import (
+    LaunchConfig,
+    WorkerLauncher,
+    WorkerProcess,
+)
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Prompt instructs push
+# ---------------------------------------------------------------------------
+
+
+class TestPromptIncludesPushInstruction:
+    """Verify the worker prompt now tells the worker to push."""
+
+    def test_prompt_contains_git_push(self) -> None:
+        wo: dict[str, Any] = {
+            "title": "Update docs",
+            "description": "Fix typo in README",
+        }
+        prompt = WorkerLauncher._build_prompt(wo)
+        assert "git push" in prompt.lower()
+
+    def test_prompt_push_is_after_commit(self) -> None:
+        wo: dict[str, Any] = {"title": "Task", "description": "Do work"}
+        prompt = WorkerLauncher._build_prompt(wo)
+        commit_pos = prompt.lower().find("git commit")
+        push_pos = prompt.lower().find("git push")
+        assert commit_pos >= 0, "prompt must mention git commit"
+        assert push_pos >= 0, "prompt must mention git push"
+        assert push_pos > commit_pos, "push instruction must come after commit"
+
+    def test_prompt_push_failure_is_acceptable(self) -> None:
+        """Push failure should be explicitly acceptable (the harness will retry)."""
+        wo: dict[str, Any] = {"title": "Task"}
+        prompt = WorkerLauncher._build_prompt(wo)
+        assert "acceptable" in prompt.lower() or "harness" in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Auto-push after auto-commit
+# ---------------------------------------------------------------------------
+
+
+class TestAutoCommitPush:
+    """Verify _auto_commit now pushes after committing."""
+
+    @pytest.mark.asyncio
+    async def test_auto_push_called_after_successful_commit(self, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run(repo, "git", "init", "-b", "main")
+        _run(repo, "git", "config", "user.email", "test@example.com")
+        _run(repo, "git", "config", "user.name", "Test User")
+        (repo / "README.md").write_text("hello\n", encoding="utf-8")
+        _run(repo, "git", "add", ".")
+        _run(repo, "git", "commit", "-m", "initial")
+
+        # Make a change for auto_commit to pick up
+        (repo / "file.py").write_text("# new file\n", encoding="utf-8")
+
+        worker = WorkerProcess(
+            work_order_id="wo-push-test",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+        )
+
+        with patch.object(WorkerLauncher, "_auto_push", new_callable=AsyncMock) as mock_push:
+            await WorkerLauncher._auto_commit(worker)
+            mock_push.assert_called_once_with(worker)
+
+    @pytest.mark.asyncio
+    async def test_auto_push_not_called_on_commit_failure(self, tmp_path: Path) -> None:
+        """If git commit fails, push should not be attempted."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run(repo, "git", "init", "-b", "main")
+        _run(repo, "git", "config", "user.email", "test@example.com")
+        _run(repo, "git", "config", "user.name", "Test User")
+        (repo / "README.md").write_text("hello\n", encoding="utf-8")
+        _run(repo, "git", "add", ".")
+        _run(repo, "git", "commit", "-m", "initial")
+
+        # No changes — commit will find nothing staged
+        worker = WorkerProcess(
+            work_order_id="wo-no-changes",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+        )
+
+        with patch.object(WorkerLauncher, "_auto_push", new_callable=AsyncMock) as mock_push:
+            await WorkerLauncher._auto_commit(worker)
+            mock_push.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_auto_push_best_effort(self, tmp_path: Path) -> None:
+        """Push failure should not crash the auto-commit flow."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        _run(repo, "git", "init", "-b", "main")
+        _run(repo, "git", "config", "user.email", "test@example.com")
+        _run(repo, "git", "config", "user.name", "Test User")
+        (repo / "README.md").write_text("hello\n", encoding="utf-8")
+        _run(repo, "git", "add", ".")
+        _run(repo, "git", "commit", "-m", "initial")
+
+        (repo / "file.py").write_text("# new\n", encoding="utf-8")
+
+        worker = WorkerProcess(
+            work_order_id="wo-push-fail",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+        )
+
+        # Push will fail (no remote) but should not raise
+        await WorkerLauncher._auto_commit(worker)
+        # Verify the commit was still made
+        result = _run(repo, "git", "log", "--oneline", "-1")
+        assert "wo-push-fail" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Exact dogfood failure shape reproduction
+# ---------------------------------------------------------------------------
+
+
+class TestDogfoodNoDeliverableShape:
+    """Reproduce the exact failure shape from dogfood runs #1 and #2.
+
+    Shape: worker dispatches, exits 0, produces no commits, no changed
+    paths, branch is set — classified as clean_exit_no_deliverable.
+    """
+
+    def test_clean_exit_zero_commits_zero_paths_is_no_deliverable(self) -> None:
+        """Exact shape: completed work order with branch but no commits."""
+        run_dict: dict[str, Any] = {
+            "status": "completed",
+            "work_orders": [
+                {
+                    "work_order_id": "wo-dogfood",
+                    "status": "completed",
+                    "branch": "codex/swarm-abcd1234-work-1234",
+                    "commit_shas": [],
+                    "changed_paths": [],
+                    "pr_url": "",
+                    "worktree_path": "/tmp/worktree",
+                },
+            ],
+        }
+        assert _extract_deliverable(run_dict) is None
+        assert _classify_terminal_run_outcome(run_dict) == "clean_exit_no_deliverable"
+
+    def test_clean_exit_with_commits_is_deliverable(self) -> None:
+        """After fix: worker commits + pushes → deliverable detected."""
+        run_dict: dict[str, Any] = {
+            "status": "completed",
+            "work_orders": [
+                {
+                    "work_order_id": "wo-fixed",
+                    "status": "completed",
+                    "branch": "codex/swarm-abcd1234-work-1234",
+                    "commit_shas": ["abc123"],
+                    "changed_paths": ["docs/README.md"],
+                    "pr_url": "",
+                },
+            ],
+        }
+        deliverable = _extract_deliverable(run_dict)
+        assert deliverable is not None
+        assert deliverable["type"] == "branch"
+        assert deliverable["commit_shas"] == ["abc123"]
+        assert _classify_terminal_run_outcome(run_dict) == "deliverable_created"
+
+
+# ---------------------------------------------------------------------------
+# WorkerOutcome classification
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerOutcomeExtraction:
+    def test_extract_worker_outcome_from_run(self) -> None:
+        run_dict: dict[str, Any] = {
+            "work_orders": [
+                {"worker_outcome": "clean_exit_no_effect", "status": "completed"},
+            ],
+        }
+        assert _extract_worker_outcome(run_dict) == "clean_exit_no_effect"
+
+    def test_extract_worker_outcome_none_when_missing(self) -> None:
+        run_dict: dict[str, Any] = {"work_orders": [{"status": "completed"}]}
+        assert _extract_worker_outcome(run_dict) is None
+
+    def test_extract_worker_outcome_skips_non_dict(self) -> None:
+        run_dict: dict[str, Any] = {"work_orders": ["not_a_dict", None]}
+        assert _extract_worker_outcome(run_dict) is None
+
+    def test_extract_worker_outcome_first_wins(self) -> None:
+        run_dict: dict[str, Any] = {
+            "work_orders": [
+                {"worker_outcome": "completed"},
+                {"worker_outcome": "crash"},
+            ],
+        }
+        assert _extract_worker_outcome(run_dict) == "completed"
+
+
+# ---------------------------------------------------------------------------
+# WorkerOutcome in supervisor _apply_worker_result
+# ---------------------------------------------------------------------------
+
+
+class TestSupervisorWorkerOutcome:
+    """Verify _apply_worker_result sets worker_outcome."""
+
+    @pytest.mark.asyncio
+    async def test_completed_with_commits_sets_completed_outcome(self, tmp_path: Path) -> None:
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+        from aragora.swarm.supervisor import SwarmSupervisor, WorkerOutcome
+
+        repo = _init_repo(tmp_path)
+        store = DevCoordinationStore(repo_root=repo)
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        (repo / "README.md").write_text("updated\n", encoding="utf-8")
+        _run(repo, "git", "add", "README.md")
+        _run(repo, "git", "commit", "-m", "worker change")
+        new_head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=["README.md"],
+            commit_shas=[new_head],
+            head_sha=new_head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.COMPLETED.value
+
+    @pytest.mark.asyncio
+    async def test_clean_exit_no_changes_sets_clean_exit_no_effect(self, tmp_path: Path) -> None:
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+        from aragora.swarm.supervisor import SwarmSupervisor, WorkerOutcome
+
+        repo = _init_repo(tmp_path)
+        store = DevCoordinationStore(repo_root=repo)
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=0,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_no_commits_sets_crash(self, tmp_path: Path) -> None:
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+        from aragora.swarm.supervisor import SwarmSupervisor, WorkerOutcome
+
+        repo = _init_repo(tmp_path)
+        store = DevCoordinationStore(repo_root=repo)
+        supervisor = _make_supervisor(repo, store)
+        head = _head(repo)
+
+        item = _make_dispatched_item(repo, initial_head=head)
+        run_id = _create_run(store, item)
+
+        result = WorkerProcess(
+            work_order_id="wo-outcome",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+            exit_code=1,
+            changed_paths=[],
+            commit_shas=[],
+            head_sha=head,
+        )
+
+        with patch.object(
+            supervisor.launcher,
+            "collect_finished",
+            new_callable=AsyncMock,
+            return_value=[result],
+        ):
+            await supervisor.collect_finished_results(run_id)
+
+        record = store.get_supervisor_run(run_id)
+        wo = record["work_orders"][0]
+        assert wo["worker_outcome"] == WorkerOutcome.CRASH.value
+        assert wo["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# BossIterationStatus worker_outcome field
+# ---------------------------------------------------------------------------
+
+
+class TestBossIterationStatusWorkerOutcome:
+    def test_includes_worker_outcome_when_set(self) -> None:
+        from aragora.swarm.boss_loop import BossIterationStatus
+
+        status = BossIterationStatus(
+            iteration=1,
+            run_id="test",
+            timestamp="2026-01-01T00:00:00Z",
+            runner_freshness={},
+            selected_issue=None,
+            worker_status="needs_human",
+            stop_reason="needs_human",
+            needs_human_reasons=["test"],
+            next_actions=[],
+            worker_outcome="clean_exit_no_effect",
+        )
+        d = status.to_dict()
+        assert d["worker_outcome"] == "clean_exit_no_effect"
+
+    def test_omits_worker_outcome_when_none(self) -> None:
+        from aragora.swarm.boss_loop import BossIterationStatus
+
+        status = BossIterationStatus(
+            iteration=1,
+            run_id="test",
+            timestamp="2026-01-01T00:00:00Z",
+            runner_freshness={},
+            selected_issue=None,
+            worker_status="idle",
+            stop_reason=None,
+            needs_human_reasons=[],
+            next_actions=[],
+        )
+        d = status.to_dict()
+        assert "worker_outcome" not in d
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _head(repo: Path) -> str:
+    return _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", "initial")
+    _run(repo, "git", "remote", "add", "origin", str(repo))
+    _run(repo, "git", "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+def _make_supervisor(repo: Path, store: Any) -> Any:
+    from aragora.swarm.supervisor import SwarmSupervisor
+
+    config = LaunchConfig(no_progress_timeout_seconds=1.0)
+    launcher = WorkerLauncher(config=config)
+    return SwarmSupervisor(repo_root=repo, store=store, launcher=launcher)
+
+
+def _make_dispatched_item(
+    repo: Path,
+    *,
+    work_order_id: str = "wo-outcome",
+    initial_head: str | None = None,
+) -> dict[str, Any]:
+    head = initial_head or _head(repo)
+    dispatched_at = datetime(2020, 1, 1, tzinfo=UTC).isoformat()
+    return {
+        "work_order_id": work_order_id,
+        "status": "dispatched",
+        "target_agent": "codex",
+        "worktree_path": str(repo),
+        "branch": "main",
+        "initial_head": head,
+        "lease_id": "",
+        "file_scope": [],
+        "pid": 99999,
+        "dispatched_at": dispatched_at,
+        "last_progress_at": dispatched_at,
+        "changed_paths": [],
+    }
+
+
+def _create_run(store: Any, item: dict[str, Any]) -> str:
+    record = store.create_supervisor_run(
+        goal="test outcome",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "test outcome"},
+        work_orders=[item],
+    )
+    return record["run_id"]


### PR DESCRIPTION
## Summary

- **Root cause**: Worker prompt instructed `git commit` but not `git push`; `_auto_commit` committed locally but never pushed; `_extract_deliverable` gate requires branch+commit_shas which local commits satisfy, but higher-level orchestrators (campaign, boss loop) need pushed artifacts for review/PR creation
- **Fix 1**: Worker prompt now includes explicit `git push origin HEAD` instruction (with note that failure is acceptable — harness will retry)
- **Fix 2**: `_auto_commit` now calls `_auto_push` after successful commit (best-effort, logs on failure, preserves local commit)
- **Fix 3**: `WorkerOutcome` enum added to supervisor — structured classification of every work-order terminal state (completed, clean_exit_no_effect, crash, crash_with_salvage, timeout_no_progress, timeout_with_salvage, scope_violation)
- **Fix 4**: `_extract_worker_outcome` and `worker_outcome` field added to `BossIterationStatus` for operator-facing output
- **Fix 5**: Detached pid-dead path now attempts result collection before marking crash, recovering commits made before worker death

## Test plan

- [x] 17 new regression tests in `tests/swarm/test_worker_no_deliverable.py`
- [x] All 13 `test_worker_outcome_classification.py` tests now pass (previously ImportError)
- [x] 406 existing swarm tests pass (0 regressions)
- [x] Pre-existing failures verified: 13 in `test_boss_model_selection.py` (missing `worker_model` field), 1 in `test_worker_launcher.py` (720 vs 120 default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)