### PR TITLE
[codex] record bootstrapped idea-to-execution program

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Aragora Product Roadmap
 
-**Last Updated:** March 2026
+**Last Updated:** March 18, 2026
 
 ---
 
@@ -203,18 +203,29 @@ for capturing this cohort is now.
 - [x] Public demo at aragora.ai/demo (PR #705; standalone demo page live)
 - [ ] EU AI Act compliance package — final packaging polish, regulator-ready validation, and customer rollout hardening
 - [ ] SOC 2 Type II audit engagement kickoff (controls are ready; external auditor engagement pending)
+- [ ] Validate the Ralph autonomy boundary with a clean spec -> repair PR -> merge-gate benchmark ([#991](https://github.com/synaptent/aragora/issues/991))
+- [ ] Start the interactive stage-transition system from ideas -> goals -> executable specs ([#994](https://github.com/synaptent/aragora/issues/994))
 
 ### Q3 2026 Priorities
 - [ ] Cloud marketplace listings: AWS Marketplace and Azure Marketplace
 - [ ] Vertical packages: Healthcare (FHIR/HIPAA), Financial Services (SOX/audit), Legal
 - [ ] Skills marketplace pilot (community agent templates)
 - [ ] Kubernetes Operator for automated horizontal scaling
+- [ ] Productize the unified local-first DAG workbench across ideas, goals, actions, and orchestration ([#993](https://github.com/synaptent/aragora/issues/993))
+- [ ] Dogfood the pipeline to generate and dispatch more of Aragora's own roadmap work ([#990](https://github.com/synaptent/aragora/issues/990))
 
 ### Q4 2026 Priorities
 - [ ] 10+ agent coordination at enterprise scale
 - [ ] Cross-organization federation foundation
 - [ ] Decision-Integrity UI Workbench (visual debate canvas)
 - [ ] OpenClaw E2E demo production-ready
+
+### Cross-Cutting 2026 Program: Bootstrapped Idea-to-Execution Workbench
+- [ ] [#989](https://github.com/synaptent/aragora/issues/989) Establish the bootstrapped local-first idea-to-execution workbench as a primary execution program
+- [ ] [#991](https://github.com/synaptent/aragora/issues/991) Close Ralph autonomy gaps from spec to repair PR
+- [ ] [#994](https://github.com/synaptent/aragora/issues/994) Add interactive stage transitions from ideas to goals to specs
+- [ ] [#993](https://github.com/synaptent/aragora/issues/993) Productize the unified local-first DAG workbench
+- [ ] [#990](https://github.com/synaptent/aragora/issues/990) Use the pipeline to build more of Aragora itself
 
 ### 2027 Horizon
 - Prover-Estimator debate protocol

--- a/docs/CANONICAL_GOALS.md
+++ b/docs/CANONICAL_GOALS.md
@@ -2,7 +2,7 @@
 
 **Single source of truth for all goals across aragoradocs.**
 **This document defines WHAT Aragora is and WHY. The [Evolution Roadmap](plans/ARAGORA_EVOLUTION_ROADMAP.md) defines HOW.**
-**Last updated: March 1, 2026**
+**Last updated: March 18, 2026**
 
 ---
 
@@ -65,6 +65,8 @@ The system should take vague ideas as input and, through a structured process, u
 
 With increasingly long-running autonomous agentic AI, people who can generate precise, fully detailed specifications for what they want are gaining 10x advantages over people who lack this discipline and clarity. There is a market opportunity to provide GUI interfaces for people who think more vaguely, don't know how to or can't be bothered to make precise specs, want AI to take ideas to execution, and want to interactively shape the process of ideas to specs to plans to execution while letting AIs automate all parts of the process they don't care about or are fine with delegating.
 
+The product posture for this pillar is now explicitly local-first and stage-transition-driven: Aragora should ask the minimum useful clarifying questions, produce best-effort goals and specs, preserve provenance at every transition, and let humans spend their effort on high-value judgment rather than manual restatement and copy-paste.
+
 **The Four-Stage Unified DAG Pipeline:**
 
 | Stage | Node Types | AI Transition | User Action |
@@ -74,7 +76,7 @@ With increasingly long-running autonomous agentic AI, people who can generate pr
 | **3. Actions** | Task, Milestone, Dependency, Acceptance Criteria | Goals decompose into dependency-aware project plans | Edit, add gates, set owners |
 | **4. Orchestration** | Agent Assignment, Parallel Run, Gate/Review, Verification, Receipt | Actions map to agent capabilities with constraint architecture | Monitor, intervene, approve |
 
-**Serves:** Prompt decomposition engine, interrogator, researcher, spec builder, refinement loop, IdeaToExecutionPipeline, UnifiedDAGCanvas, DAGOperationsCoordinator, Canvas GUI (8-stage experience from prompt to receipt), Obsidian bidirectional sync.
+**Serves:** Prompt decomposition engine, interrogator, researcher, spec builder, refinement loop, IdeaToExecutionPipeline, UnifiedDAGCanvas, DAGOperationsCoordinator, Canvas GUI (8-stage experience from prompt to receipt), Obsidian bidirectional sync, Ralph execution handoff, local-first idea-to-execution workbench.
 
 #### Pillar 4: Regulatory Audit Trail
 
@@ -85,6 +87,8 @@ The system should provide a full audit trail suitable for various regulatory fra
 #### Pillar 5: Self-Repair and Self-Improvement
 
 The system should be able to self-repair and self-improve and orchestrate swarms of heterogeneous agents to build its own software and other software repos in a higher-assurance way than swarms of a single model and faster than a single model. The Nomic Loop is the autonomous self-improvement cycle where agents debate improvements, design solutions, implement code, and verify changes.
+
+This pillar now includes a bootstrapping requirement: Aragora should increasingly use its own idea-to-execution pipeline to generate, maintain, and dispatch more of Aragora's roadmap work, with humans reserved for priority, policy, and risk decisions rather than repeated prompt restatement.
 
 **The Nomic Loop Phases:**
 
@@ -98,7 +102,7 @@ The system should be able to self-repair and self-improve and orchestrate swarms
 
 **Safety features:** Automatic backups, protected file checksums, rollback on failure, human approval for dangerous changes, gauntlet gate, worktree isolation, auto-revert.
 
-**Serves:** Nomic Loop (scripts/nomic_loop.py), MetaPlanner, BranchCoordinator, TaskDecomposer, HardenedOrchestrator, ForwardFixer, self-healing test infrastructure, meta-improver for debate protocols, STOP N-candidate implementation.
+**Serves:** Nomic Loop (scripts/nomic_loop.py), MetaPlanner, BranchCoordinator, TaskDecomposer, HardenedOrchestrator, ForwardFixer, self-healing test infrastructure, meta-improver for debate protocols, STOP N-candidate implementation, Ralph loop autonomy, pipeline dogfooding for self-development.
 
 #### Pillar 6: OpenClaw Integration for Controlled Agentic Execution
 

--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -2,7 +2,7 @@
 
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
 > Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md) and the linked GitHub issues. This file remains the capability and productization backlog truth.
-> Last updated: March 2026
+> Last updated: March 18, 2026
 
 ## How to Read This List
 
@@ -71,11 +71,13 @@
 |---------|--------|-------|
 | Prover-Estimator debate protocol | Design only | Beyond consensus to structured truth-seeking. Replaces/supplements current majority-vote consensus. |
 | Cross-verification phase (3-pass hallucination detection) | Design only | Three-agent verification pass post-synthesis. |
-| Canvas GUI (8-stage visual DAG) | Partial frontend | Prompt-engine page exists; full 8-stage visual canvas missing. |
+| Interactive stage transitions (ideas -> goals -> specs) | Partial backend, weak product UX | Core pipeline and transition infrastructure exist, but the guided interrogation/edit/approval flow is still missing. Tracked in [#994](https://github.com/synaptent/aragora/issues/994). |
+| Canvas GUI (8-stage visual DAG) | Partial frontend | Prompt-engine page exists; full unified local-first DAG workbench is not yet productized. Tracked in [#989](https://github.com/synaptent/aragora/issues/989) and [#993](https://github.com/synaptent/aragora/issues/993). |
 | Market resolution mechanism | Design only | Long-horizon settlement claim pricing via prediction market. |
 | STOP N-candidate for Nomic Loop | Design only | Multi-plan generation before committing to self-improvement path. |
 | Meta-improver for debate protocols | Design only | A/B test protocol variants using Nomic Loop. |
 | Obsidian bidirectional sync | Design only | Full sync + bidirectional updates from Obsidian vault. |
+| Pipeline dogfooding for self-development | Early program lane | Roadmap/goal docs should increasingly become pipeline artifacts and executable specs for Aragora itself. Tracked in [#990](https://github.com/synaptent/aragora/issues/990). |
 
 ---
 
@@ -93,10 +95,11 @@
 
 | Feature | Current State | Gap |
 |---------|---------------|-----|
-| Self-improving platform quality | Nomic Loop 100% wired; 82 E2E tests; CLB backbone hardened (14/14 issues closed); safety gates + gauntlet gate + evolution audit + golden-path test | Diverse benchmark validated (100% pass). Production safety gate requires ENABLE_NOMIC_LOOP=true. |
+| Self-improving platform quality | Nomic Loop 100% wired; 82 E2E tests; CLB backbone hardened (14/14 issues closed); safety gates + gauntlet gate + evolution audit + golden-path test | Diverse benchmark validated (100% pass). Production safety gate requires ENABLE_NOMIC_LOOP=true. Next gap is dogfooding the pipeline for self-development ([#990](https://github.com/synaptent/aragora/issues/990)). |
 | Blockchain receipts | SHA-256 cryptographic hashing works | On-chain storage with ERC-8004 (not deployed) |
 | Semantic convergence | **Migrated** (PR #723) | All similarity paths use embeddings. Only `unified_diff` (text display) uses difflib. |
 | OpenClaw execution | **Core loop shipped** (PR #727) | CodeImplementationTask + SpecExtractor + receipt linkage. Production validation pending. |
+| Ralph autonomous repair loop | Recent benchmark proved repair generation, PR creation, and merge-gate inspection paths | Clean no-babysitting proof still required: no manual manifest edits, no manual branch pushes, no manual repair steering. Tracked in [#991](https://github.com/synaptent/aragora/issues/991). |
 | RLM context access | Code complete (283 exports) | No user-facing guide; integration with default Arena config unclear |
 
 ---

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,6 +40,8 @@ This index intentionally links to actively maintained docs with validated paths.
 ## Architecture and Planning
 
 - [Conductor Control Plane Implementation Spec](plans/2026-03-07-conductor-control-plane.md)
+- [Bootstrapped Idea-to-Execution Program](plans/2026-03-18-bootstrapped-idea-to-execution-program.md)
+- [Aragora Evolution Roadmap](plans/ARAGORA_EVOLUTION_ROADMAP.md)
 
 ## Security and Compliance
 

--- a/docs/plans/2026-03-18-bootstrapped-idea-to-execution-program.md
+++ b/docs/plans/2026-03-18-bootstrapped-idea-to-execution-program.md
@@ -1,0 +1,84 @@
+# Bootstrapped Idea-to-Execution Program
+
+Last updated: 2026-03-18
+
+Primary execution epic: [#989](https://github.com/synaptent/aragora/issues/989)
+
+Related execution issues:
+- [#991](https://github.com/synaptent/aragora/issues/991) Close the Ralph autonomy gap from spec to repair PR
+- [#994](https://github.com/synaptent/aragora/issues/994) Add interactive stage transitions from ideas to goals to specs
+- [#993](https://github.com/synaptent/aragora/issues/993) Productize the unified local-first DAG workbench
+- [#990](https://github.com/synaptent/aragora/issues/990) Dogfood the pipeline to build more of Aragora itself
+
+## Purpose
+
+Record the near-term program for turning Aragora's existing idea/goals/actions/orchestration substrate into the primary product surface, and then using that same substrate to build more of Aragora with less repeated human prompting and copy-paste.
+
+This document is the bridge between the thesis in `docs/CANONICAL_GOALS.md`, the long-range architecture in `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md`, and the live execution order in `docs/status/NEXT_STEPS_CANONICAL.md`.
+
+## Thesis
+
+Aragora's next moat is not more disconnected backend primitives. It is a local-first workbench where:
+- vague human ideas are upgraded into connected idea graphs
+- idea graphs are upgraded into goals and principles through structured questioning
+- goals are upgraded into executable task/spec DAGs
+- those specs are submitted directly into the Ralph loop for implementation, review, repair, PR creation, and merge-gate waiting
+
+The same pipeline should also increasingly be used to plan and dispatch Aragora's own work. Human input should be concentrated on priority, risk, and policy choices rather than low-leverage technical restatement.
+
+## What Already Exists
+
+The repo already contains substantial substrate for this program:
+- idea, goal, and pipeline canvas models and storage
+- `IdeaToExecutionPipeline` and stage transition infrastructure
+- workflow DAG execution and orchestration components
+- provenance and receipt infrastructure
+- Ralph/swarm outer-loop execution with recent validation of repair and PR-gate flows
+
+The main missing layer is productization:
+- guided stage-transition UX
+- a unified local-first workbench instead of separate partial surfaces
+- autonomous handoff from approved specs into Ralph with no manual babysitting
+- dogfooding the pipeline so roadmap work becomes executable pipeline artifacts
+
+## Strategic Goals
+
+1. Make Aragora a reliable spec-to-merge engine, not just a debate/orchestration demo.
+2. Let idea-rich, execution-poor users reach executable specs without having to become expert spec writers.
+3. Unify ideas, goals, actions, and orchestration as one DAG/provenance model.
+4. Use heterogeneous models as a product advantage, with different models doing planning, implementation, review, and repair.
+5. Produce benchmarked evidence and self-bootstrapping execution lanes instead of anecdotal progress.
+
+## Operating Doctrine
+
+- Local-first is a feature, not a temporary limitation.
+- AI should ask the minimum useful questions at each stage transition.
+- Humans should intervene where they add high-value judgment, not where the system is merely missing glue.
+- Stage outputs must be editable, approval-gated, and provenance-preserving.
+- Canonical docs and GitHub issues should increasingly be generated from pipeline artifacts rather than maintained as disconnected narratives.
+
+## Program Lanes
+
+| Lane | Issue | Outcome |
+|------|-------|---------|
+| Ralph autonomy hardening | [#991](https://github.com/synaptent/aragora/issues/991) | A clean benchmark proves spec -> repair PR -> merge-gate wait with no manual manifest or branch intervention |
+| Interactive stage transitions | [#994](https://github.com/synaptent/aragora/issues/994) | Idea graphs become editable goal DAGs and then executable spec DAGs through structured questioning and approvals |
+| Unified DAG workbench | [#993](https://github.com/synaptent/aragora/issues/993) | One local-first workbench shows ideas, goals, actions, orchestration, review, repair, and provenance as one flow |
+| Self-bootstrapping lane | [#990](https://github.com/synaptent/aragora/issues/990) | Aragora uses its own pipeline to generate, maintain, and dispatch more of Aragora's roadmap work |
+
+## Success Bar
+
+This program is successful when:
+- a user can go from a local idea graph to a reviewable executable spec without manual copy-paste between tools
+- that spec can be submitted directly to Ralph
+- the workbench can show both upstream provenance and downstream execution/review/repair state
+- at least one Aragora implementation lane is driven by pipeline-generated specs and issue updates
+
+## Relationship To Other Canonical Docs
+
+- `docs/CANONICAL_GOALS.md` defines the why.
+- `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md` defines the long-range architecture and moat.
+- `docs/status/NEXT_STEPS_CANONICAL.md` defines short-horizon execution order.
+- `docs/status/ACTIVE_EXECUTION_ISSUES.md` maps this program to the live GitHub backlog.
+
+This document exists to make the March 2026 bootstrapping program explicit and durable.

--- a/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
+++ b/docs/plans/ARAGORA_EVOLUTION_ROADMAP.md
@@ -90,6 +90,20 @@ To keep delivery fast and reliable:
 3. Every meaningful decision has a tamper-evident provenance trail.
 4. The platform measurably improves its own quality over time via closed-loop evaluation.
 
+### March 2026 Execution Update
+
+The near-term program is now explicit: Aragora should use its existing pipeline substrate to become a local-first idea-to-spec-to-execution workbench, and then use that same workbench to build more of Aragora itself.
+
+Current execution epic: [#989](https://github.com/synaptent/aragora/issues/989)
+
+Current program lanes:
+- [#991](https://github.com/synaptent/aragora/issues/991) close the Ralph autonomy gap from spec to repair PR
+- [#994](https://github.com/synaptent/aragora/issues/994) add interactive stage transitions from ideas to goals to specs
+- [#993](https://github.com/synaptent/aragora/issues/993) productize the unified local-first DAG workbench
+- [#990](https://github.com/synaptent/aragora/issues/990) dogfood the pipeline to build more of Aragora itself
+
+This is the "rebuild the ship while sailing it" doctrine in concrete form: humans should mostly supply priorities, approvals, and policy choices while the system increasingly performs the transition, planning, and routing work for itself.
+
 ---
 
 ## Core Product Architecture: The Unified DAG Pipeline
@@ -116,6 +130,11 @@ Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. A
 ### Implementation Status
 
 ~70% backend, ~50% frontend. Key existing components: `IdeaToExecutionPipeline` (1,173 LOC), `UnifiedDAGCanvas` (React Flow with swim-lane stages), `DAGOperationsCoordinator`, 15+ REST endpoints, 135+ test files. Main gap: the "golden path" button that triggers the full pipeline from the canvas UI.
+
+Near-term execution gap summary:
+- Ralph is close enough to benchmark seriously, but still needs clean no-intervention proof as part of [#991](https://github.com/synaptent/aragora/issues/991).
+- The product moat is the transition UX and unified workbench, not more disconnected backend scaffolding.
+- The self-improvement program should increasingly consume pipeline-generated specs and issue updates instead of ad hoc session summaries.
 
 See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
 

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-03-07
+Last updated: 2026-03-18
 
 This document links Aragora's current execution program to the live GitHub issue tracker.
 
@@ -12,8 +12,9 @@ This document links Aragora's current execution program to the live GitHub issue
 
 1. Truthfulness and backlog canonicalization
 2. Decision Integrity Kernel unification
-3. Sequential surface productization
-4. Assurance closeout kept warm, not the main product lane
+3. Bootstrapped idea-to-execution program
+4. Sequential surface productization
+5. Assurance closeout kept warm, not the main product lane
 
 ## Truthfulness And Backlog Canonicalization
 
@@ -47,6 +48,20 @@ Current tranche: [#811](https://github.com/synaptent/aragora/issues/811) and [#8
 | [#814](https://github.com/synaptent/aragora/issues/814) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Make OpenClaw action dispatch real |
 | [#815](https://github.com/synaptent/aragora/issues/815) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Scale adversarial orchestration to 10+ agents |
 | [#816](https://github.com/synaptent/aragora/issues/816) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Deploy ERC-8004 identity and settlement integration |
+
+## Bootstrapped Idea-to-Execution Program
+
+Epic: [#989](https://github.com/synaptent/aragora/issues/989)
+
+Current tranche: [#991](https://github.com/synaptent/aragora/issues/991) -> [#994](https://github.com/synaptent/aragora/issues/994) -> [#993](https://github.com/synaptent/aragora/issues/993) -> [#990](https://github.com/synaptent/aragora/issues/990)
+
+| Issue | State | Priority | Owner | Milestone | Scope |
+|------|-------|----------|-------|-----------|-------|
+| [#989](https://github.com/synaptent/aragora/issues/989) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Bootstrapped local-first idea-to-execution workbench epic |
+| [#991](https://github.com/synaptent/aragora/issues/991) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Close the Ralph autonomy gap from spec to repair PR |
+| [#994](https://github.com/synaptent/aragora/issues/994) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Add interactive stage transitions from ideas to goals to specs |
+| [#993](https://github.com/synaptent/aragora/issues/993) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Productize the unified local-first DAG workbench |
+| [#990](https://github.com/synaptent/aragora/issues/990) | Open | `priority:high` | `owner:team-core` | `2026-M3 Strategic Moat Scale-Out` | Dogfood the pipeline to build more of Aragora itself |
 
 ## Sequential Surface Productization
 

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-03-07
+Last updated: 2026-03-18
 
 This is the single source of truth for short-horizon execution priorities.
 `docs/CANONICAL_GOALS.md` defines what Aragora is and why.
@@ -16,6 +16,8 @@ This file defines execution order.
 - GitHub issues now carry active execution status, owners, and acceptance criteria. Docs should summarize context and order, not act as the only operational backlog.
 - Truthfulness and backlog canonicalization are complete on `main` through [#809](https://github.com/synaptent/aragora/issues/809), and the first Decision Integrity Kernel bridge tranche [#810](https://github.com/synaptent/aragora/issues/810) is also complete.
 - The current M1 kernel focus is [#811](https://github.com/synaptent/aragora/issues/811) followed by [#812](https://github.com/synaptent/aragora/issues/812).
+- Recent Ralph validation moved the local idea-to-execution workbench from abstract vision to active execution program: the outer loop is close enough to benchmark, but the remaining value is in stage-transition UX and no-babysitting execution.
+- The new bootstrapped program epic is [#989](https://github.com/synaptent/aragora/issues/989). Its first execution tranche is [#991](https://github.com/synaptent/aragora/issues/991) followed by [#994](https://github.com/synaptent/aragora/issues/994), [#993](https://github.com/synaptent/aragora/issues/993), and [#990](https://github.com/synaptent/aragora/issues/990).
 - Surface area should be productized sequentially, not hidden or allowed to drift.
 
 ## Execution Order
@@ -38,7 +40,19 @@ This file defines execution order.
   - This is the architectural center of Aragora's differentiation.
   - Provider routing, OpenClaw, 10+ agent scale, and ERC-8004 only matter if they plug into the same receipt-gated kernel.
 
-### 3) Sequential Surface Productization
+### 3) Bootstrapped Idea-to-Execution Program
+- Tracking: [#989](https://github.com/synaptent/aragora/issues/989), [#991](https://github.com/synaptent/aragora/issues/991), [#994](https://github.com/synaptent/aragora/issues/994), [#993](https://github.com/synaptent/aragora/issues/993), [#990](https://github.com/synaptent/aragora/issues/990)
+- Goal: turn the existing pipeline substrate into a local-first workbench that upgrades vague ideas into executable specs and routes them directly into Ralph, while increasingly using that same pipeline to build more of Aragora itself.
+- Current tranche:
+  - [#991](https://github.com/synaptent/aragora/issues/991) prove the clean Ralph autonomy boundary
+  - [#994](https://github.com/synaptent/aragora/issues/994) add interactive stage transitions from ideas to goals to specs
+  - [#993](https://github.com/synaptent/aragora/issues/993) productize the unified local-first DAG workbench
+  - [#990](https://github.com/synaptent/aragora/issues/990) dogfood the pipeline to generate and dispatch more of Aragora's own work
+- Why now:
+  - This is the most differentiated path from the current kernel to a real end-user product.
+  - The repo already contains substantial pipeline/canvas/orchestration substrate, so the highest-value work is now integration and productization rather than another isolated subsystem.
+
+### 4) Sequential Surface Productization
 - Tracking: [#806](https://github.com/synaptent/aragora/issues/806), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
 - Goal: productize every exposed surface in waves, starting from the inbox trust wedge and public proof surfaces.
 - Rules:
@@ -46,7 +60,7 @@ This file defines execution order.
   - Keep partial surfaces visible, but label and harden them honestly.
   - Prefer one surface wave at a time over broad parallel productization.
 
-### 4) Assurance And GTM Closeout (Kept Warm, Not Main Product Lane)
+### 5) Assurance And GTM Closeout (Kept Warm, Not Main Product Lane)
 - Tracking: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
 - Goal: keep enterprise assurance truthfulness real without turning pentest/GTM work into the primary execution lane before the core kernel is unified.
 - Acceptance:


### PR DESCRIPTION
## Summary
This PR records the March 18, 2026 bootstrapped idea-to-execution program in the repo's canonical planning docs and aligns the GitHub execution backlog with that program.

The core change is to make the local-first idea-to-execution workbench an explicit execution lane instead of leaving it as an implied future vision scattered across multiple documents. The updated docs now describe a concrete program in which Aragora upgrades vague ideas into goal and spec DAGs, submits approved specs into Ralph, and increasingly uses the same pipeline to build more of Aragora itself.

## Why this change
Recent Ralph validation moved this work from abstract vision to active execution planning. The repo already contains substantial pipeline, canvas, workflow, provenance, and orchestration substrate, but the planning docs were still underspecifying the productization strategy:

- the canonical goals described vague-intent-to-execution and self-improvement, but not the local-first stage-transition posture or the explicit bootstrapping requirement
- the roadmap and evolution docs mentioned the unified DAG pipeline, but not the new execution lane for turning that substrate into the main product surface
- the canonical next-steps and live issue map were still centered on older execution lanes and did not include this new program as a tracked GitHub-backed tranche

## What changed
- added a new program doc: `docs/plans/2026-03-18-bootstrapped-idea-to-execution-program.md`
- updated `docs/CANONICAL_GOALS.md` to make the local-first stage-transition posture and self-bootstrapping requirement explicit
- updated `ROADMAP.md` to add the new program and issue-backed milestones to Q2/Q3 priorities
- updated `docs/plans/ARAGORA_EVOLUTION_ROADMAP.md` with a March 2026 execution update and near-term gap summary
- updated `docs/status/NEXT_STEPS_CANONICAL.md` to add the bootstrapped idea-to-execution program as an explicit execution lane
- updated `docs/status/ACTIVE_EXECUTION_ISSUES.md` to map the new epic and tranche issues
- updated `docs/FEATURE_GAP_LIST.md` to track stage-transition UX, the unified workbench, Ralph autonomy hardening, and pipeline dogfooding as active gaps
- updated `docs/INDEX.md` so the new plan document is discoverable from the main docs index

## New execution issues
- #989 Bootstrapped local-first idea-to-execution workbench
- #990 Dogfood the pipeline to build more of Aragora itself
- #991 Close the Ralph autonomy gap from spec to repair PR
- #993 Productize the unified local-first DAG workbench
- #994 Add interactive stage transitions from ideas to goals to specs

## Validation
I ran:

```bash
python3 scripts/validate_doc_links.py
```

That command still fails on three pre-existing broken links in `docs/plans/2026-03-10-bootstrap-plan.md`:
- `2026-03-10-bootstrap-gates.md`
- `2026-03-10-dogfood-6-evidence.md`
- `phase0a_campaign_manifest.yaml`

Those failures were present independently of this branch. This PR does not introduce new link-validator failures.
