### PR TITLE
feat(ralph): own full spec-to-merge campaign lifecycle

### DIFF
--- a/aragora/cli/commands/ralph.py
+++ b/aragora/cli/commands/ralph.py
@@ -118,6 +118,26 @@ def _cmd_status(state_path: Path, json_output: bool) -> None:
         print(f"  Budget spent: ${d['budget_spent_usd']:.2f}")
         if d.get("active_blocker"):
             print(f"  Active blocker: {d['active_blocker']}")
+        merge_target = (
+            d.get("active_merge_target") if isinstance(d.get("active_merge_target"), dict) else {}
+        )
+        if merge_target:
+            print(f"  Merge target: {merge_target.get('kind', 'unknown')}")
+            if merge_target.get("project_id"):
+                print(f"  Project: {merge_target['project_id']}")
+            if merge_target.get("branch"):
+                print(f"  Branch: {merge_target['branch']}")
+            if merge_target.get("pr_url"):
+                print(f"  PR: {merge_target['pr_url']}")
+            gate = (
+                merge_target.get("last_gate_snapshot")
+                if isinstance(merge_target.get("last_gate_snapshot"), dict)
+                else {}
+            )
+            if gate.get("disposition"):
+                print(f"  Gate disposition: {gate['disposition']}")
+            if gate.get("required_checks_green") is not None:
+                print(f"  Required checks green: {gate['required_checks_green']}")
         task = d.get("active_repair_task") if isinstance(d.get("active_repair_task"), dict) else {}
         if task.get("run_id"):
             print(f"  Repair run: {task['run_id']}")

