### PR TITLE
fix(ralph): harden reviewer blocker classification

### DIFF
--- a/aragora/ralph/classifier.py
+++ b/aragora/ralph/classifier.py
@@ -29,6 +29,7 @@ class BlockerKind(str, Enum):
     RECEIPT_EMISSION_GAP = "receipt_emission_gap"
 
     # --- escalate ---
+    REVIEWER_AUTH_OR_BILLING = "reviewer_auth_or_billing_failure"
     BUDGET_EXHAUSTION = "budget_exhaustion"
     INFRA_FAILURE = "infra_failure"
     UNKNOWN = "unknown"
@@ -90,6 +91,15 @@ def _classify_time_limit(manifest_dict: dict[str, Any]) -> BlockerKind:
 
 def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
     """Inspect project-level outcomes to classify the blocker."""
+    reviewer_failure_patterns = (
+        "billing",
+        "credit balance",
+        "purchase credits",
+        "payment required",
+        "auth",
+        "login",
+        "clisubprocesserror",
+    )
     projects = manifest_dict.get("projects", [])
 
     blocked_projects = [p for p in projects if p.get("status") in ("blocked", "failed", "skipped")]
@@ -115,6 +125,8 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
                     "violation" in finding_lower or "outside" in finding_lower
                 ):
                     return BlockerKind.SCOPE_FALSE_POSITIVE
+                if any(pattern in finding_lower for pattern in reviewer_failure_patterns):
+                    return BlockerKind.REVIEWER_AUTH_OR_BILLING
 
     # Check for reviewer false rejection pattern: deliverable_created but
     # review blocked/changes_requested.

--- a/tests/ralph/test_classifier.py
+++ b/tests/ralph/test_classifier.py
@@ -17,6 +17,7 @@ class TestBlockerKindEnum:
         assert BlockerKind.RECEIPT_EMISSION_GAP.is_deterministic
 
     def test_escalation_kinds(self) -> None:
+        assert not BlockerKind.REVIEWER_AUTH_OR_BILLING.is_deterministic
         assert not BlockerKind.BUDGET_EXHAUSTION.is_deterministic
         assert not BlockerKind.INFRA_FAILURE.is_deterministic
         assert not BlockerKind.UNKNOWN.is_deterministic
@@ -82,6 +83,57 @@ class TestClassifyBlocker:
         }
         result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
         assert result == BlockerKind.SCOPE_FALSE_POSITIVE
+
+    def test_blocked_with_billing_finding_escalates(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "deliverable_created",
+                    "review": {
+                        "status": "blocked_nonreviewable",
+                        "findings": ["Review blocked (billing): Credit balance is too low"],
+                    },
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.REVIEWER_AUTH_OR_BILLING
+
+    def test_blocked_with_auth_subprocess_finding_escalates(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "deliverable_created",
+                    "review": {
+                        "status": "blocked_nonreviewable",
+                        "findings": ["Review failed: CLISubprocessError. Run claude auth login."],
+                    },
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.REVIEWER_AUTH_OR_BILLING
+
+    def test_blocked_with_true_diff_missing_still_maps_to_reviewer_missing_diff(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "deliverable_created",
+                    "review": {
+                        "status": "blocked_nonreviewable",
+                        "findings": ["Reviewer could not verify acceptance criteria without diff."],
+                    },
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.REVIEWER_MISSING_DIFF
 
     def test_blocked_with_repeated_clean_exit(self) -> None:
         manifest = {


### PR DESCRIPTION
## Summary
- add a non-deterministic classifier blocker for reviewer auth or billing failures
- inspect review findings before mapping blocked_nonreviewable review rejections to reviewer_missing_diff
- add focused classifier tests for billing, auth/subprocess, and true diff-missing cases

## Testing
- pytest -q tests/ralph/test_classifier.py