### PR TITLE
salvage(phase0b): B-3 budget controls enforcement

### DIFF
--- a/aragora/nomic/hardened_budget.py
+++ b/aragora/nomic/hardened_budget.py
@@ -22,20 +22,110 @@ if TYPE_CHECKING:
 logger = logging.getLogger("aragora.nomic.hardened_orchestrator")
 
 
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
+
+
 class BudgetMixin:
     """Mixin providing budget enforcement methods for HardenedOrchestrator."""
 
     # These attributes are expected to be set by the host class __init__
     hardened_config: Any
     _budget_spent_usd: float
+    _budget_reserved_usd: float
+    _budget_reservations: dict[str, float]
+    _budget_lock: Any
     _budget_manager: Any
     _budget_id: str | None
+    _total_cost_usd: float
     _completed_assignments: list
     _active_assignments: list
     _call_timestamps: collections.deque
     _agent_failure_counts: dict[str, int]
     _agent_success_counts: dict[str, int]
     _agent_open_until: dict[str, float]
+
+    @staticmethod
+    def _reservation_key(assignment: AgentAssignment) -> str:
+        return assignment.subtask.id
+
+    def _estimated_assignment_cost(self, assignment: AgentAssignment) -> float:
+        be_config = self.hardened_config.budget_enforcement
+        return float(be_config.cost_per_subtask_estimate if be_config else 0.10)
+
+    def _reset_budget_tracking(self) -> None:
+        """Reset committed and reserved budget for a new orchestrator run."""
+        with self._budget_lock:
+            self._budget_spent_usd = 0.0
+            self._budget_reserved_usd = 0.0
+            self._budget_reservations.clear()
+            self._total_cost_usd = 0.0
+
+    def _budget_snapshot(
+        self,
+        *,
+        spent_usd: float | None = None,
+        limit_usd: float | None = None,
+    ) -> dict[str, float | bool | None]:
+        with self._budget_lock:
+            spent = max(float(spent_usd or 0.0), float(self._budget_spent_usd or 0.0))
+            reserved = float(self._budget_reserved_usd or 0.0)
+        limit = self.hardened_config.budget_limit_usd if limit_usd is None else limit_usd
+        committed = spent + reserved
+        remaining = None if limit is None else max(0.0, float(limit) - committed)
+        return {
+            "spent_usd": round(spent, 4),
+            "reserved_usd": round(reserved, 4),
+            "committed_usd": round(committed, 4),
+            "remaining_usd": None if remaining is None else round(remaining, 4),
+            "limit_usd": None if limit is None else round(float(limit), 4),
+            "exhausted": bool(limit is not None and committed >= float(limit)),
+        }
+
+    def _reserve_budget(self, assignment: AgentAssignment, amount_usd: float) -> None:
+        key = self._reservation_key(assignment)
+        with self._budget_lock:
+            if key in self._budget_reservations:
+                return
+            self._budget_reservations[key] = amount_usd
+            self._budget_reserved_usd += amount_usd
+        snapshot = self._budget_snapshot()
+        self._emit_event(  # type: ignore[attr-defined]
+            "budget_reserved",
+            subtask=assignment.subtask.id,
+            reserved=round(amount_usd, 4),
+            committed=snapshot["committed_usd"],
+            remaining=snapshot["remaining_usd"],
+            limit=snapshot["limit_usd"],
+        )
+
+    def _cancel_budget_reservation(self, assignment: AgentAssignment, *, reason: str) -> None:
+        key = self._reservation_key(assignment)
+        with self._budget_lock:
+            reserved = self._budget_reservations.pop(key, 0.0)
+            if reserved > 0:
+                self._budget_reserved_usd = max(0.0, self._budget_reserved_usd - reserved)
+            else:
+                reserved = 0.0
+        if reserved <= 0:
+            return
+        snapshot = self._budget_snapshot()
+        self._emit_event(  # type: ignore[attr-defined]
+            "budget_reservation_released",
+            subtask=assignment.subtask.id,
+            released=round(reserved, 4),
+            committed=snapshot["committed_usd"],
+            remaining=snapshot["remaining_usd"],
+            limit=snapshot["limit_usd"],
+            reason=reason,
+        )
 
     def _init_budget_manager(self, config: BudgetEnforcementConfig) -> None:
         """Initialize BudgetManager integration."""
@@ -76,19 +166,48 @@ class BudgetMixin:
             True if assignment may proceed, False if skipped due to budget.
         """
         be_config = self.hardened_config.budget_enforcement
-        estimate = be_config.cost_per_subtask_estimate if be_config else 0.10
+        estimate = self._estimated_assignment_cost(assignment)
+        reservation_key = self._reservation_key(assignment)
+
+        with self._budget_lock:
+            existing_reservation = self._budget_reservations.get(reservation_key)
+        if existing_reservation is not None:
+            return True
 
         # Path 1: BudgetManager integration
         if self._budget_manager is not None and self._budget_id is not None:
             budget = self._budget_manager.get_budget(self._budget_id)
             if budget is None:
                 logger.warning("budget_not_found id=%s, allowing", self._budget_id)
+                self._reserve_budget(assignment, estimate)
                 return True
 
             # Check hard_stop_percent
             hard_stop = be_config.hard_stop_percent if be_config else 1.0
-            if budget.usage_percentage >= hard_stop:
+            usage_percentage = _safe_float(getattr(budget, "usage_percentage", 0.0))
+            if usage_percentage >= hard_stop:
                 self._skip_assignment(assignment, "budget_exceeded_hard_stop")
+                return False
+
+            limit_usd = _safe_float(
+                getattr(budget, "amount_usd", self.hardened_config.budget_limit_usd or 0.0),
+                _safe_float(self.hardened_config.budget_limit_usd, 0.0),
+            )
+            spent_usd = max(
+                _safe_float(getattr(budget, "spent_usd", 0.0)),
+                _safe_float(self._budget_spent_usd, 0.0),
+            )
+            projected_total = spent_usd + float(self._budget_reserved_usd or 0.0) + estimate
+            if limit_usd > 0 and projected_total > limit_usd + 1e-9:
+                logger.warning(
+                    "budget_blocked_projected subtask=%s projected=%.2f spent=%.2f reserved=%.2f limit=%.2f",
+                    assignment.subtask.id,
+                    projected_total,
+                    spent_usd,
+                    self._budget_reserved_usd,
+                    limit_usd,
+                )
+                self._skip_assignment(assignment, "budget_exceeded")
                 return False
 
             result = budget.can_spend_extended(estimate)
@@ -103,20 +222,25 @@ class BudgetMixin:
                 self._skip_assignment(assignment, "budget_exceeded")
                 return False
 
+            self._reserve_budget(assignment, estimate)
             return True
 
         # Path 2: Simple float counter (legacy)
         if self.hardened_config.budget_limit_usd is not None:
-            if self._budget_spent_usd >= self.hardened_config.budget_limit_usd:
+            projected_total = self._budget_spent_usd + self._budget_reserved_usd + estimate
+            if projected_total > self.hardened_config.budget_limit_usd + 1e-9:
                 logger.warning(
-                    "budget_exceeded subtask=%s spent=%.2f limit=%.2f",
+                    "budget_exceeded subtask=%s projected=%.2f spent=%.2f reserved=%.2f limit=%.2f",
                     assignment.subtask.id,
+                    projected_total,
                     self._budget_spent_usd,
+                    self._budget_reserved_usd,
                     self.hardened_config.budget_limit_usd,
                 )
                 self._skip_assignment(assignment, "budget_exceeded")
                 return False
 
+        self._reserve_budget(assignment, estimate)
         return True
 
     def _record_budget_spend(
@@ -130,7 +254,14 @@ class BudgetMixin:
         increments the simple float counter.
         """
         be_config = self.hardened_config.budget_enforcement
