### PR TITLE
feat(swarm): add integrator operator surfaces

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -26,7 +26,16 @@ from uuid import uuid4
 def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | None]:
     first = getattr(args, "swarm_action_or_goal", None)
     second = getattr(args, "swarm_goal", None)
-    if first in {"run", "boss", "boss-loop", "runner", "status", "reconcile", "campaign"}:
+    if first in {
+        "run",
+        "boss",
+        "boss-loop",
+        "runner",
+        "status",
+        "reconcile",
+        "campaign",
+        "integrator",
+    }:
         return str(first), second
     return "run", first
 
@@ -126,6 +135,122 @@ def _blocked_boss_payload(
         "integrator_summary": {},
         "routing": routing,
     }
+
+
+def _load_integrator_view(repo_root: Path, *, base_branch: str) -> dict[str, object]:
+    from aragora.swarm.reporter import build_integrator_view
+    from aragora.worktree.fleet import FleetCoordinationStore, build_fleet_rows
+
+    try:
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+    except (ImportError, RuntimeError, OSError, ValueError):
+        DevCoordinationStore = None  # type: ignore[assignment]
+
+    worktrees = build_fleet_rows(repo_root, base_branch=base_branch, tail=0)
+    store = FleetCoordinationStore(repo_root)
+    claims = store.list_claims()
+    merge_queue = store.list_merge_queue()
+    coordination: dict[str, object] = {}
+    if DevCoordinationStore is not None:
+        try:
+            coordination = DevCoordinationStore(repo_root=repo_root).status_summary(
+                include_integrator_artifacts=True
+            )
+        except (RuntimeError, OSError, ValueError):
+            coordination = {}
+    return build_integrator_view(
+        runs=[],
+        worktrees=worktrees,
+        claims=claims,
+        merge_queue=merge_queue,
+        coordination=coordination,
+    )
+
+
+def _find_integrator_lane(
+    view: dict[str, object],
+    *,
+    lane_id: str = "",
+    receipt_id: str = "",
+    lease_id: str = "",
+    branch: str = "",
+) -> dict[str, object] | None:
+    lanes = [item for item in view.get("lanes", []) if isinstance(item, dict)]
+    lane_id = str(lane_id or "").strip()
+    receipt_id = str(receipt_id or "").strip()
+    lease_id = str(lease_id or "").strip()
+    branch = str(branch or "").strip()
+
+    if lane_id:
+        for lane in lanes:
+            if str(lane.get("lane_id", "")).strip() == lane_id:
+                return lane
+        return None
+    if receipt_id:
+        for lane in lanes:
+            if str(lane.get("receipt_id", "")).strip() == receipt_id:
+                return lane
+        return None
+    if lease_id:
+        for lane in lanes:
+            if str(lane.get("lease_id", "")).strip() == lease_id:
+                return lane
+        return None
+    if branch:
+        canonical = [
+            lane
+            for lane in lanes
+            if str(lane.get("branch", "")).strip() == branch and bool(lane.get("canonical_lane"))
+        ]
+        if canonical:
+            return canonical[0]
+        for lane in lanes:
+            if str(lane.get("branch", "")).strip() == branch:
+                return lane
+    return None
+
+
+def _render_integrator_table(view: dict[str, object]) -> None:
+    summary = view.get("summary", {}) if isinstance(view.get("summary"), dict) else {}
+    print(f"Swarm Integrator View ({summary.get('total_lanes', 0)} lanes)")
+    print(
+        "  ready={ready} blocked={blocked} review={review} stale={stale} superseded={superseded}".format(
+            ready=summary.get("ready_lanes", 0),
+            blocked=summary.get("blocked_lanes", 0),
+            review=summary.get("review_lanes", 0),
+            stale=summary.get("stale_heartbeat_lanes", 0),
+            superseded=summary.get("superseded_lanes", 0),
+        )
+    )
+    print()
+    icons = {"ready": "+", "blocked": "!", "review": "?", "merged": "=", "superseded": "x"}
+    lanes = [item for item in view.get("lanes", []) if isinstance(item, dict)]
+    for lane in lanes:
+        readiness = str(lane.get("merge_readiness", "unknown"))
+        icon = icons.get(readiness, " ")
+        canonical = "*" if bool(lane.get("canonical_lane")) else " "
+        print(f"{canonical}[{icon}] {lane.get('title', 'untitled')}")
+        print(
+            "    lane_id={lane_id} branch={branch} readiness={readiness} status={status}".format(
+                lane_id=lane.get("lane_id", ""),
+                branch=lane.get("branch", ""),
+                readiness=readiness,
+                status=lane.get("status", ""),
+            )
+        )
+        receipt_id = str(lane.get("receipt_id", "") or "").strip()
+        lease_id = str(lane.get("lease_id", "") or "").strip()
+        if receipt_id or lease_id:
+            print(f"    receipt={receipt_id or 'none'} lease={lease_id or 'none'}")
+        blockers = lane.get("blockers", [])
+        if isinstance(blockers, list) and blockers:
+            print(f"    blockers: {', '.join(str(item) for item in blockers)}")
+        next_action = str(lane.get("next_action", "") or "").strip()
+        if next_action:
+            print(f"    next: {next_action}")
+        print()
+    for action_text in [item for item in view.get("next_actions", []) if str(item).strip()][:5]:
+        print(f"next: {action_text}")
 
 
 def cmd_swarm(args: argparse.Namespace) -> None:
