### PR TITLE
fix(swarm): pass actual git diff to campaign reviewer

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -746,6 +746,55 @@ class CampaignPlanner:
                     dependency.project_id = id_map[dependency.project_id]
 
 
+_DIFF_MAX_CHARS = 50_000
+
+
+def _fetch_diff_content(
+    run_dict: dict[str, Any],
+    *,
+    repo_root: Path | None = None,
+    target_branch: str = "main",
+    max_chars: int = _DIFF_MAX_CHARS,
+) -> str | None:
+    """Fetch the actual git diff between the worker branch and the target branch.
+
+    Returns the diff text (truncated to *max_chars*), or ``None`` if the diff
+    cannot be obtained (missing branch, no repo_root, git error).
+    """
+    if repo_root is None:
+        return None
+    deliverable = _extract_deliverable(run_dict)
+    if not deliverable or deliverable.get("type") not in ("branch", "pr"):
+        return None
+    branch = deliverable.get("branch")
+    if not branch:
+        # For PR-type deliverables, try extracting the branch from work orders.
+        for wo in run_dict.get("work_orders", []):
+            if isinstance(wo, dict) and str(wo.get("branch", "")).strip():
+                branch = str(wo["branch"]).strip()
+                break
+    if not branch:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "diff", f"{target_branch}...{branch}"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+            timeout=30,
+        )
+        if result.returncode != 0:
+            logger.debug("_fetch_diff_content git diff failed: %s", result.stderr)
+            return None
+        diff = result.stdout
+        if len(diff) > max_chars:
+            diff = diff[:max_chars] + f"\n\n... [truncated at {max_chars} chars]"
+        return diff if diff.strip() else None
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.debug("_fetch_diff_content error: %s", exc)
+        return None
+
+
 class CampaignReviewer:
     """Blocking heterogeneous review gate for completed campaign projects."""
 
@@ -756,9 +805,16 @@ class CampaignReviewer:
         worker_model: str,
         review_model: str,
         run_dict: dict[str, Any],
+        repo_root: Path | None = None,
+        target_branch: str = "main",
     ) -> CampaignReviewGate:
         chosen_review_model = _canonical_review_model(worker_model, review_model)
-        prompt = self._build_prompt(project, run_dict, chosen_review_model)
+        diff_content = _fetch_diff_content(
+            run_dict, repo_root=repo_root, target_branch=target_branch
+        )
+        prompt = self._build_prompt(
+            project, run_dict, chosen_review_model, diff_content=diff_content
+        )
         try:
             agent = create_agent(chosen_review_model, name="campaign-review", role="critic")
             raw = await agent.generate(prompt)
@@ -791,7 +847,13 @@ class CampaignReviewer:
             )
 
     @staticmethod
-    def _build_prompt(project: CampaignProject, run_dict: dict[str, Any], review_model: str) -> str:
+    def _build_prompt(
+        project: CampaignProject,
+        run_dict: dict[str, Any],
+        review_model: str,
+        *,
+        diff_content: str | None = None,
+    ) -> str:
         deliverable = _extract_deliverable(run_dict)
         work_orders = run_dict.get("work_orders", [])
         summary = {
@@ -803,12 +865,17 @@ class CampaignReviewer:
             "deliverable": deliverable,
             "work_orders": work_orders,
         }
-        return (
+        parts = [
             "Review this completed implementation against the project specification.\n"
             "Respond with strict JSON only: "
             '{"status":"passed|changes_requested|blocked_nonreviewable","findings":["..."]}\n'
-            f"{json.dumps(summary, sort_keys=True)}"
-        )
+            f"{json.dumps(summary, sort_keys=True)}",
+        ]
+        if diff_content:
+            parts.append(
+                f"\n\n--- ACTUAL DIFF (worker branch vs base) ---\n{diff_content}\n--- END DIFF ---"
+            )
+        return "\n".join(parts)
 
 
 class CampaignExecutor:
@@ -914,6 +981,8 @@ class CampaignExecutor:
             worker_model=manifest.worker_model,
             review_model=manifest.review_model,
             run_dict=run_dict,
+            repo_root=self.repo_root,
+            target_branch=self.target_branch,
         )
         with locked_manifest_path(self.manifest_path):
             manifest = load_campaign_manifest(self.manifest_path)
@@ -993,6 +1062,8 @@ class CampaignExecutor:
                 worker_model=worker_model,
                 review_model=review_model,
                 run_dict=dict(result["run"]),
