### PR TITLE
fix(ralph): classify needs_human as worker stall in blocker taxonomy

### DIFF
--- a/aragora/ralph/classifier.py
+++ b/aragora/ralph/classifier.py
@@ -125,9 +125,12 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
     if has_deliverable and has_review_rejection:
         return BlockerKind.REVIEWER_MISSING_DIFF
 
-    # Check for repeated clean_exit_no_deliverable on docs-only tasks.
-    clean_exit_count = outcomes.count("clean_exit_no_deliverable")
-    if clean_exit_count >= 2:
+    # Check for repeated worker stalls (no usable deliverable).
+    # Both clean_exit_no_deliverable and needs_human represent the same
+    # failure family: the worker finished but produced nothing actionable.
+    _STALL_OUTCOMES = {"clean_exit_no_deliverable", "needs_human"}
+    stall_count = sum(1 for o in outcomes if o in _STALL_OUTCOMES)
+    if stall_count >= 2:
         return BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 
     # Check for receipt gaps: terminal projects without receipt_id.
@@ -145,7 +148,7 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
                 return BlockerKind.MANIFEST_IDENTIFIER_COLLISION
             seen_hints.add(hint)
 
-    if clean_exit_count >= 1:
+    if stall_count >= 1:
         return BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 
     return BlockerKind.UNKNOWN

--- a/tests/ralph/test_classifier.py
+++ b/tests/ralph/test_classifier.py
@@ -101,6 +101,56 @@ class TestClassifyBlocker:
         result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
         assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
 
+    def test_blocked_with_repeated_needs_human(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+                {
+                    "project_id": "p2",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
+    def test_blocked_with_mixed_stall_outcomes(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                },
+                {
+                    "project_id": "p2",
+                    "status": "failed",
+                    "last_run_outcome": "clean_exit_no_deliverable",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
+    def test_blocked_with_single_needs_human(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "needs_human",
+                    "receipt_id": "r1",
+                },
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.WORKER_CLEAN_EXIT_NO_EFFECT
+
     def test_blocked_with_receipt_gap(self) -> None:
         manifest = {
             "projects": [


### PR DESCRIPTION
## Summary
- Classifier only recognized `clean_exit_no_deliverable` as a worker stall signal
- Campaign 2 workers consistently return `needs_human` instead, which fell through to `UNKNOWN`
- This prevented the supervisor from triggering deterministic repair tasks
- Fix: count both `needs_human` and `clean_exit_no_deliverable` as the same stall family

## Evidence
Campaign 2 run: 7/10 projects stalled with `needs_human`, classifier returned `UNKNOWN` for all, no repair loop triggered. $13 budget spent with zero progress.

## Test plan
- [x] 17/17 classifier tests pass (3 new: repeated needs_human, mixed stall, single needs_human)
- [x] Existing tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)