### PR TITLE
feat(swarm): automatic receipt emission on terminal project transitions

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -29,6 +29,17 @@ logger = logging.getLogger(__name__)
 UTC = timezone.utc
 DEFAULT_CAMPAIGN_MANIFEST = ".aragora/campaign_manifest.yaml"
 
+# Statuses that represent terminal project transitions (no further retries).
+# Receipt emission fires only for these statuses.
+_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {
+        "completed",
+        "failed",
+        "blocked",
+        "skipped",
+    }
+)
+
 
 class CampaignProjectStatus(str, Enum):
     PENDING = "pending"
@@ -908,7 +919,7 @@ class CampaignExecutor:
             manifest = load_campaign_manifest(self.manifest_path)
             project = manifest.project_map()[project_id]
             project.review = gate
-            self._apply_review_result(project, gate)
+            self._apply_review_result(manifest, project, gate, run_dict=run_dict)
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
             return {"project_id": project_id, "review": gate.to_dict(), "status": project.status}
@@ -987,7 +998,9 @@ class CampaignExecutor:
                 manifest = load_campaign_manifest(self.manifest_path)
                 project = manifest.project_map()[project_id]
                 project.review = gate
-                self._apply_review_result(project, gate)
+                self._apply_review_result(
+                    manifest, project, gate, run_dict=dict(result.get("run") or {})
+                )
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
 
@@ -1046,13 +1059,27 @@ class CampaignExecutor:
         }:
             project.status = CampaignProjectStatus.SKIPPED.value
 
-    def _apply_review_result(self, project: CampaignProject, gate: CampaignReviewGate) -> None:
+        if project.status in _TERMINAL_STATUSES:
+            self._emit_receipt(manifest, project, run_dict)
+
+    def _apply_review_result(
+        self,
+        manifest: CampaignManifest,
+        project: CampaignProject,
+        gate: CampaignReviewGate,
+        run_dict: dict[str, Any] | None = None,
+    ) -> None:
+        project.review = gate
+
         if gate.status == CampaignReviewStatus.PASSED.value:
             project.status = CampaignProjectStatus.COMPLETED.value
         elif gate.status == CampaignReviewStatus.CHANGES_REQUESTED.value:
             project.status = CampaignProjectStatus.NEEDS_REVISION.value
         else:
             project.status = CampaignProjectStatus.BLOCKED.value
+
+        if project.status in _TERMINAL_STATUSES:
+            self._emit_receipt(manifest, project, run_dict)
 
     def _spec_for_retry(self, project: CampaignProject) -> SwarmSpec:
         spec = SwarmSpec.from_dict(project.spec.to_dict())
@@ -1114,6 +1141,7 @@ class CampaignExecutor:
                 continue
             if project.retry_count > manifest.max_retries_per_project:
                 project.status = CampaignProjectStatus.SKIPPED.value
+                self._emit_receipt(manifest, project, None)
                 continue
             deps = {dep.project_id for dep in project.dependencies}
             if deps.issubset(completed):
@@ -1129,6 +1157,81 @@ class CampaignExecutor:
         except Exception:
             record = supervisor.store.get_supervisor_run(run_id)
             return dict(record) if isinstance(record, dict) else None
