### PR TITLE
feat(rlm): export streaming query and resilience types

### DIFF
--- a/aragora/rlm/__init__.py
+++ b/aragora/rlm/__init__.py
@@ -159,6 +159,7 @@ from .debate_integration import (
     create_training_hook,
 )
 from .hierarchy_cache import RLMHierarchyCache
+from .streaming import StreamConfig, StreamMode, StreamingRLMQuery
 from .tier3_integration import (
     PipelineRLMContext,
     GauntletRLMFinding,
@@ -272,6 +273,10 @@ __all__ = [
     "collect_trajectory_for_learning",
     "store_trajectory_learning",
     "load_trajectory_insights",
+    # Streaming (progressive context delivery)
+    "StreamingRLMQuery",
+    "StreamConfig",
+    "StreamMode",
     # Exceptions (robust error handling)
     "RLMError",
     "RLMTimeoutError",


### PR DESCRIPTION
## Summary
- export `StreamingRLMQuery`, `StreamConfig`, and `StreamMode` from `aragora.rlm`
- export the existing resilience error types from the package root

## Verification
- import check for `StreamingRLMQuery`, `StreamConfig`, `StreamMode`, `RLMTimeoutError`, and `RLMCircuitOpenError`
- `ruff check aragora/rlm/__init__.py`

Harvested cleanly from the stale `worktree-llm-scope-classifier` branch.