### PR TITLE
fix(swarm): place JSON summary after diff in reviewer prompt

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -877,13 +877,13 @@ class CampaignReviewer:
         parts = [
             "Review this completed implementation against the project specification.\n"
             "Respond with strict JSON only: "
-            '{"status":"passed|changes_requested|blocked_nonreviewable","findings":["..."]}\n'
-            f"{json.dumps(summary, sort_keys=True)}",
+            '{"status":"passed|changes_requested|blocked_nonreviewable","findings":["..."]}'
         ]
         if diff_content:
             parts.append(
                 f"\n\n--- ACTUAL DIFF (worker branch vs base) ---\n{diff_content}\n--- END DIFF ---"
             )
+        parts.append(json.dumps(summary, sort_keys=True))
         return "\n".join(parts)
 
 

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -151,6 +151,8 @@ class TestBuildPromptWithDiff:
         assert "ACTUAL DIFF" in prompt
         assert "+hello world" in prompt
         assert "END DIFF" in prompt
+        parsed_json = json.loads(prompt.split("\n")[-1])
+        assert parsed_json["project_id"] == "phase0a-007"
 
     def test_prompt_excludes_diff_when_none(self) -> None:
         project = _make_project()


### PR DESCRIPTION
## Summary
- Moves the JSON summary to appear after the diff block in `CampaignReviewer._build_prompt`, so the reviewer model sees the actual code changes before the structured metadata
- Adds test assertion that the JSON summary is parseable as the last line of the prompt

## Test plan
- [x] `test_prompt_includes_diff_when_provided` verifies diff block and trailing JSON
- [x] Existing tests for no-diff and empty-diff cases still pass
- [ ] `pytest tests/swarm/test_campaign_reviewer_diff.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)