@@ -250,6 +375,155 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         else:
             print(render_runner_registration_text(payload))
         return
+
+    if action == "integrator":
+        import sys
+
+        subaction = str(goal or "view").strip().lower() or "view"
+        repo_root = resolve_repo_root(Path.cwd())
+        base_branch = str(getattr(args, "target_branch", "main") or "main")
+        view = _load_integrator_view(repo_root, base_branch=base_branch)
+        readiness_filter = str(getattr(args, "readiness", None) or "").strip()
+        if readiness_filter:
+            filtered_view = dict(view)
+            filtered_view["lanes"] = [
+                item
+                for item in view.get("lanes", [])
+                if isinstance(item, dict)
+                and str(item.get("merge_readiness", "")).strip() == readiness_filter
+            ]
+            view = filtered_view
+
+        if subaction in {"view", "status"}:
+            if as_json:
+                print(json.dumps(view, indent=2))
+            else:
+                _render_integrator_table(view)
+            return
+
+        lane = _find_integrator_lane(
+            view,
+            lane_id=str(getattr(args, "lane_id", None) or ""),
+            receipt_id=str(getattr(args, "receipt_id", None) or ""),
+            lease_id=str(getattr(args, "lease_id", None) or ""),
+            branch=str(getattr(args, "lane_branch", None) or ""),
+        )
+        if lane is None:
+            print(
+                "Error: integrator action requires a resolvable lane via "
+                "--lane-id, --receipt-id, --lease-id, or --lane-branch",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        rationale = str(getattr(args, "rationale", "") or "").strip()
+        decided_by = str(getattr(args, "decided_by", "cli-integrator") or "cli-integrator").strip()
+
+        if subaction in {"merge", "archive"}:
+            from aragora.nomic.dev_coordination import DevCoordinationStore, IntegrationDecisionType
+
+            resolved_receipt_id = str(
+                getattr(args, "receipt_id", None) or lane.get("receipt_id") or ""
+            ).strip()
+            resolved_lease_id = str(
+                getattr(args, "lease_id", None) or lane.get("lease_id") or ""
+            ).strip()
+            if not resolved_receipt_id:
+                print(
+                    "Error: selected lane has no receipt_id; cannot record an integration decision",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            decision_type = (
+                IntegrationDecisionType.MERGE
+                if subaction == "merge"
+                else IntegrationDecisionType.DISCARD
+            )
+            decision = DevCoordinationStore(repo_root=repo_root).record_integration_decision(
+                receipt_id=resolved_receipt_id,
+                lease_id=resolved_lease_id or None,
+                decided_by=decided_by,
+                decision=decision_type,
+                rationale=rationale
+                or (
+                    "Integrator approved lane for merge"
+                    if subaction == "merge"
+                    else "Integrator archived lane"
+                ),
+                target_branch=base_branch,
+            )
+            branch = str(lane.get("branch", "") or "").strip()
+            if subaction == "archive" and branch:
+                try:
+                    from aragora.swarm.pr_registry import PullRequestRegistry
+
+                    PullRequestRegistry().close(branch, outcome="archived")
+                except (ImportError, RuntimeError, OSError, ValueError):
+                    pass
+            payload = {
+                "lane_id": lane.get("lane_id"),
+                "receipt_id": resolved_receipt_id,
+                "lease_id": resolved_lease_id or None,
+                "branch": branch or None,
+                "decision": decision.decision,
+                "decision_id": decision.decision_id,
+            }
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                print(
+                    "decision_id={decision_id} decision={decision} lane_id={lane_id} receipt_id={receipt_id}".format(
+                        decision_id=payload["decision_id"],
+                        decision=payload["decision"],
+                        lane_id=payload["lane_id"],
+                        receipt_id=payload["receipt_id"],
+                    )
+                )
+            return
+
+        if subaction == "supersede":
+            from aragora.swarm.pr_registry import PullRequestRegistry
+
+            branch = str(getattr(args, "lane_branch", None) or lane.get("branch") or "").strip()
+            new_pr_url = str(getattr(args, "new_pr_url", None) or "").strip()
+            if not branch or not new_pr_url:
+                print(
+                    "Error: integrator supersede requires a lane branch and --new-pr-url",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            entry = PullRequestRegistry().supersede(
+                branch,
+                new_pr_url,
+                reason=rationale or "Integrator superseded the canonical PR",
+            )
+            if entry is None:
+                print(f"Error: branch not found in PR registry: {branch}", file=sys.stderr)
+                sys.exit(1)
+            payload = {
+                "branch": branch,
+                "new_pr_url": new_pr_url,
+                "status": entry.status,
+                "superseded_count": len(entry.superseded),
+            }
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                print(
+                    "branch={branch} superseded_count={count} new_pr={url}".format(
+                        branch=branch,
+                        count=payload["superseded_count"],
+                        url=new_pr_url,
+                    )
+                )
+            return
+
+        print(
+            "Error: swarm integrator action must be one of view, status, merge, archive, or supersede",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if action == "boss-loop":
         from aragora.swarm.boss_loop import BossLoop, BossLoopConfig

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2129,7 +2129,7 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "swarm_action_or_goal",
         nargs="?",
-        help="Action (run/status/reconcile/campaign) or your goal in plain language",
+        help="Action (run/status/reconcile/campaign/integrator) or your goal in plain language",
     )
     swarm_parser.add_argument(
         "swarm_goal",
@@ -2228,6 +2228,46 @@ def _add_swarm_parser(subparsers) -> None:
         "--run-id",
         default=None,
         help="Specific supervisor run ID for 'status'",
+    )
+    swarm_parser.add_argument(
+        "--readiness",
+        default=None,
+        help="Optional integrator readiness filter (for 'integrator' view)",
+    )
+    swarm_parser.add_argument(
+        "--lane-id",
+        default=None,
+        help="Integrator lane id for 'integrator' actions",
+    )
+    swarm_parser.add_argument(
+        "--receipt-id",
+        default=None,
+        help="Explicit completion receipt id for 'integrator' actions",
+    )
+    swarm_parser.add_argument(
+        "--lease-id",
+        default=None,
+        help="Explicit lease id for 'integrator' actions",
+    )
+    swarm_parser.add_argument(
+        "--lane-branch",
+        default=None,
+        help="Explicit lane branch for 'integrator supersede' or lane resolution",
+    )
+    swarm_parser.add_argument(
+        "--decided-by",
+        default="cli-integrator",
+        help="Integrator actor recorded on merge/archive decisions (default: cli-integrator)",
+    )
+    swarm_parser.add_argument(
+        "--rationale",
+        default="",
+        help="Integrator rationale for merge/archive/supersede actions",
+    )
+    swarm_parser.add_argument(
+        "--new-pr-url",
+        default=None,
+        help="Replacement PR URL for 'integrator supersede'",
     )
     swarm_parser.add_argument(
         "--status-limit",

--- a/aragora/server/handlers/control_plane/__init__.py
+++ b/aragora/server/handlers/control_plane/__init__.py
@@ -347,6 +347,10 @@ class ControlPlaneHandler(
         if path == "/api/v1/coordination/fleet/merge-queue":
             return self._handle_fleet_merge_queue(query_params)
 
+        # /api/v1/coordination/swarm/integrator
+        if path == "/api/v1/coordination/swarm/integrator":
+            return self._handle_swarm_integrator(query_params)
+
         # /api/v1/coordination/consent
         if path == "/api/v1/coordination/consent":
             return self._handle_list_consents(query_params)
@@ -496,6 +500,25 @@ class ControlPlaneHandler(
             if err:
                 return err
             return self._handle_fleet_merge_enqueue(body)
+
+        # /api/v1/coordination/swarm/integrator/*
+        if path == "/api/v1/coordination/swarm/integrator/merge":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_swarm_integrator_merge(body)
+
+        if path == "/api/v1/coordination/swarm/integrator/archive":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_swarm_integrator_archive(body)
+
+        if path == "/api/v1/coordination/swarm/integrator/supersede":
+            body, err = self.read_json_body_validated(handler)
+            if err:
+                return err
+            return self._handle_swarm_integrator_supersede(body)
 
         # /api/v1/coordination/approve/:id
         if path.startswith("/api/v1/coordination/approve/"):

--- a/aragora/server/handlers/control_plane/coordination.py
+++ b/aragora/server/handlers/control_plane/coordination.py
@@ -552,6 +552,76 @@ class CoordinationHandlerMixin:
     def _fleet_store(self, repo_root: Path) -> FleetCoordinationStore:
         return FleetCoordinationStore(repo_root)
 
+    def _build_integrator_lane_view(
+        self,
+        *,
+        repo_root: Path,
+        base_branch: str = "main",
+    ) -> dict[str, Any]:
+        worktrees = build_fleet_rows(repo_root, base_branch=base_branch, tail=0)
+        store = self._fleet_store(repo_root)
+        claims = store.list_claims()
+        queue = store.list_merge_queue()
+        try:
+            from aragora.nomic.dev_coordination import DevCoordinationStore
+
+            coordination_summary = DevCoordinationStore(repo_root=repo_root).status_summary(
+                include_integrator_artifacts=True
+            )
+        except (ImportError, RuntimeError, OSError, ValueError, sqlite3.Error) as exc:
+            coordination_summary = {"error": str(exc), "counts": {}}
+        return build_integrator_view(
+            runs=[],
+            worktrees=worktrees,
+            claims=claims,
+            merge_queue=queue,
+            coordination=coordination_summary,
+        )
+
+    @staticmethod
+    def _resolve_integrator_lane(
+        view: dict[str, Any],
+        *,
+        lane_id: str = "",
+        receipt_id: str = "",
+        lease_id: str = "",
+        branch: str = "",
+    ) -> dict[str, Any] | None:
+        lanes = [item for item in view.get("lanes", []) if isinstance(item, dict)]
+        lane_id = str(lane_id or "").strip()
+        receipt_id = str(receipt_id or "").strip()
+        lease_id = str(lease_id or "").strip()
+        branch = str(branch or "").strip()
+
+        if lane_id:
+            for lane in lanes:
+                if str(lane.get("lane_id", "")).strip() == lane_id:
+                    return lane
+            return None
+        if receipt_id:
+            for lane in lanes:
+                if str(lane.get("receipt_id", "")).strip() == receipt_id:
+                    return lane
+            return None
+        if lease_id:
+            for lane in lanes:
+                if str(lane.get("lease_id", "")).strip() == lease_id:
+                    return lane
+            return None
+        if branch:
+            canonical = [
+                lane
+                for lane in lanes
+                if str(lane.get("branch", "")).strip() == branch
+                and bool(lane.get("canonical_lane"))
+            ]
+            if canonical:
+                return canonical[0]
+            for lane in lanes:
+                if str(lane.get("branch", "")).strip() == branch:
+                    return lane
+        return None
+
     @api_endpoint(
         method="POST",
         path="/api/v1/coordination/swarm/run",
@@ -701,6 +771,200 @@ class CoordinationHandlerMixin:
             coordination=payload.get("coordination", {}),
         )
         return json_response(payload)
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/coordination/swarm/integrator",
+        summary="Get the unified integrator lane view",
+        tags=["Coordination"],
+    )
+    @require_permission("coordination:stats.read")
+    def _handle_swarm_integrator(self, query_params: dict[str, Any]) -> HandlerResult:
+        """Return the integrator lane view built from current coordination state."""
+        repo_root = self._fleet_repo_root()
+        base_branch = str(query_params.get("base", "main")).strip() or "main"
+        view = self._build_integrator_lane_view(repo_root=repo_root, base_branch=base_branch)
+        readiness = str(query_params.get("readiness", "")).strip()
+        if readiness:
+            filtered = dict(view)
+            filtered["lanes"] = [
+                item
+                for item in view.get("lanes", [])
+                if isinstance(item, dict)
+                and str(item.get("merge_readiness", "")).strip() == readiness
+            ]
+            view = filtered
+        return json_response(view)
+
+    @api_endpoint(
+        method="POST",
+        path="/api/v1/coordination/swarm/integrator/merge",
+        summary="Record an integrator merge decision for a lane",
+        tags=["Coordination"],
+    )
+    @handle_errors("coordination swarm integrator merge")
+    @require_permission("coordination:workspaces.write")
+    def _handle_swarm_integrator_merge(self, body: dict[str, Any]) -> HandlerResult:
+        """Record a merge decision using the resolved lane receipt."""
+        from aragora.nomic.dev_coordination import DevCoordinationStore, IntegrationDecisionType
+
+        repo_root = self._fleet_repo_root()
+        base_branch = str(body.get("target_branch", "main")).strip() or "main"
+        view = self._build_integrator_lane_view(repo_root=repo_root, base_branch=base_branch)
+        lane = self._resolve_integrator_lane(
+            view,
+            lane_id=str(body.get("lane_id", "")).strip(),
+            receipt_id=str(body.get("receipt_id", "")).strip(),
+            lease_id=str(body.get("lease_id", "")).strip(),
+            branch=str(body.get("branch", "")).strip(),
+        )
+        if lane is None:
+            return error_response(
+                "Unable to resolve integrator lane from lane_id, receipt_id, lease_id, or branch",
+                404,
+            )
+        receipt_id = str(body.get("receipt_id") or lane.get("receipt_id") or "").strip()
+        lease_id = str(body.get("lease_id") or lane.get("lease_id") or "").strip()
+        if not receipt_id:
+            return error_response("Selected lane has no receipt_id", 409)
+        decision = DevCoordinationStore(repo_root=repo_root).record_integration_decision(
+            receipt_id=receipt_id,
+            lease_id=lease_id or None,
+            decided_by=str(body.get("decided_by", "human-integrator")).strip()
+            or "human-integrator",
+            decision=IntegrationDecisionType.MERGE,
+            rationale=str(body.get("rationale", "")).strip()
+            or "Integrator approved lane for merge",
+            target_branch=base_branch,
+        )
+        return json_response(
+            {
+                "lane_id": lane.get("lane_id"),
+                "receipt_id": receipt_id,
+                "lease_id": lease_id or None,
+                "decision": decision.decision,
+                "decision_id": decision.decision_id,
+            }
+        )
+
+    @api_endpoint(
+        method="POST",
+        path="/api/v1/coordination/swarm/integrator/archive",
+        summary="Archive an integrator lane and record a discard decision",
+        tags=["Coordination"],
+    )
+    @handle_errors("coordination swarm integrator archive")
+    @require_permission("coordination:workspaces.write")
+    def _handle_swarm_integrator_archive(self, body: dict[str, Any]) -> HandlerResult:
+        """Archive a lane using the resolved receipt and optionally close its canonical PR."""
+        from aragora.nomic.dev_coordination import DevCoordinationStore, IntegrationDecisionType
+
+        repo_root = self._fleet_repo_root()
+        base_branch = str(body.get("target_branch", "main")).strip() or "main"
+        view = self._build_integrator_lane_view(repo_root=repo_root, base_branch=base_branch)
+        lane = self._resolve_integrator_lane(
+            view,
+            lane_id=str(body.get("lane_id", "")).strip(),
+            receipt_id=str(body.get("receipt_id", "")).strip(),
+            lease_id=str(body.get("lease_id", "")).strip(),
+            branch=str(body.get("branch", "")).strip(),
+        )
+        if lane is None:
+            return error_response(
+                "Unable to resolve integrator lane from lane_id, receipt_id, lease_id, or branch",
+                404,
+            )
+        receipt_id = str(body.get("receipt_id") or lane.get("receipt_id") or "").strip()
+        lease_id = str(body.get("lease_id") or lane.get("lease_id") or "").strip()
+        if not receipt_id:
+            return error_response("Selected lane has no receipt_id", 409)
+        decision = DevCoordinationStore(repo_root=repo_root).record_integration_decision(
+            receipt_id=receipt_id,
+            lease_id=lease_id or None,
+            decided_by=str(body.get("decided_by", "human-integrator")).strip()
+            or "human-integrator",
+            decision=IntegrationDecisionType.DISCARD,
+            rationale=str(body.get("rationale", "")).strip() or "Integrator archived lane",
+            target_branch=base_branch,
+        )
+        branch = str(body.get("branch") or lane.get("branch") or "").strip()
+        if branch:
+            try:
+                from aragora.swarm.pr_registry import PullRequestRegistry
+
+                PullRequestRegistry().close(branch, outcome="archived")
+            except (ImportError, RuntimeError, OSError, ValueError):
+                pass
+        return json_response(
+            {
+                "lane_id": lane.get("lane_id"),
+                "receipt_id": receipt_id,
+                "lease_id": lease_id or None,
+                "branch": branch or None,
+                "decision": decision.decision,
+                "decision_id": decision.decision_id,
+            }
+        )
+
+    @api_endpoint(
+        method="POST",
+        path="/api/v1/coordination/swarm/integrator/supersede",
+        summary="Supersede the canonical PR for an integrator lane",
+        tags=["Coordination"],
+    )
+    @handle_errors("coordination swarm integrator supersede")
+    @require_permission("coordination:workspaces.write")
+    def _handle_swarm_integrator_supersede(self, body: dict[str, Any]) -> HandlerResult:
+        """Replace the canonical PR for a lane with a new PR URL."""
+        repo_root = self._fleet_repo_root()
+        base_branch = str(body.get("target_branch", "main")).strip() or "main"
+        view = self._build_integrator_lane_view(repo_root=repo_root, base_branch=base_branch)
+        lane = self._resolve_integrator_lane(
+            view,
+            lane_id=str(body.get("lane_id", "")).strip(),
+            receipt_id=str(body.get("receipt_id", "")).strip(),
+            lease_id=str(body.get("lease_id", "")).strip(),
+            branch=str(body.get("branch", "")).strip(),
+        )
+        branch = str(body.get("branch") or (lane or {}).get("branch") or "").strip()
+        new_pr_url = str(body.get("new_pr_url", "")).strip()
+        if not branch or not new_pr_url:
+            return error_response("branch and new_pr_url are required", 400)
+        try:
+            from dataclasses import asdict, is_dataclass
+
+            from aragora.swarm.pr_registry import PullRequestRegistry
+
+            entry = PullRequestRegistry().supersede(
+                branch,
+                new_pr_url,
+                reason=str(body.get("rationale", "")).strip()
+                or "Integrator superseded the canonical PR",
+            )
+            if entry is None:
+                return error_response(f"Branch not found: {branch}", 404)
+            if is_dataclass(entry):
+                entry_payload = asdict(entry)
+            elif isinstance(entry, dict):
+                entry_payload = dict(entry)
+            else:
+                entry_payload = {
+                    "branch": getattr(entry, "branch", branch),
+                    "pr_url": getattr(entry, "pr_url", new_pr_url),
+                    "status": getattr(entry, "status", "active"),
+                    "superseded": list(getattr(entry, "superseded", []) or []),
+                    "metadata": dict(getattr(entry, "metadata", {}) or {}),
+                }
+            return json_response(
+                {
+                    "branch": branch,
+                    "new_pr_url": new_pr_url,
+                    "entry": entry_payload,
+                }
+            )
+        except (ImportError, RuntimeError, OSError, ValueError) as exc:
+            logger.warning("Supersede failed: %s", exc)
+            return error_response("Supersede failed", 500)
 
     @api_endpoint(
         method="GET",

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -23,6 +23,7 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
     defaults: dict[str, object] = {
         "swarm_action_or_goal": "run",
         "swarm_goal": None,
+        "swarm_campaign_target": None,
         "spec": None,
         "skip_interrogation": False,
         "dry_run": False,
@@ -41,6 +42,14 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "managed_dir_pattern": ".worktrees/{agent}-auto",
         "json": False,
         "run_id": None,
+        "readiness": None,
+        "lane_id": None,
+        "receipt_id": None,
+        "lease_id": None,
+        "lane_branch": None,
+        "decided_by": "cli-integrator",
+        "rationale": "",
+        "new_pr_url": None,
         "status_limit": 20,
         "refresh_scaling": False,
         "no_dispatch": False,
@@ -141,6 +150,27 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "runner"
         assert args.swarm_goal == "register"
         assert args.json is True
+
+    def test_swarm_integrator_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "integrator",
+                "merge",
+                "--lane-id",
+                "lane-1",
+                "--rationale",
+                "Ship it",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "integrator"
+        assert args.swarm_goal == "merge"
+        assert args.lane_id == "lane-1"
+        assert args.rationale == "Ship it"
 
     def test_swarm_parser_accepts_spec_dispatch_options(self):
         from aragora.cli.parser import build_parser
@@ -895,6 +925,125 @@ class TestSwarmCommand:
         out = capsys.readouterr().out
         assert '"blocked_reason": "no_fresh_registered_runners"' in out
         assert '"rejected_runner_ids": [' in out
+
+    def test_cmd_swarm_integrator_view_text(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="integrator",
+        )
+
+        with (
+            patch("aragora.worktree.fleet.resolve_repo_root") as resolve_repo_root,
+            patch("aragora.cli.commands.swarm._load_integrator_view") as load_view,
+        ):
+            resolve_repo_root.return_value = Path("/tmp/repo")
+            load_view.return_value = {
+                "summary": {
+                    "total_lanes": 1,
+                    "ready_lanes": 1,
+                    "blocked_lanes": 0,
+                    "review_lanes": 0,
+                    "stale_heartbeat_lanes": 0,
+                    "superseded_lanes": 0,
+                },
+                "lanes": [
+                    {
+                        "lane_id": "lane-1",
+                        "title": "Write operator guide",
+                        "branch": "codex/docs-lane",
+                        "status": "completed",
+                        "merge_readiness": "ready",
+                        "canonical_lane": True,
+                        "receipt_id": "rcpt-1",
+                        "lease_id": "lease-1",
+                        "blockers": [],
+                        "next_action": "Queue or validate this lane for merge.",
+                    }
+                ],
+                "next_actions": ["Queue or validate this lane for merge."],
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert "Swarm Integrator View (1 lanes)" in out
+        assert "Write operator guide" in out
+        assert "lane_id=lane-1" in out
+        assert "receipt=rcpt-1 lease=lease-1" in out
+
+    def test_cmd_swarm_integrator_merge_records_decision(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="integrator",
+            swarm_goal="merge",
+            lane_id="lane-1",
+            rationale="Ready to merge",
+            decided_by="human-integrator",
+        )
+        mock_store = MagicMock()
+        mock_store.record_integration_decision.return_value = SimpleNamespace(
+            decision="merge",
+            decision_id="dec-1",
+        )
+
+        with (
+            patch("aragora.worktree.fleet.resolve_repo_root") as resolve_repo_root,
+            patch("aragora.cli.commands.swarm._load_integrator_view") as load_view,
+            patch("aragora.nomic.dev_coordination.DevCoordinationStore", return_value=mock_store),
+        ):
+            resolve_repo_root.return_value = Path("/tmp/repo")
+            load_view.return_value = {
+                "lanes": [
+                    {
+                        "lane_id": "lane-1",
+                        "receipt_id": "rcpt-1",
+                        "lease_id": "lease-1",
+                        "branch": "codex/docs-lane",
+                    }
+                ]
+            }
+            cmd_swarm(args)
+
+        call = mock_store.record_integration_decision.call_args
+        assert call.kwargs["receipt_id"] == "rcpt-1"
+        assert call.kwargs["lease_id"] == "lease-1"
+        assert call.kwargs["decided_by"] == "human-integrator"
+        out = capsys.readouterr().out
+        assert "decision_id=dec-1" in out
+        assert "decision=merge" in out
+
+    def test_cmd_swarm_integrator_supersede_updates_registry(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="integrator",
+            swarm_goal="supersede",
+            lane_id="lane-1",
+            new_pr_url="https://github.com/synaptent/aragora/pull/9999",
+            rationale="Replacement PR is canonical",
+        )
+        mock_entry = SimpleNamespace(status="active", superseded=[{"pr_url": "old"}])
+
+        with (
+            patch("aragora.worktree.fleet.resolve_repo_root") as resolve_repo_root,
+            patch("aragora.cli.commands.swarm._load_integrator_view") as load_view,
+            patch("aragora.swarm.pr_registry.PullRequestRegistry") as registry_cls,
+        ):
+            resolve_repo_root.return_value = Path("/tmp/repo")
+            load_view.return_value = {
+                "lanes": [
+                    {
+                        "lane_id": "lane-1",
+                        "branch": "codex/docs-lane",
+                    }
+                ]
+            }
+            registry_cls.return_value.supersede.return_value = mock_entry
+            cmd_swarm(args)
+
+        registry_cls.return_value.supersede.assert_called_once_with(
+            "codex/docs-lane",
+            "https://github.com/synaptent/aragora/pull/9999",
+            reason="Replacement PR is canonical",
+        )
+        out = capsys.readouterr().out
+        assert "branch=codex/docs-lane" in out
+        assert "superseded_count=1" in out
 
     def test_cmd_swarm_reconcile_watch_uses_watch_run(self, capsys):
         args = _swarm_args(

--- a/tests/handlers/control_plane/test_coordination.py
+++ b/tests/handlers/control_plane/test_coordination.py
@@ -675,6 +675,109 @@ class TestRouteDispatch:
     @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
     @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    def test_get_coordination_swarm_integrator_view(
+        self,
+        mock_resolve,
+        mock_build_rows,
+        mock_store_cls,
+        mock_status_summary,
+        handler: ControlPlaneHandler,
+        mock_http_handler: MagicMock,
+    ):
+        mock_resolve.return_value = Path("/tmp/repo")
+        mock_build_rows.return_value = [
+            {
+                "session_id": "sess-a",
+                "path": "/tmp/repo/.worktrees/docs",
+                "branch": "codex/docs-lane",
+                "has_lock": True,
+                "pid_alive": True,
+                "agent": "codex",
+                "last_activity": "2026-03-18T10:00:00+00:00",
+            }
+        ]
+        store = MagicMock()
+        store.list_claims.return_value = []
+        store.list_merge_queue.return_value = [
+            {
+                "id": "mq-1",
+                "branch": "codex/docs-lane",
+                "session_id": "sess-a",
+                "status": "needs_human",
+                "metadata": {"receipt_id": "rcpt-1", "task_id": "docs-lane"},
+            }
+        ]
+        mock_store_cls.return_value = store
+        mock_status_summary.return_value = {
+            "integrator": {
+                "developer_tasks": [
+                    {
+                        "task_key": "run-1:docs-lane",
+                        "task_id": "docs-lane",
+                        "title": "Write operator guide",
+                        "status": "completed",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "lease_id": "lease-1",
+                        "receipt_id": "rcpt-1",
+                        "updated_at": "2026-03-18T09:58:00+00:00",
+                    }
+                ],
+                "leases": [
+                    {
+                        "lease_id": "lease-1",
+                        "task_id": "docs-lane",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "status": "completed",
+                        "updated_at": "2026-03-18T09:57:00+00:00",
+                        "expires_at": "2026-03-18T17:00:00+00:00",
+                    }
+                ],
+                "completion_receipts": [
+                    {
+                        "receipt_id": "rcpt-1",
+                        "lease_id": "lease-1",
+                        "task_id": "docs-lane",
+                        "owner_session_id": "sess-a",
+                        "branch": "codex/docs-lane",
+                        "worktree_path": "/tmp/repo/.worktrees/docs",
+                        "created_at": "2026-03-18T09:56:00+00:00",
+                        "confidence": 0.93,
+                    }
+                ],
+                "integration_decisions": [
+                    {
+                        "decision_id": "dec-1",
+                        "lease_id": "lease-1",
+                        "receipt_id": "rcpt-1",
+                        "decision": "pending_review",
+                        "target_branch": "main",
+                        "rationale": "Awaiting integrator review",
+                        "created_at": "2026-03-18T09:56:30+00:00",
+                    }
+                ],
+                "salvage_candidates": [],
+            }
+        }
+        mock_http_handler.path = "/api/v1/coordination/swarm/integrator"
+
+        result = handler.handle("/api/v1/coordination/swarm/integrator", {}, mock_http_handler)
+
+        assert result is not None
+        assert result.status_code == 200
+        data = json.loads(result.body)
+        assert data["summary"]["total_lanes"] == 1
+        assert data["lanes"][0]["branch"] == "codex/docs-lane"
+        assert data["lanes"][0]["receipt_id"] == "rcpt-1"
+        assert "merge" in data["lanes"][0]["available_actions"]
+
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore.status_summary")
+    @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
+    @patch("aragora.server.handlers.control_plane.coordination.build_fleet_rows")
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
     def test_get_coordination_fleet_status_surfaces_canonical_lane_metadata(
         self,
         mock_resolve,
@@ -849,6 +952,135 @@ class TestRouteDispatch:
         assert data["integrator_view"]["alerts"]["collisions"][0]["reasons"] == [
             "path:aragora/swarm/reporter.py"
         ]
+
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    @patch.object(ControlPlaneHandler, "_build_integrator_lane_view")
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore")
+    def test_post_coordination_swarm_integrator_merge(
+        self,
+        mock_store_cls,
+        mock_build_view,
+        mock_resolve,
+        handler: ControlPlaneHandler,
+    ):
+        from aragora.nomic.dev_coordination import IntegrationDecisionType
+
+        mock_resolve.return_value = Path("/tmp/repo")
+        mock_build_view.return_value = {
+            "lanes": [
+                {
+                    "lane_id": "lane-1",
+                    "receipt_id": "rcpt-1",
+                    "lease_id": "lease-1",
+                    "branch": "codex/docs-lane",
+                }
+            ]
+        }
+        mock_store = MagicMock()
+        mock_store.record_integration_decision.return_value = MagicMock(
+            decision=IntegrationDecisionType.MERGE.value,
+            decision_id="dec-1",
+        )
+        mock_store_cls.return_value = mock_store
+
+        result = handler._handle_swarm_integrator_merge(
+            {
+                "lane_id": "lane-1",
+                "decided_by": "human-integrator",
+                "rationale": "Ready to merge",
+            }
+        )
+
+        assert result.status_code == 200
+        call = mock_store.record_integration_decision.call_args
+        assert call.kwargs["receipt_id"] == "rcpt-1"
+        assert call.kwargs["lease_id"] == "lease-1"
+        assert call.kwargs["decision"] == IntegrationDecisionType.MERGE
+
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    @patch.object(ControlPlaneHandler, "_build_integrator_lane_view")
+    @patch("aragora.swarm.pr_registry.PullRequestRegistry")
+    @patch("aragora.nomic.dev_coordination.DevCoordinationStore")
+    def test_post_coordination_swarm_integrator_archive_closes_pr(
+        self,
+        mock_store_cls,
+        mock_registry_cls,
+        mock_build_view,
+        mock_resolve,
+        handler: ControlPlaneHandler,
+    ):
+        from aragora.nomic.dev_coordination import IntegrationDecisionType
+
+        mock_resolve.return_value = Path("/tmp/repo")
+        mock_build_view.return_value = {
+            "lanes": [
+                {
+                    "lane_id": "lane-1",
+                    "receipt_id": "rcpt-1",
+                    "lease_id": "lease-1",
+                    "branch": "codex/docs-lane",
+                }
+            ]
+        }
+        mock_store = MagicMock()
+        mock_store.record_integration_decision.return_value = MagicMock(
+            decision=IntegrationDecisionType.DISCARD.value,
+            decision_id="dec-2",
+        )
+        mock_store_cls.return_value = mock_store
+
+        result = handler._handle_swarm_integrator_archive({"lane_id": "lane-1"})
+
+        assert result.status_code == 200
+        mock_registry_cls.return_value.close.assert_called_once_with(
+            "codex/docs-lane",
+            outcome="archived",
+        )
+
+    @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")
+    @patch.object(ControlPlaneHandler, "_build_integrator_lane_view")
+    @patch("aragora.swarm.pr_registry.PullRequestRegistry")
+    def test_post_coordination_swarm_integrator_supersede(
+        self,
+        mock_registry_cls,
+        mock_build_view,
+        mock_resolve,
+        handler: ControlPlaneHandler,
+    ):
+        mock_resolve.return_value = Path("/tmp/repo")
+        mock_build_view.return_value = {
+            "lanes": [
+                {
+                    "lane_id": "lane-1",
+                    "branch": "codex/docs-lane",
+                }
+            ]
+        }
+        mock_registry_cls.return_value.supersede.return_value = MagicMock(
+            branch="codex/docs-lane",
+            pr_url="https://github.com/synaptent/aragora/pull/9999",
+            creator="codex",
+            created_at="2026-03-18T12:00:00+00:00",
+            status="active",
+            superseded=[{"pr_url": "old"}],
+            gate_snapshot=None,
+            metadata={},
+        )
+
+        result = handler._handle_swarm_integrator_supersede(
+            {
+                "lane_id": "lane-1",
+                "new_pr_url": "https://github.com/synaptent/aragora/pull/9999",
+                "rationale": "Replacement PR is canonical",
+            }
+        )
+
+        assert result.status_code == 200
+        mock_registry_cls.return_value.supersede.assert_called_once_with(
+            "codex/docs-lane",
+            "https://github.com/synaptent/aragora/pull/9999",
+            reason="Replacement PR is canonical",
+        )
 
     @patch("aragora.server.handlers.control_plane.coordination.FleetCoordinationStore")
     @patch("aragora.server.handlers.control_plane.coordination.resolve_repo_root")


### PR DESCRIPTION
## Summary
- add a dedicated `swarm integrator` CLI surface for viewing and acting on canonical lanes
- add coordination endpoints for integrator view, merge, archive, and supersede actions
- resolve actions against current lane identifiers (`lane_id`, `receipt_id`, `lease_id`, `branch`) instead of the stale branch's ambiguous id handling

## Verification
- `ruff check aragora/cli/parser.py aragora/cli/commands/swarm.py aragora/server/handlers/control_plane/coordination.py aragora/server/handlers/control_plane/__init__.py tests/cli/test_swarm_command.py tests/handlers/control_plane/test_coordination.py`
- `python -m pytest tests/cli/test_swarm_command.py tests/handlers/control_plane/test_coordination.py -q`
- result: `78 passed`

## Context
This is the clean follow-up harvest from the stale `worktree-llm-scope-classifier` branch. It intentionally lands only the operator surface that was still missing on `main`, rebuilt on top of the already-merged integrator data model and coordination store.