### PR TITLE
fix(campaign): review actual deliverable content

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -463,6 +463,120 @@ def _gh_json(cmd: list[str]) -> Any:
     return json.loads(proc.stdout)
 
 
+_REVIEW_MAX_FILES = 4
+_REVIEW_MAX_DIFF_CHARS = 12000
+_REVIEW_MAX_FILE_CHARS = 3000
+_REVIEW_TIMEOUT_SECONDS = 10
+
+
+def _truncate_review_text(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "\n... [truncated]"
+
+
+def _git_capture(repo_root: Path, args: list[str]) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        timeout=_REVIEW_TIMEOUT_SECONDS,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout
+
+
+def _review_scope_paths(project: CampaignProject, run_dict: dict[str, Any]) -> list[str]:
+    paths: set[str] = set()
+    for hint in project.file_scope_hints:
+        hint_text = str(hint).strip()
+        if hint_text:
+            paths.add(hint_text)
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        for path in work_order.get("changed_paths", []) or []:
+            path_text = str(path).strip()
+            if path_text:
+                paths.add(path_text)
+    return sorted(paths)
+
+
+def _review_branch_changed_files(
+    repo_root: Path, target_branch: str, branch: str, scope_paths: list[str]
+) -> list[str]:
+    args = ["diff", "--name-only", f"{target_branch}...{branch}"]
+    if scope_paths:
+        args.extend(["--", *scope_paths])
+    changed = _git_capture(repo_root, args)
+    return [line.strip() for line in changed.splitlines() if line.strip()]
+
+
+def _review_branch_diff(
+    repo_root: Path, target_branch: str, branch: str, scope_paths: list[str]
+) -> str:
+    args = ["diff", "--no-ext-diff", "--unified=3", f"{target_branch}...{branch}"]
+    if scope_paths:
+        args.extend(["--", *scope_paths])
+    return _git_capture(repo_root, args)
+
+
+def _review_file_snapshots(
+    repo_root: Path, branch: str, changed_files: list[str]
+) -> list[dict[str, str]]:
+    snapshots: list[dict[str, str]] = []
+    for path in changed_files[:_REVIEW_MAX_FILES]:
+        content = _git_capture(repo_root, ["show", f"{branch}:{path}"])
+        if not content:
+            continue
+        snapshots.append(
+            {
+                "path": path,
+                "content": _truncate_review_text(content, _REVIEW_MAX_FILE_CHARS),
+            }
+        )
+    return snapshots
+
+
+def _build_review_evidence(
+    project: CampaignProject,
+    run_dict: dict[str, Any],
+    *,
+    repo_root: Path | None,
+    target_branch: str,
+) -> dict[str, Any]:
+    if repo_root is None:
+        return {"available": False, "reason": "repo_root_unavailable"}
+    branch = str(project.branch or "").strip()
+    if not branch:
+        return {"available": False, "reason": "deliverable_branch_unavailable"}
+
+    scope_paths = _review_scope_paths(project, run_dict)
+    changed_files = _review_branch_changed_files(repo_root, target_branch, branch, scope_paths)
+    if not changed_files:
+        return {
+            "available": False,
+            "reason": "no_changed_files_detected",
+            "branch": branch,
+            "target_branch": target_branch,
+        }
+
+    diff_text = _review_branch_diff(repo_root, target_branch, branch, scope_paths)
+    snapshots = _review_file_snapshots(repo_root, branch, changed_files)
+    return {
+        "available": True,
+        "branch": branch,
+        "target_branch": target_branch,
+        "commit_shas": list(project.commit_shas),
+        "changed_files": changed_files[:_REVIEW_MAX_FILES],
+        "diff": _truncate_review_text(diff_text, _REVIEW_MAX_DIFF_CHARS),
+        "file_snapshots": snapshots,
+    }
+
+
 class CampaignPlanner:
     """Build a persistent campaign manifest from documents or GitHub issues."""
 
@@ -756,9 +870,17 @@ class CampaignReviewer:
         worker_model: str,
         review_model: str,
         run_dict: dict[str, Any],
+        repo_root: Path | None = None,
+        target_branch: str = "main",
     ) -> CampaignReviewGate:
         chosen_review_model = _canonical_review_model(worker_model, review_model)
-        prompt = self._build_prompt(project, run_dict, chosen_review_model)
+        prompt = self._build_prompt(
+            project,
+            run_dict,
+            chosen_review_model,
+            repo_root=repo_root,
+            target_branch=target_branch,
+        )
         try:
             agent = create_agent(chosen_review_model, name="campaign-review", role="critic")
             raw = await agent.generate(prompt)
@@ -791,9 +913,22 @@ class CampaignReviewer:
             )
 
     @staticmethod
-    def _build_prompt(project: CampaignProject, run_dict: dict[str, Any], review_model: str) -> str:
+    def _build_prompt(
+        project: CampaignProject,
+        run_dict: dict[str, Any],
+        review_model: str,
+        *,
+        repo_root: Path | None = None,
+        target_branch: str = "main",
+    ) -> str:
         deliverable = _extract_deliverable(run_dict)
         work_orders = run_dict.get("work_orders", [])
+        deliverable_evidence = _build_review_evidence(
+            project,
+            run_dict,
+            repo_root=repo_root,
+            target_branch=target_branch,
+        )
         summary = {
             "review_model": review_model,
             "project_id": project.project_id,
@@ -802,9 +937,11 @@ class CampaignReviewer:
             "file_scope_hints": project.file_scope_hints,
             "deliverable": deliverable,
             "work_orders": work_orders,
+            "deliverable_evidence": deliverable_evidence,
         }
         return (
             "Review this completed implementation against the project specification.\n"
+            "Use the concrete deliverable evidence below when evaluating content quality.\n"
             "Respond with strict JSON only: "
             '{"status":"passed|changes_requested|blocked_nonreviewable","findings":["..."]}\n'
             f"{json.dumps(summary, sort_keys=True)}"
@@ -914,6 +1051,8 @@ class CampaignExecutor:
             worker_model=manifest.worker_model,
             review_model=manifest.review_model,
             run_dict=run_dict,
+            repo_root=self.repo_root,
+            target_branch=self.target_branch,
         )
         with locked_manifest_path(self.manifest_path):
             manifest = load_campaign_manifest(self.manifest_path)
