### PR TITLE
fix(ralph): harden supervisor state machine

### DIFF
--- a/aragora/cli/commands/ralph.py
+++ b/aragora/cli/commands/ralph.py
@@ -118,6 +118,11 @@ def _cmd_status(state_path: Path, json_output: bool) -> None:
         print(f"  Budget spent: ${d['budget_spent_usd']:.2f}")
         if d.get("active_blocker"):
             print(f"  Active blocker: {d['active_blocker']}")
+        task = d.get("active_repair_task") if isinstance(d.get("active_repair_task"), dict) else {}
+        if task.get("run_id"):
+            print(f"  Repair run: {task['run_id']}")
+        if d.get("active_repair_branch"):
+            print(f"  Repair branch: {d['active_repair_branch']}")
         if d.get("active_repair_pr"):
             print(f"  Repair PR: {d['active_repair_pr']}")
         if d.get("escalation_reason"):

--- a/aragora/ralph/supervisor.py
+++ b/aragora/ralph/supervisor.py
@@ -49,6 +49,7 @@ class SupervisorAction(str, Enum):
     CAMPAIGN_ITERATION = "campaign_iteration"
     BLOCKER_CLASSIFIED = "blocker_classified"
     REPAIR_GENERATED = "repair_generated"
+    REPAIR_DISPATCHED = "repair_dispatched"
     PR_CHECKED = "pr_checked"
     CAMPAIGN_RESUMED = "campaign_resumed"
     CAMPAIGN_COMPLETED = "campaign_completed"
@@ -61,6 +62,7 @@ class SupervisorAction(str, Enum):
 # ---------------------------------------------------------------------------
 
 _DEFAULT_MAX_REPAIR_ATTEMPTS = 2
+_MAX_RESUME_ATTEMPTS = 5
 
 
 @dataclass(slots=True)
@@ -82,6 +84,7 @@ class SupervisorState:
     active_repair_branch: str | None = None
     active_repair_task: dict[str, Any] | None = None
     merge_commit_sha: str | None = None
+    resume_attempts: int = 0
     resume_cursor: str | None = None
     budget_spent_usd: float = 0.0
     escalation_reason: str | None = None
@@ -104,6 +107,7 @@ class SupervisorState:
             "active_repair_branch": self.active_repair_branch,
             "active_repair_task": self.active_repair_task,
             "merge_commit_sha": self.merge_commit_sha,
+            "resume_attempts": self.resume_attempts,
             "resume_cursor": self.resume_cursor,
             "budget_spent_usd": self.budget_spent_usd,
             "escalation_reason": self.escalation_reason,
@@ -128,6 +132,7 @@ class SupervisorState:
             active_repair_branch=data.get("active_repair_branch"),
             active_repair_task=data.get("active_repair_task"),
             merge_commit_sha=data.get("merge_commit_sha"),
+            resume_attempts=int(data.get("resume_attempts", 0)),
             resume_cursor=data.get("resume_cursor"),
             budget_spent_usd=float(data.get("budget_spent_usd", 0.0)),
             escalation_reason=data.get("escalation_reason"),
@@ -202,10 +207,12 @@ class RalphSupervisor:
         state_path: Path,
         repo_root: Path | None = None,
         merge_policy: str = "manual_review_required",
+        repair_budget_usd: float = 2.0,
     ) -> None:
         self.state_path = state_path.resolve()
         self.repo_root = (repo_root or Path.cwd()).resolve()
         self.merge_policy = merge_policy
+        self.repair_budget_usd = repair_budget_usd
 
     # -- public API --
 
@@ -218,6 +225,7 @@ class RalphSupervisor:
         repo_root: Path | None = None,
         merge_policy: str = "manual_review_required",
         max_repair_attempts: int = _DEFAULT_MAX_REPAIR_ATTEMPTS,
+        repair_budget_usd: float = 2.0,
     ) -> "RalphSupervisor":
         """Initialize a new supervisor run and persist state."""
         manifest_path = manifest_path.resolve()
@@ -242,6 +250,7 @@ class RalphSupervisor:
             state_path=state_path,
             repo_root=repo_root,
             merge_policy=merge_policy,
+            repair_budget_usd=repair_budget_usd,
         )
         logger.info(
             "Ralph supervisor started: %s (campaign=%s)",
@@ -391,7 +400,7 @@ class RalphSupervisor:
         )
 
     def _step_handle_blocker(self, state: SupervisorState) -> StepResult:
-        """Generate a repair task for a deterministic blocker, or escalate."""
+        """Generate and dispatch a repair task for a deterministic blocker, or escalate."""
         blocker_kind_str = state.active_blocker or ""
         try:
             blocker_kind = BlockerKind(blocker_kind_str)
@@ -424,18 +433,90 @@ class RalphSupervisor:
             return self._escalate(state, f"No repair template for: {blocker_kind.value}")
 
         state.repair_attempts += 1
