### PR TITLE
fix(swarm): porcelain path truncation causes spurious scope violations

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -506,7 +506,7 @@ class WorkerLauncher:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
             if proc.returncode != 0:
                 return ""
-            return stdout.decode(errors="replace").strip()
+            return stdout.decode(errors="replace").rstrip()
         except (asyncio.TimeoutError, FileNotFoundError, OSError):
             return ""
 
@@ -565,11 +565,27 @@ class WorkerLauncher:
             )
             changed.update(line.strip() for line in diff_names.splitlines() if line.strip())
 
+        # _git_output() strips the whole output, which can eat the leading
+        # space from porcelain status lines like " M docs/file.py".  Parse
+        # robustly: skip the first two status characters if the line matches
+        # the XY+space pattern, otherwise fall back to lstrip-after-status.
         status_output = await cls._git_output(worktree_path, "status", "--porcelain")
         for line in status_output.splitlines():
-            if len(line) < 4:
+            if not line or len(line) < 2:
                 continue
-            path = line[3:].strip()
+            # Porcelain v1: XY<space>PATH  (3 chars prefix when both X,Y present)
+            # After .strip(), a leading-space status " M" becomes "M" — only
+            # 2 chars before the path.  Detect by checking whether position 2
+            # is a space (full prefix) or part of the path (stripped prefix).
+            if len(line) > 2 and line[2] == " ":
+                path = line[3:].strip()
+            else:
+                # Stripped leading space: "M docs/..." or "?? docs/..."
+                # Find the first space after the status chars.
+                first_space = line.find(" ")
+                if first_space < 0:
+                    continue
+                path = line[first_space + 1 :].strip()
             if " -> " in path:
                 path = path.split(" -> ")[-1].strip()
             if path:

--- a/tests/swarm/test_worker_no_deliverable.py
+++ b/tests/swarm/test_worker_no_deliverable.py
@@ -692,3 +692,120 @@ class TestDogfood4UncommittedChanges:
         }
         assert _extract_deliverable(run_dict) is None
         assert _classify_terminal_run_outcome(run_dict) == "clean_exit_no_deliverable"
+
+
+# ---------------------------------------------------------------------------
+# Dogfood #5 failure shape: porcelain status path truncation
+# ---------------------------------------------------------------------------
+
+
+class TestPorcelainPathParsing:
+    """Regression: _git_output().strip() ate the leading space from porcelain
+    status lines like ' M docs/file.py', truncating the path by one character.
+
+    Root cause: ``git status --porcelain`` emits lines like `` M docs/file.py``
+    (space + M + space + path).  ``_git_output`` called ``.strip()`` on the
+    entire output, removing the leading space from the first line.  The fixed
+    ``line[3:]`` parser then produced ``ocs/file.py`` instead of
+    ``docs/file.py``, triggering a spurious scope violation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unstaged_modification_path_not_truncated(self, tmp_path: Path):
+        """Unstaged modification ' M docs/file.py' must not lose the first char."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        docs = repo / "docs" / "guides"
+        docs.mkdir(parents=True)
+        target = docs / "SWARM_DOGFOOD_OPERATOR.md"
+        target.write_text("# Operator Guide\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add doc"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        # Modify without staging → ' M docs/guides/...'
+        target.write_text("# Operator Guide\n\n## New Section\n")
+
+        paths = await WorkerLauncher._collect_changed_paths(
+            str(repo),
+            initial_head=head,
+            head_sha=head,
+        )
+        assert "docs/guides/SWARM_DOGFOOD_OPERATOR.md" in paths
+        assert not any(p.startswith("ocs/") for p in paths)
+
+    @pytest.mark.asyncio
+    async def test_staged_modification_path_parsed(self, tmp_path: Path):
+        """Staged modification 'M  docs/file.py' must parse the full path."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        env = {
+            **__import__("os").environ,
+            "GIT_AUTHOR_NAME": "test",
+            "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "test",
+            "GIT_COMMITTER_EMAIL": "t@t",
+        }
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "init"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        docs = repo / "docs" / "guides"
+        docs.mkdir(parents=True)
+        target = docs / "SWARM_DOGFOOD_OPERATOR.md"
+        target.write_text("# Operator Guide\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "add doc"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            env=env,
+        )
+        head = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        # Modify and stage → 'M  docs/guides/...'
+        target.write_text("# Operator Guide\n\n## New Section\n")
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+
+        paths = await WorkerLauncher._collect_changed_paths(
+            str(repo),
+            initial_head=head,
+            head_sha=head,
+        )
+        assert "docs/guides/SWARM_DOGFOOD_OPERATOR.md" in paths


### PR DESCRIPTION
## Summary
- `_git_output().strip()` was removing the leading space from `git status --porcelain` output (` M docs/file.py` → `M docs/file.py`), causing `line[3:]` to truncate paths (`ocs/file.py`)
- Truncated paths fail file-scope checks → spurious `scope_violation` → worker killed before commit → `clean_exit_no_deliverable`
- Fix: `.strip()` → `.rstrip()` in `_git_output()`, plus robust porcelain parser handling both 2-char and 3-char status prefixes

## Test plan
- [x] Two new regression tests in `TestPorcelainPathParsing` (unstaged + staged modifications in real git repos)
- [x] All 29 existing worker launcher tests pass
- [ ] Dogfood #6 campaign run validates end-to-end fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)