### PR TITLE
fix(campaign): preserve work-order debug evidence in receipts

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -30,6 +30,7 @@ from aragora.swarm.supervisor import (
     CAMPAIGN_REQUEUE_ELIGIBLE_METADATA_KEY,
     SwarmSupervisor,
 )
+from aragora.swarm.worker_launcher import MAX_WORKER_LOG_TAIL_CHARS, WorkerLauncher
 
 logger = logging.getLogger(__name__)
 
@@ -1950,6 +1951,7 @@ class CampaignExecutor:
                 "worker_branches": worker_branches,
                 "worker_commits": worker_commits,
                 "changed_files": _changed_files_from_run(run_dict),
+                "work_orders": _work_order_snapshots_from_run(run_dict),
                 "review_verdict": _receipt_review_verdict(project.review.status),
                 "verification_results": {
                     "pytest_exit_code": None,
@@ -2441,6 +2443,147 @@ def _worker_commit_from_run(
 ) -> str | None:
     commits = _worker_commits_from_run(project, run_dict)
     return commits[-1] if commits else None
+
+
+def _truncate_receipt_text(
+    value: Any,
+    *,
+    max_chars: int = MAX_WORKER_LOG_TAIL_CHARS,
+    tail: bool = False,
+) -> str:
+    text = str(value)
+    if len(text) <= max_chars:
+        return text
+    return text[-max_chars:] if tail else text[:max_chars]
+
+
+def _receipt_debug_value(value: Any, *, tail: bool = False) -> Any:
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return _truncate_receipt_text(value, tail=tail)
+    if isinstance(value, list):
+        return [_receipt_debug_value(item, tail=tail) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _receipt_debug_value(item, tail=tail) for key, item in value.items()}
+    return _truncate_receipt_text(value, tail=tail)
+
+
+def _receipt_verification_results(
+    work_order: dict[str, Any],
+) -> list[dict[str, Any]]:
+    results: list[dict[str, Any]] = []
+    for entry in work_order.get("verification_results", []):
+        if not isinstance(entry, dict):
+            continue
+        command = str(entry.get("command", "")).strip()
+        if not command:
+            continue
+        result: dict[str, Any] = {
+            "command": command,
+            "passed": bool(entry.get("passed", False)),
+            "stdout_tail": _truncate_receipt_text(entry.get("stdout", ""), tail=True),
+            "stderr_tail": _truncate_receipt_text(entry.get("stderr", ""), tail=True),
+        }
+        try:
+            result["exit_code"] = int(entry.get("exit_code", 0))
+        except (TypeError, ValueError):
+            result["exit_code"] = -1
+        try:
+            result["duration_seconds"] = float(entry.get("duration_seconds", 0.0) or 0.0)
+        except (TypeError, ValueError):
+            result["duration_seconds"] = 0.0
+        results.append(result)
+    return results
+
+
+def _receipt_merge_gate(work_order: dict[str, Any]) -> dict[str, Any] | None:
+    merge_gate = work_order.get("merge_gate")
+    if not isinstance(merge_gate, dict) or not merge_gate:
+        return None
+    return {
+        "enabled": bool(merge_gate.get("enabled", True)),
+        "checks_passed": bool(merge_gate.get("checks_passed", False)),
+        "human_approval_required": bool(merge_gate.get("human_approval_required", False)),
+        "merge_eligible": bool(merge_gate.get("merge_eligible", False)),
+        "verification_missing_reason": _optional_text(
+            merge_gate.get("verification_missing_reason")
+        ),
+        "expected_checks": [
+            str(item).strip() for item in merge_gate.get("expected_checks", []) if str(item).strip()
+        ],
+        "blocked_reasons": [
+            _truncate_receipt_text(item)
+            for item in merge_gate.get("blocked_reasons", [])
+            if str(item).strip()
+        ],
+    }
+
+
+def _work_order_snapshot_for_receipt(work_order: dict[str, Any]) -> dict[str, Any]:
+    prompt_preview = _truncate_receipt_text(
+        WorkerLauncher._build_prompt(work_order),
+        max_chars=MAX_WORKER_LOG_TAIL_CHARS,
+    )
+    stdout_tail = _truncate_receipt_text(work_order.get("stdout_tail", ""), tail=True)
+    stderr_tail = _truncate_receipt_text(work_order.get("stderr_tail", ""), tail=True)
+    return {
+        "work_order_id": _optional_text(work_order.get("work_order_id")),
+        "title": _optional_text(work_order.get("title")),
+        "description": _optional_text(work_order.get("description")),
+        "status": _optional_text(work_order.get("status")),
+        "target_agent": _optional_text(work_order.get("target_agent")),
+        "reviewer_agent": _optional_text(work_order.get("reviewer_agent")),
+        "file_scope": [
+            str(item).strip() for item in work_order.get("file_scope", []) if str(item).strip()
+        ],
+        "expected_tests": [
+            str(item).strip() for item in work_order.get("expected_tests", []) if str(item).strip()
+        ],
+        "success_criteria": _receipt_debug_value(work_order.get("success_criteria")),
+        "metadata": _receipt_debug_value(work_order.get("metadata") or {}),
+        "prompt_preview": prompt_preview,
+        "branch": _optional_text(work_order.get("branch")),
+        "commit_shas": [
+            str(item).strip() for item in work_order.get("commit_shas", []) if str(item).strip()
+        ],
+        "head_sha": _optional_text(work_order.get("head_sha")),
+        "changed_paths": [
+            str(item).strip() for item in work_order.get("changed_paths", []) if str(item).strip()
+        ],
+        "receipt_id": _optional_text(work_order.get("receipt_id")),
+        "review_status": _optional_text(work_order.get("review_status")),
+        "worker_outcome": _optional_text(work_order.get("worker_outcome")),
+        "dispatch_error": _optional_text(work_order.get("dispatch_error")),
+        "blockers": [
+            _truncate_receipt_text(item)
+            for item in work_order.get("blockers", [])
+            if str(item).strip()
+        ],
+        "verification_missing_reason": _optional_text(
+            work_order.get("verification_missing_reason")
+        ),
+        "verification_results": _receipt_verification_results(work_order),
+        "merge_gate": _receipt_merge_gate(work_order),
+        "stdout_tail": stdout_tail or None,
+        "stderr_tail": stderr_tail or None,
+        "dispatched_at": _optional_text(work_order.get("dispatched_at")),
+        "started_at": _optional_text(work_order.get("started_at")),
+        "completed_at": _optional_text(work_order.get("completed_at")),
+        "last_progress_at": _optional_text(work_order.get("last_progress_at")),
+        "last_observed_at": _optional_text(work_order.get("last_observed_at")),
+    }
+
+
+def _work_order_snapshots_from_run(run_dict: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not run_dict:
+        return []
+    snapshots: list[dict[str, Any]] = []
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        snapshots.append(_work_order_snapshot_for_receipt(work_order))
+    return snapshots
 
 
 def _planner_metadata_from_run(run_dict: dict[str, Any] | None) -> dict[str, Any]:

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -21,6 +21,7 @@ from aragora.swarm.campaign import (
     _receipt_final_status,
     _receipt_review_verdict,
 )
+from aragora.swarm.worker_launcher import MAX_WORKER_LOG_TAIL_CHARS
 
 
 # ---------------------------------------------------------------------------
@@ -332,6 +333,178 @@ class TestEmitReceipt:
         assert payload["planner_fallback_reason"] == "TimeoutError: planner timed out"
         assert payload["verification_missing_reason"] == "missing_verification_plan"
 
+    def test_receipt_includes_work_order_debug_snapshot(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="blocked", branch="")
+        manifest = _make_manifest(projects=[project])
+        run_dict = {
+            "work_orders": [
+                {
+                    "work_order_id": "wo-1",
+                    "title": "Analyze classifier blocker mapping",
+                    "description": "Trace stop_reason -> BlockerKind and add regressions.",
+                    "status": "needs_human",
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "file_scope": [
+                        "aragora/ralph/classifier.py",
+                        "tests/ralph/test_classifier.py",
+                    ],
+                    "expected_tests": ["python -m pytest tests/ralph/test_classifier.py -q"],
+                    "success_criteria": {
+                        "tests": "python -m pytest tests/ralph/test_classifier.py -q",
+                        "definition_of_done": "Classifier mapping documented and covered.",
+                    },
+                    "metadata": {
+                        "planner_strategy_requested": "model",
+                        "planner_strategy_used": "heuristic",
+                        "planner_fallback_reason": "AgentConnectionError: planner fallback",
+                        "requested_target_agent": "codex",
+                        "requested_reviewer_agent": "claude",
+                    },
+                    "branch": "codex/swarm-test",
+                    "commit_shas": ["abc123"],
+                    "head_sha": "abc123",
+                    "changed_paths": [
+                        "aragora/ralph/classifier.py",
+                        "tests/ralph/test_classifier.py",
+                    ],
+                    "review_status": "changes_requested",
+                    "worker_outcome": "merge_gate_failed",
+                    "dispatch_error": "merge gate blocked: verification failed",
+                    "blockers": ["review failed", "verification failed"],
+                    "verification_missing_reason": "missing_verification_plan",
+                    "verification_results": [
+                        {
+                            "command": "python -m pytest tests/ralph/test_classifier.py -q",
+                            "exit_code": 126,
+                            "passed": False,
+                            "stdout": "ok\n",
+                            "stderr": "exec format error\n",
+                            "duration_seconds": 0.322,
+                        }
+                    ],
+                    "merge_gate": {
+                        "enabled": True,
+                        "checks_passed": False,
+                        "human_approval_required": True,
+                        "merge_eligible": False,
+                        "verification_missing_reason": "missing_verification_plan",
+                        "expected_checks": ["python -m pytest tests/ralph/test_classifier.py -q"],
+                        "blocked_reasons": [
+                            "merge gate blocked: verification failed: python -m pytest tests/ralph/test_classifier.py -q (exit 126)"
+                        ],
+                        "verification_results": [
+                            {
+                                "command": "python -m pytest tests/ralph/test_classifier.py -q",
+                                "exit_code": 126,
+                                "passed": False,
+                            }
+                        ],
+                    },
+                    "stdout_tail": "worker stdout tail\n",
+                    "stderr_tail": "worker stderr tail\n",
+                    "dispatched_at": "2026-03-10T21:00:00+00:00",
+                    "started_at": "2026-03-10T21:00:05+00:00",
+                    "completed_at": "2026-03-10T21:05:05+00:00",
+                    "last_progress_at": "2026-03-10T21:04:55+00:00",
+                    "last_observed_at": "2026-03-10T21:05:05+00:00",
+                }
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        payload = _load_text_like_yaml(receipt_path)
+        snapshot = payload["work_orders"][0]
+        assert snapshot["work_order_id"] == "wo-1"
+        assert snapshot["target_agent"] == "codex"
+        assert snapshot["reviewer_agent"] == "claude"
+        assert snapshot["file_scope"] == [
+            "aragora/ralph/classifier.py",
+            "tests/ralph/test_classifier.py",
+        ]
+        assert snapshot["expected_tests"] == ["python -m pytest tests/ralph/test_classifier.py -q"]
+        assert snapshot["metadata"]["planner_strategy_used"] == "heuristic"
+        assert "Analyze classifier blocker mapping" in snapshot["prompt_preview"]
+        assert "FILE SCOPE GUIDANCE:" in snapshot["prompt_preview"]
+        assert "aragora/ralph/classifier.py" in snapshot["prompt_preview"]
+        assert snapshot["branch"] == "codex/swarm-test"
+        assert snapshot["commit_shas"] == ["abc123"]
+        assert snapshot["worker_outcome"] == "merge_gate_failed"
+        assert snapshot["verification_results"] == [
+            {
+                "command": "python -m pytest tests/ralph/test_classifier.py -q",
+                "duration_seconds": 0.322,
+                "exit_code": 126,
+                "passed": False,
+                "stdout_tail": "ok\n",
+                "stderr_tail": "exec format error\n",
+            }
+        ]
+        assert snapshot["merge_gate"] == {
+            "enabled": True,
+            "checks_passed": False,
+            "human_approval_required": True,
+            "merge_eligible": False,
+            "verification_missing_reason": "missing_verification_plan",
+            "expected_checks": ["python -m pytest tests/ralph/test_classifier.py -q"],
+            "blocked_reasons": [
+                "merge gate blocked: verification failed: python -m pytest tests/ralph/test_classifier.py -q (exit 126)"
+            ],
+        }
+        assert snapshot["stdout_tail"] == "worker stdout tail\n"
+        assert snapshot["stderr_tail"] == "worker stderr tail\n"
+
+    def test_receipt_truncates_debug_log_fields(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="blocked", branch="")
+        manifest = _make_manifest(projects=[project])
+        long_stdout = "a" * (MAX_WORKER_LOG_TAIL_CHARS + 25)
+        long_stderr = "b" * (MAX_WORKER_LOG_TAIL_CHARS + 25)
+        run_dict = {
+            "work_orders": [
+                {
+                    "work_order_id": "wo-1",
+                    "title": "Debug worker stall",
+                    "description": "Capture long logs.",
+                    "verification_results": [
+                        {
+                            "command": "python -m pytest tests/ralph/test_classifier.py -q",
+                            "exit_code": 1,
+                            "passed": False,
+                            "stdout": long_stdout,
+                            "stderr": long_stderr,
+                            "duration_seconds": 1.0,
+                        }
+                    ],
+                    "stdout_tail": long_stdout,
+                    "stderr_tail": long_stderr,
+                }
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        payload = _load_text_like_yaml(receipt_path)
+        snapshot = payload["work_orders"][0]
+        assert snapshot["stdout_tail"] == long_stdout[-MAX_WORKER_LOG_TAIL_CHARS:]
+        assert snapshot["stderr_tail"] == long_stderr[-MAX_WORKER_LOG_TAIL_CHARS:]
+        assert (
+            snapshot["verification_results"][0]["stdout_tail"]
+            == long_stdout[-MAX_WORKER_LOG_TAIL_CHARS:]
+        )
+        assert (
+            snapshot["verification_results"][0]["stderr_tail"]
+            == long_stderr[-MAX_WORKER_LOG_TAIL_CHARS:]
+        )
+
     def test_receipt_always_marks_rescue_false(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / "manifest.yaml"
         manifest_path.write_text("campaign_id: phase0a-test\n")
@@ -472,7 +645,7 @@ class TestApplyReviewResultEmitsReceipt:
         manifest_path.write_text("campaign_id: phase0a-test\n")
         executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
 
-        project = _make_project(status="delivered")
+        project = _make_project(status="delivered", branch="")
         manifest = _make_manifest(projects=[project])
         gate = CampaignReviewGate(status=CampaignReviewStatus.PASSED.value)
 
@@ -492,7 +665,7 @@ class TestApplyReviewResultEmitsReceipt:
         manifest_path.write_text("campaign_id: phase0a-test\n")
         executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
 
-        project = _make_project(status="delivered", estimated_cost_usd=3.5)
+        project = _make_project(status="delivered", estimated_cost_usd=3.5, branch="")
         manifest = _make_manifest(projects=[project])
         gate = CampaignReviewGate(status=CampaignReviewStatus.PASSED.value)
 


### PR DESCRIPTION
## Summary
- persist a compact per-work-order snapshot inside campaign receipts
- preserve the generated worker prompt, planner metadata, verification status, merge-gate state, and log tails so stalled runs remain debuggable after worktree cleanup
- add regression coverage for the new receipt evidence fields and truncation behavior

## Why
V6/V7 benchmark analysis showed the next autonomy gap is partly observational: once autopilot cleans up worker worktrees, the exact work orders, prompts, verification stderr, and merge-gate state disappear. Campaign receipts already survive cleanup, so they are the right durable place to keep a compact debugging snapshot.

## Receipt additions
Each emitted campaign receipt now includes `work_orders`, with per-lane snapshots for:
- bounded prompt preview
- title/description/status/agents
- file scope, expected tests, success criteria, planner metadata
- branch/commit/changed paths/receipt id
- worker outcome, dispatch error, blockers
- verification results with truncated stdout/stderr tails
- merge-gate summary
- worker stdout/stderr tails and key timestamps

## Validation
- `python3 -m pytest tests/swarm/test_campaign_receipt.py -q`
- `python3 -m pytest tests/swarm/test_worker_launcher.py tests/ralph/test_classifier.py -q`
- `python3 -m ruff check aragora/swarm/campaign.py tests/swarm/test_campaign_receipt.py tests/swarm/test_worker_launcher.py`
- `python3 -m ruff format --check aragora/swarm/campaign.py tests/swarm/test_campaign_receipt.py tests/swarm/test_worker_launcher.py`
