### PR TITLE
fix(swarm): increase worker timeout defaults for Phase 0B task scope

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -96,8 +96,8 @@ class LaunchConfig:
 
     claude_path: str = "claude"
     codex_path: str = "codex"
-    timeout_seconds: float = 600.0
-    no_progress_timeout_seconds: float = 720.0
+    timeout_seconds: float = 2400.0
+    no_progress_timeout_seconds: float = 1800.0
     claude_model: str | None = None
     codex_model: str | None = None
     auto_commit: bool = True


### PR DESCRIPTION
## Summary

- Increases `timeout_seconds` from 600s (10 min) to 2400s (40 min)
- Increases `no_progress_timeout_seconds` from 720s (12 min) to 1800s (30 min)
- `timeout_seconds` remains greater than `no_progress_timeout_seconds` so both controls retain distinct semantics

Phase 0B code-change tasks (B-1, B-2) consistently timed out at the old defaults — workers produced real production code and tests but were killed before the reviewer could assess. This caused repeated salvage cycles.

## Test plan

- [x] `ruff format` clean
- [x] `ruff check` clean
- [x] Syntax check passes
- [x] Pre-commit hooks pass
- Change is config-only (default values in `LaunchConfig` dataclass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)