### PR TITLE
feat(swarm): benchmark framework with model-driven planning and fail-closed merge gate

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -321,13 +321,19 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             return CampaignPlanner(
                 repo_root=Path.cwd(),
                 planner_model=str(getattr(args, "planner_model", "claude") or "claude"),
+                planner_strategy=str(getattr(args, "planner_strategy", "heuristic") or "heuristic"),
                 worker_model=str(getattr(args, "worker_model", "codex") or "codex"),
                 review_model=str(getattr(args, "review_model", "claude") or "claude"),
+                enforce_cross_model_review=not bool(
+                    getattr(args, "allow_same_model_review", False)
+                ),
                 budget_limit_usd=float(getattr(args, "budget_limit", 50.0) or 50.0),
                 max_parallel_ready_projects=int(
                     getattr(args, "max_parallel_ready_projects", parallel_default)
                     or parallel_default
                 ),
+                experiment_id=str(getattr(args, "experiment_id", "")).strip() or None,
+                experiment_label=str(getattr(args, "experiment_label", "")).strip() or None,
             )
 
         def _plan_campaign(planner):

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2325,6 +2325,12 @@ def _add_swarm_parser(subparsers) -> None:
         help="Planner model for campaign planning (default: claude)",
     )
     swarm_parser.add_argument(
+        "--planner-strategy",
+        default="heuristic",
+        choices=("heuristic", "model"),
+        help="Planner strategy for campaign planning/execution (default: heuristic)",
+    )
+    swarm_parser.add_argument(
         "--worker-model",
         default="codex",
         help="Worker model for campaign execution (default: codex)",
@@ -2333,6 +2339,21 @@ def _add_swarm_parser(subparsers) -> None:
         "--review-model",
         default="claude",
         help="Review model for campaign cross-check/review (default: claude)",
+    )
+    swarm_parser.add_argument(
+        "--allow-same-model-review",
+        action="store_true",
+        help="Allow worker and reviewer to use the same model for experiment runs",
+    )
+    swarm_parser.add_argument(
+        "--experiment-id",
+        default=None,
+        help="Optional experiment identifier for campaign benchmark runs",
+    )
+    swarm_parser.add_argument(
+        "--experiment-label",
+        default=None,
+        help="Optional human-readable experiment label for campaign benchmark runs",
     )
     swarm_parser.add_argument(
         "--manifest",

--- a/aragora/nomic/task_decomposer.py
+++ b/aragora/nomic/task_decomposer.py
@@ -17,6 +17,7 @@ Oracle-driven validation:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -301,6 +302,85 @@ class TaskDecomposer:
         self._concept_pattern = re.compile(
             r"\b(" + "|".join(DECOMPOSITION_CONCEPTS) + r")\b",
             re.IGNORECASE,
+        )
+
+    async def analyze_with_model(
+        self,
+        task_description: str,
+        *,
+        planner_model: str,
+        timeout_seconds: float = 120.0,
+        file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
+    ) -> TaskDecomposition:
+        """Decompose a task using the configured planner model.
+
+        This is the runtime planner path used by campaign benchmarking. The
+        planner must return strict JSON so the output shape is comparable across
+        models and can be converted into explicit work orders deterministically.
+        """
+        if not task_description:
+            return TaskDecomposition(
+                original_task="",
+                complexity_score=0,
+                complexity_level="low",
+                should_decompose=False,
+                rationale="Empty task",
+            )
+
+        from aragora.agents.base import create_agent
+
+        prompt = self._build_model_planning_prompt(
+            task_description,
+            file_scope_hints=file_scope_hints,
+            acceptance_criteria=acceptance_criteria,
+            constraints=constraints,
+        )
+        agent = create_agent(planner_model, name="task-planner", role="planner")
+        timeout = max(1.0, float(timeout_seconds or 0.0))
+        raw = await asyncio.wait_for(agent.generate(prompt), timeout=timeout)
+        payload = self._extract_first_json_payload(raw)
+        subtasks, rationale = self._parse_model_subtasks(
+            payload,
+            file_scope_hints=file_scope_hints,
+        )
+        if not subtasks:
+            raise ValueError("Planner model returned no valid subtasks.")
+
+        complexity_score = max(
+            self._calculate_complexity(task_description),
+            self.config.complexity_threshold,
+        )
+        return TaskDecomposition(
+            original_task=task_description,
+            complexity_score=complexity_score,
+            complexity_level=self._score_to_level(complexity_score),
+            should_decompose=True,
+            subtasks=subtasks[: self.config.max_subtasks],
+            rationale=rationale,
+        )
+
+    def analyze_with_model_sync(
+        self,
+        task_description: str,
+        *,
+        planner_model: str,
+        timeout_seconds: float = 120.0,
+        file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
+    ) -> TaskDecomposition:
+        """Synchronous wrapper for model-based planning."""
+        return asyncio.run(
+            self.analyze_with_model(
+                task_description,
+                planner_model=planner_model,
+                timeout_seconds=timeout_seconds,
+                file_scope_hints=file_scope_hints,
+                acceptance_criteria=acceptance_criteria,
+                constraints=constraints,
+            )
         )
 
     def analyze(
@@ -645,6 +725,163 @@ class TaskDecomposer:
                 total += 1
 
         return max(1, min(10, round(total)))
+
+    @staticmethod
+    def _extract_first_json_payload(text: str) -> dict[str, Any]:
+        content = str(text or "").strip()
+        if not content:
+            return {}
+        for candidate in (content, TaskDecomposer._slice_json_candidate(content, "{", "}")):
+            if not candidate:
+                continue
+            try:
+                parsed = json.loads(candidate)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if isinstance(parsed, dict):
+                return parsed
+            if isinstance(parsed, list):
+                return {"subtasks": parsed}
+        array_candidate = TaskDecomposer._slice_json_candidate(content, "[", "]")
+        if array_candidate:
+            try:
+                parsed = json.loads(array_candidate)
+            except (json.JSONDecodeError, ValueError):
+                return {}
+            if isinstance(parsed, list):
+                return {"subtasks": parsed}
+        return {}
+
+    @staticmethod
+    def _slice_json_candidate(text: str, start_char: str, end_char: str) -> str:
+        start = text.find(start_char)
+        end = text.rfind(end_char)
+        if start == -1 or end == -1 or end <= start:
+            return ""
+        return text[start : end + 1]
+
+    def _build_model_planning_prompt(
+        self,
+        task_description: str,
+        *,
+        file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
+    ) -> str:
+        scope_text = (
+            "\n".join(f"- {item}" for item in file_scope_hints or [])
+            if file_scope_hints
+            else "- none"
+        )
+        acceptance_text = (
+            "\n".join(f"- {item}" for item in acceptance_criteria or [])
+            if acceptance_criteria
+            else "- none"
+        )
+        constraints_text = (
+            "\n".join(f"- {item}" for item in constraints or []) if constraints else "- none"
+        )
+        return (
+            "You are a bounded task planner for a supervised code-change swarm.\n"
+            "Return strict JSON only. Do not include markdown fences or prose outside JSON.\n\n"
+            "Task:\n"
+            f"{task_description}\n\n"
+            "File scope hints:\n"
+            f"{scope_text}\n\n"
+            "Acceptance criteria:\n"
+            f"{acceptance_text}\n\n"
+            "Constraints:\n"
+            f"{constraints_text}\n\n"
+            "Requirements:\n"
+            "- Produce 1-5 subtasks.\n"
+            "- If the task is narrow, return exactly 1 subtask.\n"
+            "- Keep every file_scope entry within the file scope hints when hints are provided.\n"
+            "- Prefer concrete work orders over generic phases.\n"
+            "- Use dependency IDs only when one subtask must finish before another can start.\n"
+            "- Include a success_criteria.tests command when a relevant pytest command is obvious.\n"
+            "- estimated_complexity must be one of: low, medium, high.\n\n"
+            "JSON schema:\n"
+            "{\n"
+            '  "rationale": "short explanation",\n'
+            '  "subtasks": [\n'
+            "    {\n"
+            '      "id": "subtask_1",\n'
+            '      "title": "short title",\n'
+            '      "description": "bounded implementation task",\n'
+            '      "dependencies": ["subtask_0"],\n'
+            '      "estimated_complexity": "low",\n'
+            '      "file_scope": ["aragora/path.py"],\n'
+            '      "success_criteria": {\n'
+            '        "tests": "python -m pytest path/to/test.py -q",\n'
+            '        "definition_of_done": "brief measurable result"\n'
+            "      }\n"
+            "    }\n"
+            "  ]\n"
+            "}\n"
+        )
+
+    def _parse_model_subtasks(
+        self,
+        payload: dict[str, Any],
+        *,
+        file_scope_hints: list[str] | None = None,
+    ) -> tuple[list[SubTask], str]:
+        raw_subtasks = payload.get("subtasks")
+        if not isinstance(raw_subtasks, list):
+            raw_subtasks = []
+
+        subtasks: list[SubTask] = []
+        seen_ids: set[str] = set()
+        for index, item in enumerate(raw_subtasks, start=1):
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get("title", "")).strip()
+            description = str(item.get("description", "")).strip() or title
+            if not title and not description:
+                continue
+            raw_id = str(item.get("id", "")).strip() or f"subtask_{index}"
+            subtask_id = raw_id
+            suffix = 2
+            while subtask_id in seen_ids:
+                subtask_id = f"{raw_id}_{suffix}"
+                suffix += 1
+            seen_ids.add(subtask_id)
+
+            complexity = str(item.get("estimated_complexity", "medium")).strip().lower()
+            if complexity not in {"low", "medium", "high"}:
+                complexity = "medium"
+
+            success_criteria = dict(item.get("success_criteria") or {})
+            expected_tests = [
+                str(test).strip() for test in item.get("expected_tests", []) if str(test).strip()
+            ]
+            if expected_tests and "tests" not in success_criteria:
+                success_criteria["tests"] = (
+                    expected_tests[0] if len(expected_tests) == 1 else expected_tests
+                )
+
+            subtasks.append(
+                SubTask(
+                    id=subtask_id,
+                    title=title or description[:80],
+                    description=description,
+                    dependencies=[
+                        str(dep).strip() for dep in item.get("dependencies", []) if str(dep).strip()
+                    ],
+                    estimated_complexity=complexity,
+                    file_scope=[
+                        str(path).strip()
+                        for path in item.get("file_scope", [])
+                        if str(path).strip()
+                    ],
+                    success_criteria=success_criteria,
+                )
+            )
+
+        if file_scope_hints:
+            subtasks = self._constrain_scopes_to_hints(subtasks, file_scope_hints)
+        rationale = str(payload.get("rationale", "")).strip() or "model-based planner output"
+        return subtasks, rationale
 
     _SPECIFIC_ACTION_VERBS = {
         "add",

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -16,6 +16,7 @@ from typing import Any
 
 from aragora.agents.base import create_agent
 from aragora.agents.errors import CLISubprocessError
+from aragora.nomic.pipeline_bridge import NomicPipelineBridge
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
 from aragora.swarm.boss_loop import (
     _extract_deliverable,
@@ -281,8 +282,12 @@ class CampaignManifest:
     source_kind: str
     source_ref: str
     planner_model: str = "claude"
+    planner_strategy: str = "heuristic"
     worker_model: str = "codex"
     review_model: str = "claude"
+    enforce_cross_model_review: bool = True
+    experiment_id: str | None = None
+    experiment_label: str | None = None
     max_parallel_ready_projects: int = 2
     max_retries_per_project: int = 2
     budget_limit_usd: float = 50.0
@@ -292,6 +297,14 @@ class CampaignManifest:
     planning_findings: list[str] = field(default_factory=list)
     manifest_version: int = 1
 
+    def __post_init__(self) -> None:
+        self.planner_strategy = _canonical_planner_strategy(self.planner_strategy)
+        self.review_model = _canonical_review_model(
+            self.worker_model,
+            self.review_model,
+            enforce_cross_model_review=self.enforce_cross_model_review,
+        )
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "campaign_id": self.campaign_id,
@@ -299,8 +312,12 @@ class CampaignManifest:
             "source_kind": self.source_kind,
             "source_ref": self.source_ref,
             "planner_model": self.planner_model,
+            "planner_strategy": self.planner_strategy,
             "worker_model": self.worker_model,
             "review_model": self.review_model,
+            "enforce_cross_model_review": self.enforce_cross_model_review,
+            "experiment_id": self.experiment_id,
+            "experiment_label": self.experiment_label,
             "max_parallel_ready_projects": self.max_parallel_ready_projects,
             "max_retries_per_project": self.max_retries_per_project,
             "budget_limit_usd": self.budget_limit_usd,
@@ -313,14 +330,27 @@ class CampaignManifest:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> CampaignManifest:
+        planner_model = str(data.get("planner_model", "claude")).strip() or "claude"
+        planner_strategy = _canonical_planner_strategy(data.get("planner_strategy"))
+        worker_model = str(data.get("worker_model", "codex")).strip() or "codex"
+        enforce_cross_model_review = bool(data.get("enforce_cross_model_review", True))
+        review_model = _canonical_review_model(
+            worker_model,
+            str(data.get("review_model", "claude")).strip() or "claude",
+            enforce_cross_model_review=enforce_cross_model_review,
+        )
         return cls(
             campaign_id=str(data.get("campaign_id", "")).strip(),
             created_at=str(data.get("created_at", "")).strip(),
             source_kind=str(data.get("source_kind", "")).strip(),
             source_ref=str(data.get("source_ref", "")).strip(),
-            planner_model=str(data.get("planner_model", "claude")).strip() or "claude",
-            worker_model=str(data.get("worker_model", "codex")).strip() or "codex",
-            review_model=str(data.get("review_model", "claude")).strip() or "claude",
+            planner_model=planner_model,
+            planner_strategy=planner_strategy,
+            worker_model=worker_model,
+            review_model=review_model,
+            enforce_cross_model_review=enforce_cross_model_review,
+            experiment_id=str(data.get("experiment_id", "")).strip() or None,
+            experiment_label=str(data.get("experiment_label", "")).strip() or None,
             max_parallel_ready_projects=max(
                 1, int(data.get("max_parallel_ready_projects", 2) or 2)
             ),
@@ -422,9 +452,19 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _canonical_review_model(worker_model: str, requested: str | None = None) -> str:
+def _canonical_planner_strategy(value: Any) -> str:
+    strategy = str(value or "heuristic").strip().lower()
+    return "model" if strategy == "model" else "heuristic"
+
+
+def _canonical_review_model(
+    worker_model: str,
+    requested: str | None = None,
+    *,
+    enforce_cross_model_review: bool = True,
+) -> str:
     candidate = str(requested or "").strip() or ("claude" if worker_model == "codex" else "codex")
-    if candidate == worker_model:
+    if enforce_cross_model_review and candidate == worker_model:
         return "claude" if worker_model == "codex" else "codex"
     return candidate
 
@@ -539,21 +579,34 @@ class CampaignPlanner:
         *,
         repo_root: Path | None = None,
         planner_model: str = "claude",
+        planner_strategy: str = "heuristic",
         worker_model: str = "codex",
         review_model: str = "claude",
+        enforce_cross_model_review: bool = True,
         budget_limit_usd: float = 50.0,
         max_parallel_ready_projects: int = 2,
         decomposer: TaskDecomposer | None = None,
         enable_model_crosscheck: bool = False,
+        experiment_id: str | None = None,
+        experiment_label: str | None = None,
     ) -> None:
         self.repo_root = (repo_root or Path.cwd()).resolve()
         self.planner_model = planner_model
+        self.planner_strategy = _canonical_planner_strategy(planner_strategy)
         self.worker_model = worker_model
-        self.review_model = _canonical_review_model(worker_model, review_model)
+        self.enforce_cross_model_review = bool(enforce_cross_model_review)
+        self.review_model = _canonical_review_model(
+            worker_model,
+            review_model,
+            enforce_cross_model_review=self.enforce_cross_model_review,
+        )
         self.budget_limit_usd = budget_limit_usd
         self.max_parallel_ready_projects = max(1, int(max_parallel_ready_projects))
         self.decomposer = decomposer or TaskDecomposer()
         self.enable_model_crosscheck = enable_model_crosscheck
+        self.experiment_id = experiment_id
+        self.experiment_label = experiment_label
+        self._planner_fallbacks: list[str] = []
 
     def plan_from_source_file(self, path: Path) -> CampaignManifest:
         text = path.read_text(encoding="utf-8")
@@ -623,6 +676,7 @@ class CampaignPlanner:
     ) -> CampaignManifest:
         projects: list[CampaignProject] = []
         source_findings: list[str] = []
+        self._planner_fallbacks = []
         source_index = 0
         for item in items:
             source_index += 1
@@ -631,6 +685,7 @@ class CampaignPlanner:
                 source_findings.append(f"Skipped under-specified candidate: {item[:80]}")
                 continue
             projects.extend(created)
+        source_findings.extend(self._planner_fallbacks)
         self._apply_overlap_dependencies(projects, findings=source_findings)
         projects = self._topological_sort_projects(projects)
         self._renumber_projects(projects)
@@ -642,8 +697,12 @@ class CampaignPlanner:
             source_kind=source_kind,
             source_ref=source_ref,
             planner_model=self.planner_model,
+            planner_strategy=self.planner_strategy,
             worker_model=self.worker_model,
             review_model=self.review_model,
+            enforce_cross_model_review=self.enforce_cross_model_review,
+            experiment_id=self.experiment_id,
+            experiment_label=self.experiment_label,
             max_parallel_ready_projects=self.max_parallel_ready_projects,
             budget_limit_usd=self.budget_limit_usd,
             projects=projects,
@@ -659,7 +718,23 @@ class CampaignPlanner:
             requires_approval=True,
             user_expertise="developer",
         )
-        decomposition = self.decomposer.analyze(item)
+        if self.planner_strategy == "model":
+            try:
+                decomposition = self.decomposer.analyze_with_model_sync(
+                    item,
+                    planner_model=self.planner_model,
+                    file_scope_hints=base_spec.file_scope_hints or None,
+                    acceptance_criteria=base_spec.acceptance_criteria,
+                    constraints=base_spec.constraints,
+                )
+            except Exception as exc:
+                self._planner_fallbacks.append(
+                    f"planner fallback to heuristic for source item {source_index}: "
+                    f"{type(exc).__name__}: {exc}"
+                )
+                decomposition = self.decomposer.analyze(item)
+        else:
+            decomposition = self.decomposer.analyze(item)
         projects: list[CampaignProject] = []
         if decomposition.should_decompose and decomposition.subtasks:
             subtask_id_map: dict[str, str] = {}
@@ -881,12 +956,17 @@ class CampaignReviewer:
         project: CampaignProject,
         worker_model: str,
         review_model: str,
+        enforce_cross_model_review: bool = True,
         run_dict: dict[str, Any],
         budget_context: dict[str, Any] | None = None,
         repo_root: Path | None = None,
         target_branch: str = "main",
     ) -> CampaignReviewGate:
-        chosen_review_model = _canonical_review_model(worker_model, review_model)
+        chosen_review_model = _canonical_review_model(
+            worker_model,
+            review_model,
+            enforce_cross_model_review=enforce_cross_model_review,
+        )
         diff_content = _fetch_diff_content(
             run_dict, repo_root=repo_root, target_branch=target_branch
         )
@@ -998,11 +1078,15 @@ class CampaignExecutor:
         repo_root: Path | None = None,
         target_branch: str = "main",
         reviewer: CampaignReviewer | None = None,
+        decomposer: TaskDecomposer | None = None,
+        bridge: NomicPipelineBridge | None = None,
     ) -> None:
         self.manifest_path = manifest_path.resolve()
         self.repo_root = (repo_root or Path.cwd()).resolve()
         self.target_branch = target_branch
         self.reviewer = reviewer or CampaignReviewer()
+        self.decomposer = decomposer or TaskDecomposer()
+        self.bridge = bridge or NomicPipelineBridge(repo_path=self.repo_root)
 
     async def execute_once(self) -> dict[str, Any]:
         with locked_manifest_path(self.manifest_path):
@@ -1140,6 +1224,7 @@ class CampaignExecutor:
             project=project,
             worker_model=manifest.worker_model,
             review_model=manifest.review_model,
