### PR TITLE
fix(ralph): discover merged repair PRs

### DIFF
--- a/aragora/ralph/supervisor.py
+++ b/aragora/ralph/supervisor.py
@@ -811,21 +811,43 @@ class RalphSupervisor:
         )
 
     def _find_pr_for_branch(self, branch: str) -> str | None:
-        """Use gh CLI to find an open PR for the given branch."""
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "list", "--head", branch, "--json", "url", "--limit", "1"],
-                capture_output=True,
-                text=True,
-                cwd=str(self.repo_root),
-                timeout=15,
-            )
-            if result.returncode == 0:
+        """Use gh CLI to find the current or most recent PR for the given branch."""
+        for pr_state in ("open", "merged"):
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "pr",
+                        "list",
+                        "--head",
+                        branch,
+                        "--state",
+                        pr_state,
+                        "--json",
+                        "url,mergedAt",
+                        "--limit",
+                        "10",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    cwd=str(self.repo_root),
+                    timeout=15,
+                )
+                if result.returncode != 0:
+                    continue
+
                 prs = json.loads(result.stdout)
-                if prs and isinstance(prs, list):
-                    return str(prs[0].get("url", ""))
-        except Exception as exc:
-            logger.debug("gh pr list failed: %s", exc)
+                if not prs or not isinstance(prs, list):
+                    continue
+
+                if pr_state == "merged":
+                    prs = sorted(prs, key=lambda pr: str(pr.get("mergedAt") or ""), reverse=True)
+
+                url = str(prs[0].get("url", "")).strip()
+                if url:
+                    return url
+            except Exception as exc:
+                logger.debug("gh pr list failed for state %s: %s", pr_state, exc)
         return None
 
     def _check_pr_merged(self, pr_url: str) -> tuple[bool, str | None]:

--- a/tests/ralph/test_supervisor.py
+++ b/tests/ralph/test_supervisor.py
@@ -504,6 +504,57 @@ class TestStepPRChecking:
 
 
 # ---------------------------------------------------------------------------
+# PR discovery helper
+# ---------------------------------------------------------------------------
+
+
+class TestFindPrForBranch:
+    def test_prefers_open_pr(self, tmp_path: Path) -> None:
+        supervisor = RalphSupervisor(state_path=tmp_path / "state.yaml", repo_root=tmp_path)
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            return_value=MagicMock(
+                returncode=0,
+                stdout='[{"url":"https://github.com/org/repo/pull/42","mergedAt":null}]',
+            ),
+        ) as run_mock:
+            pr_url = supervisor._find_pr_for_branch("fix/reviewer-diff")
+
+        assert pr_url == "https://github.com/org/repo/pull/42"
+        run_mock.assert_called_once()
+        assert "--state" in run_mock.call_args.args[0]
+        assert "open" in run_mock.call_args.args[0]
+
+    def test_falls_back_to_latest_merged_pr(self, tmp_path: Path) -> None:
+        supervisor = RalphSupervisor(state_path=tmp_path / "state.yaml", repo_root=tmp_path)
+
+        with patch(
+            "aragora.ralph.supervisor.subprocess.run",
+            side_effect=[
+                MagicMock(returncode=0, stdout="[]"),
+                MagicMock(
+                    returncode=0,
+                    stdout=(
+                        '[{"url":"https://github.com/org/repo/pull/41",'
+                        '"mergedAt":"2026-03-10T12:00:00Z"},'
+                        '{"url":"https://github.com/org/repo/pull/43",'
+                        '"mergedAt":"2026-03-11T09:00:00Z"}]'
+                    ),
+                ),
+            ],
+        ) as run_mock:
+            pr_url = supervisor._find_pr_for_branch("fix/reviewer-diff")
+
+        assert pr_url == "https://github.com/org/repo/pull/43"
+        assert run_mock.call_count == 2
+        first_call = run_mock.call_args_list[0].args[0]
+        second_call = run_mock.call_args_list[1].args[0]
+        assert "open" in first_call
+        assert "merged" in second_call
+
+
+# ---------------------------------------------------------------------------
 # Step: resume
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- keep Ralph PR discovery scoped to _find_pr_for_branch()
- fall back from open PR lookup to the most recent merged PR for the same branch
- add focused supervisor tests for open and merged discovery paths

## Testing
- pytest -q tests/ralph/test_supervisor.py -k "find_pr_for_branch or waiting_for_pr"
- pytest -q tests/ralph/test_supervisor.py