### PR TITLE
feat(pipeline): add Decision Integrity Phase 1 receipt enforcement gate

### DIFF
--- a/aragora/config/feature_flags.py
+++ b/aragora/config/feature_flags.py
@@ -631,6 +631,48 @@ class FeatureFlagRegistry:
             FlagCategory.BILLING,
         )
 
+        # Decision integrity rollout flags
+        self.register(
+            "receipt_enforcement_openclaw",
+            bool,
+            False,
+            "Require approved execution receipts for OpenClaw action execution paths",
+            FlagCategory.CORE,
+            FlagStatus.ALPHA,
+        )
+        self.register(
+            "receipt_enforcement_canvas",
+            bool,
+            False,
+            "Require approved execution receipts for canvas action execution paths",
+            FlagCategory.CORE,
+            FlagStatus.ALPHA,
+        )
+        self.register(
+            "receipt_enforcement_computer_use",
+            bool,
+            False,
+            "Require approved execution receipts for computer-use orchestration paths",
+            FlagCategory.CORE,
+            FlagStatus.ALPHA,
+        )
+        self.register(
+            "receipt_enforcement_inbox",
+            bool,
+            False,
+            "Require approved execution receipts for inbox mutation paths",
+            FlagCategory.CORE,
+            FlagStatus.ALPHA,
+        )
+        self.register(
+            "receipt_enforcement_shared_inbox",
+            bool,
+            False,
+            "Require approved execution receipts for shared inbox mutation paths",
+            FlagCategory.CORE,
+            FlagStatus.ALPHA,
+        )
+
         # Oracle streaming
         self.register(
             "enable_oracle_streaming",

--- a/aragora/pipeline/receipt_enforcement.py
+++ b/aragora/pipeline/receipt_enforcement.py
@@ -1,0 +1,263 @@
+"""Canonical receipt enforcement helpers for action-taking paths.
+
+Phase 1 adds a single enforcement surface that write-capable handlers can call
+without changing default behavior. Enforcement stays disabled until the
+per-domain feature flag is enabled.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Final
+
+from aragora.config.feature_flags import is_enabled
+from aragora.gauntlet.receipt_models import DecisionReceipt
+from aragora.gauntlet.receipt_store import (
+    ReceiptState,
+    ReceiptStateError,
+    StoredReceipt,
+    get_receipt_store,
+)
+
+logger = logging.getLogger(__name__)
+
+_FEATURE_FLAG_BY_DOMAIN: Final[dict[str, str]] = {
+    "openclaw": "receipt_enforcement_openclaw",
+    "canvas": "receipt_enforcement_canvas",
+    "computer_use": "receipt_enforcement_computer_use",
+    "inbox": "receipt_enforcement_inbox",
+    "shared_inbox": "receipt_enforcement_shared_inbox",
+}
+
+
+class ReceiptEnforcementError(RuntimeError):
+    """Raised when an action-taking path lacks a valid execution receipt."""
+
+    status_code = 428
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        action_domain: str,
+        action_type: str,
+        receipt_id: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.action_domain = action_domain
+        self.action_type = action_type
+        self.receipt_id = receipt_id
+
+
+@dataclass(frozen=True, slots=True)
+class ReceiptExemption:
+    """Documented exemption for read-only or legacy-admin execution paths."""
+
+    reason: str
+    approved_by: str
+    category: str = "read_only"
+
+
+def _normalize_domain(action_domain: str) -> str:
+    normalized = str(action_domain or "").strip().lower().replace("-", "_")
+    if normalized not in _FEATURE_FLAG_BY_DOMAIN:
+        raise ValueError(f"Unsupported receipt enforcement domain: {action_domain!r}")
+    return normalized
+
+
+def _log_enforcement_event(
+    *,
+    result: str,
+    action_domain: str,
+    action_type: str,
+    actor_id: str,
+    resource_id: str,
+    receipt_id: str | None = None,
+    detail: str | None = None,
+) -> None:
+    logger.info(
+        "receipt_enforcement result=%s domain=%s action=%s actor=%s resource=%s receipt=%s detail=%s",
+        result,
+        action_domain,
+        action_type,
+        actor_id or "<unknown>",
+        resource_id or "<unknown>",
+        receipt_id or "<none>",
+        detail or "",
+    )
+
+
+def is_receipt_enforcement_enabled(domain: str) -> bool:
+    """Return whether receipt enforcement is enabled for one action domain."""
+
+    normalized = _normalize_domain(domain)
+    return is_enabled(_FEATURE_FLAG_BY_DOMAIN[normalized])
+
+
+def require_receipt_gate(
+    *,
+    action_domain: str,
+    action_type: str,
+    actor_id: str,
+    resource_id: str,
+    receipt_id: str | None = None,
+    exempt: ReceiptExemption | None = None,
+) -> StoredReceipt | None:
+    """Validate an approved receipt before an action-taking path proceeds."""
+
+    normalized_domain = _normalize_domain(action_domain)
+    normalized_receipt_id = str(receipt_id or "").strip() or None
+
+    if exempt is not None:
+        _log_enforcement_event(
+            result="exempted",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            actor_id=actor_id,
+            resource_id=resource_id,
+            receipt_id=normalized_receipt_id,
+            detail=f"{exempt.category}:{exempt.approved_by}:{exempt.reason}",
+        )
+        return None
+
+    if not is_receipt_enforcement_enabled(normalized_domain):
+        _log_enforcement_event(
+            result="disabled",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            actor_id=actor_id,
+            resource_id=resource_id,
+            receipt_id=normalized_receipt_id,
+        )
+        return None
+
+    if normalized_receipt_id is None:
+        raise ReceiptEnforcementError(
+            f"{normalized_domain} action {action_type!r} requires an approved execution receipt",
+            action_domain=normalized_domain,
+            action_type=action_type,
+        )
+
+    store = get_receipt_store()
+    stored = store.get(normalized_receipt_id)
+    if stored is None:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} not found",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        )
+
+    if stored.state != ReceiptState.APPROVED:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} is in state {stored.state.value}, expected APPROVED",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        )
+
+    if not stored.signature:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} is missing a cryptographic signature",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        )
+
+    if not store.verify_receipt(normalized_receipt_id):
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} failed signature verification",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        )
+
+    try:
+        receipt = DecisionReceipt.from_dict(stored.receipt_data)
+    except (TypeError, ValueError, KeyError) as exc:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} could not be reconstructed for integrity validation",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        ) from exc
+    if not receipt.verify_integrity():
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} failed integrity verification",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            receipt_id=normalized_receipt_id,
+        )
+
+    _log_enforcement_event(
+        result="allowed",
+        action_domain=normalized_domain,
+        action_type=action_type,
+        actor_id=actor_id,
+        resource_id=resource_id,
+        receipt_id=normalized_receipt_id,
+    )
+    return stored
+
+
+def transition_receipt_executed(receipt_id: str) -> StoredReceipt:
+    """Transition an approved receipt to EXECUTED after successful mutation."""
+
+    normalized_receipt_id = str(receipt_id or "").strip()
+    if not normalized_receipt_id:
+        raise ReceiptEnforcementError(
+            "receipt_id is required to transition a receipt to EXECUTED",
+            action_domain="unknown",
+            action_type="transition",
+        )
+
+    store = get_receipt_store()
+    stored = store.get(normalized_receipt_id)
+    if stored is None:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} not found",
+            action_domain="unknown",
+            action_type="transition",
+            receipt_id=normalized_receipt_id,
+        )
+
+    if stored.state == ReceiptState.EXECUTED:
+        _log_enforcement_event(
+            result="already_executed",
+            action_domain="unknown",
+            action_type="transition",
+            actor_id="system",
+            resource_id=normalized_receipt_id,
+            receipt_id=normalized_receipt_id,
+        )
+        return stored
+
+    try:
+        updated = store.transition(normalized_receipt_id, ReceiptState.EXECUTED)
+    except ReceiptStateError as exc:
+        raise ReceiptEnforcementError(
+            f"Receipt {normalized_receipt_id!r} could not transition to EXECUTED from {stored.state.value}",
+            action_domain="unknown",
+            action_type="transition",
+            receipt_id=normalized_receipt_id,
+        ) from exc
+
+    _log_enforcement_event(
+        result="executed",
+        action_domain="unknown",
+        action_type="transition",
+        actor_id="system",
+        resource_id=normalized_receipt_id,
+        receipt_id=normalized_receipt_id,
+    )
+    return updated
+
+
+__all__ = [
+    "ReceiptEnforcementError",
+    "ReceiptExemption",
+    "is_receipt_enforcement_enabled",
+    "require_receipt_gate",
+    "transition_receipt_executed",
+]

--- a/tests/pipeline/test_receipt_enforcement.py
+++ b/tests/pipeline/test_receipt_enforcement.py
@@ -1,0 +1,227 @@
+"""Tests for the canonical receipt enforcement helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aragora.config.feature_flags import reset_flag_registry
+from aragora.gauntlet.receipt_models import DecisionReceipt
+from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
+from aragora.pipeline.receipt_enforcement import (
+    ReceiptEnforcementError,
+    ReceiptExemption,
+    is_receipt_enforcement_enabled,
+    require_receipt_gate,
+    transition_receipt_executed,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> None:
+    reset_receipt_store()
+    reset_flag_registry()
+    yield
+    reset_receipt_store()
+    reset_flag_registry()
+
+
+def _debate_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        debate_id="debate-receipt-enforcement",
+        task="Ship the approved execution plan",
+        final_answer="Proceed with the approved execution plan.",
+        confidence=0.92,
+        consensus_reached=True,
+        rounds_used=3,
+        duration_seconds=1.25,
+        consensus_strength="majority",
+        participants=["claude", "codex", "gemini"],
+        dissenting_views=["critic: verify rollback path"],
+        messages=[],
+        votes=[],
+        winner="codex",
+    )
+
+
+def _persist_signed_receipt(
+    *,
+    receipt_id: str = "receipt-1",
+    state: ReceiptState = ReceiptState.APPROVED,
+    tamper_signature: bool = False,
+    tamper_integrity: bool = False,
+) -> None:
+    receipt = DecisionReceipt.from_debate_result(_debate_result())
+    receipt.receipt_id = receipt_id
+    if tamper_integrity:
+        receipt.artifact_hash = "tampered-artifact-hash"
+    else:
+        receipt.artifact_hash = receipt._calculate_hash()
+    receipt.sign()
+
+    store = get_receipt_store()
+    store.persist(
+        receipt_id=receipt_id,
+        receipt_data=receipt.to_dict(),
+        signature=receipt.signature,
+        signature_key_id=receipt.signature_key_id,
+        signed_at=receipt.signed_at,
+        signature_algorithm=receipt.signature_algorithm,
+        state=state,
+    )
+    if tamper_signature:
+        stored = store.get(receipt_id)
+        assert stored is not None
+        stored.signature = "tampered-signature"
+
+
+def test_known_domains_default_to_disabled() -> None:
+    assert is_receipt_enforcement_enabled("openclaw") is False
+    assert is_receipt_enforcement_enabled("canvas") is False
+    assert is_receipt_enforcement_enabled("computer_use") is False
+    assert is_receipt_enforcement_enabled("inbox") is False
+    assert is_receipt_enforcement_enabled("shared_inbox") is False
+
+
+def test_feature_flag_env_override_enables_domain(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+
+    assert is_receipt_enforcement_enabled("openclaw") is True
+
+
+def test_require_receipt_gate_skips_when_flag_disabled() -> None:
+    result = require_receipt_gate(
+        action_domain="openclaw",
+        action_type="execute_action",
+        actor_id="user-1",
+        resource_id="action-1",
+        receipt_id=None,
+    )
+
+    assert result is None
+
+
+def test_require_receipt_gate_allows_documented_exemption(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+
+    result = require_receipt_gate(
+        action_domain="openclaw",
+        action_type="execute_action",
+        actor_id="admin-user",
+        resource_id="action-2",
+        exempt=ReceiptExemption(
+            reason="Legacy admin remediation path",
+            approved_by="security-admin",
+            category="legacy_admin",
+        ),
+    )
+
+    assert result is None
+
+
+def test_require_receipt_gate_returns_stored_receipt_for_valid_signed_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+    _persist_signed_receipt(receipt_id="receipt-ok")
+
+    stored = require_receipt_gate(
+        action_domain="openclaw",
+        action_type="execute_action",
+        actor_id="user-42",
+        resource_id="action-3",
+        receipt_id="receipt-ok",
+    )
+
+    assert stored is not None
+    assert stored.receipt_id == "receipt-ok"
+    assert stored.state == ReceiptState.APPROVED
+
+
+def test_require_receipt_gate_raises_without_receipt_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+
+    with pytest.raises(ReceiptEnforcementError, match="requires an approved execution receipt"):
+        require_receipt_gate(
+            action_domain="openclaw",
+            action_type="execute_action",
+            actor_id="user-42",
+            resource_id="action-4",
+        )
+
+
+def test_require_receipt_gate_raises_for_wrong_receipt_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+    _persist_signed_receipt(receipt_id="receipt-expired", state=ReceiptState.EXPIRED)
+
+    with pytest.raises(ReceiptEnforcementError, match="expected APPROVED"):
+        require_receipt_gate(
+            action_domain="openclaw",
+            action_type="execute_action",
+            actor_id="user-42",
+            resource_id="action-5",
+            receipt_id="receipt-expired",
+        )
+
+
+def test_require_receipt_gate_raises_for_tampered_signature(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+    _persist_signed_receipt(receipt_id="receipt-badsig", tamper_signature=True)
+
+    with pytest.raises(ReceiptEnforcementError, match="signature verification"):
+        require_receipt_gate(
+            action_domain="openclaw",
+            action_type="execute_action",
+            actor_id="user-42",
+            resource_id="action-6",
+            receipt_id="receipt-badsig",
+        )
+
+
+def test_require_receipt_gate_raises_for_integrity_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+    reset_flag_registry()
+    _persist_signed_receipt(receipt_id="receipt-badintegrity", tamper_integrity=True)
+
+    with pytest.raises(ReceiptEnforcementError, match="integrity verification"):
+        require_receipt_gate(
+            action_domain="openclaw",
+            action_type="execute_action",
+            actor_id="user-42",
+            resource_id="action-7",
+            receipt_id="receipt-badintegrity",
+        )
+
+
+def test_transition_receipt_executed_advances_state() -> None:
+    _persist_signed_receipt(receipt_id="receipt-transition")
+
+    updated = transition_receipt_executed("receipt-transition")
+
+    assert updated.state == ReceiptState.EXECUTED
+
+
+def test_transition_receipt_executed_is_idempotent_for_executed_receipt() -> None:
+    _persist_signed_receipt(receipt_id="receipt-executed")
+    first = transition_receipt_executed("receipt-executed")
+    second = transition_receipt_executed("receipt-executed")
+
+    assert first.state == ReceiptState.EXECUTED
+    assert second.state == ReceiptState.EXECUTED


### PR DESCRIPTION
## Summary
- add `aragora/pipeline/receipt_enforcement.py` as the canonical action-path receipt gate for future OpenClaw, canvas, computer-use, inbox, and shared-inbox enforcement
- register five rollout feature flags, all defaulting to `False`, so Phase 1 changes behavior nowhere by default
- add focused tests for valid signed receipts, exemptions, missing receipts, wrong states, tampered signatures, integrity failures, and executed-state transitions

## Verification
- `python -m pytest tests/pipeline/test_receipt_enforcement.py tests/pipeline/test_receipt_gate.py -q`
- `python -m pytest tests/config/test_feature_flags.py -q`
- `python -m ruff check aragora/pipeline/receipt_enforcement.py aragora/config/feature_flags.py tests/pipeline/test_receipt_enforcement.py tests/pipeline/test_receipt_gate.py`
- `python -m ruff format --check aragora/pipeline/receipt_enforcement.py aragora/config/feature_flags.py tests/pipeline/test_receipt_enforcement.py tests/pipeline/test_receipt_gate.py`
- `python -m py_compile aragora/pipeline/receipt_enforcement.py aragora/config/feature_flags.py`

## Note
- `python -m mypy aragora/pipeline/receipt_enforcement.py` was not a useful gate in this repo state because the configured mypy invocation expands into a large pre-existing backlog of unrelated type/stub failures outside this change.