-        cost = amount_usd or (be_config.cost_per_subtask_estimate if be_config else 0.10)
+        cost = float(amount_usd or (be_config.cost_per_subtask_estimate if be_config else 0.10))
+        reservation_key = self._reservation_key(assignment)
+        with self._budget_lock:
+            reserved = self._budget_reservations.pop(reservation_key, 0.0)
+            if reserved > 0:
+                self._budget_reserved_usd = max(0.0, self._budget_reserved_usd - reserved)
+            self._budget_spent_usd += cost
+            self._total_cost_usd = self._budget_spent_usd
 
         # Path 1: BudgetManager
         if self._budget_manager is not None and self._budget_id is not None:
@@ -146,22 +277,23 @@ class BudgetMixin:
                     assignment.subtask.id,
                     cost,
                 )
-            return
-
-        # Path 2: Simple counter
-        self._budget_spent_usd += cost
+        snapshot = self._budget_snapshot()
 
         # Emit budget tracking event
         self._emit_event(  # type: ignore[attr-defined]
             "budget_update",
             subtask=assignment.subtask.id,
             cost=round(cost, 4),
-            total_spent=round(self._budget_spent_usd, 4),
-            limit=self.hardened_config.budget_limit_usd,
+            released_reservation=round(reserved, 4),
+            total_spent=snapshot["spent_usd"],
+            reserved=snapshot["reserved_usd"],
+            remaining=snapshot["remaining_usd"],
+            limit=snapshot["limit_usd"],
         )
 
     def _skip_assignment(self, assignment: AgentAssignment, reason: str) -> None:
         """Mark an assignment as skipped and move to completed list."""
+        self._cancel_budget_reservation(assignment, reason=reason)
         assignment.status = "skipped"
         assignment.result = {"reason": reason}
         assignment.completed_at = datetime.now(timezone.utc)

--- a/aragora/nomic/hardened_orchestrator.py
+++ b/aragora/nomic/hardened_orchestrator.py
@@ -33,6 +33,7 @@ import json
 import logging
 import secrets
 import subprocess
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -217,6 +218,10 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
 
         # Budget tracking (simple float counter, legacy)
         self._budget_spent_usd: float = 0.0
+        self._budget_reserved_usd: float = 0.0
+        self._budget_reservations: dict[str, float] = {}
+        self._budget_lock = threading.Lock()
+        self.budget_limit = budget_limit_usd
 
         # BudgetManager integration (persistent, org-aware)
         self._budget_manager: Any | None = None
@@ -412,7 +417,7 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
         if self.hardened_config.enable_prompt_defense:
             self._scan_for_injection(goal, context)
 
-        self._budget_spent_usd = 0.0
+        self._reset_budget_tracking()
         self._spectate_events.clear()
         self._receipts.clear()
 
@@ -798,7 +803,7 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
             )
 
         # Reset budget tracking for this run
-        self._budget_spent_usd = 0.0
+        self._reset_budget_tracking()
         self._spectate_events.clear()
         self._receipts.clear()
 
@@ -2324,39 +2329,43 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
         if not self._check_budget_allows(assignment):
             return
 
-        # J. Circuit breaker check (per agent type)
-        if not self._check_agent_circuit_breaker(assignment.agent_type):
-            self._skip_assignment(assignment, "circuit_breaker_open")
-            return
+        try:
+            # J. Circuit breaker check (per agent type)
+            if not self._check_agent_circuit_breaker(assignment.agent_type):
+                self._skip_assignment(assignment, "circuit_breaker_open")
+                return
 
-        # I. Rate limiting
-        await self._enforce_rate_limit()
+            # I. Rate limiting
+            await self._enforce_rate_limit()
 
-        # A. Worktree isolation path
-        if self.hardened_config.use_worktree_isolation:
-            await self._execute_in_worktree(assignment, max_cycles)
+            # A. Worktree isolation path
+            if self.hardened_config.use_worktree_isolation:
+                await self._execute_in_worktree(assignment, max_cycles)
+                # Record agent outcome for circuit breaker
+                self._record_agent_outcome(
+                    assignment.agent_type,
+                    assignment.status == "completed",
+                )
+                return
+
+            # Non-worktree path: delegate to parent
+            await super()._execute_single_assignment(assignment, max_cycles)
+
             # Record agent outcome for circuit breaker
             self._record_agent_outcome(
                 assignment.agent_type,
                 assignment.status == "completed",
             )
-            return
 
-        # Non-worktree path: delegate to parent
-        await super()._execute_single_assignment(assignment, max_cycles)
+            # Record budget spend (cost incurred regardless of gauntlet outcome)
+            self._record_budget_spend(assignment)
 
-        # Record agent outcome for circuit breaker
-        self._record_agent_outcome(
-            assignment.agent_type,
-            assignment.status == "completed",
-        )
-
-        # Record budget spend (cost incurred regardless of gauntlet outcome)
-        self._record_budget_spend(assignment)
-
-        # C. Post-execution gauntlet validation
-        if self.hardened_config.enable_gauntlet_validation and assignment.status == "completed":
-            await self._run_gauntlet_validation(assignment)
+            # C. Post-execution gauntlet validation
+            if self.hardened_config.enable_gauntlet_validation and assignment.status == "completed":
+                await self._run_gauntlet_validation(assignment)
+        except Exception:
+            self._cancel_budget_reservation(assignment, reason="assignment_aborted")
+            raise
 
     async def _execute_in_worktree(
         self,
@@ -2366,6 +2375,7 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
         """Execute an assignment inside an isolated worktree."""
         manager = self._get_worktree_manager()
         ctx = None
+        budget_recorded = False
 
         try:
             # Create worktree
@@ -2398,6 +2408,7 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
 
             # Record budget spend (cost incurred regardless of merge outcome)
             self._record_budget_spend(assignment)
+            budget_recorded = True
 
             # Run gauntlet on completed work (with optional retry)
             if self.hardened_config.enable_gauntlet_validation and assignment.status == "completed":
@@ -2576,6 +2587,11 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
             assignment.result = {"error": f"Worktree execution failed: {type(e).__name__}"}
 
         finally:
+            if not budget_recorded:
+                self._cancel_budget_reservation(
+                    assignment,
+                    reason="worktree_execution_failed",
+                )
             # Always clean up the worktree
             if ctx is not None:
                 try:

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 UTC = timezone.utc
 DEFAULT_CAMPAIGN_MANIFEST = ".aragora/campaign_manifest.yaml"
+_BUDGET_EPSILON = 1e-9
 
 # Statuses that represent terminal project transitions (no further retries).
 # Receipt emission fires only for these statuses.
@@ -141,6 +142,7 @@ class CampaignExecutionState:
     failed_projects: list[str] = field(default_factory=list)
     skipped_projects: list[str] = field(default_factory=list)
     total_cost_usd: float = 0.0
+    reserved_cost_usd: float = 0.0
     last_run_at: str | None = None
     last_result: dict[str, Any] = field(default_factory=dict)
 
@@ -152,6 +154,7 @@ class CampaignExecutionState:
             "failed_projects": list(self.failed_projects),
             "skipped_projects": list(self.skipped_projects),
             "total_cost_usd": self.total_cost_usd,
+            "reserved_cost_usd": self.reserved_cost_usd,
             "last_run_at": self.last_run_at,
             "last_result": dict(self.last_result),
         }
