### PR TITLE
feat(ralph): add orchestration observability dashboard

### DIFF
--- a/aragora/ralph/dashboard.py
+++ b/aragora/ralph/dashboard.py
@@ -1,0 +1,159 @@
+"""Ralph orchestration observability dashboard — pure data functions.
+
+Reads SupervisorState and CampaignManifest YAML files and returns
+dashboard-ready dicts for the REST API layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from aragora.ralph.classifier import BlockerKind
+
+logger = logging.getLogger(__name__)
+
+
+def load_dashboard_summary(
+    state_path: Path,
+    manifest_path: Path,
+) -> dict[str, Any]:
+    """Campaign overview: status, budget, active blocker, project count.
+
+    Returns ``{"found": False}`` when either file is missing.
+    """
+    if not state_path.exists() or not manifest_path.exists():
+        return {"found": False}
+
+    state = _load_yaml(state_path)
+    manifest = _load_yaml(manifest_path)
+    if state is None or manifest is None:
+        return {"found": False}
+
+    current_step = int(state.get("current_step", 0))
+    budget_spent = float(state.get("budget_spent_usd", 0.0))
+    budget_limit = float(manifest.get("budget_limit_usd", 0.0))
+    burn_rate = budget_spent / max(current_step, 1)
+
+    projects = manifest.get("projects", [])
+
+    summary: dict[str, Any] = {
+        "found": True,
+        "campaign_id": state.get("campaign_id", ""),
+        "status": state.get("status", "unknown"),
+        "current_step": current_step,
+        "budget_spent_usd": budget_spent,
+        "budget_limit_usd": budget_limit,
+        "burn_rate_per_step": round(burn_rate, 6),
+        "project_count": len(projects),
+    }
+
+    active_blocker = state.get("active_blocker")
+    if active_blocker:
+        summary["active_blocker"] = active_blocker
+
+    return summary
+
+
+def load_project_lifecycle(manifest_path: Path) -> dict[str, Any]:
+    """Project breakdown by status with per-project details.
+
+    Returns ``{"found": False}`` when the manifest file is missing.
+    """
+    if not manifest_path.exists():
+        return {"found": False}
+
+    manifest = _load_yaml(manifest_path)
+    if manifest is None:
+        return {"found": False}
+
+    projects = manifest.get("projects", [])
+    status_groups: dict[str, list[dict[str, Any]]] = {}
+
+    for proj in projects:
+        status = str(proj.get("status", "unknown"))
+        entry = {
+            "project_id": proj.get("project_id", ""),
+            "title": proj.get("title", ""),
+            "status": status,
+            "retry_count": int(proj.get("retry_count", 0)),
+            "last_run_outcome": proj.get("last_run_outcome"),
+            "estimated_cost_usd": float(proj.get("estimated_cost_usd", 0.0)),
+        }
+        status_groups.setdefault(status, []).append(entry)
+
+    return {
+        "found": True,
+        "campaign_id": manifest.get("campaign_id", ""),
+        "total_projects": len(projects),
+        "by_status": status_groups,
+    }
+
+
+def load_blocker_history(state_path: Path) -> dict[str, Any]:
+    """Blocker frequency analysis: by kind, deterministic vs escalation.
+
+    Returns ``{"found": False}`` when the state file is missing.
+    """
+    if not state_path.exists():
+        return {"found": False}
+
+    state = _load_yaml(state_path)
+    if state is None:
+        return {"found": False}
+
+    history = state.get("blocker_history", [])
+    if not isinstance(history, list):
+        history = []
+
+    kind_counter: Counter[str] = Counter()
+    deterministic_count = 0
+    escalation_count = 0
+
+    for entry in history:
+        if not isinstance(entry, dict):
+            continue
+        kind_str = str(entry.get("kind", "unknown"))
+        kind_counter[kind_str] += 1
+
+        # Classify as deterministic or escalation using BlockerKind enum
+        try:
+            kind_enum = BlockerKind(kind_str)
+            if kind_enum.is_deterministic:
+                deterministic_count += 1
+            else:
+                escalation_count += 1
+        except ValueError:
+            # Unknown kind string — treat as escalation
+            escalation_count += 1
+
+    return {
+        "found": True,
+        "total_blockers": len(history),
+        "by_kind": dict(kind_counter),
+        "deterministic_count": deterministic_count,
+        "escalation_count": escalation_count,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict[str, Any] | None:
+    """Load a YAML file, returning None on any parse or I/O error."""
+    try:
+        text = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+        if isinstance(data, dict):
+            return data
+        logger.warning("Expected dict in %s, got %s", path, type(data).__name__)
+        return None
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning("Failed to load %s: %s", path, exc)
+        return None

--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -351,6 +351,8 @@ HANDLER_MODULES: dict[str, str] = {
     "SpectateStreamHandler": "aragora.server.handlers.spectate_ws",
     # Readiness check (SME onboarding)
     "ReadinessCheckHandler": "aragora.server.handlers.readiness_check",
+    # Ralph orchestration dashboard
+    "RalphDashboardHandler": "aragora.server.handlers.ralph_dashboard",
 }
 
 # List of all handler class names (in priority order for dispatch)
@@ -660,4 +662,6 @@ ALL_HANDLER_NAMES: list[str] = [
     "UnifiedMetricsHandler",
     # workflows/ sub-handlers
     "WorkflowBuilderHandler",
+    # ralph
+    "RalphDashboardHandler",
 ]

--- a/aragora/server/handlers/_stability.py
+++ b/aragora/server/handlers/_stability.py
@@ -279,6 +279,8 @@ HANDLER_STABILITY: dict[str, Stability] = {
     "TemplateRegistryHandler": Stability.EXPERIMENTAL,
     "ThreatIntelHandler": Stability.EXPERIMENTAL,
     "UnifiedMetricsHandler": Stability.EXPERIMENTAL,
+    # ralph
+    "RalphDashboardHandler": Stability.EXPERIMENTAL,
     # workflows/ sub-handlers
     "WorkflowBuilderHandler": Stability.EXPERIMENTAL,
     # Readiness check (SME onboarding)

--- a/aragora/server/handlers/ralph_dashboard.py
+++ b/aragora/server/handlers/ralph_dashboard.py
@@ -1,0 +1,203 @@
+"""Ralph orchestration observability dashboard endpoints.
+
+Endpoints:
+- GET /api/ralph/dashboard/summary   — Campaign overview (status, budget, blocker)
+- GET /api/ralph/dashboard/projects  — Project lifecycle breakdown by status
+- GET /api/ralph/dashboard/blockers  — Blocker frequency analysis
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from aragora.server.versioning.compat import strip_version_prefix
+
+from .base import (
+    HandlerResult,
+    error_response,
+    json_response,
+    handle_errors,
+)
+from .secure import ForbiddenError, SecureHandler, UnauthorizedError
+from .utils.rate_limit import RateLimiter, get_client_ip
+
+logger = logging.getLogger(__name__)
+
+RALPH_DASHBOARD_PERMISSION = "ralph:dashboard:read"
+
+_ralph_dashboard_limiter = RateLimiter(requests_per_minute=60)
+
+
+def _is_demo_mode() -> bool:
+    """Check if server is running in demo/offline mode."""
+    return os.environ.get("ARAGORA_DEMO_MODE", "").lower() in ("true", "1", "yes")
+
+
+_DEMO_DATA: dict[str, dict[str, Any]] = {
+    "/api/ralph/dashboard/summary": {
+        "found": True,
+        "campaign_id": "demo-campaign-001",
+        "status": "running",
+        "current_step": 12,
+        "budget_spent_usd": 3.45,
+        "budget_limit_usd": 50.0,
+        "burn_rate_per_step": 0.2875,
+        "project_count": 5,
+    },
+    "/api/ralph/dashboard/projects": {
+        "found": True,
+        "campaign_id": "demo-campaign-001",
+        "total_projects": 5,
+        "by_status": {
+            "completed": [
+                {
+                    "project_id": "proj-1",
+                    "title": "Fix auth flow",
+                    "status": "completed",
+                    "retry_count": 0,
+                    "last_run_outcome": "deliverable_created",
+                    "estimated_cost_usd": 1.20,
+                },
+            ],
+            "active": [
+                {
+                    "project_id": "proj-2",
+                    "title": "Add rate limiting",
+                    "status": "active",
+                    "retry_count": 0,
+                    "last_run_outcome": None,
+                    "estimated_cost_usd": 0.80,
+                },
+            ],
+            "pending": [
+                {
+                    "project_id": "proj-3",
+                    "title": "Refactor DB layer",
+                    "status": "pending",
+                    "retry_count": 0,
+                    "last_run_outcome": None,
+                    "estimated_cost_usd": 2.00,
+                },
+                {
+                    "project_id": "proj-4",
+                    "title": "Update docs",
+                    "status": "pending",
+                    "retry_count": 0,
+                    "last_run_outcome": None,
+                    "estimated_cost_usd": 0.50,
+                },
+            ],
+            "failed": [
+                {
+                    "project_id": "proj-5",
+                    "title": "Migrate legacy API",
+                    "status": "failed",
+                    "retry_count": 2,
+                    "last_run_outcome": "crash",
+                    "estimated_cost_usd": 1.50,
+                },
+            ],
+        },
+    },
+    "/api/ralph/dashboard/blockers": {
+        "found": True,
+        "total_blockers": 3,
+        "by_kind": {
+            "scope_false_positive": 1,
+            "worker_context_overflow": 1,
+            "budget_exhaustion": 1,
+        },
+        "deterministic_count": 2,
+        "escalation_count": 1,
+    },
+}
+
+
+class RalphDashboardHandler(SecureHandler):
+    """Handler for Ralph orchestration observability dashboard.
+
+    Provides read-only endpoints for campaign status, project lifecycle,
+    and blocker history from SupervisorState/CampaignManifest YAML files.
+    """
+
+    RESOURCE_TYPE = "ralph_dashboard"
+
+    ROUTES = [
+        "/api/ralph/dashboard/summary",
+        "/api/ralph/dashboard/projects",
+        "/api/ralph/dashboard/blockers",
+    ]
+
+    def can_handle(self, path: str, method: str = "GET") -> bool:
+        """Check if this handler can process the given path."""
+        normalized = strip_version_prefix(path)
+        return normalized in self.ROUTES
+
+    @handle_errors("ralph dashboard read")
+    async def handle(
+        self, path: str, query_params: dict[str, Any], handler: Any
+    ) -> HandlerResult | None:
+        """Route GET requests to dashboard endpoints."""
+        normalized = strip_version_prefix(path)
+
+        # Demo mode: return sample data without auth
+        if _is_demo_mode():
+            data = _DEMO_DATA.get(normalized)
+            if data is not None:
+                return json_response(data)
+
+        # Rate limit check
+        client_ip = get_client_ip(handler)
+        if not _ralph_dashboard_limiter.is_allowed(client_ip):
+            logger.warning("Rate limit exceeded for ralph dashboard: %s", client_ip)
+            return error_response(
+                "Rate limit exceeded. Please try again later.",
+                429,
+            )
+
+        # RBAC: Require authentication and permission
+        try:
+            auth_context = await self.get_auth_context(handler, require_auth=True)
+            self.check_permission(auth_context, RALPH_DASHBOARD_PERMISSION)
+        except UnauthorizedError:
+            return error_response("Authentication required", 401, code="AUTH_REQUIRED")
+        except ForbiddenError as exc:
+            logger.warning("Ralph dashboard access denied: %s", exc)
+            return error_response("Permission denied", 403, code="PERMISSION_DENIED")
+
+        # Resolve file paths from query params or defaults
+        state_path = Path(query_params.get("state_path", ".aragora/supervisor_state.yaml"))
+        manifest_path = Path(query_params.get("manifest_path", ".aragora/campaign_manifest.yaml"))
+
+        if normalized == "/api/ralph/dashboard/summary":
+            return self._handle_summary(state_path, manifest_path)
+        elif normalized == "/api/ralph/dashboard/projects":
+            return self._handle_projects(manifest_path)
+        elif normalized == "/api/ralph/dashboard/blockers":
+            return self._handle_blockers(state_path)
+
+        return None
+
+    def _handle_summary(self, state_path: Path, manifest_path: Path) -> HandlerResult:
+        from aragora.ralph.dashboard import load_dashboard_summary
+
+        data = load_dashboard_summary(state_path, manifest_path)
+        return json_response(data)
+
+    def _handle_projects(self, manifest_path: Path) -> HandlerResult:
+        from aragora.ralph.dashboard import load_project_lifecycle
+
+        data = load_project_lifecycle(manifest_path)
+        return json_response(data)
+
+    def _handle_blockers(self, state_path: Path) -> HandlerResult:
+        from aragora.ralph.dashboard import load_blocker_history
+
+        data = load_blocker_history(state_path)
+        return json_response(data)
+
+
+__all__ = ["RalphDashboardHandler"]

