### PR TITLE
salvage(phase0b): preserve B-1 worker-type circuit breaker branch

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1295,7 +1295,9 @@ class SwarmSupervisor:
                 continue
             entry = self._default_worker_type_circuit_breaker(policy)
             payload = dict(raw_entry or {})
-            entry["status"] = str(payload.get("status", entry["status"])).strip().lower() or "closed"
+            entry["status"] = (
+                str(payload.get("status", entry["status"])).strip().lower() or "closed"
+            )
             if entry["status"] not in {"open", "closed"}:
                 entry["status"] = "closed"
             try:
@@ -1306,15 +1308,11 @@ class SwarmSupervisor:
                 entry["trip_count"] = max(0, int(payload.get("trip_count", 0) or 0))
             except (TypeError, ValueError):
                 entry["trip_count"] = 0
-            entry["last_failure_reason"] = (
-                str(payload.get("last_failure_reason", "")).strip()
-            )
-            entry["last_failure_detail"] = (
-                str(payload.get("last_failure_detail", "")).strip()[:1000]
-            )
-            entry["last_failure_at"] = self._normalized_timestamp(
-                payload.get("last_failure_at")
-            )
+            entry["last_failure_reason"] = str(payload.get("last_failure_reason", "")).strip()
+            entry["last_failure_detail"] = str(payload.get("last_failure_detail", "")).strip()[
+                :1000
+            ]
+            entry["last_failure_at"] = self._normalized_timestamp(payload.get("last_failure_at"))
             entry["opened_at"] = self._normalized_timestamp(payload.get("opened_at"))
             blocked_until = self._normalized_timestamp(payload.get("blocked_until"))
             if entry["status"] == "open" and not blocked_until and entry["opened_at"]:
@@ -1336,10 +1334,10 @@ class SwarmSupervisor:
     ) -> dict[str, Any]:
         policy = self._worker_type_circuit_breaker_policy(metadata)
         normalized_breakers = {
-            worker_type: dict(entry)
-            for worker_type, entry in sorted(circuit_breakers.items())
+            worker_type: dict(entry) for worker_type, entry in sorted(circuit_breakers.items())
         }
         return {
+            **dict(metadata),
             WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY: policy,
             WORKER_TYPE_CIRCUIT_BREAKERS_KEY: normalized_breakers,
         }
@@ -1422,7 +1420,9 @@ class SwarmSupervisor:
         was_open = str(entry.get("status", "")).strip().lower() == "open"
         failure_count = threshold if open_immediately else int(entry.get("failure_count", 0)) + 1
 
-        entry["failure_count"] = max(failure_count, threshold if open_immediately else failure_count)
+        entry["failure_count"] = max(
+            failure_count, threshold if open_immediately else failure_count
+        )
         entry["last_failure_at"] = now.isoformat()
         entry["last_failure_reason"] = str(reason).strip()
         entry["last_failure_detail"] = str(detail).strip()[:1000]

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -714,10 +714,12 @@ async def test_dispatch_workers_trips_and_skips_worker_type_circuit_breaker(
         ],
         status="active",
         metadata={
+            "max_concurrency": 3,
+            "managed_dir_pattern": ".worktrees/custom-{agent}",
             WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY: {
                 "failure_threshold": 2,
                 "reset_timeout_seconds": 300.0,
-            }
+            },
         },
     )
 
@@ -738,6 +740,8 @@ async def test_dispatch_workers_trips_and_skips_worker_type_circuit_breaker(
 
     updated = store.get_supervisor_run(run_record["run_id"])
     assert updated is not None
+    assert updated["metadata"]["max_concurrency"] == 3
+    assert updated["metadata"]["managed_dir_pattern"] == ".worktrees/custom-{agent}"
     breaker = updated["metadata"][WORKER_TYPE_CIRCUIT_BREAKERS_KEY]["claude"]
     assert breaker["status"] == "open"
     assert breaker["failure_count"] == 2
@@ -809,7 +813,11 @@ async def test_collect_finished_results_requeues_capacity_failure_to_fallback_ag
         launcher=mock_launcher,
         decomposer=decomposer,
     )
-    run = supervisor.start_run(spec=SwarmSpec(raw_goal="Goal", refined_goal="Goal"))
+    run = supervisor.start_run(
+        spec=SwarmSpec(raw_goal="Goal", refined_goal="Goal"),
+        max_concurrency=4,
+        managed_dir_pattern=".worktrees/phase0b-{agent}",
+    )
     run.work_orders[0]["status"] = "dispatched"
     run.work_orders[0]["target_agent"] = "claude"
     run.work_orders[0]["reviewer_agent"] = "codex"
@@ -821,6 +829,8 @@ async def test_collect_finished_results_requeues_capacity_failure_to_fallback_ag
     assert len(completed) == 1
     refreshed = store.get_supervisor_run(run.run_id)
     assert refreshed is not None
+    assert refreshed["metadata"]["max_concurrency"] == 4
+    assert refreshed["metadata"]["managed_dir_pattern"] == ".worktrees/phase0b-{agent}"
     work_order = refreshed["work_orders"][0]
     assert work_order["status"] == "leased"
     assert work_order["target_agent"] == "codex"
@@ -834,6 +844,53 @@ async def test_collect_finished_results_requeues_capacity_failure_to_fallback_ag
     assert breaker["last_failure_reason"] == "agent_capacity"
     assert breaker["last_failure_detail"] == "Credit balance is too low"
     assert store.status_summary()["counts"]["active_leases"] == 1
+
+
+def test_reset_worker_type_circuit_breaker_preserves_run_metadata(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    run_record = store.create_supervisor_run(
+        goal="reset breaker metadata",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "reset breaker metadata"},
+        work_orders=[],
+        status="active",
+        metadata={
+            "max_concurrency": 5,
+            "managed_dir_pattern": ".worktrees/preserve-{agent}",
+            WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY: {
+                "failure_threshold": 2,
+                "reset_timeout_seconds": 300.0,
+            },
+            WORKER_TYPE_CIRCUIT_BREAKERS_KEY: {
+                "claude": {
+                    "status": "open",
+                    "failure_count": 2,
+                    "failure_threshold": 2,
+                    "reset_timeout_seconds": 300.0,
+                    "opened_at": datetime.now(timezone.utc).isoformat(),
+                    "blocked_until": (
+                        datetime.now(timezone.utc) + timedelta(minutes=5)
+                    ).isoformat(),
+                    "last_failure_reason": "agent_unavailable",
+                    "last_failure_detail": "CLI not found",
+                }
+            },
+        },
+    )
+
+    supervisor = SwarmSupervisor(repo_root=repo, store=store)
+
+    updated = supervisor.reset_worker_type_circuit_breaker(run_record["run_id"], "claude")
+
+    assert updated.metadata["max_concurrency"] == 5
+    assert updated.metadata["managed_dir_pattern"] == ".worktrees/preserve-{agent}"
+    breaker = updated.metadata[WORKER_TYPE_CIRCUIT_BREAKERS_KEY]["claude"]
+    assert breaker["status"] == "closed"
+    assert breaker["failure_count"] == 0
+    assert breaker["last_reset_at"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- salvage the existing branch produced during Phase 0B B-1
- preserve the worker's committed supervisor implementation and focused tests for human review
- package the branch without modifying the blocked Phase 0B runtime state

## Provenance
This branch was produced during Phase 0B B-1. The worker timed out after committing production code, so the branch is being salvaged for human review rather than discarded.

## Verification
- pytest -q tests/swarm/test_supervisor.py
- pytest -q tests/ralph/test_supervisor.py