### PR TITLE
fix(ralph): align classifier with campaign needs_human outcome

### DIFF
--- a/aragora/ralph/classifier.py
+++ b/aragora/ralph/classifier.py
@@ -125,8 +125,12 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
     if has_deliverable and has_review_rejection:
         return BlockerKind.REVIEWER_MISSING_DIFF
 
-    # Check for repeated clean_exit_no_deliverable on docs-only tasks.
-    clean_exit_count = outcomes.count("clean_exit_no_deliverable")
+    # Campaign manifests can record the same "worker produced no usable
+    # deliverable" family as either the legacy clean_exit_no_deliverable
+    # outcome or the newer needs_human terminal outcome.
+    clean_exit_count = sum(
+        1 for outcome in outcomes if outcome in {"clean_exit_no_deliverable", "needs_human"}
+    )
     if clean_exit_count >= 2:
         return BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 

--- a/tests/ralph/test_classifier.py
+++ b/tests/ralph/test_classifier.py
@@ -101,6 +101,40 @@ class TestClassifyBlocker:
         result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
         assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 
+    def test_blocked_with_needs_human_maps_to_clean_exit_family(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "failed",
+                    "last_run_outcome": "needs_human",
+                    "receipt_id": "r1",
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
+    def test_blocked_with_mixed_no_deliverable_outcomes(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "failed",
+                    "last_run_outcome": "clean_exit_no_deliverable",
+                    "receipt_id": "r1",
+                },
+                {
+                    "project_id": "p2",
+                    "status": "skipped",
+                    "last_run_outcome": "needs_human",
+                    "receipt_id": "r2",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
     def test_blocked_with_receipt_gap(self) -> None:
         manifest = {
             "projects": [


### PR DESCRIPTION
## Summary
- treat campaign \ outcomes as the same clean-no-effect blocker family as \
- keep the existing classifier precedence and behavior for other outcome families unchanged
- add focused classifier regressions for \ and mixed legacy/new vocabulary manifests

## Testing
- python3 -m pytest tests/ralph/test_classifier.py -q
- python3 -m ruff check aragora/ralph/classifier.py tests/ralph/test_classifier.py