--- a/tests/ralph/test_dashboard.py
+++ b/tests/ralph/test_dashboard.py
@@ -1,0 +1,272 @@
+"""Tests for Ralph orchestration observability dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from aragora.ralph.dashboard import (
+    load_blocker_history,
+    load_dashboard_summary,
+    load_project_lifecycle,
+)
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+
+
+def _make_state(
+    *,
+    campaign_id: str = "camp-1",
+    status: str = "running",
+    current_step: int = 10,
+    budget_spent_usd: float = 2.5,
+    active_blocker: str | None = None,
+    blocker_history: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "supervisor_id": "sup-1",
+        "campaign_id": campaign_id,
+        "status": status,
+        "current_step": current_step,
+        "budget_spent_usd": budget_spent_usd,
+        "blocker_history": blocker_history or [],
+    }
+    if active_blocker is not None:
+        state["active_blocker"] = active_blocker
+    return state
+
+
+def _make_manifest(
+    *,
+    campaign_id: str = "camp-1",
+    budget_limit_usd: float = 50.0,
+    projects: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    return {
+        "campaign_id": campaign_id,
+        "created_at": "2026-03-18T00:00:00Z",
+        "source_kind": "issue",
+        "source_ref": "#1007",
+        "budget_limit_usd": budget_limit_usd,
+        "projects": projects or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# test_summary_basic
+# ---------------------------------------------------------------------------
+
+
+def test_summary_basic(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.yaml"
+    manifest_path = tmp_path / "manifest.yaml"
+
+    _write_yaml(state_path, _make_state(current_step=10, budget_spent_usd=2.5))
+    _write_yaml(
+        manifest_path,
+        _make_manifest(
+            projects=[
+                {"project_id": "p1", "title": "A", "status": "completed"},
+                {"project_id": "p2", "title": "B", "status": "active"},
+            ]
+        ),
+    )
+
+    result = load_dashboard_summary(state_path, manifest_path)
+
+    assert result["found"] is True
+    assert result["campaign_id"] == "camp-1"
+    assert result["status"] == "running"
+    assert result["current_step"] == 10
+    assert result["project_count"] == 2
+    assert result["budget_spent_usd"] == 2.5
+    assert result["budget_limit_usd"] == 50.0
+    assert "active_blocker" not in result
+
+
+# ---------------------------------------------------------------------------
+# test_summary_with_blocker
+# ---------------------------------------------------------------------------
+
+
+def test_summary_with_blocker(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.yaml"
+    manifest_path = tmp_path / "manifest.yaml"
+
+    _write_yaml(
+        state_path,
+        _make_state(active_blocker="scope_false_positive"),
+    )
+    _write_yaml(manifest_path, _make_manifest())
+
+    result = load_dashboard_summary(state_path, manifest_path)
+
+    assert result["found"] is True
+    assert result["active_blocker"] == "scope_false_positive"
+
+
+# ---------------------------------------------------------------------------
+# test_summary_budget_tracking
+# ---------------------------------------------------------------------------
+
+
+def test_summary_budget_tracking(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.yaml"
+    manifest_path = tmp_path / "manifest.yaml"
+
+    _write_yaml(
+        state_path,
+        _make_state(current_step=4, budget_spent_usd=8.0),
+    )
+    _write_yaml(manifest_path, _make_manifest(budget_limit_usd=100.0))
+
+    result = load_dashboard_summary(state_path, manifest_path)
+
+    assert result["found"] is True
+    # burn_rate = 8.0 / max(4, 1) = 2.0
+    assert result["burn_rate_per_step"] == 2.0
+    assert result["budget_limit_usd"] == 100.0
+    assert result["budget_spent_usd"] == 8.0
+
+
+# ---------------------------------------------------------------------------
+# test_summary_file_not_found
+# ---------------------------------------------------------------------------
+
+
+def test_summary_file_not_found(tmp_path: Path) -> None:
+    missing_state = tmp_path / "nonexistent_state.yaml"
+    missing_manifest = tmp_path / "nonexistent_manifest.yaml"
+
+    result = load_dashboard_summary(missing_state, missing_manifest)
+    assert result == {"found": False}
+
+    # Also test with only one file missing
+    state_path = tmp_path / "state.yaml"
+    _write_yaml(state_path, _make_state())
+    result2 = load_dashboard_summary(state_path, missing_manifest)
+    assert result2 == {"found": False}
+
+
+# ---------------------------------------------------------------------------
+# test_project_lifecycle_mixed
+# ---------------------------------------------------------------------------
+
+
+def test_project_lifecycle_mixed(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.yaml"
+
+    projects = [
+        {
+            "project_id": "p1",
+            "title": "Auth fix",
+            "status": "completed",
+            "retry_count": 0,
+            "last_run_outcome": "deliverable_created",
+            "estimated_cost_usd": 1.0,
+        },
+        {
+            "project_id": "p2",
+            "title": "Rate limiting",
+            "status": "active",
+            "retry_count": 0,
+            "estimated_cost_usd": 0.5,
+        },
+        {
+            "project_id": "p3",
+            "title": "DB migration",
+            "status": "failed",
+            "retry_count": 2,
+            "last_run_outcome": "crash",
+            "estimated_cost_usd": 2.0,
+        },
+        {
+            "project_id": "p4",
+            "title": "Docs update",
+            "status": "pending",
+            "retry_count": 0,
+            "estimated_cost_usd": 0.3,
+        },
+        {
+            "project_id": "p5",
+            "title": "Cleanup",
+            "status": "completed",
+            "retry_count": 1,
+            "last_run_outcome": "deliverable_created",
+            "estimated_cost_usd": 0.8,
+        },
+    ]
+    _write_yaml(manifest_path, _make_manifest(projects=projects))
+
+    result = load_project_lifecycle(manifest_path)
+
+    assert result["found"] is True
+    assert result["total_projects"] == 5
+    assert len(result["by_status"]["completed"]) == 2
+    assert len(result["by_status"]["active"]) == 1
+    assert len(result["by_status"]["failed"]) == 1
+    assert len(result["by_status"]["pending"]) == 1
+
+    # Verify project detail shape
+    completed = result["by_status"]["completed"][0]
+    assert completed["project_id"] == "p1"
+    assert completed["title"] == "Auth fix"
+    assert completed["retry_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# test_blocker_history_by_kind
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_history_by_kind(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.yaml"
+
+    history = [
+        {"kind": "scope_false_positive", "step": 2},
+        {"kind": "scope_false_positive", "step": 5},
+        {"kind": "worker_context_overflow", "step": 7},
+        {"kind": "budget_exhaustion", "step": 9},
+    ]
+    _write_yaml(state_path, _make_state(blocker_history=history))
+
+    result = load_blocker_history(state_path)
+
+    assert result["found"] is True
+    assert result["total_blockers"] == 4
+    assert result["by_kind"]["scope_false_positive"] == 2
+    assert result["by_kind"]["worker_context_overflow"] == 1
+    assert result["by_kind"]["budget_exhaustion"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_blocker_deterministic_vs_escalation
+# ---------------------------------------------------------------------------
+
+
+def test_blocker_deterministic_vs_escalation(tmp_path: Path) -> None:
+    state_path = tmp_path / "state.yaml"
+
+    history = [
+        # Deterministic kinds
+        {"kind": "scope_false_positive"},
+        {"kind": "worker_context_overflow"},
+        {"kind": "receipt_emission_gap"},
+        # Escalation kinds
+        {"kind": "budget_exhaustion"},
+        {"kind": "unknown"},
+    ]
+    _write_yaml(state_path, _make_state(blocker_history=history))
+
+    result = load_blocker_history(state_path)
+
+    assert result["found"] is True
+    assert result["deterministic_count"] == 3
+    assert result["escalation_count"] == 2
+    assert result["total_blockers"] == 5


### PR DESCRIPTION
## Summary
- Add `aragora/ralph/dashboard.py` with 3 pure functions: `load_dashboard_summary`, `load_project_lifecycle`, `load_blocker_history`
- Add `RalphDashboardHandler` with 3 endpoints: `/api/ralph/dashboard/{summary,projects,blockers}`
- RBAC (`ralph:dashboard:read`), rate limiting (60 req/min), demo mode support
- Registered as EXPERIMENTAL stability

## Test plan
- 7 new tests in `tests/ralph/test_dashboard.py`
- Handler registered in `_lazy_imports.py` and `_stability.py`

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)