@@ -993,6 +1132,8 @@ class CampaignExecutor:
                 worker_model=worker_model,
                 review_model=review_model,
                 run_dict=dict(result["run"]),
+                repo_root=self.repo_root,
+                target_branch=self.target_branch,
             )
             with locked_manifest_path(self.manifest_path):
                 manifest = load_campaign_manifest(self.manifest_path)

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -16,6 +17,7 @@ from aragora.swarm.campaign import (
     CampaignPlanner,
     CampaignProject,
     CampaignProjectStatus,
+    CampaignReviewer,
     CampaignReviewGate,
     CampaignReviewStatus,
     CampaignRunOutcome,
@@ -37,6 +39,17 @@ def _bounded_spec(goal: str, scope: list[str] | None = None) -> SwarmSpec:
         file_scope_hints=scope or ["aragora/swarm/campaign.py"],
         budget_limit_usd=5.0,
     )
+
+
+def _git(tmp_repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=tmp_repo,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return proc.stdout.strip()
 
 
 class TestCampaignPlanner:
@@ -258,6 +271,81 @@ class TestCampaignExecutor:
         assert project.status == CampaignProjectStatus.NEEDS_REVISION.value
         assert project.last_run_outcome == CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value
         assert project.retry_count == 1
+
+
+class TestCampaignReviewer:
+    def test_build_prompt_includes_docs_only_deliverable_evidence(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        repo_root.mkdir()
+        _git(repo_root, "init", "-b", "main")
+        _git(repo_root, "config", "user.email", "test@example.com")
+        _git(repo_root, "config", "user.name", "Test User")
+        docs_dir = repo_root / "docs" / "adr"
+        docs_dir.mkdir(parents=True, exist_ok=True)
+        baseline = docs_dir / "README.md"
+        baseline.write_text("# ADR Index\n", encoding="utf-8")
+        _git(repo_root, "add", ".")
+        _git(repo_root, "commit", "-m", "initial")
+
+        branch_name = "codex/docs-phase0a-007"
+        _git(repo_root, "checkout", "-b", branch_name)
+        adr_path = docs_dir / "phase0a-007-backend-runtime.md"
+        adr_path.write_text(
+            "# ADR phase0a-007\n\n"
+            "Decision: standardize the backend worker runtime.\n\n"
+            "Rationale:\n"
+            "- reduce campaign review ambiguity\n"
+            "- make docs-only deliverables reviewable\n",
+            encoding="utf-8",
+        )
+        _git(repo_root, "add", str(adr_path.relative_to(repo_root)))
+        _git(repo_root, "commit", "-m", "Add phase0a-007 ADR")
+        head_sha = _git(repo_root, "rev-parse", "HEAD")
+
+        project = CampaignProject(
+            project_id="phase0a-007",
+            title="Finalize backend runtime ADR",
+            spec=_bounded_spec(
+                "Finalize backend runtime ADR", ["docs/adr/phase0a-007-backend-runtime.md"]
+            ),
+            file_scope_hints=["docs/adr/phase0a-007-backend-runtime.md"],
+            acceptance_criteria=["ADR explains the backend runtime decision"],
+            constraints=["docs only"],
+            branch=branch_name,
+            commit_shas=[head_sha],
+        )
+        run_dict = {
+            "run_id": "run-adr-1",
+            "status": "completed",
+            "work_orders": [
+                {
+                    "status": "completed",
+                    "branch": branch_name,
+                    "commit_shas": [head_sha],
+                    "changed_paths": ["docs/adr/phase0a-007-backend-runtime.md"],
+                }
+            ],
+        }
+
+        prompt = CampaignReviewer._build_prompt(
+            project,
+            run_dict,
+            "claude",
+            repo_root=repo_root,
+            target_branch="main",
+        )
+
+        payload = json.loads(prompt.splitlines()[-1])
+        evidence = payload["deliverable_evidence"]
+        assert evidence["available"] is True
+        assert evidence["branch"] == branch_name
+        assert evidence["target_branch"] == "main"
+        assert evidence["changed_files"] == ["docs/adr/phase0a-007-backend-runtime.md"]
+        assert "standardize the backend worker runtime" in evidence["diff"]
+        assert "make docs-only deliverables reviewable" in evidence["diff"]
+        assert evidence["file_snapshots"][0]["path"] == "docs/adr/phase0a-007-backend-runtime.md"
+        assert "ADR phase0a-007" in evidence["file_snapshots"][0]["content"]
+        assert "concrete deliverable evidence" in prompt.lower()
 
     @pytest.mark.asyncio
     async def test_execute_once_reconciles_active_project_without_redispatch(


### PR DESCRIPTION
## Summary
- pass bounded concrete deliverable evidence into campaign review prompts
- derive docs-only branch evidence from local git diff and file snapshots
- add a regression proving docs-only ADR deliverables are reviewable

## Testing
- pytest -q tests/swarm/test_campaign.py
- python3 -m py_compile aragora/swarm/campaign.py tests/swarm/test_campaign.py
- python3 -m ruff check aragora/swarm/campaign.py tests/swarm/test_campaign.py
- python3 -m ruff format --check aragora/swarm/campaign.py tests/swarm/test_campaign.py