### PR TITLE
fix(swarm): grant Codex sandbox access to common git dir

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -450,9 +450,16 @@ class WorkerLauncher:
             cmd = [self.config.codex_path, "exec", prompt, "--full-auto"]
             if self.config.codex_model:
                 cmd.extend(["--model", self.config.codex_model])
-            git_dir = self._resolve_worktree_gitdir(worktree_path)
-            if git_dir:
-                cmd.extend(["--add-dir", git_dir])
+            git_access_dirs = [
+                path
+                for path in (
+                    self._resolve_worktree_gitdir(worktree_path),
+                    self._resolve_worktree_common_gitdir(worktree_path),
+                )
+                if path
+            ]
+            for access_dir in dict.fromkeys(git_access_dirs):
+                cmd.extend(["--add-dir", access_dir])
             return cmd
 
         logger.warning("Unknown agent %r, falling back to claude", agent)
@@ -465,9 +472,7 @@ class WorkerLauncher:
         Git worktrees have a `.git` *file* (not directory) containing
         ``gitdir: <path>``.  That path points to the parent repo's
         ``.git/worktrees/<name>/`` directory where the index and lock
-        files live.  The Codex ``--full-auto`` sandbox only allows writes
-        inside the worktree itself, so we need ``--add-dir <gitdir>`` to
-        let ``git add``/``git commit`` create ``index.lock``.
+        files live.
         """
         if not worktree_path:
             return ""
@@ -481,6 +486,32 @@ class WorkerLauncher:
                 resolved = (dot_git.parent / gitdir).resolve()
                 if resolved.is_dir():
                     return str(resolved)
+        except OSError:
+            pass
+        return ""
+
+    @classmethod
+    def _resolve_worktree_common_gitdir(cls, worktree_path: str) -> str:
+        """Return the shared common git dir for a worktree, or '' if unknown.
+
+        Worktrees keep their shared object store and most refs in the parent
+        repository's main ``.git`` directory.  Codex needs write access there
+        in addition to the per-worktree gitdir so ``git add`` can write new
+        objects and ``git commit`` can update refs.
+        """
+        gitdir = cls._resolve_worktree_gitdir(worktree_path)
+        if not gitdir:
+            return ""
+        commondir = Path(gitdir) / "commondir"
+        if not commondir.exists():
+            return ""
+        try:
+            text = commondir.read_text().strip()
+            if not text:
+                return ""
+            resolved = (Path(gitdir) / text).resolve()
+            if resolved.is_dir():
+                return str(resolved)
         except OSError:
             pass
         return ""

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -168,18 +168,20 @@ class TestBuildCommand:
         assert cmd[0] == "claude"
         assert "-p" in cmd
 
-    def test_codex_adds_worktree_gitdir_to_sandbox(self, tmp_path: Path):
-        """Codex in a worktree gets --add-dir pointing to the real gitdir."""
+    def test_codex_adds_worktree_git_access_dirs_to_sandbox(self, tmp_path: Path):
+        """Codex in a worktree gets add-dir entries for gitdir and common dir."""
         wt = tmp_path / "wt"
         wt.mkdir()
         real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
         real_gitdir.mkdir(parents=True)
+        common_gitdir = tmp_path / "repo" / ".git"
+        common_gitdir.mkdir(parents=True, exist_ok=True)
+        (real_gitdir / "commondir").write_text("../..")
         (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
         launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
         cmd = launcher._build_command("codex", "task", str(wt))
-        assert "--add-dir" in cmd
-        idx = cmd.index("--add-dir")
-        assert cmd[idx + 1] == str(real_gitdir)
+        add_dirs = [cmd[idx + 1] for idx, token in enumerate(cmd[:-1]) if token == "--add-dir"]
+        assert add_dirs == [str(real_gitdir), str(common_gitdir)]
         assert "--full-auto" in cmd
 
     def test_codex_no_add_dir_for_regular_repo(self, tmp_path: Path):
@@ -211,6 +213,27 @@ class TestBuildCommand:
         repo.mkdir()
         (repo / ".git").mkdir()
         assert WorkerLauncher._resolve_worktree_gitdir(str(repo)) == ""
+
+    def test_resolve_worktree_common_gitdir(self, tmp_path: Path):
+        """Resolves commondir from the per-worktree gitdir metadata."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+        real_gitdir.mkdir(parents=True)
+        common_gitdir = tmp_path / "repo" / ".git"
+        common_gitdir.mkdir(parents=True, exist_ok=True)
+        (real_gitdir / "commondir").write_text("../..")
+        (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
+        assert WorkerLauncher._resolve_worktree_common_gitdir(str(wt)) == str(common_gitdir)
+
+    def test_resolve_worktree_common_gitdir_missing_metadata(self, tmp_path: Path):
+        """Missing commondir metadata returns empty string."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+        real_gitdir.mkdir(parents=True)
+        (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
+        assert WorkerLauncher._resolve_worktree_common_gitdir(str(wt)) == ""
 
 
 class TestLaunch:


### PR DESCRIPTION
## Summary
- add the shared common `.git` directory alongside the per-worktree gitdir when launching Codex in worktrees
- keep the existing worktree metadata access, but also grant object-store and ref writes needed by `git add` and `git commit`
- extend worker-launcher tests to cover common-dir resolution and both repeatable `--add-dir` flags

## Why
The merged `#978` fix grants access to `.git/worktrees/<name>`, which is enough for `index.lock`, but not for the shared object store and refs under the parent repo's main `.git` directory. A direct Codex smoke test reached the repo hooks only after both paths were added; with only the worktree gitdir, `git add` failed before commit.

## Validation
- `python3 -m pytest -q tests/swarm/test_worker_launcher.py`
- `python3 -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py`
- `python3 -m ruff format --check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py`
