### PR TITLE
fix(swarm): use origin/main for reviewer diff base

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -775,9 +775,18 @@ def _fetch_diff_content(
                 break
     if not branch:
         return None
+    # Use origin/ prefix to avoid stale local refs in worktrees.
+    diff_base = target_branch if "/" in target_branch else f"origin/{target_branch}"
     try:
+        # Fetch to ensure the remote ref is current.
+        subprocess.run(
+            ["git", "fetch", "origin", target_branch],
+            capture_output=True,
+            cwd=str(repo_root),
+            timeout=15,
+        )
         result = subprocess.run(
-            ["git", "diff", f"{target_branch}...{branch}"],
+            ["git", "diff", f"{diff_base}...{branch}"],
             capture_output=True,
             text=True,
             cwd=str(repo_root),

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -69,10 +69,11 @@ class TestFetchDiffContent:
             result = _fetch_diff_content(_make_run_dict(), repo_root=tmp_path, target_branch="main")
 
         assert result == diff_text
-        mock_run.assert_called_once()
-        args = mock_run.call_args
-        assert args[0][0] == ["git", "diff", "main...codex/worker-branch"]
-        assert args[1]["cwd"] == str(tmp_path)
+        # Two calls: fetch + diff
+        assert mock_run.call_count == 2
+        diff_call = mock_run.call_args_list[1]
+        assert diff_call[0][0] == ["git", "diff", "origin/main...codex/worker-branch"]
+        assert diff_call[1]["cwd"] == str(tmp_path)
 
     def test_truncates_large_diffs(self, tmp_path: Path) -> None:
         large_diff = "x" * (_DIFF_MAX_CHARS + 1000)


### PR DESCRIPTION
## Summary

- Reviewer diff was polluted with unrelated merged commits because `git diff main...branch` used a stale local `main` ref in worktrees
- Fix: fetch `origin/main` first, then diff against `origin/main` instead of local `main`
- Discovered during Campaign 2 resume: reviewer correctly saw diff content (#933 working) but falsely flagged merged #933/#934 code as "out-of-scope worker changes"

## Files changed (2 only)

- `aragora/swarm/campaign.py` — prepend `origin/` to diff base, add fetch before diff
- `tests/swarm/test_campaign_reviewer_diff.py` — update test assertion for 2-call pattern

## Test plan

- [x] 70 campaign tests pass in clean worktree
- [x] No other files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)