### PR TITLE
fix(swarm): disable nested worktree for campaign workers, fail-closed no-effect

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -458,6 +458,7 @@ async def dispatch_bounded_spec(
     repo_path: Any | None = None,
     default_target_agent: str | None = None,
     default_reviewer_agent: str | None = None,
+    use_managed_session_script: bool = True,
 ) -> dict[str, Any]:
     """Dispatch one bounded spec via the supervisor-backed Boss path.
 
@@ -496,6 +497,7 @@ async def dispatch_bounded_spec(
             max_ticks=max_ticks,
             default_target_agent=default_target_agent,
             default_reviewer_agent=default_reviewer_agent,
+            use_managed_session_script=use_managed_session_script,
         )
         run_dict = run.to_dict()
         outcome = _classify_terminal_run_outcome(run_dict)

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -958,6 +958,7 @@ class CampaignExecutor:
             repo_path=self.repo_root,
             default_target_agent=worker_model,
             default_reviewer_agent=review_model,
+            use_managed_session_script=False,
         )
 
         with locked_manifest_path(self.manifest_path):

--- a/aragora/swarm/commander.py
+++ b/aragora/swarm/commander.py
@@ -236,18 +236,26 @@ class SwarmCommander:
         max_ticks: int | None = None,
         default_target_agent: str | None = None,
         default_reviewer_agent: str | None = None,
+        use_managed_session_script: bool = True,
     ) -> SupervisorRun:
         """Dispatch a spec through the supervisor-backed Codex/Claude worker pool.
 
         Args:
             dispatch: If True, spawn CLI worker processes after provisioning.
             wait: If True, reconcile until the run reaches a stable stop condition.