@@ -174,6 +177,7 @@ class CampaignExecutionState:
                 str(item) for item in data.get("skipped_projects", []) if str(item).strip()
             ],
             total_cost_usd=float(data.get("total_cost_usd", 0.0) or 0.0),
+            reserved_cost_usd=float(data.get("reserved_cost_usd", 0.0) or 0.0),
             last_run_at=str(data.get("last_run_at", "")).strip() or None,
             last_result=dict(data.get("last_result") or {}),
         )
@@ -424,6 +428,52 @@ def _canonical_review_model(worker_model: str, requested: str | None = None) -> 
 def _complexity_cost(label: str) -> float:
     lowered = str(label or "").strip().lower()
     return {"low": 0.5, "medium": 1.0, "moderate": 1.0, "high": 2.0}.get(lowered, 1.0)
+
+
+def _project_estimated_cost(project: CampaignProject) -> float:
+    return max(0.0, float(project.estimated_cost_usd or 0.0))
+
+
+def _campaign_budget_snapshot(manifest: CampaignManifest) -> dict[str, float | bool]:
+    spent = max(0.0, float(manifest.execution_state.total_cost_usd or 0.0))
+    reserved = sum(
+        _project_estimated_cost(project)
+        for project in manifest.projects
+        if project.status == CampaignProjectStatus.ACTIVE.value
+    )
+    limit = max(0.0, float(manifest.budget_limit_usd or 0.0))
+    committed = spent + reserved
+    available = max(0.0, limit - committed)
+    return {
+        "budget_limit_usd": round(limit, 4),
+        "spent_cost_usd": round(spent, 4),
+        "reserved_cost_usd": round(reserved, 4),
+        "committed_cost_usd": round(committed, 4),
+        "available_budget_usd": round(available, 4),
+        "budget_exhausted": bool(available <= _BUDGET_EPSILON),
+    }
+
+
+def _dispatchable_projects(manifest: CampaignManifest) -> list[CampaignProject]:
+    completed = {
+        project.project_id
+        for project in manifest.projects
+        if project.status == CampaignProjectStatus.COMPLETED.value
+    }
+    candidates: list[CampaignProject] = []
+    for project in manifest.projects:
+        if project.status not in {
+            CampaignProjectStatus.PENDING.value,
+            CampaignProjectStatus.READY.value,
+            CampaignProjectStatus.NEEDS_REVISION.value,
+        }:
+            continue
+        if project.retry_count > manifest.max_retries_per_project:
+            continue
+        deps = {dep.project_id for dep in project.dependencies}
+        if deps.issubset(completed):
+            candidates.append(project)
+    return candidates
 
 
 def _success_criteria_to_list(success_criteria: dict[str, Any]) -> list[str]:
@@ -828,6 +878,7 @@ class CampaignReviewer:
         worker_model: str,
         review_model: str,
         run_dict: dict[str, Any],
+        budget_context: dict[str, Any] | None = None,
         repo_root: Path | None = None,
         target_branch: str = "main",
     ) -> CampaignReviewGate:
@@ -836,7 +887,11 @@ class CampaignReviewer:
             run_dict, repo_root=repo_root, target_branch=target_branch
         )
         prompt = self._build_prompt(
-            project, run_dict, chosen_review_model, diff_content=diff_content
+            project,
+            run_dict,
+            chosen_review_model,
+            diff_content=diff_content,
+            budget_context=budget_context,
         )
         try:
             agent = create_agent(chosen_review_model, name="campaign-review", role="critic")
@@ -900,6 +955,7 @@ class CampaignReviewer:
         review_model: str,
         *,
         diff_content: str | None = None,
+        budget_context: dict[str, Any] | None = None,
     ) -> str:
         deliverable = _extract_deliverable(run_dict)
         work_orders = run_dict.get("work_orders", [])
@@ -909,6 +965,9 @@ class CampaignReviewer:
             "title": project.title,
             "acceptance_criteria": project.acceptance_criteria,
             "file_scope_hints": project.file_scope_hints,
+            "budget": dict(
+                budget_context or {"project_estimated_cost_usd": project.estimated_cost_usd}
+            ),
             "deliverable": deliverable,
             "work_orders": work_orders,
         }
@@ -945,13 +1004,28 @@ class CampaignExecutor:
         with locked_manifest_path(self.manifest_path):
             manifest = load_campaign_manifest(self.manifest_path)
             self._reconcile_active_projects(manifest)
+            _refresh_execution_state(manifest)
             stop_reason = _compute_stop_reason(manifest)
             if stop_reason != CampaignStopReason.STILL_RUNNING.value:
+                budget_snapshot = _campaign_budget_snapshot(manifest)
+                blocked_projects: list[str] = []
+                if stop_reason == CampaignStopReason.BUDGET_EXHAUSTED.value:
+                    available_budget = float(budget_snapshot["available_budget_usd"])
+                    blocked_projects = [
+                        project.project_id
+                        for project in _dispatchable_projects(manifest)
+                        if _project_estimated_cost(project) > available_budget + _BUDGET_EPSILON
+                    ]
                 manifest.execution_state.last_run_at = _now_iso()
                 manifest.execution_state.last_result = {
                     "stop_reason": stop_reason,
                     "dispatched_projects": [],
+                    "budget": budget_snapshot,
                 }
+                if blocked_projects:
+                    manifest.execution_state.last_result["budget_blocked_projects"] = (
+                        blocked_projects
+                    )
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
                 return manifest.execution_state.last_result
@@ -965,7 +1039,23 @@ class CampaignExecutor:
                 ]
             )
             capacity = max(0, manifest.max_parallel_ready_projects - active_count)
