### PR TITLE
fix(swarm): Codex lane closure, verification inheritance, and result capture

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -1674,6 +1674,15 @@ class CampaignExecutor:
         )
         work_orders = [item.to_dict() for item in self.bridge.build_work_orders(subtasks)]
         for item in work_orders:
+            inherited_tests = self._inherited_expected_tests_for_planned_work_order(item, spec)
+            if inherited_tests:
+                item["expected_tests"] = inherited_tests
+                success_criteria = dict(item.get("success_criteria") or {})
+                if "tests" not in success_criteria:
+                    success_criteria["tests"] = (
+                        inherited_tests[0] if len(inherited_tests) == 1 else list(inherited_tests)
+                    )
+                item["success_criteria"] = success_criteria
             item["target_agent"] = worker_model
             item["reviewer_agent"] = chosen_review_model
             item["metadata"] = {
@@ -1687,6 +1696,27 @@ class CampaignExecutor:
                 "requested_reviewer_agent": chosen_review_model,
             }
         return work_orders
+
+    @staticmethod
+    def _inherited_expected_tests_for_planned_work_order(
+        work_order: dict[str, Any],
+        spec: SwarmSpec,
+    ) -> list[str]:
+        existing = [
+            str(item).strip() for item in work_order.get("expected_tests", []) if str(item).strip()
+        ]
+        if existing:
+            return list(dict.fromkeys(existing))
+
+        inferred: list[str] = []
+        for raw_path in work_order.get("file_scope", []):
+            path = str(raw_path).strip()
+            if path.startswith("tests/") and path.endswith(".py"):
+                inferred.append(f"python -m pytest {path} -q")
+        if inferred:
+            return list(dict.fromkeys(inferred))
+
+        return _tests_from_acceptance_criteria(spec.acceptance_criteria)
 
     def _reconcile_active_projects(self, manifest: CampaignManifest) -> None:
         for project in manifest.projects:
@@ -1782,6 +1812,8 @@ class CampaignExecutor:
                 manifest_input = str(self.manifest_path)
             planner_metadata = _planner_metadata_from_run(run_dict)
             verification_missing_reason = _verification_missing_reason_from_run(run_dict)
