### PR TITLE
feat(swarm): build canonical integrator lane view

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -66,11 +66,23 @@ def _build_boss_payload(
     from aragora.swarm.reporter import build_boss_payload, build_integrator_view
     from aragora.worktree.fleet import FleetCoordinationStore, build_fleet_rows
 
+    try:
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+    except (ImportError, RuntimeError, OSError, ValueError):
+        DevCoordinationStore = None  # type: ignore[assignment]
+
     worktrees = build_fleet_rows(repo_root, base_branch=target_branch, tail=0)
     store = FleetCoordinationStore(repo_root)
     claims = store.list_claims()
     merge_queue = store.list_merge_queue()
     coordination = store.status_summary()
+    if DevCoordinationStore is not None:
+        try:
+            coordination = DevCoordinationStore(repo_root=repo_root).status_summary(
+                include_integrator_artifacts=True
+            )
+        except (RuntimeError, OSError, ValueError):
+            pass
     integrator_view = build_integrator_view(
         runs=[run],
         worktrees=worktrees,

--- a/aragora/cli/commands/worktree.py
+++ b/aragora/cli/commands/worktree.py
@@ -441,7 +441,9 @@ def _cmd_worktree_fleet_status(
     try:
         from aragora.nomic.dev_coordination import DevCoordinationStore
 
-        coordination_summary = DevCoordinationStore(repo_root=repo_path).status_summary()
+        coordination_summary = DevCoordinationStore(repo_root=repo_path).status_summary(
+            include_integrator_artifacts=True
+        )
     except (ImportError, RuntimeError, OSError, ValueError) as exc:
         coordination_summary = {"error": str(exc), "counts": {}}
     claims_by_session: dict[str, list[str]] = {}
@@ -541,6 +543,11 @@ def _cmd_worktree_fleet_status(
                 f"  lease_health: {lane.get('lease_health', 'idle')} "
                 f"merge_readiness: {lane.get('merge_readiness', 'unknown')}"
             )
+            if lane.get("task_key") or lane.get("task_id"):
+                task_ref = lane.get("task_key") or lane.get("task_id")
+                print(
+                    f"  task: {task_ref} canonical: {'yes' if lane.get('canonical_lane') else 'no'}"
+                )
             if lane.get("collisions"):
                 print(f"  collisions: {', '.join(lane['collisions'])}")
             if isinstance(lane.get("scope_violation"), dict):
@@ -549,6 +556,11 @@ def _cmd_worktree_fleet_status(
                 print("  receipt: missing")
             elif lane.get("receipt_id"):
                 print(f"  receipt: {lane['receipt_id']}")
+            if lane.get("integration_decision"):
+                print(f"  decision: {lane['integration_decision']}")
+            actions = lane.get("available_actions")
+            if isinstance(actions, list) and actions:
+                print(f"  actions: {', '.join(str(item) for item in actions[:4])}")
         claimed_paths = row.get("claimed_paths")
         if isinstance(claimed_paths, list) and claimed_paths:
             print(f"  claimed_paths({len(claimed_paths)}): {', '.join(claimed_paths[:8])}")

--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -666,7 +666,12 @@ class DevCoordinationStore:
             "CREATE INDEX IF NOT EXISTS idx_receipts_task ON completion_receipts(task_id, created_at)"
         )
 
-    def status_summary(self) -> dict[str, Any]:
+    def status_summary(
+        self,
+        *,
+        include_integrator_artifacts: bool = False,
+        integrator_limit: int = 200,
+    ) -> dict[str, Any]:
         active_leases = self.list_active_leases()
         pending_integrations = self.list_integration_decisions(only_pending=True)
         salvage = self.list_salvage_candidates(statuses=sorted(_OPEN_SALVAGE_STATUSES))
@@ -689,7 +694,7 @@ class DevCoordinationStore:
                     **violation,
                 }
             )
-        return {
+        payload = {
             "db_path": str(self.db_path),
             "fleet_path": str(self.fleet_store.path),
             "active_leases": [item.to_dict() for item in active_leases],
@@ -709,6 +714,9 @@ class DevCoordinationStore:
                 "scope_violations": len(scope_violations),
             },
         }
+        if include_integrator_artifacts:
+            payload["integrator"] = self.integrator_snapshot(limit=integrator_limit)
+        return payload
 
     def create_supervisor_run(
         self,
@@ -870,6 +878,28 @@ class DevCoordinationStore:
             active.append(lease)
         return active
 
+    def list_leases(
+        self,
+        *,
+        statuses: list[str] | None = None,
+        limit: int | None = 500,
+    ) -> list[WorkLease]:
+        query = "SELECT * FROM leases ORDER BY updated_at DESC"
+        params: tuple[Any, ...] = ()
+        if isinstance(limit, int) and limit > 0:
+            query += " LIMIT ?"
+            params = (limit,)
+        conn = self._connect()
+        try:
+            rows = conn.execute(query, params).fetchall()
+        finally:
+            conn.close()
+        leases = [WorkLease.from_row(row) for row in rows]
+        if statuses is None:
+            return leases
+        allowed = set(statuses)
+        return [item for item in leases if item.status in allowed]
+
     def reap_expired_leases(self) -> list[WorkLease]:
         now = _utcnow()
         conn = self._connect()
@@ -990,22 +1020,37 @@ class DevCoordinationStore:
         lease_id: str | None = None,
         *,
         task_id: str | None = None,
+        limit: int | None = None,
     ) -> list[CompletionReceipt]:
+        suffix = ""
+        params: list[Any] = []
+        if isinstance(limit, int) and limit > 0:
+            suffix = " LIMIT ?"
         conn = self._connect()
         try:
             if lease_id:
+                params = [lease_id]
+                if suffix:
+                    params.append(limit)
                 rows = conn.execute(
-                    "SELECT * FROM completion_receipts WHERE lease_id = ? ORDER BY created_at DESC",
-                    (lease_id,),
+                    "SELECT * FROM completion_receipts WHERE lease_id = ? ORDER BY created_at DESC"
+                    + suffix,
+                    tuple(params),
                 ).fetchall()
             elif task_id:
+                params = [task_id]
+                if suffix:
+                    params.append(limit)
                 rows = conn.execute(
-                    "SELECT * FROM completion_receipts WHERE task_id = ? ORDER BY created_at DESC",
-                    (task_id,),
+                    "SELECT * FROM completion_receipts WHERE task_id = ? ORDER BY created_at DESC"
+                    + suffix,
+                    tuple(params),
                 ).fetchall()
             else:
+                params = [limit] if suffix else []
                 rows = conn.execute(
-                    "SELECT * FROM completion_receipts ORDER BY created_at DESC"
+                    "SELECT * FROM completion_receipts ORDER BY created_at DESC" + suffix,
+                    tuple(params),
                 ).fetchall()
         finally:
             conn.close()
@@ -1027,17 +1072,28 @@ class DevCoordinationStore:
         *,
         only_pending: bool = False,
         receipt_id: str | None = None,
+        limit: int | None = None,
     ) -> list[IntegrationDecision]:
+        suffix = ""
+        params: list[Any] = []
+        if isinstance(limit, int) and limit > 0:
+            suffix = " LIMIT ?"
         conn = self._connect()
         try:
             if receipt_id:
+                params = [receipt_id]
+                if suffix:
+                    params.append(limit)
                 rows = conn.execute(
-                    "SELECT * FROM integration_decisions WHERE receipt_id = ? ORDER BY created_at DESC",
-                    (receipt_id,),
+                    "SELECT * FROM integration_decisions WHERE receipt_id = ? ORDER BY created_at DESC"
+                    + suffix,
+                    tuple(params),
                 ).fetchall()
             else:
+                params = [limit] if suffix else []
                 rows = conn.execute(
-                    "SELECT * FROM integration_decisions ORDER BY created_at DESC"
+                    "SELECT * FROM integration_decisions ORDER BY created_at DESC" + suffix,
+                    tuple(params),
                 ).fetchall()
         finally:
             conn.close()
@@ -1045,6 +1101,27 @@ class DevCoordinationStore:
         if only_pending:
             return [item for item in decisions if item.decision in _PENDING_INTEGRATION_DECISIONS]
         return decisions
