### PR TITLE
fix(ralph): classify needs_human outcome as deterministic blocker

### DIFF
--- a/aragora/ralph/classifier.py
+++ b/aragora/ralph/classifier.py
@@ -125,8 +125,11 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
     if has_deliverable and has_review_rejection:
         return BlockerKind.REVIEWER_MISSING_DIFF
 
-    # Check for repeated clean_exit_no_deliverable on docs-only tasks.
-    clean_exit_count = outcomes.count("clean_exit_no_deliverable")
+    # Check for repeated worker-produced-nothing outcomes on docs-only tasks.
+    # The campaign executor uses "needs_human" while boss_loop uses
+    # "clean_exit_no_deliverable" — both mean the worker ran but produced
+    # no usable deliverable.
+    clean_exit_count = sum(outcomes.count(o) for o in ("clean_exit_no_deliverable", "needs_human"))
     if clean_exit_count >= 2:
         return BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 

--- a/tests/ralph/test_classifier.py
+++ b/tests/ralph/test_classifier.py
@@ -150,3 +150,41 @@ class TestClassifyBlocker:
     def test_blocked_with_no_projects(self) -> None:
         result = classify_blocker(stop_reason="campaign_blocked", manifest_dict={"projects": []})
         assert result == BlockerKind.UNKNOWN
+
+    def test_blocked_with_needs_human_maps_to_clean_exit(self) -> None:
+        """Campaign executor uses 'needs_human' for worker-produced-nothing."""
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+                {
+                    "project_id": "p2",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
+    def test_blocked_with_mixed_needs_human_and_clean_exit(self) -> None:
+        """Both outcome strings should count toward the same blocker kind."""
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+                {
+                    "project_id": "p2",
+                    "status": "failed",
+                    "last_run_outcome": "clean_exit_no_deliverable",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT


### PR DESCRIPTION
## Summary
- The campaign executor uses `needs_human` while boss_loop uses `clean_exit_no_deliverable` for the same worker-produced-nothing scenario
- The blocker classifier only checked `clean_exit_no_deliverable`, so `needs_human` outcomes fell through to `UNKNOWN` and caused Ralph to escalate instead of dispatching a deterministic repair
- Fix: count both outcome strings toward `WORKER_CLEAN_EXIT_NO_EFFECT`

## Context
Discovered during Campaign 2 dogfood run: 6 of 10 docs-only projects blocked with `needs_human` outcome. The classifier returned `UNKNOWN`, Ralph escalated at step 12 instead of dispatching a repair. After manually patching the classifier locally, the repair dispatch path worked correctly (PR #941 created, merged, resume succeeded).

## Changes
- `aragora/ralph/classifier.py`: count `needs_human` alongside `clean_exit_no_deliverable` (2 lines changed)
- `tests/ralph/test_classifier.py`: 2 new tests covering `needs_human`-only and mixed vocabulary scenarios

## Test plan
- [x] `pytest tests/ralph/test_classifier.py` — 16/16 pass
- [x] `pytest tests/ralph/` — 77/77 pass
- [x] Verified semantically correct: both outcomes map to `"stall"` in `campaign.py:1514-1515`

🤖 Generated with [Claude Code](https://claude.com/claude-code)