+
+    def _emit_receipt(
+        self,
+        manifest: CampaignManifest,
+        project: CampaignProject,
+        run_dict: dict[str, Any] | None,
+    ) -> Path:
+        """Write an authoritative receipt file at terminal project transition.
+
+        Receipts are written to docs/receipts/<campaign_id>/<project_id>.yaml
+        atomically (temp file + replace). Raises RuntimeError on failure so
+        the caller knows the receipt was not persisted.
+        """
+        receipt_dir = self.repo_root / "docs" / "receipts" / manifest.campaign_id
+        receipt_path = receipt_dir / f"{project.project_id}.yaml"
+        try:
+            try:
+                manifest_input = str(self.manifest_path.relative_to(self.repo_root))
+            except ValueError:
+                manifest_input = str(self.manifest_path)
+
+            payload: dict[str, Any] = {
+                "task_id": project.project_id,
+                "campaign_id": manifest.campaign_id,
+                "phase": _derive_phase(manifest.campaign_id),
+                "manifest_input": manifest_input,
+                "worker_branch": _worker_branch_from_run(project, run_dict),
+                "worker_commit": _worker_commit_from_run(project, run_dict),
+                "changed_files": _changed_files_from_run(run_dict),
+                "review_verdict": _receipt_review_verdict(project.review.status),
+                "verification_results": {
+                    "pytest_exit_code": None,
+                    "syntax_check": None,
+                    "truth_suite": None,
+                },
+                "final_status": _receipt_final_status(project.status),
+                "failure_classification": _failure_classification_from_outcome(
+                    project.last_run_outcome
+                ),
+                "rescue_required": False,
+                "rescue_description": None,
+                "cost_usd": project.estimated_cost_usd,
+                "duration_seconds": _duration_seconds_from_run(run_dict),
+                "created_at": datetime.now(UTC).isoformat(),
+            }
+
+            try:
+                import yaml
+
+                content = yaml.safe_dump(payload, sort_keys=True, allow_unicode=False)
+            except ImportError:
+                content = json.dumps(payload, indent=2, sort_keys=True)
+
+            receipt_dir.mkdir(parents=True, exist_ok=True)
+            tmp_path = receipt_path.with_suffix(".yaml.tmp")
+            tmp_path.write_text(content, encoding="utf-8")
+            tmp_path.replace(receipt_path)
+
+            project.receipt_id = str(receipt_path.relative_to(self.repo_root))
+            logger.info(
+                "receipt_emitted: project=%s status=%s path=%s",
+                project.project_id,
+                project.status,
+                project.receipt_id,
+            )
+            return receipt_path
+
+        except Exception as exc:
+            logger.error(
+                "receipt_emit_failed: project=%s status=%s error=%s",
+                project.project_id,
+                project.status,
+                exc,
+            )
+            raise RuntimeError(f"Failed to emit receipt for {project.project_id}: {exc}") from exc
 
 
 def _parse_dt(value: str | None) -> datetime | None:
@@ -1303,3 +1406,118 @@ def _extract_json_list(text: str) -> list[str]:
     if isinstance(findings, list):
         return [str(item) for item in findings if str(item).strip()]
     return []