-            selected_ids = [project.project_id for project in ready[:capacity]]
+            budget_snapshot = _campaign_budget_snapshot(manifest)
+            if capacity <= 0:
+                manifest.execution_state.last_result = {
+                    "stop_reason": CampaignStopReason.STILL_RUNNING.value,
+                    "dispatched_projects": [],
+                    "budget": budget_snapshot,
+                }
+                _refresh_execution_state(manifest)
+                save_campaign_manifest(self.manifest_path, manifest)
+                return manifest.execution_state.last_result
+
+            selected_projects, budget_blocked_ids = self._select_projects_for_dispatch(
+                manifest,
+                ready,
+                capacity=capacity,
+            )
+            selected_ids = [project.project_id for project in selected_projects]
             if not selected_ids and not ready:
                 # No ready projects: distinguish "waiting for in-flight" from "truly blocked"
                 if active_count > 0:
@@ -975,6 +1065,22 @@ class CampaignExecutor:
                 manifest.execution_state.last_result = {
                     "stop_reason": stop_reason,
                     "dispatched_projects": [],
+                    "budget": budget_snapshot,
+                }
+                _refresh_execution_state(manifest)
+                save_campaign_manifest(self.manifest_path, manifest)
+                return manifest.execution_state.last_result
+            if not selected_ids:
+                stop_reason = (
+                    CampaignStopReason.STILL_RUNNING.value
+                    if active_count > 0
+                    else CampaignStopReason.BUDGET_EXHAUSTED.value
+                )
+                manifest.execution_state.last_result = {
+                    "stop_reason": stop_reason,
+                    "dispatched_projects": [],
+                    "budget": budget_snapshot,
+                    "budget_blocked_projects": budget_blocked_ids,
                 }
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
@@ -987,6 +1093,7 @@ class CampaignExecutor:
             manifest.execution_state.last_result = {
                 "stop_reason": CampaignStopReason.STILL_RUNNING.value,
                 "dispatched_projects": list(selected_ids),
+                "budget": _campaign_budget_snapshot(manifest),
             }
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
@@ -1001,6 +1108,7 @@ class CampaignExecutor:
             manifest.execution_state.last_result = {
                 "stop_reason": _compute_stop_reason(manifest),
                 "dispatched_projects": dispatched,
+                "budget": _campaign_budget_snapshot(manifest),
             }
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
@@ -1023,11 +1131,13 @@ class CampaignExecutor:
             run_dict = self._refresh_run_dict(project.run_id)
             if not run_dict:
                 raise ValueError(f"Project {project_id} run {project.run_id} is not available.")
+            budget_context = self._review_budget_context(manifest, project)
         gate = await self.reviewer.review(
             project=project,
             worker_model=manifest.worker_model,
             review_model=manifest.review_model,
             run_dict=run_dict,
+            budget_context=budget_context,
             repo_root=self.repo_root,
             target_branch=self.target_branch,
         )
@@ -1065,6 +1175,37 @@ class CampaignExecutor:
                 "source_kind": manifest.source_kind,
                 "items": items,
             }
+
+    @staticmethod
+    def _select_projects_for_dispatch(
+        manifest: CampaignManifest,
+        ready_projects: list[CampaignProject],
+        *,
+        capacity: int,
+    ) -> tuple[list[CampaignProject], list[str]]:
+        available_budget = float(_campaign_budget_snapshot(manifest)["available_budget_usd"])
+        selected: list[CampaignProject] = []
+        blocked_ids: list[str] = []
+        for project in ready_projects:
+            if len(selected) >= capacity:
+                break
+            project_cost = _project_estimated_cost(project)
+            if project_cost <= available_budget + _BUDGET_EPSILON:
+                selected.append(project)
+                available_budget = max(0.0, available_budget - project_cost)
+            else:
+                blocked_ids.append(project.project_id)
+        return selected, blocked_ids
+
+    @staticmethod
+    def _review_budget_context(
+        manifest: CampaignManifest,
+        project: CampaignProject,
+    ) -> dict[str, Any]:
+        return {
+            **_campaign_budget_snapshot(manifest),
+            "project_estimated_cost_usd": round(_project_estimated_cost(project), 4),
+        }
 
     async def _execute_project_id(self, project_id: str) -> dict[str, Any]:
         with locked_manifest_path(self.manifest_path):
@@ -1104,11 +1245,13 @@ class CampaignExecutor:
                 project = manifest.project_map()[project_id]
                 worker_model = manifest.worker_model
                 review_model = manifest.review_model
+                budget_context = self._review_budget_context(manifest, project)
             gate = await self.reviewer.review(
                 project=project,
                 worker_model=worker_model,
                 review_model=review_model,
                 run_dict=dict(result["run"]),
+                budget_context=budget_context,
                 repo_root=self.repo_root,
                 target_branch=self.target_branch,
             )
@@ -1193,6 +1336,7 @@ class CampaignExecutor:
             run_dict=run_dict,
             outcome=outcome,
             blockers=run_blockers,
+            budget_snapshot=self._review_budget_context(manifest, project),
             requeue_eligible=self._run_requeue_eligible(run_dict, outcome)
             and self._project_recovery_eligible(manifest, project),
         )
@@ -1295,6 +1439,7 @@ class CampaignExecutor:
         run_dict: dict[str, Any],
         outcome: str,
         blockers: list[str],
+        budget_snapshot: dict[str, Any] | None,
         requeue_eligible: bool,
     ) -> None:
         record = {
@@ -1309,6 +1454,11 @@ class CampaignExecutor:
             "review_status": project.review.status,
             "requeue_eligible": requeue_eligible,
         }
+        if budget_snapshot:
+            record["budget_limit_usd"] = budget_snapshot.get("budget_limit_usd")
+            record["budget_spent_usd"] = budget_snapshot.get("spent_cost_usd")
+            record["budget_reserved_usd"] = budget_snapshot.get("reserved_cost_usd")
+            record["budget_available_usd"] = budget_snapshot.get("available_budget_usd")
         if blockers:
             record["blockers"] = list(blockers[:10])
             record["failure_detail"] = blockers[0]
@@ -1437,6 +1587,7 @@ class CampaignExecutor:
                 "rescue_required": False,
                 "rescue_description": None,
                 "cost_usd": project.estimated_cost_usd,
+                "budget": self._review_budget_context(manifest, project),
                 "duration_seconds": _duration_seconds_from_run(run_dict),
                 "created_at": datetime.now(UTC).isoformat(),
             }
@@ -1521,12 +1672,16 @@ def _refresh_execution_state(manifest: CampaignManifest) -> None:
         for project in manifest.projects
         if project.status == CampaignProjectStatus.SKIPPED.value
     ]
+    manifest.execution_state.reserved_cost_usd = float(
+        _campaign_budget_snapshot(manifest)["reserved_cost_usd"]
+    )
 
 
 def _manifest_summary(manifest: CampaignManifest) -> dict[str, Any]:
     counts: dict[str, int] = {}
     for project in manifest.projects:
         counts[project.status] = counts.get(project.status, 0) + 1
