### PR TITLE
fix(swarm): strengthen Codex commit-early lane discipline

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -577,12 +577,14 @@ class WorkerLauncher:
 
         if target_agent == "codex":
             parts.append(
-                "Codex lane discipline:\n"
-                "  - If you have a real bounded code change, create a checkpoint commit before long "
-                "or fragile validation.\n"
+                "Codex lane discipline (CRITICAL — commit early):\n"
+                "  - IMMEDIATELY after writing your code changes, run `git add <files> && "
+                'git commit -m "..."` BEFORE running any validation or tests.\n'
+                "  - Do not spend tokens on exploration after code is written — commit first, "
+                "then validate if budget remains.\n"
                 "  - Do not exit 0 with staged or unstaged changes remaining.\n"
-                "  - If validation is slow or fails late, still preserve the bounded deliverable "
-                "with an honest commit message and report the failing command."
+                "  - If validation is slow or fails, the commit still preserves your deliverable "
+                "with an honest commit message."
             )
 
         lease_id = str(work_order.get("lease_id", "")).strip()

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -112,8 +112,9 @@ class TestBuildPrompt:
             }
         )
 
-        assert "Codex lane discipline:" in prompt
-        assert "checkpoint commit before long" in prompt
+        assert "Codex lane discipline (CRITICAL" in prompt
+        assert "IMMEDIATELY after writing" in prompt
+        assert "commit first, then validate" in prompt
         assert "Do not exit 0 with staged or unstaged changes remaining." in prompt
 
     def test_claude_prompt_omits_codex_lane_closure_guidance(self):


### PR DESCRIPTION
## Summary
- Codex workers in B-3 validation wrote code (3 of 5 workers) but never reached `git add`/`git commit` — they ran out of tokens during exploration/writing
- The lane discipline prompt now urgently instructs Codex to commit **immediately after writing code**, before running any validation or tests
- This front-loads the commit so the deliverable is preserved even if the worker exhausts its token budget during validation

## Evidence
B-3 validation run with PR #980:
- subtask_2: **committed** 636 lines (the only worker that reached `git add && git commit`)
- subtask_1: wrote code via `apply_patch` but **never ran `git add`** — 0 git exec commands
- subtask_4: wrote code via `apply_patch` but **never ran `git add`** — 0 git exec commands  
- subtask_5: wrote test file but **never ran `git add`** — 0 git exec commands

## Test plan
- [x] `test_codex_prompt_includes_lane_closure_guidance` — updated assertions
- [x] All 42 worker launcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)