+
+
+# ---------------------------------------------------------------------------
+# Receipt emission helpers
+# ---------------------------------------------------------------------------
+
+
+def _derive_phase(campaign_id: str) -> str | None:
+    cid = str(campaign_id or "").lower()
+    for prefix, label in (
+        ("phase0a", "0a"),
+        ("phase0b", "0b"),
+        ("phase1", "1"),
+        ("phase2", "2"),
+    ):
+        if cid.startswith(prefix):
+            return label
+    return None
+
+
+def _failure_classification_from_outcome(outcome: str | None) -> str | None:
+    mapping = {
+        CampaignRunOutcome.CRASH.value: "worker_crash",
+        CampaignRunOutcome.TIMEOUT.value: "timeout",
+        CampaignRunOutcome.BLOCKED.value: "stall",
+        CampaignRunOutcome.NEEDS_HUMAN.value: "stall",
+        CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value: "stall",
+    }
+    return mapping.get(str(outcome or ""))
+
+
+def _receipt_final_status(project_status: str) -> str:
+    return {
+        "completed": "completed",
+        "failed": "failed",
+        "skipped": "failed",
+        "blocked": "rejected",
+    }.get(project_status, "failed")
+
+
+def _receipt_review_verdict(review_status: str) -> str:
+    return {
+        CampaignReviewStatus.PASSED.value: "passed",
+        CampaignReviewStatus.CHANGES_REQUESTED.value: "failed",
+        CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value: "failed",
+        CampaignReviewStatus.PENDING.value: "skipped",
+    }.get(review_status, "skipped")
+
+
+def _duration_seconds_from_run(run_dict: dict[str, Any] | None) -> int | None:
+    if not run_dict:
+        return None
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        started = str(wo.get("started_at", "")).strip()
+        ended = str(wo.get("completed_at", "")).strip()
+        if started and ended:
+            try:
+                t_start = datetime.fromisoformat(started)
+                t_end = datetime.fromisoformat(ended)
+                return max(0, int((t_end - t_start).total_seconds()))
+            except (ValueError, TypeError):
+                continue
+    return None
+
+
+def _changed_files_from_run(run_dict: dict[str, Any] | None) -> list[str]:
+    if not run_dict:
+        return []
+    paths: list[str] = []
+    seen: set[str] = set()
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        for p in wo.get("changed_paths", []):
+            text = str(p).strip()
+            if text and text not in seen:
+                seen.add(text)
+                paths.append(text)
+    return paths
+
+
+def _worker_branch_from_run(
+    project: CampaignProject, run_dict: dict[str, Any] | None
+) -> str | None:
+    if project.branch:
+        return project.branch
+    if not run_dict:
+        return None
+    for wo in run_dict.get("work_orders", []):
+        if isinstance(wo, dict):
+            branch = str(wo.get("branch", "")).strip()
+            if branch:
+                return branch
+    return None
+
+
+def _worker_commit_from_run(
+    project: CampaignProject, run_dict: dict[str, Any] | None
+) -> str | None:
+    if project.commit_shas:
+        return project.commit_shas[-1]
+    if not run_dict:
+        return None
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        sha = str(wo.get("head_sha", "")).strip()
+        if sha:
+            return sha
+        shas = [str(s).strip() for s in wo.get("commit_shas", []) if str(s).strip()]
+        if shas:
+            return shas[-1]
+    return None

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -1,0 +1,380 @@
+"""Tests for automatic receipt emission on terminal project transitions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.swarm.campaign import (
+    CampaignExecutor,
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    CampaignReviewGate,
+    CampaignReviewStatus,
+    CampaignRunOutcome,
+    _derive_phase,
+    _failure_classification_from_outcome,
+    _receipt_final_status,
+    _receipt_review_verdict,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper free-function tests
+# ---------------------------------------------------------------------------
+
+
+class TestDerivePhase:
+    def test_phase0a(self) -> None:
+        assert _derive_phase("phase0a-bootstrap-governance") == "0a"
+
+    def test_phase0b(self) -> None:
+        assert _derive_phase("phase0b-engine-hardening") == "0b"
+
+    def test_phase1(self) -> None:
+        assert _derive_phase("phase1-controlled-repair") == "1"
+
+    def test_phase2(self) -> None:
+        assert _derive_phase("phase2-broader-cleanup") == "2"
+
+    def test_unknown_campaign_id(self) -> None:
+        assert _derive_phase("campaign-dogfood-6") is None
+
+    def test_empty_string(self) -> None:
+        assert _derive_phase("") is None
+
+    def test_case_insensitive(self) -> None:
+        assert _derive_phase("Phase0A-test") == "0a"
+
+
+class TestFailureClassification:
+    def test_crash(self) -> None:
+        assert _failure_classification_from_outcome("crash") == "worker_crash"
+
+    def test_timeout(self) -> None:
+        assert _failure_classification_from_outcome("timeout") == "timeout"
+
+    def test_blocked(self) -> None:
+        assert _failure_classification_from_outcome("blocked") == "stall"
+
+    def test_needs_human(self) -> None:
+        assert _failure_classification_from_outcome("needs_human") == "stall"
+
+    def test_deliverable_created(self) -> None:
+        assert _failure_classification_from_outcome("deliverable_created") is None
+
+    def test_none(self) -> None:
+        assert _failure_classification_from_outcome(None) is None
+
+
+class TestReceiptFinalStatus:
+    def test_completed(self) -> None:
+        assert _receipt_final_status("completed") == "completed"
+
+    def test_failed(self) -> None:
+        assert _receipt_final_status("failed") == "failed"
+
+    def test_skipped(self) -> None:
+        assert _receipt_final_status("skipped") == "failed"
+
+    def test_blocked(self) -> None:
+        assert _receipt_final_status("blocked") == "rejected"
+
+
+class TestReceiptReviewVerdict:
+    def test_passed(self) -> None:
+        assert _receipt_review_verdict("passed") == "passed"
+
+    def test_changes_requested(self) -> None:
+        assert _receipt_review_verdict("changes_requested") == "failed"
+
+    def test_pending(self) -> None:
+        assert _receipt_review_verdict("pending") == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Receipt emission integration tests
+# ---------------------------------------------------------------------------
+
+
+def _make_project(
+    project_id: str = "test-001",
+    status: str = "ready",
+    *,
+    branch: str = "codex/test-branch",
+    estimated_cost_usd: float = 1.0,
+) -> CampaignProject:
+    return CampaignProject(
+        project_id=project_id,
+        title=f"Test project {project_id}",
+        status=status,
+        estimated_cost_usd=estimated_cost_usd,
+        branch=branch,
+        spec=MagicMock(to_dict=lambda: {}),
+    )
+
+
+def _make_manifest(
+    campaign_id: str = "phase0a-test",
+    projects: list[CampaignProject] | None = None,
+) -> CampaignManifest:
+    m = CampaignManifest(
+        campaign_id=campaign_id,
+        created_at="2026-03-10T21:00:00+00:00",
+        source_kind="test",
+        source_ref="test",
+    )
+    if projects:
+        m.projects = projects
+    return m
+
+
+class TestEmitReceipt:
+    def test_receipt_written_on_completed(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed")
+        manifest = _make_manifest(projects=[project])
+
+        receipt_path = executor._emit_receipt(manifest, project, None)
+
+        assert receipt_path.exists()
+        content = receipt_path.read_text()
+        assert "task_id: test-001" in content
+        assert "campaign_id: phase0a-test" in content
+        assert "phase: 0a" in content
+        assert "final_status: completed" in content
+        assert "rescue_required: false" in content
+
+    def test_receipt_written_on_failed(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="failed")
+        project.last_run_outcome = CampaignRunOutcome.TIMEOUT.value
+        manifest = _make_manifest(projects=[project])
+
+        receipt_path = executor._emit_receipt(manifest, project, None)
+
+        content = receipt_path.read_text()
+        assert "final_status: failed" in content
+        assert "failure_classification: timeout" in content
+
+    def test_receipt_written_on_blocked(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="blocked")
+        project.review = CampaignReviewGate(
+            status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
+        )
+        manifest = _make_manifest(projects=[project])
+
+        receipt_path = executor._emit_receipt(manifest, project, None)
+
+        content = receipt_path.read_text()
+        assert "final_status: rejected" in content
+
+    def test_receipt_path_correct(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: my-campaign\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(project_id="proj-007", status="completed")
+        manifest = _make_manifest(campaign_id="my-campaign", projects=[project])
+
+        receipt_path = executor._emit_receipt(manifest, project, None)
+
+        assert receipt_path == tmp_path / "docs" / "receipts" / "my-campaign" / "proj-007.yaml"
+
+    def test_receipt_sets_receipt_id_on_project(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed")
+        manifest = _make_manifest(projects=[project])
+
+        executor._emit_receipt(manifest, project, None)
+
+        assert project.receipt_id == "docs/receipts/phase0a-test/test-001.yaml"
+
+    def test_receipt_raises_on_write_failure(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed")
+        manifest = _make_manifest(projects=[project])
+
+        with patch.object(Path, "mkdir", side_effect=PermissionError("denied")):
+            with pytest.raises(RuntimeError, match="Failed to emit receipt"):
+                executor._emit_receipt(manifest, project, None)
+
+    def test_receipt_extracts_worker_info_from_run_dict(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed", branch="")
+        manifest = _make_manifest(projects=[project])
+        run_dict = {
+            "work_orders": [
+                {
+                    "branch": "codex/from-run",
+                    "head_sha": "abc123",
+                    "changed_paths": ["docs/test.md"],
+                    "started_at": "2026-03-10T21:00:00+00:00",
+                    "completed_at": "2026-03-10T21:05:00+00:00",
+                }
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        content = receipt_path.read_text()
+        assert "codex/from-run" in content
+        assert "abc123" in content
+        assert "docs/test.md" in content
+        assert "duration_seconds: 300" in content
+
+    def test_receipt_always_marks_rescue_false(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed")
+        manifest = _make_manifest(projects=[project])
+
+        receipt_path = executor._emit_receipt(manifest, project, None)
+
+        content = receipt_path.read_text()
+        assert "rescue_required: false" in content
+        assert "rescue_description: null" in content
+
+
+class TestApplyDispatchResultEmitsReceipt:
+    def test_receipt_emitted_on_terminal_dispatch(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="active")
+        manifest = _make_manifest(projects=[project])
+        manifest.max_retries_per_project = 0
+
+        result = {
+            "run_id": "run-001",
+            "run": {},
+            "deliverable": {},
+            "outcome": CampaignRunOutcome.NEEDS_HUMAN.value,
+        }
+        executor._apply_dispatch_result(manifest, project, result)
+
+        assert project.status == CampaignProjectStatus.BLOCKED.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert receipt_path.exists()
+
+    def test_no_receipt_on_delivered(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="active")
+        manifest = _make_manifest(projects=[project])
+
+        result = {
+            "run_id": "run-001",
+            "run": {},
+            "deliverable": {},
+            "outcome": CampaignRunOutcome.DELIVERABLE_CREATED.value,
+        }
+        executor._apply_dispatch_result(manifest, project, result)
+
+        assert project.status == CampaignProjectStatus.DELIVERED.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert not receipt_path.exists()
+
+    def test_no_receipt_on_needs_revision(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="active")
+        manifest = _make_manifest(projects=[project])
+        manifest.max_retries_per_project = 5
+
+        result = {
+            "run_id": "run-001",
+            "run": {},
+            "deliverable": {},
+            "outcome": CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value,
+        }
+        executor._apply_dispatch_result(manifest, project, result)
+
+        assert project.status == CampaignProjectStatus.NEEDS_REVISION.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert not receipt_path.exists()
+
+
+class TestReadyProjectsEmitsReceipt:
+    def test_receipt_emitted_when_retry_exhausted(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="needs_revision")
+        project.retry_count = 3
+        manifest = _make_manifest(projects=[project])
+        manifest.max_retries_per_project = 2
+
+        executor._ready_projects(manifest)
+
+        assert project.status == CampaignProjectStatus.SKIPPED.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert receipt_path.exists()
+        content = receipt_path.read_text()
+        assert "final_status: failed" in content  # skipped maps to failed
+
+
+class TestApplyReviewResultEmitsReceipt:
+    def test_receipt_emitted_on_completed_review(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="delivered")
+        manifest = _make_manifest(projects=[project])
+        gate = CampaignReviewGate(status=CampaignReviewStatus.PASSED.value)
+
+        executor._apply_review_result(manifest, project, gate)
+
+        assert project.status == CampaignProjectStatus.COMPLETED.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert receipt_path.exists()
+        content = receipt_path.read_text()
+        assert "review_verdict: passed" in content
+        assert "final_status: completed" in content
+
+    def test_no_receipt_on_changes_requested(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="delivered")
+        manifest = _make_manifest(projects=[project])
+        gate = CampaignReviewGate(status=CampaignReviewStatus.CHANGES_REQUESTED.value)
+
+        executor._apply_review_result(manifest, project, gate)
+
+        assert project.status == CampaignProjectStatus.NEEDS_REVISION.value
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        assert not receipt_path.exists()


### PR DESCRIPTION
## Summary
- Campaign executor now writes authoritative YAML receipts to `docs/receipts/{campaign_id}/{project_id}.yaml` at terminal transitions
- Receipts emitted from 3 paths: dispatch result, review result, retry exhaustion
- Atomic writes via temp file + `Path.replace()`, fails loudly on write error
- Split from #923 for focused review

## Test plan
- [x] 34 tests covering helpers, direct emission, integration paths, and negative cases
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)