### PR TITLE
feat(receipts): Phase 4 — enforcement metrics, exemption registry

### DIFF
--- a/aragora/pipeline/receipt_enforcement.py
+++ b/aragora/pipeline/receipt_enforcement.py
@@ -3,13 +3,17 @@
 Phase 1 adds a single enforcement surface that write-capable handlers can call
 without changing default behavior. Enforcement stays disabled until the
 per-domain feature flag is enabled.
+
+Phase 4 adds Prometheus metrics (counter + latency histogram) and automatic
+exemption checks via the ExemptionRegistry.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
-from typing import Final
+from typing import Any, Final
 
 from aragora.config.feature_flags import is_enabled
 from aragora.gauntlet.receipt_models import DecisionReceipt
@@ -21,6 +25,58 @@ from aragora.gauntlet.receipt_store import (
 )
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prometheus metrics — lazy-initialized to avoid import cost when
+# prometheus_client is not installed.
+# ---------------------------------------------------------------------------
+
+_metrics_initialized = False
+_enforcement_total: Any = None
+_enforcement_latency: Any = None
+
+
+def _ensure_metrics() -> None:
+    """Lazily initialize Prometheus metrics; no-op if already done."""
+    global _metrics_initialized, _enforcement_total, _enforcement_latency
+    if _metrics_initialized:
+        return
+    try:
+        from prometheus_client import Counter, Histogram
+
+        _enforcement_total = Counter(
+            "aragora_receipt_enforcement_total",
+            "Receipt enforcement decisions",
+            ["domain", "result"],
+        )
+        _enforcement_latency = Histogram(
+            "aragora_receipt_enforcement_latency_seconds",
+            "Receipt enforcement check latency",
+            ["domain"],
+        )
+    except (ImportError, ValueError):
+        # ImportError: prometheus_client not installed
+        # ValueError: metrics already registered in the default registry
+        pass
+    _metrics_initialized = True
+
+
+def _record_enforcement_metric(domain: str, result: str, elapsed: float) -> None:
+    """Emit Prometheus counter + histogram if metrics are available."""
+    _ensure_metrics()
+    if _enforcement_total is not None:
+        _enforcement_total.labels(domain=domain, result=result).inc()
+    if _enforcement_latency is not None:
+        _enforcement_latency.labels(domain=domain).observe(elapsed)
+
+
+def reset_enforcement_metrics() -> None:
+    """Reset metrics initialization flag (for testing)."""
+    global _metrics_initialized, _enforcement_total, _enforcement_latency
+    _metrics_initialized = False
+    _enforcement_total = None
+    _enforcement_latency = None
+
 
 _FEATURE_FLAG_BY_DOMAIN: Final[dict[str, str]] = {
     "openclaw": "receipt_enforcement_openclaw",
@@ -106,10 +162,13 @@ def require_receipt_gate(
 ) -> StoredReceipt | None:
     """Validate an approved receipt before an action-taking path proceeds."""
 
+    t0 = time.monotonic()
     normalized_domain = _normalize_domain(action_domain)
     normalized_receipt_id = str(receipt_id or "").strip() or None
 
+    # --- Explicit exemption supplied by caller ---
     if exempt is not None:
+        elapsed = time.monotonic() - t0
         _log_enforcement_event(
             result="exempted",
             action_domain=normalized_domain,
@@ -119,9 +178,33 @@ def require_receipt_gate(
             receipt_id=normalized_receipt_id,
             detail=f"{exempt.category}:{exempt.approved_by}:{exempt.reason}",
         )
+        _record_enforcement_metric(normalized_domain, "exempted", elapsed)
         return None
 
+    # --- Check the ExemptionRegistry for automatic exemptions ---
+    from aragora.pipeline.receipt_exemptions import ExemptionRegistry
+
+    registry_exemption = ExemptionRegistry.get_instance().is_exempt(
+        normalized_domain,
+        action_type,
+    )
+    if registry_exemption is not None:
+        elapsed = time.monotonic() - t0
+        _log_enforcement_event(
+            result="exempted",
+            action_domain=normalized_domain,
+            action_type=action_type,
+            actor_id=actor_id,
+            resource_id=resource_id,
+            receipt_id=normalized_receipt_id,
+            detail=f"{registry_exemption.category}:{registry_exemption.approved_by}:{registry_exemption.reason}",
+        )
+        _record_enforcement_metric(normalized_domain, "exempted", elapsed)
+        return None
+
+    # --- Feature flag disabled → pass-through ---
     if not is_receipt_enforcement_enabled(normalized_domain):
+        elapsed = time.monotonic() - t0
         _log_enforcement_event(
             result="disabled",
             action_domain=normalized_domain,
@@ -130,9 +213,13 @@ def require_receipt_gate(
             resource_id=resource_id,
             receipt_id=normalized_receipt_id,
         )
+        _record_enforcement_metric(normalized_domain, "disabled", elapsed)
         return None
 
+    # --- Enforcement is ON — receipt is required ---
     if normalized_receipt_id is None:
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"{normalized_domain} action {action_type!r} requires an approved execution receipt",
             action_domain=normalized_domain,
@@ -142,6 +229,8 @@ def require_receipt_gate(
     store = get_receipt_store()
     stored = store.get(normalized_receipt_id)
     if stored is None:
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} not found",
             action_domain=normalized_domain,
@@ -150,6 +239,8 @@ def require_receipt_gate(
         )
 
     if stored.state != ReceiptState.APPROVED:
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} is in state {stored.state.value}, expected APPROVED",
             action_domain=normalized_domain,
@@ -158,6 +249,8 @@ def require_receipt_gate(
         )
 
     if not stored.signature:
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} is missing a cryptographic signature",
             action_domain=normalized_domain,
@@ -166,6 +259,8 @@ def require_receipt_gate(
         )
 
     if not store.verify_receipt(normalized_receipt_id):
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} failed signature verification",
             action_domain=normalized_domain,
