### PR TITLE
fix(ralph): find merged PRs in repair branch discovery

### DIFF
--- a/aragora/ralph/supervisor.py
+++ b/aragora/ralph/supervisor.py
@@ -811,10 +811,22 @@ class RalphSupervisor:
         )
 
     def _find_pr_for_branch(self, branch: str) -> str | None:
-        """Use gh CLI to find an open PR for the given branch."""
+        """Use gh CLI to find a PR (open or merged) for the given branch."""
         try:
             result = subprocess.run(
-                ["gh", "pr", "list", "--head", branch, "--json", "url", "--limit", "1"],
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--head",
+                    branch,
+                    "--state",
+                    "all",
+                    "--json",
+                    "url",
+                    "--limit",
+                    "1",
+                ],
                 capture_output=True,
                 text=True,
                 cwd=str(self.repo_root),


### PR DESCRIPTION
## Summary
- `_find_pr_for_branch` used `gh pr list --head <branch>` which defaults to open PRs only
- When a repair PR merges before the supervisor polls, PR detection stays stuck in `waiting_for_pr` forever
- Fix: add `--state all` so both open and merged PRs are discovered

## Test plan
- [x] Proven in supervised Campaign 2 loop: PR #941 (merged) was discovered after this fix
- [x] State transition `waiting_for_pr → waiting_for_merge` confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)