### PR TITLE
fix(swarm): detect untracked files in subdirs for docs-only tasks

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -518,7 +518,14 @@ class WorkerLauncher:
         or when only binary files changed.  ``git status --porcelain`` is
         cheaper and more reliable for a yes/no dirty-tree check.
         """
-        status = await cls._git_output(worktree_path, "status", "--porcelain")
+        # Expand untracked directories into file paths so docs-only tasks that
+        # create new trees still qualify as concrete deliverables.
+        status = await cls._git_output(
+            worktree_path,
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        )
         for line in status.splitlines():
             if len(line) < 4:
                 continue
@@ -568,7 +575,12 @@ class WorkerLauncher:
         # space from porcelain status lines like " M docs/file.py".  Parse
         # robustly: skip the first two status characters if the line matches
         # the XY+space pattern, otherwise fall back to lstrip-after-status.
-        status_output = await cls._git_output(worktree_path, "status", "--porcelain")
+        status_output = await cls._git_output(
+            worktree_path,
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+        )
         for line in status_output.splitlines():
             if not line or len(line) < 2:
                 continue


### PR DESCRIPTION
## Summary
- Adds `--untracked-files=all` to `git status --porcelain` in `WorkerLauncher` so new files created in subdirectories (e.g. docs-only tasks creating `docs/governance/foo.md`) are detected as concrete deliverables
- Without this flag, git collapses untracked directories into a single entry (e.g. `?? docs/`) which the auto-commit gate may not parse as a changed file

## Context
Discovered during Ralph Campaign 2 dogfood run: 6 of 10 docs-only projects produced `needs_human` / `blocked` because the worker exited cleanly but the deliverable detection missed untracked files in new subdirectories.

Ralph classified this as `worker_clean_exit_no_effect` and autonomously dispatched this repair.

## Test plan
- [ ] Existing `tests/swarm/` tests pass
- [ ] Manual verification: docs-only task creating a new file in a subdirectory is detected as a deliverable

🤖 Generated by Ralph supervisor (repair dispatch for campaign phase0a-campaign2)