### PR TITLE
feat(nomic): add canonical repo assessment compiler

### DIFF
--- a/aragora/cli/commands/assess.py
+++ b/aragora/cli/commands/assess.py
@@ -1,0 +1,106 @@
+"""CLI command: aragora assess — run canonical repository assessment."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+
+def cmd_assess(args) -> None:
+    """Run canonical repo assessment."""
+    asyncio.run(_run_assessment(args))
+
+
+async def _run_assessment(args) -> None:
+    from aragora.nomic.canonical_assessment import (
+        CanonicalAssessmentCompiler,
+        compute_delta,
+        load_latest_assessment,
+        save_assessment,
+    )
+
+    compiler = CanonicalAssessmentCompiler()
+    assessment = await compiler.compile()
+
+    if getattr(args, "save", False):
+        aid = save_assessment(assessment)
+        print(f"Saved: {aid}", file=sys.stderr)
+
+    if getattr(args, "diff", False):
+        previous = load_latest_assessment()
+        if previous and previous.assessment_id != assessment.assessment_id:
+            delta = compute_delta(assessment, previous)
+            _print_delta(delta)
+        elif previous is None:
+            print("No previous assessment found for diff.", file=sys.stderr)
+
+    fmt = getattr(args, "format", "text")
+    if fmt == "json":
+        print(json.dumps(assessment.to_dict(), indent=2, default=str))
+    else:
+        _print_summary(assessment)
+
+
+def _print_summary(assessment) -> None:
+    """Print a human-readable assessment summary."""
+    health = assessment.health_report.get("health_score", "N/A")
+    if isinstance(health, float):
+        health = f"{health:.2f}"
+
+    print(f"\nCanonical Repo Assessment: {assessment.assessment_id}")
+    print("=" * 60)
+    print(f"Timestamp:     {assessment.timestamp:.0f}")
+    print(f"Health Score:  {health}")
+
+    if assessment.scanner_metrics:
+        m = assessment.scanner_metrics
+        print(f"Total Modules: {m.get('total_modules', 'N/A')}")
+        print(f"Test Files:    {m.get('total_test_files', 'N/A')}")
+        print(f"Tested %:      {m.get('tested_pct', 'N/A')}")
+
+    if assessment.feature_inventory:
+        by_status: dict[str, int] = {}
+        for f in assessment.feature_inventory:
+            by_status[f.status] = by_status.get(f.status, 0) + 1
+        print(f"\nFeatures ({len(assessment.feature_inventory)}):")
+        for status, count in sorted(by_status.items()):
+            print(f"  {status}: {count}")
+
+    if assessment.improvement_candidates:
+        print(f"\nTop Improvement Candidates ({len(assessment.improvement_candidates)}):")
+        for c in assessment.improvement_candidates[:5]:
+            desc = c.get("description", "")[:60]
+            prio = c.get("priority", 0)
+            print(f"  [{prio:.2f}] {desc}")
+
+    if assessment.recurring_findings:
+        print(f"\nRecurring Findings: {len(assessment.recurring_findings)}")
+
+    if assessment.metadata.get("commit_sha"):
+        sha = assessment.metadata["commit_sha"][:12]
+        branch = assessment.metadata.get("branch", "?")
+        dirty = " (dirty)" if assessment.metadata.get("dirty") else ""
+        print(f"\nGit: {sha} on {branch}{dirty}")
+
+    print()
+
+
+def _print_delta(delta) -> None:
+    """Print delta between two assessments."""
+    print(f"\nDelta: {delta.previous_id} -> {delta.current_id}")
+    print("-" * 50)
+    hours = delta.time_elapsed_seconds / 3600
+    print(f"Time elapsed:      {hours:.1f}h")
+    sign = "+" if delta.health_score_change >= 0 else ""
+    print(f"Health change:     {sign}{delta.health_score_change:.3f}")
+    if delta.new_features:
+        print(f"New features:      {', '.join(delta.new_features[:5])}")
+    if delta.resolved_features:
+        print(f"Resolved features: {', '.join(delta.resolved_features[:5])}")
+    if delta.status_changes:
+        for sc in delta.status_changes[:5]:
+            print(f"  {sc['name']}: {sc['old_status']} -> {sc['new_status']}")
+    print(f"New findings:      {delta.new_findings}")
+    print(f"Resolved findings: {delta.resolved_findings}")
+    print()

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -193,6 +193,7 @@ Examples:
     _add_inbox_wedge_parser(subparsers)
     _add_triage_parser(subparsers)
     _add_ralph_parser(subparsers)
+    _add_assess_parser(subparsers)
 
     return parser
 
@@ -2437,3 +2438,25 @@ def _add_ralph_parser(subparsers) -> None:
             "aragora.cli.commands.ralph", fromlist=["cmd_ralph"]
         ).cmd_ralph(args)
     )
+
+
+def _add_assess_parser(subparsers) -> None:
+    """Add the 'assess' subcommand for canonical repository assessment."""
+    p = subparsers.add_parser("assess", help="Run canonical repository assessment")
+    p.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    p.add_argument(
+        "--save",
+        action="store_true",
+        help="Persist assessment to strategic memory store",
+    )
+    p.add_argument(
+        "--diff",
+        action="store_true",
+        help="Show delta from previous assessment",
+    )
+    p.set_defaults(func=_lazy("aragora.cli.commands.assess", "cmd_assess"))

--- a/aragora/nomic/canonical_assessment.py
+++ b/aragora/nomic/canonical_assessment.py
@@ -1,0 +1,711 @@
+"""Canonical Repo Assessment Compiler — single-artifact codebase assessment.
+
+Aggregates signals from AutonomousAssessmentEngine, StrategicScanner,
+StrategicMemoryStore, and FEATURE_GAP_LIST.md into one
+CanonicalRepoAssessment artifact with delta analysis, SQLite persistence,
+and pipeline bridge.
+
+No LLM calls — pure signal aggregation.
+
+Usage:
+    compiler = CanonicalAssessmentCompiler()
+    assessment = await compiler.compile()
+    print(f"Health: {assessment.health_report['health_score']:.2f}")
+    print(f"Features: {len(assessment.feature_inventory)}")
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FeatureEntry:
+    """A single feature from the gap list with evidence cross-references."""
+
+    name: str
+    status: str  # "shipped" | "scaffolding" | "stale" | "gap"
+    evidence: list[str] = field(default_factory=list)  # ["file:path", "test:path", ...]
+    priority: str = "P3"  # "P0"-"P5"
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "evidence": self.evidence,
+            "priority": self.priority,
+            "notes": self.notes,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> FeatureEntry:
+        return cls(
+            name=data["name"],
+            status=data["status"],
+            evidence=data.get("evidence", []),
+            priority=data.get("priority", "P3"),
+            notes=data.get("notes", ""),
+        )
+
+
+@dataclass
+class AssessmentDelta:
+    """Diff between two consecutive canonical assessments."""
+
+    previous_id: str
+    current_id: str
+    time_elapsed_seconds: float
+    health_score_change: float
+    new_features: list[str] = field(default_factory=list)
+    resolved_features: list[str] = field(default_factory=list)
+    status_changes: list[dict[str, str]] = field(default_factory=list)
+    new_findings: int = 0
+    resolved_findings: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "previous_id": self.previous_id,
+            "current_id": self.current_id,
+            "time_elapsed_seconds": self.time_elapsed_seconds,
+            "health_score_change": self.health_score_change,
+            "new_features": self.new_features,
+            "resolved_features": self.resolved_features,
+            "status_changes": self.status_changes,
+            "new_findings": self.new_findings,
+            "resolved_findings": self.resolved_findings,
+        }
+
+
+@dataclass
+class CanonicalRepoAssessment:
+    """Complete canonical repository assessment artifact."""
+
+    assessment_id: str
+    timestamp: float
+    health_report: dict[str, Any] = field(default_factory=dict)
+    scanner_metrics: dict[str, Any] = field(default_factory=dict)
+    feature_inventory: list[FeatureEntry] = field(default_factory=list)
+    improvement_candidates: list[dict[str, Any]] = field(default_factory=list)
+    recurring_findings: list[dict[str, Any]] = field(default_factory=list)
+    audit_results: dict[str, Any] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "assessment_id": self.assessment_id,
+            "timestamp": self.timestamp,
+            "health_report": self.health_report,
+            "scanner_metrics": self.scanner_metrics,
+            "feature_inventory": [f.to_dict() for f in self.feature_inventory],
+            "improvement_candidates": self.improvement_candidates,
+            "recurring_findings": self.recurring_findings,
+            "audit_results": self.audit_results,
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CanonicalRepoAssessment:
+        return cls(
+            assessment_id=data["assessment_id"],
+            timestamp=data["timestamp"],
+            health_report=data.get("health_report", {}),
+            scanner_metrics=data.get("scanner_metrics", {}),
+            feature_inventory=[
+                FeatureEntry.from_dict(f) for f in data.get("feature_inventory", [])
+            ],
+            improvement_candidates=data.get("improvement_candidates", []),
+            recurring_findings=data.get("recurring_findings", []),
+            audit_results=data.get("audit_results", {}),
+            metadata=data.get("metadata", {}),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Compiler
+# ---------------------------------------------------------------------------
+
+
+class CanonicalAssessmentCompiler:
+    """Compile all signal sources into one CanonicalRepoAssessment.
+
+    Signal sources (all lazy-imported, all fail gracefully):
+    1. AutonomousAssessmentEngine.assess() -> health_report
+    2. StrategicScanner.scan() -> scanner_metrics
+    3. StrategicMemoryStore.get_recurring_findings() -> recurring
+    4. _collect_audit_signals() -> audit_results
+    5. _classify_features() -> feature_inventory
+    6. _collect_git_metadata() -> metadata
+    """
+
+    def __init__(self, repo_path: Path | None = None) -> None:
+        self._repo_path = repo_path or Path.cwd()
+
+    async def compile(self) -> CanonicalRepoAssessment:
+        """Run all signal sources, compile into one assessment."""
+        assessment_id = f"ca-{uuid.uuid4().hex[:12]}"
+        ts = time.time()
+
+        # 1. Health report from AutonomousAssessmentEngine
+        health_report, improvement_candidates = self._collect_health_report()
+
+        # 2. Scanner metrics from StrategicScanner
+        scanner_metrics, scanner_findings = self._collect_scanner_metrics()
+
+        # 3. Recurring findings from StrategicMemoryStore
+        recurring_findings = self._collect_recurring_findings()
+
+        # 4. Lightweight audit signals
+        audit_results = self._collect_audit_signals()
+
+        # 5. Feature inventory from FEATURE_GAP_LIST.md cross-referenced
+        feature_inventory = self._classify_features(scanner_findings, health_report)
+
+        # 6. Git metadata
+        metadata = self._collect_git_metadata()
+
+        return CanonicalRepoAssessment(
+            assessment_id=assessment_id,
+            timestamp=ts,
+            health_report=health_report,
+            scanner_metrics=scanner_metrics,
+            feature_inventory=feature_inventory,
+            improvement_candidates=improvement_candidates,
+            recurring_findings=recurring_findings,
+            audit_results=audit_results,
+            metadata=metadata,
+        )
+
+    # --- Signal collectors ---
+
+    def _collect_health_report(self) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        """Collect health report from AutonomousAssessmentEngine."""
+        try:
+            import asyncio
+
+            from aragora.nomic.assessment_engine import AutonomousAssessmentEngine
+
+            engine = AutonomousAssessmentEngine()
+            # Use asyncio to run the async assess() method
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop and loop.is_running():
+                # We're inside an event loop already — create a task
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor() as pool:
+                    report = loop.run_in_executor(pool, lambda: asyncio.run(engine.assess()))
+                    # Can't await here synchronously; fall back to empty
+                    report_dict = {}
+                    candidates = []
+                    logger.debug("Nested event loop detected, skipping health report")
+                    return report_dict, candidates
+            else:
+                report = asyncio.run(engine.assess())
+
+            report_dict = report.to_dict()
+            candidates = [c.to_dict() for c in report.improvement_candidates]
+            return report_dict, candidates
+        except ImportError:
+            logger.debug("AutonomousAssessmentEngine not available")
+            return {}, []
+        except (RuntimeError, ValueError, OSError) as e:
+            logger.debug("Health report collection failed: %s", e)
+            return {}, []
+
+    def _collect_scanner_metrics(self) -> tuple[dict[str, Any], list[Any]]:
+        """Collect scanner metrics from StrategicScanner."""
+        try:
+            from aragora.nomic.strategic_scanner import StrategicScanner
+
+            scanner = StrategicScanner(repo_path=self._repo_path)
+            assessment = scanner.scan()
+            return assessment.metrics, assessment.findings
+        except ImportError:
+            logger.debug("StrategicScanner not available")
+            return {}, []
+        except (RuntimeError, ValueError, OSError) as e:
+            logger.debug("Scanner metrics collection failed: %s", e)
+            return {}, []
+
+    def _collect_recurring_findings(self) -> list[dict[str, Any]]:
+        """Collect recurring findings from StrategicMemoryStore."""
+        try:
+            from aragora.nomic.strategic_memory import StrategicMemoryStore
+
+            store = StrategicMemoryStore()
+            findings = store.get_recurring_findings(min_occurrences=2)
+            return [
+                {
+                    "category": f.category,
+                    "severity": f.severity,
+                    "file_path": f.file_path,
+                    "description": f.description,
+                }
+                for f in findings
+            ]
+        except ImportError:
+            logger.debug("StrategicMemoryStore not available")
+            return []
+        except (RuntimeError, ValueError, OSError, sqlite3.Error) as e:
+            logger.debug("Recurring findings collection failed: %s", e)
+            return []
+
+    def _collect_audit_signals(self) -> dict[str, Any]:
+        """Lightweight inline audit checks (no subprocess).
+
+        Checks for common code quality signals by scanning key paths.
+        """
+        results: dict[str, Any] = {
+            "bare_except_count": 0,
+            "todo_count": 0,
+            "fixme_count": 0,
+            "missing_init_files": [],
+        }
+
+        src_root = self._repo_path / "aragora"
+        if not src_root.exists():
+            return results
+
+        todo_pattern = re.compile(r"#\s*(TODO|FIXME)\b", re.IGNORECASE)
+
+        try:
+            for py_file in src_root.rglob("*.py"):
+                if py_file.name.startswith("__"):
+                    continue
+                try:
+                    content = py_file.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+
+                for line in content.splitlines():
+                    stripped = line.strip()
+                    if stripped.startswith("except:") or stripped == "except:":
+                        results["bare_except_count"] += 1
+                    m = todo_pattern.search(stripped)
+                    if m:
+                        tag = m.group(1).upper()
+                        if tag == "TODO":
+                            results["todo_count"] += 1
+                        elif tag == "FIXME":
+                            results["fixme_count"] += 1
+
+            # Check for missing __init__.py
+            for subdir in src_root.iterdir():
+                if subdir.is_dir() and not subdir.name.startswith("."):
+                    init_path = subdir / "__init__.py"
+                    if not init_path.exists():
+                        rel = str(subdir.relative_to(self._repo_path))
+                        results["missing_init_files"].append(rel)
+        except OSError as e:
+            logger.debug("Audit signal collection failed: %s", e)
+
+        return results
+
+    def _classify_features(
+        self,
+        scanner_findings: list[Any],
+        health_report: dict[str, Any],
+    ) -> list[FeatureEntry]:
+        """Parse FEATURE_GAP_LIST.md, cross-ref with scanner findings."""
+        raw_features = self._parse_feature_gap_list()
+        if not raw_features:
+            return []
+
+        # Build a set of file paths from scanner findings for cross-referencing
+        finding_paths: set[str] = set()
+        for f in scanner_findings:
+            path = getattr(f, "file_path", None) if not isinstance(f, dict) else f.get("file_path")
+            if path:
+                finding_paths.add(path)
+
+        entries: list[FeatureEntry] = []
+        for raw in raw_features:
+            name = raw.get("name", "")
+            status_text = raw.get("status", "").lower()
+            priority = raw.get("priority", "P3")
+            notes = raw.get("notes", "")
+
+            # Classify status based on status text
+            status = self._classify_status(status_text, name, finding_paths)
+
+            evidence: list[str] = []
+            if raw.get("issue"):
+                evidence.append(f"issue:{raw['issue']}")
+
+            entries.append(
+                FeatureEntry(
+                    name=name,
+                    status=status,
+                    evidence=evidence,
+                    priority=priority,
+                    notes=notes,
+                )
+            )
+
+        return entries
+
+    @staticmethod
+    def _classify_status(status_text: str, name: str, finding_paths: set[str]) -> str:
+        """Determine feature status from gap list text and scanner evidence."""
+        completed_indicators = [
+            "complete",
+            "shipped",
+            "validated",
+            "live",
+            "verified",
+            "closed",
+            "deployed",
+            "working",
+        ]
+        scaffolding_indicators = [
+            "scaffolding",
+            "partial",
+            "contracts written",
+            "design only",
+            "code exists",
+        ]
+        not_started_indicators = ["not started"]
+
+        for indicator in completed_indicators:
+            if indicator in status_text:
+                return "shipped"
+
+        for indicator in scaffolding_indicators:
+            if indicator in status_text:
+                return "scaffolding"
+
+        for indicator in not_started_indicators:
+            if indicator in status_text:
+                return "gap"
+
+        # Default: if status text is non-empty, treat as scaffolding
+        if status_text:
+            return "scaffolding"
+        return "gap"
+
+    def _parse_feature_gap_list(self) -> list[dict[str, Any]]:
+        """Regex-based markdown table parser for FEATURE_GAP_LIST.md."""
+        gap_file = self._repo_path / "docs" / "FEATURE_GAP_LIST.md"
+        if not gap_file.exists():
+            logger.debug("FEATURE_GAP_LIST.md not found at %s", gap_file)
+            return []
+
+        try:
+            content = gap_file.read_text(encoding="utf-8", errors="replace")
+        except OSError as e:
+            logger.debug("Failed to read FEATURE_GAP_LIST.md: %s", e)
+            return []
+
+        features: list[dict[str, Any]] = []
+        current_priority = "P3"
+
+        # Match priority headers like "## P0 — GA Blockers"
+        priority_pattern = re.compile(r"^##\s+(P\d)\b", re.MULTILINE)
+        # Match table rows: | Feature | Status | Notes |
+        row_pattern = re.compile(r"^\|\s*(.+?)\s*\|\s*(.+?)\s*\|\s*(.*?)\s*\|$")
+        # Extract issue references like [#123](...)
+        issue_pattern = re.compile(r"\[#(\d+)\]")
+
+        for line in content.splitlines():
+            # Check for priority header
+            pm = priority_pattern.match(line)
+            if pm:
+                current_priority = pm.group(1)
+                continue
+
+            # Skip header/separator rows
+            if line.strip().startswith("|--") or line.strip().startswith("| Feature"):
+                continue
+
+            # Check for completed section
+            if "## Completed" in line or "## Scaffolding" in line:
+                # Scaffolding section uses same priority, completed uses "shipped"
+                if "Completed" in line:
+                    current_priority = "shipped"
+                continue
+
+            rm = row_pattern.match(line.strip())
+            if not rm:
+                continue
+
+            name = rm.group(1).strip()
+            status = rm.group(2).strip()
+            notes = rm.group(3).strip()
+
+            # Skip header rows that leaked through
+            if name.lower() in ("feature", "------", "---"):
+                continue
+
+            # Extract issue number if present
+            issue_match = issue_pattern.search(notes) or issue_pattern.search(status)
+            issue = f"#{issue_match.group(1)}" if issue_match else ""
+
+            features.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "priority": current_priority,
+                    "notes": notes,
+                    "issue": issue,
+                }
+            )
+
+        return features
+
+    def _collect_git_metadata(self) -> dict[str, Any]:
+        """Collect git rev-parse HEAD, branch, dirty status via subprocess."""
+        metadata: dict[str, Any] = {
+            "repo_path": str(self._repo_path),
+        }
+
+        try:
+            # HEAD commit
+            proc = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=str(self._repo_path),
+                timeout=10,
+            )
+            if proc.returncode == 0:
+                metadata["commit_sha"] = proc.stdout.strip()
+
+            # Current branch
+            proc = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                capture_output=True,
+                text=True,
+                cwd=str(self._repo_path),
+                timeout=10,
+            )
+            if proc.returncode == 0:
+                metadata["branch"] = proc.stdout.strip()
+
+            # Dirty status
+            proc = subprocess.run(
+                ["git", "status", "--porcelain"],
+                capture_output=True,
+                text=True,
+                cwd=str(self._repo_path),
+                timeout=10,
+            )
+            if proc.returncode == 0:
+                metadata["dirty"] = bool(proc.stdout.strip())
+            else:
+                metadata["dirty"] = None
+
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            logger.debug("Git metadata collection failed: %s", e)
+            metadata["git_error"] = str(type(e).__name__)
+
+        return metadata
+
+
+# ---------------------------------------------------------------------------
+# Delta
+# ---------------------------------------------------------------------------
+
+
+def compute_delta(
+    current: CanonicalRepoAssessment,
+    previous: CanonicalRepoAssessment,
+) -> AssessmentDelta:
+    """Pure data comparison between two assessments."""
+    # Health score change
+    cur_health = current.health_report.get("health_score", 0.0)
+    prev_health = previous.health_report.get("health_score", 0.0)
+
+    # Feature diff
+    cur_names = {f.name for f in current.feature_inventory}
+    prev_names = {f.name for f in previous.feature_inventory}
+    new_features = sorted(cur_names - prev_names)
+    resolved_features = sorted(prev_names - cur_names)
+
+    # Status changes for features present in both
+    prev_status_map = {f.name: f.status for f in previous.feature_inventory}
+    status_changes: list[dict[str, str]] = []
+    for feat in current.feature_inventory:
+        old_status = prev_status_map.get(feat.name)
+        if old_status and old_status != feat.status:
+            status_changes.append(
+                {
+                    "name": feat.name,
+                    "old_status": old_status,
+                    "new_status": feat.status,
+                }
+            )
+
+    # Findings diff
+    cur_findings = len(current.recurring_findings)
+    prev_findings = len(previous.recurring_findings)
+
+    return AssessmentDelta(
+        previous_id=previous.assessment_id,
+        current_id=current.assessment_id,
+        time_elapsed_seconds=current.timestamp - previous.timestamp,
+        health_score_change=cur_health - prev_health,
+        new_features=new_features,
+        resolved_features=resolved_features,
+        status_changes=status_changes,
+        new_findings=max(0, cur_findings - prev_findings),
+        resolved_findings=max(0, prev_findings - cur_findings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+_DEFAULT_DB_DIR = os.environ.get("ARAGORA_DATA_DIR", str(Path.home() / ".aragora"))
+_DEFAULT_DB_PATH = os.path.join(_DEFAULT_DB_DIR, "canonical_assessments.db")
+
+
+def _get_db_path() -> str:
+    """Resolve the canonical assessments database path."""
+    try:
+        from aragora.config import resolve_db_path
+
+        return resolve_db_path("canonical_assessments.db")
+    except ImportError:
+        return _DEFAULT_DB_PATH
+
+
+def _ensure_table(conn: sqlite3.Connection) -> None:
+    """Create the canonical_assessments table if it does not exist."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS canonical_assessments (
+            assessment_id TEXT PRIMARY KEY,
+            timestamp REAL NOT NULL,
+            data_json TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_canonical_timestamp
+        ON canonical_assessments(timestamp DESC)
+    """)
+    conn.commit()
+
+
+def _connect(db_path: str) -> sqlite3.Connection:
+    """Create a new connection with WAL mode."""
+    parent = Path(db_path).parent
+    parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path, timeout=10)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.row_factory = sqlite3.Row
+    _ensure_table(conn)
+    return conn
+
+
+def save_assessment(
+    assessment: CanonicalRepoAssessment,
+    db_path: str | None = None,
+) -> str:
+    """Persist a canonical assessment to SQLite.
+
+    Args:
+        assessment: The assessment to persist.
+        db_path: Optional custom DB path.
+
+    Returns:
+        The assessment ID.
+    """
+    path = db_path or _get_db_path()
+    conn = _connect(path)
+    try:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO canonical_assessments
+                (assessment_id, timestamp, data_json)
+            VALUES (?, ?, ?)
+            """,
+            (
+                assessment.assessment_id,
+                assessment.timestamp,
+                json.dumps(assessment.to_dict()),
+            ),
+        )
+        conn.commit()
+        logger.debug("Canonical assessment saved: %s", assessment.assessment_id)
+        return assessment.assessment_id
+    finally:
+        conn.close()
+
+
+def load_latest_assessment(
+    db_path: str | None = None,
+) -> CanonicalRepoAssessment | None:
+    """Load the most recent canonical assessment from SQLite."""
+    path = db_path or _get_db_path()
+    conn = _connect(path)
+    try:
+        row = conn.execute(
+            """
+            SELECT data_json
+            FROM canonical_assessments
+            ORDER BY timestamp DESC
+            LIMIT 1
+            """,
+        ).fetchone()
+        if row is None:
+            return None
+        return CanonicalRepoAssessment.from_dict(json.loads(row["data_json"]))
+    finally:
+        conn.close()
+
+
+def load_assessment(
+    assessment_id: str,
+    db_path: str | None = None,
+) -> CanonicalRepoAssessment | None:
+    """Load a specific canonical assessment by ID."""
+    path = db_path or _get_db_path()
+    conn = _connect(path)
+    try:
+        row = conn.execute(
+            """
+            SELECT data_json
+            FROM canonical_assessments
+            WHERE assessment_id = ?
+            """,
+            (assessment_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        return CanonicalRepoAssessment.from_dict(json.loads(row["data_json"]))
+    finally:
+        conn.close()
+
+
+__all__ = [
+    "AssessmentDelta",
+    "CanonicalAssessmentCompiler",
+    "CanonicalRepoAssessment",
+    "FeatureEntry",
+    "compute_delta",
+    "load_assessment",
+    "load_latest_assessment",
+    "save_assessment",
+]

--- a/aragora/pipeline/idea_to_execution.py
+++ b/aragora/pipeline/idea_to_execution.py
@@ -499,6 +499,67 @@ class IdeaToExecutionPipeline:
         )
         return result
 
+    @classmethod
+    async def from_assessment(
+        cls,
+        assessment: Any | None = None,
+        pipeline_id: str | None = None,
+    ) -> PipelineResult:
+        """Create pipeline from canonical assessment.
+
+        Derives improvement ideas from the assessment's candidates and
+        feature inventory, then feeds them into the standard pipeline.
+
+        Args:
+            assessment: Optional CanonicalRepoAssessment. If None, one
+                will be compiled on the fly.
+            pipeline_id: Optional external pipeline ID.
+
+        Returns:
+            PipelineResult with assessment-derived improvement ideas.
+        """
+        pid = pipeline_id or f"assess-{uuid.uuid4().hex[:12]}"
+
+        if assessment is None:
+            try:
+                from aragora.nomic.canonical_assessment import CanonicalAssessmentCompiler
+
+                compiler = CanonicalAssessmentCompiler()
+                assessment = await compiler.compile()
+            except (ImportError, AttributeError):
+                logger.debug("CanonicalAssessmentCompiler unavailable")
+                assessment = None
+
+        ideas: list[str] = []
+
+        if assessment is not None:
+            # Derive ideas from improvement candidates
+            for candidate in getattr(assessment, "improvement_candidates", [])[:10]:
+                prio_val = candidate.get("priority", 0) if isinstance(candidate, dict) else 0
+                priority = "high" if prio_val > 0.7 else "medium"
+                desc = candidate.get("description", "") if isinstance(candidate, dict) else ""
+                if desc:
+                    ideas.append(f"[{priority}] {desc}")
+
+            # Derive ideas from scaffolding features
+            for feature in getattr(assessment, "feature_inventory", []):
+                if getattr(feature, "status", None) == "scaffolding":
+                    ideas.append(f"[medium] Harden scaffolding: {feature.name}")
+
+        if not ideas:
+            ideas = [
+                "[low] Review and update test coverage",
+                "[low] Check for dependency updates",
+            ]
+
+        pipeline = cls()
+        result = pipeline.from_ideas(
+            ideas,
+            auto_advance=True,
+            pipeline_id=pid,
+        )
+        return result
+
     def from_debate(
         self,
         cartographer_data: dict[str, Any],

--- a/tests/nomic/test_canonical_assessment.py
+++ b/tests/nomic/test_canonical_assessment.py
@@ -1,0 +1,397 @@
+"""Tests for the Canonical Repo Assessment Compiler."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.nomic.canonical_assessment import (
+    AssessmentDelta,
+    CanonicalAssessmentCompiler,
+    CanonicalRepoAssessment,
+    FeatureEntry,
+    compute_delta,
+    load_assessment,
+    load_latest_assessment,
+    save_assessment,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_assessment(
+    assessment_id: str = "ca-test123",
+    timestamp: float = 1000.0,
+    health_score: float = 0.85,
+    features: list[FeatureEntry] | None = None,
+    candidates: list[dict] | None = None,
+    recurring: list[dict] | None = None,
+) -> CanonicalRepoAssessment:
+    return CanonicalRepoAssessment(
+        assessment_id=assessment_id,
+        timestamp=timestamp,
+        health_report={"health_score": health_score},
+        scanner_metrics={"total_modules": 100, "tested_pct": 80.0},
+        feature_inventory=features or [],
+        improvement_candidates=candidates or [],
+        recurring_findings=recurring or [],
+        audit_results={"todo_count": 5},
+        metadata={"commit_sha": "abc123", "branch": "main", "dirty": False},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trips
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureEntrySerialization:
+    def test_round_trip(self):
+        entry = FeatureEntry(
+            name="Blockchain receipts",
+            status="scaffolding",
+            evidence=["file:aragora/blockchain/receipt.py", "issue:#42"],
+            priority="P2",
+            notes="Needs mainnet deploy",
+        )
+        d = entry.to_dict()
+        restored = FeatureEntry.from_dict(d)
+        assert restored.name == entry.name
+        assert restored.status == entry.status
+        assert restored.evidence == entry.evidence
+        assert restored.priority == entry.priority
+        assert restored.notes == entry.notes
+
+    def test_minimal_from_dict(self):
+        entry = FeatureEntry.from_dict({"name": "X", "status": "gap"})
+        assert entry.name == "X"
+        assert entry.priority == "P3"  # default
+        assert entry.evidence == []
+
+
+class TestAssessmentRoundTrip:
+    def test_full_round_trip(self):
+        features = [
+            FeatureEntry(name="Widget", status="shipped", priority="P1"),
+            FeatureEntry(name="Gadget", status="scaffolding", priority="P2"),
+        ]
+        original = _make_assessment(
+            features=features, candidates=[{"description": "Fix X", "priority": 0.8}]
+        )
+        d = original.to_dict()
+        restored = CanonicalRepoAssessment.from_dict(d)
+        assert restored.assessment_id == original.assessment_id
+        assert restored.timestamp == original.timestamp
+        assert restored.health_report == original.health_report
+        assert len(restored.feature_inventory) == 2
+        assert restored.feature_inventory[0].name == "Widget"
+        assert restored.feature_inventory[1].status == "scaffolding"
+        assert restored.improvement_candidates == original.improvement_candidates
+        assert restored.metadata == original.metadata
+
+
+# ---------------------------------------------------------------------------
+# Compiler with mocked sources
+# ---------------------------------------------------------------------------
+
+
+class TestCompileWithMockedSources:
+    def test_compile_aggregates_all_sources(self, tmp_path):
+        # Set up a mock repo with a feature gap list
+        (tmp_path / "aragora").mkdir()
+        (tmp_path / "aragora" / "__init__.py").write_text("")
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "docs").mkdir()
+        (tmp_path / "docs" / "FEATURE_GAP_LIST.md").write_text(
+            "## P1 — GTM\n\n| Feature | Status | Notes |\n|---|---|---|\n| Widget | **Shipped** | Done |\n"
+        )
+
+        # Mock health report
+        mock_report = MagicMock()
+        mock_report.to_dict.return_value = {"health_score": 0.9}
+        mock_report.improvement_candidates = []
+
+        mock_engine = MagicMock()
+        mock_engine.assess = AsyncMock(return_value=mock_report)
+
+        # Mock scanner
+        mock_finding = MagicMock()
+        mock_finding.file_path = "aragora/core.py"
+        mock_scanner_instance = MagicMock()
+        mock_scanner_instance.scan.return_value = MagicMock(
+            metrics={"total_modules": 50}, findings=[mock_finding]
+        )
+
+        # Mock memory store
+        mock_store_instance = MagicMock()
+        mock_store_instance.get_recurring_findings.return_value = []
+
+        with (
+            patch(
+                "aragora.nomic.canonical_assessment.CanonicalAssessmentCompiler._collect_git_metadata",
+                return_value={"commit_sha": "deadbeef", "branch": "main", "dirty": False},
+            ),
+            patch.dict(os.environ, {"ARAGORA_DATA_DIR": str(tmp_path)}),
+        ):
+            compiler = CanonicalAssessmentCompiler(repo_path=tmp_path)
+
+            # Patch lazy imports inside methods
+            with (
+                patch(
+                    "aragora.nomic.assessment_engine.AutonomousAssessmentEngine",
+                    return_value=mock_engine,
+                ),
+                patch(
+                    "aragora.nomic.strategic_scanner.StrategicScanner",
+                    return_value=mock_scanner_instance,
+                ),
+                patch(
+                    "aragora.nomic.strategic_memory.StrategicMemoryStore",
+                    return_value=mock_store_instance,
+                ),
+            ):
+                assessment = asyncio.run(compiler.compile())
+
+        assert assessment.assessment_id.startswith("ca-")
+        assert assessment.timestamp > 0
+        assert isinstance(assessment.feature_inventory, list)
+        assert isinstance(assessment.audit_results, dict)
+        assert assessment.metadata.get("commit_sha") == "deadbeef"
+
+
+# ---------------------------------------------------------------------------
+# Feature classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyFeatures:
+    def _make_compiler(self, tmp_path, gap_content=""):
+        (tmp_path / "aragora").mkdir(exist_ok=True)
+        (tmp_path / "docs").mkdir(exist_ok=True)
+        if gap_content:
+            (tmp_path / "docs" / "FEATURE_GAP_LIST.md").write_text(gap_content)
+        return CanonicalAssessmentCompiler(repo_path=tmp_path)
+
+    def test_shipped_feature(self, tmp_path):
+        content = (
+            "## P1 — GTM\n\n"
+            "| Feature | Status | Notes |\n"
+            "|---|---|---|\n"
+            "| Auth system | **Shipped and verified** | All tests pass |\n"
+        )
+        compiler = self._make_compiler(tmp_path, content)
+        features = compiler._classify_features([], {})
+        assert len(features) == 1
+        assert features[0].status == "shipped"
+        assert features[0].priority == "P1"
+
+    def test_scaffolding_feature(self, tmp_path):
+        content = (
+            "## P2 — Hardening\n\n"
+            "| Feature | Status | Notes |\n"
+            "|---|---|---|\n"
+            "| Blockchain | Scaffolding | Code exists but untested |\n"
+        )
+        compiler = self._make_compiler(tmp_path, content)
+        features = compiler._classify_features([], {})
+        assert len(features) == 1
+        assert features[0].status == "scaffolding"
+        assert features[0].priority == "P2"
+
+    def test_gap_feature(self, tmp_path):
+        content = (
+            "## P0 — Blockers\n\n"
+            "| Feature | Status | Notes |\n"
+            "|---|---|---|\n"
+            "| Pen test | Not started | Vendor needed |\n"
+        )
+        compiler = self._make_compiler(tmp_path, content)
+        features = compiler._classify_features([], {})
+        assert len(features) == 1
+        assert features[0].status == "gap"
+        assert features[0].priority == "P0"
+
+    def test_issue_evidence_extracted(self, tmp_path):
+        content = (
+            "## P1 — GTM\n\n"
+            "| Feature | Status | Notes |\n"
+            "|---|---|---|\n"
+            "| Widget | Working | Tracked in [#817](url) |\n"
+        )
+        compiler = self._make_compiler(tmp_path, content)
+        features = compiler._classify_features([], {})
+        assert len(features) == 1
+        assert "issue:#817" in features[0].evidence
+
+    def test_no_gap_file(self, tmp_path):
+        compiler = self._make_compiler(tmp_path, "")
+        features = compiler._classify_features([], {})
+        assert features == []
+
+
+# ---------------------------------------------------------------------------
+# Delta computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDelta:
+    def test_health_improvement(self):
+        prev = _make_assessment(assessment_id="ca-prev", timestamp=1000.0, health_score=0.7)
+        curr = _make_assessment(assessment_id="ca-curr", timestamp=2000.0, health_score=0.85)
+        delta = compute_delta(curr, prev)
+        assert delta.previous_id == "ca-prev"
+        assert delta.current_id == "ca-curr"
+        assert delta.time_elapsed_seconds == pytest.approx(1000.0)
+        assert delta.health_score_change == pytest.approx(0.15)
+
+    def test_new_features(self):
+        prev = _make_assessment(
+            assessment_id="ca-prev",
+            features=[FeatureEntry(name="A", status="shipped")],
+        )
+        curr = _make_assessment(
+            assessment_id="ca-curr",
+            features=[
+                FeatureEntry(name="A", status="shipped"),
+                FeatureEntry(name="B", status="scaffolding"),
+            ],
+        )
+        delta = compute_delta(curr, prev)
+        assert delta.new_features == ["B"]
+        assert delta.resolved_features == []
+
+    def test_status_changes(self):
+        prev = _make_assessment(
+            assessment_id="ca-prev",
+            features=[FeatureEntry(name="Widget", status="scaffolding")],
+        )
+        curr = _make_assessment(
+            assessment_id="ca-curr",
+            features=[FeatureEntry(name="Widget", status="shipped")],
+        )
+        delta = compute_delta(curr, prev)
+        assert len(delta.status_changes) == 1
+        assert delta.status_changes[0]["name"] == "Widget"
+        assert delta.status_changes[0]["old_status"] == "scaffolding"
+        assert delta.status_changes[0]["new_status"] == "shipped"
+
+    def test_findings_diff(self):
+        prev = _make_assessment(
+            assessment_id="ca-prev",
+            recurring=[{"description": "issue1"}, {"description": "issue2"}],
+        )
+        curr = _make_assessment(
+            assessment_id="ca-curr",
+            recurring=[{"description": "issue1"}],
+        )
+        delta = compute_delta(curr, prev)
+        assert delta.resolved_findings == 1
+        assert delta.new_findings == 0
+
+
+# ---------------------------------------------------------------------------
+# SQLite persistence
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_save_and_load(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        assessment = _make_assessment(
+            features=[FeatureEntry(name="X", status="shipped", priority="P1")],
+        )
+        aid = save_assessment(assessment, db_path=db_path)
+        assert aid == "ca-test123"
+
+        loaded = load_assessment("ca-test123", db_path=db_path)
+        assert loaded is not None
+        assert loaded.assessment_id == assessment.assessment_id
+        assert loaded.health_report == assessment.health_report
+        assert len(loaded.feature_inventory) == 1
+        assert loaded.feature_inventory[0].name == "X"
+
+    def test_load_latest(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        old = _make_assessment(assessment_id="ca-old", timestamp=100.0)
+        new = _make_assessment(assessment_id="ca-new", timestamp=200.0)
+        save_assessment(old, db_path=db_path)
+        save_assessment(new, db_path=db_path)
+
+        latest = load_latest_assessment(db_path=db_path)
+        assert latest is not None
+        assert latest.assessment_id == "ca-new"
+
+    def test_load_nonexistent(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        loaded = load_assessment("ca-nonexistent", db_path=db_path)
+        assert loaded is None
+
+    def test_load_latest_empty(self, tmp_path):
+        db_path = str(tmp_path / "test.db")
+        latest = load_latest_assessment(db_path=db_path)
+        assert latest is None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_json_output(self, capsys, tmp_path):
+        """Test cmd_assess with --format json produces valid JSON."""
+        from argparse import Namespace
+
+        from aragora.cli.commands.assess import cmd_assess
+
+        mock_assessment = _make_assessment()
+
+        with (
+            patch(
+                "aragora.nomic.canonical_assessment.CanonicalAssessmentCompiler.compile",
+                new_callable=AsyncMock,
+                return_value=mock_assessment,
+            ),
+            patch.dict(os.environ, {"ARAGORA_DATA_DIR": str(tmp_path)}),
+        ):
+            args = Namespace(format="json", save=False, diff=False)
+            cmd_assess(args)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["assessment_id"] == "ca-test123"
+        assert data["health_report"]["health_score"] == 0.85
+
+    def test_text_output(self, capsys, tmp_path):
+        """Test cmd_assess with --format text prints summary."""
+        from argparse import Namespace
+
+        from aragora.cli.commands.assess import cmd_assess
+
+        mock_assessment = _make_assessment(
+            features=[FeatureEntry(name="Widget", status="shipped")],
+        )
+
+        with (
+            patch(
+                "aragora.nomic.canonical_assessment.CanonicalAssessmentCompiler.compile",
+                new_callable=AsyncMock,
+                return_value=mock_assessment,
+            ),
+            patch.dict(os.environ, {"ARAGORA_DATA_DIR": str(tmp_path)}),
+        ):
+            args = Namespace(format="text", save=False, diff=False)
+            cmd_assess(args)
+
+        captured = capsys.readouterr()
+        assert "ca-test123" in captured.out
+        assert "Health Score" in captured.out
+        assert "shipped" in captured.out


### PR DESCRIPTION
Harvested cleanly from stale #1042 onto current `main`.

This lands the canonical repo assessment compiler for #1037:
- `CanonicalAssessmentCompiler` and persistence/delta support
- `aragora assess` CLI command
- `IdeaToExecutionPipeline.from_assessment()` bridge

Local verification on the harvested branch:
- `python -m pytest tests/nomic/test_canonical_assessment.py -q`
- `ruff check aragora/cli/commands/assess.py aragora/cli/parser.py aragora/nomic/canonical_assessment.py aragora/pipeline/idea_to_execution.py tests/nomic/test_canonical_assessment.py`
- parser smoke via `build_parser()` for `assess --format json`

Supersedes #1042.

Closes #1037