+            worker_branches = _worker_branches_from_run(project, run_dict)
+            worker_commits = _worker_commits_from_run(project, run_dict)
 
             payload: dict[str, Any] = {
                 "task_id": project.project_id,
@@ -1795,8 +1827,10 @@ class CampaignExecutor:
                 "planner_fallback_reason": planner_metadata.get("planner_fallback_reason"),
                 "verification_missing_reason": verification_missing_reason,
                 "worker_receipt_id": project.worker_receipt_id,
-                "worker_branch": _worker_branch_from_run(project, run_dict),
-                "worker_commit": _worker_commit_from_run(project, run_dict),
+                "worker_branch": worker_branches[0] if worker_branches else None,
+                "worker_commit": worker_commits[-1] if worker_commits else None,
+                "worker_branches": worker_branches,
+                "worker_commits": worker_commits,
                 "changed_files": _changed_files_from_run(run_dict),
                 "review_verdict": _receipt_review_verdict(project.review.status),
                 "verification_results": {
@@ -2182,38 +2216,72 @@ def _changed_files_from_run(run_dict: dict[str, Any] | None) -> list[str]:
     return paths
 
 
+def _tests_from_acceptance_criteria(acceptance_criteria: list[str]) -> list[str]:
+    tests: list[str] = []
+    for item in acceptance_criteria:
+        text = str(item).strip()
+        if text.startswith("python -m pytest") or text.startswith("pytest"):
+            tests.append(text)
+    return list(dict.fromkeys(tests))
+
+
+def _ordered_unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+def _worker_branches_from_run(
+    project: CampaignProject, run_dict: dict[str, Any] | None
+) -> list[str]:
+    branches: list[str] = []
+    if project.branch:
+        branches.append(project.branch)
+    if run_dict:
+        for wo in run_dict.get("work_orders", []):
+            if not isinstance(wo, dict):
+                continue
+            branch = str(wo.get("branch", "")).strip()
+            if branch:
+                branches.append(branch)
+    return _ordered_unique(branches)
+
+
+def _worker_commits_from_run(
+    project: CampaignProject, run_dict: dict[str, Any] | None
+) -> list[str]:
+    commits: list[str] = [str(sha).strip() for sha in project.commit_shas if str(sha).strip()]
+    if run_dict:
+        for wo in run_dict.get("work_orders", []):
+            if not isinstance(wo, dict):
+                continue
+            commits.extend(
+                str(sha).strip() for sha in wo.get("commit_shas", []) if str(sha).strip()
+            )
+            head_sha = str(wo.get("head_sha", "")).strip()
+            if head_sha:
+                commits.append(head_sha)
+    return _ordered_unique(commits)
+
+
 def _worker_branch_from_run(
     project: CampaignProject, run_dict: dict[str, Any] | None
 ) -> str | None:
-    if project.branch:
-        return project.branch
-    if not run_dict:
-        return None
-    for wo in run_dict.get("work_orders", []):
-        if isinstance(wo, dict):
-            branch = str(wo.get("branch", "")).strip()
-            if branch:
-                return branch
-    return None
+    branches = _worker_branches_from_run(project, run_dict)
+    return branches[0] if branches else None
 
 
 def _worker_commit_from_run(
     project: CampaignProject, run_dict: dict[str, Any] | None
 ) -> str | None:
-    if project.commit_shas:
-        return project.commit_shas[-1]
-    if not run_dict:
-        return None
-    for wo in run_dict.get("work_orders", []):
-        if not isinstance(wo, dict):
-            continue
-        sha = str(wo.get("head_sha", "")).strip()
-        if sha:
-            return sha
-        shas = [str(s).strip() for s in wo.get("commit_shas", []) if str(s).strip()]
-        if shas:
-            return shas[-1]
-    return None
+    commits = _worker_commits_from_run(project, run_dict)
+    return commits[-1] if commits else None
 
 
 def _planner_metadata_from_run(run_dict: dict[str, Any] | None) -> dict[str, Any]:

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -34,10 +34,10 @@ SESSION_ARTIFACTS: frozenset[str] = frozenset(
 )
 
 # Exit codes where the worker likely completed its work but the process was
-# terminated by a transport-level signal (e.g. broken pipe).  Only these
-# codes are eligible for auto-commit salvage — all other non-zero exits are
-# treated as genuine failures whose partial output must NOT become a
-# concrete deliverable.
+# terminated by a transport-level signal (e.g. broken pipe). These codes are
+# eligible for auto-commit salvage for all worker types. Codex lanes also get
+# a best-effort salvage path when they exit non-zero after producing a real
+# commit so review/verification can still judge the recovered deliverable.
 _SALVAGEABLE_EXIT_CODES: frozenset[int] = frozenset(
     {
         141,  # SIGPIPE — stdout pipe closed before process finished writing
@@ -236,15 +236,17 @@ class WorkerLauncher:
         try:
             worker.diff = await self._collect_diff(worker.worktree_path)
 
-            _exit_ok = worker.exit_code == 0 or worker.exit_code in _SALVAGEABLE_EXIT_CODES
+            _can_query_dirty_tree = self._can_query_dirty_tree(worker)
             # ``git diff HEAD`` only detects modifications to tracked files.
             # Workers that create NEW (untracked) files show no diff.
             # Always fall back to ``git status --porcelain`` which detects
             # both untracked and modified files.
             _has_changes = bool(worker.diff) or (
-                _exit_ok and await self._has_working_tree_changes(worker.worktree_path)
+                _can_query_dirty_tree and await self._has_working_tree_changes(worker.worktree_path)
             )
-            if self.config.auto_commit and _has_changes and _exit_ok:
+            if self.config.auto_commit and self._should_attempt_auto_commit(
+                worker, has_changes=_has_changes
+            ):
                 await self._auto_commit(worker)
 
             worker.head_sha = await self._git_output(worker.worktree_path, "rev-parse", "HEAD")
@@ -258,6 +260,7 @@ class WorkerLauncher:
                 initial_head=worker.initial_head,
                 head_sha=worker.head_sha,
             )
+            self._promote_salvaged_codex_exit(worker)
             if worker.exit_code == 0 and worker.expected_tests:
                 worker.verification_results = await self._run_verification_commands(
                     worker.worktree_path,
@@ -438,6 +441,7 @@ class WorkerLauncher:
         """Build the task prompt from a work order dict."""
         parts: list[str] = []
         metadata = work_order.get("metadata", {})
+        target_agent = str(work_order.get("target_agent", "")).strip().lower()
 
         title = str(work_order.get("title", "")).strip()
         if title:
@@ -485,6 +489,16 @@ class WorkerLauncher:
                 "Decision boundary:\n"
                 "  - If you hit a real ambiguity, approval boundary, or blocker, stop cleanly and "
                 "report the exact reason instead of widening scope."
+            )
+
+        if target_agent == "codex":
+            parts.append(
+                "Codex lane discipline:\n"
+                "  - If you have a real bounded code change, create a checkpoint commit before long "
+                "or fragile validation.\n"
+                "  - Do not exit 0 with staged or unstaged changes remaining.\n"
+                "  - If validation is slow or fails late, still preserve the bounded deliverable "
+                "with an honest commit message and report the failing command."
             )
 
         lease_id = str(work_order.get("lease_id", "")).strip()
@@ -666,15 +680,15 @@ class WorkerLauncher:
         try:
             worker.diff = await cls._collect_diff(worktree_path)
 
-            _exit_ok = worker.exit_code == 0 or worker.exit_code in _SALVAGEABLE_EXIT_CODES
+            _can_query_dirty_tree = cls._can_query_dirty_tree(worker)
             # ``git diff HEAD`` only detects modifications to tracked files.
             # Workers that create NEW (untracked) files show no diff.
             # Always fall back to ``git status --porcelain`` which detects
             # both untracked and modified files.
             _has_changes = bool(worker.diff) or (
-                _exit_ok and await cls._has_working_tree_changes(worktree_path)
+                _can_query_dirty_tree and await cls._has_working_tree_changes(worktree_path)
             )
-            if auto_commit and _has_changes and _exit_ok:
+            if auto_commit and cls._should_attempt_auto_commit(worker, has_changes=_has_changes):
                 await cls._auto_commit(worker)
 
             worker.head_sha = await cls._git_output(worktree_path, "rev-parse", "HEAD")
@@ -688,6 +702,7 @@ class WorkerLauncher:
                 initial_head=initial_head,
                 head_sha=worker.head_sha,
             )
+            cls._promote_salvaged_codex_exit(worker)
             if worker.exit_code == 0 and worker.expected_tests:
                 worker.verification_results = await cls._run_verification_commands(
                     worktree_path,
@@ -855,6 +870,37 @@ class WorkerLauncher:
                 }
             )
         return results
+
+    @staticmethod
+    def _can_query_dirty_tree(worker: WorkerProcess) -> bool:
+        return (
+            worker.exit_code == 0
+            or worker.exit_code in _SALVAGEABLE_EXIT_CODES
+            or worker.agent == "codex"
+        )
+
+    @staticmethod
+    def _should_attempt_auto_commit(worker: WorkerProcess, *, has_changes: bool) -> bool:
+        if not has_changes:
+            return False
+        if worker.exit_code == 0 or worker.exit_code in _SALVAGEABLE_EXIT_CODES:
+            return True
+        return worker.agent == "codex"
+
+    @staticmethod
+    def _promote_salvaged_codex_exit(worker: WorkerProcess) -> None:
+        if worker.agent != "codex":
+            return
+        if worker.exit_code in (None, 0):
+            return
+        if not worker.commit_shas:
+            return
+        note = (
+            f"Codex exited {worker.exit_code} after producing a salvageable commit; "
+            "verification continued on the recovered deliverable."
+        )
+        worker.stderr = "\n".join(part for part in (worker.stderr.strip(), note) if part).strip()
+        worker.exit_code = 0
 
     @staticmethod
     def _read_log_file(worktree_path: str, stream: str) -> str:

--- a/scripts/phase0b_role_benchmark.py
+++ b/scripts/phase0b_role_benchmark.py
@@ -53,6 +53,10 @@ RESULT_COLUMNS = [
     "review_status",
     "worker_branch",
     "worker_commit",
+    "worker_branch_count",
+    "worker_commit_count",
+    "worker_branches_json",
+    "worker_commits_json",
     "pr_url",
     "pr_state",
     "ci_status",
@@ -272,6 +276,17 @@ def build_result_row(runtime_manifest_path: Path) -> dict[str, Any]:
     receipt_path = PROJECT_ROOT / project.receipt_id if project.receipt_id else None
     receipt = _load_receipt(receipt_path)
     branch = str(receipt.get("worker_branch") or project.branch or "").strip() or None
+    worker_branches = [
+        str(item).strip() for item in receipt.get("worker_branches", []) if str(item).strip()
+    ]
+    if not worker_branches and branch:
+        worker_branches = [branch]
+    worker_commit = str(receipt.get("worker_commit") or "").strip()
+    worker_commits = [
+        str(item).strip() for item in receipt.get("worker_commits", []) if str(item).strip()
+    ]
+    if not worker_commits and worker_commit:
+        worker_commits = [worker_commit]
     pr_lookup = _lookup_pr(branch)
     pr_number = int(pr_lookup["number"]) if isinstance(pr_lookup.get("number"), int) else None
     review_model = manifest.review_model
@@ -295,7 +310,11 @@ def build_result_row(runtime_manifest_path: Path) -> dict[str, Any]:
         "last_run_outcome": project.last_run_outcome,
         "review_status": project.review.status,
         "worker_branch": branch or "",
-        "worker_commit": str(receipt.get("worker_commit") or "").strip(),
+        "worker_commit": worker_commit,
+        "worker_branch_count": len(worker_branches),
+        "worker_commit_count": len(worker_commits),
+        "worker_branches_json": json.dumps(worker_branches),
+        "worker_commits_json": json.dumps(worker_commits),
         "pr_url": str(project.pr_url or pr_lookup.get("url") or "").strip(),
         "pr_state": str(pr_lookup.get("state") or "").strip(),
         "ci_status": _lookup_ci_status(pr_number),

--- a/tests/scripts/test_phase0b_role_benchmark.py
+++ b/tests/scripts/test_phase0b_role_benchmark.py
@@ -1,0 +1,100 @@
+"""Tests for scripts/phase0b_role_benchmark.py result capture."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+from aragora.swarm.campaign import CampaignManifest, CampaignProject, save_campaign_manifest
+from aragora.swarm.spec import SwarmSpec
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import phase0b_role_benchmark  # noqa: E402
+
+
+def test_build_result_row_includes_multi_branch_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    worktree = tmp_path / "bench-run"
+    runtime_manifest_path = worktree / ".aragora" / "phase0b_runtime_manifest.yaml"
+    receipt_path = tmp_path / "docs" / "receipts" / "phase0b-engine-hardening" / "B-6.yaml"
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_text(
+        yaml.safe_dump(
+            {
+                "worker_branch": "codex/swarm-subtask-1",
+                "worker_commit": "def456",
+                "worker_branches": [
+                    "codex/swarm-subtask-1",
+                    "codex/swarm-subtask-2",
+                ],
+                "worker_commits": ["abc123", "def456"],
+                "changed_files": [
+                    "docs/test.md",
+                    "aragora/swarm/campaign.py",
+                ],
+                "duration_seconds": 321,
+                "cost_usd": 3.0,
+                "planner_strategy_requested": "model",
+                "planner_strategy_used": "model",
+                "planner_fallback_reason": None,
+                "verification_missing_reason": None,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+    manifest = CampaignManifest(
+        campaign_id="phase0b-engine-hardening",
+        created_at="2026-03-17T00:00:00+00:00",
+        source_kind="test",
+        source_ref="test",
+        planner_model="codex",
+        planner_strategy="model",
+        worker_model="claude",
+        review_model="claude",
+        enforce_cross_model_review=False,
+        experiment_id="exp-001",
+        experiment_label="p-codex_w-claude_r-claude",
+        projects=[
+            CampaignProject(
+                project_id="B-6",
+                title="Engine hardening",
+                spec=SwarmSpec(
+                    raw_goal="goal",
+                    refined_goal="goal",
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                ),
+                status="completed",
+                last_run_outcome="deliverable_created",
+                receipt_id="docs/receipts/phase0b-engine-hardening/B-6.yaml",
+            )
+        ],
+    )
+    save_campaign_manifest(runtime_manifest_path, manifest)
+
+    monkeypatch.setattr(phase0b_role_benchmark, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(phase0b_role_benchmark, "_lookup_pr", lambda branch: {})
+    monkeypatch.setattr(phase0b_role_benchmark, "_lookup_ci_status", lambda pr_number: "")
+
+    row = phase0b_role_benchmark.build_result_row(runtime_manifest_path)
+
+    assert row["worker_branch"] == "codex/swarm-subtask-1"
+    assert row["worker_commit"] == "def456"
+    assert row["worker_branch_count"] == 2
+    assert row["worker_commit_count"] == 2
+    assert json.loads(row["worker_branches_json"]) == [
+        "codex/swarm-subtask-1",
+        "codex/swarm-subtask-2",
+    ]
+    assert json.loads(row["worker_commits_json"]) == ["abc123", "def456"]
+    assert row["changed_files_count"] == 2

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -402,10 +402,112 @@ class TestCampaignExecutor:
         work_order = passed_spec.work_orders[0]
         assert work_order["target_agent"] == "claude"
         assert work_order["reviewer_agent"] == "claude"
+        assert work_order["expected_tests"] == ["python -m pytest tests/swarm/test_campaign.py -q"]
         assert work_order["metadata"]["planner_strategy_requested"] == "model"
         assert work_order["metadata"]["planner_strategy_used"] == "model"
         assert work_order["metadata"]["experiment_id"] == "exp-001"
         executor.decomposer.analyze_with_model.assert_awaited_once()
+
+    def test_planned_work_orders_inherit_expected_tests_when_planner_omits_them(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-model-planner-fallback-tests",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            planner_model="claude",
+            planner_strategy="model",
+            worker_model="claude",
+            review_model="claude",
+            enforce_cross_model_review=False,
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+        spec = _bounded_spec(
+            "Enable quality gates by default",
+            ["aragora/nomic/hardened_orchestrator.py"],
+        )
+
+        work_orders = executor._planned_work_orders_from_decomposition(
+            SimpleNamespace(
+                subtasks=[
+                    SubTask(
+                        id="subtask_1",
+                        title="Planner lane",
+                        description="Wire default quality gates",
+                        dependencies=[],
+                        estimated_complexity="medium",
+                        file_scope=["aragora/nomic/hardened_orchestrator.py"],
+                        success_criteria={},
+                    )
+                ]
+            ),
+            spec=spec,
+            worker_model="claude",
+            review_model="claude",
+            enforce_cross_model_review=False,
+            planner_metadata={
+                "planner_strategy_requested": "model",
+                "planner_strategy_used": "model",
+            },
+        )
+
+        assert work_orders[0]["expected_tests"] == ["pytest -q tests/swarm/test_campaign.py"]
+        assert (
+            work_orders[0]["success_criteria"]["tests"] == "pytest -q tests/swarm/test_campaign.py"
+        )
+
+    def test_planned_work_orders_preserve_explicit_planner_tests(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-model-planner-explicit-tests",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            planner_model="claude",
+            planner_strategy="model",
+            worker_model="claude",
+            review_model="claude",
+            enforce_cross_model_review=False,
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+        spec = _bounded_spec(
+            "Enable quality gates by default",
+            ["aragora/nomic/hardened_orchestrator.py"],
+        )
+
+        work_orders = executor._planned_work_orders_from_decomposition(
+            SimpleNamespace(
+                subtasks=[
+                    SubTask(
+                        id="subtask_1",
+                        title="Planner lane",
+                        description="Wire default quality gates",
+                        dependencies=[],
+                        estimated_complexity="medium",
+                        file_scope=["aragora/nomic/hardened_orchestrator.py"],
+                        success_criteria={
+                            "tests": "python -m pytest tests/custom/test_quality_gates.py -q"
+                        },
+                    )
+                ]
+            ),
+            spec=spec,
+            worker_model="claude",
+            review_model="claude",
+            enforce_cross_model_review=False,
+            planner_metadata={
+                "planner_strategy_requested": "model",
+                "planner_strategy_used": "model",
+            },
+        )
+
+        assert work_orders[0]["expected_tests"] == [
+            "python -m pytest tests/custom/test_quality_gates.py -q"
+        ]
 
     @pytest.mark.asyncio
     async def test_execute_once_redispatches_needs_revision_with_review_findings(

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -266,6 +266,40 @@ class TestEmitReceipt:
         assert "docs/test.md" in content
         assert "duration_seconds: 300" in content
 
+    def test_receipt_includes_multi_branch_worker_metadata(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="completed", branch="")
+        manifest = _make_manifest(projects=[project])
+        run_dict = {
+            "work_orders": [
+                {
+                    "branch": "codex/swarm-subtask-1",
+                    "commit_shas": ["abc123"],
+                    "changed_paths": ["docs/test.md"],
+                },
+                {
+                    "branch": "codex/swarm-subtask-2",
+                    "head_sha": "def456",
+                    "changed_paths": ["aragora/swarm/campaign.py"],
+                },
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        payload = _load_text_like_yaml(receipt_path)
+        assert payload["worker_branch"] == "codex/swarm-subtask-1"
+        assert payload["worker_commit"] == "def456"
+        assert payload["worker_branches"] == [
+            "codex/swarm-subtask-1",
+            "codex/swarm-subtask-2",
+        ]
+        assert payload["worker_commits"] == ["abc123", "def456"]
+        assert payload["changed_files"] == ["docs/test.md", "aragora/swarm/campaign.py"]
+
     def test_receipt_includes_planner_and_verification_metadata(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / "manifest.yaml"
         manifest_path.write_text("campaign_id: phase0a-test\n")

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -104,6 +104,28 @@ class TestBuildPrompt:
         assert "All tests pass" in prompt
         assert "Do not modify CLAUDE.md" in prompt
 
+    def test_codex_prompt_includes_lane_closure_guidance(self):
+        prompt = WorkerLauncher._build_prompt(
+            {
+                "target_agent": "codex",
+                "title": "Harden execution",
+            }
+        )
+
+        assert "Codex lane discipline:" in prompt
+        assert "checkpoint commit before long" in prompt
+        assert "Do not exit 0 with staged or unstaged changes remaining." in prompt
+
+    def test_claude_prompt_omits_codex_lane_closure_guidance(self):
+        prompt = WorkerLauncher._build_prompt(
+            {
+                "target_agent": "claude",
+                "title": "Harden execution",
+            }
+        )
+
+        assert "Codex lane discipline:" not in prompt
+
 
 class TestBuildCommand:
     def test_claude_command(self):
@@ -266,6 +288,64 @@ class TestWait:
         assert result.exit_code == -1
         assert "Timed out" in result.stderr
         mock_proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_wait_salvages_codex_timeout_with_commit_and_runs_verification(self):
+        launcher = WorkerLauncher(LaunchConfig(timeout_seconds=0.01, auto_commit=True))
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+
+        worker = WorkerProcess(
+            work_order_id="wo-timeout-salvage",
+            agent="codex",
+            worktree_path="/tmp/wt",
+            branch="main",
+            pid=200,
+            expected_tests=[expected_test],
+        )
+        launcher._workers["wo-timeout-salvage"] = worker
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        launcher._processes["wo-timeout-salvage"] = mock_proc
+
+        verification_results = [
+            {
+                "command": expected_test,
+                "exit_code": 0,
+                "passed": True,
+                "stdout": "1 passed",
+                "stderr": "",
+                "duration_seconds": 0.2,
+            }
+        ]
+
+        with (
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher,
+                "_has_working_tree_changes",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(WorkerLauncher, "_auto_commit", new=AsyncMock()) as mock_commit,
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(
+                WorkerLauncher,
+                "_run_verification_commands",
+                new=AsyncMock(return_value=verification_results),
+            ) as mock_verify,
+        ):
+            result = await launcher.wait("wo-timeout-salvage")
+
+        assert result.exit_code == 0
+        assert result.commit_shas == ["abc123"]
+        assert "salvageable commit" in result.stderr
+        mock_proc.kill.assert_called_once()
+        mock_commit.assert_awaited_once()
+        mock_verify.assert_awaited_once_with("/tmp/wt", [expected_test])
 
     @pytest.mark.asyncio
     async def test_wait_unknown_raises(self):


### PR DESCRIPTION
## Summary
- **Codex-specific prompt + salvage**: Workers get checkpoint/clean-exit guidance; dirty non-zero exits trigger best-effort auto-commit so review/verification can judge recovered deliverables
- **Verification-plan inheritance**: Model-planned work orders inherit `expected_tests` from file_scope or spec acceptance_criteria when planner omits them, reducing false merge-gate blocks
- **Multi-branch result capture**: Receipts now record `worker_branches` and `worker_commits` lists so decomposed runs get fair credit in benchmark scoring

## Context
Phase 0B benchmark matrix (8 configs) revealed:
- Codex workers produce code but never commit (0/4 lane closure)
- Codex reviewer fails on fragmented multi-branch artifacts (0/2 completed)
- Benchmark recorder under-credits multi-branch output

These fixes target all three issues to enable a fair Phase 2 rerun.

## Test plan
- [x] 138 focused tests pass (`test_worker_launcher`, `test_campaign`, `test_campaign_receipt`, `test_supervisor`, `test_phase0b_role_benchmark`)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [ ] Phase 2 rerun after merge: `p-claude_w-codex_r-claude`, `p-codex_w-claude_r-claude`, `p-claude_w-claude_r-claude`

🤖 Generated with [Claude Code](https://claude.com/claude-code)