-        state.active_repair_task = repair.to_dict()
-        state.status = SupervisorStatus.WAITING_FOR_PR.value
+        task_payload = repair.to_dict()
+        state.active_repair_task = task_payload
+
+        # Dispatch the repair lane.
+        spec = self._build_repair_spec(repair)
+        try:
+            from aragora.swarm.boss_loop import dispatch_bounded_spec
+
+            dispatch_result = asyncio.run(
+                dispatch_bounded_spec(
+                    spec,
+                    repo_path=self.repo_root,
+                    budget_limit_usd=self.repair_budget_usd,
+                )
+            )
+        except Exception as exc:
+            logger.warning("Repair dispatch failed: %s", exc)
+            dispatch_result = {"status": "failed", "outcome": "crash"}
+
+        # Extract deliverable info.
+        run_id = str(dispatch_result.get("run_id", "")).strip() or None
+        deliverable = dispatch_result.get("deliverable") or {}
+
+        pr_url = str(deliverable.get("pr_url", "")).strip()
+        branch = str(deliverable.get("branch", "")).strip()
+        if run_id:
+            task_payload["run_id"] = run_id
+        if branch:
+            task_payload["branch"] = branch
+        if pr_url:
+            task_payload["pr_url"] = pr_url
+
+        if pr_url:
+            state.active_repair_pr = pr_url
+            state.active_repair_branch = branch or None
+            state.status = SupervisorStatus.WAITING_FOR_MERGE.value
+        elif branch:
+            state.active_repair_branch = branch
+            state.status = SupervisorStatus.WAITING_FOR_PR.value
+        elif run_id:
+            state.status = SupervisorStatus.WAITING_FOR_PR.value
+        # else: no trackable output — stay RUNNING for retry via max_repair_attempts
+
+        detail = f"Repair dispatched: {repair.title} (status={dispatch_result.get('status')})"
+        if pr_url:
+            detail += f" PR: {pr_url}"
 
         return StepResult(
-            action=SupervisorAction.REPAIR_GENERATED.value,
-            status=SupervisorStatus.WAITING_FOR_PR.value,
-            detail=f"Repair task generated: {repair.title}",
+            action=SupervisorAction.REPAIR_DISPATCHED.value,
+            status=state.status,
+            detail=detail,
             repair_task=repair,
         )
 
     def _step_check_pr(self, state: SupervisorState) -> StepResult:
         """Check if a repair PR has been opened."""
+        run_id = self._repair_run_id(state)
+        if run_id and not (state.active_repair_pr or state.active_repair_branch):
+            run_dict = self._refresh_dispatch_run(run_id)
+            if run_dict:
+                branch, pr_url = self._update_repair_tracking_from_run(state, run_dict)
+                if pr_url:
+                    state.status = SupervisorStatus.WAITING_FOR_MERGE.value
+                    return StepResult(
+                        action=SupervisorAction.PR_CHECKED.value,
+                        status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                        detail=f"PR discovered from repair run: {pr_url}. Waiting for merge.",
+                    )
+                if branch:
+                    state.status = SupervisorStatus.WAITING_FOR_PR.value
+                    return StepResult(
+                        action=SupervisorAction.PR_CHECKED.value,
+                        status=SupervisorStatus.WAITING_FOR_PR.value,
+                        detail=f"Repair branch discovered from run: {branch}. Waiting for PR.",
+                    )
+                if str(run_dict.get("status", "")).strip() in {
+                    "completed",
+                    "needs_human",
+                }:
+                    return self._escalate(
+                        state,
+                        "Repair run reached a terminal state without a tracked branch or PR.",
+                    )
+
         if state.active_repair_pr:
             # PR exists, wait for merge.
             state.status = SupervisorStatus.WAITING_FOR_MERGE.value
@@ -476,6 +557,13 @@ class RalphSupervisor:
 
         merged, merge_sha = self._check_pr_merged(pr_url)
         if not merged:
+            # Optionally trigger auto-merge when policy allows (once per PR).
+            if self.merge_policy == "admin_merge_allowed":
+                task = dict(state.active_repair_task or {})
+                if not task.get("auto_merge_requested"):
+                    if self._auto_merge_pr(pr_url):
+                        task["auto_merge_requested"] = True
+                        state.active_repair_task = task
             return StepResult(
                 action=SupervisorAction.PR_CHECKED.value,
                 status=SupervisorStatus.WAITING_FOR_MERGE.value,
@@ -491,24 +579,125 @@ class RalphSupervisor:
         )
 
     def _step_resume(self, state: SupervisorState) -> StepResult:
-        """Resume campaign after a repair PR was merged."""
-        # Fetch latest main.
+        """Resume campaign after a repair PR was merged.
+
+        Fail-closed: the worktree must be verified as synchronized with the
+        merged repair before clearing blocker state and transitioning to
+        RUNNING.  ``git fetch`` alone only updates refs — it does NOT update
+        checked-out files, so we must also confirm the merge commit SHA is
+        reachable and attempt a fast-forward merge to pull the changes in.
+        """
+        merge_sha = state.merge_commit_sha
+
+        # 0. Escalate if we have been stuck in RESUMING too many times.
+        state.resume_attempts += 1
+        if state.resume_attempts > _MAX_RESUME_ATTEMPTS:
+            return self._escalate(
+                state,
+                f"Failed to synchronize worktree after {_MAX_RESUME_ATTEMPTS} "
+                "resume attempts; manual intervention required.",
+            )
+
+        # 1. Fetch latest origin/main.
         try:
-            subprocess.run(
+            fetch = subprocess.run(
                 ["git", "fetch", "origin", "main"],
                 capture_output=True,
                 cwd=str(self.repo_root),
                 timeout=30,
             )
+            if fetch.returncode != 0:
+                logger.warning(
+                    "git fetch origin main failed (rc=%d): %s",
+                    fetch.returncode,
+                    fetch.stderr[:200] if isinstance(fetch.stderr, (str, bytes)) else "",
+                )
+                return StepResult(
+                    action=SupervisorAction.NOOP.value,
+                    status=SupervisorStatus.RESUMING.value,
+                    detail="git fetch origin main failed; staying in RESUMING.",
+                )
         except Exception as exc:
-            logger.debug("git fetch failed: %s", exc)
+            logger.warning("git fetch origin main raised: %s", exc)
+            return StepResult(
+                action=SupervisorAction.NOOP.value,
+                status=SupervisorStatus.RESUMING.value,
+                detail=f"git fetch origin main raised: {type(exc).__name__}; staying in RESUMING.",
+            )
 
-        # Clear blocker state.
+        # 2. If we have a merge SHA, verify it landed on origin/main.
+        if merge_sha:
+            if not self._is_ancestor(merge_sha, "origin/main"):
+                logger.warning(
+                    "Merge commit %s not found on origin/main after fetch; staying in RESUMING.",
+                    merge_sha,
+                )
+                return StepResult(
+                    action=SupervisorAction.NOOP.value,
+                    status=SupervisorStatus.RESUMING.value,
+                    detail=(
+                        f"Merge commit {merge_sha} is not an ancestor of "
+                        f"origin/main; staying in RESUMING."
+                    ),
+                )
+
+            # 3. Try to incorporate the repair into the worktree.
+            if not self._is_ancestor(merge_sha, "HEAD"):
+                # Worktree doesn't include the merge yet — try ff-only merge.
+                try:
+                    ff = subprocess.run(
+                        ["git", "merge", "--ff-only", "origin/main"],
+                        capture_output=True,
+                        cwd=str(self.repo_root),
+                        timeout=30,
+                    )
+                    if ff.returncode != 0:
+                        logger.warning(
+                            "git merge --ff-only origin/main failed (rc=%d); staying in RESUMING.",
+                            ff.returncode,
+                        )
+                        return StepResult(
+                            action=SupervisorAction.NOOP.value,
+                            status=SupervisorStatus.RESUMING.value,
+                            detail=(
+                                "Worktree could not fast-forward to include "
+                                f"merge commit {merge_sha}; staying in RESUMING."
+                            ),
+                        )
+                except Exception as exc:
+                    logger.warning("git merge --ff-only raised: %s", exc)
+                    return StepResult(
+                        action=SupervisorAction.NOOP.value,
+                        status=SupervisorStatus.RESUMING.value,
+                        detail=(
+                            f"git merge --ff-only raised: {type(exc).__name__}; "
+                            "staying in RESUMING."
+                        ),
+                    )
+
+                # Verify again after the merge attempt.
+                if not self._is_ancestor(merge_sha, "HEAD"):
+                    logger.warning(
+                        "Merge commit %s still not in HEAD after ff-merge; staying in RESUMING.",
+                        merge_sha,
+                    )
+                    return StepResult(
+                        action=SupervisorAction.NOOP.value,
+                        status=SupervisorStatus.RESUMING.value,
+                        detail=(
+                            f"Merge commit {merge_sha} not reachable from HEAD "
+                            "even after ff-merge; staying in RESUMING."
+                        ),
+                    )
+
+        # All checks passed — clear blocker state and resume.
         state.active_blocker = None
         state.active_repair_pr = None
         state.active_repair_branch = None
         state.active_repair_task = None
         state.merge_commit_sha = None
+        state.repair_attempts = 0
+        state.resume_attempts = 0
         state.status = SupervisorStatus.RUNNING.value
 
         return StepResult(
@@ -517,7 +706,99 @@ class RalphSupervisor:
             detail="Campaign resumed after repair merge. Next step will run iteration.",
         )
 
+    def _is_ancestor(self, commit: str, ref: str) -> bool:
+        """Check if *commit* is an ancestor of *ref* using ``git merge-base --is-ancestor``."""
+        try:
+            result = subprocess.run(
+                ["git", "merge-base", "--is-ancestor", commit, ref],
+                capture_output=True,
+                cwd=str(self.repo_root),
+                timeout=15,
+            )
+            return result.returncode == 0
+        except Exception as exc:
+            logger.debug("git merge-base --is-ancestor failed: %s", exc)
+            return False
+
     # -- helpers --
+
+    def _build_repair_spec(self, repair: RepairTask) -> Any:
+        """Convert a RepairTask to a dispatch-bounded SwarmSpec."""
+        from aragora.swarm.spec import SwarmSpec
+
+        goal = f"{repair.title}\n\n{repair.problem_statement}"
+        spec = SwarmSpec.from_direct_goal(
+            goal,
+            budget_limit_usd=self.repair_budget_usd,
+            requires_approval=False,
+            user_expertise="developer",
+        )
+        # Override inferred hints with the repair's explicit allowed_paths.
+        spec.file_scope_hints = list(repair.allowed_paths)
+        # Set acceptance criteria from done_condition + required_tests.
+        spec.acceptance_criteria = [repair.done_condition]
+        if repair.required_tests:
+            spec.acceptance_criteria.append(f"Tests pass: {', '.join(repair.required_tests)}")
+        return spec
+
+    def _auto_merge_pr(self, pr_url: str) -> bool:
+        """Attempt to auto-merge a PR via gh CLI. Returns True if merge was initiated."""
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "merge", pr_url, "--squash", "--auto"],
+                capture_output=True,
+                text=True,
+                cwd=str(self.repo_root),
+                timeout=30,
+            )
+            if result.returncode == 0:
+                logger.info("Auto-merge initiated for %s", pr_url)
+                return True
+            logger.debug("gh pr merge failed (rc=%d): %s", result.returncode, result.stderr)
+        except Exception as exc:
+            logger.debug("gh pr merge raised: %s", exc)
+        return False
+
+    def _repair_run_id(self, state: SupervisorState) -> str | None:
+        task = state.active_repair_task if isinstance(state.active_repair_task, dict) else {}
+        text = str(task.get("run_id", "")).strip()
+        return text or None
+
+    def _refresh_dispatch_run(self, run_id: str) -> dict[str, Any] | None:
+        from aragora.swarm.supervisor import SwarmSupervisor
+
+        supervisor = SwarmSupervisor(repo_root=self.repo_root)
+        try:
+            return supervisor.refresh_run(run_id).to_dict()
+        except Exception as exc:
+            logger.debug("refresh_run failed for repair run %s: %s", run_id, exc)
+            return None
+
+    def _update_repair_tracking_from_run(
+        self,
+        state: SupervisorState,
+        run_dict: dict[str, Any],
+    ) -> tuple[str | None, str | None]:
+        task = dict(state.active_repair_task or {})
+        branch: str | None = None
+        pr_url: str | None = None
+        for item in run_dict.get("work_orders", []):
+            if not isinstance(item, dict):
+                continue
+            branch = branch or str(item.get("branch", "")).strip() or None
+            pr_url = pr_url or str(item.get("pull_request_url", "")).strip() or None
+            meta = item.get("metadata")
+            if isinstance(meta, dict):
+                pr_url = pr_url or str(meta.get("pull_request_url", "")).strip() or None
+        if branch:
+            state.active_repair_branch = branch
+            task["branch"] = branch
+        if pr_url:
+            state.active_repair_pr = pr_url
+            task["pr_url"] = pr_url
+        task["run_status"] = str(run_dict.get("status", "")).strip()
+        state.active_repair_task = task
+        return branch, pr_url
 
     def _escalate(self, state: SupervisorState, reason: str) -> StepResult:
         state.status = SupervisorStatus.ESCALATED.value