+                repo_root=self.repo_root,
+                target_branch=self.target_branch,
             )
             with locked_manifest_path(self.manifest_path):
                 manifest = load_campaign_manifest(self.manifest_path)

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -1,0 +1,181 @@
+"""Tests for reviewer diff-fidelity: _fetch_diff_content and _build_prompt with diff."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.swarm.campaign import (
+    CampaignProject,
+    CampaignReviewGate,
+    CampaignReviewStatus,
+    CampaignReviewer,
+    _DIFF_MAX_CHARS,
+    _fetch_diff_content,
+)
+
+
+def _make_run_dict(*, branch: str = "codex/worker-branch", commit: str = "abc123") -> dict:
+    return {
+        "work_orders": [
+            {
+                "work_order_id": "wo-1",
+                "status": "completed",
+                "branch": branch,
+                "commit_shas": [commit],
+            }
+        ],
+    }
+
+
+def _make_project(**overrides) -> CampaignProject:
+    defaults = {
+        "project_id": "phase0a-007",
+        "title": "Test project",
+        "status": "active",
+        "acceptance_criteria": ["File exists"],
+        "file_scope_hints": ["docs/test.md"],
+    }
+    defaults.update(overrides)
+    return CampaignProject(**defaults)
+
+
+class TestFetchDiffContent:
+    def test_returns_none_when_no_repo_root(self) -> None:
+        assert _fetch_diff_content(_make_run_dict(), repo_root=None) is None
+
+    def test_returns_none_when_no_deliverable(self) -> None:
+        run_dict: dict = {"work_orders": []}
+        assert _fetch_diff_content(run_dict, repo_root=Path("/tmp")) is None
+
+    def test_returns_none_when_deliverable_has_no_branch(self) -> None:
+        run_dict: dict = {
+            "work_orders": [{"status": "completed", "pr_url": "https://github.com/org/repo/pull/1"}]
+        }
+        # PR type without branch — should return None
+        assert _fetch_diff_content(run_dict, repo_root=Path("/tmp")) is None
+
+    def test_returns_diff_on_success(self, tmp_path: Path) -> None:
+        diff_text = "diff --git a/docs/test.md b/docs/test.md\n+hello world\n"
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = diff_text
+
+        with patch("aragora.swarm.campaign.subprocess.run", return_value=mock_result) as mock_run:
+            result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path, target_branch="main")
+
+        assert result == diff_text
+        mock_run.assert_called_once()
+        args = mock_run.call_args
+        assert args[0][0] == ["git", "diff", "main...codex/worker-branch"]
+        assert args[1]["cwd"] == str(tmp_path)
+
+    def test_truncates_large_diffs(self, tmp_path: Path) -> None:
+        large_diff = "x" * (_DIFF_MAX_CHARS + 1000)
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = large_diff
+
+        with patch("aragora.swarm.campaign.subprocess.run", return_value=mock_result):
+            result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path, max_chars=100)
+
+        assert result is not None
+        assert len(result) < 200  # truncated + message
+        assert "truncated" in result
+
+    def test_returns_none_on_git_error(self, tmp_path: Path) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 128
+        mock_result.stderr = "fatal: bad revision"
+
+        with patch("aragora.swarm.campaign.subprocess.run", return_value=mock_result):
+            result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path)
+
+        assert result is None
+
+    def test_returns_none_on_timeout(self, tmp_path: Path) -> None:
+        with patch(
+            "aragora.swarm.campaign.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=30),
+        ):
+            result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path)
+
+        assert result is None
+
+    def test_returns_none_on_empty_diff(self, tmp_path: Path) -> None:
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "   \n  "
+
+        with patch("aragora.swarm.campaign.subprocess.run", return_value=mock_result):
+            result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path)
+
+        assert result is None
+
+    def test_extracts_branch_from_work_order_for_pr_deliverable(self, tmp_path: Path) -> None:
+        run_dict: dict = {
+            "work_orders": [
+                {
+                    "status": "completed",
+                    "pr_url": "https://github.com/org/repo/pull/1",
+                    "branch": "codex/pr-branch",
+                    "commit_shas": ["abc"],
+                }
+            ]
+        }
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "+new content\n"
+
+        with patch("aragora.swarm.campaign.subprocess.run", return_value=mock_result) as mock_run:
+            result = _fetch_diff_content(run_dict, repo_root=tmp_path)
+
+        assert result is not None
+        args = mock_run.call_args
+        assert "codex/pr-branch" in args[0][0][2]
+
+
+class TestBuildPromptWithDiff:
+    def test_prompt_includes_diff_when_provided(self) -> None:
+        project = _make_project()
+        run_dict = _make_run_dict()
+        diff = "diff --git a/docs/test.md\n+hello world\n"
+
+        prompt = CampaignReviewer._build_prompt(project, run_dict, "claude", diff_content=diff)
+
+        assert "ACTUAL DIFF" in prompt
+        assert "+hello world" in prompt
+        assert "END DIFF" in prompt
+
+    def test_prompt_excludes_diff_when_none(self) -> None:
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        prompt = CampaignReviewer._build_prompt(project, run_dict, "claude", diff_content=None)
+
+        assert "ACTUAL DIFF" not in prompt
+        assert "END DIFF" not in prompt
+
+    def test_prompt_excludes_diff_when_empty(self) -> None:
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        prompt = CampaignReviewer._build_prompt(project, run_dict, "claude", diff_content="")
+
+        assert "ACTUAL DIFF" not in prompt
+
+    def test_prompt_backward_compatible_without_diff(self) -> None:
+        """Calling without diff_content produces same format as before."""
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        prompt = CampaignReviewer._build_prompt(project, run_dict, "claude")
+
+        assert "Review this completed implementation" in prompt
+        assert '"status":"passed|changes_requested|blocked_nonreviewable"' in prompt
+        parsed_json = json.loads(prompt.split("\n")[-1])
+        assert parsed_json["project_id"] == "phase0a-007"


### PR DESCRIPTION
## Summary

- Add `_fetch_diff_content()` to retrieve actual git diff between worker branch and target branch (bounded to 50K chars)
- Thread `repo_root` and `target_branch` through `CampaignReviewer.review()` to enable diff retrieval
- Update `_build_prompt()` to include actual diff content when available

**Root cause**: CampaignReviewer was rejecting valid deliverables because it only received metadata (branch/commit) without actual file changes. The reviewer had no way to verify acceptance criteria against the actual diff.

Split from #932. Cherry-pick of `ab7dee654f`.

## Test plan

- [x] `tests/swarm/test_campaign_reviewer_diff.py` — 8 tests covering: missing repo_root, empty diff, truncation, git errors, prompt formatting with/without diff
- [x] Backward-compatible: calling without diff_content produces same prompt format as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)