### PR TITLE
fix(swarm): grant Codex sandbox access to worktree gitdir via --add-dir

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -378,7 +378,7 @@ class WorkerLauncher:
         session_id: str = "",
     ) -> list[str]:
         """Build the launch command for the given agent type."""
-        inner = self._build_agent_command(agent, prompt)
+        inner = self._build_agent_command(agent, prompt, worktree_path=worktree_path)
         if not self.config.use_managed_session_script:
             return inner
 
@@ -402,7 +402,9 @@ class WorkerLauncher:
         cmd.extend(inner)
         return cmd
 
-    def _build_agent_command(self, agent: str, prompt: str) -> list[str]:
+    def _build_agent_command(
+        self, agent: str, prompt: str, *, worktree_path: str = ""
+    ) -> list[str]:
         if agent == "claude":
             cmd = [self.config.claude_path, "-p", prompt, "--dangerously-skip-permissions"]
             if self.config.claude_model:
@@ -413,10 +415,40 @@ class WorkerLauncher:
             cmd = [self.config.codex_path, "exec", prompt, "--full-auto"]
             if self.config.codex_model:
                 cmd.extend(["--model", self.config.codex_model])
+            git_dir = self._resolve_worktree_gitdir(worktree_path)
+            if git_dir:
+                cmd.extend(["--add-dir", git_dir])
             return cmd
 
         logger.warning("Unknown agent %r, falling back to claude", agent)
         return [self.config.claude_path, "-p", prompt, "--dangerously-skip-permissions"]
+
+    @staticmethod
+    def _resolve_worktree_gitdir(worktree_path: str) -> str:
+        """Return the real gitdir for a git worktree, or '' for regular repos.
+
+        Git worktrees have a `.git` *file* (not directory) containing
+        ``gitdir: <path>``.  That path points to the parent repo's
+        ``.git/worktrees/<name>/`` directory where the index and lock
+        files live.  The Codex ``--full-auto`` sandbox only allows writes
+        inside the worktree itself, so we need ``--add-dir <gitdir>`` to
+        let ``git add``/``git commit`` create ``index.lock``.
+        """
+        if not worktree_path:
+            return ""
+        dot_git = Path(worktree_path) / ".git"
+        if not dot_git.exists() or dot_git.is_dir():
+            return ""
+        try:
+            text = dot_git.read_text().strip()
+            if text.startswith("gitdir:"):
+                gitdir = text.split(":", 1)[1].strip()
+                resolved = (dot_git.parent / gitdir).resolve()
+                if resolved.is_dir():
+                    return str(resolved)
+        except OSError:
+            pass
+        return ""
 
     def _validate_launch_command(self, cmd: list[str], agent: str) -> None:
         if not cmd:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -168,6 +168,50 @@ class TestBuildCommand:
         assert cmd[0] == "claude"
         assert "-p" in cmd
 
+    def test_codex_adds_worktree_gitdir_to_sandbox(self, tmp_path: Path):
+        """Codex in a worktree gets --add-dir pointing to the real gitdir."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+        real_gitdir.mkdir(parents=True)
+        (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
+        launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
+        cmd = launcher._build_command("codex", "task", str(wt))
+        assert "--add-dir" in cmd
+        idx = cmd.index("--add-dir")
+        assert cmd[idx + 1] == str(real_gitdir)
+        assert "--full-auto" in cmd
+
+    def test_codex_no_add_dir_for_regular_repo(self, tmp_path: Path):
+        """Regular repos (.git is a directory) should NOT get --add-dir."""
+        wt = tmp_path / "repo"
+        wt.mkdir()
+        (wt / ".git").mkdir()
+        launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
+        cmd = launcher._build_command("codex", "task", str(wt))
+        assert "--add-dir" not in cmd
+        assert "--full-auto" in cmd
+
+    def test_resolve_worktree_gitdir(self, tmp_path: Path):
+        """Resolves gitdir from a .git file in a worktree."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+        real_gitdir.mkdir(parents=True)
+        (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
+        assert WorkerLauncher._resolve_worktree_gitdir(str(wt)) == str(real_gitdir)
+
+    def test_resolve_worktree_gitdir_empty(self):
+        """Empty path returns empty string."""
+        assert WorkerLauncher._resolve_worktree_gitdir("") == ""
+
+    def test_resolve_worktree_gitdir_regular_repo(self, tmp_path: Path):
+        """.git directory (not file) returns empty string."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        assert WorkerLauncher._resolve_worktree_gitdir(str(repo)) == ""
+
 
 class TestLaunch:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- **Root cause found** for Codex 0% lane closure in swarm benchmarks
- Git worktrees store their index under `.git/worktrees/<name>/` — outside the `workspace-write` sandbox
- `git add` / `git commit` fail with EPERM (cannot create `index.lock`)
- **Fix**: resolve the real gitdir from the `.git` file and pass `--add-dir <gitdir>` to the Codex CLI
- Keeps `--full-auto` sandboxing intact — only grants the minimum needed directory access

## Evidence
Reproduced in an aragora worktree:
```
git add and git commit could not be completed in this sandbox.
Git for this worktree writes to /Users/.../aragora/.git/worktrees/...,
and the sandbox denied creating index.lock there: Operation not permitted.
```
Same command in a standalone repo (`.git` is a directory): commits succeed.

## Implementation
- `_resolve_worktree_gitdir()` reads `.git` file → parses `gitdir:` → resolves path → returns real gitdir
- `_build_agent_command()` calls resolver, conditionally appends `--add-dir <gitdir>` for codex
- Regular repos (`.git` is a directory) are unaffected — no `--add-dir` added

## Test plan
- [x] `test_codex_adds_worktree_gitdir_to_sandbox` — verifies `--add-dir` points to resolved gitdir
- [x] `test_codex_no_add_dir_for_regular_repo` — confirms no `--add-dir` for normal repos
- [x] `test_resolve_worktree_gitdir` — unit test for gitdir resolution
- [x] `test_resolve_worktree_gitdir_empty` — empty path returns ""
- [x] `test_resolve_worktree_gitdir_regular_repo` — .git directory returns ""
- [x] All 38 worker launcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)