--- a/tests/ralph/test_supervisor.py
+++ b/tests/ralph/test_supervisor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -309,9 +310,18 @@ class TestStepHandleBlocker:
         )
 
         supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
-        result = supervisor.step()
 
-        assert result.action == SupervisorAction.REPAIR_GENERATED.value
+        # Mock dispatch to return a branch (no PR).
+        mock_dispatch = {
+            "status": "completed",
+            "outcome": "deliverable_created",
+            "run_id": "run-test",
+            "deliverable": {"type": "branch", "branch": "fix/test", "commit_shas": ["sha1"]},
+        }
+        with patch("aragora.ralph.supervisor.asyncio.run", return_value=mock_dispatch):
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.REPAIR_DISPATCHED.value
         assert result.status == SupervisorStatus.WAITING_FOR_PR.value
         assert result.repair_task is not None
         assert (
@@ -411,6 +421,57 @@ class TestStepPRChecking:
 
         assert result.status == SupervisorStatus.WAITING_FOR_PR.value
 
+    def test_waiting_for_pr_refreshes_run_tracking(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.WAITING_FOR_PR.value,
+            active_repair_task={"title": "fix", "run_id": "run-123"},
+        )
+
+        run_dict = {
+            "status": "active",
+            "work_orders": [
+                {
+                    "branch": "fix/reviewer-diff",
+                    "metadata": {"pull_request_url": "https://github.com/org/repo/pull/77"},
+                }
+            ],
+        }
+
+        with patch.object(RalphSupervisor, "_refresh_dispatch_run", return_value=run_dict):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        state = load_supervisor_state(state_path)
+        assert state.active_repair_branch == "fix/reviewer-diff"
+        assert state.active_repair_pr == "https://github.com/org/repo/pull/77"
+        assert state.active_repair_task is not None
+        assert state.active_repair_task["run_status"] == "active"
+
+    def test_waiting_for_pr_escalates_when_run_finishes_without_tracking(
+        self, tmp_path: Path
+    ) -> None:
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.WAITING_FOR_PR.value,
+            active_repair_task={"title": "fix", "run_id": "run-123"},
+        )
+
+        run_dict = {
+            "status": "needs_human",
+            "work_orders": [{"status": "blocked"}],
+        }
+
+        with patch.object(RalphSupervisor, "_refresh_dispatch_run", return_value=run_dict):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.ESCALATED.value
+        assert result.status == SupervisorStatus.ESCALATED.value
+
     def test_waiting_for_merge_not_merged(self, tmp_path: Path) -> None:
         state_path = tmp_path / "state.yaml"
         _write_state(
@@ -447,7 +508,90 @@ class TestStepPRChecking:
 # ---------------------------------------------------------------------------
 
 
+def _mock_subprocess_for_resume(
+    *,
+    fetch_rc: int = 0,
+    ancestor_origin_rc: int = 0,
+    ancestor_head_rc: int = 0,
+    ff_merge_rc: int = 0,
+    ancestor_post_ff_rc: int = 0,
+    fetch_raises: Exception | None = None,
+    ff_merge_raises: Exception | None = None,
+):
+    """Build a side_effect function for subprocess.run that simulates the
+    multi-step resume sync: fetch, merge-base checks, and ff-merge.
+
+    Call order expected by _step_resume():
+      1. git fetch origin main
+      2. git merge-base --is-ancestor <sha> origin/main
+      3. git merge-base --is-ancestor <sha> HEAD
+      4. (if HEAD check fails) git merge --ff-only origin/main
+      5. (if ff succeeds) git merge-base --is-ancestor <sha> HEAD  (post-ff)
+    """
+    call_index = 0
+
+    def side_effect(cmd, **kwargs):
+        nonlocal call_index
+        call_index += 1
+
+        if cmd[:3] == ["git", "fetch", "origin"]:
+            if fetch_raises:
+                raise fetch_raises
+            return MagicMock(returncode=fetch_rc, stderr=b"")
+
+        if cmd[:3] == ["git", "merge-base", "--is-ancestor"]:
+            ref = cmd[-1] if len(cmd) > 4 else ""
+            if ref == "origin/main":
+                return MagicMock(returncode=ancestor_origin_rc)
+            # HEAD check — distinguish first vs post-ff-merge
+            if ref == "HEAD":
+                # If ancestor_head_rc != 0 (worktree doesn't have it yet),
+                # the first HEAD check fails; after ff-merge the post-ff check
+                # uses ancestor_post_ff_rc.
+                if ancestor_head_rc != 0 and call_index > 4:
+                    return MagicMock(returncode=ancestor_post_ff_rc)
+                return MagicMock(returncode=ancestor_head_rc)
+            return MagicMock(returncode=ancestor_head_rc)
+
+        if cmd[:3] == ["git", "merge", "--ff-only"]:
+            if ff_merge_raises:
+                raise ff_merge_raises
+            return MagicMock(returncode=ff_merge_rc)
+
+        return MagicMock(returncode=0)
+
+    return side_effect
+
+
 class TestStepResume:
+    def test_resume_resets_repair_attempts(self, tmp_path: Path) -> None:
+        """After successful repair->merge->resume, repair_attempts resets to 0."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+            active_repair_pr="https://github.com/org/repo/pull/1",
+            merge_commit_sha="abc123",
+            repair_attempts=2,
+            max_repair_attempts=2,
+        )
+
+        # SHA already on origin/main AND already in HEAD -> direct resume.
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        state = load_supervisor_state(state_path)
+        assert state.repair_attempts == 0
+
     def test_resume_clears_blocker_and_sets_running(self, tmp_path: Path) -> None:
         state_path = tmp_path / "state.yaml"
         _write_state(
@@ -460,7 +604,13 @@ class TestStepResume:
             merge_commit_sha="abc",
         )
 
-        with patch("aragora.ralph.supervisor.subprocess.run"):
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ):
             supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
             result = supervisor.step()
 
@@ -474,6 +624,339 @@ class TestStepResume:
         assert state.active_repair_task is None
         assert state.merge_commit_sha is None
         assert state.status == SupervisorStatus.RUNNING.value
+
+
+# ---------------------------------------------------------------------------
+# Resume sync verification (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestResumeSyncVerification:
+    """Verify that _step_resume() fails closed: the campaign worktree must be
+    synchronized to the merged repair before transitioning to RUNNING."""
+
+    def test_sync_success_sha_already_in_head(self, tmp_path: Path) -> None:
+        """Happy path: merge SHA on origin/main AND already in HEAD -> RUNNING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        assert result.status == SupervisorStatus.RUNNING.value
+        state = load_supervisor_state(state_path)
+        assert state.status == SupervisorStatus.RUNNING.value
+        assert state.active_blocker is None
+        assert state.merge_commit_sha is None
+
+    def test_sync_success_ff_merge_needed(self, tmp_path: Path) -> None:
+        """SHA on origin/main but not in HEAD; ff-merge succeeds -> RUNNING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=1,  # not in HEAD yet
+                ff_merge_rc=0,  # ff succeeds
+                ancestor_post_ff_rc=0,  # now reachable
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        assert result.status == SupervisorStatus.RUNNING.value
+
+    def test_sync_failure_fetch_fails(self, tmp_path: Path) -> None:
+        """git fetch fails -> stay RESUMING, do NOT clear state."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(fetch_rc=128),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.action == SupervisorAction.NOOP.value
+        assert result.status == SupervisorStatus.RESUMING.value
+        state = load_supervisor_state(state_path)
+        assert state.status == SupervisorStatus.RESUMING.value
+        assert state.active_blocker == "reviewer_missing_diff"
+        assert state.merge_commit_sha == "deadbeef"
+
+    def test_sync_failure_fetch_raises(self, tmp_path: Path) -> None:
+        """git fetch raises exception -> stay RESUMING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                fetch_raises=OSError("network down"),
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        state = load_supervisor_state(state_path)
+        assert state.merge_commit_sha == "deadbeef"
+
+    def test_sync_failure_sha_not_on_origin_main(self, tmp_path: Path) -> None:
+        """Merge SHA not ancestor of origin/main -> stay RESUMING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=1,  # not on origin/main
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        assert "not an ancestor" in result.detail
+        state = load_supervisor_state(state_path)
+        assert state.active_blocker == "reviewer_missing_diff"
+
+    def test_sync_failure_ff_merge_fails(self, tmp_path: Path) -> None:
+        """SHA on origin/main, not in HEAD, ff-merge fails -> stay RESUMING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=1,  # not in HEAD
+                ff_merge_rc=128,  # ff-merge fails (diverged)
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        assert "could not fast-forward" in result.detail.lower()
+        state = load_supervisor_state(state_path)
+        assert state.merge_commit_sha == "deadbeef"
+
+    def test_sync_failure_ff_merge_raises(self, tmp_path: Path) -> None:
+        """ff-merge raises exception -> stay RESUMING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=1,
+                ff_merge_raises=subprocess.TimeoutExpired(cmd="git", timeout=30),
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+
+    def test_sync_failure_post_ff_head_check_fails(self, tmp_path: Path) -> None:
+        """ff-merge returns 0 but merge-base still shows SHA not in HEAD -> stay RESUMING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=1,  # not in HEAD initially
+                ff_merge_rc=0,  # ff reports success
+                ancestor_post_ff_rc=1,  # but still not reachable!
+            ),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        assert "not reachable from HEAD" in result.detail
+
+    def test_no_premature_running_when_blocker_state_present(self, tmp_path: Path) -> None:
+        """Even with a successful fetch, if sync verification fails the
+        blocker state must NOT be cleared and status must NOT be RUNNING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+            active_repair_branch="fix/branch",
+            active_repair_task={"title": "fix something"},
+            repair_attempts=1,
+        )
+
+        # Fetch succeeds but SHA not on origin/main.
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(ancestor_origin_rc=1),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        state = load_supervisor_state(state_path)
+        # All repair state must be preserved.
+        assert state.status == SupervisorStatus.RESUMING.value
+        assert state.active_blocker == "reviewer_missing_diff"
+        assert state.active_repair_pr == "https://github.com/org/repo/pull/1"
+        assert state.active_repair_branch == "fix/branch"
+        assert state.active_repair_task == {"title": "fix something"}
+        assert state.merge_commit_sha == "deadbeef"
+        assert state.repair_attempts == 1
+
+    def test_resume_without_merge_sha_proceeds(self, tmp_path: Path) -> None:
+        """Backward compat: if merge_commit_sha is None (legacy state),
+        fetch-only is sufficient and resume proceeds to RUNNING."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            active_blocker="reviewer_missing_diff",
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        assert result.status == SupervisorStatus.RUNNING.value
+
+    def test_resume_escalates_after_max_attempts(self, tmp_path: Path) -> None:
+        """Stuck RESUMING escalates after _MAX_RESUME_ATTEMPTS failed syncs."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+            resume_attempts=5,  # already at the limit
+        )
+
+        # Fetch will fail — but escalation fires first due to resume_attempts > 5
+        sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+        result = sup.step()
+
+        assert result.action == SupervisorAction.ESCALATED.value
+        assert result.status == SupervisorStatus.ESCALATED.value
+        assert "resume attempts" in result.detail.lower()
+        state = load_supervisor_state(state_path)
+        assert state.status == SupervisorStatus.ESCALATED.value
+
+    def test_resume_attempts_increments_on_each_failure(self, tmp_path: Path) -> None:
+        """Each failed resume sync increments resume_attempts toward the limit."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+            resume_attempts=0,
+        )
+
+        sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        # Fetch fails on every attempt
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(fetch_rc=1),
+        ):
+            result = sup.step()
+
+        assert result.status == SupervisorStatus.RESUMING.value
+        state = load_supervisor_state(state_path)
+        assert state.resume_attempts == 1  # incremented from 0
+
+    def test_resume_attempts_resets_on_success(self, tmp_path: Path) -> None:
+        """Successful resume resets resume_attempts to 0."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="deadbeef",
+            active_blocker="reviewer_missing_diff",
+            active_repair_pr="https://github.com/org/repo/pull/1",
+            resume_attempts=3,
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(),
+        ):
+            sup = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = sup.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        state = load_supervisor_state(state_path)
+        assert state.resume_attempts == 0
 
 
 # ---------------------------------------------------------------------------
