### PR TITLE
fix(swarm): resolve common .git dir for Codex worktree sandbox

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -460,14 +460,18 @@ class WorkerLauncher:
 
     @staticmethod
     def _resolve_worktree_gitdir(worktree_path: str) -> str:
-        """Return the real gitdir for a git worktree, or '' for regular repos.
+        """Return the common git directory for a git worktree, or '' for regular repos.
 
         Git worktrees have a `.git` *file* (not directory) containing
-        ``gitdir: <path>``.  That path points to the parent repo's
-        ``.git/worktrees/<name>/`` directory where the index and lock
-        files live.  The Codex ``--full-auto`` sandbox only allows writes
-        inside the worktree itself, so we need ``--add-dir <gitdir>`` to
-        let ``git add``/``git commit`` create ``index.lock``.
+        ``gitdir: <path>`` pointing to ``.git/worktrees/<name>/``.
+        That worktree-specific dir has a ``commondir`` file pointing
+        back to the parent ``.git/`` directory.
+
+        The Codex ``--full-auto`` sandbox only allows writes inside the
+        worktree itself.  ``git add`` needs write access to both
+        ``.git/worktrees/<name>/`` (index, HEAD) and ``.git/objects/``
+        (blob storage), so we return the common ``.git/`` directory to
+        cover both via a single ``--add-dir``.
         """
         if not worktree_path:
             return ""
@@ -476,11 +480,24 @@ class WorkerLauncher:
             return ""
         try:
             text = dot_git.read_text().strip()
-            if text.startswith("gitdir:"):
-                gitdir = text.split(":", 1)[1].strip()
-                resolved = (dot_git.parent / gitdir).resolve()
-                if resolved.is_dir():
-                    return str(resolved)
+            if not text.startswith("gitdir:"):
+                return ""
+            gitdir = text.split(":", 1)[1].strip()
+            resolved = (dot_git.parent / gitdir).resolve()
+            if not resolved.is_dir():
+                return ""
+            # Resolve the common directory (parent .git/) via commondir
+            # file.  This covers .git/objects/, .git/refs/, and the
+            # worktree-specific .git/worktrees/<name>/ subdirectory.
+            commondir_file = resolved / "commondir"
+            if commondir_file.is_file():
+                commondir = commondir_file.read_text().strip()
+                common = (resolved / commondir).resolve()
+                if common.is_dir():
+                    return str(common)
+            # Fallback to the worktree gitdir itself if commondir
+            # is missing (shouldn't happen in practice).
+            return str(resolved)
         except OSError:
             pass
         return ""

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -169,17 +169,19 @@ class TestBuildCommand:
         assert "-p" in cmd
 
     def test_codex_adds_worktree_gitdir_to_sandbox(self, tmp_path: Path):
-        """Codex in a worktree gets --add-dir pointing to the real gitdir."""
+        """Codex in a worktree gets --add-dir pointing to the common .git dir."""
         wt = tmp_path / "wt"
         wt.mkdir()
-        real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"
+        parent_git = tmp_path / "repo" / ".git"
+        real_gitdir = parent_git / "worktrees" / "wt"
         real_gitdir.mkdir(parents=True)
+        (real_gitdir / "commondir").write_text("../..\n")
         (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
         launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
         cmd = launcher._build_command("codex", "task", str(wt))
         assert "--add-dir" in cmd
         idx = cmd.index("--add-dir")
-        assert cmd[idx + 1] == str(real_gitdir)
+        assert cmd[idx + 1] == str(parent_git.resolve())
         assert "--full-auto" in cmd
 
     def test_codex_no_add_dir_for_regular_repo(self, tmp_path: Path):
@@ -192,8 +194,19 @@ class TestBuildCommand:
         assert "--add-dir" not in cmd
         assert "--full-auto" in cmd
 
-    def test_resolve_worktree_gitdir(self, tmp_path: Path):
-        """Resolves gitdir from a .git file in a worktree."""
+    def test_resolve_worktree_gitdir_returns_common_dir(self, tmp_path: Path):
+        """Resolves to the common .git directory, not the worktree subdir."""
+        wt = tmp_path / "wt"
+        wt.mkdir()
+        parent_git = tmp_path / "repo" / ".git"
+        real_gitdir = parent_git / "worktrees" / "wt"
+        real_gitdir.mkdir(parents=True)
+        (real_gitdir / "commondir").write_text("../..\n")
+        (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
+        assert WorkerLauncher._resolve_worktree_gitdir(str(wt)) == str(parent_git.resolve())
+
+    def test_resolve_worktree_gitdir_fallback_without_commondir(self, tmp_path: Path):
+        """Falls back to worktree gitdir when commondir file is missing."""
         wt = tmp_path / "wt"
         wt.mkdir()
         real_gitdir = tmp_path / "repo" / ".git" / "worktrees" / "wt"


### PR DESCRIPTION
## Summary
- Follow-up to #978 — the worktree-specific `.git/worktrees/<name>/` directory is **not enough** for `--add-dir`
- `git add` also needs write access to `.git/objects/` for blob storage, causing `Operation not permitted` on `git add`
- Fix: resolve the `commondir` file to get the parent `.git/` directory, which covers both objects and worktree index
- **Live-verified**: Codex successfully created, staged, and committed a file in a worktree with this fix (SHA `c61f4efa3`)

## Evidence
With only `.git/worktrees/<name>/` in sandbox:
```
error: unable to create temporary file: Operation not permitted
error: codex_add_dir_smoke.txt: failed to insert into database
fatal: adding files failed
```

With parent `.git/` in sandbox:
```
sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/.../aragora/.git]
git add codex_add_dir_smoke.txt ... succeeded
git commit -m '...' ... succeeded
[detached HEAD c61f4efa3] test: verify add-dir worktree sandbox access
```

## Test plan
- [x] `test_codex_adds_worktree_gitdir_to_sandbox` — verifies `--add-dir` points to common `.git/`
- [x] `test_resolve_worktree_gitdir_returns_common_dir` — commondir resolution
- [x] `test_resolve_worktree_gitdir_fallback_without_commondir` — falls back to worktree gitdir
- [x] `test_codex_no_add_dir_for_regular_repo` — no `--add-dir` for normal repos
- [x] `test_resolve_worktree_gitdir_empty` / `test_resolve_worktree_gitdir_regular_repo`
- [x] All 41 worker launcher tests pass
- [x] Live smoke test: Codex commit succeeded in worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)