+
+    def integrator_snapshot(self, *, limit: int = 200) -> dict[str, Any]:
+        bounded_limit = max(1, int(limit))
+        return {
+            "generated_at": _utcnow().isoformat(),
+            "leases": [item.to_dict() for item in self.list_leases(limit=bounded_limit)],
+            "developer_tasks": [
+                item.to_dict()
+                for item in self.list_developer_tasks(open_only=False, limit=bounded_limit)
+            ],
+            "completion_receipts": [
+                item.to_dict() for item in self.list_completion_receipts(limit=bounded_limit)
+            ],
+            "integration_decisions": [
+                item.to_dict() for item in self.list_integration_decisions(limit=bounded_limit)
+            ],
+            "salvage_candidates": [
+                item.to_dict()
+                for item in self.list_salvage_candidates(statuses=sorted(_OPEN_SALVAGE_STATUSES))
+            ],
+        }
 
     def list_salvage_candidates(self, statuses: list[str] | None = None) -> list[SalvageCandidate]:
         conn = self._connect()

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -726,7 +726,9 @@ class CoordinationHandlerMixin:
         try:
             from aragora.nomic.dev_coordination import DevCoordinationStore
 
-            coordination_summary = DevCoordinationStore(repo_root=repo_root).status_summary()
+            coordination_summary = DevCoordinationStore(repo_root=repo_root).status_summary(
+                include_integrator_artifacts=True
+            )
         except (ImportError, RuntimeError, OSError, ValueError, sqlite3.Error) as exc:
             coordination_summary = {"error": str(exc), "counts": {}}
         claims_by_session: dict[str, list[str]] = {}

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -184,6 +184,7 @@ def _merge_readiness(
 def _next_action(
     *,
     readiness: str,
+    lane_health: str,
     stale_heartbeat: bool,
     missing_receipt: bool,
     scope_violation: bool,
@@ -191,8 +192,12 @@ def _next_action(
     collisions: list[str],
     queue_status: str,
 ) -> str:
-    if superseded:
-        return "Close or archive the superseded lane."
+    if superseded or lane_health == "superseded":
+        return "Archive the superseded lane and keep the canonical lane."
+    if lane_health == "expired":
+        return "Salvage or reassign the expired lane before resuming work."
+    if lane_health == "stalled":
+        return "Inspect the stalled lane and decide whether to salvage, supersede, or reassign it."
     if collisions:
         return "Resolve the branch or file-scope collision before integrating."
     if scope_violation:
@@ -208,6 +213,85 @@ def _next_action(
     if readiness == "merged":
         return "No action needed; the lane is already merged."
     return "Monitor the lane or reconcile it if progress stalls."
+
+
+def _item_timestamp(item: dict[str, Any] | None, *keys: str) -> datetime:
+    if not isinstance(item, dict):
+        return datetime.min.replace(tzinfo=UTC)
+    for key in keys:
+        parsed = _parse_iso_timestamp(item.get(key))
+        if parsed is not None:
+            return parsed
+    meta = _metadata(item)
+    for key in keys:
+        parsed = _parse_iso_timestamp(meta.get(key))
+        if parsed is not None:
+            return parsed
+    return datetime.min.replace(tzinfo=UTC)
+
+
+def _sort_newest(items: list[dict[str, Any]], *keys: str) -> list[dict[str, Any]]:
+    return sorted(items, key=lambda item: _item_timestamp(item, *keys), reverse=True)
+
+
+def _lane_health(
+    *,
+    readiness: str,
+    status: str,
+    lease_status: str,
+    stale_heartbeat: bool,
+    missing_receipt: bool,
+    scope_violation: bool,
+    superseded: bool,
+    collisions: list[str],
+) -> str:
+    if superseded or status == "discarded":
+        return "superseded"
+    if lease_status == "expired" or status == "timed_out":
+        return "expired"
+    if stale_heartbeat or status in {"dispatch_failed", "failed"}:
+        return "stalled"
+    if readiness == "merged":
+        return "merged"
+    if readiness == "blocked" or missing_receipt or scope_violation or collisions:
+        return "blocked"
+    return "healthy"
+
+
+def _available_actions(
+    *,
+    canonical_lane: bool,
+    readiness: str,
+    lane_health: str,
+    missing_receipt: bool,
+    scope_violation: bool,
+    superseded: bool,
+    collisions: list[str],
+    decision: str,
+) -> list[str]:
+    if superseded or lane_health == "superseded" or readiness == "superseded":
+        return ["archive"]
+    if readiness == "merged":
+        return ["archive"]
+
+    actions: list[str] = []
+    if lane_health in {"expired", "stalled"}:
+        actions.extend(["salvage", "reassign", "archive"])
+    if collisions or scope_violation:
+        actions.extend(["request_changes", "supersede"])
+    if missing_receipt:
+        actions.append("attach_receipt")
+    if decision == "request_changes":
+        actions.extend(["request_changes", "supersede"])
+    if decision == "salvage":
+        actions.extend(["salvage", "archive"])
+    if readiness in {"ready", "review"} and not (collisions or scope_violation or missing_receipt):
+        actions.extend(["merge", "cherry_pick", "request_changes"])
+    if not canonical_lane and readiness not in {"merged", "superseded"}:
+        actions.append("supersede")
+    if not actions:
+        actions.append("monitor")
+    return list(dict.fromkeys(actions))
 
 
 def build_integrator_view(
@@ -226,6 +310,54 @@ def build_integrator_view(
     merge_queue = [item for item in (merge_queue or []) if isinstance(item, dict)]
     coordination = coordination if isinstance(coordination, dict) else {}
     now = now or datetime.now(UTC)
+    integrator = coordination.get("integrator", {})
+    integrator = integrator if isinstance(integrator, dict) else {}
+
+    tasks = _sort_newest(
+        [dict(item) for item in integrator.get("developer_tasks", []) if isinstance(item, dict)],
+        "updated_at",
+        "created_at",
+    )
+    leases = _sort_newest(
+        [dict(item) for item in integrator.get("leases", []) if isinstance(item, dict)],
+        "updated_at",
+        "created_at",
+        "expires_at",
+    )
+    receipts = _sort_newest(
+        [
+            dict(item)
+            for item in integrator.get("completion_receipts", [])
+            if isinstance(item, dict)
+        ],
+        "created_at",
+    )
+    decisions = _sort_newest(
+        [
+            dict(item)
+            for item in integrator.get("integration_decisions", [])
+            if isinstance(item, dict)
+        ],
+        "created_at",
+    )
+    salvage_candidates = _sort_newest(
+        [dict(item) for item in integrator.get("salvage_candidates", []) if isinstance(item, dict)],
+        "updated_at",
+        "created_at",
+    )
+
+    run_by_id: dict[str, dict[str, Any]] = {}
+    work_order_by_key: dict[tuple[str, str], dict[str, Any]] = {}
+    for run in runs:
+        run_id = _text(run.get("run_id"))
+        if run_id:
+            run_by_id[run_id] = run
+        for work_order in run.get("work_orders", []):
+            if not isinstance(work_order, dict):
+                continue
+            work_order_id = _first_text(work_order.get("work_order_id"), work_order.get("task_id"))
+            if run_id and work_order_id:
+                work_order_by_key[(run_id, work_order_id)] = work_order
 
     worktrees_by_branch: dict[str, list[dict[str, Any]]] = defaultdict(list)
     worktrees_by_path: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -253,6 +385,7 @@ def build_integrator_view(
 
     worktree_branch_counts: dict[str, int] = defaultdict(int)
     work_order_branch_counts: dict[str, int] = defaultdict(int)
+    task_branch_counts: dict[str, int] = defaultdict(int)
     queue_branch_counts: dict[str, int] = defaultdict(int)
     for branch, rows_for_branch in worktrees_by_branch.items():
         worktree_branch_counts[branch] += len(rows_for_branch)
@@ -263,17 +396,30 @@ def build_integrator_view(
             branch = _text(work_order.get("branch"))
             if branch:
                 work_order_branch_counts[branch] += 1
+    for task in tasks:
+        branch = _text(task.get("branch"))
+        if branch:
+            task_branch_counts[branch] += 1
 
     queue_by_branch: dict[str, list[dict[str, Any]]] = defaultdict(list)
     queue_by_session: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    queue_by_receipt: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    queue_by_task: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for item in merge_queue:
         branch = _text(item.get("branch"))
         session_id = _text(item.get("session_id"))
+        meta = _metadata(item)
+        receipt_id = _first_text(item.get("receipt_id"), meta.get("receipt_id"))
+        task_id = _first_text(item.get("task_id"), meta.get("task_id"))
         if branch:
             queue_by_branch[branch].append(item)
             queue_branch_counts[branch] += 1
         if session_id:
             queue_by_session[session_id].append(item)
+        if receipt_id:
+            queue_by_receipt[receipt_id].append(item)
+        if task_id:
+            queue_by_task[task_id].append(item)
 
     scope_violations = coordination.get("scope_violations", [])
     scope_violation_by_lease: dict[str, dict[str, Any]] = {}
@@ -289,23 +435,141 @@ def build_integrator_view(
         if session_id or branch:
             scope_violation_by_session_branch[(session_id, branch)] = item
 
+    tasks_by_key: dict[str, dict[str, Any]] = {}
+    tasks_by_run_task: dict[tuple[str, str], dict[str, Any]] = {}
+    tasks_by_session_branch: dict[tuple[str, str], dict[str, Any]] = {}
+    for task in tasks:
+        task_key = _text(task.get("task_key"))
+        if task_key:
+            tasks_by_key[task_key] = task
+        run_id = _text(task.get("run_id"))
+        task_id = _text(task.get("task_id"))
+        if run_id and task_id:
+            tasks_by_run_task[(run_id, task_id)] = task
+        session_id = _text(task.get("owner_session_id"))
+        branch = _text(task.get("branch"))
+        if session_id or branch:
+            tasks_by_session_branch[(session_id, branch)] = task
+
+    leases_by_id: dict[str, dict[str, Any]] = {}
+    leases_by_task: dict[str, dict[str, Any]] = {}
+    leases_by_session_branch: dict[tuple[str, str], dict[str, Any]] = {}
+    for lease in leases:
+        lease_id = _text(lease.get("lease_id"))
+        if lease_id and lease_id not in leases_by_id:
+            leases_by_id[lease_id] = lease
+        task_id = _text(lease.get("task_id"))
+        if task_id and task_id not in leases_by_task:
+            leases_by_task[task_id] = lease
+        key = (_text(lease.get("owner_session_id")), _text(lease.get("branch")))
+        if (key[0] or key[1]) and key not in leases_by_session_branch:
+            leases_by_session_branch[key] = lease
+
+    receipts_by_id: dict[str, dict[str, Any]] = {}
+    receipts_by_task: dict[str, dict[str, Any]] = {}
+    receipts_by_lease: dict[str, dict[str, Any]] = {}
+    receipts_by_session_branch: dict[tuple[str, str], dict[str, Any]] = {}
+    for receipt in receipts:
+        receipt_id = _text(receipt.get("receipt_id"))
+        if receipt_id and receipt_id not in receipts_by_id:
+            receipts_by_id[receipt_id] = receipt
+        task_id = _text(receipt.get("task_id"))
+        if task_id and task_id not in receipts_by_task:
+            receipts_by_task[task_id] = receipt
+        lease_id = _text(receipt.get("lease_id"))
+        if lease_id and lease_id not in receipts_by_lease:
+            receipts_by_lease[lease_id] = receipt
+        key = (_text(receipt.get("owner_session_id")), _text(receipt.get("branch")))
+        if (key[0] or key[1]) and key not in receipts_by_session_branch:
+            receipts_by_session_branch[key] = receipt
+
+    decisions_by_receipt: dict[str, dict[str, Any]] = {}
+    for decision in decisions:
+        receipt_id = _text(decision.get("receipt_id"))
+        if receipt_id and receipt_id not in decisions_by_receipt:
+            decisions_by_receipt[receipt_id] = decision
+
+    salvage_by_branch: dict[str, dict[str, Any]] = {}
+    salvage_by_path: dict[str, dict[str, Any]] = {}
+    for candidate in salvage_candidates:
+        branch = _text(candidate.get("branch"))
+        if branch and branch not in salvage_by_branch:
+            salvage_by_branch[branch] = candidate
+        path = _text(candidate.get("worktree_path"))
+        if path and path not in salvage_by_path:
+            salvage_by_path[path] = candidate
+
     lanes: list[dict[str, Any]] = []
+    seen_task_keys: set[str] = set()
+    seen_work_order_keys: set[tuple[str, str]] = set()
     seen_worktree_keys: set[tuple[str, str]] = set()
     seen_queue_keys: set[tuple[str, str, str]] = set()
+
+    def _queue_key(item: dict[str, Any] | None) -> tuple[str, str, str]:
+        item = item if isinstance(item, dict) else {}
+        return (
+            _text(item.get("id")),
+            _text(item.get("branch")),
+            _text(item.get("session_id")),
+        )
+
+    def _pick_first(*candidates: Any) -> dict[str, Any] | None:
+        for candidate in candidates:
+            if isinstance(candidate, dict):
+                return candidate
+            if isinstance(candidate, list):
+                for item in candidate:
+                    if isinstance(item, dict):
+                        return item
+        return None
+
+    def _mark_lane_sources(
+        *,
+        task: dict[str, Any] | None = None,
+        worktree_row: dict[str, Any] | None = None,
+        queue_item: dict[str, Any] | None = None,
+    ) -> None:
+        if isinstance(task, dict):
+            task_key = _text(task.get("task_key"))
+            if task_key:
+                seen_task_keys.add(task_key)
+            run_id = _text(task.get("run_id"))
+            task_id = _text(task.get("task_id"))
+            if run_id and task_id:
+                seen_work_order_keys.add((run_id, task_id))
+        if isinstance(worktree_row, dict):
+            seen_worktree_keys.add(
+                (_text(worktree_row.get("session_id")), _text(worktree_row.get("branch")))
+            )
+        if isinstance(queue_item, dict):
+            seen_queue_keys.add(_queue_key(queue_item))
 
     def build_lane(
         *,
         source: str,
         run: dict[str, Any] | None = None,
         work_order: dict[str, Any] | None = None,
+        task: dict[str, Any] | None = None,
+        lease: dict[str, Any] | None = None,
+        receipt: dict[str, Any] | None = None,
+        decision: dict[str, Any] | None = None,
+        salvage: dict[str, Any] | None = None,
         worktree_row: dict[str, Any] | None = None,
         queue_item: dict[str, Any] | None = None,
+        canonical_lane: bool,
     ) -> dict[str, Any]:
         work_order = work_order or {}
+        task = task or {}
+        lease = lease or {}
+        receipt = receipt or {}
+        decision = decision or {}
+        salvage = salvage or {}
         worktree_row = worktree_row or {}
         queue_item = queue_item or {}
         run = run or {}
         work_order_meta = _metadata(work_order)
+        lease_meta = _metadata(lease)
+        receipt_meta = _metadata(receipt)
         queue_meta = _metadata(queue_item)
         inferred_status = ""
         if bool(worktree_row.get("has_lock")) and bool(worktree_row.get("pid_alive")):
@@ -313,45 +577,106 @@ def build_integrator_view(
         elif bool(worktree_row.get("has_lock")):
             inferred_status = "needs_human"
         status = _first_text(
-            work_order.get("status"), worktree_row.get("status"), inferred_status, "unknown"
+            task.get("status"),
+            work_order.get("status"),
+            worktree_row.get("status"),
+            inferred_status,
+            "unknown",
         ).lower()
         branch = _first_text(
-            work_order.get("branch"), worktree_row.get("branch"), queue_item.get("branch")
+            task.get("branch"),
+            lease.get("branch"),
+            receipt.get("branch"),
+            work_order.get("branch"),
+            worktree_row.get("branch"),
+            queue_item.get("branch"),
         )
         worktree_path = _first_text(
+            task.get("worktree_path"),
+            lease.get("worktree_path"),
+            receipt.get("worktree_path"),
             work_order.get("worktree_path"),
             worktree_row.get("path"),
             queue_meta.get("integration_workspace_path"),
         )
         session_id = _first_text(
+            task.get("owner_session_id"),
+            lease.get("owner_session_id"),
+            receipt.get("owner_session_id"),
+            lease_meta.get("owner_session_id"),
             work_order_meta.get("owner_session_id"),
             worktree_row.get("session_id"),
             queue_item.get("session_id"),
         )
         owner_agent = _first_text(
+            task.get("owner_agent"),
+            lease.get("owner_agent"),
+            receipt.get("owner_agent"),
             work_order.get("target_agent"),
             work_order_meta.get("owner_agent"),
             worktree_row.get("agent"),
         )
-        receipt_id = _extract_receipt_id(work_order, queue_item)
+        reviewer_agent = _first_text(
+            task.get("reviewer_agent"),
+            receipt_meta.get("reviewer_agent"),
+            work_order.get("reviewer_agent"),
+            work_order_meta.get("reviewer_agent"),
+        )
+        task_key = _first_text(
+            task.get("task_key"),
+            receipt_meta.get("task_key"),
+            lease_meta.get("task_key"),
+        )
+        task_id = _first_text(
+            task.get("task_id"),
+            receipt.get("task_id"),
+            lease.get("task_id"),
+            work_order.get("work_order_id"),
+            work_order.get("task_id"),
+        )
+        receipt_id = _first_text(
+            task.get("receipt_id"),
+            receipt.get("receipt_id"),
+            lease_meta.get("last_receipt_id"),
+            _extract_receipt_id(work_order, queue_item),
+        )
         queue_status = _merge_queue_status(queue_item)
+        decision_type = _first_text(
+            decision.get("decision"),
+            queue_meta.get("integration_decision"),
+        ).lower()
         branch_collision = bool(
             branch
             and (
                 worktree_branch_counts.get(branch, 0) > 1
                 or work_order_branch_counts.get(branch, 0) > 1
+                or task_branch_counts.get(branch, 0) > 1
                 or queue_branch_counts.get(branch, 0) > 1
             )
         )
 
+        lease_claimed_paths = [
+            _text(path) for path in lease.get("claimed_paths", []) if _text(path)
+        ]
         claimed_paths = sorted(
-            {
-                _text(claim.get("path"))
-                for claim in claims_by_session.get(session_id, [])
-                if _text(claim.get("path"))
-            }
+            set(lease_claimed_paths).union(
+                {
+                    _text(claim.get("path"))
+                    for claim in claims_by_session.get(session_id, [])
+                    if _text(claim.get("path"))
+                }
+            )
         )
-        file_scope = [_text(path) for path in work_order.get("file_scope", []) if _text(path)]
+        file_scope = [
+            _text(path)
+            for path in (
+                task.get("allowed_paths")
+                or work_order.get("file_scope")
+                or lease.get("allowed_globs")
+                or []
+            )
+            if _text(path)
+        ]
         collision_reasons: list[str] = []
         if branch_collision:
             collision_reasons.append(f"branch:{branch}")
@@ -362,50 +687,109 @@ def build_integrator_view(
         collision_reasons = sorted(set(collision_reasons))
 
         heartbeat_source = _first_text(
+            task.get("updated_at"),
+            lease.get("updated_at"),
             work_order.get("last_progress_at"),
             work_order.get("last_observed_at"),
             work_order.get("dispatched_at"),
             worktree_row.get("last_activity"),
             queue_item.get("updated_at"),
+            receipt.get("created_at"),
         )
         heartbeat_age_seconds = _age_seconds(heartbeat_source, now=now)
+        lease_status = _text(lease.get("status")).lower()
+        lane_in_flight = (
+            status in {"queued", "leased", "dispatched", "active", "integrating"}
+            or lease_status == "active"
+            or queue_status in {"queued", "validating", "integrating"}
+        )
         stale_heartbeat = bool(
             (
-                work_order
-                and status in {"leased", "dispatched", "active"}
+                (work_order or task or lease)
+                and lane_in_flight
                 and heartbeat_age_seconds is not None
                 and heartbeat_age_seconds >= _STALE_LANE_AFTER_SECONDS
             )
             or (bool(worktree_row.get("has_lock")) and not bool(worktree_row.get("pid_alive")))
         )
 
-        superseded = _is_superseded(work_order, queue_item)
+        superseded = _is_superseded(task, work_order, queue_item) or status == "discarded"
         missing_receipt = _explicit_missing_receipt(work_order, queue_item) or (
-            _receipt_expected(status, queue_status) and not receipt_id
+            (
+                _receipt_expected(status, queue_status)
+                or bool(decision_type)
+                or status in {"completed", "changes_requested", "integrating", "merged", "salvage"}
+            )
+            and not receipt_id
         )
         if status in {"queued", "leased", "dispatched"} and queue_status in {"", "queued"}:
             missing_receipt = (
                 False if not _explicit_missing_receipt(work_order, queue_item) else True
             )
 
-        lease_id = _first_text(work_order.get("lease_id"), work_order_meta.get("lease_id"))
+        lease_id = _first_text(
+            task.get("lease_id"),
+            lease.get("lease_id"),
+            work_order.get("lease_id"),
+            work_order_meta.get("lease_id"),
+        )
         scope_violation_record = (
             scope_violation_by_lease.get(lease_id)
             if lease_id
             else scope_violation_by_session_branch.get((session_id, branch))
         )
+        if not isinstance(scope_violation_record, dict):
+            fallback_violation = _metadata(task).get("last_scope_violation")
+            if isinstance(fallback_violation, dict):
+                scope_violation_record = fallback_violation
         scope_violation = isinstance(scope_violation_record, dict)
-        lease_health = "idle"
-        if lease_id:
-            lease_health = "stale" if stale_heartbeat else "healthy"
+
+        if superseded or decision_type == "discard":
+            readiness = "superseded"
+        elif queue_status == "merged" or status == "merged":
+            readiness = "merged"
+        elif decision_type in {"merge", "cherry_pick"}:
+            readiness = "merged" if queue_status == "merged" else "integrating"
+        elif decision_type == "pending_review":
+            readiness = "review"
+        elif decision_type in {"request_changes", "salvage"}:
+            readiness = "blocked"
+        elif receipt_id and status in {
+            "completed",
+            "needs_human",
+            "changes_requested",
+            "integrating",
+        }:
+            readiness = "blocked" if missing_receipt else "review"
+        else:
+            readiness = _merge_readiness(
+                status=status,
+                queue_status=queue_status,
+                stale_heartbeat=stale_heartbeat,
+                missing_receipt=missing_receipt,
+                scope_violation=scope_violation,
+                superseded=superseded,
+                collisions=collision_reasons,
+            )
+
+        if superseded:
+            lease_health = "superseded"
+        elif lease_status == "expired" or status == "timed_out":
+            lease_health = "expired"
+        elif stale_heartbeat:
+            lease_health = "stalled"
+        elif lease_status in {"completed", "released"}:
+            lease_health = lease_status
+        elif lease_id or bool(worktree_row.get("has_lock")):
+            lease_health = "healthy"
         elif status in {"leased", "dispatched"}:
             lease_health = "missing"
-        elif bool(worktree_row.get("has_lock")):
-            lease_health = "stale" if stale_heartbeat else "healthy"
-
-        readiness = _merge_readiness(
+        else:
+            lease_health = "idle"
+        lane_health = _lane_health(
+            readiness=readiness,
             status=status,
-            queue_status=queue_status,
+            lease_status=lease_status,
             stale_heartbeat=stale_heartbeat,
             missing_receipt=missing_receipt,
             scope_violation=scope_violation,
@@ -414,6 +798,7 @@ def build_integrator_view(
         )
 
         title = _first_text(
+            task.get("title"),
             work_order.get("title"),
             work_order.get("description"),
             queue_item.get("title"),
@@ -422,9 +807,10 @@ def build_integrator_view(
             session_id,
             "lane",
         )
-        pr = _extract_pr_link(work_order, queue_item)
+        pr = _extract_pr_link(receipt, work_order, queue_item)
         blockers = sorted(
             {
+                *[_text(item) for item in task.get("blocked_by", []) if _text(item)],
                 *[_text(item) for item in work_order.get("blockers", []) if _text(item)],
                 *collision_reasons,
             }
@@ -437,9 +823,23 @@ def build_integrator_view(
             blockers.append("scope_violation")
         if superseded:
             blockers.append("superseded")
+        if decision_type in {"request_changes", "salvage"}:
+            blockers.append(f"decision:{decision_type}")
         blockers = sorted(set(blockers))
 
+        available_actions = _available_actions(
+            canonical_lane=canonical_lane,
+            readiness=readiness,
+            lane_health=lane_health,
+            missing_receipt=missing_receipt,
+            scope_violation=scope_violation,
+            superseded=superseded,
+            collisions=collision_reasons,
+            decision=decision_type,
+        )
+        decision_needed = canonical_lane and readiness in {"ready", "review", "blocked"}
         lane_id = _first_text(
+            task_key,
             work_order.get("work_order_id"),
             queue_item.get("id"),
             branch,
@@ -452,14 +852,20 @@ def build_integrator_view(
             "source": source,
             "run_id": _text(run.get("run_id")),
             "work_order_id": _text(work_order.get("work_order_id")),
+            "task_key": task_key or None,
+            "task_id": task_id or None,
             "title": title,
             "status": status,
+            "canonical_lane": canonical_lane,
             "owner_agent": owner_agent or None,
+            "reviewer_agent": reviewer_agent or None,
             "owner_session_id": session_id or None,
             "branch": branch or None,
             "worktree_path": worktree_path or None,
             "lease_id": lease_id or None,
+            "lease_status": lease_status or None,
             "lease_health": lease_health,
+            "lane_health": lane_health,
             "heartbeat_at": heartbeat_source or None,
             "heartbeat_age_seconds": round(heartbeat_age_seconds, 1)
             if heartbeat_age_seconds is not None
@@ -470,15 +876,41 @@ def build_integrator_view(
             "queue_item_id": _text(queue_item.get("id")) or None,
             "merge_queue_status": queue_status or None,
             "receipt_id": receipt_id or None,
+            "receipt_summary": {
+                "confidence": receipt.get("confidence"),
+                "outcome": _text(receipt.get("outcome")) or None,
+                "created_at": _text(receipt.get("created_at")) or None,
+                "tests_run": [_text(item) for item in receipt.get("tests_run", []) if _text(item)],
+                "validations_run": [
+                    _text(item) for item in receipt.get("validations_run", []) if _text(item)
+                ],
+            }
+            if receipt_id
+            else None,
+            "integration_decision": decision_type or None,
+            "integration_decision_id": _text(decision.get("decision_id")) or None,
+            "decision_context": {
+                "rationale": _text(decision.get("rationale")) or None,
+                "followups": [_text(item) for item in decision.get("followups", []) if _text(item)],
+                "chosen_commits": [
+                    _text(item) for item in decision.get("chosen_commits", []) if _text(item)
+                ],
+            }
+            if decision_type
+            else None,
             "missing_receipt": missing_receipt,
             "scope_violation": scope_violation_record,
             "superseded": superseded,
             "collisions": collision_reasons,
             "pr": pr,
             "merge_readiness": readiness,
+            "decision_needed": decision_needed,
+            "available_actions": available_actions,
+            "salvage_candidate_id": _text(salvage.get("candidate_id")) or None,
             "blockers": blockers,
             "next_action": _next_action(
                 readiness=readiness,
+                lane_health=lane_health,
                 stale_heartbeat=stale_heartbeat,
                 missing_receipt=missing_receipt,
                 scope_violation=scope_violation,
@@ -488,37 +920,142 @@ def build_integrator_view(
             ),
         }
 
+    for task in tasks:
+        run_id = _text(task.get("run_id"))
+        task_id = _text(task.get("task_id"))
+        worktree_path = _text(task.get("worktree_path"))
+        branch = _text(task.get("branch"))
+        session_id = _text(task.get("owner_session_id"))
+        receipt_id = _text(task.get("receipt_id"))
+        lease_id = _text(task.get("lease_id"))
+        matched_run = run_by_id.get(run_id, {})
+        work_order = work_order_by_key.get((run_id, task_id), {})
+        matched_lease = _pick_first(
+            leases_by_id.get(lease_id),
+            leases_by_task.get(task_id),
+            leases_by_session_branch.get((session_id, branch)),
+        )
+        matched_receipt = _pick_first(
+            receipts_by_id.get(receipt_id),
+            receipts_by_lease.get(lease_id),
+            receipts_by_task.get(task_id),
+            receipts_by_session_branch.get((session_id, branch)),
+        )
+        effective_receipt_id = _first_text(
+            receipt_id,
+            matched_receipt.get("receipt_id") if isinstance(matched_receipt, dict) else "",
+        )
+        matched_decision = _pick_first(
+            decisions_by_receipt.get(effective_receipt_id),
+        )
+        matched_row = _pick_first(
+            worktrees_by_path.get(worktree_path, []),
+            worktrees_by_session.get(session_id, []),
+            worktrees_by_branch.get(branch, []),
+        )
+        matched_queue = _pick_first(
+            queue_by_receipt.get(effective_receipt_id, []),
+            queue_by_task.get(task_id, []),
+            queue_by_branch.get(branch, []),
+            queue_by_session.get(session_id, []),
+        )
+        matched_salvage = _pick_first(
+            salvage_by_path.get(worktree_path),
+            salvage_by_branch.get(branch),
+        )
+        _mark_lane_sources(task=task, worktree_row=matched_row, queue_item=matched_queue)
+        lanes.append(
+            build_lane(
+                source="task",
+                run=matched_run,
+                work_order=work_order,
+                task=task,
+                lease=matched_lease,
+                receipt=matched_receipt,
+                decision=matched_decision,
+                salvage=matched_salvage,
+                worktree_row=matched_row,
+                queue_item=matched_queue,
+                canonical_lane=True,
+            )
+        )
+
     for run in runs:
         for work_order in run.get("work_orders", []):
             if not isinstance(work_order, dict):
                 continue
+            run_id = _text(run.get("run_id"))
+            work_order_id = _first_text(work_order.get("work_order_id"), work_order.get("task_id"))
+            if (run_id, work_order_id) in seen_work_order_keys:
+                continue
+            matched_task = tasks_by_run_task.get((run_id, work_order_id))
+            if (
+                isinstance(matched_task, dict)
+                and _text(matched_task.get("task_key")) in seen_task_keys
+            ):
+                continue
             branch = _text(work_order.get("branch"))
             worktree_path = _text(work_order.get("worktree_path"))
-            matched_row = None
-            if branch and worktrees_by_branch.get(branch):
-                matched_row = worktrees_by_branch[branch][0]
-            elif worktree_path and worktrees_by_path.get(worktree_path):
-                matched_row = worktrees_by_path[worktree_path][0]
-            queue_item = queue_by_branch.get(branch, [None])[0] if branch else None
-            if matched_row:
-                seen_worktree_keys.add(
-                    (_text(matched_row.get("session_id")), _text(matched_row.get("branch")))
-                )
-            if isinstance(queue_item, dict):
-                seen_queue_keys.add(
-                    (
-                        _text(queue_item.get("id")),
-                        _text(queue_item.get("branch")),
-                        _text(queue_item.get("session_id")),
-                    )
-                )
+            session_id = _first_text(
+                work_order.get("owner_session_id"),
+                _metadata(work_order).get("owner_session_id"),
+            )
+            lease_id = _first_text(
+                work_order.get("lease_id"), _metadata(work_order).get("lease_id")
+            )
+            receipt_id = _first_text(
+                work_order.get("receipt_id"),
+                _metadata(work_order).get("last_receipt_id"),
+            )
+            matched_row = _pick_first(
+                worktrees_by_path.get(worktree_path, []),
+                worktrees_by_session.get(session_id, []),
+                worktrees_by_branch.get(branch, []),
+            )
+            matched_lease = _pick_first(
+                leases_by_id.get(lease_id),
+                leases_by_task.get(work_order_id),
+                leases_by_session_branch.get((session_id, branch)),
+            )
+            matched_receipt = _pick_first(
+                receipts_by_id.get(receipt_id),
+                receipts_by_lease.get(lease_id),
+                receipts_by_task.get(work_order_id),
+                receipts_by_session_branch.get((session_id, branch)),
+            )
+            effective_receipt_id = _first_text(
+                receipt_id,
+                matched_receipt.get("receipt_id") if isinstance(matched_receipt, dict) else "",
+            )
+            matched_decision = _pick_first(decisions_by_receipt.get(effective_receipt_id))
+            queue_item = _pick_first(
+                queue_by_receipt.get(effective_receipt_id, []),
+                queue_by_task.get(work_order_id, []),
+                queue_by_branch.get(branch, []),
+                queue_by_session.get(session_id, []),
+            )
+            matched_salvage = _pick_first(
+                salvage_by_path.get(worktree_path),
+                salvage_by_branch.get(branch),
+            )
+            _mark_lane_sources(
+                task=matched_task,
+                worktree_row=matched_row,
+                queue_item=queue_item,
+            )
             lanes.append(
                 build_lane(
                     source="swarm",
                     run=run,
                     work_order=work_order,
+                    task=matched_task,
+                    lease=matched_lease,
+                    receipt=matched_receipt,
+                    decision=matched_decision,
+                    salvage=matched_salvage,
                     worktree_row=matched_row,
-                    queue_item=queue_item if isinstance(queue_item, dict) else None,
+                    queue_item=queue_item,
+                    canonical_lane=not bool(tasks),
                 )
             )
 
@@ -527,42 +1064,115 @@ def build_integrator_view(
         if key in seen_worktree_keys:
             continue
         branch = _text(row.get("branch"))
-        queue_item = queue_by_branch.get(branch, [None])[0] if branch else None
-        if isinstance(queue_item, dict):
-            seen_queue_keys.add(
-                (
-                    _text(queue_item.get("id")),
-                    _text(queue_item.get("branch")),
-                    _text(queue_item.get("session_id")),
-                )
-            )
+        session_id = _text(row.get("session_id"))
+        matched_task = _pick_first(tasks_by_session_branch.get((session_id, branch)))
+        lease_id = _first_text(
+            matched_task.get("lease_id") if isinstance(matched_task, dict) else "",
+        )
+        receipt_id = _first_text(
+            matched_task.get("receipt_id") if isinstance(matched_task, dict) else "",
+        )
+        matched_lease = _pick_first(
+            leases_by_id.get(lease_id),
+            leases_by_session_branch.get((session_id, branch)),
+        )
+        matched_receipt = _pick_first(
+            receipts_by_id.get(receipt_id),
+            receipts_by_lease.get(lease_id),
+            receipts_by_session_branch.get((session_id, branch)),
+        )
+        effective_receipt_id = _first_text(
+            receipt_id,
+            matched_receipt.get("receipt_id") if isinstance(matched_receipt, dict) else "",
+        )
+        matched_decision = _pick_first(decisions_by_receipt.get(effective_receipt_id))
+        queue_item = _pick_first(
+            queue_by_receipt.get(effective_receipt_id, []),
+            queue_by_task.get(
+                _text(matched_task.get("task_id")) if isinstance(matched_task, dict) else "",
+                [],
+            ),
+            queue_by_branch.get(branch, []),
+            queue_by_session.get(session_id, []),
+        )
+        matched_salvage = _pick_first(
+            salvage_by_path.get(_text(row.get("path"))),
+            salvage_by_branch.get(branch),
+        )
+        _mark_lane_sources(task=matched_task, worktree_row=row, queue_item=queue_item)
         lanes.append(
             build_lane(
                 source="fleet",
+                task=matched_task,
+                lease=matched_lease,
+                receipt=matched_receipt,
+                decision=matched_decision,
+                salvage=matched_salvage,
                 worktree_row=row,
-                queue_item=queue_item if isinstance(queue_item, dict) else None,
+                queue_item=queue_item,
+                canonical_lane=False,
             )
         )
 
     for item in merge_queue:
-        queue_key = (
-            _text(item.get("id")),
-            _text(item.get("branch")),
-            _text(item.get("session_id")),
-        )
+        queue_key = _queue_key(item)
         if queue_key in seen_queue_keys:
             continue
         session_id = _text(item.get("session_id"))
-        matched_row = worktrees_by_session.get(session_id, [None])[0] if session_id else None
+        branch = _text(item.get("branch"))
+        meta = _metadata(item)
+        receipt_id = _first_text(item.get("receipt_id"), meta.get("receipt_id"))
+        task_id = _first_text(item.get("task_id"), meta.get("task_id"))
+        matched_task = _pick_first(
+            tasks_by_session_branch.get((session_id, branch)),
+            tasks_by_run_task.get((_text(meta.get("run_id")), task_id)),
+        )
+        lease_id = _first_text(
+            meta.get("lease_id"),
+            matched_task.get("lease_id") if isinstance(matched_task, dict) else "",
+        )
+        matched_lease = _pick_first(
+            leases_by_id.get(lease_id),
+            leases_by_task.get(task_id),
+            leases_by_session_branch.get((session_id, branch)),
+        )
+        matched_receipt = _pick_first(
+            receipts_by_id.get(receipt_id),
+            receipts_by_lease.get(lease_id),
+            receipts_by_task.get(task_id),
+            receipts_by_session_branch.get((session_id, branch)),
+        )
+        effective_receipt_id = _first_text(
+            receipt_id,
+            matched_receipt.get("receipt_id") if isinstance(matched_receipt, dict) else "",
+        )
+        matched_decision = _pick_first(decisions_by_receipt.get(effective_receipt_id))
+        matched_row = _pick_first(
+            worktrees_by_session.get(session_id, []),
+            worktrees_by_branch.get(branch, []),
+        )
+        matched_salvage = _pick_first(
+            salvage_by_branch.get(branch),
+            salvage_by_path.get(
+                _text(matched_row.get("path")) if isinstance(matched_row, dict) else ""
+            ),
+        )
+        _mark_lane_sources(task=matched_task, worktree_row=matched_row, queue_item=item)
         lanes.append(
             build_lane(
                 source="merge_queue",
+                task=matched_task,
+                lease=matched_lease,
+                receipt=matched_receipt,
+                decision=matched_decision,
+                salvage=matched_salvage,
                 worktree_row=matched_row if isinstance(matched_row, dict) else None,
                 queue_item=item,
+                canonical_lane=False,
             )
         )
 
-    def lane_sort_key(item: dict[str, Any]) -> tuple[int, str, str]:
+    def lane_sort_key(item: dict[str, Any]) -> tuple[int, int, str, str]:
         readiness = _text(item.get("merge_readiness"))
         priority = {
             "blocked": 0,
@@ -574,14 +1184,24 @@ def build_integrator_view(
             "merged": 6,
             "superseded": 7,
         }.get(readiness, 8)
-        return (priority, _text(item.get("branch")), _text(item.get("lane_id")))
+        canonical_priority = 0 if bool(item.get("canonical_lane")) else 1
+        return (
+            canonical_priority,
+            priority,
+            _text(item.get("branch")),
+            _text(item.get("lane_id")),
+        )
 
     lanes.sort(key=lane_sort_key)
 
     alerts = {
         "collisions": [],
+        "stalled_lanes": [],
+        "expired_lanes": [],
         "stale_heartbeats": [],
         "superseded_lanes": [],
+        "orphan_lanes": [],
+        "needs_decision": [],
         "missing_receipts": [],
         "scope_violations": [],
         "merge_ready": [],
@@ -595,10 +1215,18 @@ def build_integrator_view(
         }
         if lane["collisions"]:
             alerts["collisions"].append({**ref, "reasons": lane["collisions"]})
+        if lane.get("lane_health") == "stalled":
+            alerts["stalled_lanes"].append(ref)
+        if lane.get("lane_health") == "expired":
+            alerts["expired_lanes"].append(ref)
         if lane["stale_heartbeat"]:
             alerts["stale_heartbeats"].append(ref)
         if lane["superseded"]:
             alerts["superseded_lanes"].append(ref)
+        if not lane.get("canonical_lane", False):
+            alerts["orphan_lanes"].append(ref)
+        if lane.get("decision_needed"):
+            alerts["needs_decision"].append(ref)
         if lane["missing_receipt"]:
             alerts["missing_receipts"].append(ref)
         if isinstance(lane.get("scope_violation"), dict):
@@ -623,6 +1251,12 @@ def build_integrator_view(
         "blocked_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "blocked"),
         "review_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "review"),
         "in_progress_lanes": sum(1 for lane in lanes if lane["merge_readiness"] == "in_progress"),
+        "healthy_lanes": sum(1 for lane in lanes if lane.get("lane_health") == "healthy"),
+        "stalled_lanes": len(alerts["stalled_lanes"]),
+        "expired_lanes": len(alerts["expired_lanes"]),
+        "canonical_lanes": sum(1 for lane in lanes if lane.get("canonical_lane")),
+        "orphan_lanes": len(alerts["orphan_lanes"]),
+        "decision_lanes": len(alerts["needs_decision"]),
         "collision_lanes": len(alerts["collisions"]),
         "stale_heartbeat_lanes": len(alerts["stale_heartbeats"]),
         "superseded_lanes": len(alerts["superseded_lanes"]),

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -432,7 +432,7 @@ class SwarmSupervisor:
                 else SupervisorRun.from_record(record)
             )
             runs.append(current)
-        coordination = self.store.status_summary()
+        coordination = self.store.status_summary(include_integrator_artifacts=True)
         return {
             "runs": [run.to_dict() for run in runs],
             "counts": {

--- a/tests/cli/test_worktree_command.py
+++ b/tests/cli/test_worktree_command.py
@@ -435,6 +435,74 @@ class TestWorktreeFleetStatus:
             "Narrow the lane scope or split ownership before it can re-enter merge review." in out
         )
 
+    @patch("aragora.cli.commands.worktree.build_integrator_view")
+    @patch("aragora.cli.commands.worktree.FleetCoordinationStore")
+    @patch("aragora.cli.commands.worktree.build_fleet_rows")
+    def test_fleet_status_prints_task_and_decision_context(
+        self, mock_rows, mock_store_cls, mock_integrator_view, capsys, tmp_path: Path
+    ):
+        mock_rows.return_value = [
+            {
+                "session_id": "session-a",
+                "path": str(tmp_path),
+                "branch": "codex/test-session",
+                "detached": False,
+                "has_lock": True,
+                "pid": 123,
+                "pid_alive": True,
+                "agent": "codex",
+                "mode": "codex",
+                "dirty_files": 0,
+                "ahead": 1,
+                "behind": 0,
+                "last_activity": "2026-03-07T00:00:00+00:00",
+                "orchestration_pattern": "generic",
+                "log_path": None,
+                "log_tail": [],
+            }
+        ]
+        mock_integrator_view.return_value = {
+            "summary": {
+                "ready_lanes": 0,
+                "review_lanes": 1,
+                "blocked_lanes": 0,
+                "stale_heartbeat_lanes": 0,
+                "collision_lanes": 0,
+                "missing_receipt_lanes": 0,
+                "scope_violation_lanes": 0,
+                "superseded_lanes": 0,
+            },
+            "next_actions": ["Review the canonical lane."],
+            "lanes": [
+                {
+                    "owner_session_id": "session-a",
+                    "worktree_path": str(tmp_path),
+                    "lease_health": "healthy",
+                    "merge_readiness": "review",
+                    "task_key": "run-1:docs-lane",
+                    "canonical_lane": True,
+                    "receipt_id": "rcpt-1",
+                    "integration_decision": "pending_review",
+                    "available_actions": ["merge", "cherry_pick", "request_changes"],
+                }
+            ],
+        }
+        store = MagicMock()
+        store.list_claims.return_value = []
+        store.list_merge_queue.return_value = []
+        mock_store_cls.return_value = store
+
+        _cmd_worktree_fleet_status(
+            _fleet_args(tail=0),
+            repo_path=tmp_path,
+            base_branch="main",
+        )
+
+        out = capsys.readouterr().out
+        assert "task: run-1:docs-lane canonical: yes" in out
+        assert "decision: pending_review" in out
+        assert "actions: merge, cherry_pick, request_changes" in out
+
 
 class TestWorktreeFleetOwnership:
     @patch("aragora.cli.commands.worktree.FleetCoordinationStore")

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -671,6 +671,112 @@ class TestRouteDispatch:
         data = json.loads(result.body)
         assert data["integrator_view"]["summary"]["total_lanes"] == 0
 
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore.status_summary")
+    @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
+    @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    def test_get_coordination_fleet_status_surfaces_canonical_lane_metadata(
+        self,
+        mock_resolve,
+        mock_build_rows,
+        mock_store_cls,
+        mock_status_summary,
+        handler: ControlPlaneHandler,
+    ):
+        mock_resolve.return_value = Path(__file__).resolve().parents[3]
+        mock_build_rows.return_value = [
+            {
+                "session_id": "sess-a",
+                "path": "/tmp/repo/.worktrees/docs",
+                "branch": "codex/docs-lane",
+                "has_lock": True,
+                "pid_alive": True,
+                "agent": "codex",
+                "last_activity": "2026-03-18T10:00:00+00:00",
+            }
+        ]
+        mock_status_summary.return_value = {
+            "counts": {"active_leases": 1},
+            "integrator": {
+                "developer_tasks": [
+                    {
+                        "task_key": "run-1:docs-lane",
+                        "task_id": "docs-lane",
+                        "run_id": "run-1",
+                        "goal": "Ship docs lane",
+                        "title": "Write operator guide",
+                        "status": "completed",
+                        "owner_agent": "codex",
+                        "reviewer_agent": "claude",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "lease_id": "lease-1",
+                        "receipt_id": "rcpt-1",
+                        "updated_at": "2026-03-18T09:58:00+00:00",
+                    }
+                ],
+                "leases": [
+                    {
+                        "lease_id": "lease-1",
+                        "task_id": "docs-lane",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "status": "completed",
+                        "updated_at": "2026-03-18T09:57:00+00:00",
+                        "expires_at": "2026-03-18T17:00:00+00:00",
+                    }
+                ],
+                "completion_receipts": [
+                    {
+                        "receipt_id": "rcpt-1",
+                        "lease_id": "lease-1",
+                        "task_id": "docs-lane",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "created_at": "2026-03-18T09:56:00+00:00",
+                        "confidence": 0.93,
+                    }
+                ],
+                "integration_decisions": [
+                    {
+                        "decision_id": "dec-1",
+                        "lease_id": "lease-1",
+                        "receipt_id": "rcpt-1",
+                        "decision": "pending_review",
+                        "target_branch": "main",
+                        "rationale": "Awaiting integrator review",
+                        "created_at": "2026-03-18T09:56:30+00:00",
+                    }
+                ],
+                "salvage_candidates": [],
+            },
+        }
+        store = MagicMock()
+        store.list_claims.return_value = [{"session_id": "sess-a", "path": "aragora/docs.md"}]
+        store.list_merge_queue.return_value = [
+            {
+                "id": "mq-1",
+                "branch": "codex/docs-lane",
+                "session_id": "sess-a",
+                "status": "needs_human",
+                "metadata": {"receipt_id": "rcpt-1", "task_id": "docs-lane"},
+            }
+        ]
+        mock_store_cls.return_value = store
+
+        result = handler._handle_fleet_status({})
+
+        assert result.status_code == 200
+        data = json.loads(result.body)
+        lane = data["integrator_view"]["lanes"][0]
+        assert lane["canonical_lane"] is True
+        assert lane["task_key"] == "run-1:docs-lane"
+        assert lane["integration_decision"] == "pending_review"
+        assert "merge" in lane["available_actions"]
+
     @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
     @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
     @patch("aragora.swarm.SwarmSupervisor")

--- a/tests/swarm/test_reporter.py
+++ b/tests/swarm/test_reporter.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
 
-from aragora.swarm.reporter import SwarmReport, SwarmReporter
+from aragora.swarm.reporter import SwarmReport, SwarmReporter, build_integrator_view
 from aragora.swarm.spec import SwarmSpec
 
 
@@ -189,3 +190,252 @@ class TestSwarmReporter:
         report = await reporter.generate(spec, result)
 
         assert report.success is False
+
+
+class TestIntegratorView:
+    def test_build_integrator_view_prefers_canonical_task_lane(self):
+        now = datetime(2026, 3, 18, 12, 0, tzinfo=UTC)
+        payload = build_integrator_view(
+            runs=[
+                {
+                    "run_id": "run-1",
+                    "status": "active",
+                    "goal": "Ship the integrator lane",
+                    "work_orders": [
+                        {
+                            "work_order_id": "wo-1",
+                            "title": "Build integrator lane",
+                            "status": "completed",
+                            "branch": "codex/integrator-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/integrator",
+                            "target_agent": "codex",
+                            "reviewer_agent": "claude",
+                        }
+                    ],
+                }
+            ],
+            worktrees=[
+                {
+                    "session_id": "sess-1",
+                    "path": "/tmp/repo/.worktrees/integrator",
+                    "branch": "codex/integrator-lane",
+                    "has_lock": True,
+                    "pid_alive": True,
+                    "agent": "codex",
+                    "last_activity": (now - timedelta(minutes=2)).isoformat(),
+                }
+            ],
+            claims=[{"session_id": "sess-1", "path": "aragora/swarm/reporter.py"}],
+            merge_queue=[
+                {
+                    "id": "mq-1",
+                    "branch": "codex/integrator-lane",
+                    "session_id": "sess-1",
+                    "status": "needs_human",
+                    "metadata": {
+                        "receipt_id": "rcpt-1",
+                        "task_id": "wo-1",
+                        "pr_url": "https://github.com/synaptent/aragora/pull/1051",
+                        "pr_number": 1051,
+                    },
+                }
+            ],
+            coordination={
+                "counts": {"active_leases": 1},
+                "integrator": {
+                    "developer_tasks": [
+                        {
+                            "task_key": "run-1:wo-1",
+                            "task_id": "wo-1",
+                            "run_id": "run-1",
+                            "goal": "Ship the integrator lane",
+                            "title": "Build integrator lane",
+                            "status": "completed",
+                            "owner_agent": "codex",
+                            "reviewer_agent": "claude",
+                            "owner_session_id": "sess-1",
+                            "branch": "codex/integrator-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/integrator",
+                            "lease_id": "lease-1",
+                            "receipt_id": "rcpt-1",
+                            "allowed_paths": ["aragora/swarm/reporter.py"],
+                            "updated_at": (now - timedelta(minutes=3)).isoformat(),
+                        }
+                    ],
+                    "leases": [
+                        {
+                            "lease_id": "lease-1",
+                            "task_id": "wo-1",
+                            "owner_agent": "codex",
+                            "owner_session_id": "sess-1",
+                            "branch": "codex/integrator-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/integrator",
+                            "claimed_paths": ["aragora/swarm/reporter.py"],
+                            "status": "completed",
+                            "updated_at": (now - timedelta(minutes=4)).isoformat(),
+                            "expires_at": (now + timedelta(hours=2)).isoformat(),
+                            "metadata": {"task_key": "run-1:wo-1"},
+                        }
+                    ],
+                    "completion_receipts": [
+                        {
+                            "receipt_id": "rcpt-1",
+                            "lease_id": "lease-1",
+                            "task_id": "wo-1",
+                            "owner_agent": "codex",
+                            "owner_session_id": "sess-1",
+                            "branch": "codex/integrator-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/integrator",
+                            "confidence": 0.94,
+                            "outcome": "deliverable_created",
+                            "tests_run": ["python -m pytest tests/swarm/test_reporter.py -q"],
+                            "validations_run": [
+                                "python -m pytest tests/swarm/test_reporter.py -q",
+                                "ruff check aragora/swarm/reporter.py",
+                            ],
+                            "created_at": (now - timedelta(minutes=5)).isoformat(),
+                            "metadata": {
+                                "task_key": "run-1:wo-1",
+                                "reviewer_agent": "claude",
+                            },
+                            "pr_url": "https://github.com/synaptent/aragora/pull/1051",
+                            "pr_number": 1051,
+                        }
+                    ],
+                    "integration_decisions": [
+                        {
+                            "decision_id": "dec-1",
+                            "lease_id": "lease-1",
+                            "receipt_id": "rcpt-1",
+                            "decision": "pending_review",
+                            "target_branch": "main",
+                            "rationale": "Awaiting integrator review",
+                            "chosen_commits": ["abc12345"],
+                            "followups": ["check merge gate"],
+                            "decided_by": "system",
+                            "created_at": (now - timedelta(minutes=4)).isoformat(),
+                        }
+                    ],
+                    "salvage_candidates": [],
+                },
+            },
+            now=now,
+        )
+
+        lane = payload["lanes"][0]
+        assert payload["summary"]["canonical_lanes"] == 1
+        assert payload["summary"]["decision_lanes"] == 1
+        assert payload["alerts"]["needs_decision"][0]["lane_id"] == "run-1:wo-1"
+        assert lane["source"] == "task"
+        assert lane["canonical_lane"] is True
+        assert lane["task_key"] == "run-1:wo-1"
+        assert lane["merge_readiness"] == "review"
+        assert lane["lane_health"] == "healthy"
+        assert lane["integration_decision"] == "pending_review"
+        assert lane["pr"]["number"] == 1051
+        assert lane["available_actions"][:3] == ["merge", "cherry_pick", "request_changes"]
+
+    def test_build_integrator_view_marks_expired_and_superseded_lanes(self):
+        now = datetime(2026, 3, 18, 12, 0, tzinfo=UTC)
+        payload = build_integrator_view(
+            coordination={
+                "integrator": {
+                    "developer_tasks": [
+                        {
+                            "task_key": "run-1:wo-expired",
+                            "task_id": "wo-expired",
+                            "run_id": "run-1",
+                            "goal": "Recover expired lane",
+                            "title": "Recover expired lane",
+                            "status": "timed_out",
+                            "owner_session_id": "sess-expired",
+                            "branch": "codex/expired",
+                            "worktree_path": "/tmp/repo/.worktrees/expired",
+                            "lease_id": "lease-expired",
+                            "updated_at": (now - timedelta(hours=2)).isoformat(),
+                        },
+                        {
+                            "task_key": "run-1:wo-superseded",
+                            "task_id": "wo-superseded",
+                            "run_id": "run-1",
+                            "goal": "Replace stale lane",
+                            "title": "Replace stale lane",
+                            "status": "discarded",
+                            "owner_session_id": "sess-old",
+                            "branch": "codex/old-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/old",
+                            "lease_id": "lease-old",
+                            "receipt_id": "rcpt-old",
+                            "updated_at": (now - timedelta(minutes=45)).isoformat(),
+                        },
+                    ],
+                    "leases": [
+                        {
+                            "lease_id": "lease-expired",
+                            "task_id": "wo-expired",
+                            "owner_session_id": "sess-expired",
+                            "branch": "codex/expired",
+                            "worktree_path": "/tmp/repo/.worktrees/expired",
+                            "status": "expired",
+                            "updated_at": (now - timedelta(hours=2)).isoformat(),
+                            "expires_at": (now - timedelta(hours=1)).isoformat(),
+                        },
+                        {
+                            "lease_id": "lease-old",
+                            "task_id": "wo-superseded",
+                            "owner_session_id": "sess-old",
+                            "branch": "codex/old-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/old",
+                            "status": "completed",
+                            "updated_at": (now - timedelta(hours=1)).isoformat(),
+                            "expires_at": (now + timedelta(hours=1)).isoformat(),
+                        },
+                    ],
+                    "completion_receipts": [
+                        {
+                            "receipt_id": "rcpt-old",
+                            "lease_id": "lease-old",
+                            "task_id": "wo-superseded",
+                            "owner_session_id": "sess-old",
+                            "branch": "codex/old-lane",
+                            "worktree_path": "/tmp/repo/.worktrees/old",
+                            "created_at": (now - timedelta(hours=1)).isoformat(),
+                        }
+                    ],
+                    "integration_decisions": [
+                        {
+                            "decision_id": "dec-old",
+                            "lease_id": "lease-old",
+                            "receipt_id": "rcpt-old",
+                            "decision": "discard",
+                            "target_branch": "main",
+                            "rationale": "Superseded by a cleaner replacement lane",
+                            "created_at": (now - timedelta(minutes=50)).isoformat(),
+                        }
+                    ],
+                    "salvage_candidates": [
+                        {
+                            "candidate_id": "salv-1",
+                            "branch": "codex/expired",
+                            "worktree_path": "/tmp/repo/.worktrees/expired",
+                            "status": "detected",
+                            "updated_at": (now - timedelta(minutes=20)).isoformat(),
+                        }
+                    ],
+                }
+            },
+            now=now,
+        )
+
+        lanes = {lane["task_id"]: lane for lane in payload["lanes"]}
+        expired = lanes["wo-expired"]
+        superseded = lanes["wo-superseded"]
+
+        assert payload["summary"]["expired_lanes"] == 1
+        assert payload["summary"]["superseded_lanes"] == 1
+        assert expired["lane_health"] == "expired"
+        assert expired["available_actions"][:2] == ["salvage", "reassign"]
+        assert expired["salvage_candidate_id"] == "salv-1"
+        assert superseded["merge_readiness"] == "superseded"
+        assert superseded["lane_health"] == "superseded"
+        assert superseded["available_actions"] == ["archive"]


### PR DESCRIPTION
## Summary
- upgrade the existing integrator view to use canonical developer tasks, leases, receipts, and integration decisions
- expose canonical lane, lane health, available actions, and decision context through the existing swarm/fleet CLI and control-plane APIs
- add focused reporter, handler, and CLI coverage for canonical lane selection, expired/superseded lanes, and integrator decision surfacing

## Verification
- All checks passed!
- ........................................................................ [ 45%]
........................................................................ [ 90%]
...............                                                          [100%]
159 passed in 16.51s

Closes #843