@@ -550,27 +1033,35 @@ class TestFullLoopSimulation:
         state = load_supervisor_state(state_path)
         assert state.active_blocker == BlockerKind.REVIEWER_MISSING_DIFF.value
 
-        # Step 2: handle blocker -> generate repair
-        r2 = supervisor.step()
-        assert r2.action == SupervisorAction.REPAIR_GENERATED.value
+        # Step 2: handle blocker -> dispatch repair (with PR)
+        dispatch_result = {
+            "status": "completed",
+            "outcome": "deliverable",
+            "run_id": "run-full-loop",
+            "deliverable": {
+                "pr_url": "https://github.com/org/repo/pull/99",
+                "branch": "codex/repair-branch",
+            },
+        }
+        with patch("aragora.ralph.supervisor.asyncio.run", return_value=dispatch_result):
+            r2 = supervisor.step()
+        assert r2.action == SupervisorAction.REPAIR_DISPATCHED.value
         assert r2.repair_task is not None
-
-        # Simulate: someone opens a PR
-        state = load_supervisor_state(state_path)
-        state.active_repair_pr = "https://github.com/org/repo/pull/99"
-        save_supervisor_state(state_path, state)
-
-        # Step 3: check PR -> found, wait for merge
-        r3 = supervisor.step()
-        assert r3.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        assert r2.status == SupervisorStatus.WAITING_FOR_MERGE.value
 
         # Step 4: check merge -> merged
         with patch.object(RalphSupervisor, "_check_pr_merged", return_value=(True, "merged-sha")):
             r4 = supervisor.step()
         assert r4.status == SupervisorStatus.RESUMING.value
 