@@ -176,6 +271,8 @@ def require_receipt_gate(
     try:
         receipt = DecisionReceipt.from_dict(stored.receipt_data)
     except (TypeError, ValueError, KeyError) as exc:
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} could not be reconstructed for integrity validation",
             action_domain=normalized_domain,
@@ -183,6 +280,8 @@ def require_receipt_gate(
             receipt_id=normalized_receipt_id,
         ) from exc
     if not receipt.verify_integrity():
+        elapsed = time.monotonic() - t0
+        _record_enforcement_metric(normalized_domain, "blocked", elapsed)
         raise ReceiptEnforcementError(
             f"Receipt {normalized_receipt_id!r} failed integrity verification",
             action_domain=normalized_domain,
@@ -190,6 +289,7 @@ def require_receipt_gate(
             receipt_id=normalized_receipt_id,
         )
 
+    elapsed = time.monotonic() - t0
     _log_enforcement_event(
         result="allowed",
         action_domain=normalized_domain,
@@ -198,6 +298,7 @@ def require_receipt_gate(
         resource_id=resource_id,
         receipt_id=normalized_receipt_id,
     )
+    _record_enforcement_metric(normalized_domain, "allowed", elapsed)
     return stored
 
 
@@ -259,5 +360,6 @@ __all__ = [
     "ReceiptExemption",
     "is_receipt_enforcement_enabled",
     "require_receipt_gate",
+    "reset_enforcement_metrics",
     "transition_receipt_executed",
 ]

--- a/aragora/pipeline/receipt_exemptions.py
+++ b/aragora/pipeline/receipt_exemptions.py
@@ -1,0 +1,117 @@
+"""Centralized registry of documented receipt enforcement exemptions.
+
+Provides a singleton ``ExemptionRegistry`` that tracks which
+(domain, action_type) pairs are exempt from receipt enforcement and why.
+
+Built-in exemptions cover read-only operations, health checks, and
+metrics collection.  Additional exemptions can be registered at runtime
+or at import time by calling ``ExemptionRegistry.get_instance().register(…)``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class RegisteredExemption:
+    """A single documented exemption from receipt enforcement."""
+
+    domain: str  # "*" matches any domain
+    action_pattern: str  # fnmatch-style pattern (e.g. "read_*")
+    reason: str
+    approved_by: str
+    category: str  # "read_only", "metadata_only", "health_check", "system_internal"
+
+
+class ExemptionRegistry:
+    """Singleton registry for documented receipt enforcement exemptions."""
+
+    _instance: ExemptionRegistry | None = None
+
+    def __init__(self) -> None:
+        self._exemptions: list[RegisteredExemption] = []
+        self._register_builtins()
+
+    # ------------------------------------------------------------------
+    # Built-in exemptions
+    # ------------------------------------------------------------------
+
+    def _register_builtins(self) -> None:
+        """Register exemptions for operations that legitimately don't need receipts."""
+        builtins = [
+            ("*", "read_*", "Read-only operations", "system", "read_only"),
+            ("*", "list_*", "List operations", "system", "read_only"),
+            ("*", "get_*", "Get operations", "system", "read_only"),
+            ("*", "health_check", "Health check endpoints", "system", "health_check"),
+            ("*", "metrics", "Metrics collection", "system", "system_internal"),
+        ]
+        for domain, pattern, reason, approved_by, category in builtins:
+            self.register(domain, pattern, reason, approved_by, category)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        domain: str,
+        action_pattern: str,
+        reason: str,
+        approved_by: str,
+        category: str,
+    ) -> RegisteredExemption:
+        """Register a new exemption and return it."""
+        exemption = RegisteredExemption(
+            domain=domain,
+            action_pattern=action_pattern,
+            reason=reason,
+            approved_by=approved_by,
+            category=category,
+        )
+        self._exemptions.append(exemption)
+        return exemption
+
+    def is_exempt(
+        self,
+        domain: str,
+        action_type: str,
+    ) -> RegisteredExemption | None:
+        """Return the first matching exemption, or ``None`` if the action is not exempt."""
+        for exemption in self._exemptions:
+            if exemption.domain != "*" and exemption.domain != domain:
+                continue
+            if fnmatch.fnmatch(action_type, exemption.action_pattern):
+                return exemption
+        return None
+
+    @property
+    def exemptions(self) -> list[RegisteredExemption]:
+        """Return a copy of all registered exemptions."""
+        return list(self._exemptions)
+
+    # ------------------------------------------------------------------
+    # Singleton accessor
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def get_instance(cls) -> ExemptionRegistry:
+        """Return the singleton instance, creating it if needed."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset the singleton (for testing)."""
+        cls._instance = None
+
+
+__all__ = [
+    "ExemptionRegistry",
+    "RegisteredExemption",
+]

--- a/tests/pipeline/test_receipt_enforcement_metrics.py
+++ b/tests/pipeline/test_receipt_enforcement_metrics.py
@@ -1,0 +1,246 @@
+"""Tests for Prometheus metrics integration in receipt enforcement."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.config.feature_flags import reset_flag_registry
+from aragora.gauntlet.receipt_models import DecisionReceipt
+from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
+from aragora.pipeline.receipt_enforcement import (
+    ReceiptEnforcementError,
+    ReceiptExemption,
+    require_receipt_gate,
+    reset_enforcement_metrics,
+)
+from aragora.pipeline.receipt_exemptions import ExemptionRegistry
+
+
+@pytest.fixture(autouse=True)
+def _reset_globals() -> None:  # type: ignore[misc]
+    reset_receipt_store()
+    reset_flag_registry()
+    reset_enforcement_metrics()
+    ExemptionRegistry.reset_instance()
+    yield
+    reset_receipt_store()
+    reset_flag_registry()
+    reset_enforcement_metrics()
+    ExemptionRegistry.reset_instance()
+
+
+def _debate_result() -> SimpleNamespace:
+    return SimpleNamespace(
+        debate_id="debate-metrics",
+        task="Test metrics emission",
+        final_answer="Metrics emitted.",
+        confidence=0.88,
+        consensus_reached=True,
+        rounds_used=2,
+        duration_seconds=0.5,
+        consensus_strength="majority",
+        participants=["claude"],
+        dissenting_views=[],
+        messages=[],
+        votes=[],
+        winner="claude",
+    )
+
+
+def _persist_signed_receipt(
+    *,
+    receipt_id: str = "receipt-m1",
+    state: ReceiptState = ReceiptState.APPROVED,
+) -> None:
+    receipt = DecisionReceipt.from_debate_result(_debate_result())
+    receipt.receipt_id = receipt_id
+    receipt.artifact_hash = receipt._calculate_hash()
+    receipt.sign()
+
+    store = get_receipt_store()
+    store.persist(
+        receipt_id=receipt_id,
+        receipt_data=receipt.to_dict(),
+        signature=receipt.signature,
+        signature_key_id=receipt.signature_key_id,
+        signed_at=receipt.signed_at,
+        signature_algorithm=receipt.signature_algorithm,
+        state=state,
+    )
+
+
+# ------------------------------------------------------------------
+# Counter tests
+# ------------------------------------------------------------------
+
+
+class TestEnforcementMetricsCounter:
+    """Verify that the Prometheus counter is incremented for each outcome."""
+
+    def test_counter_incremented_on_allow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+        reset_flag_registry()
+        _persist_signed_receipt(receipt_id="receipt-allow")
+
+        with patch(
+            "aragora.pipeline.receipt_enforcement._record_enforcement_metric"
+        ) as mock_record:
+            require_receipt_gate(
+                action_domain="openclaw",
+                action_type="execute_action",
+                actor_id="user-1",
+                resource_id="res-1",
+                receipt_id="receipt-allow",
+            )
+            mock_record.assert_called_once()
+            call_args = mock_record.call_args
+            assert call_args[0][0] == "openclaw"
+            assert call_args[0][1] == "allowed"
+            assert isinstance(call_args[0][2], float)
+
+    def test_counter_incremented_on_block(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+        reset_flag_registry()
+
+        with patch(
+            "aragora.pipeline.receipt_enforcement._record_enforcement_metric"
+        ) as mock_record:
+            with pytest.raises(ReceiptEnforcementError):
+                require_receipt_gate(
+                    action_domain="openclaw",
+                    action_type="execute_action",
+                    actor_id="user-1",
+                    resource_id="res-1",
+                    receipt_id=None,
+                )
+            mock_record.assert_called_once()
+            call_args = mock_record.call_args
+            assert call_args[0][1] == "blocked"
+
+    def test_counter_incremented_on_exempt(self) -> None:
+        with patch(
+            "aragora.pipeline.receipt_enforcement._record_enforcement_metric"
+        ) as mock_record:
+            require_receipt_gate(
+                action_domain="openclaw",
+                action_type="execute_action",
+                actor_id="admin",
+                resource_id="res-1",
+                exempt=ReceiptExemption(
+                    reason="Test exemption",
+                    approved_by="test",
+                    category="read_only",
+                ),
+            )
+            mock_record.assert_called_once()
+            call_args = mock_record.call_args
+            assert call_args[0][1] == "exempted"
+
+    def test_counter_incremented_on_disabled(self) -> None:
+        with patch(
+            "aragora.pipeline.receipt_enforcement._record_enforcement_metric"
+        ) as mock_record:
+            require_receipt_gate(
+                action_domain="openclaw",
+                action_type="execute_action",
+                actor_id="user-1",
+                resource_id="res-1",
+            )
+            mock_record.assert_called_once()
+            call_args = mock_record.call_args
+            assert call_args[0][1] == "disabled"
+
+
+# ------------------------------------------------------------------
+# Latency tests
+# ------------------------------------------------------------------
+
+
+class TestEnforcementMetricsLatency:
+    """Verify that latency is observed for every enforcement decision."""
+
+    def test_latency_is_non_negative(self) -> None:
+        with patch(
+            "aragora.pipeline.receipt_enforcement._record_enforcement_metric"
+        ) as mock_record:
+            require_receipt_gate(
+                action_domain="canvas",
+                action_type="update_node",
+                actor_id="user-1",
+                resource_id="res-1",
+            )
+            elapsed = mock_record.call_args[0][2]
+            assert elapsed >= 0.0
+
+
+# ------------------------------------------------------------------
+# Graceful degradation without prometheus_client
+# ------------------------------------------------------------------
+
+
+class TestMetricsWithoutPrometheus:
+    """Verify that enforcement works when prometheus_client is not installed."""
+
+    def test_graceful_without_prometheus(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Enforcement should succeed even when prometheus_client import fails."""
+        reset_enforcement_metrics()
+
+        # Temporarily hide prometheus_client from the import system
+        real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def _blocked_import(name, *args, **kwargs):
+            if name == "prometheus_client":
+                raise ImportError("simulated: no prometheus_client")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _blocked_import)
+
+        # Should still work — metrics just become no-ops
+        result = require_receipt_gate(
+            action_domain="openclaw",
+            action_type="execute_action",
+            actor_id="user-1",
+            resource_id="res-1",
+        )
+        assert result is None  # disabled → pass-through
+
+
+# ------------------------------------------------------------------
+# Registry-based automatic exemption wiring
+# ------------------------------------------------------------------
+
+
+class TestRegistryExemptionWiring:
+    """Verify that ExemptionRegistry automatically exempts matching actions."""
+
+    def test_registry_exempts_read_operations(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """read_* actions should be auto-exempted via the registry, even when
+        enforcement is enabled."""
+        monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+        reset_flag_registry()
+
+        # read_config matches built-in "read_*" pattern → exempted
+        result = require_receipt_gate(
+            action_domain="openclaw",
+            action_type="read_config",
+            actor_id="user-1",
+            resource_id="res-1",
+        )
+        assert result is None  # exempted, not blocked
+
+    def test_registry_does_not_exempt_mutations(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mutating actions should NOT be auto-exempted."""
+        monkeypatch.setenv("ARAGORA_RECEIPT_ENFORCEMENT_OPENCLAW", "true")
+        reset_flag_registry()
+
+        with pytest.raises(ReceiptEnforcementError):
+            require_receipt_gate(
+                action_domain="openclaw",
+                action_type="execute_action",
+                actor_id="user-1",
+                resource_id="res-1",
+            )

--- a/tests/pipeline/test_receipt_exemptions.py
+++ b/tests/pipeline/test_receipt_exemptions.py
@@ -1,0 +1,143 @@
+"""Tests for the ExemptionRegistry and built-in receipt exemptions."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.pipeline.receipt_exemptions import ExemptionRegistry, RegisteredExemption
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry() -> None:  # type: ignore[misc]
+    ExemptionRegistry.reset_instance()
+    yield
+    ExemptionRegistry.reset_instance()
+
+
+# ------------------------------------------------------------------
+# Built-in exemptions
+# ------------------------------------------------------------------
+
+
+class TestBuiltinExemptions:
+    """Verify that built-in exemptions are registered on construction."""
+
+    def test_read_operations_exempt(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("openclaw", "read_state")
+        assert result is not None
+        assert result.category == "read_only"
+
+    def test_list_operations_exempt(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("canvas", "list_items")
+        assert result is not None
+        assert result.category == "read_only"
+
+    def test_get_operations_exempt(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("inbox", "get_messages")
+        assert result is not None
+        assert result.category == "read_only"
+
+    def test_health_check_exempt(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("computer_use", "health_check")
+        assert result is not None
+        assert result.category == "health_check"
+
+    def test_metrics_exempt(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("shared_inbox", "metrics")
+        assert result is not None
+        assert result.category == "system_internal"
+
+
+# ------------------------------------------------------------------
+# Custom exemptions
+# ------------------------------------------------------------------
+
+
+class TestCustomExemptions:
+    """Verify custom exemption registration and matching."""
+
+    def test_register_and_match(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        reg.register(
+            domain="canvas",
+            action_pattern="preview_*",
+            reason="Preview actions are read-only renders",
+            approved_by="eng-team",
+            category="read_only",
+        )
+        result = reg.is_exempt("canvas", "preview_layout")
+        assert result is not None
+        assert result.approved_by == "eng-team"
+        assert result.reason == "Preview actions are read-only renders"
+
+    def test_register_returns_exemption(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        exemption = reg.register("inbox", "ack_*", "Ack is metadata", "ops", "metadata_only")
+        assert isinstance(exemption, RegisteredExemption)
+        assert exemption.domain == "inbox"
+
+    def test_non_exempt_action_returns_none(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("openclaw", "execute_action")
+        assert result is None
+
+    def test_non_exempt_mutating_action(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        result = reg.is_exempt("inbox", "delete_message")
+        assert result is None
+
+
+# ------------------------------------------------------------------
+# Wildcard domain matching
+# ------------------------------------------------------------------
+
+
+class TestWildcardDomain:
+    """Verify wildcard domain matching in built-in and custom exemptions."""
+
+    def test_wildcard_domain_matches_any(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        # Built-in "read_*" uses domain="*"
+        for domain in ("openclaw", "canvas", "computer_use", "inbox", "shared_inbox"):
+            result = reg.is_exempt(domain, "read_config")
+            assert result is not None, f"Expected exemption for {domain}/read_config"
+
+    def test_specific_domain_does_not_cross_match(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        reg.register("canvas", "render_*", "Canvas render", "system", "read_only")
+        assert reg.is_exempt("canvas", "render_frame") is not None
+        assert reg.is_exempt("openclaw", "render_frame") is None
+
+
+# ------------------------------------------------------------------
+# Singleton
+# ------------------------------------------------------------------
+
+
+class TestSingleton:
+    """Verify singleton behaviour."""
+
+    def test_get_instance_returns_same_object(self) -> None:
+        a = ExemptionRegistry.get_instance()
+        b = ExemptionRegistry.get_instance()
+        assert a is b
+
+    def test_reset_instance_creates_new(self) -> None:
+        a = ExemptionRegistry.get_instance()
+        ExemptionRegistry.reset_instance()
+        b = ExemptionRegistry.get_instance()
+        assert a is not b
+
+    def test_exemptions_property_returns_copy(self) -> None:
+        reg = ExemptionRegistry.get_instance()
+        exemptions = reg.exemptions
+        assert isinstance(exemptions, list)
+        assert len(exemptions) == 5  # 5 built-in exemptions
+        # Mutating the copy should not affect the registry
+        exemptions.clear()
+        assert len(reg.exemptions) == 5


### PR DESCRIPTION
## Summary
- Adds Prometheus `Counter` (`aragora_receipt_enforcement_total`) and `Histogram` (`aragora_receipt_enforcement_latency_seconds`) to `require_receipt_gate()`, lazy-initialized to gracefully degrade when `prometheus_client` is not installed
- Creates `ExemptionRegistry` singleton in `aragora/pipeline/receipt_exemptions.py` with built-in exemptions for read-only (`read_*`, `list_*`, `get_*`), health checks, and metrics collection using `fnmatch` patterns
- Wires `ExemptionRegistry` into `require_receipt_gate()` so matching actions are automatically exempted before the feature-flag check
- MCP tool gating deferred: existing MCP tools don't cleanly map to the 5 enforcement domains (openclaw, canvas, computer_use, inbox, shared_inbox); will be addressed when domain-specific MCP mutation tools are introduced
- 48 tests pass (11 existing + 14 exemption registry + 8 metrics + 15 related receipt tests), zero regressions

## Test plan
- [x] `test_receipt_exemptions.py` — 14 tests: built-in exemptions, custom registration, wildcard domain matching, singleton behavior
- [x] `test_receipt_enforcement_metrics.py` — 8 tests: counter incremented on allow/block/exempt/disabled, latency non-negative, graceful without prometheus, registry auto-exemption wiring
- [x] `test_receipt_enforcement.py` — 11 existing tests pass unchanged (no regression)
- [x] `test_receipt_gate.py` + `test_receipt_store_facade.py` — 15 related tests pass
- [x] `ruff check` clean on all 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)