+    budget = _campaign_budget_snapshot(manifest)
     return {
         "mode": "campaign-status",
         "campaign_id": manifest.campaign_id,
@@ -1537,6 +1692,9 @@ def _manifest_summary(manifest: CampaignManifest) -> dict[str, Any]:
         "review_model": manifest.review_model,
         "budget_limit_usd": manifest.budget_limit_usd,
         "total_cost_usd": manifest.execution_state.total_cost_usd,
+        "reserved_cost_usd": manifest.execution_state.reserved_cost_usd,
+        "budget_available_usd": budget["available_budget_usd"],
+        "budget": budget,
         "counts": counts,
         "stop_reason": _compute_stop_reason(manifest),
         "projects": [
@@ -1544,6 +1702,7 @@ def _manifest_summary(manifest: CampaignManifest) -> dict[str, Any]:
                 "project_id": project.project_id,
                 "title": project.title,
                 "status": project.status,
+                "estimated_cost_usd": project.estimated_cost_usd,
                 "retry_count": project.retry_count,
                 "run_id": project.run_id,
                 "last_run_outcome": project.last_run_outcome,
@@ -1583,14 +1742,13 @@ def _project_recovery_eligible(manifest: CampaignManifest, project: CampaignProj
 
 
 def _compute_stop_reason(manifest: CampaignManifest) -> str:
-    if manifest.execution_state.total_cost_usd >= manifest.budget_limit_usd:
-        return CampaignStopReason.BUDGET_EXHAUSTED.value
-    started_at = _parse_dt(manifest.execution_state.last_run_at)
-    if started_at and manifest.time_limit_hours > 0:
-        elapsed_hours = (datetime.now(UTC) - started_at).total_seconds() / 3600.0
-        if elapsed_hours >= manifest.time_limit_hours:
-            return CampaignStopReason.TIME_LIMIT_EXCEEDED.value
     statuses = {project.status for project in manifest.projects}
+    active_statuses = {
+        CampaignProjectStatus.ACTIVE.value,
+        CampaignProjectStatus.DELIVERED.value,
+    }
+    active_present = bool(statuses & active_statuses)
+
     if statuses and statuses.issubset(
         {
             CampaignProjectStatus.COMPLETED.value,
@@ -1605,14 +1763,36 @@ def _compute_stop_reason(manifest: CampaignManifest) -> str:
     }
     if statuses and statuses.issubset(blocked_like | {CampaignProjectStatus.COMPLETED.value}):
         return CampaignStopReason.CAMPAIGN_BLOCKED.value
+
+    budget = _campaign_budget_snapshot(manifest)
+    dispatchable = _dispatchable_projects(manifest)
+    if (
+        dispatchable
+        and not active_present
+        and not any(
+            _project_estimated_cost(project)
+            <= float(budget["available_budget_usd"]) + _BUDGET_EPSILON
+            for project in dispatchable
+        )
+    ):
+        return CampaignStopReason.BUDGET_EXHAUSTED.value
+    if (
+        dispatchable
+        and not active_present
+        and float(budget["available_budget_usd"]) <= _BUDGET_EPSILON
+    ):
+        return CampaignStopReason.BUDGET_EXHAUSTED.value
+
+    started_at = _parse_dt(manifest.execution_state.last_run_at)
+    if started_at and manifest.time_limit_hours > 0:
+        elapsed_hours = (datetime.now(UTC) - started_at).total_seconds() / 3600.0
+        if elapsed_hours >= manifest.time_limit_hours:
+            return CampaignStopReason.TIME_LIMIT_EXCEEDED.value
+
     # Check for unreachable pending projects: if every non-terminal project
     # has at least one dependency in a terminal-but-not-completed state, the
     # campaign is effectively blocked even though raw statuses include pending.
     terminal_not_completed = blocked_like
-    active_statuses = {
-        CampaignProjectStatus.ACTIVE.value,
-        CampaignProjectStatus.DELIVERED.value,
-    }
     if not statuses & active_statuses:
         project_status_map = {p.project_id: p.status for p in manifest.projects}
         reachable = [

--- a/tests/nomic/test_hardened_budget_enforcement.py
+++ b/tests/nomic/test_hardened_budget_enforcement.py
@@ -1,0 +1,94 @@
+"""Focused tests for hardened orchestrator budget enforcement."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.nomic.autonomous_orchestrator import AgentAssignment, Track, reset_orchestrator
+from aragora.nomic.hardened_orchestrator import HardenedOrchestrator
+from aragora.nomic.task_decomposer import SubTask
+
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    reset_orchestrator()
+    yield
+    reset_orchestrator()
+
+
+def _make_subtask(id: str = "sub-1") -> SubTask:
+    return SubTask(
+        id=id,
+        title=f"Task {id}",
+        description=f"Description for {id}",
+        file_scope=[],
+        estimated_complexity="medium",
+    )
+
+
+def _make_assignment(subtask: SubTask | None = None) -> AgentAssignment:
+    return AgentAssignment(
+        subtask=subtask or _make_subtask(),
+        track=Track.DEVELOPER,
+        agent_type="claude",
+    )
+
+
+@pytest.mark.asyncio
+async def test_projected_over_budget_skips_assignment_before_execution():
+    orch = HardenedOrchestrator(budget_limit_usd=1.0)
+    orch._budget_spent_usd = 0.95
+    orch._total_cost_usd = 0.95
+
+    assignment = _make_assignment()
+    orch._active_assignments.append(assignment)
+
+    allowed = orch._check_budget_allows(assignment)
+
+    assert allowed is False
+    assert assignment.status == "skipped"
+    assert assignment.result == {"reason": "budget_exceeded"}
+
+
+@pytest.mark.asyncio
+async def test_inflight_budget_reservation_blocks_second_assignment():
+    orch = HardenedOrchestrator(budget_limit_usd=0.15)
+    first = _make_assignment(_make_subtask("first"))
+    second = _make_assignment(_make_subtask("second"))
+    orch._active_assignments.extend([first, second])
+
+    assert orch._check_budget_allows(first) is True
+    assert orch._budget_reserved_usd == pytest.approx(0.10)
+
+    allowed = orch._check_budget_allows(second)
+
+    assert allowed is False
+    assert second.status == "skipped"
+    assert second.result == {"reason": "budget_exceeded"}
+
+
+@pytest.mark.asyncio
+async def test_budget_spend_is_visible_after_execution():
+    orch = HardenedOrchestrator(
+        budget_limit_usd=2.0,
+        use_worktree_isolation=False,
+        enable_gauntlet_validation=False,
+    )
+    assignment = _make_assignment()
+    orch._active_assignments.append(assignment)
+
+    with patch(
+        "aragora.nomic.autonomous_orchestrator.AutonomousOrchestrator._execute_single_assignment",
+        new_callable=AsyncMock,
+    ) as mock_parent:
+        assignment.status = "completed"
+        await orch._execute_single_assignment(assignment, max_cycles=1)
+
+    mock_parent.assert_awaited_once()
+    event = orch._spectate_events[-1]
+    assert event["type"] == "budget_update"
+    assert event["subtask"] == assignment.subtask.id
+    assert event["total_spent"] == 0.1
+    assert event["limit"] == 2.0

--- a/tests/nomic/test_hardened_orchestrator.py
+++ b/tests/nomic/test_hardened_orchestrator.py
@@ -517,6 +517,21 @@ class TestBudgetEnforcement:
         assert assignment.result == {"reason": "budget_exceeded"}
 
     @pytest.mark.asyncio
+    async def test_projected_over_budget_skips_assignment_before_execution(self):
+        """Projected spend should halt execution before crossing the configured cap."""
+        orch = HardenedOrchestrator(budget_limit_usd=1.0)
+        orch._budget_spent_usd = 0.95
+
+        assignment = _make_assignment()
+        orch._active_assignments.append(assignment)
+
+        allowed = orch._check_budget_allows(assignment)
+
+        assert allowed is False
+        assert assignment.status == "skipped"
+        assert assignment.result == {"reason": "budget_exceeded"}
+
+    @pytest.mark.asyncio
     async def test_under_budget_proceeds(self):
         """Assignment proceeds when under budget."""
         orch = HardenedOrchestrator(
@@ -542,6 +557,39 @@ class TestBudgetEnforcement:
             await orch._execute_single_assignment(assignment, max_cycles=3)
 
             mock_parent.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_projected_over_budget_skips_assignment(self):
+        """Assignment is skipped before projected spend would cross the cap."""
+        orch = HardenedOrchestrator(budget_limit_usd=1.0)
+        orch._budget_spent_usd = 0.95
+        orch._total_cost_usd = 0.95
+
+        assignment = _make_assignment()
+        orch._active_assignments.append(assignment)
+
+        result = orch._check_budget_allows(assignment)
+
+        assert result is False
+        assert assignment.status == "skipped"
+        assert assignment.result == {"reason": "budget_exceeded"}
+
+    @pytest.mark.asyncio
+    async def test_inflight_budget_reservation_blocks_second_assignment(self):
+        """A reserved in-flight budget slice prevents parallel overrun."""
+        orch = HardenedOrchestrator(budget_limit_usd=0.15)
+        first = _make_assignment(subtask=_make_subtask(id="first"))
+        second = _make_assignment(subtask=_make_subtask(id="second"))
+        orch._active_assignments.extend([first, second])
+
+        assert orch._check_budget_allows(first) is True
+        assert orch._budget_reserved_usd == pytest.approx(0.10)
+
+        result = orch._check_budget_allows(second)
+
+        assert result is False
+        assert second.status == "skipped"
+        assert second.result == {"reason": "budget_exceeded"}
 
     @pytest.mark.asyncio
     async def test_no_budget_limit_proceeds(self):
@@ -752,6 +800,20 @@ class TestBudgetManagerIntegration:
 
         orch._record_budget_spend(assignment, amount_usd=0.75)
         assert orch._budget_spent_usd == 1.00
+
+    def test_record_budget_spend_emits_budget_update_event(self):
+        """Budget accounting remains visible through spectate events."""
+        orch = HardenedOrchestrator(budget_limit_usd=2.0)
+        assignment = _make_assignment()
+
+        orch._record_budget_spend(assignment, amount_usd=0.25)
+
+        event = orch._spectate_events[-1]
+        assert event["type"] == "budget_update"
+        assert event["subtask"] == assignment.subtask.id
+        assert event["cost"] == 0.25
+        assert event["total_spent"] == 0.25
+        assert event["limit"] == 2.0
 
     @pytest.mark.asyncio
     async def test_budget_spend_recorded_after_execution(self):

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -398,6 +398,60 @@ class TestCampaignExecutor:
         assert payload["dispatched_projects"][0]["project_id"] == "proj-001"
 
     @pytest.mark.asyncio
+    async def test_execute_once_halts_before_dispatch_when_remaining_budget_is_insufficient(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-budget-preflight",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            budget_limit_usd=1.0,
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Would exceed remaining budget",
+                    spec=_bounded_spec("Would exceed remaining budget"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    constraints=["do not widen scope"],
+                    estimated_cost_usd=0.50,
+                )
+            ],
+            execution_state=CampaignExecutionState(total_cost_usd=0.75),
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with patch(
+            "aragora.swarm.campaign.dispatch_bounded_spec",
+            new=AsyncMock(
+                return_value={
+                    "status": "unexpected-dispatch",
+                    "outcome": CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value,
+                    "run_id": "run-unexpected",
+                    "run": {
+                        "run_id": "run-unexpected",
+                        "status": "completed",
+                        "work_orders": [],
+                    },
+                }
+            ),
+        ) as mock_dispatch:
+            payload = await executor.execute_once()
+
+        reloaded = load_campaign_manifest(manifest_path)
+        assert mock_dispatch.await_count == 0
+        assert payload["stop_reason"] == CampaignStopReason.BUDGET_EXHAUSTED.value
+        assert payload["dispatched_projects"] == []
+        assert reloaded.execution_state.total_cost_usd == pytest.approx(0.75)
+        assert reloaded.projects[0].status in {
+            CampaignProjectStatus.PENDING.value,
+            CampaignProjectStatus.READY.value,
+        }
+
+    @pytest.mark.asyncio
     async def test_execute_once_marks_clean_exit_no_deliverable_needs_revision(
         self, tmp_path: Path
     ) -> None:
@@ -438,6 +492,50 @@ class TestCampaignExecutor:
         assert project.status == CampaignProjectStatus.NEEDS_REVISION.value
         assert project.last_run_outcome == CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value
         assert project.retry_count == 1
+
+    @pytest.mark.asyncio
+    async def test_execute_once_halts_before_over_budget_dispatch(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-budget-cap",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            budget_limit_usd=1.0,
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Too expensive",
+                    spec=_bounded_spec("Too expensive"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    constraints=["do not widen scope"],
+                    estimated_cost_usd=2.0,
+                )
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with patch(
+            "aragora.swarm.campaign.dispatch_bounded_spec", new=AsyncMock()
+        ) as mock_dispatch:
+            payload = await executor.execute_once()
+
+        reloaded = load_campaign_manifest(manifest_path)
+        status_payload = executor.status()
+
+        assert mock_dispatch.await_count == 0
+        assert payload["stop_reason"] == CampaignStopReason.BUDGET_EXHAUSTED.value
+        assert payload["budget_blocked_projects"] == ["proj-001"]
+        assert payload["budget"]["available_budget_usd"] == 1.0
+        assert reloaded.projects[0].status in {
+            CampaignProjectStatus.PENDING.value,
+            CampaignProjectStatus.READY.value,
+        }
+        assert status_payload["stop_reason"] == CampaignStopReason.BUDGET_EXHAUSTED.value
+        assert status_payload["budget"]["available_budget_usd"] == 1.0
+        assert status_payload["projects"][0]["estimated_cost_usd"] == 2.0
 
     def test_reconcile_active_needs_human_run_blocks_and_emits_receipt(
         self, tmp_path: Path
@@ -787,6 +885,63 @@ class TestCampaignExecutor:
         reloaded = load_campaign_manifest(manifest_path)
         assert reloaded.projects[0].status == CampaignProjectStatus.ACTIVE.value
 
+    @pytest.mark.asyncio
+    async def test_execute_once_keeps_running_while_active_budget_is_reserved(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-budget-reserved",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            budget_limit_usd=1.0,
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="In-flight expensive task",
+                    spec=_bounded_spec("In-flight expensive task"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["tests pass"],
+                    constraints=["stay in scope"],
+                    status=CampaignProjectStatus.ACTIVE.value,
+                    run_id="run-expensive",
+                    estimated_cost_usd=0.75,
+                ),
+                CampaignProject(
+                    project_id="proj-002",
+                    title="Ready but unaffordable",
+                    spec=_bounded_spec("Ready but unaffordable", ["docs/CLI_REFERENCE.md"]),
+                    file_scope_hints=["docs/CLI_REFERENCE.md"],
+                    acceptance_criteria=["tests pass"],
+                    constraints=["stay in scope"],
+                    estimated_cost_usd=0.50,
+                ),
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with (
+            patch.object(
+                executor,
+                "_refresh_run_dict",
+                return_value={"run_id": "run-expensive", "status": "running", "work_orders": []},
+            ),
+            patch("aragora.swarm.campaign.dispatch_bounded_spec", new=AsyncMock()) as mock_dispatch,
+        ):
+            payload = await executor.execute_once()
+
+        status_payload = executor.status()
+
+        assert mock_dispatch.await_count == 0
+        assert payload["stop_reason"] == CampaignStopReason.STILL_RUNNING.value
+        assert payload["budget_blocked_projects"] == ["proj-002"]
+        assert payload["budget"]["reserved_cost_usd"] == 0.75
+        assert payload["budget"]["available_budget_usd"] == 0.25
+        assert status_payload["budget"]["reserved_cost_usd"] == 0.75
+        assert status_payload["budget"]["available_budget_usd"] == 0.25
+
     def test_status_reports_invalid_manifest_truthfully(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
         manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -798,6 +953,41 @@ class TestCampaignExecutor:
         executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
         with pytest.raises(ValueError):
             executor.status()
+
+    def test_status_exposes_budget_accounting_and_review_state(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-budget-status",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            budget_limit_usd=3.0,
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Reviewed project",
+                    spec=_bounded_spec("Reviewed project"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    constraints=["do not widen scope"],
+                    status=CampaignProjectStatus.DELIVERED.value,
+                    review=CampaignReviewGate(
+                        required=True,
+                        review_model="claude",
+                        status=CampaignReviewStatus.PENDING.value,
+                    ),
+                )
+            ],
+            execution_state=CampaignExecutionState(total_cost_usd=1.25),
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        status = executor.status()
+
+        assert status["budget_limit_usd"] == pytest.approx(3.0)
+        assert status["total_cost_usd"] == pytest.approx(1.25)
+        assert status["projects"][0]["review_status"] == CampaignReviewStatus.PENDING.value
 
 
 class TestComputeStopReason:

--- a/tests/swarm/test_campaign_budget_enforcement.py
+++ b/tests/swarm/test_campaign_budget_enforcement.py
@@ -1,0 +1,198 @@
+"""Focused tests for campaign budget gating and visibility."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aragora.swarm.campaign import (
+    CampaignExecutor,
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    CampaignReviewGate,
+    CampaignReviewStatus,
+    CampaignReviewer,
+    CampaignStopReason,
+    CampaignExecutionState,
+    load_campaign_manifest,
+    save_campaign_manifest,
+)
+from aragora.swarm.spec import SwarmSpec
+
+
+def _bounded_spec(goal: str, scope: list[str] | None = None) -> SwarmSpec:
+    return SwarmSpec(
+        raw_goal=goal,
+        refined_goal=goal,
+        acceptance_criteria=["pytest -q tests/swarm/test_campaign_budget_enforcement.py"],
+        constraints=["do not widen scope"],
+        file_scope_hints=scope or ["aragora/swarm/campaign.py"],
+        budget_limit_usd=5.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_once_halts_before_over_budget_dispatch(tmp_path: Path):
+    manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+    manifest = CampaignManifest(
+        campaign_id="campaign-budget-cap",
+        created_at="2026-03-10T00:00:00+00:00",
+        source_kind="source_file",
+        source_ref="roadmap.md",
+        budget_limit_usd=1.0,
+        projects=[
+            CampaignProject(
+                project_id="proj-001",
+                title="Too expensive",
+                spec=_bounded_spec("Too expensive"),
+                file_scope_hints=["aragora/swarm/campaign.py"],
+                acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                constraints=["do not widen scope"],
+                estimated_cost_usd=2.0,
+            )
+        ],
+    )
+    save_campaign_manifest(manifest_path, manifest)
+    executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+    with patch("aragora.swarm.campaign.dispatch_bounded_spec", new=AsyncMock()) as mock_dispatch:
+        payload = await executor.execute_once()
+
+    reloaded = load_campaign_manifest(manifest_path)
+    status_payload = executor.status()
+
+    assert mock_dispatch.await_count == 0
+    assert payload["stop_reason"] == CampaignStopReason.BUDGET_EXHAUSTED.value
+    assert payload["budget_blocked_projects"] == ["proj-001"]
+    assert payload["budget"]["available_budget_usd"] == 1.0
+    assert reloaded.projects[0].status in {
+        CampaignProjectStatus.PENDING.value,
+        CampaignProjectStatus.READY.value,
+    }
+    assert status_payload["stop_reason"] == CampaignStopReason.BUDGET_EXHAUSTED.value
+    assert status_payload["budget"]["available_budget_usd"] == 1.0
+    assert status_payload["projects"][0]["estimated_cost_usd"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_execute_once_keeps_running_while_active_budget_is_reserved(tmp_path: Path):
+    manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+    manifest = CampaignManifest(
+        campaign_id="campaign-budget-reserved",
+        created_at="2026-03-10T00:00:00+00:00",
+        source_kind="source_file",
+        source_ref="roadmap.md",
+        budget_limit_usd=1.0,
+        projects=[
+            CampaignProject(
+                project_id="proj-001",
+                title="In-flight expensive task",
+                spec=_bounded_spec("In-flight expensive task"),
+                file_scope_hints=["aragora/swarm/campaign.py"],
+                acceptance_criteria=["tests pass"],
+                constraints=["stay in scope"],
+                status=CampaignProjectStatus.ACTIVE.value,
+                run_id="run-expensive",
+                estimated_cost_usd=0.75,
+            ),
+            CampaignProject(
+                project_id="proj-002",
+                title="Ready but unaffordable",
+                spec=_bounded_spec("Ready but unaffordable", ["docs/CLI_REFERENCE.md"]),
+                file_scope_hints=["docs/CLI_REFERENCE.md"],
+                acceptance_criteria=["tests pass"],
+                constraints=["stay in scope"],
+                estimated_cost_usd=0.50,
+            ),
+        ],
+    )
+    save_campaign_manifest(manifest_path, manifest)
+    executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+    with (
+        patch.object(
+            executor,
+            "_refresh_run_dict",
+            return_value={"run_id": "run-expensive", "status": "running", "work_orders": []},
+        ),
+        patch("aragora.swarm.campaign.dispatch_bounded_spec", new=AsyncMock()) as mock_dispatch,
+    ):
+        payload = await executor.execute_once()
+
+    status_payload = executor.status()
+
+    assert mock_dispatch.await_count == 0
+    assert payload["stop_reason"] == CampaignStopReason.STILL_RUNNING.value
+    assert payload["budget_blocked_projects"] == ["proj-002"]
+    assert payload["budget"]["reserved_cost_usd"] == 0.75
+    assert payload["budget"]["available_budget_usd"] == 0.25
+    assert status_payload["budget"]["reserved_cost_usd"] == 0.75
+    assert status_payload["budget"]["available_budget_usd"] == 0.25
+
+
+def test_status_exposes_budget_accounting_and_review_state(tmp_path: Path):
+    manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+    manifest = CampaignManifest(
+        campaign_id="campaign-budget-status",
+        created_at="2026-03-10T00:00:00+00:00",
+        source_kind="source_file",
+        source_ref="roadmap.md",
+        budget_limit_usd=3.0,
+        projects=[
+            CampaignProject(
+                project_id="proj-001",
+                title="Reviewed project",
+                spec=_bounded_spec("Reviewed project"),
+                file_scope_hints=["aragora/swarm/campaign.py"],
+                acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                constraints=["do not widen scope"],
+                status=CampaignProjectStatus.DELIVERED.value,
+                review=CampaignReviewGate(
+                    required=True,
+                    review_model="claude",
+                    status=CampaignReviewStatus.PENDING.value,
+                ),
+            )
+        ],
+        execution_state=CampaignExecutionState(total_cost_usd=1.25),
+    )
+    save_campaign_manifest(manifest_path, manifest)
+    executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+    status = executor.status()
+
+    assert status["budget_limit_usd"] == pytest.approx(3.0)
+    assert status["total_cost_usd"] == pytest.approx(1.25)
+    assert status["budget"]["available_budget_usd"] == pytest.approx(1.75)
+    assert status["projects"][0]["review_status"] == CampaignReviewStatus.PENDING.value
+
+
+def test_review_prompt_includes_budget_context():
+    project = CampaignProject(
+        project_id="proj-001",
+        title="Budget visible review",
+        spec=_bounded_spec("Budget visible review"),
+        acceptance_criteria=["review the budget context"],
+        file_scope_hints=["aragora/swarm/campaign.py"],
+    )
+    prompt = CampaignReviewer._build_prompt(
+        project,
+        {"work_orders": []},
+        "claude",
+        budget_context={
+            "budget_limit_usd": 5.0,
+            "spent_cost_usd": 1.5,
+            "reserved_cost_usd": 0.5,
+            "available_budget_usd": 3.0,
+            "project_estimated_cost_usd": 1.0,
+        },
+    )
+
+    parsed = json.loads(prompt.split("\n")[-1])
+    assert parsed["budget"]["budget_limit_usd"] == 5.0
+    assert parsed["budget"]["available_budget_usd"] == 3.0
+    assert parsed["budget"]["project_estimated_cost_usd"] == 1.0

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -414,6 +414,24 @@ class TestApplyReviewResultEmitsReceipt:
         assert "review_verdict: passed" in content
         assert "final_status: completed" in content
 
+    def test_completed_review_receipt_includes_budget_accounting_and_truth_suite_placeholder(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="delivered", estimated_cost_usd=3.5)
+        manifest = _make_manifest(projects=[project])
+        gate = CampaignReviewGate(status=CampaignReviewStatus.PASSED.value)
+
+        executor._apply_review_result(manifest, project, gate)
+
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0a-test" / "test-001.yaml"
+        content = receipt_path.read_text()
+        assert "cost_usd: 3.5" in content
+        assert "truth_suite: null" in content
+
     def test_no_receipt_on_changes_requested(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / "manifest.yaml"
         manifest_path.write_text("campaign_id: phase0a-test\n")

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -185,6 +185,28 @@ class TestBuildPromptWithDiff:
         parsed_json = json.loads(prompt.split("\n")[-1])
         assert parsed_json["project_id"] == "phase0a-007"
 
+    def test_prompt_includes_budget_context(self) -> None:
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        prompt = CampaignReviewer._build_prompt(
+            project,
+            run_dict,
+            "claude",
+            budget_context={
+                "budget_limit_usd": 5.0,
+                "spent_cost_usd": 1.5,
+                "reserved_cost_usd": 0.5,
+                "available_budget_usd": 3.0,
+                "project_estimated_cost_usd": 1.0,
+            },
+        )
+
+        parsed_json = json.loads(prompt.split("\n")[-1])
+        assert parsed_json["budget"]["budget_limit_usd"] == 5.0
+        assert parsed_json["budget"]["available_budget_usd"] == 3.0
+        assert parsed_json["budget"]["project_estimated_cost_usd"] == 1.0
+
 
 class TestReviewerBillingErrorDetection:
     """Tests that billing/credit errors from the Claude CLI are surfaced clearly."""


### PR DESCRIPTION
## Summary
- Implements hard budget enforcement in both the hardened orchestrator and campaign execution path (Phase 0B B-3)
- Adds budget reservation system that prevents over-commitment during concurrent execution by tracking spent + reserved + estimated costs
- Campaign-level budget tracking blocks dispatch when projected costs exceed configured limits, with budget snapshots visible to review flows
- New `hardened_budget.py` mixin provides `_reserve_budget()`, `_cancel_budget_reservation()`, `_budget_snapshot()`, and projected-cost gate checking

## Files changed (962 insertions across 9 files)
- `aragora/nomic/hardened_budget.py` (+154) — budget reservation system, projected cost gate
- `aragora/nomic/hardened_orchestrator.py` (+68) — integration with enhanced budget mixin
- `aragora/swarm/campaign.py` (+206) — campaign-level budget tracking, dispatch blocking, reviewer context
- 6 test files (+584) — comprehensive coverage of budget enforcement at both layers

## Acceptance criteria addressed
- [x] Configured budget caps are checked before and during execution
- [x] Execution halts or escalates before budget overrun occurs
- [x] Budget accounting remains visible to campaign state and review flows
- [x] Behavior is covered by automated tests for cap enforcement and escalation

## Test results
- 235 focused tests pass (0 failures)
- `ruff check` and `ruff format` clean

## Notes
- Worker outcome was `timeout` — changes salvaged manually from worker worktree
- `hardened_budget.py` was not in manifest `file_scope_hints` but is the budget mixin inherited by `hardened_orchestrator.py` — architecturally justified factoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)