+            use_managed_session_script: If False, skip the codex_session.sh wrapper
+                and run the worker CLI directly in the harness-managed worktree.
         """
         self._spec = spec
         self._require_dispatch_bounded(spec)
         from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher
 
-        launcher = WorkerLauncher(config=LaunchConfig(detach=not wait))
+        launcher = WorkerLauncher(
+            config=LaunchConfig(
+                detach=not wait,
+                use_managed_session_script=use_managed_session_script,
+            )
+        )
         supervisor = SwarmSupervisor(repo_root=repo_path or Path.cwd(), launcher=launcher)
         run = supervisor.start_run(
             spec=spec,

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -892,7 +892,7 @@ class SwarmSupervisor:
                 item["exit_code"] = result.exit_code
                 return
 
-            # Clean exit with zero changes of any kind
+            # Clean exit with zero changes of any kind — fail closed
             if not clean_paths and not result.commit_shas:
                 if not _pre_outcome:
                     item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
@@ -904,6 +904,13 @@ class SwarmSupervisor:
                     result.initial_head,
                     result.head_sha,
                 )
+                self._mark_needs_human(
+                    item,
+                    "worker exited 0 with no commits and no changed paths",
+                )
+                self._release_terminal_lease(item)
+                item["exit_code"] = result.exit_code
+                return
             elif not _pre_outcome:
                 item["worker_outcome"] = WorkerOutcome.COMPLETED.value
 

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -489,10 +489,10 @@ class TestDetachedWorkerEndToEndFailClosed:
         # Should proceed to completed, not rejected
         assert item["status"] != "needs_human"
 
-    def test_genuine_no_op_worker_not_rejected(
+    def test_genuine_no_op_worker_fails_closed(
         self, repo: Path, store: DevCoordinationStore
     ) -> None:
-        """A worker with no changes AND no commits should not be rejected by artifact guard."""
+        """A worker with no changes AND no commits must fail closed to needs_human."""
         supervisor = self._make_supervisor(repo, store)
         item = {
             "work_order_id": "no-op",
@@ -513,5 +513,5 @@ class TestDetachedWorkerEndToEndFailClosed:
         )
         supervisor._apply_worker_result(item, result)
 
-        # Genuine no-op should still complete (no deliverables but no ghost commits)
-        assert item["status"] == "completed"
+        # Genuine no-op must fail closed — a worker that produces nothing is not "completed"
+        assert item["status"] == "needs_human"

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -452,6 +452,8 @@ async def test_collect_results_updates_work_orders(repo: Path, store: DevCoordin
         exit_code=0,
         completed_at="2026-03-06T20:00:00+00:00",
         diff="diff --git a/test.py",
+        changed_paths=["test.py"],
+        commit_shas=["abc123"],
     )
     mock_launcher.get_worker = MagicMock(return_value=completed_worker)
     mock_launcher.wait = AsyncMock(return_value=completed_worker)

--- a/tests/swarm/test_worker_no_deliverable.py
+++ b/tests/swarm/test_worker_no_deliverable.py
@@ -328,6 +328,9 @@ class TestSupervisorWorkerOutcome:
         record = store.get_supervisor_run(run_id)
         wo = record["work_orders"][0]
         assert wo["worker_outcome"] == WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
+        assert wo["status"] == "needs_human", (
+            "clean_exit_no_effect must fail closed to needs_human, not completed"
+        )
 
     @pytest.mark.asyncio
     async def test_nonzero_exit_no_commits_sets_crash(self, tmp_path: Path) -> None:
@@ -478,3 +481,86 @@ def _create_run(store: Any, item: dict[str, Any]) -> str:
         work_orders=[item],
     )
     return record["run_id"]
+
+
+# ---------------------------------------------------------------------------
+# Campaign dispatch disables managed session script
+# ---------------------------------------------------------------------------
+
+
+class TestCampaignDisablesManagedSessionScript:
+    """Campaign executor must pass use_managed_session_script=False to avoid
+    the nested-worktree problem where codex_session.sh creates a second
+    worktree that the harness never inspects."""
+
+    @pytest.mark.asyncio
+    async def test_campaign_dispatch_passes_use_managed_session_script_false(
+        self, tmp_path: Path
+    ) -> None:
+        """Verify dispatch_bounded_spec receives use_managed_session_script=False
+        when called from the campaign executor."""
+        from unittest.mock import ANY
+
+        from aragora.swarm.campaign import (
+            CampaignExecutor,
+            CampaignManifest,
+            CampaignProject,
+            save_campaign_manifest,
+        )
+        from aragora.swarm.spec import SwarmSpec
+
+        manifest_dir = tmp_path / ".aragora"
+        manifest_dir.mkdir()
+        manifest_path = manifest_dir / "campaign_manifest.yaml"
+
+        spec = SwarmSpec(
+            raw_goal="test",
+            refined_goal="test",
+            acceptance_criteria=["test passes"],
+            file_scope_hints=["test.md"],
+        )
+        project = CampaignProject(
+            project_id="proj-001",
+            title="test project",
+            spec=spec,
+            acceptance_criteria=["test passes"],
+            file_scope_hints=["test.md"],
+            estimated_cost_usd=1.0,
+        )
+        manifest = CampaignManifest(
+            campaign_id="test-campaign",
+            created_at="2026-01-01T00:00:00Z",
+            source_kind="prebuilt",
+            source_ref="test",
+            worker_model="codex",
+            review_model="claude",
+            max_retries_per_project=0,
+            projects=[project],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+
+        captured_kwargs: dict[str, Any] = {}
+
+        async def mock_dispatch(spec: Any, **kwargs: Any) -> dict[str, Any]:
+            captured_kwargs.update(kwargs)
+            return {
+                "status": "needs_human",
+                "outcome": "clean_exit_no_deliverable",
+                "run": {"status": "completed", "work_orders": []},
+                "run_id": "test-run-id",
+            }
+
+        executor = CampaignExecutor(
+            manifest_path=manifest_path,
+            repo_root=tmp_path,
+        )
+        with patch(
+            "aragora.swarm.campaign.dispatch_bounded_spec",
+            side_effect=mock_dispatch,
+        ):
+            await executor.execute_once()
+
+        assert captured_kwargs.get("use_managed_session_script") is False, (
+            "Campaign executor must pass use_managed_session_script=False "
+            "to prevent codex_session.sh from creating a nested worktree"
+        )


### PR DESCRIPTION
## Summary

- Campaign workers now run directly in the harness-managed worktree (`use_managed_session_script=False`), fixing the root cause of all three dogfood runs producing no deliverables
- `clean_exit_no_effect` now fails closed to `needs_human` instead of falling through to `completed`

## Root Cause

`codex_session.sh` creates a nested worktree via `codex_worktree_autopilot.py ensure`. The worker CLI runs in the inner worktree, but `WorkerLauncher.wait()` checks the outer worktree for changes — finds nothing — `clean_exit_no_deliverable`.

## Changes

- `aragora/swarm/campaign.py`: Pass `use_managed_session_script=False` to `dispatch_bounded_spec`
- `aragora/swarm/boss_loop.py`: Thread `use_managed_session_script` parameter through `dispatch_bounded_spec`
- `aragora/swarm/commander.py`: Thread parameter to `LaunchConfig` in `run_supervised_from_spec`
- `aragora/swarm/supervisor.py`: `clean_exit_no_effect` now calls `_mark_needs_human` and returns (fail-closed)
- `tests/swarm/test_worker_no_deliverable.py`: Add test verifying campaign passes `use_managed_session_script=False`; strengthen `clean_exit_no_effect` test to assert `needs_human` status
- `tests/swarm/test_supervisor.py`: Fix test to use realistic worker with `changed_paths` and `commit_shas`
- `tests/swarm/test_session_artifact_prevention.py`: Update no-op test to expect `needs_human` (fail-closed)

## Test plan

- [x] `tests/swarm/test_worker_no_deliverable.py` — 18/18 pass
- [x] `tests/swarm/test_campaign.py` — 23/23 pass
- [x] `tests/swarm/test_supervisor.py` — updated test passes
- [x] `tests/swarm/test_session_artifact_prevention.py` — updated test passes
- [x] Full swarm suite — 79 relevant tests pass, pre-existing failures unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)