--- a/aragora/ralph/github_control.py
+++ b/aragora/ralph/github_control.py
@@ -1,0 +1,550 @@
+"""GitHub PR control helpers for Ralph supervisor."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_GITHUB_URL_RE = re.compile(r"https://github\.com/[^\s]+")
+
+
+class GitHubControlError(RuntimeError):
+    """Raised when a GitHub control operation cannot be completed."""
+
+
+@dataclass(slots=True)
+class GitHubCheck:
+    name: str
+    status: str
+    conclusion: str | None = None
+    required: bool = False
+    details_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "conclusion": self.conclusion,
+            "required": self.required,
+            "details_url": self.details_url,
+        }
+
+
+@dataclass(slots=True)
+class GitHubGateSnapshot:
+    pr_url: str
+    state: str
+    draft: bool
+    head_branch: str | None
+    base_branch: str | None
+    review_decision: str | None
+    merge_state_status: str | None
+    merge_commit_sha: str | None
+    required_checks: list[GitHubCheck]
+    advisory_checks: list[GitHubCheck]
+    required_checks_green: bool
+    required_checks_known: bool
+    required_checks_source: str | None
+    disposition: str
+    blocker_detail: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pr_url": self.pr_url,
+            "state": self.state,
+            "draft": self.draft,
+            "head_branch": self.head_branch,
+            "base_branch": self.base_branch,
+            "review_decision": self.review_decision,
+            "merge_state_status": self.merge_state_status,
+            "merge_commit_sha": self.merge_commit_sha,
+            "required_checks": [item.to_dict() for item in self.required_checks],
+            "advisory_checks": [item.to_dict() for item in self.advisory_checks],
+            "required_checks_green": self.required_checks_green,
+            "required_checks_known": self.required_checks_known,
+            "required_checks_source": self.required_checks_source,
+            "disposition": self.disposition,
+            "blocker_detail": self.blocker_detail,
+        }
+
+
+@dataclass(slots=True)
+class GitHubMergeResult:
+    merged: bool
+    action: str
+    used_admin: bool = False
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "merged": self.merged,
+            "action": self.action,
+            "used_admin": self.used_admin,
+            "detail": self.detail,
+        }
+
+
+class GitHubControl:
+    """Thin gh CLI wrapper for Ralph PR discovery, gating, and merge."""
+
+    def __init__(self, *, repo_root: Path) -> None:
+        self.repo_root = repo_root.resolve()
+
+    def find_pr_for_branch(self, branch: str) -> str | None:
+        result = self._run_gh(
+            [
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "all",
+                "--json",
+                "url",
+                "--limit",
+                "1",
+            ],
+            raise_on_error=False,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(payload, list) and payload:
+            first = payload[0]
+            if isinstance(first, dict):
+                return _optional_text(first.get("url"))
+        return None
+
+    def create_pr_for_branch(self, branch: str, target_branch: str) -> str:
+        result = self._run_gh(
+            ["pr", "create", "--fill", "--head", branch, "--base", target_branch],
+            raise_on_error=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise GitHubControlError(detail or "gh pr create failed")
+        url = _extract_first_github_url(result.stdout) or _extract_first_github_url(result.stderr)
+        if not url:
+            raise GitHubControlError("gh pr create succeeded but returned no PR URL")
+        return url
+
+    def fetch_gate_snapshot(self, pr_ref: str) -> GitHubGateSnapshot:
+        view = self._pr_view(pr_ref)
+        pr_url = _optional_text(view.get("url")) or str(pr_ref).strip()
+        state = str(view.get("state", "")).strip().upper()
+        draft = bool(view.get("isDraft", False))
+        head_branch = _optional_text(view.get("headRefName"))
+        base_branch = _optional_text(view.get("baseRefName"))
+        review_decision = _optional_text(view.get("reviewDecision"))
+        merge_state_status = _optional_text(view.get("mergeStateStatus"))
+        merge_commit = view.get("mergeCommit") or {}
+        merge_commit_sha = (
+            _optional_text(merge_commit.get("oid")) if isinstance(merge_commit, dict) else None
+        )
+
+        repo = self._resolve_repo_slug(pr_url)
+        required_contexts, known, source, detail = self._required_status_contexts(
+            repo=repo,
+            base_branch=base_branch,
+        )
+
+        parsed_checks = _parse_status_checks(view.get("statusCheckRollup"))
+        required_checks, advisory_checks, required_green = _partition_checks(
+            parsed_checks,
+            required_contexts=required_contexts,
+            required_known=known,
+        )
+
+        disposition = "merge_now"
+        blocker_detail = detail
+        if state == "MERGED":
+            disposition = "merged"
+        elif state and state != "OPEN":
+            disposition = "blocked_nonreviewable"
+            blocker_detail = blocker_detail or f"PR state is {state}."
+        elif draft:
+            disposition = "wait_for_review"
+        elif review_decision in {"REVIEW_REQUIRED", "CHANGES_REQUESTED"}:
+            disposition = "wait_for_review"
+        elif not known:
+            disposition = "blocked_nonreviewable"
+            blocker_detail = blocker_detail or "Required-check truth could not be determined."
+        elif not required_green:
+            disposition = "wait_for_required_checks"
+        elif merge_state_status == "DIRTY":
+            disposition = "blocked_nonreviewable"
+            blocker_detail = blocker_detail or "PR has merge conflicts."
+
+        return GitHubGateSnapshot(
+            pr_url=pr_url,
+            state=state,
+            draft=draft,
+            head_branch=head_branch,
+            base_branch=base_branch,
+            review_decision=review_decision,
+            merge_state_status=merge_state_status,
+            merge_commit_sha=merge_commit_sha,
+            required_checks=required_checks,
+            advisory_checks=advisory_checks,
+            required_checks_green=required_green,
+            required_checks_known=known,
+            required_checks_source=source,
+            disposition=disposition,
+            blocker_detail=blocker_detail,
+        )
+
+    def merge_pr(
+        self,
+        pr_ref: str,
+        *,
+        required_checks_green: bool,
+        allow_admin: bool,
+    ) -> GitHubMergeResult:
+        if not required_checks_green:
+            return GitHubMergeResult(
+                merged=False,
+                action="blocked",
+                detail="Required checks are not green.",
+            )
+
+        normal = self._run_gh(
+            ["pr", "merge", pr_ref, "--squash"],
+            raise_on_error=False,
+            timeout=30,
+        )
+        if normal.returncode == 0:
+            return GitHubMergeResult(
+                merged=True,
+                action="merge",
+                used_admin=False,
+                detail=(normal.stdout or "").strip(),
+            )
+
+        stderr = (normal.stderr or normal.stdout or "").strip()
+        if allow_admin and _looks_like_admin_override_candidate(stderr):
+            admin = self._run_gh(
+                ["pr", "merge", pr_ref, "--squash", "--admin"],
+                raise_on_error=False,
+                timeout=30,
+            )
+            if admin.returncode == 0:
+                return GitHubMergeResult(
+                    merged=True,
+                    action="merge_admin",
+                    used_admin=True,
+                    detail=(admin.stdout or "").strip(),
+                )
+            stderr = (admin.stderr or admin.stdout or "").strip()
+
+        return GitHubMergeResult(
+            merged=False,
+            action="merge_failed",
+            used_admin=False,
+            detail=stderr or "gh pr merge failed",
+        )
+
+    def _pr_view(self, pr_ref: str) -> dict[str, Any]:
+        result = self._run_gh(
+            [
+                "pr",
+                "view",
+                pr_ref,
+                "--json",
+                ",".join(
+                    [
+                        "url",
+                        "state",
+                        "isDraft",
+                        "headRefName",
+                        "baseRefName",
+                        "reviewDecision",
+                        "mergeStateStatus",
+                        "mergeCommit",
+                        "statusCheckRollup",
+                    ]
+                ),
+            ],
+            timeout=20,
+        )
+        try:
+            payload = json.loads(result.stdout)
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise GitHubControlError(f"gh pr view returned invalid JSON: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise GitHubControlError("gh pr view returned a non-object payload")
+        return payload
+
+    def _required_status_contexts(
+        self,
+        *,
+        repo: str | None,
+        base_branch: str | None,
+    ) -> tuple[set[str], bool, str | None, str | None]:
+        if not repo or not base_branch:
+            return set(), False, None, "Missing repo or base branch for required-check lookup."
+
+        rules_result = self._run_gh(
+            ["api", f"repos/{repo}/rules/branches/{base_branch}"],
+            raise_on_error=False,
+            timeout=20,
+        )
+        if rules_result.returncode == 0:
+            try:
+                payload = json.loads(rules_result.stdout)
+            except (json.JSONDecodeError, ValueError):
+                payload = None
+            contexts = _extract_required_contexts_from_rules(payload)
+            return contexts, True, "ruleset", None
+
+        protection_result = self._run_gh(
+            ["api", f"repos/{repo}/branches/{base_branch}/protection"],
+            raise_on_error=False,
+            timeout=20,
+        )
+        stderr = (protection_result.stderr or "").strip().lower()
+        if protection_result.returncode == 0:
+            try:
+                payload = json.loads(protection_result.stdout)
+            except (json.JSONDecodeError, ValueError):
+                payload = None
+            contexts = _extract_required_contexts_from_protection(payload)
+            return contexts, True, "branch_protection", None
+        if "branch not protected" in stderr or "404" in stderr:
+            return set(), True, "branch_protection", None
+
+        detail = (rules_result.stderr or protection_result.stderr or "").strip()
+        return set(), False, None, detail or "Unable to determine required GitHub checks."
+
+    def _resolve_repo_slug(self, pr_ref: str) -> str | None:
+        parsed = _repo_slug_from_pr_ref(pr_ref)
+        if parsed:
+            return parsed
+
+        result = self._run_gh(
+            ["repo", "view", "--json", "nameWithOwner"],
+            raise_on_error=False,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(payload, dict):
+            return _optional_text(payload.get("nameWithOwner"))
+        return None
+
+    def _run_gh(
+        self,
+        args: list[str],
+        *,
+        raise_on_error: bool = True,
+        timeout: int = 30,
+    ) -> subprocess.CompletedProcess[str]:
+        cmd = ["gh", *args]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                cwd=str(self.repo_root),
+                timeout=timeout,
+                check=False,
+            )
+        except (FileNotFoundError, OSError, subprocess.TimeoutExpired) as exc:
+            raise GitHubControlError(f"{' '.join(cmd)} failed: {exc}") from exc
+
+        if raise_on_error and result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            raise GitHubControlError(detail or f"{' '.join(cmd)} failed")
+        return result
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _extract_first_github_url(text: str | None) -> str | None:
+    if not text:
+        return None
+    match = _GITHUB_URL_RE.search(text)
+    return match.group(0) if match else None
+
+
+def _repo_slug_from_pr_ref(pr_ref: str) -> str | None:
+    text = str(pr_ref).strip()
+    if not text.startswith("http"):
+        return None
+    parsed = urlparse(text)
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) >= 4 and parts[2] == "pull":
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def _looks_like_admin_override_candidate(detail: str) -> bool:
+    lowered = str(detail or "").lower()
+    return any(
+        token in lowered
+        for token in (
+            "admin",
+            "administrator",
+            "repository rules",
+            "protected branch",
+        )
+    )
+
+
+def _extract_required_contexts_from_rules(payload: Any) -> set[str]:
+    contexts: set[str] = set()
+    rules = (
+        payload
+        if isinstance(payload, list)
+        else payload.get("rules", [])
+        if isinstance(payload, dict)
+        else []
+    )
+    if isinstance(rules, dict):
+        rules = [rules]
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        parameters = rule.get("parameters")
+        if not isinstance(parameters, dict):
+            parameters = rule
+        for key in ("required_status_checks", "requiredStatusChecks"):
+            checks = parameters.get(key, [])
+            if not isinstance(checks, list):
+                continue
+            for check in checks:
+                if isinstance(check, dict):
+                    name = _optional_text(
+                        check.get("context") or check.get("name") or check.get("check_name")
+                    )
+                else:
+                    name = _optional_text(check)
+                if name:
+                    contexts.add(name)
+    return contexts
+
+
+def _extract_required_contexts_from_protection(payload: Any) -> set[str]:
+    if not isinstance(payload, dict):
+        return set()
+    contexts: set[str] = set()
+    required = payload.get("required_status_checks") or {}
+    if not isinstance(required, dict):
+        return contexts
+    for name in required.get("contexts", []) or []:
+        text = _optional_text(name)
+        if text:
+            contexts.add(text)
+    for check in required.get("checks", []) or []:
+        if isinstance(check, dict):
+            text = _optional_text(check.get("context") or check.get("name"))
+            if text:
+                contexts.add(text)
+    return contexts
+
+
+def _parse_status_checks(payload: Any) -> list[GitHubCheck]:
+    items: list[Any]
+    if isinstance(payload, dict):
+        if isinstance(payload.get("contexts"), dict):
+            items = payload["contexts"].get("nodes", []) or []
+        else:
+            items = payload.get("nodes", []) or []
+    elif isinstance(payload, list):
+        items = payload
+    else:
+        items = []
+
+    parsed: list[GitHubCheck] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = _optional_text(item.get("context") or item.get("name"))
+        if not name:
+            continue
+        status = _optional_text(item.get("status") or item.get("state")) or "UNKNOWN"
+        conclusion = _optional_text(item.get("conclusion"))
+        details_url = _optional_text(item.get("detailsUrl") or item.get("targetUrl"))
+        parsed.append(
+            GitHubCheck(
+                name=name,
+                status=status.upper(),
+                conclusion=conclusion.upper() if conclusion else None,
+                details_url=details_url,
+            )
+        )
+    return parsed
+
+
+def _partition_checks(
+    checks: list[GitHubCheck],
+    *,
+    required_contexts: set[str],
+    required_known: bool,
+) -> tuple[list[GitHubCheck], list[GitHubCheck], bool]:
+    by_name = {check.name: check for check in checks}
+    required_checks: list[GitHubCheck] = []
+    advisory_checks: list[GitHubCheck] = []
+
+    if required_known:
+        for name in sorted(required_contexts):
+            existing = by_name.get(name)
+            if existing:
+                required_checks.append(
+                    GitHubCheck(
+                        name=existing.name,
+                        status=existing.status,
+                        conclusion=existing.conclusion,
+                        required=True,
+                        details_url=existing.details_url,
+                    )
+                )
+            else:
+                required_checks.append(
+                    GitHubCheck(name=name, status="MISSING", conclusion=None, required=True)
+                )
+
+    advisory_names = set(by_name) - set(required_contexts)
+    for name in sorted(advisory_names):
+        check = by_name[name]
+        advisory_checks.append(
+            GitHubCheck(
+                name=check.name,
+                status=check.status,
+                conclusion=check.conclusion,
+                required=False,
+                details_url=check.details_url,
+            )
+        )
+
+    required_green = required_known and all(_check_is_green(check) for check in required_checks)
+    return required_checks, advisory_checks, required_green
+
+
+def _check_is_green(check: GitHubCheck) -> bool:
+    if check.status in {"QUEUED", "IN_PROGRESS", "PENDING", "EXPECTED", "MISSING", "UNKNOWN"}:
+        return False
+    if check.conclusion:
+        return check.conclusion in {"SUCCESS", "NEUTRAL", "SKIPPED"}
+    return check.status in {"COMPLETED", "SUCCESS"}

--- a/aragora/ralph/supervisor.py
+++ b/aragora/ralph/supervisor.py
@@ -8,7 +8,6 @@ call advances the state machine by exactly one action.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import subprocess
 import uuid
@@ -20,6 +19,7 @@ from typing import Any
 
 import yaml
 
+from aragora.ralph.github_control import GitHubControl, GitHubControlError
 from aragora.ralph.classifier import BlockerKind, classify_blocker
 from aragora.ralph.repair import RepairTask, generate_repair_task
 
@@ -80,6 +80,7 @@ class SupervisorState:
     blocker_history: list[dict[str, Any]] = field(default_factory=list)
     repair_attempts: int = 0
     max_repair_attempts: int = _DEFAULT_MAX_REPAIR_ATTEMPTS
+    active_merge_target: dict[str, Any] | None = None
     active_repair_pr: str | None = None
     active_repair_branch: str | None = None
     active_repair_task: dict[str, Any] | None = None
@@ -91,6 +92,7 @@ class SupervisorState:
     updated_at: str = ""
 
     def to_dict(self) -> dict[str, Any]:
+        compat = _compat_repair_fields_from_target(self.active_merge_target)
         return {
             "supervisor_id": self.supervisor_id,
             "campaign_manifest_path": self.campaign_manifest_path,
@@ -103,9 +105,12 @@ class SupervisorState:
             "blocker_history": list(self.blocker_history),
             "repair_attempts": self.repair_attempts,
             "max_repair_attempts": self.max_repair_attempts,
-            "active_repair_pr": self.active_repair_pr,
-            "active_repair_branch": self.active_repair_branch,
-            "active_repair_task": self.active_repair_task,
+            "active_merge_target": dict(self.active_merge_target)
+            if isinstance(self.active_merge_target, dict) and self.active_merge_target
+            else None,
+            "active_repair_pr": self.active_repair_pr or compat["pr_url"],
+            "active_repair_branch": self.active_repair_branch or compat["branch"],
+            "active_repair_task": self.active_repair_task or compat["task"],
             "merge_commit_sha": self.merge_commit_sha,
             "resume_attempts": self.resume_attempts,
             "resume_cursor": self.resume_cursor,
@@ -116,6 +121,10 @@ class SupervisorState:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SupervisorState:
+        active_merge_target = data.get("active_merge_target")
+        if not isinstance(active_merge_target, dict) or not active_merge_target:
+            active_merge_target = _synthesize_merge_target_from_legacy_fields(data)
+        compat = _compat_repair_fields_from_target(active_merge_target)
         return cls(
             supervisor_id=str(data.get("supervisor_id", "")),
             campaign_manifest_path=str(data.get("campaign_manifest_path", "")),
@@ -128,9 +137,10 @@ class SupervisorState:
             blocker_history=list(data.get("blocker_history") or []),
             repair_attempts=int(data.get("repair_attempts", 0)),
             max_repair_attempts=int(data.get("max_repair_attempts", _DEFAULT_MAX_REPAIR_ATTEMPTS)),
-            active_repair_pr=data.get("active_repair_pr"),
-            active_repair_branch=data.get("active_repair_branch"),
-            active_repair_task=data.get("active_repair_task"),
+            active_merge_target=active_merge_target,
+            active_repair_pr=data.get("active_repair_pr") or compat["pr_url"],
+            active_repair_branch=data.get("active_repair_branch") or compat["branch"],
+            active_repair_task=data.get("active_repair_task") or compat["task"],
             merge_commit_sha=data.get("merge_commit_sha"),
             resume_attempts=int(data.get("resume_attempts", 0)),
             resume_cursor=data.get("resume_cursor"),
@@ -138,6 +148,54 @@ class SupervisorState:
             escalation_reason=data.get("escalation_reason"),
             updated_at=str(data.get("updated_at", "")),
         )
+
+
+def _compat_repair_fields_from_target(
+    target: dict[str, Any] | None,
+) -> dict[str, dict[str, Any] | str | None]:
+    if not isinstance(target, dict) or target.get("kind") != "repair":
+        return {"pr_url": None, "branch": None, "task": None}
+    task = target.get("repair_task")
+    if not isinstance(task, dict):
+        task = None
+    return {
+        "pr_url": _optional_text(target.get("pr_url")),
+        "branch": _optional_text(target.get("branch")),
+        "task": task,
+    }
+
+
+def _synthesize_merge_target_from_legacy_fields(data: dict[str, Any]) -> dict[str, Any] | None:
+    pr_url = _optional_text(data.get("active_repair_pr"))
+    branch = _optional_text(data.get("active_repair_branch"))
+    task = data.get("active_repair_task")
+    if not pr_url and not branch and not isinstance(task, dict):
+        return None
+    target: dict[str, Any] = {
+        "kind": "repair",
+        "project_id": None,
+        "run_id": _optional_text(task.get("run_id")) if isinstance(task, dict) else None,
+        "branch": branch,
+        "pr_url": pr_url,
+        "target_branch": "main",
+        "auto_merge_requested": bool(task.get("auto_merge_requested"))
+        if isinstance(task, dict)
+        else False,
+        "last_gate_snapshot": None,
+        "last_merge_action": None,
+    }
+    if isinstance(task, dict):
+        target["repair_task"] = dict(task)
+    return target
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"none", "null"}:
+        return None
+    return text
 
 
 def load_supervisor_state(path: Path) -> SupervisorState:
@@ -213,6 +271,7 @@ class RalphSupervisor:
         self.repo_root = (repo_root or Path.cwd()).resolve()
         self.merge_policy = merge_policy
         self.repair_budget_usd = repair_budget_usd
+        self.github = GitHubControl(repo_root=self.repo_root)
 
     # -- public API --
 
@@ -316,6 +375,98 @@ class RalphSupervisor:
             detail="Supervisor stopped by operator.",
         )
 
+    def _merge_target(self, state: SupervisorState) -> dict[str, Any] | None:
+        target = state.active_merge_target
+        return dict(target) if isinstance(target, dict) and target else None
+
+    def _set_merge_target(self, state: SupervisorState, target: dict[str, Any] | None) -> None:
+        state.active_merge_target = dict(target) if isinstance(target, dict) and target else None
+        compat = _compat_repair_fields_from_target(state.active_merge_target)
+        state.active_repair_pr = compat["pr_url"] if isinstance(compat["pr_url"], str) else None
+        state.active_repair_branch = compat["branch"] if isinstance(compat["branch"], str) else None
+        state.active_repair_task = compat["task"] if isinstance(compat["task"], dict) else None
+
+    def _clear_merge_target(self, state: SupervisorState) -> None:
+        self._set_merge_target(state, None)
+
+    def _merge_target_run_id(self, state: SupervisorState) -> str | None:
+        target = self._merge_target(state)
+        return _optional_text(target.get("run_id")) if target else None
+
+    def _persist_merge_target_pr(
+        self,
+        state: SupervisorState,
+        *,
+        pr_url: str,
+        branch: str | None = None,
+    ) -> None:
+        target = self._merge_target(state)
+        if not target:
+            return
+        target["pr_url"] = pr_url
+        if branch:
+            target["branch"] = branch
+        self._set_merge_target(state, target)
+
+        if target.get("kind") == "project" and target.get("project_id"):
+            from aragora.swarm.campaign import CampaignExecutor
+
+            executor = CampaignExecutor(
+                manifest_path=Path(state.campaign_manifest_path),
+                repo_root=self.repo_root,
+                target_branch=str(target.get("target_branch") or "main"),
+            )
+            executor.record_project_pr(str(target["project_id"]), pr_url=pr_url)
+
+    def _register_project_merge_target(
+        self,
+        state: SupervisorState,
+        target: dict[str, Any],
+    ) -> tuple[str, str]:
+        merge_target = {
+            "kind": "project",
+            "project_id": _optional_text(target.get("project_id")),
+            "run_id": _optional_text(target.get("run_id")),
+            "branch": _optional_text(target.get("branch")),
+            "pr_url": _optional_text(target.get("pr_url")),
+            "target_branch": _optional_text(target.get("target_branch")) or "main",
+            "auto_merge_requested": False,
+            "last_gate_snapshot": None,
+            "last_merge_action": None,
+        }
+        self._set_merge_target(state, merge_target)
+        if merge_target["pr_url"]:
+            state.status = SupervisorStatus.WAITING_FOR_MERGE.value
+            return state.status, f"Project PR ready: {merge_target['pr_url']}"
+        state.status = SupervisorStatus.WAITING_FOR_PR.value
+        return state.status, (
+            f"Project {merge_target['project_id']} awaiting PR creation for branch "
+            f"{merge_target['branch']}."
+        )
+
+    def _register_repair_merge_target(
+        self,
+        state: SupervisorState,
+        *,
+        task_payload: dict[str, Any],
+        branch: str | None,
+        pr_url: str | None,
+        run_id: str | None,
+    ) -> None:
+        target = {
+            "kind": "repair",
+            "project_id": None,
+            "run_id": run_id,
+            "branch": branch,
+            "pr_url": pr_url,
+            "target_branch": "main",
+            "auto_merge_requested": False,
+            "last_gate_snapshot": None,
+            "last_merge_action": None,
+            "repair_task": dict(task_payload),
+        }
+        self._set_merge_target(state, target)
+
     # -- step implementations --
 
     def _step_campaign_iteration(self, state: SupervisorState) -> StepResult:
@@ -350,6 +501,9 @@ class RalphSupervisor:
         state.last_campaign_result = result
         stop_reason = str(result.get("stop_reason", ""))
         state.last_stop_reason = stop_reason
+        merge_ready_projects = [
+            item for item in result.get("merge_ready_projects", []) if isinstance(item, dict)
+        ]
 
         # Update budget from manifest.
         try:
@@ -358,6 +512,16 @@ class RalphSupervisor:
             state.budget_spent_usd = float(exec_state.get("total_cost_usd", 0.0))
         except Exception:
             pass
+
+        if merge_ready_projects and not self._merge_target(state):
+            next_status, detail = self._register_project_merge_target(
+                state, merge_ready_projects[0]
+            )
+            return StepResult(
+                action=SupervisorAction.CAMPAIGN_ITERATION.value,
+                status=next_status,
+                detail=detail,
+            )
 
         if stop_reason == "campaign_complete":
             state.status = SupervisorStatus.COMPLETED.value
@@ -434,7 +598,6 @@ class RalphSupervisor:
 
         state.repair_attempts += 1
         task_payload = repair.to_dict()
-        state.active_repair_task = task_payload
 
         # Dispatch the repair lane.
         spec = self._build_repair_spec(repair)
@@ -465,12 +628,16 @@ class RalphSupervisor:
         if pr_url:
             task_payload["pr_url"] = pr_url
 
+        self._register_repair_merge_target(
+            state,
+            task_payload=task_payload,
+            branch=branch or None,
+            pr_url=pr_url or None,
+            run_id=run_id,
+        )
         if pr_url:
-            state.active_repair_pr = pr_url
-            state.active_repair_branch = branch or None
             state.status = SupervisorStatus.WAITING_FOR_MERGE.value
         elif branch:
-            state.active_repair_branch = branch
             state.status = SupervisorStatus.WAITING_FOR_PR.value
         elif run_id:
             state.status = SupervisorStatus.WAITING_FOR_PR.value
@@ -488,25 +655,33 @@ class RalphSupervisor:
         )
 
     def _step_check_pr(self, state: SupervisorState) -> StepResult:
-        """Check if a repair PR has been opened."""
-        run_id = self._repair_run_id(state)
-        if run_id and not (state.active_repair_pr or state.active_repair_branch):
+        """Check if the active merge target has a PR yet, creating one if needed."""
+        target = self._merge_target(state)
+        if not target:
+            return self._escalate(state, "No active merge target while waiting for PR.")
+
+        run_id = self._merge_target_run_id(state)
+        if run_id and not (
+            _optional_text(target.get("pr_url")) or _optional_text(target.get("branch"))
+        ):
             run_dict = self._refresh_dispatch_run(run_id)
             if run_dict:
                 branch, pr_url = self._update_repair_tracking_from_run(state, run_dict)
                 if pr_url:
+                    self._persist_merge_target_pr(state, pr_url=pr_url, branch=branch)
                     state.status = SupervisorStatus.WAITING_FOR_MERGE.value
                     return StepResult(
                         action=SupervisorAction.PR_CHECKED.value,
                         status=SupervisorStatus.WAITING_FOR_MERGE.value,
-                        detail=f"PR discovered from repair run: {pr_url}. Waiting for merge.",
+                        detail=f"PR discovered from run: {pr_url}. Waiting for merge.",
                     )
                 if branch:
+                    target = self._merge_target(state) or target
                     state.status = SupervisorStatus.WAITING_FOR_PR.value
                     return StepResult(
                         action=SupervisorAction.PR_CHECKED.value,
                         status=SupervisorStatus.WAITING_FOR_PR.value,
-                        detail=f"Repair branch discovered from run: {branch}. Waiting for PR.",
+                        detail=f"Branch discovered from run: {branch}. Waiting for PR.",
                     )
                 if str(run_dict.get("status", "")).strip() in {
                     "completed",
@@ -514,29 +689,45 @@ class RalphSupervisor:
                 }:
                     return self._escalate(
                         state,
-                        "Repair run reached a terminal state without a tracked branch or PR.",
+                        "Tracked run reached a terminal state without a branch or PR.",
                     )
 
-        if state.active_repair_pr:
-            # PR exists, wait for merge.
+        target = self._merge_target(state) or target
+        pr_url = _optional_text(target.get("pr_url"))
+        branch = _optional_text(target.get("branch"))
+
+        if pr_url:
             state.status = SupervisorStatus.WAITING_FOR_MERGE.value
             return StepResult(
                 action=SupervisorAction.PR_CHECKED.value,
                 status=SupervisorStatus.WAITING_FOR_MERGE.value,
-                detail=f"PR found: {state.active_repair_pr}. Waiting for merge.",
+                detail=f"PR found: {pr_url}. Waiting for merge.",
             )
 
-        # Check if a PR was created on the repair branch.
-        if state.active_repair_branch:
-            pr_url = self._find_pr_for_branch(state.active_repair_branch)
-            if pr_url:
-                state.active_repair_pr = pr_url
+        if branch:
+            discovered = self._find_pr_for_branch(branch)
+            if discovered:
+                self._persist_merge_target_pr(state, pr_url=discovered, branch=branch)
                 state.status = SupervisorStatus.WAITING_FOR_MERGE.value
                 return StepResult(
                     action=SupervisorAction.PR_CHECKED.value,
                     status=SupervisorStatus.WAITING_FOR_MERGE.value,
-                    detail=f"PR discovered: {pr_url}. Waiting for merge.",
+                    detail=f"PR discovered: {discovered}. Waiting for merge.",
                 )
+            try:
+                created = self._create_pr_for_branch(
+                    branch=branch,
+                    target_branch=str(target.get("target_branch") or "main"),
+                )
+            except GitHubControlError as exc:
+                return self._escalate(state, f"PR creation failed: {exc}")
+            self._persist_merge_target_pr(state, pr_url=created, branch=branch)
+            state.status = SupervisorStatus.WAITING_FOR_MERGE.value
+            return StepResult(
+                action=SupervisorAction.PR_CHECKED.value,
+                status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                detail=f"PR created: {created}. Waiting for merge.",
+            )
 
         return StepResult(
             action=SupervisorAction.PR_CHECKED.value,
@@ -545,8 +736,12 @@ class RalphSupervisor:
         )
 
     def _step_check_merge(self, state: SupervisorState) -> StepResult:
-        """Check if the repair PR has been merged."""
-        pr_url = state.active_repair_pr
+        """Check gate truth and merge status for the active PR target."""
+        target = self._merge_target(state)
+        if not target:
+            return self._escalate(state, "No active merge target while waiting for merge.")
+
+        pr_url = _optional_text(target.get("pr_url"))
         if not pr_url:
             state.status = SupervisorStatus.WAITING_FOR_PR.value
             return StepResult(
@@ -555,27 +750,103 @@ class RalphSupervisor:
                 detail="No PR URL. Reverting to waiting_for_pr.",
             )
 
-        merged, merge_sha = self._check_pr_merged(pr_url)
-        if not merged:
-            # Optionally trigger auto-merge when policy allows (once per PR).
-            if self.merge_policy == "admin_merge_allowed":
-                task = dict(state.active_repair_task or {})
-                if not task.get("auto_merge_requested"):
-                    if self._auto_merge_pr(pr_url):
-                        task["auto_merge_requested"] = True
-                        state.active_repair_task = task
+        try:
+            snapshot = self._fetch_pr_gate_snapshot(pr_url)
+        except GitHubControlError as exc:
+            return self._escalate(state, f"GitHub gate lookup failed: {exc}")
+
+        target["last_gate_snapshot"] = snapshot.to_dict()
+        self._set_merge_target(state, target)
+
+        if snapshot.disposition == "merged":
+            state.merge_commit_sha = snapshot.merge_commit_sha
+            if target.get("kind") == "repair":
+                state.status = SupervisorStatus.RESUMING.value
+                return StepResult(
+                    action=SupervisorAction.PR_CHECKED.value,
+                    status=SupervisorStatus.RESUMING.value,
+                    detail=f"PR merged (SHA: {snapshot.merge_commit_sha}). Ready to resume campaign.",
+                )
+            project_id = _optional_text(target.get("project_id"))
+            if not project_id:
+                return self._escalate(state, "Merged project target is missing project_id.")
+            if snapshot.merge_commit_sha:
+                sync_result = self._synchronize_merged_commit(snapshot.merge_commit_sha)
+                if not sync_result["ok"]:
+                    return StepResult(
+                        action=SupervisorAction.NOOP.value,
+                        status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                        detail=str(sync_result["detail"]),
+                    )
+            from aragora.swarm.campaign import CampaignExecutor
+
+            executor = CampaignExecutor(
+                manifest_path=Path(state.campaign_manifest_path),
+                repo_root=self.repo_root,
+                target_branch=str(target.get("target_branch") or "main"),
+            )
+            executor.complete_project(
+                project_id,
+                pr_url=pr_url,
+                merge_sha=snapshot.merge_commit_sha,
+            )
+            self._clear_merge_target(state)
+            state.merge_commit_sha = None
+            state.resume_attempts = 0
+            state.status = SupervisorStatus.RUNNING.value
+            return StepResult(
+                action=SupervisorAction.CAMPAIGN_ITERATION.value,
+                status=SupervisorStatus.RUNNING.value,
+                detail=f"Project {project_id} completed after merge {pr_url}.",
+            )
+
+        if snapshot.disposition == "blocked_nonreviewable":
+            return self._escalate(
+                state,
+                snapshot.blocker_detail or f"PR {pr_url} is blocked in a non-reviewable state.",
+            )
+
+        if snapshot.disposition in {"wait_for_review", "wait_for_required_checks"}:
             return StepResult(
                 action=SupervisorAction.PR_CHECKED.value,
                 status=SupervisorStatus.WAITING_FOR_MERGE.value,
-                detail=f"PR {pr_url} not yet merged.",
+                detail=snapshot.blocker_detail or f"PR {pr_url} waiting on merge gates.",
             )
 
-        state.merge_commit_sha = merge_sha
-        state.status = SupervisorStatus.RESUMING.value
+        if snapshot.disposition == "merge_now":
+            if self.merge_policy != "admin_merge_allowed":
+                return StepResult(
+                    action=SupervisorAction.PR_CHECKED.value,
+                    status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                    detail=f"PR {pr_url} is merge-ready and awaiting manual merge.",
+                )
+            target = self._merge_target(state) or target
+            if target.get("auto_merge_requested"):
+                return StepResult(
+                    action=SupervisorAction.PR_CHECKED.value,
+                    status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                    detail=f"Merge already requested for {pr_url}; waiting for GitHub to confirm.",
+                )
+            merge_result = self._merge_pr(
+                pr_url,
+                required_checks_green=snapshot.required_checks_green,
+                allow_admin=True,
+            )
+            target["auto_merge_requested"] = True
+            target["last_merge_action"] = merge_result.to_dict()
+            self._set_merge_target(state, target)
+            if merge_result.merged:
+                return StepResult(
+                    action=SupervisorAction.PR_CHECKED.value,
+                    status=SupervisorStatus.WAITING_FOR_MERGE.value,
+                    detail=f"Merge initiated for {pr_url}; waiting for GitHub to confirm.",
+                )
+            return self._escalate(state, merge_result.detail or f"Failed to merge {pr_url}.")
+
         return StepResult(
             action=SupervisorAction.PR_CHECKED.value,
-            status=SupervisorStatus.RESUMING.value,
-            detail=f"PR merged (SHA: {merge_sha}). Ready to resume campaign.",
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            detail=f"PR {pr_url} not yet merged.",
         )
 
     def _step_resume(self, state: SupervisorState) -> StepResult:
@@ -695,9 +966,7 @@ class RalphSupervisor:
         reconciled = self._reconcile_manifest_projects(state, affected_ids)
 
         state.active_blocker = None
-        state.active_repair_pr = None
-        state.active_repair_branch = None
-        state.active_repair_task = None
+        self._clear_merge_target(state)
         state.merge_commit_sha = None
         state.repair_attempts = 0
         state.resume_attempts = 0
@@ -728,12 +997,64 @@ class RalphSupervisor:
             logger.debug("git merge-base --is-ancestor failed: %s", exc)
             return False
 
+    def _synchronize_merged_commit(self, merge_sha: str) -> dict[str, Any]:
+        """Fetch origin/main and fast-forward the worktree until *merge_sha* is present."""
+        try:
+            fetch = subprocess.run(
+                ["git", "fetch", "origin", "main"],
+                capture_output=True,
+                cwd=str(self.repo_root),
+                timeout=30,
+            )
+            if fetch.returncode != 0:
+                return {"ok": False, "detail": "git fetch origin main failed."}
+        except Exception as exc:
+            return {"ok": False, "detail": f"git fetch origin main raised: {type(exc).__name__}."}
+
+        if not self._is_ancestor(merge_sha, "origin/main"):
+            return {
+                "ok": False,
+                "detail": f"Merge commit {merge_sha} is not an ancestor of origin/main yet.",
+            }
+
+        if self._is_ancestor(merge_sha, "HEAD"):
+            return {"ok": True, "detail": f"Merge commit {merge_sha} already present in HEAD."}
+
+        try:
+            ff = subprocess.run(
+                ["git", "merge", "--ff-only", "origin/main"],
+                capture_output=True,
+                cwd=str(self.repo_root),
+                timeout=30,
+            )
+            if ff.returncode != 0:
+                return {
+                    "ok": False,
+                    "detail": f"Worktree could not fast-forward to include {merge_sha}.",
+                }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "detail": f"git merge --ff-only raised: {type(exc).__name__}.",
+            }
+
+        if not self._is_ancestor(merge_sha, "HEAD"):
+            return {
+                "ok": False,
+                "detail": f"Merge commit {merge_sha} still not reachable from HEAD.",
+            }
+        return {"ok": True, "detail": f"Merge commit {merge_sha} synchronized into HEAD."}
+
     # -- resume reconciliation --
 
     @staticmethod
     def _affected_project_ids(state: SupervisorState) -> list[str]:
         """Extract affected project IDs from the active repair task."""
         task = state.active_repair_task if isinstance(state.active_repair_task, dict) else {}
+        if not task and isinstance(state.active_merge_target, dict):
+            maybe_task = state.active_merge_target.get("repair_task")
+            if isinstance(maybe_task, dict):
+                task = maybe_task
         ids = task.get("affected_project_ids", [])
         return [str(pid) for pid in ids if str(pid).strip()] if isinstance(ids, list) else []
 
@@ -831,27 +1152,12 @@ class RalphSupervisor:
         return spec
 
     def _auto_merge_pr(self, pr_url: str) -> bool:
-        """Attempt to auto-merge a PR via gh CLI. Returns True if merge was initiated."""
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "merge", pr_url, "--squash", "--auto"],
-                capture_output=True,
-                text=True,
-                cwd=str(self.repo_root),
-                timeout=30,
-            )
-            if result.returncode == 0:
-                logger.info("Auto-merge initiated for %s", pr_url)
-                return True
-            logger.debug("gh pr merge failed (rc=%d): %s", result.returncode, result.stderr)
-        except Exception as exc:
-            logger.debug("gh pr merge raised: %s", exc)
-        return False
+        """Backward-compatible wrapper around GitHubControl.merge_pr()."""
+        result = self._merge_pr(pr_url, required_checks_green=True, allow_admin=True)
+        return result.merged
 
     def _repair_run_id(self, state: SupervisorState) -> str | None:
-        task = state.active_repair_task if isinstance(state.active_repair_task, dict) else {}
-        text = str(task.get("run_id", "")).strip()
-        return text or None
+        return self._merge_target_run_id(state)
 
     def _refresh_dispatch_run(self, run_id: str) -> dict[str, Any] | None:
         from aragora.swarm.supervisor import SwarmSupervisor
@@ -868,7 +1174,8 @@ class RalphSupervisor:
         state: SupervisorState,
         run_dict: dict[str, Any],
     ) -> tuple[str | None, str | None]:
-        task = dict(state.active_repair_task or {})
+        target = self._merge_target(state) or {}
+        task = dict(state.active_repair_task or target.get("repair_task") or {})
         branch: str | None = None
         pr_url: str | None = None
         for item in run_dict.get("work_orders", []):
@@ -880,13 +1187,14 @@ class RalphSupervisor:
             if isinstance(meta, dict):
                 pr_url = pr_url or str(meta.get("pull_request_url", "")).strip() or None
         if branch:
-            state.active_repair_branch = branch
+            target["branch"] = branch
             task["branch"] = branch
         if pr_url:
-            state.active_repair_pr = pr_url
+            target["pr_url"] = pr_url
             task["pr_url"] = pr_url
         task["run_status"] = str(run_dict.get("status", "")).strip()
-        state.active_repair_task = task
+        target["repair_task"] = task
+        self._set_merge_target(state, target)
         return branch, pr_url
 
     def _escalate(self, state: SupervisorState, reason: str) -> StepResult:
@@ -900,51 +1208,28 @@ class RalphSupervisor:
         )
 
     def _find_pr_for_branch(self, branch: str) -> str | None:
-        """Use gh CLI to find a PR (open or merged) for the given branch."""
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "list",
-                    "--head",
-                    branch,
-                    "--state",
-                    "all",
-                    "--json",
-                    "url",
-                    "--limit",
-                    "1",
-                ],
-                capture_output=True,
-                text=True,
-                cwd=str(self.repo_root),
-                timeout=15,
-            )
-            if result.returncode == 0:
-                prs = json.loads(result.stdout)
-                if prs and isinstance(prs, list):
-                    return str(prs[0].get("url", ""))
-        except Exception as exc:
-            logger.debug("gh pr list failed: %s", exc)
-        return None
+        return self.github.find_pr_for_branch(branch)
+
+    def _create_pr_for_branch(self, *, branch: str, target_branch: str) -> str:
+        return self.github.create_pr_for_branch(branch, target_branch)
+
+    def _fetch_pr_gate_snapshot(self, pr_url: str) -> Any:
+        return self.github.fetch_gate_snapshot(pr_url)
+
+    def _merge_pr(
+        self,
+        pr_url: str,
+        *,
+        required_checks_green: bool,
+        allow_admin: bool,
+    ) -> Any:
+        return self.github.merge_pr(
+            pr_url,
+            required_checks_green=required_checks_green,
+            allow_admin=allow_admin,
+        )
 
     def _check_pr_merged(self, pr_url: str) -> tuple[bool, str | None]:
-        """Check if a PR has been merged using gh CLI."""
-        try:
-            result = subprocess.run(
-                ["gh", "pr", "view", pr_url, "--json", "state,mergeCommit"],
-                capture_output=True,
-                text=True,
-                cwd=str(self.repo_root),
-                timeout=15,
-            )
-            if result.returncode == 0:
-                data = json.loads(result.stdout)
-                if data.get("state") == "MERGED":
-                    merge_commit = data.get("mergeCommit", {})
-                    sha = str(merge_commit.get("oid", "")) if merge_commit else None
-                    return True, sha
-        except Exception as exc:
-            logger.debug("gh pr view failed: %s", exc)
-        return False, None
+        """Backward-compatible merge-status helper used by existing tests."""
+        snapshot = self._fetch_pr_gate_snapshot(pr_url)
+        return snapshot.disposition == "merged", snapshot.merge_commit_sha

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -37,6 +37,16 @@ UTC = timezone.utc
 DEFAULT_CAMPAIGN_MANIFEST = ".aragora/campaign_manifest.yaml"
 _BUDGET_EPSILON = 1e-9
 
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or text.lower() in {"none", "null"}:
+        return None
+    return text
+
+
 # Statuses that represent terminal project transitions (no further retries).
 # Receipt emission fires only for these statuses.
 _TERMINAL_STATUSES: frozenset[str] = frozenset(
@@ -55,6 +65,8 @@ class CampaignProjectStatus(str, Enum):
     READY = "ready"
     ACTIVE = "active"
     DELIVERED = "delivered"
+    WAITING_FOR_PR = "waiting_for_pr"
+    WAITING_FOR_MERGE = "waiting_for_merge"
     NEEDS_REVISION = "needs_revision"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -134,7 +146,7 @@ class CampaignReviewGate:
             status=str(data.get("status", CampaignReviewStatus.PENDING.value)).strip()
             or CampaignReviewStatus.PENDING.value,
             findings=[str(item) for item in data.get("findings", []) if str(item).strip()],
-            reviewed_at=str(data.get("reviewed_at", "")).strip() or None,
+            reviewed_at=_optional_text(data.get("reviewed_at")),
             raw_review=dict(data.get("raw_review") or {}),
         )
 
@@ -260,13 +272,13 @@ class CampaignProject:
             status=str(data.get("status", CampaignProjectStatus.PENDING.value)).strip()
             or CampaignProjectStatus.PENDING.value,
             retry_count=int(data.get("retry_count", 0) or 0),
-            last_run_outcome=str(data.get("last_run_outcome", "")).strip() or None,
-            run_id=str(data.get("run_id", "")).strip() or None,
-            worker_receipt_id=str(data.get("worker_receipt_id", "")).strip() or None,
-            receipt_id=str(data.get("receipt_id", "")).strip() or None,
-            pr_url=str(data.get("pr_url", "")).strip() or None,
-            adopted_pr=str(data.get("adopted_pr", "")).strip() or None,
-            branch=str(data.get("branch", "")).strip() or None,
+            last_run_outcome=_optional_text(data.get("last_run_outcome")),
+            run_id=_optional_text(data.get("run_id")),
+            worker_receipt_id=_optional_text(data.get("worker_receipt_id")),
+            receipt_id=_optional_text(data.get("receipt_id")),
+            pr_url=_optional_text(data.get("pr_url")),
+            adopted_pr=_optional_text(data.get("adopted_pr")),
+            branch=_optional_text(data.get("branch")),
             commit_shas=[str(item) for item in data.get("commit_shas", []) if str(item).strip()],
             attempt_history=[
                 dict(item) for item in data.get("attempt_history", []) if isinstance(item, dict)
@@ -349,8 +361,8 @@ class CampaignManifest:
             worker_model=worker_model,
             review_model=review_model,
             enforce_cross_model_review=enforce_cross_model_review,
-            experiment_id=str(data.get("experiment_id", "")).strip() or None,
-            experiment_label=str(data.get("experiment_label", "")).strip() or None,
+            experiment_id=_optional_text(data.get("experiment_id")),
+            experiment_label=_optional_text(data.get("experiment_label")),
             max_parallel_ready_projects=max(
                 1, int(data.get("max_parallel_ready_projects", 2) or 2)
             ),
@@ -1109,6 +1121,9 @@ class CampaignExecutor:
                     "stop_reason": stop_reason,
                     "dispatched_projects": [],
                     "budget": budget_snapshot,
+                    "merge_ready_projects": _merge_ready_projects(
+                        manifest, target_branch=self.target_branch
+                    ),
                 }
                 if blocked_projects:
                     manifest.execution_state.last_result["budget_blocked_projects"] = (
@@ -1133,6 +1148,9 @@ class CampaignExecutor:
                     "stop_reason": CampaignStopReason.STILL_RUNNING.value,
                     "dispatched_projects": [],
                     "budget": budget_snapshot,
+                    "merge_ready_projects": _merge_ready_projects(
+                        manifest, target_branch=self.target_branch
+                    ),
                 }
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
@@ -1154,6 +1172,9 @@ class CampaignExecutor:
                     "stop_reason": stop_reason,
                     "dispatched_projects": [],
                     "budget": budget_snapshot,
+                    "merge_ready_projects": _merge_ready_projects(
+                        manifest, target_branch=self.target_branch
+                    ),
                 }
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
@@ -1169,6 +1190,9 @@ class CampaignExecutor:
                     "dispatched_projects": [],
                     "budget": budget_snapshot,
                     "budget_blocked_projects": budget_blocked_ids,
+                    "merge_ready_projects": _merge_ready_projects(
+                        manifest, target_branch=self.target_branch
+                    ),
                 }
                 _refresh_execution_state(manifest)
                 save_campaign_manifest(self.manifest_path, manifest)
@@ -1182,6 +1206,9 @@ class CampaignExecutor:
                 "stop_reason": CampaignStopReason.STILL_RUNNING.value,
                 "dispatched_projects": list(selected_ids),
                 "budget": _campaign_budget_snapshot(manifest),
+                "merge_ready_projects": _merge_ready_projects(
+                    manifest, target_branch=self.target_branch
+                ),
             }
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
@@ -1197,6 +1224,9 @@ class CampaignExecutor:
                 "stop_reason": _compute_stop_reason(manifest),
                 "dispatched_projects": dispatched,
                 "budget": _campaign_budget_snapshot(manifest),
+                "merge_ready_projects": _merge_ready_projects(
+                    manifest, target_branch=self.target_branch
+                ),
             }
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
@@ -1238,6 +1268,76 @@ class CampaignExecutor:
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
             return {"project_id": project_id, "review": gate.to_dict(), "status": project.status}
+
+    def record_project_pr(self, project_id: str, *, pr_url: str) -> dict[str, Any]:
+        """Persist PR discovery or creation for a project awaiting merge."""
+        normalized_pr_url = str(pr_url).strip()
+        if not normalized_pr_url:
+            raise ValueError("pr_url is required")
+
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            project = manifest.project_map().get(project_id)
+            if project is None:
+                raise KeyError(f"Unknown project_id: {project_id}")
+            if project.status not in {
+                CampaignProjectStatus.WAITING_FOR_PR.value,
+                CampaignProjectStatus.WAITING_FOR_MERGE.value,
+            }:
+                raise ValueError(
+                    f"Project {project_id} is not waiting for PR/merge (status={project.status})."
+                )
+
+            project.pr_url = normalized_pr_url
+            project.status = CampaignProjectStatus.WAITING_FOR_MERGE.value
+            _refresh_execution_state(manifest)
+            save_campaign_manifest(self.manifest_path, manifest)
+            return {
+                "project_id": project.project_id,
+                "status": project.status,
+                "pr_url": project.pr_url,
+            }
+
+    def complete_project(
+        self,
+        project_id: str,
+        *,
+        pr_url: str | None = None,
+        merge_sha: str | None = None,
+    ) -> dict[str, Any]:
+        """Mark a PR-backed project completed after the merge lands."""
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            project = manifest.project_map().get(project_id)
+            if project is None:
+                raise KeyError(f"Unknown project_id: {project_id}")
+            if project.status not in {
+                CampaignProjectStatus.WAITING_FOR_PR.value,
+                CampaignProjectStatus.WAITING_FOR_MERGE.value,
+            }:
+                raise ValueError(
+                    f"Project {project_id} is not waiting for PR/merge (status={project.status})."
+                )
+
+            normalized_pr_url = str(pr_url or "").strip()
+            normalized_merge_sha = str(merge_sha or "").strip()
+            if normalized_pr_url:
+                project.pr_url = normalized_pr_url
+            if normalized_merge_sha and normalized_merge_sha not in project.commit_shas:
+                project.commit_shas.append(normalized_merge_sha)
+            project.status = CampaignProjectStatus.COMPLETED.value
+
+            run_dict = self._refresh_run_dict(project.run_id) if project.run_id else None
+            self._emit_receipt(manifest, project, run_dict)
+            _refresh_execution_state(manifest)
+            save_campaign_manifest(self.manifest_path, manifest)
+            return {
+                "project_id": project.project_id,
+                "status": project.status,
+                "pr_url": project.pr_url,
+                "merge_sha": normalized_merge_sha or None,
+                "receipt_id": project.receipt_id,
+            }
 
     def sync_issue_plan(self) -> dict[str, Any]:
         with locked_manifest_path(self.manifest_path):
@@ -1450,7 +1550,12 @@ class CampaignExecutor:
         project.review = gate
 
         if gate.status == CampaignReviewStatus.PASSED.value:
-            project.status = CampaignProjectStatus.COMPLETED.value
+            if _project_pr_reference(project):
+                project.status = CampaignProjectStatus.WAITING_FOR_MERGE.value
+            elif project.branch:
+                project.status = CampaignProjectStatus.WAITING_FOR_PR.value
+            else:
+                project.status = CampaignProjectStatus.COMPLETED.value
         elif gate.status == CampaignReviewStatus.CHANGES_REQUESTED.value:
             project.status = CampaignProjectStatus.NEEDS_REVISION.value
         else:
@@ -1912,7 +2017,12 @@ def _refresh_execution_state(manifest: CampaignManifest) -> None:
     manifest.execution_state.active_projects = [
         project.project_id
         for project in manifest.projects
-        if project.status == CampaignProjectStatus.ACTIVE.value
+        if project.status
+        in {
+            CampaignProjectStatus.ACTIVE.value,
+            CampaignProjectStatus.WAITING_FOR_PR.value,
+            CampaignProjectStatus.WAITING_FOR_MERGE.value,
+        }
     ]
     manifest.execution_state.completed_projects = [
         project.project_id
@@ -2018,6 +2128,8 @@ def _compute_stop_reason(manifest: CampaignManifest) -> str:
     active_statuses = {
         CampaignProjectStatus.ACTIVE.value,
         CampaignProjectStatus.DELIVERED.value,
+        CampaignProjectStatus.WAITING_FOR_PR.value,
+        CampaignProjectStatus.WAITING_FOR_MERGE.value,
     }
     active_present = bool(statuses & active_statuses)
 
@@ -2103,6 +2215,40 @@ def _compute_stop_reason(manifest: CampaignManifest) -> str:
             if not dependency_free:
                 return CampaignStopReason.CAMPAIGN_BLOCKED.value
     return CampaignStopReason.STILL_RUNNING.value
+
+
+def _project_pr_reference(project: CampaignProject) -> str | None:
+    for candidate in (project.pr_url, project.adopted_pr):
+        text = str(candidate or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _merge_ready_projects(
+    manifest: CampaignManifest,
+    *,
+    target_branch: str,
+) -> list[dict[str, Any]]:
+    ready: list[dict[str, Any]] = []
+    for project in manifest.projects:
+        if project.status not in {
+            CampaignProjectStatus.WAITING_FOR_PR.value,
+            CampaignProjectStatus.WAITING_FOR_MERGE.value,
+        }:
+            continue
+        ready.append(
+            {
+                "project_id": project.project_id,
+                "kind": "project",
+                "status": project.status,
+                "pr_url": _project_pr_reference(project),
+                "branch": project.branch,
+                "run_id": project.run_id,
+                "target_branch": target_branch,
+            }
+        )
+    return ready
 
 
 def _extract_first_json_object(text: str) -> dict[str, Any]:

--- a/tests/ralph/test_github_control.py
+++ b/tests/ralph/test_github_control.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.ralph.github_control import GitHubControl, GitHubControlError
+
+
+def _completed_process(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+):
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+class TestGitHubControlBranchDiscovery:
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_find_pr_for_branch_returns_url(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(
+            stdout=json.dumps([{"url": "https://github.com/org/repo/pull/42"}])
+        )
+
+        control = GitHubControl(repo_root=tmp_path)
+        assert control.find_pr_for_branch("codex/test") == "https://github.com/org/repo/pull/42"
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_find_pr_for_branch_returns_none_when_absent(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(stdout="[]")
+
+        control = GitHubControl(repo_root=tmp_path)
+        assert control.find_pr_for_branch("codex/test") is None
+
+
+class TestGitHubControlPRCreation:
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_create_pr_for_branch_returns_url(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(stdout="https://github.com/org/repo/pull/77\n")
+
+        control = GitHubControl(repo_root=tmp_path)
+        pr_url = control.create_pr_for_branch("codex/test", "main")
+
+        assert pr_url == "https://github.com/org/repo/pull/77"
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_create_pr_for_branch_raises_on_error(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(returncode=1, stderr="auth failed")
+
+        control = GitHubControl(repo_root=tmp_path)
+        with pytest.raises(GitHubControlError, match="auth failed"):
+            control.create_pr_for_branch("codex/test", "main")
+
+
+class TestGitHubControlGateSnapshots:
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_fetch_gate_snapshot_detects_merged_pr(self, mock_run, tmp_path: Path) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                stdout=json.dumps(
+                    {
+                        "url": "https://github.com/org/repo/pull/55",
+                        "state": "MERGED",
+                        "isDraft": False,
+                        "headRefName": "codex/test",
+                        "baseRefName": "main",
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "CLEAN",
+                        "mergeCommit": {"oid": "merge-sha"},
+                        "statusCheckRollup": [],
+                    }
+                )
+            ),
+            _completed_process(stdout=json.dumps([])),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        snapshot = control.fetch_gate_snapshot("https://github.com/org/repo/pull/55")
+
+        assert snapshot.disposition == "merged"
+        assert snapshot.merge_commit_sha == "merge-sha"
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_fetch_gate_snapshot_waits_for_review(self, mock_run, tmp_path: Path) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                stdout=json.dumps(
+                    {
+                        "url": "https://github.com/org/repo/pull/55",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "codex/test",
+                        "baseRefName": "main",
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "mergeStateStatus": "BLOCKED",
+                        "mergeCommit": None,
+                        "statusCheckRollup": [],
+                    }
+                )
+            ),
+            _completed_process(stdout=json.dumps([])),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        snapshot = control.fetch_gate_snapshot("https://github.com/org/repo/pull/55")
+
+        assert snapshot.disposition == "wait_for_review"
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_fetch_gate_snapshot_waits_for_required_checks(self, mock_run, tmp_path: Path) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                stdout=json.dumps(
+                    {
+                        "url": "https://github.com/org/repo/pull/55",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "codex/test",
+                        "baseRefName": "main",
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "BLOCKED",
+                        "mergeCommit": None,
+                        "statusCheckRollup": [
+                            {"context": "ci/unit", "state": "PENDING"},
+                            {"context": "lint", "state": "SUCCESS"},
+                        ],
+                    }
+                )
+            ),
+            _completed_process(
+                stdout=json.dumps(
+                    [
+                        {
+                            "parameters": {
+                                "required_status_checks": [
+                                    {"context": "ci/unit"},
+                                ]
+                            }
+                        }
+                    ]
+                )
+            ),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        snapshot = control.fetch_gate_snapshot("https://github.com/org/repo/pull/55")
+
+        assert snapshot.disposition == "wait_for_required_checks"
+        assert snapshot.required_checks_green is False
+        assert [check.name for check in snapshot.required_checks] == ["ci/unit"]
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_fetch_gate_snapshot_ignores_advisory_failures_when_required_green(
+        self, mock_run, tmp_path: Path
+    ) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                stdout=json.dumps(
+                    {
+                        "url": "https://github.com/org/repo/pull/55",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "codex/test",
+                        "baseRefName": "main",
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "CLEAN",
+                        "mergeCommit": None,
+                        "statusCheckRollup": [
+                            {"context": "ci/unit", "state": "SUCCESS"},
+                            {"context": "lint", "state": "FAILURE"},
+                        ],
+                    }
+                )
+            ),
+            _completed_process(
+                stdout=json.dumps(
+                    [
+                        {
+                            "parameters": {
+                                "required_status_checks": [
+                                    {"context": "ci/unit"},
+                                ]
+                            }
+                        }
+                    ]
+                )
+            ),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        snapshot = control.fetch_gate_snapshot("https://github.com/org/repo/pull/55")
+
+        assert snapshot.disposition == "merge_now"
+        assert snapshot.required_checks_green is True
+        assert [check.name for check in snapshot.advisory_checks] == ["lint"]
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_fetch_gate_snapshot_fails_closed_when_required_truth_unknown(
+        self, mock_run, tmp_path: Path
+    ) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                stdout=json.dumps(
+                    {
+                        "url": "https://github.com/org/repo/pull/55",
+                        "state": "OPEN",
+                        "isDraft": False,
+                        "headRefName": "codex/test",
+                        "baseRefName": "main",
+                        "reviewDecision": "APPROVED",
+                        "mergeStateStatus": "CLEAN",
+                        "mergeCommit": None,
+                        "statusCheckRollup": [{"context": "ci/unit", "state": "SUCCESS"}],
+                    }
+                )
+            ),
+            _completed_process(returncode=1, stderr="rules api unavailable"),
+            _completed_process(returncode=1, stderr="protection api unavailable"),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        snapshot = control.fetch_gate_snapshot("https://github.com/org/repo/pull/55")
+
+        assert snapshot.disposition == "blocked_nonreviewable"
+        assert snapshot.required_checks_known is False
+
+
+class TestGitHubControlMerge:
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_merge_pr_uses_normal_merge_first(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(stdout="merged")
+
+        control = GitHubControl(repo_root=tmp_path)
+        result = control.merge_pr(
+            "https://github.com/org/repo/pull/88",
+            required_checks_green=True,
+            allow_admin=True,
+        )
+
+        assert result.merged is True
+        assert result.used_admin is False
+        called = mock_run.call_args.args[0]
+        assert called == ["gh", "pr", "merge", "https://github.com/org/repo/pull/88", "--squash"]
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_merge_pr_falls_back_to_admin_when_needed(self, mock_run, tmp_path: Path) -> None:
+        mock_run.side_effect = [
+            _completed_process(
+                returncode=1, stderr="Repository rules require administrator override"
+            ),
+            _completed_process(stdout="merged with admin"),
+        ]
+
+        control = GitHubControl(repo_root=tmp_path)
+        result = control.merge_pr(
+            "https://github.com/org/repo/pull/88",
+            required_checks_green=True,
+            allow_admin=True,
+        )
+
+        assert result.merged is True
+        assert result.used_admin is True
+        assert mock_run.call_args_list[1].args[0] == [
+            "gh",
+            "pr",
+            "merge",
+            "https://github.com/org/repo/pull/88",
+            "--squash",
+            "--admin",
+        ]
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_merge_pr_does_not_attempt_admin_without_signal(self, mock_run, tmp_path: Path) -> None:
+        mock_run.return_value = _completed_process(returncode=1, stderr="merge conflict")
+
+        control = GitHubControl(repo_root=tmp_path)
+        result = control.merge_pr(
+            "https://github.com/org/repo/pull/88",
+            required_checks_green=True,
+            allow_admin=True,
+        )
+
+        assert result.merged is False
+        assert result.used_admin is False
+        assert mock_run.call_count == 1
+
+    @patch("aragora.ralph.github_control.subprocess.run")
+    def test_merge_pr_blocks_when_required_checks_not_green(self, mock_run, tmp_path: Path) -> None:
+        control = GitHubControl(repo_root=tmp_path)
+        result = control.merge_pr(
+            "https://github.com/org/repo/pull/88",
+            required_checks_green=False,
+            allow_admin=True,
+        )
+
+        assert result.merged is False
+        assert result.action == "blocked"
+        assert mock_run.call_count == 0

--- a/tests/ralph/test_supervisor.py
+++ b/tests/ralph/test_supervisor.py
@@ -11,6 +11,7 @@ import pytest
 import yaml
 
 from aragora.ralph.classifier import BlockerKind
+from aragora.ralph.github_control import GitHubGateSnapshot
 from aragora.ralph.supervisor import (
     RalphSupervisor,
     StepResult,
@@ -20,6 +21,7 @@ from aragora.ralph.supervisor import (
     load_supervisor_state,
     save_supervisor_state,
 )
+from aragora.swarm.campaign import load_campaign_manifest
 
 
 # ---------------------------------------------------------------------------
@@ -63,6 +65,35 @@ def _write_state(path: Path, **overrides) -> SupervisorState:
     )
     save_supervisor_state(path, state)
     return state
+
+
+def _gate_snapshot(
+    *,
+    pr_url: str = "https://github.com/org/repo/pull/1",
+    disposition: str,
+    state: str = "OPEN",
+    merge_commit_sha: str | None = None,
+    blocker_detail: str | None = None,
+    required_checks_green: bool = True,
+    required_checks_known: bool = True,
+) -> GitHubGateSnapshot:
+    return GitHubGateSnapshot(
+        pr_url=pr_url,
+        state=state,
+        draft=False,
+        head_branch="codex/test",
+        base_branch="main",
+        review_decision="APPROVED",
+        merge_state_status="CLEAN",
+        merge_commit_sha=merge_commit_sha,
+        required_checks=[],
+        advisory_checks=[],
+        required_checks_green=required_checks_green,
+        required_checks_known=required_checks_known,
+        required_checks_source="ruleset" if required_checks_known else None,
+        disposition=disposition,
+        blocker_detail=blocker_detail,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -415,11 +446,18 @@ class TestStepPRChecking:
             active_repair_branch="fix/reviewer-diff",
         )
 
-        with patch.object(RalphSupervisor, "_find_pr_for_branch", return_value=None):
+        with (
+            patch.object(RalphSupervisor, "_find_pr_for_branch", return_value=None),
+            patch.object(
+                RalphSupervisor,
+                "_create_pr_for_branch",
+                return_value="https://github.com/org/repo/pull/42",
+            ),
+        ):
             supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
             result = supervisor.step()
 
-        assert result.status == SupervisorStatus.WAITING_FOR_PR.value
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
 
     def test_waiting_for_pr_refreshes_run_tracking(self, tmp_path: Path) -> None:
         state_path = tmp_path / "state.yaml"
@@ -480,7 +518,16 @@ class TestStepPRChecking:
             active_repair_pr="https://github.com/org/repo/pull/1",
         )
 
-        with patch.object(RalphSupervisor, "_check_pr_merged", return_value=(False, None)):
+        with patch.object(
+            RalphSupervisor,
+            "_fetch_pr_gate_snapshot",
+            return_value=_gate_snapshot(
+                pr_url="https://github.com/org/repo/pull/1",
+                disposition="wait_for_required_checks",
+                blocker_detail="checks pending",
+                required_checks_green=False,
+            ),
+        ):
             supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
             result = supervisor.step()
 
@@ -494,13 +541,265 @@ class TestStepPRChecking:
             active_repair_pr="https://github.com/org/repo/pull/1",
         )
 
-        with patch.object(RalphSupervisor, "_check_pr_merged", return_value=(True, "abc123")):
+        with patch.object(
+            RalphSupervisor,
+            "_fetch_pr_gate_snapshot",
+            return_value=_gate_snapshot(
+                pr_url="https://github.com/org/repo/pull/1",
+                disposition="merged",
+                state="MERGED",
+                merge_commit_sha="abc123",
+            ),
+        ):
             supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
             result = supervisor.step()
 
         assert result.status == SupervisorStatus.RESUMING.value
         state = load_supervisor_state(state_path)
         assert state.merge_commit_sha == "abc123"
+
+
+class TestProjectMergeTargets:
+    def test_campaign_iteration_registers_project_merge_target(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+        )
+
+        with patch(
+            "aragora.ralph.supervisor.asyncio.run",
+            return_value={
+                "stop_reason": "still_running",
+                "dispatched_projects": [],
+                "merge_ready_projects": [
+                    {
+                        "project_id": "proj-001",
+                        "kind": "project",
+                        "status": "waiting_for_pr",
+                        "pr_url": None,
+                        "branch": "codex/proj-001",
+                        "run_id": "run-001",
+                        "target_branch": "main",
+                    }
+                ],
+            },
+        ):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_PR.value
+        state = load_supervisor_state(state_path)
+        assert state.active_merge_target is not None
+        assert state.active_merge_target["kind"] == "project"
+        assert state.active_merge_target["project_id"] == "proj-001"
+
+    def test_waiting_for_pr_creates_project_pr_and_updates_manifest(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_data = {
+            "campaign_id": "project-pr-create",
+            "created_at": "2026-01-01",
+            "source_kind": "manual",
+            "source_ref": "test",
+            "worker_model": "codex",
+            "review_model": "claude",
+            "max_parallel_ready_projects": 1,
+            "max_retries_per_project": 2,
+            "budget_limit_usd": 20.0,
+            "time_limit_hours": 4.0,
+            "projects": [
+                {
+                    "project_id": "proj-001",
+                    "title": "Branch ready",
+                    "status": "waiting_for_pr",
+                    "branch": "codex/proj-001",
+                    "run_id": "run-001",
+                    "spec": {
+                        "raw_goal": "x",
+                        "refined_goal": "x",
+                        "acceptance_criteria": ["pass"],
+                        "constraints": ["stay in scope"],
+                        "file_scope_hints": ["README.md"],
+                    },
+                    "review": {"status": "passed", "findings": []},
+                }
+            ],
+            "execution_state": {
+                "ready_queue": [],
+                "active_projects": ["proj-001"],
+                "completed_projects": [],
+                "failed_projects": [],
+                "skipped_projects": [],
+                "total_cost_usd": 0.0,
+            },
+        }
+        manifest_path.write_text(yaml.dump(manifest_data), encoding="utf-8")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.WAITING_FOR_PR.value,
+            active_merge_target={
+                "kind": "project",
+                "project_id": "proj-001",
+                "run_id": "run-001",
+                "branch": "codex/proj-001",
+                "pr_url": None,
+                "target_branch": "main",
+                "auto_merge_requested": False,
+                "last_gate_snapshot": None,
+                "last_merge_action": None,
+            },
+        )
+
+        with (
+            patch.object(RalphSupervisor, "_find_pr_for_branch", return_value=None),
+            patch.object(
+                RalphSupervisor,
+                "_create_pr_for_branch",
+                return_value="https://github.com/org/repo/pull/201",
+            ),
+        ):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        manifest = load_campaign_manifest(manifest_path)
+        project = manifest.project_map()["proj-001"]
+        assert project.status == "waiting_for_merge"
+        assert project.pr_url == "https://github.com/org/repo/pull/201"
+
+    def test_waiting_for_merge_waits_on_review_without_merging(self, tmp_path: Path) -> None:
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            active_merge_target={
+                "kind": "project",
+                "project_id": "proj-001",
+                "pr_url": "https://github.com/org/repo/pull/301",
+                "branch": "codex/proj-001",
+                "target_branch": "main",
+                "auto_merge_requested": False,
+                "last_gate_snapshot": None,
+                "last_merge_action": None,
+            },
+        )
+
+        supervisor = RalphSupervisor(
+            state_path=state_path,
+            repo_root=tmp_path,
+            merge_policy="admin_merge_allowed",
+        )
+        with (
+            patch.object(
+                supervisor,
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/301",
+                    disposition="wait_for_review",
+                    blocker_detail="review required",
+                ),
+            ),
+            patch.object(supervisor, "_merge_pr") as mock_merge,
+        ):
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
+        mock_merge.assert_not_called()
+
+    def test_merged_project_pr_completes_project_and_clears_target(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_data = {
+            "campaign_id": "project-pr-merged",
+            "created_at": "2026-01-01",
+            "source_kind": "manual",
+            "source_ref": "test",
+            "worker_model": "codex",
+            "review_model": "claude",
+            "max_parallel_ready_projects": 1,
+            "max_retries_per_project": 2,
+            "budget_limit_usd": 20.0,
+            "time_limit_hours": 4.0,
+            "projects": [
+                {
+                    "project_id": "proj-001",
+                    "title": "PR ready",
+                    "status": "waiting_for_merge",
+                    "pr_url": "https://github.com/org/repo/pull/401",
+                    "run_id": "run-401",
+                    "last_run_outcome": "deliverable_created",
+                    "spec": {
+                        "raw_goal": "x",
+                        "refined_goal": "x",
+                        "acceptance_criteria": ["pass"],
+                        "constraints": ["stay in scope"],
+                        "file_scope_hints": ["README.md"],
+                    },
+                    "review": {"status": "passed", "findings": []},
+                }
+            ],
+            "execution_state": {
+                "ready_queue": [],
+                "active_projects": ["proj-001"],
+                "completed_projects": [],
+                "failed_projects": [],
+                "skipped_projects": [],
+                "total_cost_usd": 0.0,
+            },
+        }
+        manifest_path.write_text(yaml.dump(manifest_data), encoding="utf-8")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.WAITING_FOR_MERGE.value,
+            active_merge_target={
+                "kind": "project",
+                "project_id": "proj-001",
+                "run_id": "run-401",
+                "pr_url": "https://github.com/org/repo/pull/401",
+                "branch": "codex/proj-001",
+                "target_branch": "main",
+                "auto_merge_requested": False,
+                "last_gate_snapshot": None,
+                "last_merge_action": None,
+            },
+        )
+
+        supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+        with (
+            patch.object(
+                supervisor,
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/401",
+                    disposition="merged",
+                    state="MERGED",
+                    merge_commit_sha="merge-sha-401",
+                ),
+            ),
+            patch.object(
+                supervisor,
+                "_synchronize_merged_commit",
+                return_value={"ok": True, "detail": "synced"},
+            ),
+            patch(
+                "aragora.swarm.campaign.CampaignExecutor._refresh_run_dict",
+                return_value={"work_orders": []},
+            ),
+        ):
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.RUNNING.value
+        state = load_supervisor_state(state_path)
+        assert state.active_merge_target is None
+        manifest = load_campaign_manifest(manifest_path)
+        project = manifest.project_map()["proj-001"]
+        assert project.status == "completed"
+        assert project.receipt_id is not None
 
 
 # ---------------------------------------------------------------------------
@@ -1290,7 +1589,16 @@ class TestFullLoopSimulation:
         assert r2.status == SupervisorStatus.WAITING_FOR_MERGE.value
 
         # Step 4: check merge -> merged
-        with patch.object(RalphSupervisor, "_check_pr_merged", return_value=(True, "merged-sha")):
+        with patch.object(
+            RalphSupervisor,
+            "_fetch_pr_gate_snapshot",
+            return_value=_gate_snapshot(
+                pr_url="https://github.com/org/repo/pull/99",
+                disposition="merged",
+                state="MERGED",
+                merge_commit_sha="merged-sha",
+            ),
+        ):
             r4 = supervisor.step()
         assert r4.status == SupervisorStatus.RESUMING.value
 
@@ -1568,8 +1876,15 @@ class TestStepDispatch:
         )
 
         with (
-            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
-            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+            patch.object(
+                supervisor,
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/99",
+                    disposition="merge_now",
+                ),
+            ),
+            patch.object(supervisor, "_merge_pr") as mock_merge,
         ):
             supervisor.step()
 
@@ -1592,13 +1907,28 @@ class TestStepDispatch:
         )
 
         with (
-            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
-            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+            patch.object(
+                supervisor,
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/99",
+                    disposition="merge_now",
+                ),
+            ),
+            patch.object(
+                supervisor,
+                "_merge_pr",
+                return_value=MagicMock(merged=True, to_dict=lambda: {"merged": True}),
+            ) as mock_merge,
         ):
             result = supervisor.step()
 
         assert result.status == SupervisorStatus.WAITING_FOR_MERGE.value
-        mock_merge.assert_called_once_with("https://github.com/org/repo/pull/99")
+        mock_merge.assert_called_once_with(
+            "https://github.com/org/repo/pull/99",
+            required_checks_green=True,
+            allow_admin=True,
+        )
 
     def test_auto_merge_not_called_for_manual_policy(self, tmp_path: Path) -> None:
         manifest_path = _write_manifest(tmp_path / "manifest.yaml")
@@ -1617,8 +1947,15 @@ class TestStepDispatch:
         )
 
         with (
-            patch.object(supervisor, "_check_pr_merged", return_value=(False, None)),
-            patch.object(supervisor, "_auto_merge_pr", return_value=True) as mock_merge,
+            patch.object(
+                supervisor,
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/99",
+                    disposition="merge_now",
+                ),
+            ),
+            patch.object(supervisor, "_merge_pr") as mock_merge,
         ):
             result = supervisor.step()
 
@@ -1700,8 +2037,13 @@ class TestStepDispatch:
         with (
             patch.object(
                 supervisor,
-                "_check_pr_merged",
-                return_value=(True, "abc123def"),
+                "_fetch_pr_gate_snapshot",
+                return_value=_gate_snapshot(
+                    pr_url="https://github.com/org/repo/pull/100",
+                    disposition="merged",
+                    state="MERGED",
+                    merge_commit_sha="abc123def",
+                ),
             ),
             patch.object(supervisor, "_auto_merge_pr"),
         ):

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -562,7 +562,7 @@ class TestCampaignExecutor:
         assert payload["dispatched_projects"][0]["project_id"] == "proj-001"
 
     @pytest.mark.asyncio
-    async def test_execute_once_records_completed_project_after_review(
+    async def test_execute_once_records_waiting_for_merge_after_review(
         self, tmp_path: Path
     ) -> None:
         manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
@@ -623,11 +623,104 @@ class TestCampaignExecutor:
 
         reloaded = load_campaign_manifest(manifest_path)
         project = reloaded.projects[0]
-        assert project.status == CampaignProjectStatus.COMPLETED.value
+        assert project.status == CampaignProjectStatus.WAITING_FOR_MERGE.value
         assert project.run_id == "run-123"
         assert project.pr_url == "https://github.com/example/pull/1"
         assert project.review.status == CampaignReviewStatus.PASSED.value
+        assert project.receipt_id is None
         assert payload["dispatched_projects"][0]["project_id"] == "proj-001"
+        assert payload["merge_ready_projects"] == [
+            {
+                "project_id": "proj-001",
+                "kind": "project",
+                "status": CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                "pr_url": "https://github.com/example/pull/1",
+                "branch": None,
+                "run_id": "run-123",
+                "target_branch": "main",
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_execute_once_records_waiting_for_pr_after_branch_only_review(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="campaign-exec-branch",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            worker_model="codex",
+            review_model="claude",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Implement manifest",
+                    spec=_bounded_spec("Implement manifest"),
+                    file_scope_hints=["aragora/swarm/campaign.py"],
+                    acceptance_criteria=["pytest -q tests/swarm/test_campaign.py"],
+                    constraints=["do not widen scope"],
+                    estimated_cost_usd=1.0,
+                )
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        dispatch_result = {
+            "status": "completed",
+            "outcome": CampaignRunOutcome.DELIVERABLE_CREATED.value,
+            "run_id": "run-branch-123",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/proj-001",
+                "commit_shas": ["branch-sha-1"],
+            },
+            "run": {
+                "run_id": "run-branch-123",
+                "status": "completed",
+                "work_orders": [
+                    {
+                        "status": "completed",
+                        "branch": "codex/proj-001",
+                        "receipt_id": "receipt-branch-1",
+                    }
+                ],
+            },
+        }
+        review_gate = CampaignReviewGate(
+            required=True,
+            review_model="claude",
+            status=CampaignReviewStatus.PASSED.value,
+            findings=[],
+        )
+
+        with (
+            patch(
+                "aragora.swarm.campaign.dispatch_bounded_spec",
+                new=AsyncMock(return_value=dispatch_result),
+            ),
+            patch.object(executor.reviewer, "review", new=AsyncMock(return_value=review_gate)),
+        ):
+            payload = await executor.execute_once()
+
+        reloaded = load_campaign_manifest(manifest_path)
+        project = reloaded.projects[0]
+        assert project.status == CampaignProjectStatus.WAITING_FOR_PR.value
+        assert project.branch == "codex/proj-001"
+        assert project.receipt_id is None
+        assert payload["merge_ready_projects"] == [
+            {
+                "project_id": "proj-001",
+                "kind": "project",
+                "status": CampaignProjectStatus.WAITING_FOR_PR.value,
+                "pr_url": None,
+                "branch": "codex/proj-001",
+                "run_id": "run-branch-123",
+                "target_branch": "main",
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_execute_once_halts_before_dispatch_when_remaining_budget_is_insufficient(
@@ -1114,14 +1207,26 @@ class TestCampaignExecutor:
             CampaignStopReason.STILL_RUNNING.value,
             CampaignStopReason.CAMPAIGN_COMPLETE.value,
         }
-        assert reloaded.status == CampaignProjectStatus.COMPLETED.value
+        assert reloaded.status == CampaignProjectStatus.WAITING_FOR_MERGE.value
         assert reloaded.pr_url == "https://github.com/example/pull/2"
+        assert reloaded.receipt_id is None
         assert reloaded.worker_receipt_id == "worker-receipt-2"
         assert len(reloaded.attempt_history) == 2
         assert reloaded.attempt_history[0]["outcome"] == CampaignRunOutcome.TIMEOUT.value
         assert (
             reloaded.attempt_history[1]["outcome"] == CampaignRunOutcome.DELIVERABLE_CREATED.value
         )
+        assert second_payload["merge_ready_projects"] == [
+            {
+                "project_id": "proj-001",
+                "kind": "project",
+                "status": CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                "pr_url": "https://github.com/example/pull/2",
+                "branch": None,
+                "run_id": "run-success-2",
+                "target_branch": "main",
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_execute_once_returns_still_running_when_active_projects_exist(
@@ -1282,6 +1387,76 @@ class TestCampaignExecutor:
         assert status["budget_limit_usd"] == pytest.approx(3.0)
         assert status["total_cost_usd"] == pytest.approx(1.25)
         assert status["projects"][0]["review_status"] == CampaignReviewStatus.PENDING.value
+
+
+class TestCampaignMergeLifecycle:
+    def test_record_project_pr_transitions_waiting_for_pr_to_waiting_for_merge(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="phase0b-project-merge",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="Branch ready",
+                    spec=_bounded_spec("Branch ready"),
+                    status=CampaignProjectStatus.WAITING_FOR_PR.value,
+                    branch="codex/proj-001",
+                    run_id="run-branch-1",
+                    last_run_outcome=CampaignRunOutcome.DELIVERABLE_CREATED.value,
+                )
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        result = executor.record_project_pr(
+            "proj-001",
+            pr_url="https://github.com/example/repo/pull/42",
+        )
+
+        reloaded = load_campaign_manifest(manifest_path).projects[0]
+        assert result["status"] == CampaignProjectStatus.WAITING_FOR_MERGE.value
+        assert reloaded.status == CampaignProjectStatus.WAITING_FOR_MERGE.value
+        assert reloaded.pr_url == "https://github.com/example/repo/pull/42"
+
+    def test_complete_project_emits_receipt_after_merge(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+        manifest = CampaignManifest(
+            campaign_id="phase0b-project-complete",
+            created_at="2026-03-10T00:00:00+00:00",
+            source_kind="source_file",
+            source_ref="roadmap.md",
+            projects=[
+                CampaignProject(
+                    project_id="proj-001",
+                    title="PR awaiting merge",
+                    spec=_bounded_spec("PR awaiting merge"),
+                    status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                    pr_url="https://github.com/example/repo/pull/43",
+                    run_id="run-pr-1",
+                    worker_receipt_id="worker-receipt-1",
+                    last_run_outcome=CampaignRunOutcome.DELIVERABLE_CREATED.value,
+                )
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with patch.object(executor, "_refresh_run_dict", return_value={"work_orders": []}):
+            result = executor.complete_project("proj-001", merge_sha="merge-sha-1")
+
+        reloaded = load_campaign_manifest(manifest_path).projects[0]
+        receipt_path = tmp_path / "docs" / "receipts" / "phase0b-project-complete" / "proj-001.yaml"
+        assert result["status"] == CampaignProjectStatus.COMPLETED.value
+        assert reloaded.status == CampaignProjectStatus.COMPLETED.value
+        assert reloaded.receipt_id == "docs/receipts/phase0b-project-complete/proj-001.yaml"
+        assert reloaded.commit_shas[-1] == "merge-sha-1"
+        assert receipt_path.exists()
 
 
 class TestComputeStopReason:


### PR DESCRIPTION
## Summary
- **GitHubControl** module (`aragora/ralph/github_control.py`): wraps `gh` CLI with structured gate snapshots, queries actual branch protection rules/rulesets for required checks, fail-closed when check truth unavailable
- **Campaign status model**: adds `WAITING_FOR_PR` and `WAITING_FOR_MERGE` to `CampaignProjectStatus`, defers receipt emission until `complete_project()` after merge, exposes `merge_ready_projects` from `execute_once()`
- **Ralph supervisor**: generalizes `active_repair_*` into `active_merge_target` supporting both repair and project merges with backward-compat migration; auto-creates PRs, fetches gate snapshots, merges when gates green and policy allows
- **Heterogeneous model cooperation**: planned by Claude (Opus), implemented by Codex, cross-reviewed by Claude — validates Aragora's approach of different models checking each other's work

This eliminates the manual copy-paste routing between sessions that was required to get code from "review passed" to "merged into main."

## Test plan
- [x] `tests/ralph/test_github_control.py` — 18 tests for GitHubControl, GitHubGateSnapshot, merge gating
- [x] `tests/ralph/test_supervisor.py` — 30+ tests including new project merge flow, merge target serialization, backward compat
- [x] `tests/swarm/test_campaign.py` — campaign status transitions, `complete_project()`, `record_project_pr()`, merge-ready signaling
- [x] All 116 tests pass (`python -m pytest tests/swarm/test_campaign.py tests/ralph/ -q`)
- [ ] Validate with a real benchmark run (next step after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)