### PR TITLE
fix(ralph): register dashboard handler in server registries

### DIFF
--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -296,6 +296,7 @@ HANDLER_MODULES: dict[str, str] = {
     "TranscriptionHandler": "aragora.server.handlers.transcription",
     "UncertaintyHandler": "aragora.server.handlers.uncertainty",
     "UnifiedMetricsHandler": "aragora.server.handlers.metrics_endpoint",
+    "RalphDashboardHandler": "aragora.server.handlers.ralph_dashboard",
     "UsageMeteringHandler": "aragora.server.handlers.usage_metering",
     "VerticalsHandler": "aragora.server.handlers.verticals",
     "VoiceHandler": "aragora.server.handlers.voice.handler",
@@ -658,6 +659,7 @@ ALL_HANDLER_NAMES: list[str] = [
     "TemplateRegistryHandler",
     "ThreatIntelHandler",
     "UnifiedMetricsHandler",
+    "RalphDashboardHandler",
     # workflows/ sub-handlers
     "WorkflowBuilderHandler",
 ]

--- a/aragora/server/handlers/_stability.py
+++ b/aragora/server/handlers/_stability.py
@@ -279,6 +279,7 @@ HANDLER_STABILITY: dict[str, Stability] = {
     "TemplateRegistryHandler": Stability.EXPERIMENTAL,
     "ThreatIntelHandler": Stability.EXPERIMENTAL,
     "UnifiedMetricsHandler": Stability.EXPERIMENTAL,
+    "RalphDashboardHandler": Stability.EXPERIMENTAL,
     # workflows/ sub-handlers
     "WorkflowBuilderHandler": Stability.EXPERIMENTAL,
     # Readiness check (SME onboarding)

--- a/tests/handlers/test_stability.py
+++ b/tests/handlers/test_stability.py
@@ -859,6 +859,9 @@ class TestMiscellaneous:
     def test_threat_intel_handler_is_experimental(self):
         assert HANDLER_STABILITY["ThreatIntelHandler"] == Stability.EXPERIMENTAL
 
+    def test_ralph_dashboard_handler_is_experimental(self):
+        assert HANDLER_STABILITY["RalphDashboardHandler"] == Stability.EXPERIMENTAL
+
     def test_moderation_handlers_are_experimental(self):
         assert HANDLER_STABILITY["ModerationHandler"] == Stability.EXPERIMENTAL
         assert HANDLER_STABILITY["ModerationAnalyticsHandler"] == Stability.EXPERIMENTAL

--- a/tests/server/handlers/test_lazy_imports.py
+++ b/tests/server/handlers/test_lazy_imports.py
@@ -75,6 +75,10 @@ class TestHandlerModules:
         for name in core_handlers:
             assert name in HANDLER_MODULES, f"Core handler {name!r} missing from HANDLER_MODULES"
 
+    def test_ralph_dashboard_handler_is_registered(self):
+        assert HANDLER_MODULES["RalphDashboardHandler"] == "aragora.server.handlers.ralph_dashboard"
+        assert "RalphDashboardHandler" in ALL_HANDLER_NAMES
+
     def test_handler_names_use_handler_suffix_convention(self):
         """Most handler class names should end with 'Handler' or 'Handlers'."""
         # Count how many follow the convention


### PR DESCRIPTION
## Summary
- register `RalphDashboardHandler` in the lazy-import handler map
- classify the handler in the stability registry
- add explicit regression checks for both registries

## Verification
- `python -m pytest tests/server/handlers/test_lazy_imports.py tests/handlers/test_stability.py -q`
- `ruff check aragora/server/handlers/_lazy_imports.py aragora/server/handlers/_stability.py tests/server/handlers/test_lazy_imports.py tests/handlers/test_stability.py`

Salvages the one useful integration sliver left behind by stale PR #1024.