-        # Step 5: resume -> running
-        with patch("aragora.ralph.supervisor.subprocess.run"):
+        # Step 5: resume -> running (with sync verification)
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ):
             r5 = supervisor.step()
         assert r5.action == SupervisorAction.CAMPAIGN_RESUMED.value
         assert r5.status == SupervisorStatus.RUNNING.value
@@ -614,3 +1105,403 @@ class TestFullLoopSimulation:
         r2 = supervisor.step()
         assert r2.action == SupervisorAction.ESCALATED.value
         assert r2.status == SupervisorStatus.ESCALATED.value
+
+
+# ---------------------------------------------------------------------------
+# Dispatch integration tests
+# ---------------------------------------------------------------------------
+
+
+def _write_blocked_manifest(path: Path) -> Path:
+    """Write a manifest with a blocked project that triggers reviewer_missing_diff."""
+    manifest = {
+        "campaign_id": "test-campaign",
+        "created_at": "2026-03-10T00:00:00Z",
+        "source_kind": "manual",
+        "source_ref": "test",
+        "worker_model": "codex",
+        "review_model": "claude",
+        "max_parallel_ready_projects": 1,
+        "max_retries_per_project": 2,
+        "budget_limit_usd": 20.0,
+        "time_limit_hours": 4.0,
+        "projects": [
+            {
+                "project_id": "proj-001",
+                "title": "Test project",
+                "status": "blocked",
+                "last_run_outcome": "deliverable_created",
+                "review": {
+                    "status": "changes_requested",
+                    "findings": ["Scope violation detected"],
+                },
+            }
+        ],
+        "execution_state": {
+            "ready_queue": [],
+            "active_projects": [],
+            "completed_projects": [],
+            "failed_projects": [],
+            "skipped_projects": [],
+            "total_cost_usd": 0.0,
+        },
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(manifest), encoding="utf-8")
+    return path
+
+
+class TestStepDispatch:
+    """Tests for the dispatch wiring in _step_handle_blocker."""
+
+    def test_handle_blocker_dispatches_and_stores_pr(self, tmp_path: Path) -> None:
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        mock_dispatch_result = {
+            "status": "completed",
+            "outcome": "deliverable_created",
+            "run_id": "run-abc123",
+            "deliverable": {
+                "type": "pr",
+                "pr_url": "https://github.com/org/repo/pull/55",
+                "branch": "fix/reviewer-diff",
+                "commit_shas": ["sha1"],
+            },
+        }
+
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value=mock_dispatch_result,
+        ):
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.REPAIR_DISPATCHED.value
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        assert "PR: https://github.com/org/repo/pull/55" in result.detail
+
+        state = load_supervisor_state(state_path)
+        assert state.active_repair_pr == "https://github.com/org/repo/pull/55"
+        assert state.active_repair_branch == "fix/reviewer-diff"
+        assert state.active_repair_task is not None
+        assert state.active_repair_task["run_id"] == "run-abc123"
+
+    def test_handle_blocker_dispatches_branch_only(self, tmp_path: Path) -> None:
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        mock_dispatch_result = {
+            "status": "completed",
+            "outcome": "deliverable_created",
+            "run_id": "run-def456",
+            "deliverable": {
+                "type": "branch",
+                "branch": "fix/reviewer-diff-v2",
+                "commit_shas": ["sha2"],
+            },
+        }
+
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value=mock_dispatch_result,
+        ):
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.REPAIR_DISPATCHED.value
+        assert result.status == SupervisorStatus.WAITING_FOR_PR.value
+
+        state = load_supervisor_state(state_path)
+        assert state.active_repair_pr is None
+        assert state.active_repair_branch == "fix/reviewer-diff-v2"
+
+    def test_handle_blocker_dispatch_failure_stays_running(self, tmp_path: Path) -> None:
+        """Dispatch returns no trackable output → stays RUNNING for retry."""
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        mock_dispatch_result = {
+            "status": "failed",
+            "outcome": "crash",
+        }
+
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value=mock_dispatch_result,
+        ):
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.REPAIR_DISPATCHED.value
+        # No run_id, branch, or PR — stays RUNNING for retry
+        assert result.status == SupervisorStatus.RUNNING.value
+        state = load_supervisor_state(state_path)
+        assert state.active_blocker is not None
+
+    def test_handle_blocker_dispatch_exception_stays_running(self, tmp_path: Path) -> None:
+        """Dispatch raises exception with no trackable output → stays RUNNING."""
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            side_effect=RuntimeError("dispatch exploded"),
+        ):
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.REPAIR_DISPATCHED.value
+        assert result.status == SupervisorStatus.RUNNING.value
+
+    def test_dispatch_crash_eventually_escalates_via_max_attempts(self, tmp_path: Path) -> None:
+        """Repeated dispatch crashes exhaust max_repair_attempts → escalate."""
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.REVIEWER_MISSING_DIFF.value,
+            repair_attempts=0,
+            max_repair_attempts=2,
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        # Two dispatch crashes — uses up all attempts
+        for _ in range(2):
+            with patch(
+                "aragora.ralph.supervisor.asyncio.run",
+                side_effect=RuntimeError("crash"),
+            ):
+                result = supervisor.step()
+            assert result.status == SupervisorStatus.RUNNING.value
+
+        # Third attempt: max_repair_attempts exceeded → escalate
+        result = supervisor.step()
+        assert result.action == SupervisorAction.ESCALATED.value
+        assert result.status == SupervisorStatus.ESCALATED.value
+
+    def test_auto_merge_not_called_twice(self, tmp_path: Path) -> None:
+        """Auto-merge is only requested once per PR, not on every poll tick."""
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            active_repair_pr="https://github.com/org/repo/pull/99",
+            active_repair_task={"title": "fix", "auto_merge_requested": True},
+        )
+
+        supervisor = RalphSupervisor(
+            state_path=state_path,
+            repo_root=tmp_path,
+            merge_policy="admin_merge_allowed",
+        )
+
+        with (
+            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
+            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+        ):
+            supervisor.step()
+
+        mock_merge.assert_not_called()
+
+    def test_auto_merge_called_when_policy_allows(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            active_repair_pr="https://github.com/org/repo/pull/99",
+        )
+
+        supervisor = RalphSupervisor(
+            state_path=state_path,
+            repo_root=tmp_path,
+            merge_policy="admin_merge_allowed",
+        )
+
+        with (
+            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
+            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+        ):
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        mock_merge.assert_called_once_with("https://github.com/org/repo/pull/99")
+
+    def test_auto_merge_not_called_for_manual_policy(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            active_repair_pr="https://github.com/org/repo/pull/99",
+        )
+
+        supervisor = RalphSupervisor(
+            state_path=state_path,
+            repo_root=tmp_path,
+            merge_policy="manual_review_required",
+        )
+
+        with (
+            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
+            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+        ):
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        mock_merge.assert_not_called()
+
+    def test_resume_uses_fetch_not_pull(self, tmp_path: Path) -> None:
+        """Resume uses git fetch (worktree-safe), not git pull."""
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RESUMING.value,
+            merge_commit_sha="abc123",
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ) as mock_run:
+            result = supervisor.step()
+
+        assert result.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        assert result.status == SupervisorStatus.RUNNING.value
+        # First call must be fetch.
+        first_call = mock_run.call_args_list[0]
+        assert first_call[0][0] == ["git", "fetch", "origin", "main"]
+        # No git pull in any call.
+        for call in mock_run.call_args_list:
+            assert "pull" not in call[0][0]
+
+    def test_full_loop_with_dispatch(self, tmp_path: Path) -> None:
+        """Full loop: RUNNING → classify → dispatch(PR) → merge → resume → complete."""
+        manifest_path = _write_blocked_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+
+        supervisor = RalphSupervisor.start(
+            manifest_path=manifest_path,
+            state_path=state_path,
+            repo_root=tmp_path,
+            merge_policy="admin_merge_allowed",
+        )
+
+        # Step 1: Campaign iteration → blocked
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value={"stop_reason": "campaign_blocked", "dispatched_projects": []},
+        ):
+            r1 = supervisor.step()
+        assert r1.action == SupervisorAction.BLOCKER_CLASSIFIED.value
+
+        # Step 2: Handle blocker → dispatch repair → gets PR
+        mock_dispatch = {
+            "status": "completed",
+            "outcome": "deliverable_created",
+            "run_id": "run-loop-1",
+            "deliverable": {
+                "type": "pr",
+                "pr_url": "https://github.com/org/repo/pull/100",
+                "branch": "fix/reviewer-fidelity",
+                "commit_shas": ["sha1"],
+            },
+        }
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value=mock_dispatch,
+        ):
+            r2 = supervisor.step()
+        assert r2.action == SupervisorAction.REPAIR_DISPATCHED.value
+        assert r2.status == SupervisorStatus.WAITING_FOR_MERGE.value
+
+        # Step 3: Check merge → merged
+        with (
+            patch.object(
+                supervisor,
+                "_check_pr_merged",
+                return_value=(True, "abc123def"),
+            ),
+            patch.object(supervisor, "_auto_merge_pr"),
+        ):
+            r3 = supervisor.step()
+        assert r3.status == SupervisorStatus.RESUMING.value
+
+        # Step 4: Resume → sync verification → RUNNING
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=_mock_subprocess_for_resume(
+                ancestor_origin_rc=0,
+                ancestor_head_rc=0,
+            ),
+        ):
+            r4 = supervisor.step()
+        assert r4.action == SupervisorAction.CAMPAIGN_RESUMED.value
+        assert r4.status == SupervisorStatus.RUNNING.value
+
+        # Step 5: Campaign iteration → complete
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value={"stop_reason": "campaign_complete", "dispatched_projects": []},
+        ):
+            r5 = supervisor.step()
+        assert r5.action == SupervisorAction.CAMPAIGN_COMPLETED.value
+        assert r5.status == SupervisorStatus.COMPLETED.value
+
+
+# ---------------------------------------------------------------------------
+# Repair spec
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRepairSpec:
+    def test_repair_spec_does_not_require_approval(self, tmp_path: Path) -> None:
+        """Repair specs are autonomous — requires_approval must be False."""
+        from aragora.ralph.repair import generate_repair_task
+
+        supervisor = RalphSupervisor(state_path=tmp_path / "s.yaml", repo_root=tmp_path)
+        repair = generate_repair_task(BlockerKind.REVIEWER_MISSING_DIFF)
+        assert repair is not None
+        spec = supervisor._build_repair_spec(repair)
+        assert spec.requires_approval is False


### PR DESCRIPTION
## Summary
- carry forward only the still-needed Ralph supervisor closure delta onto current origin/main
- keep the PR limited to the Ralph supervisor, Ralph CLI status output, and focused supervisor tests
- include the dispatch-run tracking, fail-closed resume sync, bounded resume escalation, and auto-merge spam guard fixes

## Validation
- python3 -m pytest tests/ralph/test_supervisor.py -q
- python3 -m ruff check aragora/ralph/supervisor.py aragora/cli/commands/ralph.py tests/ralph/test_supervisor.py

Supersedes #937, #938, and #939.