### PR TITLE
fix(ralph): stabilize verification runner and infra blocker classification

### DIFF
--- a/aragora/ralph/classifier.py
+++ b/aragora/ralph/classifier.py
@@ -100,6 +100,14 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
         "login",
         "clisubprocesserror",
     )
+    infra_failure_patterns = (
+        "agentconnectionerror",
+        "connection failed",
+        "certificate verify failed",
+        "ssl: certificate_verify_failed",
+        "cannot execute binary file",
+        "exec format error",
+    )
     projects = manifest_dict.get("projects", [])
 
     blocked_projects = [
@@ -120,15 +128,32 @@ def _classify_campaign_blocked(manifest_dict: dict[str, Any]) -> BlockerKind:
             rstatus = review.get("status", "")
             if rstatus:
                 review_statuses.append(rstatus)
-            findings = review.get("findings", [])
-            for finding in findings:
-                finding_lower = str(finding).lower()
-                if "scope" in finding_lower and (
-                    "violation" in finding_lower or "outside" in finding_lower
+            diagnostics: list[str] = [str(finding) for finding in review.get("findings", [])]
+
+            raw_review = review.get("raw_review", {})
+            if isinstance(raw_review, dict):
+                diagnostics.extend(str(value) for value in raw_review.values() if value)
+
+            for attempt in proj.get("attempt_history", []):
+                if not isinstance(attempt, dict):
+                    continue
+                failure_detail = attempt.get("failure_detail")
+                if failure_detail:
+                    diagnostics.append(str(failure_detail))
+                diagnostics.extend(
+                    str(blocker) for blocker in attempt.get("blockers", []) if str(blocker).strip()
+                )
+
+            for detail in diagnostics:
+                detail_lower = detail.lower()
+                if "scope" in detail_lower and (
+                    "violation" in detail_lower or "outside" in detail_lower
                 ):
                     return BlockerKind.SCOPE_FALSE_POSITIVE
-                if any(pattern in finding_lower for pattern in reviewer_failure_patterns):
+                if any(pattern in detail_lower for pattern in reviewer_failure_patterns):
                     return BlockerKind.REVIEWER_AUTH_OR_BILLING
+                if any(pattern in detail_lower for pattern in infra_failure_patterns):
+                    return BlockerKind.INFRA_FAILURE
 
     # Check for reviewer false rejection pattern: deliverable_created but
     # review blocked/changes_requested.

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -13,7 +13,10 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+import re
+import shlex
 import shutil
+import sys
 import time
 from typing import Any
 
@@ -921,13 +924,14 @@ class WorkerLauncher:
             command = str(raw_command).strip()
             if not command:
                 continue
+            execution_command = cls._normalize_verification_command(command)
 
             started = time.monotonic()
             try:
                 proc = await asyncio.create_subprocess_exec(
                     "/bin/bash",
                     "-lc",
-                    command,
+                    execution_command,
                     cwd=worktree_path,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
@@ -971,6 +975,22 @@ class WorkerLauncher:
                 }
             )
         return results
+
+    @staticmethod
+    def _normalize_verification_command(command: str) -> str:
+        """Rewrite leading ``python`` to the current interpreter.
+
+        Verification commands are executed under ``bash -lc`` and therefore
+        inherit the caller's PATH. On this machine ``python`` can resolve to
+        a non-executable AWS CLI shim, which breaks merge-gate verification
+        even when the worker produced a valid deliverable. Preserve the
+        original command for reporting, but execute with a stable interpreter.
+        """
+        match = re.match(r"(?P<prefix>\s*)python(?=\s|$)", command)
+        if not match:
+            return command
+        prefix = match.group("prefix")
+        return f"{prefix}{shlex.quote(sys.executable)}{command[match.end() :]}"
 
     @staticmethod
     def _can_query_dirty_tree(worker: WorkerProcess) -> bool:

--- a/tests/ralph/test_classifier.py
+++ b/tests/ralph/test_classifier.py
@@ -118,6 +118,56 @@ class TestClassifyBlocker:
         result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
         assert result == BlockerKind.REVIEWER_AUTH_OR_BILLING
 
+    def test_blocked_with_review_connection_error_escalates_infra(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "deliverable_created",
+                    "review": {
+                        "status": "blocked_nonreviewable",
+                        "findings": ["Review failed: AgentConnectionError"],
+                        "raw_review": {"error": "AgentConnectionError"},
+                    },
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.INFRA_FAILURE
+
+    def test_blocked_with_verification_exec_format_error_escalates_infra(self) -> None:
+        manifest = {
+            "projects": [
+                {
+                    "project_id": "p1",
+                    "status": "blocked",
+                    "last_run_outcome": "deliverable_created",
+                    "review": {
+                        "status": "blocked_nonreviewable",
+                        "findings": [],
+                    },
+                    "attempt_history": [
+                        {
+                            "failure_detail": (
+                                "merge gate blocked: verification failed: "
+                                "python -m pytest tests/ralph/test_classifier.py -q "
+                                "(exit 126) - /bin/bash: "
+                                "/Users/armand/local/aws-cli/python: cannot execute "
+                                "binary file: Exec format error"
+                            ),
+                            "blockers": [
+                                "merge gate blocked: verification failed: python -m pytest "
+                                "tests/ralph/test_classifier.py -q (exit 126)"
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        result = classify_blocker(stop_reason="campaign_blocked", manifest_dict=manifest)
+        assert result == BlockerKind.INFRA_FAILURE
+
     def test_blocked_with_true_diff_missing_still_maps_to_reviewer_missing_diff(self) -> None:
         manifest = {
             "projects": [

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -529,6 +530,36 @@ class TestLaunchAndWait:
 
         assert result.exit_code == 0
         assert result.stdout == "done"
+
+
+class TestVerificationCommands:
+    @pytest.mark.asyncio
+    async def test_run_verification_commands_uses_current_python_interpreter(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_python = tmp_path / "python"
+        fake_python.write_text(
+            "#!/bin/sh\necho 'broken python on PATH' >&2\nexit 126\n",
+            encoding="utf-8",
+        )
+        fake_python.chmod(0o755)
+
+        script = tmp_path / "hello.py"
+        script.write_text("print('ok from stable python')\n", encoding="utf-8")
+
+        monkeypatch.setenv("PATH", f"{tmp_path}:{os.environ['PATH']}")
+
+        result = await WorkerLauncher._run_verification_commands(
+            str(tmp_path),
+            ["python hello.py"],
+            timeout=30.0,
+        )
+
+        assert len(result) == 1
+        assert result[0]["command"] == "python hello.py"
+        assert result[0]["exit_code"] == 0
+        assert result[0]["passed"] is True
+        assert result[0]["stdout"].strip() == "ok from stable python"
 
 
 class TestWaitDetached:


### PR DESCRIPTION
## Summary
- normalize merge-gate verification commands so leading `python` uses the current interpreter instead of shell PATH
- classify review/verification environment failures as `infra_failure` before falling through to reviewer-missing-diff
- add regressions for broken PATH python and live receipt-inspired infra failure cases

## Validation
- `python3 -m pytest tests/swarm/test_worker_launcher.py tests/ralph/test_classifier.py -q`

## Benchmark context
V6 produced a real worker commit, but the run was blocked by merge-gate verification resolving `python` to a broken AWS CLI binary and by review-side connection errors. This patch fixes the verification runner and prevents those environment failures from being misclassified as `reviewer_missing_diff_context`.
