### PR TITLE
fix(campaign): preserve reviewer infra failure diagnostics

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -1042,7 +1042,7 @@ class CampaignReviewer:
                 status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
                 findings=[f"Review failed: {type(exc).__name__}"],
                 reviewed_at=_now_iso(),
-                raw_review={"error": type(exc).__name__},
+                raw_review={"error": type(exc).__name__, "detail": str(exc)[:500]},
             )
 
     @staticmethod
@@ -1952,6 +1952,7 @@ class CampaignExecutor:
                 "worker_commits": worker_commits,
                 "changed_files": _changed_files_from_run(run_dict),
                 "work_orders": _work_order_snapshots_from_run(run_dict),
+                "review_gate": project.review.to_dict(),
                 "review_verdict": _receipt_review_verdict(project.review.status),
                 "verification_results": {
                     "pytest_exit_code": None,

--- a/tests/swarm/test_campaign_receipt.py
+++ b/tests/swarm/test_campaign_receipt.py
@@ -333,6 +333,56 @@ class TestEmitReceipt:
         assert payload["planner_fallback_reason"] == "TimeoutError: planner timed out"
         assert payload["verification_missing_reason"] == "missing_verification_plan"
 
+    def test_receipt_includes_review_gate_snapshot(self, tmp_path: Path) -> None:
+        manifest_path = tmp_path / "manifest.yaml"
+        manifest_path.write_text("campaign_id: phase0a-test\n")
+        executor = CampaignExecutor(manifest_path=manifest_path, repo_root=tmp_path)
+
+        project = _make_project(status="blocked", branch="")
+        project.review = CampaignReviewGate(
+            required=True,
+            review_model="claude",
+            status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
+            findings=["Review failed: AgentConnectionError"],
+            reviewed_at="2026-03-18T16:43:23.301884+00:00",
+            raw_review={
+                "error": "AgentConnectionError",
+                "detail": (
+                    "[campaign-review] Connection failed "
+                    "(caused by: RuntimeError: certificate verify failed)"
+                ),
+            },
+        )
+        manifest = _make_manifest(projects=[project])
+        run_dict = {
+            "work_orders": [
+                {
+                    "branch": "codex/from-run",
+                    "head_sha": "abc123",
+                    "changed_paths": ["aragora/ralph/classifier.py"],
+                }
+            ]
+        }
+
+        receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        payload = _load_text_like_yaml(receipt_path)
+        assert payload["review_gate"] == {
+            "required": True,
+            "review_model": "claude",
+            "status": "blocked_nonreviewable",
+            "findings": ["Review failed: AgentConnectionError"],
+            "reviewed_at": "2026-03-18T16:43:23.301884+00:00",
+            "raw_review": {
+                "error": "AgentConnectionError",
+                "detail": (
+                    "[campaign-review] Connection failed "
+                    "(caused by: RuntimeError: certificate verify failed)"
+                ),
+            },
+        }
+        assert payload["review_verdict"] == "failed"
+
     def test_receipt_includes_work_order_debug_snapshot(self, tmp_path: Path) -> None:
         manifest_path = tmp_path / "manifest.yaml"
         manifest_path.write_text("campaign_id: phase0a-test\n")

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aragora.agents.errors import CLISubprocessError
+from aragora.agents.errors import AgentConnectionError, CLISubprocessError
 from aragora.swarm.campaign import (
     CampaignProject,
     CampaignReviewGate,
@@ -336,3 +336,33 @@ class TestReviewerBillingErrorDetection:
         assert any("ValueError" in f for f in gate.findings)
         # Raw exception detail should not be in findings
         assert not any("secret internal detail" in f for f in gate.findings)
+        assert gate.raw_review["error"] == "ValueError"
+        assert gate.raw_review["detail"] == "secret internal detail"
+
+    @pytest.mark.asyncio
+    async def test_agent_connection_error_keeps_detail_in_raw_review(self) -> None:
+        reviewer = CampaignReviewer()
+        project = _make_project()
+        run_dict = _make_run_dict()
+
+        review_error = AgentConnectionError(
+            "Connection failed",
+            agent_name="campaign-review",
+            cause=RuntimeError("certificate verify failed"),
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.generate = AsyncMock(side_effect=review_error)
+
+        with patch("aragora.swarm.campaign.create_agent", return_value=mock_agent):
+            gate = await reviewer.review(
+                project=project,
+                worker_model="codex",
+                review_model="claude",
+                run_dict=run_dict,
+            )
+
+        assert gate.status == CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value
+        assert gate.findings == ["Review failed: AgentConnectionError"]
+        assert gate.raw_review["error"] == "AgentConnectionError"
+        assert "certificate verify failed" in gate.raw_review["detail"]


### PR DESCRIPTION
## Summary
- preserve generic reviewer exception detail in campaign review raw_review without leaking it into findings
- include the final review gate snapshot in campaign receipts so blocked delivered runs keep their review diagnostics
- add regression coverage for AgentConnectionError reviewer failures and receipt review snapshots

## Validation
- python3 -m pytest tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_campaign_receipt.py -q
- python3 -m ruff check aragora/swarm/campaign.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_campaign_receipt.py
- python3 -m ruff format --check aragora/swarm/campaign.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_campaign_receipt.py

## Benchmark diagnosis
A diagnostic replay of the V9 reviewer path now shows the underlying failure chain that the old manifest lost:
- Claude review CLI returns "Credit balance is too low"
- fallback then fails with OpenRouter TLS certificate verification
