### PR TITLE
fix(swarm): harden benchmark recovery and profile tooling

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -1102,6 +1102,7 @@ class CampaignExecutor:
         self.bridge = bridge or NomicPipelineBridge(repo_path=self.repo_root)
 
     async def execute_once(self) -> dict[str, Any]:
+        await self._reconcile_delivered_projects()
         with locked_manifest_path(self.manifest_path):
             manifest = load_campaign_manifest(self.manifest_path)
             self._reconcile_active_projects(manifest)
@@ -1232,6 +1233,134 @@ class CampaignExecutor:
             _refresh_execution_state(manifest)
             save_campaign_manifest(self.manifest_path, manifest)
             return manifest.execution_state.last_result
+
+    async def _reconcile_delivered_projects(self) -> None:
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            pending_ids = [
+                project.project_id
+                for project in manifest.projects
+                if project.status == CampaignProjectStatus.DELIVERED.value
+                and project.run_id
+                and project.review.status == CampaignReviewStatus.PENDING.value
+            ]
+
+        for project_id in pending_ids:
+            await self._reconcile_delivered_project(project_id)
+
+    async def _reconcile_delivered_project(self, project_id: str) -> None:
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            project = manifest.project_map().get(project_id)
+            if (
+                project is None
+                or project.status != CampaignProjectStatus.DELIVERED.value
+                or not project.run_id
+                or project.review.status != CampaignReviewStatus.PENDING.value
+            ):
+                return
+            run_id = str(project.run_id).strip()
+            worker_model = manifest.worker_model
+            review_model = manifest.review_model
+            enforce_cross_model_review = manifest.enforce_cross_model_review
+
+        run_dict = self._refresh_run_dict(run_id)
+        if not run_dict:
+            return
+
+        gate = self._review_gate_from_run_metadata(
+            run_dict,
+            review_model=review_model,
+        )
+        if gate is None:
+            with locked_manifest_path(self.manifest_path):
+                manifest = load_campaign_manifest(self.manifest_path)
+                project = manifest.project_map().get(project_id)
+                if project is None:
+                    return
+                budget_context = self._review_budget_context(manifest, project)
+            gate = await self.reviewer.review(
+                project=project,
+                worker_model=worker_model,
+                review_model=review_model,
+                enforce_cross_model_review=enforce_cross_model_review,
+                run_dict=dict(run_dict),
+                budget_context=budget_context,
+                repo_root=self.repo_root,
+                target_branch=self.target_branch,
+            )
+
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            project = manifest.project_map().get(project_id)
+            if (
+                project is None
+                or project.status != CampaignProjectStatus.DELIVERED.value
+                or project.review.status != CampaignReviewStatus.PENDING.value
+            ):
+                return
+            self._hydrate_project_deliverable(project, run_dict)
+            project.review = gate
+            self._apply_review_result(manifest, project, gate, run_dict=dict(run_dict))
+            _refresh_execution_state(manifest)
+            save_campaign_manifest(self.manifest_path, manifest)
+
+    @staticmethod
+    def _hydrate_project_deliverable(project: CampaignProject, run_dict: dict[str, Any]) -> None:
+        deliverable = _extract_deliverable(run_dict)
+        if deliverable:
+            if deliverable.get("type") == "pr":
+                project.pr_url = str(deliverable.get("pr_url", "")).strip() or project.pr_url
+            elif deliverable.get("type") == "adopted_pr":
+                project.adopted_pr = (
+                    str(deliverable.get("adopted_pr", "")).strip() or project.adopted_pr
+                )
+            elif deliverable.get("type") == "branch":
+                project.branch = str(deliverable.get("branch", "")).strip() or project.branch
+                commit_shas = [
+                    str(item).strip()
+                    for item in deliverable.get("commit_shas", [])
+                    if str(item).strip()
+                ]
+                if commit_shas:
+                    project.commit_shas = commit_shas
+
+        # Recovery runs can persist branch/commit metadata on work orders even
+        # when the top-level deliverable blob is absent or incomplete.
+        project.branch = _worker_branch_from_run(project, run_dict) or project.branch
+        commit_shas = _worker_commits_from_run(project, run_dict)
+        if commit_shas:
+            project.commit_shas = commit_shas
+        project.worker_receipt_id = _first_receipt_id(run_dict) or project.worker_receipt_id
+
+    @staticmethod
+    def _review_gate_from_run_metadata(
+        run_dict: dict[str, Any],
+        *,
+        review_model: str,
+    ) -> CampaignReviewGate | None:
+        blockers = CampaignExecutor._dispatch_blockers(run_dict)
+        verification_missing_reason = _verification_missing_reason_from_run(run_dict)
+        if verification_missing_reason or blockers:
+            findings = list(blockers)
+            if verification_missing_reason:
+                findings.append(f"Worker verification incomplete: {verification_missing_reason}.")
+            deduped_findings = [
+                item for item in dict.fromkeys(str(f).strip() for f in findings) if item
+            ]
+            return CampaignReviewGate(
+                required=True,
+                review_model=review_model,
+                status=CampaignReviewStatus.CHANGES_REQUESTED.value,
+                findings=deduped_findings or ["Worker reported an unresolved merge-gate issue."],
+                reviewed_at=_now_iso(),
+                raw_review={
+                    "source": "run_metadata_recovery",
+                    "blockers": blockers,
+                    "verification_missing_reason": verification_missing_reason,
+                },
+            )
+        return None
 
     def status(self) -> dict[str, Any]:
         with locked_manifest_path(self.manifest_path):

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -247,6 +247,15 @@ class SwarmSupervisor:
         return run
 
     def refresh_run(self, run_id: str) -> SupervisorRun:
+        # Reap dead-session active leases before deriving run status so
+        # orphaned leased work orders do not remain "active" indefinitely.
+        try:
+            stale = self.store.reap_stale_leases()
+            if stale:
+                logger.info("reaped %d stale leases during refresh_run", len(stale))
+        except Exception:
+            logger.debug("reap_stale_leases failed during refresh_run", exc_info=True)
+
         # Proactively reap TTL-expired leases so stale locks don't accumulate
         # when no new claim_lease() calls are attempted (e.g. all work orders
         # stuck in waiting_conflict).

--- a/scripts/claude_profile.sh
+++ b/scripts/claude_profile.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Explicit Claude CLI profile selector for local Aragora runs.
+#
+# This helper is intentionally explicit. It does not auto-fail over between
+# accounts. Instead, it lets you choose which Claude profile Aragora should
+# inherit for one command or one login flow.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  claude_profile.sh home <profile-name-or-home>
+  claude_profile.sh status <profile-name-or-home>
+  claude_profile.sh login <profile-name-or-home>
+  claude_profile.sh logout <profile-name-or-home>
+  claude_profile.sh exec <profile-name-or-home> -- <command...>
+
+Examples:
+  scripts/claude_profile.sh status max-01
+  scripts/claude_profile.sh login max-02
+  scripts/claude_profile.sh exec max-01 -- \
+    python3 -m aragora.cli.main ralph campaign-supervisor status --json
+
+Conventions:
+  Bare profile names resolve under ~/.aragora-claude by default.
+  <profile-home> is a directory that contains its own .claude state.
+  The helper sets HOME=<profile-home> for the command it runs.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+MODE="$1"
+PROFILE_HOME="$2"
+shift 2
+
+require_command claude
+
+ORIGINAL_HOME="$HOME"
+ORIGINAL_GH_CONFIG_DIR="${GH_CONFIG_DIR:-${ORIGINAL_HOME}/.config/gh}"
+ORIGINAL_GH_TOKEN=""
+
+PROFILE_ROOT="${CLAUDE_PROFILE_ROOT:-${HOME}/.aragora-claude}"
+
+resolve_profile_home() {
+  local raw_path="$1"
+
+  case "$raw_path" in
+    "~") raw_path="${HOME}" ;;
+    "~"/*) raw_path="${HOME}${raw_path#"~"}" ;;
+    /*) ;;
+    ./*|../*)
+      raw_path="$(cd "$(dirname "$raw_path")" && pwd)/$(basename "$raw_path")"
+      ;;
+    *)
+      raw_path="${PROFILE_ROOT}/${raw_path}"
+      ;;
+  esac
+
+  local raw_parent
+  raw_parent="$(dirname "$raw_path")"
+  mkdir -p "$raw_parent"
+  raw_path="$(cd "$raw_parent" && pwd)/$(basename "$raw_path")"
+  mkdir -p "$raw_path"
+  printf '%s\n' "$raw_path"
+}
+
+PROFILE_HOME="$(resolve_profile_home "$PROFILE_HOME")"
+
+if command -v gh >/dev/null 2>&1; then
+  if ORIGINAL_GH_TOKEN="$(
+    HOME="${ORIGINAL_HOME}" \
+    GH_CONFIG_DIR="${ORIGINAL_GH_CONFIG_DIR}" \
+    gh auth token 2>/dev/null
+  )"; then
+    :
+  else
+    ORIGINAL_GH_TOKEN=""
+  fi
+fi
+
+run_with_profile() {
+  HOME="$PROFILE_HOME" \
+  XDG_CONFIG_HOME="${PROFILE_HOME}/.config" \
+  CLAUDE_CONFIG_DIR="${PROFILE_HOME}/.claude" \
+  CODEX_HOME="${CODEX_HOME:-${ORIGINAL_HOME}/.codex}" \
+  GH_CONFIG_DIR="${ORIGINAL_GH_CONFIG_DIR}" \
+  GH_TOKEN="${GH_TOKEN:-${ORIGINAL_GH_TOKEN}}" \
+  PATH="${PATH}" \
+  env \
+    -u ANTHROPIC_API_KEY \
+    -u CLAUDECODE \
+    -u CLAUDE_CODE_ENTRYPOINT \
+    ARAGORA_OPENROUTER_FALLBACK_ENABLED=false \
+    OPENROUTER_API_KEY= \
+    "$@"
+}
+
+case "$MODE" in
+  home)
+    if [[ $# -ne 0 ]]; then
+      die "home does not take extra arguments"
+    fi
+    printf '%s\n' "$PROFILE_HOME"
+    ;;
+  status)
+    if [[ $# -ne 0 ]]; then
+      die "status does not take extra arguments"
+    fi
+    run_with_profile claude auth status
+    ;;
+  login)
+    if [[ $# -ne 0 ]]; then
+      die "login does not take extra arguments"
+    fi
+    mkdir -p "${PROFILE_HOME}/.claude" "${PROFILE_HOME}/.config"
+    echo "Using profile home: ${PROFILE_HOME}"
+    run_with_profile claude auth login
+    ;;
+  logout)
+    if [[ $# -ne 0 ]]; then
+      die "logout does not take extra arguments"
+    fi
+    run_with_profile claude auth logout
+    ;;
+  exec)
+    if [[ $# -lt 2 || "$1" != "--" ]]; then
+      die "exec requires '-- <command...>'"
+    fi
+    shift
+    mkdir -p "${PROFILE_HOME}/.claude" "${PROFILE_HOME}/.config"
+    echo "Using profile home: ${PROFILE_HOME}"
+    echo "Command: $*"
+    run_with_profile "$@"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/claude_profiles_bootstrap.sh
+++ b/scripts/claude_profiles_bootstrap.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Sequential Claude profile login/status helper.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  claude_profiles_bootstrap.sh login [--force] [profile-name...]
+  claude_profiles_bootstrap.sh status [profile-name...]
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROFILE_TOOL="${SCRIPT_DIR}/claude_profile.sh"
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+MODE="$1"
+shift
+
+FORCE_LOGIN=0
+if [[ "$MODE" == "login" && $# -gt 0 && "$1" == "--force" ]]; then
+  FORCE_LOGIN=1
+  shift
+fi
+
+default_profiles=(
+  max-01
+  max-02
+  max-03
+  max-04
+  max-05
+  max-06
+  max-07
+  max-08
+  max-09
+  max-10
+  max-11
+  max-12
+  max-13
+)
+
+if [[ $# -gt 0 ]]; then
+  profiles=("$@")
+else
+  profiles=("${default_profiles[@]}")
+fi
+
+already_logged_in() {
+  local profile="$1"
+  local status_output
+
+  if ! status_output="$("${PROFILE_TOOL}" status "$profile" 2>/dev/null)"; then
+    return 1
+  fi
+  grep -q '"loggedIn": true' <<<"$status_output"
+}
+
+print_status() {
+  local profile="$1"
+  echo
+  echo "=== ${profile} ==="
+  "${PROFILE_TOOL}" status "$profile" || true
+}
+
+profile_home() {
+  "${PROFILE_TOOL}" home "$1"
+}
+
+launch_login_with_profile() {
+  local profile_home="$1"
+  HOME="$profile_home" \
+  XDG_CONFIG_HOME="${profile_home}/.config" \
+  CLAUDE_CONFIG_DIR="${profile_home}/.claude" \
+  PATH="${PATH}" \
+  env \
+    -u ANTHROPIC_API_KEY \
+    -u CLAUDECODE \
+    -u CLAUDE_CODE_ENTRYPOINT \
+    ARAGORA_OPENROUTER_FALLBACK_ENABLED=false \
+    OPENROUTER_API_KEY= \
+    claude auth login
+}
+
+extract_auth_url() {
+  local log_file="$1"
+  python3 - "$log_file" <<'PY'
+import pathlib
+import re
+import sys
+
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+matches = re.findall(r"https://claude\.ai/oauth/authorize\?[^\s]+", text)
+print(matches[-1] if matches else "")
+PY
+}
+
+extract_state_from_url() {
+  local auth_url="$1"
+  python3 - "$auth_url" <<'PY'
+import sys
+import urllib.parse
+
+parsed = urllib.parse.urlparse(sys.argv[1])
+query = urllib.parse.parse_qs(parsed.query)
+print(query.get("state", [""])[0])
+PY
+}
+
+wait_for_auth_url() {
+  local pid="$1"
+  local log_file="$2"
+  local attempts="${3:-100}"
+  local auth_url=""
+
+  for ((i = 0; i < attempts; i++)); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    auth_url="$(extract_auth_url "$log_file")"
+    if [[ -n "$auth_url" ]]; then
+      printf '%s\n' "$auth_url"
+      return 0
+    fi
+    sleep 0.2
+  done
+
+  printf '%s\n' ""
+  return 1
+}
+
+wait_for_callback_port() {
+  local pid="$1"
+  local attempts="${2:-100}"
+  local port=""
+
+  for ((i = 0; i < attempts; i++)); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    port="$(lsof -a -p "$pid" -nP -iTCP -sTCP:LISTEN 2>/dev/null | awk 'NR>1 {print $9}' | sed -E 's/.*:([0-9]+)$/\1/' | head -n1)"
+    if [[ -n "$port" ]]; then
+      printf '%s\n' "$port"
+      return 0
+    fi
+    sleep 0.2
+  done
+
+  printf '%s\n' ""
+  return 1
+}
+
+post_callback() {
+  local port="$1"
+  local code="$2"
+  local state="$3"
+  local encoded_code
+  local encoded_state
+  encoded_code="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$code")"
+  encoded_state="$(python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$state")"
+  curl -g -fsS "http://[::1]:${port}/callback?code=${encoded_code}&state=${encoded_state}" >/dev/null
+}
+
+login_profile_manual_code() {
+  local profile="$1"
+  local profile_home_path
+  local auth_log
+  local pid=""
+  local auth_url=""
+  local callback_port=""
+  local state=""
+  local auth_result=""
+  local code=""
+  local pasted_state=""
+
+  profile_home_path="$(profile_home "$profile")"
+  mkdir -p "${profile_home_path}/.claude" "${profile_home_path}/.config"
+  auth_log="$(mktemp -t "claude-auth-${profile}.XXXXXX")"
+
+  cleanup_login() {
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+    fi
+    rm -f "$auth_log"
+  }
+  trap cleanup_login RETURN
+
+  launch_login_with_profile "$profile_home_path" >"$auth_log" 2>&1 &
+  pid=$!
+
+  auth_url="$(wait_for_auth_url "$pid" "$auth_log" || true)"
+  callback_port="$(wait_for_callback_port "$pid" || true)"
+
+  if [[ -z "$auth_url" || -z "$callback_port" ]]; then
+    echo "Failed to initialize Claude login flow for ${profile}."
+    cat "$auth_log"
+    return 1
+  fi
+
+  state="$(extract_state_from_url "$auth_url")"
+
+  echo "Using profile home: ${profile_home_path}"
+  echo "If the browser didn't open, visit:"
+  echo "${auth_url}"
+  echo
+  echo "After Google OAuth completes, paste the returned code or code#state:"
+
+  while true; do
+    if already_logged_in "$profile"; then
+      wait "$pid" || true
+      echo "Completed login flow."
+      "${PROFILE_TOOL}" status "$profile"
+      return 0
+    fi
+
+    if read -r -t 1 auth_result; then
+      break
+    fi
+  done
+
+  code="${auth_result%%#*}"
+  pasted_state=""
+  if [[ "$auth_result" == *"#"* ]]; then
+    pasted_state="${auth_result#*#}"
+  fi
+  if [[ -n "$pasted_state" ]]; then
+    state="$pasted_state"
+  fi
+
+  if [[ -z "$code" || -z "$state" ]]; then
+    echo "Missing code or state; cannot complete callback."
+    cat "$auth_log"
+    return 1
+  fi
+
+  if ! post_callback "$callback_port" "$code" "$state"; then
+    echo "Failed to post callback for ${profile}."
+    cat "$auth_log"
+    return 1
+  fi
+
+  wait "$pid" || true
+  echo "Completed login flow."
+  "${PROFILE_TOOL}" status "$profile"
+}
+
+case "$MODE" in
+  status)
+    for profile in "${profiles[@]}"; do
+      print_status "$profile"
+    done
+    ;;
+  login)
+    for profile in "${profiles[@]}"; do
+      echo
+      echo "=== ${profile} ==="
+      if [[ "$FORCE_LOGIN" -ne 1 ]] && already_logged_in "$profile"; then
+        echo "Already logged in; skipping."
+        "${PROFILE_TOOL}" status "$profile" || true
+        continue
+      fi
+      login_profile_manual_code "$profile"
+    done
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/scripts/phase0b_benchmark_with_profile.sh
+++ b/scripts/phase0b_benchmark_with_profile.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run the Phase 0B benchmark tooling through an explicit Claude profile.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  phase0b_benchmark_with_profile.sh [--profile PROFILE] [--show-auth] <benchmark-args...>
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROFILE_TOOL="${SCRIPT_DIR}/claude_profile.sh"
+BENCHMARK_TOOL="${SCRIPT_DIR}/phase0b_role_benchmark.py"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PROFILE="${CLAUDE_BENCHMARK_PROFILE:-max-12}"
+SHOW_AUTH=0
+
+resolve_python() {
+  if [[ -n "${ARAGORA_BENCHMARK_PYTHON:-}" ]]; then
+    printf '%s\n' "${ARAGORA_BENCHMARK_PYTHON}"
+    return 0
+  fi
+
+  if [[ -f "${PROJECT_ROOT}/.python-version" ]]; then
+    local version
+    version="$(tr -d '[:space:]' < "${PROJECT_ROOT}/.python-version")"
+    local pyenv_python="${HOME}/.pyenv/versions/${version}/bin/python"
+    if [[ -x "${pyenv_python}" ]]; then
+      printf '%s\n' "${pyenv_python}"
+      return 0
+    fi
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+    return 0
+  fi
+
+  die "could not resolve a Python interpreter; set ARAGORA_BENCHMARK_PYTHON"
+}
+
+PYTHON_BIN="$(resolve_python)"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      [[ $# -ge 2 ]] || die "--profile requires a value"
+      PROFILE="$2"
+      shift 2
+      ;;
+    --show-auth)
+      SHOW_AUTH=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[[ $# -gt 0 ]] || {
+  usage
+  exit 1
+}
+
+STATUS_JSON="$("${PROFILE_TOOL}" status "${PROFILE}" 2>/dev/null || true)"
+if [[ -z "${STATUS_JSON}" ]] || ! grep -q '"loggedIn": true' <<<"${STATUS_JSON}"; then
+  die "Claude profile ${PROFILE} is not logged in. Run: ${PROFILE_TOOL} login ${PROFILE}"
+fi
+
+if [[ "${SHOW_AUTH}" -eq 1 ]]; then
+  echo "Claude profile: ${PROFILE}"
+  echo "${STATUS_JSON}"
+fi
+
+exec "${PROFILE_TOOL}" exec "${PROFILE}" -- env ARAGORA_SKIP_SECRETS="${ARAGORA_SKIP_SECRETS:-1}" "${PYTHON_BIN}" "${BENCHMARK_TOOL}" "$@"

--- a/tests/swarm/test_campaign.py
+++ b/tests/swarm/test_campaign.py
@@ -2134,3 +2134,81 @@ class TestNeedsHumanWithDeliverable:
         executor._apply_review_result(reloaded, project, gate)
 
         assert project.status == CampaignProjectStatus.WAITING_FOR_PR.value
+
+    @pytest.mark.asyncio
+    async def test_reconcile_delivered_project_recovers_pending_review_from_run_metadata(
+        self, tmp_path: Path
+    ) -> None:
+        repo = _init_repo(tmp_path)
+        manifest_path = repo / ".aragora" / "manifest.yaml"
+        manifest_path.parent.mkdir(parents=True)
+
+        manifest = CampaignManifest(
+            campaign_id="test-review-recovery",
+            created_at=datetime.now(UTC).isoformat(),
+            source_kind="manual",
+            source_ref="test",
+            planner_strategy="model",
+            planner_model="codex",
+            worker_model="codex",
+            review_model="claude",
+            projects=[
+                CampaignProject(
+                    project_id="P-1",
+                    title="Recovered deliverable",
+                    status=CampaignProjectStatus.DELIVERED.value,
+                    run_id="run-recover",
+                    review=CampaignReviewGate(
+                        required=True,
+                        status=CampaignReviewStatus.PENDING.value,
+                        review_model="claude",
+                    ),
+                    spec=SwarmSpec(
+                        raw_goal="Recover delivered project review",
+                        refined_goal="Recover delivered project review",
+                        file_scope_hints=["aragora/swarm/campaign.py"],
+                    ),
+                ),
+            ],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+
+        executor = CampaignExecutor(
+            manifest_path=manifest_path,
+            repo_root=repo,
+            target_branch="main",
+        )
+
+        run_dict = {
+            "run_id": "run-recover",
+            "status": "needs_human",
+            "metadata": {
+                CAMPAIGN_OUTCOME_METADATA_KEY: CampaignRunOutcome.DELIVERABLE_CREATED.value,
+                CAMPAIGN_BLOCKERS_METADATA_KEY: [
+                    "merge gate blocked: missing verification plan for code-change lane"
+                ],
+                CAMPAIGN_REQUEUE_ELIGIBLE_METADATA_KEY: False,
+            },
+            "work_orders": [
+                {
+                    "work_order_id": "wo-1",
+                    "status": "needs_human",
+                    "branch": "codex/swarm-recover-subtask_1",
+                    "commit_shas": ["deadbeef"],
+                    "receipt_id": "worker-receipt-1",
+                    "verification_missing_reason": "missing_verification_plan",
+                }
+            ],
+        }
+
+        with patch.object(executor, "_refresh_run_dict", return_value=run_dict):
+            await executor._reconcile_delivered_projects()
+
+        reloaded = load_campaign_manifest(manifest_path)
+        project = reloaded.project_map()["P-1"]
+        assert project.status == CampaignProjectStatus.NEEDS_REVISION.value
+        assert project.branch == "codex/swarm-recover-subtask_1"
+        assert project.commit_shas == ["deadbeef"]
+        assert project.worker_receipt_id == "worker-receipt-1"
+        assert project.review.status == CampaignReviewStatus.CHANGES_REQUESTED.value
+        assert "missing verification plan" in project.review.findings[0]

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -2171,3 +2171,63 @@ def test_refresh_run_reaps_expired_leases(repo: Path, store: DevCoordinationStor
     supervisor.refresh_run(run.run_id)
     active_lease_ids = {l.lease_id for l in store.list_active_leases()}
     assert expired.lease_id not in active_lease_ids
+
+
+def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordinationStore) -> None:
+    """refresh_run should not leave dead leased work orders active forever."""
+    lifecycle = MagicMock()
+    session_path = repo / "wt-stale"
+    session_path.mkdir()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="stale-worker",
+        agent="codex",
+        branch="codex/stale-worker",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="stale-lane",
+                title="Stale work",
+                description="Do stale work.",
+                file_scope=["other/file.py"],
+            )
+        ],
+    )
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+    run = supervisor.start_run(spec=SwarmSpec(raw_goal="Goal", refined_goal="Goal"))
+    lease_id = str(run.work_orders[0]["lease_id"])
+    assert lease_id
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE leases SET updated_at = ? WHERE lease_id = ?",
+            ("2020-01-01T00:00:00+00:00", lease_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    refreshed = supervisor.refresh_run(run.run_id)
+
+    assert refreshed.status == "needs_human"
+    work_order = refreshed.work_orders[0]
+    assert work_order["status"] == "needs_human"
+    assert work_order["failure_reason"] == "stale_lease_reaped"
+    assert lease_id not in {lease.lease_id for lease in store.list_active_leases()}


### PR DESCRIPTION
## Summary
- reap stale leases during `refresh_run()` so dead leased work orders stop presenting as active
- recover delivered campaign projects that got stranded in pending review by reconciling persisted run metadata
- add explicit Claude profile benchmark helpers that preserve Codex and GitHub auth under profile-swapped HOME

## Verification
- `python -m pytest tests/swarm/test_supervisor.py -q -k 'refresh_run_reaps_stale_leased_work_order or refresh_run_reaps_expired_leases or refresh_run_releases_managed_conflicts_without_active_session or refresh_run_keeps_conflict_for_live_managed_session'`
- `python -m pytest tests/swarm/test_campaign.py -q -k 'reconcile_delivered_project_recovers_pending_review_from_run_metadata or needs_human'`
- `python -m pytest tests/swarm/test_supervisor.py tests/swarm/test_campaign.py -q`
- `python -m ruff check aragora/swarm/supervisor.py aragora/swarm/campaign.py tests/swarm/test_supervisor.py tests/swarm/test_campaign.py`
- `python -m ruff format --check aragora/swarm/supervisor.py aragora/swarm/campaign.py tests/swarm/test_supervisor.py tests/swarm/test_campaign.py`
- `python -m py_compile aragora/swarm/supervisor.py aragora/swarm/campaign.py`
- `bash -n scripts/claude_profile.sh scripts/claude_profiles_bootstrap.sh scripts/phase0b_benchmark_with_profile.sh`
