### PR TITLE
fix(cli): surface Claude CLI billing errors in reviewer diagnostics

### DIFF
--- a/aragora/agents/cli_agents.py
+++ b/aragora/agents/cli_agents.py
@@ -416,6 +416,7 @@ class CLIAgent(CritiqueMixin, Agent):
                         self._circuit_breaker.record_failure()
                     # Build informative error message with return code
                     stderr_text = stderr.decode("utf-8", errors="replace").strip()
+                    stdout_text_err = stdout.decode("utf-8", errors="replace").strip()
                     error_msg = f"CLI command failed with return code {proc.returncode}"
                     if stderr_text:
                         # For verbose CLIs (like Codex), extract last meaningful line
@@ -423,13 +424,23 @@ class CLIAgent(CritiqueMixin, Agent):
                         if lines:
                             last_line = lines[-1][:200]
                             error_msg += f": {last_line}"
+                    elif stdout_text_err:
+                        # Some CLIs (e.g. Claude) write errors to stdout.
+                        # Surface stdout when stderr is empty so billing/auth
+                        # errors like "Credit balance is too low" are visible.
+                        lines = [
+                            line.strip() for line in stdout_text_err.split("\n") if line.strip()
+                        ]
+                        if lines:
+                            last_line = lines[-1][:200]
+                            error_msg += f" (stdout): {last_line}"
                     else:
-                        error_msg += " (stderr empty)"
+                        error_msg += " (no output)"
                     raise CLISubprocessError(
                         message=error_msg,
                         agent_name=self.name,
                         returncode=proc.returncode,
-                        stderr=stderr_text or None,
+                        stderr=stderr_text or stdout_text_err or None,
                     )
 
                 stdout_text = stdout.decode("utf-8", errors="replace").strip()

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.agents.base import create_agent
+from aragora.agents.errors import CLISubprocessError
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
 from aragora.swarm.boss_loop import (
     _extract_deliverable,
@@ -845,14 +846,38 @@ class CampaignReviewer:
                 reviewed_at=_now_iso(),
                 raw_review={"response": raw},
             )
+        except CLISubprocessError as exc:
+            error_str = str(exc).lower()
+            is_billing = any(
+                p in error_str
+                for p in ("credit balance", "billing", "payment required", "purchase credits")
+            )
+            if is_billing:
+                detail = (
+                    "CLI subscription usage exhausted. "
+                    "Run 'claude auth status' to check the active account, "
+                    "then 'claude auth logout && claude auth login' to switch "
+                    "to an account with available capacity."
+                )
+                findings = [f"Review blocked (billing): {detail}"]
+            else:
+                findings = [f"Review failed: {type(exc).__name__}"]
+            return CampaignReviewGate(
+                required=True,
+                review_model=chosen_review_model,
+                status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
+                findings=findings,
+                reviewed_at=_now_iso(),
+                raw_review={"error": type(exc).__name__, "detail": str(exc)[:500]},
+            )
         except Exception as exc:
             return CampaignReviewGate(
                 required=True,
                 review_model=chosen_review_model,
                 status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
-                findings=[f"Review failed: {type(exc).__name__}: {exc}"],
+                findings=[f"Review failed: {type(exc).__name__}"],
                 reviewed_at=_now_iso(),
-                raw_review={"error": str(exc)},
+                raw_review={"error": type(exc).__name__},
             )
 
     @staticmethod

--- a/tests/agents/test_cli_agents.py
+++ b/tests/agents/test_cli_agents.py
@@ -685,6 +685,42 @@ class TestCLIAgentAsyncOps:
         # Circuit should still be open after success
         assert agent._circuit_breaker.can_proceed() is True
 