+            enforce_cross_model_review=manifest.enforce_cross_model_review,
             run_dict=run_dict,
             budget_context=budget_context,
             repo_root=self.repo_root,
@@ -1217,10 +1302,17 @@ class CampaignExecutor:
             project = manifest.project_map().get(project_id)
             if project is None:
                 raise KeyError(f"Unknown project_id: {project_id}")
-            retry_spec = self._spec_for_retry(project)
             worker_model = manifest.worker_model
-            review_model = manifest.review_model
+            review_model = _canonical_review_model(
+                worker_model,
+                manifest.review_model,
+                enforce_cross_model_review=manifest.enforce_cross_model_review,
+            )
             budget_limit = project.spec.budget_limit_usd or manifest.budget_limit_usd
+            manifest_snapshot = CampaignManifest.from_dict(manifest.to_dict())
+            project_snapshot = CampaignProject.from_dict(project.to_dict())
+
+        retry_spec = await self._spec_for_retry(manifest_snapshot, project_snapshot)
 
         result = await dispatch_bounded_spec(
             retry_spec,
@@ -1254,6 +1346,7 @@ class CampaignExecutor:
                 project=project,
                 worker_model=worker_model,
                 review_model=review_model,
+                enforce_cross_model_review=manifest.enforce_cross_model_review,
                 run_dict=dict(result["run"]),
                 budget_context=budget_context,
                 repo_root=self.repo_root,
@@ -1468,16 +1561,132 @@ class CampaignExecutor:
         if blockers:
             record["blockers"] = list(blockers[:10])
             record["failure_detail"] = blockers[0]
+        planner_metadata = _planner_metadata_from_run(run_dict)
+        if planner_metadata.get("planner_strategy_requested"):
+            record["planner_strategy_requested"] = planner_metadata["planner_strategy_requested"]
+        if planner_metadata.get("planner_strategy_used"):
+            record["planner_strategy_used"] = planner_metadata["planner_strategy_used"]
+        if planner_metadata.get("planner_fallback_reason"):
+            record["planner_fallback_reason"] = planner_metadata["planner_fallback_reason"]
+        verification_missing_reason = _verification_missing_reason_from_run(run_dict)
+        if verification_missing_reason:
+            record["verification_missing_reason"] = verification_missing_reason
         project.attempt_history.append(record)
 
-    def _spec_for_retry(self, project: CampaignProject) -> SwarmSpec:
+    async def _spec_for_retry(
+        self,
+        manifest: CampaignManifest,
+        project: CampaignProject,
+    ) -> SwarmSpec:
         spec = SwarmSpec.from_dict(project.spec.to_dict())
         if project.review.findings:
             extra_constraints = [
                 f"Address prior review finding: {finding}" for finding in project.review.findings
             ]
             spec.constraints = list(dict.fromkeys(list(spec.constraints) + extra_constraints))
+        if spec.work_orders or manifest.planner_strategy != "model":
+            return spec
+
+        planning_prompt = self._planner_task_prompt(project, spec)
+        planner_metadata = {
+            "planner_model": manifest.planner_model,
+            "planner_strategy_requested": manifest.planner_strategy,
+            "planner_strategy_used": "model",
+            "planner_fallback_reason": None,
+            "experiment_id": manifest.experiment_id,
+            "experiment_label": manifest.experiment_label,
+        }
+        try:
+            decomposition = await self.decomposer.analyze_with_model(
+                planning_prompt,
+                planner_model=manifest.planner_model,
+                file_scope_hints=spec.file_scope_hints or None,
+                acceptance_criteria=spec.acceptance_criteria,
+                constraints=spec.constraints,
+            )
+        except Exception as exc:
+            planner_metadata["planner_strategy_used"] = "heuristic"
+            planner_metadata["planner_fallback_reason"] = f"{type(exc).__name__}: {exc}"[:500]
+            decomposition = self.decomposer.analyze(
+                planning_prompt,
+                file_scope_hints=spec.file_scope_hints or None,
+            )
+
+        spec.work_orders = self._planned_work_orders_from_decomposition(
+            decomposition,
+            spec=spec,
+            worker_model=manifest.worker_model,
+            review_model=manifest.review_model,
+            enforce_cross_model_review=manifest.enforce_cross_model_review,
+            planner_metadata=planner_metadata,
+        )
         return spec
+
+    @staticmethod
+    def _planner_task_prompt(project: CampaignProject, spec: SwarmSpec) -> str:
+        parts = [spec.refined_goal or spec.raw_goal or project.title]
+        if spec.file_scope_hints:
+            parts.append("File scope hints: " + ", ".join(spec.file_scope_hints))
+        if spec.acceptance_criteria:
+            parts.append("Acceptance criteria: " + "; ".join(spec.acceptance_criteria))
+        if spec.constraints:
+            parts.append("Constraints: " + "; ".join(spec.constraints))
+        return "\n".join(parts)
+
+    def _planned_work_orders_from_decomposition(
+        self,
+        decomposition: Any,
+        *,
+        spec: SwarmSpec,
+        worker_model: str,
+        review_model: str,
+        enforce_cross_model_review: bool,
+        planner_metadata: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        subtasks = list(getattr(decomposition, "subtasks", []) or [])
+        if not subtasks:
+            subtasks = [
+                SubTask(
+                    id="subtask_1",
+                    title=(spec.refined_goal or spec.raw_goal or "Planned work")[:80],
+                    description=spec.refined_goal or spec.raw_goal or "Planned work",
+                    file_scope=list(spec.file_scope_hints),
+                    success_criteria={
+                        "tests": (
+                            spec.acceptance_criteria[0]
+                            if spec.acceptance_criteria
+                            and (
+                                spec.acceptance_criteria[0].startswith("pytest")
+                                or spec.acceptance_criteria[0].startswith("python -m pytest")
+                            )
+                            else ""
+                        ),
+                        "definition_of_done": spec.acceptance_criteria[0]
+                        if spec.acceptance_criteria
+                        else "Complete the bounded task.",
+                    },
+                )
+            ]
+        chosen_review_model = _canonical_review_model(
+            worker_model,
+            review_model,
+            enforce_cross_model_review=enforce_cross_model_review,
+        )
+        work_orders = [item.to_dict() for item in self.bridge.build_work_orders(subtasks)]
+        for item in work_orders:
+            item["target_agent"] = worker_model
+            item["reviewer_agent"] = chosen_review_model
+            item["metadata"] = {
+                **dict(item.get("metadata") or {}),
+                **{
+                    key: value
+                    for key, value in planner_metadata.items()
+                    if value is not None and value != ""
+                },
+                "requested_target_agent": worker_model,
+                "requested_reviewer_agent": chosen_review_model,
+            }
+        return work_orders
 
     def _reconcile_active_projects(self, manifest: CampaignManifest) -> None:
         for project in manifest.projects:
@@ -1571,12 +1780,20 @@ class CampaignExecutor:
                 manifest_input = str(self.manifest_path.relative_to(self.repo_root))
             except ValueError:
                 manifest_input = str(self.manifest_path)
+            planner_metadata = _planner_metadata_from_run(run_dict)
+            verification_missing_reason = _verification_missing_reason_from_run(run_dict)
 
             payload: dict[str, Any] = {
                 "task_id": project.project_id,
                 "campaign_id": manifest.campaign_id,
                 "phase": _derive_phase(manifest.campaign_id),
                 "manifest_input": manifest_input,
+                "planner_strategy_requested": planner_metadata.get("planner_strategy_requested")
+                or manifest.planner_strategy,
+                "planner_strategy_used": planner_metadata.get("planner_strategy_used")
+                or manifest.planner_strategy,
+                "planner_fallback_reason": planner_metadata.get("planner_fallback_reason"),
+                "verification_missing_reason": verification_missing_reason,
                 "worker_receipt_id": project.worker_receipt_id,
                 "worker_branch": _worker_branch_from_run(project, run_dict),
                 "worker_commit": _worker_commit_from_run(project, run_dict),
@@ -1699,8 +1916,12 @@ def _manifest_summary(manifest: CampaignManifest) -> dict[str, Any]:
         "source_kind": manifest.source_kind,
         "source_ref": manifest.source_ref,
         "planner_model": manifest.planner_model,
+        "planner_strategy": manifest.planner_strategy,
         "worker_model": manifest.worker_model,
         "review_model": manifest.review_model,
+        "enforce_cross_model_review": manifest.enforce_cross_model_review,
+        "experiment_id": manifest.experiment_id,
+        "experiment_label": manifest.experiment_label,
         "budget_limit_usd": manifest.budget_limit_usd,
         "total_cost_usd": manifest.execution_state.total_cost_usd,
         "reserved_cost_usd": manifest.execution_state.reserved_cost_usd,
@@ -1992,4 +2213,48 @@ def _worker_commit_from_run(
         shas = [str(s).strip() for s in wo.get("commit_shas", []) if str(s).strip()]
         if shas:
             return shas[-1]
+    return None
+
+
+def _planner_metadata_from_run(run_dict: dict[str, Any] | None) -> dict[str, Any]:
+    if not run_dict:
+        return {}
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        metadata = dict(wo.get("metadata") or {})
+        if any(
+            key in metadata
+            for key in (
+                "planner_strategy_requested",
+                "planner_strategy_used",
+                "planner_fallback_reason",
+            )
+        ):
+            return {
+                "planner_strategy_requested": str(
+                    metadata.get("planner_strategy_requested", "")
+                ).strip()
+                or None,
+                "planner_strategy_used": str(metadata.get("planner_strategy_used", "")).strip()
+                or None,
+                "planner_fallback_reason": str(metadata.get("planner_fallback_reason", "")).strip()
+                or None,
+            }
+    return {}
+
+
+def _verification_missing_reason_from_run(run_dict: dict[str, Any] | None) -> str | None:
+    if not run_dict:
+        return None
+    for wo in run_dict.get("work_orders", []):
+        if not isinstance(wo, dict):
+            continue
+        reason = str(wo.get("verification_missing_reason", "")).strip()
+        if reason:
+            return reason
+        merge_gate = dict(wo.get("merge_gate") or {})
+        reason = str(merge_gate.get("verification_missing_reason", "")).strip()
+        if reason:
+            return reason
     return None

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1177,6 +1177,8 @@ class SwarmSupervisor:
 
             merge_gate = self._merge_gate_state(item)
             item["merge_gate"] = merge_gate
+            if merge_gate.get("verification_missing_reason"):
+                item["verification_missing_reason"] = merge_gate["verification_missing_reason"]
             if not bool(merge_gate.get("checks_passed")):
                 self._mark_needs_human(item, self._merge_gate_failure_reason(merge_gate))
                 item["review_status"] = "changes_requested"
@@ -1800,6 +1802,12 @@ class SwarmSupervisor:
         ]
 
         blocked_reasons: list[str] = []
+        verification_missing_reason: str | None = None
+        if not expected_checks:
+            verification_missing_reason = "missing_verification_plan"
+            blocked_reasons.append(
+                "merge gate blocked: missing verification plan for code-change lane"
+            )
         if missing_checks:
             blocked_reasons.append(
                 "merge gate blocked: required verification did not run: "
@@ -1816,11 +1824,12 @@ class SwarmSupervisor:
                 reason = f"{reason} - {stderr.splitlines()[0][:200]}"
             blocked_reasons.append(reason)
 
-        checks_passed = not expected_checks or (not missing_checks and not failed_checks)
+        checks_passed = bool(expected_checks) and not missing_checks and not failed_checks
         return {
             "enabled": True,
             "expected_checks": expected_checks,
             "verification_results": verification_results,
+            "verification_missing_reason": verification_missing_reason,
             "checks_passed": checks_passed,
             "human_approval_required": True,
             "merge_eligible": checks_passed,

--- a/docs/experiments/phase0b_role_benchmark/README.md
+++ b/docs/experiments/phase0b_role_benchmark/README.md
@@ -1,0 +1,15 @@
+# Phase 0B Role Benchmark
+
+This directory stores normalized results for the Codex/Claude planner, worker,
+and reviewer permutation benchmark.
+
+Expected artifacts:
+
+- `active_run.json`: lock file for the single authoritative live benchmark run
+- `results.json`: machine-readable benchmark rows
+- `results.csv`: flat table for quick comparison and spreadsheet import
+- `runs/<experiment_id>/<config_id>.json`: per-config runtime preparation records
+
+Use `scripts/phase0b_role_benchmark.py` to prepare runtime manifests, enforce
+one active benchmark lane at a time, and record finished runs into the
+normalized result tables.

--- a/scripts/phase0b_role_benchmark.py
+++ b/scripts/phase0b_role_benchmark.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""Support tooling for the Phase 0B Codex/Claude role benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from aragora.swarm.campaign import (
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    CampaignReviewGate,
+    CampaignReviewStatus,
+    load_campaign_manifest,
+    save_campaign_manifest,
+)
+
+UTC = timezone.utc
+DEFAULT_SOURCE_MANIFEST = PROJECT_ROOT / "docs" / "plans" / "phase0b_campaign_manifest.yaml"
+EXPERIMENT_DIR = PROJECT_ROOT / "docs" / "experiments" / "phase0b_role_benchmark"
+RUNS_DIR = EXPERIMENT_DIR / "runs"
+ACTIVE_RUN_PATH = EXPERIMENT_DIR / "active_run.json"
+RESULTS_JSON_PATH = EXPERIMENT_DIR / "results.json"
+RESULTS_CSV_PATH = EXPERIMENT_DIR / "results.csv"
+DEFAULT_RUNTIME_MANIFEST = Path(".aragora/phase0b_runtime_manifest.yaml")
+RESULT_COLUMNS = [
+    "recorded_at",
+    "experiment_id",
+    "experiment_label",
+    "config_id",
+    "campaign_id",
+    "project_id",
+    "runtime_path",
+    "runtime_manifest_path",
+    "planner_model",
+    "planner_strategy",
+    "worker_model",
+    "review_model",
+    "enforce_cross_model_review",
+    "project_status",
+    "last_run_outcome",
+    "review_status",
+    "worker_branch",
+    "worker_commit",
+    "pr_url",
+    "pr_state",
+    "ci_status",
+    "duration_seconds",
+    "cost_usd",
+    "changed_files_count",
+    "planner_strategy_requested",
+    "planner_strategy_used",
+    "planner_fallback_reason",
+    "verification_missing_reason",
+]
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _config_id(planner_model: str, worker_model: str, review_model: str) -> str:
+    return f"p-{planner_model}_w-{worker_model}_r-{review_model}"
+
+
+def _ensure_layout() -> None:
+    EXPERIMENT_DIR.mkdir(parents=True, exist_ok=True)
+    RUNS_DIR.mkdir(parents=True, exist_ok=True)
+    if not RESULTS_JSON_PATH.exists():
+        RESULTS_JSON_PATH.write_text(json.dumps({"runs": []}, indent=2), encoding="utf-8")
+    if not RESULTS_CSV_PATH.exists():
+        with RESULTS_CSV_PATH.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=RESULT_COLUMNS)
+            writer.writeheader()
+
+
+def _load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return default
+
+
+def _write_json(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _active_run() -> dict[str, Any] | None:
+    payload = _load_json(ACTIVE_RUN_PATH, None)
+    return payload if isinstance(payload, dict) and payload else None
+
+
+def _load_receipt(path: Path | None) -> dict[str, Any]:
+    if path is None or not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml
+
+        payload = yaml.safe_load(text)
+    except ImportError:
+        payload = json.loads(text)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _gh_json(cmd: list[str]) -> Any:
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False, timeout=30)
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+
+def _gh_text(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, text=True, capture_output=True, check=False, timeout=30)
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _prepare_project(project: CampaignProject) -> CampaignProject:
+    prepared = CampaignProject.from_dict(project.to_dict())
+    prepared.status = CampaignProjectStatus.PENDING.value
+    prepared.retry_count = 0
+    prepared.last_run_outcome = None
+    prepared.run_id = None
+    prepared.worker_receipt_id = None
+    prepared.receipt_id = None
+    prepared.pr_url = None
+    prepared.adopted_pr = None
+    prepared.branch = None
+    prepared.commit_shas = []
+    prepared.attempt_history = []
+    prepared.dependencies = []
+    prepared.review = CampaignReviewGate(
+        required=True,
+        review_model=prepared.review.review_model,
+        status=CampaignReviewStatus.PENDING.value,
+        findings=[],
+        reviewed_at=None,
+        raw_review={},
+    )
+    return prepared
+
+
+def prepare_runtime_manifest(
+    *,
+    source_manifest: Path,
+    worktree: Path,
+    project_id: str,
+    planner_model: str,
+    planner_strategy: str,
+    worker_model: str,
+    review_model: str,
+    enforce_cross_model_review: bool,
+    experiment_id: str,
+    experiment_label: str | None,
+    budget_limit_usd: float | None,
+    time_limit_hours: float | None,
+) -> dict[str, Any]:
+    manifest = load_campaign_manifest(source_manifest)
+    project_map = manifest.project_map()
+    if project_id not in project_map:
+        raise KeyError(f"Unknown project_id {project_id!r} in {source_manifest}")
+
+    prepared_project = _prepare_project(project_map[project_id])
+    runtime_manifest = CampaignManifest(
+        campaign_id=manifest.campaign_id,
+        created_at=manifest.created_at,
+        source_kind=manifest.source_kind,
+        source_ref=manifest.source_ref,
+        planner_model=planner_model,
+        planner_strategy=planner_strategy,
+        worker_model=worker_model,
+        review_model=review_model,
+        enforce_cross_model_review=enforce_cross_model_review,
+        experiment_id=experiment_id,
+        experiment_label=experiment_label,
+        max_parallel_ready_projects=1,
+        max_retries_per_project=manifest.max_retries_per_project,
+        budget_limit_usd=budget_limit_usd
+        if budget_limit_usd is not None
+        else manifest.budget_limit_usd,
+        time_limit_hours=time_limit_hours
+        if time_limit_hours is not None
+        else manifest.time_limit_hours,
+        projects=[prepared_project],
+        planning_findings=list(manifest.planning_findings),
+        manifest_version=manifest.manifest_version,
+    )
+    runtime_path = worktree / DEFAULT_RUNTIME_MANIFEST
+    save_campaign_manifest(runtime_path, runtime_manifest)
+
+    config_id = _config_id(planner_model, worker_model, runtime_manifest.review_model)
+    run_record = {
+        "recorded_at": _now_iso(),
+        "experiment_id": experiment_id,
+        "experiment_label": experiment_label,
+        "config_id": config_id,
+        "project_id": project_id,
+        "runtime_path": str(worktree),
+        "runtime_manifest_path": str(runtime_path),
+    }
+    _write_json(RUNS_DIR / experiment_id / f"{config_id}.json", run_record)
+    return {
+        **run_record,
+        "runtime_manifest_path": str(runtime_path),
+        "effective_review_model": runtime_manifest.review_model,
+    }
+
+
+def _lookup_pr(branch: str | None) -> dict[str, Any]:
+    if not branch:
+        return {}
+    payload = _gh_json(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--json",
+            "number,url,state",
+            "--limit",
+            "1",
+        ]
+    )
+    if isinstance(payload, list) and payload:
+        first = payload[0]
+        if isinstance(first, dict):
+            return first
+    return {}
+
+
+def _lookup_ci_status(pr_number: int | None) -> str:
+    if pr_number is None:
+        return ""
+    text = _gh_text(["gh", "pr", "checks", str(pr_number)])
+    if not text:
+        return ""
+    lowered = text.lower()
+    if " fail " in lowered or lowered.startswith("fail"):
+        return "failing"
+    if " pending " in lowered or "pending" in lowered:
+        return "pending"
+    if " pass " in lowered or lowered.startswith("pass"):
+        return "passing"
+    return "mixed"
+
+
+def build_result_row(runtime_manifest_path: Path) -> dict[str, Any]:
+    manifest = load_campaign_manifest(runtime_manifest_path)
+    if not manifest.projects:
+        raise ValueError(f"No projects in runtime manifest {runtime_manifest_path}")
+    project = manifest.projects[0]
+    receipt_path = PROJECT_ROOT / project.receipt_id if project.receipt_id else None
+    receipt = _load_receipt(receipt_path)
+    branch = str(receipt.get("worker_branch") or project.branch or "").strip() or None
+    pr_lookup = _lookup_pr(branch)
+    pr_number = int(pr_lookup["number"]) if isinstance(pr_lookup.get("number"), int) else None
+    review_model = manifest.review_model
+    config_id = _config_id(manifest.planner_model, manifest.worker_model, review_model)
+
+    return {
+        "recorded_at": _now_iso(),
+        "experiment_id": manifest.experiment_id,
+        "experiment_label": manifest.experiment_label,
+        "config_id": config_id,
+        "campaign_id": manifest.campaign_id,
+        "project_id": project.project_id,
+        "runtime_path": str(runtime_manifest_path.parent.parent),
+        "runtime_manifest_path": str(runtime_manifest_path),
+        "planner_model": manifest.planner_model,
+        "planner_strategy": manifest.planner_strategy,
+        "worker_model": manifest.worker_model,
+        "review_model": review_model,
+        "enforce_cross_model_review": manifest.enforce_cross_model_review,
+        "project_status": project.status,
+        "last_run_outcome": project.last_run_outcome,
+        "review_status": project.review.status,
+        "worker_branch": branch or "",
+        "worker_commit": str(receipt.get("worker_commit") or "").strip(),
+        "pr_url": str(project.pr_url or pr_lookup.get("url") or "").strip(),
+        "pr_state": str(pr_lookup.get("state") or "").strip(),
+        "ci_status": _lookup_ci_status(pr_number),
+        "duration_seconds": receipt.get("duration_seconds"),
+        "cost_usd": receipt.get("cost_usd", project.estimated_cost_usd),
+        "changed_files_count": len(receipt.get("changed_files") or []),
+        "planner_strategy_requested": receipt.get("planner_strategy_requested"),
+        "planner_strategy_used": receipt.get("planner_strategy_used"),
+        "planner_fallback_reason": receipt.get("planner_fallback_reason"),
+        "verification_missing_reason": receipt.get("verification_missing_reason"),
+    }
+
+
+def _upsert_result(row: dict[str, Any]) -> None:
+    _ensure_layout()
+    payload = _load_json(RESULTS_JSON_PATH, {"runs": []})
+    runs = [dict(item) for item in payload.get("runs", []) if isinstance(item, dict)]
+    key = (
+        str(row.get("experiment_id", "")),
+        str(row.get("config_id", "")),
+        str(row.get("project_id", "")),
+        str(row.get("runtime_manifest_path", "")),
+    )
+    filtered = [
+        item
+        for item in runs
+        if (
+            str(item.get("experiment_id", "")),
+            str(item.get("config_id", "")),
+            str(item.get("project_id", "")),
+            str(item.get("runtime_manifest_path", "")),
+        )
+        != key
+    ]
+    filtered.append(dict(row))
+    filtered.sort(
+        key=lambda item: (
+            str(item.get("experiment_id", "")),
+            str(item.get("config_id", "")),
+            str(item.get("recorded_at", "")),
+        )
+    )
+    _write_json(RESULTS_JSON_PATH, {"runs": filtered})
+    with RESULTS_CSV_PATH.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=RESULT_COLUMNS)
+        writer.writeheader()
+        for item in filtered:
+            writer.writerow({key: item.get(key, "") for key in RESULT_COLUMNS})
+
+
+def cmd_prepare(args: argparse.Namespace) -> int:
+    _ensure_layout()
+    active = _active_run()
+    if active and not args.force:
+        raise SystemExit(
+            "Active benchmark run is locked. Record or clear it before preparing another run."
+        )
+    payload = prepare_runtime_manifest(
+        source_manifest=args.source_manifest.resolve(),
+        worktree=args.worktree.resolve(),
+        project_id=args.project_id,
+        planner_model=args.planner_model,
+        planner_strategy=args.planner_strategy,
+        worker_model=args.worker_model,
+        review_model=args.review_model,
+        enforce_cross_model_review=not args.allow_same_model_review,
+        experiment_id=args.experiment_id,
+        experiment_label=args.experiment_label,
+        budget_limit_usd=args.budget_limit_usd,
+        time_limit_hours=args.time_limit_hours,
+    )
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_start(args: argparse.Namespace) -> int:
+    _ensure_layout()
+    active = _active_run()
+    runtime_manifest = args.runtime_manifest.resolve()
+    if active and str(active.get("runtime_manifest_path", "")) != str(runtime_manifest):
+        raise SystemExit(
+            "Another benchmark runtime is active. Record it before starting a new one."
+        )
+    payload = _gh_json(
+        [
+            sys.executable,
+            "-m",
+            "aragora.cli.main",
+            "ralph",
+            "campaign-supervisor",
+            "start",
+            "--manifest",
+            str(runtime_manifest),
+            "--json",
+        ]
+    )
+    if not isinstance(payload, dict):
+        raise SystemExit("Failed to start benchmark supervisor run.")
+    active_payload = {
+        "recorded_at": _now_iso(),
+        "runtime_manifest_path": str(runtime_manifest),
+        "runtime_path": str(runtime_manifest.parent.parent),
+        "supervisor_id": payload.get("supervisor_id"),
+    }
+    _write_json(ACTIVE_RUN_PATH, active_payload)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def cmd_record(args: argparse.Namespace) -> int:
+    _ensure_layout()
+    active = _active_run()
+    runtime_manifest = (
+        args.runtime_manifest.resolve()
+        if args.runtime_manifest
+        else Path(str(active.get("runtime_manifest_path", ""))).resolve()
+        if active
+        else None
+    )
+    if runtime_manifest is None:
+        raise SystemExit("No runtime manifest supplied and no active benchmark run is locked.")
+    row = build_result_row(runtime_manifest)
+    _upsert_result(row)
+    if active and str(active.get("runtime_manifest_path", "")) == str(runtime_manifest):
+        ACTIVE_RUN_PATH.unlink(missing_ok=True)
+    print(json.dumps(row, indent=2))
+    return 0
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    _ensure_layout()
+    active = _active_run()
+    payload = {
+        "active_run": active,
+        "results_path": str(RESULTS_JSON_PATH),
+        "csv_path": str(RESULTS_CSV_PATH),
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare", help="Create a fresh benchmark runtime manifest")
+    prepare.add_argument("--source-manifest", type=Path, default=DEFAULT_SOURCE_MANIFEST)
+    prepare.add_argument("--worktree", type=Path, required=True)
+    prepare.add_argument("--project-id", required=True)
+    prepare.add_argument("--planner-model", choices=("codex", "claude"), required=True)
+    prepare.add_argument("--planner-strategy", choices=("heuristic", "model"), default="model")
+    prepare.add_argument("--worker-model", choices=("codex", "claude"), required=True)
+    prepare.add_argument("--review-model", choices=("codex", "claude"), required=True)
+    prepare.add_argument("--allow-same-model-review", action="store_true")
+    prepare.add_argument("--experiment-id", required=True)
+    prepare.add_argument("--experiment-label", default=None)
+    prepare.add_argument("--budget-limit-usd", type=float, default=None)
+    prepare.add_argument("--time-limit-hours", type=float, default=None)
+    prepare.add_argument("--force", action="store_true")
+    prepare.set_defaults(func=cmd_prepare)
+
+    start = subparsers.add_parser("start", help="Start the prepared benchmark runtime")
+    start.add_argument("--runtime-manifest", type=Path, required=True)
+    start.set_defaults(func=cmd_start)
+
+    record = subparsers.add_parser(
+        "record", help="Record a runtime result into the experiment table"
+    )
+    record.add_argument("--runtime-manifest", type=Path, default=None)
+    record.set_defaults(func=cmd_record)
+
+    status = subparsers.add_parser("status", help="Show current benchmark lock/result paths")
+    status.set_defaults(func=cmd_status)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/nomic/test_task_decomposer.py
+++ b/tests/nomic/test_task_decomposer.py
@@ -1,5 +1,8 @@
 """Tests for Nomic Loop task decomposer."""
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
 import pytest
 
 from aragora.nomic.task_decomposer import (
@@ -112,6 +115,54 @@ class TestTaskDecomposer:
 
         # Same complexity, different decomposition decisions possible
         assert result_low.complexity_score == result_high.complexity_score
+
+    @pytest.mark.asyncio
+    async def test_analyze_with_model_parses_strict_json(self):
+        decomposer = TaskDecomposer()
+        mock_agent = SimpleNamespace(
+            generate=AsyncMock(
+                return_value=(
+                    '{"rationale":"planner output","subtasks":[{"id":"lane_1","title":"Gate defaults",'
+                    '"description":"Enable defaults","dependencies":[],"estimated_complexity":"medium",'
+                    '"file_scope":["aragora/nomic/hardened_orchestrator.py"],'
+                    '"success_criteria":{"tests":"python -m pytest tests/swarm/test_campaign.py -q"}}]}'
+                )
+            )
+        )
+
+        with patch("aragora.agents.base.create_agent", return_value=mock_agent):
+            result = await decomposer.analyze_with_model(
+                "Enable quality gates by default",
+                planner_model="claude",
+                file_scope_hints=["aragora/nomic/hardened_orchestrator.py"],
+            )
+
+        assert result.should_decompose is True
+        assert len(result.subtasks) == 1
+        assert result.subtasks[0].id == "lane_1"
+        assert result.subtasks[0].file_scope == ["aragora/nomic/hardened_orchestrator.py"]
+
+    @pytest.mark.asyncio
+    async def test_analyze_with_model_wraps_json_array_payload(self):
+        decomposer = TaskDecomposer()
+        mock_agent = SimpleNamespace(
+            generate=AsyncMock(
+                return_value=(
+                    '[{"title":"Gate defaults","description":"Enable defaults",'
+                    '"estimated_complexity":"medium","file_scope":["aragora/nomic/hardened_orchestrator.py"]}]'
+                )
+            )
+        )
+
+        with patch("aragora.agents.base.create_agent", return_value=mock_agent):
+            result = await decomposer.analyze_with_model(
+                "Enable quality gates by default",
+                planner_model="codex",
+                file_scope_hints=["aragora/nomic/hardened_orchestrator.py"],
+            )
+
+        assert len(result.subtasks) == 1
+        assert result.subtasks[0].title == "Gate defaults"
 
 
 class TestSubTask:

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aragora.nomic.dev_coordination import DevCoordinationStore
+from aragora.nomic.task_decomposer import SubTask
 from aragora.swarm.campaign import (
     CampaignDependency,
     CampaignExecutionState,
@@ -247,6 +248,34 @@ class TestCampaignPlanner:
         assert any("overlapping scope" in finding for finding in manifest.planning_findings)
         assert manifest.projects[1].dependencies[0].project_id == manifest.projects[0].project_id
 
+    def test_model_planner_falls_back_to_heuristic_and_records_finding(
+        self, tmp_path: Path
+    ) -> None:
+        planner = CampaignPlanner(
+            repo_root=tmp_path,
+            planner_model="codex",
+            planner_strategy="model",
+        )
+        planner.decomposer = MagicMock()
+        planner.decomposer.analyze_with_model_sync.side_effect = RuntimeError("planner timeout")
+        planner.decomposer.analyze.return_value = SimpleNamespace(
+            should_decompose=False,
+            subtasks=[],
+            complexity_level="medium",
+        )
+
+        manifest = planner.plan_from_items(
+            ["Enable quality gates in aragora/nomic/hardened_orchestrator.py"],
+            source_kind="source_file",
+            source_ref="roadmap.md",
+        )
+
+        planner.decomposer.analyze_with_model_sync.assert_called_once()
+        planner.decomposer.analyze.assert_called_once()
+        assert any(
+            "planner fallback to heuristic" in finding for finding in manifest.planning_findings
+        )
+
 
 class TestCampaignManifestIO:
     def test_round_trip_yaml(self, tmp_path: Path) -> None:
@@ -275,8 +304,109 @@ class TestCampaignManifestIO:
         assert loaded.projects[0].project_id == "proj-001"
         assert loaded.projects[0].spec.is_dispatch_bounded() is True
 
+    def test_same_model_review_requires_opt_in(self) -> None:
+        enforced = CampaignManifest(
+            campaign_id="campaign-enforced",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            worker_model="codex",
+            review_model="codex",
+            enforce_cross_model_review=True,
+        )
+        allowed = CampaignManifest(
+            campaign_id="campaign-allowed",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            worker_model="codex",
+            review_model="codex",
+            enforce_cross_model_review=False,
+        )
+
+        assert enforced.review_model == "claude"
+        assert allowed.review_model == "codex"
+
 
 class TestCampaignExecutor:
+    @pytest.mark.asyncio
+    async def test_execute_once_uses_model_planner_to_create_explicit_work_orders(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-model-planner",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            planner_model="claude",
+            planner_strategy="model",
+            worker_model="claude",
+            review_model="claude",
+            enforce_cross_model_review=False,
+            experiment_id="exp-001",
+            experiment_label="claude-all-the-way",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Enable quality gates by default",
+                    spec=_bounded_spec(
+                        "Enable quality gates by default",
+                        ["aragora/nomic/hardened_orchestrator.py"],
+                    ),
+                    file_scope_hints=["aragora/nomic/hardened_orchestrator.py"],
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    constraints=["do not widen scope"],
+                )
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+        executor.decomposer.analyze_with_model = AsyncMock(
+            return_value=SimpleNamespace(
+                subtasks=[
+                    SubTask(
+                        id="subtask_1",
+                        title="Planner lane",
+                        description="Wire default quality gates",
+                        dependencies=[],
+                        estimated_complexity="medium",
+                        file_scope=["aragora/nomic/hardened_orchestrator.py"],
+                        success_criteria={
+                            "tests": "python -m pytest tests/swarm/test_campaign.py -q"
+                        },
+                    )
+                ]
+            )
+        )
+
+        with patch(
+            "aragora.swarm.campaign.dispatch_bounded_spec",
+            new=AsyncMock(
+                return_value={
+                    "status": "needs_human",
+                    "outcome": CampaignRunOutcome.CLEAN_EXIT_NO_DELIVERABLE.value,
+                    "run_id": "run-model-planner",
+                    "run": {
+                        "run_id": "run-model-planner",
+                        "status": "completed",
+                        "work_orders": [],
+                    },
+                }
+            ),
+        ) as mock_dispatch:
+            await executor.execute_once()
+
+        passed_spec = mock_dispatch.await_args.args[0]
+        assert passed_spec.work_orders
+        work_order = passed_spec.work_orders[0]
+        assert work_order["target_agent"] == "claude"
+        assert work_order["reviewer_agent"] == "claude"
+        assert work_order["metadata"]["planner_strategy_requested"] == "model"
+        assert work_order["metadata"]["planner_strategy_used"] == "model"
+        assert work_order["metadata"]["experiment_id"] == "exp-001"
+        executor.decomposer.analyze_with_model.assert_awaited_once()
+
     @pytest.mark.asyncio
     async def test_execute_once_redispatches_needs_revision_with_review_findings(
         self, tmp_path: Path
@@ -1311,6 +1441,37 @@ class TestCampaignCLI:
         assert args.swarm_action_or_goal == "campaign"
         assert args.swarm_goal == "run"
         assert args.source_file == "ROADMAP.md"
+
+    def test_swarm_parser_accepts_campaign_experiment_flags(self) -> None:
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "campaign",
+                "plan",
+                "--source-file",
+                "ROADMAP.md",
+                "--planner-strategy",
+                "model",
+                "--planner-model",
+                "codex",
+                "--worker-model",
+                "claude",
+                "--review-model",
+                "claude",
+                "--allow-same-model-review",
+                "--experiment-id",
+                "exp-001",
+                "--experiment-label",
+                "planner-benchmark",
+            ]
+        )
+
+        assert args.planner_strategy == "model"
+        assert args.allow_same_model_review is True
+        assert args.experiment_id == "exp-001"
 
     def test_campaign_run_plans_then_executes(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
 from aragora.swarm.campaign import (
     CampaignExecutor,
@@ -131,6 +131,11 @@ def _make_manifest(
     if projects:
         m.projects = projects
     return m
+
+
+def _load_text_like_yaml(path: Path) -> dict:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
 
 
 class TestEmitReceipt:
@@ -260,6 +265,38 @@ class TestEmitReceipt:
         assert "abc123" in content
         assert "docs/test.md" in content
         assert "duration_seconds: 300" in content
+
+    def test_receipt_includes_planner_and_verification_metadata(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed", branch="")
+        manifest = _make_manifest(projects=[project])
+        manifest.planner_strategy = "model"
+        run_dict = {
+            "work_orders": [
+                {
+                    "branch": "codex/from-run",
+                    "head_sha": "abc123",
+                    "changed_paths": ["docs/test.md"],
+                    "metadata": {
+                        "planner_strategy_requested": "model",
+                        "planner_strategy_used": "heuristic",
+                        "planner_fallback_reason": "TimeoutError: planner timed out",
+                    },
+                    "verification_missing_reason": "missing_verification_plan",
+                }
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        payload = _load_text_like_yaml(receipt_path)
+        assert payload["planner_strategy_requested"] == "model"
+        assert payload["planner_strategy_used"] == "heuristic"
+        assert payload["planner_fallback_reason"] == "TimeoutError: planner timed out"
+        assert payload["verification_missing_reason"] == "missing_verification_plan"
 
     def test_receipt_always_marks_rescue_false(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / "manifest.yaml"

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -6,7 +6,7 @@ import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -392,7 +392,7 @@ def test_start_run_initializes_worker_type_circuit_breaker_metadata(
 
 # ---------- dispatch_workers / collect_results tests ----------
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from aragora.swarm.worker_launcher import WorkerProcess
 
 UTC = timezone.utc
@@ -487,6 +487,7 @@ async def test_collect_results_updates_work_orders(repo: Path, store: DevCoordin
                 "worktree_path": str(repo),
                 "branch": "main",
                 "target_agent": "claude",
+                "expected_tests": ["python -m pytest tests/swarm/test_supervisor.py -q"],
             }
         ],
         status="active",
@@ -506,6 +507,17 @@ async def test_collect_results_updates_work_orders(repo: Path, store: DevCoordin
         diff="diff --git a/test.py",
         changed_paths=["test.py"],
         commit_shas=["abc123"],
+        tests_run=["python -m pytest tests/swarm/test_supervisor.py -q"],
+        verification_results=[
+            {
+                "command": "python -m pytest tests/swarm/test_supervisor.py -q",
+                "exit_code": 0,
+                "passed": True,
+                "stdout": "1 passed",
+                "stderr": "",
+                "duration_seconds": 0.2,
+            }
+        ],
     )
     mock_launcher.get_worker = MagicMock(return_value=completed_worker)
     mock_launcher.wait = AsyncMock(return_value=completed_worker)
@@ -701,6 +713,85 @@ async def test_collect_results_blocks_merge_gate_when_required_checks_fail(
 
 
 @pytest.mark.asyncio
+async def test_collect_results_blocks_merge_gate_without_verification_plan(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    lease = store.claim_lease(
+        task_id="merge-missing-plan",
+        title="Merge missing plan lane",
+        owner_agent="claude",
+        owner_session_id="merge-missing-plan-session",
+        branch="main",
+        worktree_path=str(repo),
+        claimed_paths=["aragora/swarm/supervisor.py"],
+        expected_tests=[],
+    )
+    run_record = store.create_supervisor_run(
+        goal="merge gate missing verification plan",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "merge gate missing verification plan"},
+        work_orders=[
+            {
+                "work_order_id": "wo-merge-missing-plan",
+                "status": "dispatched",
+                "worktree_path": str(repo),
+                "branch": "main",
+                "target_agent": "claude",
+                "owner_session_id": "merge-missing-plan-session",
+                "lease_id": lease.lease_id,
+                "review_status": "pending",
+                "file_scope": ["aragora/swarm/supervisor.py"],
+                "expected_tests": [],
+            }
+        ],
+        status="active",
+    )
+    run_id = run_record["run_id"]
+
+    mock_launcher = MagicMock(spec=WorkerLauncher)
+    completed_worker = WorkerProcess(
+        work_order_id="wo-merge-missing-plan",
+        agent="claude",
+        worktree_path=str(repo),
+        branch="main",
+        session_id="merge-missing-plan-session",
+        pid=100,
+        exit_code=0,
+        completed_at="2026-03-06T20:00:00+00:00",
+        diff="diff --git a/aragora/swarm/supervisor.py",
+        changed_paths=["aragora/swarm/supervisor.py"],
+        commit_shas=["abc12345"],
+        tests_run=[],
+        verification_results=[],
+    )
+    mock_launcher.get_worker = MagicMock(return_value=completed_worker)
+    mock_launcher.wait = AsyncMock(return_value=completed_worker)
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        launcher=mock_launcher,
+    )
+
+    results = await supervisor.collect_results(run_id)
+    assert len(results) == 1
+
+    updated = store.get_supervisor_run(run_id)
+    assert updated is not None
+    wo = updated["work_orders"][0]
+    assert wo["status"] == "needs_human"
+    assert wo["review_status"] == "changes_requested"
+    assert wo["receipt_id"] is None
+    assert wo["worker_outcome"] == "merge_gate_failed"
+    assert wo["merge_gate"]["checks_passed"] is False
+    assert wo["merge_gate"]["verification_missing_reason"] == "missing_verification_plan"
+    assert wo["verification_missing_reason"] == "missing_verification_plan"
+    assert "missing verification plan" in wo["dispatch_error"]
+
+
+@pytest.mark.asyncio
 async def test_collect_results_marks_scope_violation_needs_human(
     repo: Path, store: DevCoordinationStore
 ) -> None:
@@ -728,6 +819,7 @@ async def test_collect_results_marks_scope_violation_needs_human(
                 "target_agent": "claude",
                 "owner_session_id": "scope-session",
                 "lease_id": lease.lease_id,
+                "file_scope": ["aragora/server/auth_checks.py"],
                 "review_status": "pending",
             }
         ],
@@ -766,10 +858,10 @@ async def test_collect_results_marks_scope_violation_needs_human(
     updated = store.get_supervisor_run(run_id)
     assert updated is not None
     wo = updated["work_orders"][0]
-    assert wo["status"] == "needs_human"
+    assert wo["status"] == "scope_violation"
     assert wo["review_status"] == "changes_requested"
-    assert "file-scope ownership" in wo["dispatch_error"]
-    assert wo["receipt_id"] is None
+    assert "outside permitted scope" in wo["dispatch_error"]
+    assert wo.get("receipt_id") is None
     assert wo["lease_id"] == lease.lease_id
     assert wo["scope_violation"]["violations"][0]["type"] == "out_of_scope"
 


### PR DESCRIPTION
## Summary
- **Model-driven planning**: `planner_strategy=model` routes task decomposition through a real LLM agent (`analyze_with_model()`), producing structured JSON work orders. Falls back to heuristic on failure with recorded metadata.
- **Fail-closed merge gate**: Code-change lanes with no verification commands are blocked (`missing_verification_plan`) instead of treated as passing.
- **Same-model review opt-in**: `enforce_cross_model_review=false` allows same-model review for benchmark runs while keeping cross-model review as the production default.
- **Experiment metadata**: `experiment_id` and `experiment_label` fields propagate through manifests, attempts, and receipts.
- **Benchmark harness**: `scripts/phase0b_role_benchmark.py` provides sequential launch, result capture, and normalized comparison tables for all planner/worker/reviewer permutations.

Builds on #972 (session-key collision + Claude CLI flag fix).

## Test plan
- [x] 137 targeted tests passing (campaign, campaign_receipt, supervisor, task_decomposer)
- [x] `test_execute_once_uses_model_planner_to_create_explicit_work_orders` — model planner dispatch
- [x] `test_analyze_with_model_parses_strict_json` — LLM response parsing
- [x] `test_collect_results_blocks_merge_gate_without_verification_plan` — fail-closed gate
- [x] `test_same_model_review_requires_opt_in` — cross-model enforcement
- [x] Pre-commit hooks (ruff lint + format, gitleaks) all passing
- [x] Benchmark harness CLI (`--help`, `prepare --help`) boots correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)