+    @pytest.mark.asyncio
+    async def test_run_cli_surfaces_stdout_when_stderr_empty(self):
+        """When CLI writes error to stdout (not stderr), the error message includes it."""
+        from aragora.agents.errors import CLISubprocessError
+
+        agent = DummyCLIAgent(name="test-agent", model="test-model")
+
+        # Simulate a process that writes error to stdout only (like Claude CLI
+        # "Credit balance is too low")
+        with pytest.raises(CLISubprocessError, match="Credit balance is too low"):
+            await agent._run_cli(["bash", "-c", "echo 'Credit balance is too low' && exit 1"])
+
+    @pytest.mark.asyncio
+    async def test_run_cli_prefers_stderr_over_stdout(self):
+        """When both stderr and stdout have content, error message uses stderr."""
+        from aragora.agents.errors import CLISubprocessError
+
+        agent = DummyCLIAgent(name="test-agent", model="test-model")
+
+        with pytest.raises(CLISubprocessError, match="real error") as exc_info:
+            await agent._run_cli(
+                ["bash", "-c", "echo 'stdout noise'; echo 'real error' >&2; exit 1"]
+            )
+        # Should NOT contain stdout noise
+        assert "stdout noise" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_cli_no_output_message(self):
+        """When both stderr and stdout are empty, error says 'no output'."""
+        from aragora.agents.errors import CLISubprocessError
+
+        agent = DummyCLIAgent(name="test-agent", model="test-model")
+
+        with pytest.raises(CLISubprocessError, match="no output"):
+            await agent._run_cli(["bash", "-c", "exit 1"])
+
 
 # =============================================================================
 # Critique Functionality Tests

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.agents.errors import CLISubprocessError
 from aragora.swarm.campaign import (
     CampaignProject,
     CampaignReviewGate,
@@ -180,3 +182,88 @@ class TestBuildPromptWithDiff:
         assert '"status":"passed|changes_requested|blocked_nonreviewable"' in prompt
         parsed_json = json.loads(prompt.split("\n")[-1])
         assert parsed_json["project_id"] == "phase0a-007"
+
+
+class TestReviewerBillingErrorDetection:
+    """Tests that billing/credit errors from the Claude CLI are surfaced clearly."""
+
+    @pytest.mark.asyncio
+    async def test_credit_balance_error_surfaces_billing_message(self) -> None:
+        """CLISubprocessError with 'credit balance' triggers actionable finding."""
+        reviewer = CampaignReviewer()
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        billing_error = CLISubprocessError(
+            message="CLI command failed with return code 1 (stdout): Credit balance is too low",
+            agent_name="campaign-review",
+            returncode=1,
+            stderr="Credit balance is too low",
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.generate = AsyncMock(side_effect=billing_error)
+
+        with patch("aragora.swarm.campaign.create_agent", return_value=mock_agent):
+            gate = await reviewer.review(
+                project=project,
+                worker_model="codex",
+                review_model="claude",
+                run_dict=run_dict,
+            )
+
+        assert gate.status == CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value
+        assert any("billing" in f.lower() for f in gate.findings)
+        assert any("claude auth" in f.lower() for f in gate.findings)
+
+    @pytest.mark.asyncio
+    async def test_non_billing_cli_error_does_not_trigger_billing_message(self) -> None:
+        """Regular CLISubprocessError does not produce billing guidance."""
+        reviewer = CampaignReviewer()
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        cli_error = CLISubprocessError(
+            message="CLI command failed with return code 1: connection refused",
+            agent_name="campaign-review",
+            returncode=1,
+            stderr="connection refused",
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.generate = AsyncMock(side_effect=cli_error)
+
+        with patch("aragora.swarm.campaign.create_agent", return_value=mock_agent):
+            gate = await reviewer.review(
+                project=project,
+                worker_model="codex",
+                review_model="claude",
+                run_dict=run_dict,
+            )
+
+        assert gate.status == CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value
+        assert not any("billing" in f.lower() for f in gate.findings)
+        assert any("CLISubprocessError" in f for f in gate.findings)
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_does_not_leak_details(self) -> None:
+        """Non-CLI exceptions report type name only, not raw str(exc)."""
+        reviewer = CampaignReviewer()
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        mock_agent = AsyncMock()
+        mock_agent.generate = AsyncMock(side_effect=ValueError("secret internal detail"))
+
+        with patch("aragora.swarm.campaign.create_agent", return_value=mock_agent):
+            gate = await reviewer.review(
+                project=project,
+                worker_model="codex",
+                review_model="claude",
+                run_dict=run_dict,
+            )
+
+        assert gate.status == CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value
+        assert any("ValueError" in f for f in gate.findings)
+        # Raw exception detail should not be in findings
+        assert not any("secret internal detail" in f for f in gate.findings)


### PR DESCRIPTION
## Summary

Improve diagnosis of Claude CLI reviewer failures without changing execution semantics.

This PR makes two narrow fixes:

1. `aragora/agents/cli_agents.py`
   - when a CLI subprocess exits non-zero and `stderr` is empty, surface meaningful `stdout` content in the `CLISubprocessError`
   - this makes failures like `Credit balance is too low` visible instead of reporting only `(stderr empty)`

2. `aragora/swarm/campaign.py`
   - handle `CLISubprocessError` explicitly in `CampaignReviewer.review()`
   - detect billing / credit exhaustion patterns and return an actionable `blocked_nonreviewable` finding
   - avoid leaking raw exception detail for unrelated generic exceptions

## Why

During Campaign 2 dogfooding, reviewer failures were being recorded as:

- `Review failed: CLISubprocessError: [campaign-review] CLI command failed with return code 1 (stderr empty)`

That hid the real operational cause. The actual Claude CLI failure was a billing/usage exhaustion message written to stdout/stderr by the CLI.

This PR makes that class of failure immediately diagnosable.

## Files

- `aragora/agents/cli_agents.py`
- `aragora/swarm/campaign.py`
- `tests/agents/test_cli_agents.py`
- `tests/swarm/test_campaign_reviewer_diff.py`

## Test plan

- [x] `python -m pytest tests/agents/test_cli_agents.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_campaign.py -x --timeout=30` — 105 passed locally
- [ ] CI required checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)