### PR TITLE
Add public task queue and lease operator surfaces

### DIFF
--- a/aragora/cli/commands/__init__.py
+++ b/aragora/cli/commands/__init__.py
@@ -85,6 +85,9 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     # coordinate (multi-agent worktree coordination)
     "cmd_coordinate": ("aragora.cli.commands.coordinate", "cmd_coordinate"),
     "add_coordinate_parser": ("aragora.cli.commands.coordinate", "add_coordinate_parser"),
+    # tasks (public operator surface over queue / leases)
+    "cmd_tasks": ("aragora.cli.commands.tasks", "cmd_tasks"),
+    "add_tasks_parser": ("aragora.cli.commands.tasks", "add_tasks_parser"),
     # pipeline (idea-to-execution pipeline)
     "cmd_pipeline": ("aragora.cli.commands.pipeline", "cmd_pipeline"),
     "add_pipeline_parser": ("aragora.cli.commands.pipeline", "add_pipeline_parser"),

--- a/aragora/cli/commands/tasks.py
+++ b/aragora/cli/commands/tasks.py
@@ -1,0 +1,449 @@
+"""Public CLI for the developer task queue and lease lifecycle."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import inspect
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from aragora.worktree.fleet import resolve_repo_root
+
+
+def _resolve(result: Any) -> Any:
+    """Resolve an awaitable from sync CLI code."""
+    if inspect.isawaitable(result):
+        return asyncio.run(result)
+    return result
+
+
+def _repo_root() -> Path:
+    return resolve_repo_root(Path.cwd())
+
+
+def _load_queue():
+    from aragora.nomic.global_work_queue import GlobalWorkQueue
+
+    queue = GlobalWorkQueue(storage_dir=_repo_root() / ".work_queue")
+    _resolve(queue.initialize())
+    return queue
+
+
+def _load_store():
+    from aragora.nomic.dev_coordination import DevCoordinationStore
+
+    return DevCoordinationStore(repo_root=_repo_root())
+
+
+def _current_branch(repo_root: Path) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout.strip()
+
+
+def _default_agent() -> str:
+    user = getpass.getuser().strip() or "unknown"
+    return f"cli:{user}"
+
+
+def _default_session() -> str:
+    user = getpass.getuser().strip() or "unknown"
+    return f"cli-session:{user}"
+
+
+def _serialize(item: Any) -> dict[str, Any]:
+    if hasattr(item, "to_dict"):
+        return item.to_dict()
+    if isinstance(item, dict):
+        return item
+    raise TypeError(f"Unsupported item type: {type(item)!r}")
+
+
+def _queue_task_defaults(
+    task_id: str, *, queue: Any, store: Any
+) -> tuple[str, list[str], list[str]]:
+    title = task_id
+    allowed_globs: list[str] = []
+    expected_tests: list[str] = []
+
+    item = _resolve(queue.get(task_id))
+    if item is not None:
+        payload = _serialize(item)
+        title = str(payload.get("title") or title)
+        metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+        if isinstance(metadata, dict):
+            allowed_globs = [str(p) for p in metadata.get("allowed_paths", []) if str(p).strip()]
+            expected_tests = [
+                str(item) for item in metadata.get("acceptance_checks", []) if str(item).strip()
+            ]
+
+    if task_id.startswith("task:"):
+        developer_task = store.get_developer_task(task_id.split("task:", 1)[1])
+        if developer_task is not None:
+            title = developer_task.title or title
+            if not allowed_globs:
+                allowed_globs = [str(p) for p in developer_task.allowed_paths if str(p).strip()]
+            if not expected_tests:
+                expected_tests = [
+                    str(item) for item in developer_task.acceptance_checks if str(item).strip()
+                ]
+
+    return title, allowed_globs, expected_tests
+
+
+def _active_lease(store: Any, lease_id: str) -> Any | None:
+    for lease in store.list_active_leases():
+        if getattr(lease, "lease_id", "") == lease_id:
+            return lease
+    return None
+
+
+def _print_json(payload: Any) -> None:
+    print(json.dumps(payload, indent=2, default=str))  # noqa: T201
+
+
+def _print_queue_table(items: list[dict[str, Any]]) -> None:
+    print(f"{'ID':28s} {'Status':12s} {'Type':12s} {'Pri':>4s} Title")  # noqa: T201
+    print("-" * 88)  # noqa: T201
+    for item in items:
+        priority = item.get("computed_priority", item.get("base_priority", 0))
+        print(  # noqa: T201
+            f"{str(item.get('id', ''))[:28]:28s} "
+            f"{str(item.get('status', ''))[:12]:12s} "
+            f"{str(item.get('work_type', ''))[:12]:12s} "
+            f"{int(priority):>4d} "
+            f"{str(item.get('title', ''))[:28]}"
+        )
+
+
+def _print_leases_table(items: list[dict[str, Any]]) -> None:
+    print(  # noqa: T201
+        f"{'Lease ID':14s} {'Task ID':28s} {'Agent':18s} {'Status':12s} {'Branch':18s} Expires"
+    )
+    print("-" * 118)  # noqa: T201
+    for item in items:
+        print(  # noqa: T201
+            f"{str(item.get('lease_id', ''))[:14]:14s} "
+            f"{str(item.get('task_id', ''))[:28]:28s} "
+            f"{str(item.get('owner_agent', ''))[:18]:18s} "
+            f"{str(item.get('status', ''))[:12]:12s} "
+            f"{str(item.get('branch', ''))[:18]:18s} "
+            f"{str(item.get('expires_at', ''))}"
+        )
+
+
+def _print_salvage_table(items: list[dict[str, Any]]) -> None:
+    print(f"{'Candidate ID':14s} {'Source':12s} {'Branch':18s} Summary")  # noqa: T201
+    print("-" * 88)  # noqa: T201
+    for item in items:
+        print(  # noqa: T201
+            f"{str(item.get('candidate_id', ''))[:14]:14s} "
+            f"{str(item.get('source_kind', ''))[:12]:12s} "
+            f"{str(item.get('branch', ''))[:18]:18s} "
+            f"{str(item.get('summary', ''))[:36]}"
+        )
+
+
+def add_tasks_parser(subparsers: argparse._SubParsersAction) -> None:
+    """Register the public tasks command."""
+    parser = subparsers.add_parser(
+        "tasks",
+        help="Inspect and operate the developer task queue",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    sub = parser.add_subparsers(dest="tasks_command")
+
+    list_p = sub.add_parser("list", help="List queued work items")
+    list_p.add_argument(
+        "--status",
+        choices=["pending", "ready", "claimed", "in_progress", "blocked", "completed", "failed"],
+    )
+    list_p.add_argument(
+        "--work-type",
+        choices=["bead", "convoy", "molecule", "escalation", "maintenance", "custom"],
+    )
+    list_p.add_argument("--limit", type=int, default=20)
+    list_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="table"
+    )
+
+    show_p = sub.add_parser("show", help="Show one queued work item")
+    show_p.add_argument("task_id")
+    show_p.add_argument("--format", dest="output_format", choices=["table", "json"], default="json")
+
+    claim_p = sub.add_parser("claim", help="Claim a queued task and create a lease")
+    claim_p.add_argument("task_id")
+    claim_p.add_argument("--agent", default=None, help="Owner agent id")
+    claim_p.add_argument("--session-id", default=None, help="Owner session id")
+    claim_p.add_argument("--title", default=None, help="Override lease title")
+    claim_p.add_argument("--branch", default=None, help="Branch for the lease")
+    claim_p.add_argument("--worktree", default=None, help="Worktree path for the lease")
+    claim_p.add_argument("--ttl-hours", type=float, default=8.0)
+    claim_p.add_argument("--write-scope", action="append", default=[], help="Allowed path glob")
+    claim_p.add_argument(
+        "--claimed-path", action="append", default=[], help="Explicit claimed path"
+    )
+    claim_p.add_argument("--test", action="append", default=[], help="Expected test")
+    claim_p.add_argument("--allow-overlap", action="store_true")
+    claim_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="json"
+    )
+
+    leases_p = sub.add_parser("leases", help="List active leases")
+    leases_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="table"
+    )
+
+    heartbeat_p = sub.add_parser("heartbeat", help="Refresh a lease heartbeat")
+    heartbeat_p.add_argument("lease_id")
+    heartbeat_p.add_argument("--ttl-hours", type=float, default=None)
+    heartbeat_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="json"
+    )
+
+    release_p = sub.add_parser("release", help="Release a lease")
+    release_p.add_argument("lease_id")
+    release_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="json"
+    )
+
+    complete_p = sub.add_parser("complete", help="Complete a lease and emit a receipt")
+    complete_p.add_argument("lease_id")
+    complete_p.add_argument("--agent", default=None, help="Owner agent id")
+    complete_p.add_argument("--session-id", default=None, help="Owner session id")
+    complete_p.add_argument("--branch", default=None)
+    complete_p.add_argument("--worktree", default=None)
+    complete_p.add_argument("--base-sha", default=None)
+    complete_p.add_argument("--head-sha", default=None)
+    complete_p.add_argument("--commit", action="append", default=[])
+    complete_p.add_argument("--changed-path", action="append", default=[])
+    complete_p.add_argument("--test", action="append", default=[])
+    complete_p.add_argument("--validation", action="append", default=[])
+    complete_p.add_argument("--assumption", action="append", default=[])
+    complete_p.add_argument("--blocker", action="append", default=[])
+    complete_p.add_argument("--risk", action="append", default=[])
+    complete_p.add_argument("--outcome", default="completed")
+    complete_p.add_argument("--pr-url", default=None)
+    complete_p.add_argument("--pr-number", type=int, default=None)
+    complete_p.add_argument("--confidence", type=float, default=0.0)
+    complete_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="json"
+    )
+
+    salvage_p = sub.add_parser("salvage", help="List salvage candidates")
+    salvage_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="table"
+    )
+
+    stats_p = sub.add_parser("stats", help="Show queue statistics")
+    stats_p.add_argument(
+        "--format", dest="output_format", choices=["table", "json"], default="json"
+    )
+
+    sync_p = sub.add_parser("sync", help="Project developer and pending work into the queue")
+    sync_p.add_argument("--skip-developer-tasks", action="store_true")
+    sync_p.add_argument("--skip-pending", action="store_true")
+    sync_p.add_argument("--keep-missing-open", action="store_true")
+    sync_p.add_argument("--format", dest="output_format", choices=["table", "json"], default="json")
+
+    parser.set_defaults(func=cmd_tasks)
+
+
+def cmd_tasks(args: argparse.Namespace) -> None:
+    command = getattr(args, "tasks_command", None)
+    if not command:
+        print(  # noqa: T201
+            "Usage: aragora tasks {list|show|claim|leases|heartbeat|release|complete|salvage|stats|sync}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    dispatch = {
+        "list": _cmd_list,
+        "show": _cmd_show,
+        "claim": _cmd_claim,
+        "leases": _cmd_leases,
+        "heartbeat": _cmd_heartbeat,
+        "release": _cmd_release,
+        "complete": _cmd_complete,
+        "salvage": _cmd_salvage,
+        "stats": _cmd_stats,
+        "sync": _cmd_sync,
+    }
+    dispatch[command](args)
+
+
+def _cmd_list(args: argparse.Namespace) -> None:
+    from aragora.nomic.global_work_queue import WorkStatus, WorkType
+
+    queue = _load_queue()
+    status = WorkStatus(args.status) if args.status else None
+    work_type = WorkType(args.work_type) if getattr(args, "work_type", None) else None
+    items = [
+        _serialize(item)
+        for item in _resolve(queue.list_items(status=status, work_type=work_type, limit=args.limit))
+    ]
+    if args.output_format == "json":
+        _print_json(items)
+        return
+    _print_queue_table(items)
+
+
+def _cmd_show(args: argparse.Namespace) -> None:
+    queue = _load_queue()
+    item = _resolve(queue.get(args.task_id))
+    if item is None:
+        print(f"Task {args.task_id} not found", file=sys.stderr)  # noqa: T201
+        raise SystemExit(1)
+    payload = _serialize(item)
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    _print_queue_table([payload])
+
+
+def _cmd_claim(args: argparse.Namespace) -> None:
+    store = _load_store()
+    queue = _load_queue()
+    repo_root = _repo_root()
+    title, default_scopes, default_tests = _queue_task_defaults(
+        args.task_id, queue=queue, store=store
+    )
+    lease = store.claim_lease(
+        task_id=args.task_id,
+        title=args.title or title,
+        owner_agent=args.agent or _default_agent(),
+        owner_session_id=args.session_id or _default_session(),
+        branch=args.branch or _current_branch(repo_root),
+        worktree_path=args.worktree or str(Path.cwd()),
+        allowed_globs=list(args.write_scope or default_scopes),
+        claimed_paths=list(args.claimed_path or []),
+        expected_tests=list(args.test or default_tests),
+        ttl_hours=args.ttl_hours,
+        allow_overlap=bool(args.allow_overlap),
+    )
+    payload = lease.to_dict()
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    _print_leases_table([payload])
+
+
+def _cmd_leases(args: argparse.Namespace) -> None:
+    store = _load_store()
+    items = [lease.to_dict() for lease in store.list_active_leases()]
+    if args.output_format == "json":
+        _print_json(items)
+        return
+    _print_leases_table(items)
+
+
+def _cmd_heartbeat(args: argparse.Namespace) -> None:
+    store = _load_store()
+    lease = store.heartbeat_lease(args.lease_id, ttl_hours=args.ttl_hours)
+    payload = lease.to_dict()
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    _print_leases_table([payload])
+
+
+def _cmd_release(args: argparse.Namespace) -> None:
+    store = _load_store()
+    lease = store.release_lease(args.lease_id)
+    payload = lease.to_dict()
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    _print_leases_table([payload])
+
+
+def _cmd_complete(args: argparse.Namespace) -> None:
+    store = _load_store()
+    repo_root = _repo_root()
+    active_lease = _active_lease(store, args.lease_id)
+    receipt = store.record_completion(
+        lease_id=args.lease_id,
+        owner_agent=args.agent or getattr(active_lease, "owner_agent", "") or _default_agent(),
+        owner_session_id=args.session_id
+        or getattr(active_lease, "owner_session_id", "")
+        or _default_session(),
+        branch=args.branch or getattr(active_lease, "branch", "") or _current_branch(repo_root),
+        worktree_path=args.worktree
+        or getattr(active_lease, "worktree_path", "")
+        or str(Path.cwd()),
+        base_sha=args.base_sha,
+        head_sha=args.head_sha,
+        commit_shas=list(args.commit or []),
+        changed_paths=list(args.changed_path or []),
+        tests_run=list(args.test or []),
+        validations_run=list(args.validation or []),
+        assumptions=list(args.assumption or []),
+        blockers=list(args.blocker or []),
+        outcome=args.outcome,
+        risks=list(args.risk or []),
+        pr_url=args.pr_url,
+        pr_number=args.pr_number,
+        confidence=args.confidence,
+    )
+    payload = receipt.to_dict()
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    print(f"receipt_id={payload['receipt_id']} lease_id={payload['lease_id']}")  # noqa: T201
+
+
+def _cmd_salvage(args: argparse.Namespace) -> None:
+    store = _load_store()
+    items = [candidate.to_dict() for candidate in store.list_salvage_candidates()]
+    if args.output_format == "json":
+        _print_json(items)
+        return
+    _print_salvage_table(items)
+
+
+def _cmd_stats(args: argparse.Namespace) -> None:
+    queue = _load_queue()
+    payload = _resolve(queue.get_statistics())
+    if args.output_format == "json":
+        _print_json(payload)
+        return
+    print(  # noqa: T201
+        "total_items={total_items} pending_items={pending_items} completed_items={completed_items}".format(
+            total_items=payload.get("total_items", 0),
+            pending_items=payload.get("pending_items", 0),
+            completed_items=payload.get("completed_items", 0),
+        )
+    )
+
+
+def _cmd_sync(args: argparse.Namespace) -> None:
+    store = _load_store()
+    queue = _load_queue()
+    counts: dict[str, Any] = {}
+    complete_missing = not args.keep_missing_open
+    if not args.skip_developer_tasks:
+        counts["developer_tasks"] = _resolve(
+            store.sync_developer_task_queue(queue, complete_missing=complete_missing)
+        )
+    if not args.skip_pending:
+        counts["pending"] = _resolve(
+            store.sync_pending_work_queue(queue, complete_missing=complete_missing)
+        )
+    if args.output_format == "json":
+        _print_json(counts)
+        return
+    for section, payload in counts.items():
+        print(section)  # noqa: T201
+        print(json.dumps(payload, indent=2))  # noqa: T201

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -182,6 +182,7 @@ Examples:
     _add_coordinate_parser(subparsers)
     _add_self_improve_parser(subparsers)
     _add_swarm_parser(subparsers)
+    _add_tasks_parser(subparsers)
     _add_worktree_parser(subparsers)
     _add_outcome_parser(subparsers)
     _add_explain_parser(subparsers)
@@ -2417,6 +2418,13 @@ def _add_swarm_parser(subparsers) -> None:
             "aragora.cli.commands.swarm", fromlist=["cmd_swarm"]
         ).cmd_swarm(args)
     )
+
+
+def _add_tasks_parser(subparsers) -> None:
+    """Add the public tasks command."""
+    from aragora.cli.commands.tasks import add_tasks_parser
+
+    add_tasks_parser(subparsers)
 
 
 def _add_ralph_parser(subparsers) -> None:

--- a/aragora/server/handler_registry/admin.py
+++ b/aragora/server/handler_registry/admin.py
@@ -421,6 +421,7 @@ ConnectorManagementHandler = _safe_import(
 TaskExecutionHandler = _safe_import(
     "aragora.server.handlers.tasks.execution", "TaskExecutionHandler"
 )
+TaskQueueHandler = _safe_import("aragora.server.handlers.tasks.queue", "TaskQueueHandler")
 
 # Decision plans
 PlansHandler = _safe_import("aragora.server.handlers.plans", "PlansHandler")
@@ -629,6 +630,7 @@ ADMIN_HANDLER_REGISTRY: list[tuple[str, object]] = [
     ("_gastown_dashboard_handler", GasTownDashboardHandler),
     ("_connector_management_handler", ConnectorManagementHandler),
     ("_task_execution_handler", TaskExecutionHandler),
+    ("_task_queue_handler", TaskQueueHandler),
     # Decision plans
     ("_plans_handler", PlansHandler),
     # Playground (public demo)
@@ -823,6 +825,7 @@ __all__ = [
     "GasTownDashboardHandler",
     "ConnectorManagementHandler",
     "TaskExecutionHandler",
+    "TaskQueueHandler",
     # Decision plans
     "PlansHandler",
     # Playground

--- a/aragora/server/handlers/__init__.py
+++ b/aragora/server/handlers/__init__.py
@@ -405,6 +405,7 @@ if TYPE_CHECKING:
     from .sso import SSOHandler
     from .streaming.handler import StreamingConnectorHandler
     from .tasks.execution import TaskExecutionHandler
+    from .tasks.queue import TaskQueueHandler
     from .template_discovery import TemplateDiscoveryHandler
     from .template_marketplace import TemplateMarketplaceHandler
     from .threat_intel import ThreatIntelHandler
@@ -855,6 +856,7 @@ __all__ = [
     "StreamingConnectorHandler",
     # tasks
     "TaskExecutionHandler",
+    "TaskQueueHandler",
     # top-level handlers
     "AuditTrailHandler",
     "BenchmarkingHandler",

--- a/aragora/server/handlers/_lazy_imports.py
+++ b/aragora/server/handlers/_lazy_imports.py
@@ -181,6 +181,7 @@ HANDLER_MODULES: dict[str, str] = {
     "StreamingConnectorHandler": "aragora.server.handlers.streaming.handler",
     # tasks/ directory
     "TaskExecutionHandler": "aragora.server.handlers.tasks.execution",
+    "TaskQueueHandler": "aragora.server.handlers.tasks.queue",
     # verification/ directory
     "FormalVerificationHandler": "aragora.server.handlers.verification",
     "VerificationHandler": "aragora.server.handlers.verification",
@@ -630,6 +631,7 @@ ALL_HANDLER_NAMES: list[str] = [
     "StreamingConnectorHandler",
     # tasks
     "TaskExecutionHandler",
+    "TaskQueueHandler",
     # top-level handlers
     "AuditTrailHandler",
     "BenchmarkingHandler",

--- a/aragora/server/handlers/_stability.py
+++ b/aragora/server/handlers/_stability.py
@@ -252,6 +252,7 @@ HANDLER_STABILITY: dict[str, Stability] = {
     "StreamingConnectorHandler": Stability.EXPERIMENTAL,
     # tasks
     "TaskExecutionHandler": Stability.EXPERIMENTAL,
+    "TaskQueueHandler": Stability.EXPERIMENTAL,
     # top-level handlers
     "AuditTrailHandler": Stability.STABLE,
     "BenchmarkingHandler": Stability.EXPERIMENTAL,

--- a/aragora/server/handlers/tasks/__init__.py
+++ b/aragora/server/handlers/tasks/__init__.py
@@ -1,15 +1,17 @@
 """
 Task Execution Handler Package.
 
-Exposes the TaskExecutionHandler for registration with the server's
-handler registry. This handler bridges debate decisions to actionable
-task execution via the workflow engine and control plane scheduler.
+Exposes task-oriented handlers for registration with the server's
+handler registry. These handlers cover both execution-oriented tasks
+and the public queue / lease operator surface.
 """
 
 from __future__ import annotations
 
 from aragora.server.handlers.tasks.execution import TaskExecutionHandler
+from aragora.server.handlers.tasks.queue import TaskQueueHandler
 
 __all__ = [
     "TaskExecutionHandler",
+    "TaskQueueHandler",
 ]

--- a/aragora/server/handlers/tasks/queue.py
+++ b/aragora/server/handlers/tasks/queue.py
@@ -1,0 +1,354 @@
+"""Public REST surface for the developer task queue and lease lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from aragora.server.http_utils import run_async as _run_async
+from aragora.server.handlers.base import (
+    BaseHandler,
+    HandlerResult,
+    error_response,
+    handle_errors,
+    json_response,
+)
+from aragora.server.handlers.utils.rate_limit import rate_limit
+from aragora.worktree.fleet import resolve_repo_root
+
+logger = logging.getLogger(__name__)
+
+
+def _await_if_needed(result: Any) -> Any:
+    if inspect.isawaitable(result):
+        return asyncio.run(result)
+    return result
+
+
+class TaskQueueHandler(BaseHandler):
+    """Expose queue inspection plus lease-scoped lifecycle endpoints."""
+
+    ROUTES = [
+        "/api/v1/tasks/queue",
+        "/api/v1/tasks/queue/*",
+        "/api/v1/tasks/leases",
+        "/api/v1/tasks/leases/*",
+        "/api/v1/tasks/salvage",
+    ]
+
+    def can_handle(self, path: str, method: str = "GET") -> bool:
+        return (
+            path.startswith("/api/v1/tasks/queue")
+            or path.startswith("/api/v1/tasks/leases")
+            or path == "/api/v1/tasks/salvage"
+        )
+
+    def _repo_root(self) -> Path:
+        repo_hint = Path(str(self.ctx.get("repo_root", ".")))
+        return resolve_repo_root(repo_hint)
+
+    def _get_store(self):  # type: ignore[return]
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+
+        return DevCoordinationStore(repo_root=self._repo_root())
+
+    def _get_queue(self):  # type: ignore[return]
+        from aragora.nomic.global_work_queue import GlobalWorkQueue
+
+        queue = GlobalWorkQueue(storage_dir=self._repo_root() / ".work_queue")
+        _run_async(queue.initialize())
+        return queue
+
+    @staticmethod
+    def _serialize(item: Any) -> dict[str, Any]:
+        if hasattr(item, "to_dict"):
+            return item.to_dict()
+        if isinstance(item, dict):
+            return item
+        raise TypeError(f"Unsupported payload type: {type(item)!r}")
+
+    @staticmethod
+    def _active_lease(store: Any, lease_id: str) -> Any | None:
+        for lease in store.list_active_leases():
+            if getattr(lease, "lease_id", "") == lease_id:
+                return lease
+        return None
+
+    @staticmethod
+    def _parse_queue_filters(query_params: dict[str, Any]) -> tuple[Any, Any, int] | HandlerResult:
+        from aragora.nomic.global_work_queue import WorkStatus, WorkType
+
+        status = query_params.get("status")
+        work_type = query_params.get("work_type")
+        limit_raw = query_params.get("limit", 20)
+        try:
+            limit = int(limit_raw)
+        except (ValueError, TypeError):
+            return error_response("limit must be an integer", 400)
+        limit = max(1, min(limit, 100))
+
+        try:
+            parsed_status = WorkStatus(str(status)) if status else None
+        except ValueError:
+            return error_response(f"Invalid status: {status}", 400)
+        try:
+            parsed_type = WorkType(str(work_type)) if work_type else None
+        except ValueError:
+            return error_response(f"Invalid work_type: {work_type}", 400)
+        return parsed_status, parsed_type, limit
+
+    @rate_limit(requests_per_minute=60)
+    def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        if not self.can_handle(path):
+            return None
+
+        user, err = self.require_auth_or_error(handler)
+        if err:
+            return err
+        _, perm_err = self.require_permission_or_error(handler, "tasks:read")
+        if perm_err:
+            return perm_err
+        _ = user
+
+        if path == "/api/v1/tasks/leases":
+            return self._handle_list_leases()
+        if path == "/api/v1/tasks/salvage":
+            return self._handle_list_salvage()
+        if path == "/api/v1/tasks/queue/stats":
+            return self._handle_stats()
+        if path == "/api/v1/tasks/queue":
+            return self._handle_list_queue(query_params)
+
+        parts = path.rstrip("/").split("/")
+        if len(parts) == 6 and parts[4] == "queue":
+            return self._handle_get_task(parts[5])
+        return error_response("Not found", 404)
+
+    @handle_errors("task queue")
+    @rate_limit(requests_per_minute=30)
+    def handle_post(
+        self, path: str, query_params: dict[str, Any], handler: Any
+    ) -> HandlerResult | None:
+        if not self.can_handle(path):
+            return None
+
+        user, err = self.require_auth_or_error(handler)
+        if err:
+            return err
+        _, perm_err = self.require_permission_or_error(handler, "tasks:execute")
+        if perm_err:
+            return perm_err
+        _ = user
+
+        body = self.read_json_body(handler) or {}
+        parts = path.rstrip("/").split("/")
+
+        if path == "/api/v1/tasks/queue/sync":
+            return self._handle_sync(body)
+        if len(parts) == 7 and parts[4] == "queue" and parts[6] == "claim":
+            return self._handle_claim(parts[5], body)
+        if len(parts) == 7 and parts[4] == "leases":
+            lease_id = parts[5]
+            action = parts[6]
+            if action == "heartbeat":
+                return self._handle_heartbeat(lease_id, body)
+            if action == "release":
+                return self._handle_release(lease_id)
+            if action == "complete":
+                return self._handle_complete(lease_id, body)
+        return error_response("Not found", 404)
+
+    def _handle_list_queue(self, query_params: dict[str, Any]) -> HandlerResult:
+        parsed = self._parse_queue_filters(query_params)
+        if isinstance(parsed, HandlerResult):
+            return parsed
+        status, work_type, limit = parsed
+        queue = self._get_queue()
+        items = _await_if_needed(queue.list_items(status=status, work_type=work_type, limit=limit))
+        payload = [self._serialize(item) for item in items]
+        return json_response({"data": payload, "count": len(payload)})
+
+    def _handle_get_task(self, task_id: str) -> HandlerResult:
+        queue = self._get_queue()
+        item = _await_if_needed(queue.get(task_id))
+        if item is None:
+            return error_response(f"Task {task_id} not found", 404)
+        return json_response({"data": self._serialize(item)})
+
+    def _handle_list_leases(self) -> HandlerResult:
+        store = self._get_store()
+        payload = [lease.to_dict() for lease in store.list_active_leases()]
+        return json_response({"data": payload, "count": len(payload)})
+
+    def _handle_list_salvage(self) -> HandlerResult:
+        store = self._get_store()
+        payload = [candidate.to_dict() for candidate in store.list_salvage_candidates()]
+        return json_response({"data": payload, "count": len(payload)})
+
+    def _handle_stats(self) -> HandlerResult:
+        queue = self._get_queue()
+        return json_response({"data": _await_if_needed(queue.get_statistics())})
+
+    def _handle_claim(self, task_id: str, body: dict[str, Any]) -> HandlerResult:
+        from aragora.nomic.dev_coordination import LeaseConflictError
+
+        store = self._get_store()
+        queue = self._get_queue()
+        title = str(body.get("title") or task_id).strip() or task_id
+        expected_tests = [str(item) for item in body.get("expected_tests", []) if str(item).strip()]
+        allowed_globs = [str(item) for item in body.get("allowed_globs", []) if str(item).strip()]
+        claimed_paths = [str(item) for item in body.get("claimed_paths", []) if str(item).strip()]
+
+        item = _await_if_needed(queue.get(task_id))
+        developer_task = None
+        if item is not None:
+            payload = self._serialize(item)
+            if title == task_id:
+                title = str(payload.get("title") or title)
+            metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+            if isinstance(metadata, dict):
+                if not allowed_globs:
+                    allowed_globs = [
+                        str(path) for path in metadata.get("allowed_paths", []) if str(path).strip()
+                    ]
+                if not expected_tests:
+                    expected_tests = [
+                        str(test)
+                        for test in metadata.get("acceptance_checks", [])
+                        if str(test).strip()
+                    ]
+        elif task_id.startswith("task:"):
+            developer_task = store.get_developer_task(task_id.split("task:", 1)[1])
+            if developer_task is not None:
+                if title == task_id:
+                    title = developer_task.title or title
+                if not allowed_globs:
+                    allowed_globs = [
+                        str(path) for path in developer_task.allowed_paths if str(path).strip()
+                    ]
+                if not expected_tests:
+                    expected_tests = [
+                        str(test) for test in developer_task.acceptance_checks if str(test).strip()
+                    ]
+
+        if item is None and developer_task is None:
+            return error_response(f"Task {task_id} not found", 404)
+
+        ttl_hours = float(body.get("ttl_hours", 8.0))
+        try:
+            lease = store.claim_lease(
+                task_id=task_id,
+                title=title,
+                owner_agent=str(body.get("owner_agent", "unknown")).strip() or "unknown",
+                owner_session_id=str(body.get("owner_session_id", "public-api")).strip()
+                or "public-api",
+                branch=str(body.get("branch", "")).strip(),
+                worktree_path=str(body.get("worktree_path", self._repo_root())).strip()
+                or str(self._repo_root()),
+                allowed_globs=allowed_globs,
+                claimed_paths=claimed_paths,
+                expected_tests=expected_tests,
+                ttl_hours=ttl_hours,
+                metadata=body.get("metadata") if isinstance(body.get("metadata"), dict) else None,
+                allow_overlap=bool(body.get("allow_overlap", False)),
+            )
+        except LeaseConflictError as exc:
+            return json_response({"error": str(exc), "conflicts": exc.conflicts}, status=409)
+        return json_response({"data": lease.to_dict()}, status=201)
+
+    def _handle_heartbeat(self, lease_id: str, body: dict[str, Any]) -> HandlerResult:
+        store = self._get_store()
+        ttl_hours = body.get("ttl_hours")
+        try:
+            lease = store.heartbeat_lease(
+                lease_id, ttl_hours=float(ttl_hours) if ttl_hours is not None else None
+            )
+        except KeyError as exc:
+            return error_response(str(exc), 404)
+        return json_response({"data": lease.to_dict()})
+
+    def _handle_release(self, lease_id: str) -> HandlerResult:
+        store = self._get_store()
+        try:
+            lease = store.release_lease(lease_id)
+        except KeyError as exc:
+            return error_response(str(exc), 404)
+        return json_response({"data": lease.to_dict()})
+
+    def _handle_complete(self, lease_id: str, body: dict[str, Any]) -> HandlerResult:
+        from aragora.nomic.dev_coordination import FileScopeViolationError, LeaseConflictError
+
+        store = self._get_store()
+        active_lease = self._active_lease(store, lease_id)
+        try:
+            receipt = store.record_completion(
+                lease_id=lease_id,
+                owner_agent=str(
+                    body.get("owner_agent") or getattr(active_lease, "owner_agent", "") or "unknown"
+                ),
+                owner_session_id=str(
+                    body.get("owner_session_id")
+                    or getattr(active_lease, "owner_session_id", "")
+                    or "public-api"
+                ),
+                branch=str(body.get("branch") or getattr(active_lease, "branch", "") or ""),
+                worktree_path=str(
+                    body.get("worktree_path")
+                    or getattr(active_lease, "worktree_path", "")
+                    or self._repo_root()
+                ),
+                base_sha=str(body.get("base_sha") or "").strip() or None,
+                head_sha=str(body.get("head_sha") or "").strip() or None,
+                commit_shas=[
+                    str(item) for item in body.get("commit_shas", []) if str(item).strip()
+                ],
+                changed_paths=[
+                    str(item) for item in body.get("changed_paths", []) if str(item).strip()
+                ],
+                tests_run=[str(item) for item in body.get("tests_run", []) if str(item).strip()],
+                validations_run=[
+                    str(item) for item in body.get("validations_run", []) if str(item).strip()
+                ],
+                assumptions=[
+                    str(item) for item in body.get("assumptions", []) if str(item).strip()
+                ],
+                blockers=[str(item) for item in body.get("blockers", []) if str(item).strip()],
+                outcome=str(body.get("outcome", "completed")).strip() or "completed",
+                risks=[str(item) for item in body.get("risks", []) if str(item).strip()],
+                pr_url=str(body.get("pr_url") or "").strip() or None,
+                pr_number=body.get("pr_number"),
+                confidence=float(body.get("confidence", 0.0)),
+                metadata=body.get("metadata") if isinstance(body.get("metadata"), dict) else None,
+            )
+        except KeyError as exc:
+            return error_response(str(exc), 404)
+        except FileScopeViolationError as exc:
+            return json_response({"error": str(exc), "violations": exc.violations}, status=409)
+        except LeaseConflictError as exc:
+            return json_response({"error": str(exc), "conflicts": exc.conflicts}, status=409)
+        return json_response({"data": receipt.to_dict()})
+
+    def _handle_sync(self, body: dict[str, Any]) -> HandlerResult:
+        store = self._get_store()
+        queue = self._get_queue()
+        include_pending = bool(body.get("include_pending", True))
+        include_developer_tasks = bool(body.get("include_developer_tasks", True))
+        complete_missing = bool(body.get("complete_missing", True))
+        payload: dict[str, Any] = {}
+        try:
+            if include_developer_tasks:
+                payload["developer_tasks"] = _await_if_needed(
+                    store.sync_developer_task_queue(queue, complete_missing=complete_missing)
+                )
+            if include_pending:
+                payload["pending"] = _await_if_needed(
+                    store.sync_pending_work_queue(queue, complete_missing=complete_missing)
+                )
+        except (RuntimeError, OSError, ValueError, sqlite3.Error) as exc:
+            logger.warning("Task queue sync failed: %s", exc)
+            return error_response(str(exc), 500)
+        return json_response({"data": payload})

--- a/tests/cli/test_tasks_command.py
+++ b/tests/cli/test_tasks_command.py
@@ -1,0 +1,155 @@
+"""Tests for the public ``aragora tasks`` command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from aragora.cli.parser import build_parser
+
+
+def _lease_payload(lease_id: str = "lease-1") -> dict[str, object]:
+    return {
+        "lease_id": lease_id,
+        "task_id": "task:demo",
+        "owner_agent": "codex",
+        "owner_session_id": "session-1",
+        "branch": "codex/demo",
+        "worktree_path": "/tmp/wt",
+        "status": "active",
+        "expires_at": "2026-03-18T12:00:00+00:00",
+    }
+
+
+class TestTasksParser:
+    def test_tasks_registered_in_root_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "claim", "task:demo", "--ttl-hours", "4"])
+        assert args.command == "tasks"
+        assert args.tasks_command == "claim"
+        assert args.task_id == "task:demo"
+        assert args.ttl_hours == 4.0
+
+    def test_tasks_release_uses_lease_id(self):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "release", "lease-123"])
+        assert args.command == "tasks"
+        assert args.tasks_command == "release"
+        assert args.lease_id == "lease-123"
+
+
+class TestTasksCommand:
+    def test_list_json_output(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "list", "--status", "pending", "--format", "json"])
+        queue = MagicMock()
+        item = MagicMock()
+        item.to_dict.return_value = {
+            "id": "task:demo",
+            "status": "pending",
+            "work_type": "custom",
+            "computed_priority": 88,
+            "title": "Demo task",
+        }
+        queue.list_items.return_value = [item]
+
+        with patch("aragora.cli.commands.tasks._load_queue", return_value=queue):
+            args.func(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload[0]["id"] == "task:demo"
+        queue.list_items.assert_called_once()
+
+    def test_claim_uses_queue_defaults(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "claim", "task:demo", "--format", "json"])
+        queue = MagicMock()
+        queue_item = MagicMock()
+        queue_item.to_dict.return_value = {
+            "id": "task:demo",
+            "title": "Refactor queue API",
+            "metadata": {
+                "allowed_paths": ["aragora/nomic/dev_coordination.py"],
+                "acceptance_checks": ["pytest tests/nomic/test_dev_coordination.py -q"],
+            },
+        }
+        queue.get.return_value = queue_item
+
+        store = MagicMock()
+        store.get_developer_task.return_value = None
+        lease = MagicMock()
+        lease.to_dict.return_value = _lease_payload()
+        store.claim_lease.return_value = lease
+
+        with (
+            patch("aragora.cli.commands.tasks._load_queue", return_value=queue),
+            patch("aragora.cli.commands.tasks._load_store", return_value=store),
+            patch("aragora.cli.commands.tasks._repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.cli.commands.tasks._current_branch", return_value="codex/demo"),
+        ):
+            args.func(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["lease_id"] == "lease-1"
+        store.claim_lease.assert_called_once()
+        kwargs = store.claim_lease.call_args.kwargs
+        assert kwargs["task_id"] == "task:demo"
+        assert kwargs["title"] == "Refactor queue API"
+        assert kwargs["allowed_globs"] == ["aragora/nomic/dev_coordination.py"]
+        assert kwargs["expected_tests"] == ["pytest tests/nomic/test_dev_coordination.py -q"]
+
+    def test_complete_uses_active_lease_defaults(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "complete", "lease-1", "--head-sha", "abc123"])
+        active_lease = SimpleNamespace(
+            lease_id="lease-1",
+            owner_agent="codex",
+            owner_session_id="session-1",
+            branch="codex/demo",
+            worktree_path="/tmp/wt",
+        )
+        receipt = MagicMock()
+        receipt.to_dict.return_value = {
+            "receipt_id": "receipt-1",
+            "lease_id": "lease-1",
+            "head_sha": "abc123",
+        }
+        store = MagicMock()
+        store.list_active_leases.return_value = [active_lease]
+        store.record_completion.return_value = receipt
+
+        with (
+            patch("aragora.cli.commands.tasks._load_store", return_value=store),
+            patch("aragora.cli.commands.tasks._repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.cli.commands.tasks._current_branch", return_value="codex/demo"),
+        ):
+            args.func(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["receipt_id"] == "receipt-1"
+        kwargs = store.record_completion.call_args.kwargs
+        assert kwargs["lease_id"] == "lease-1"
+        assert kwargs["owner_agent"] == "codex"
+        assert kwargs["branch"] == "codex/demo"
+        assert kwargs["worktree_path"] == "/tmp/wt"
+        assert kwargs["head_sha"] == "abc123"
+
+    def test_sync_runs_both_projections(self, capsys):
+        parser = build_parser()
+        args = parser.parse_args(["tasks", "sync", "--format", "json"])
+        queue = MagicMock()
+        store = MagicMock()
+        store.sync_developer_task_queue.return_value = {"created": 2}
+        store.sync_pending_work_queue.return_value = {"updated": 1}
+
+        with (
+            patch("aragora.cli.commands.tasks._load_store", return_value=store),
+            patch("aragora.cli.commands.tasks._load_queue", return_value=queue),
+        ):
+            args.func(args)
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["developer_tasks"]["created"] == 2
+        assert payload["pending"]["updated"] == 1

--- a/tests/handlers/tasks/test_queue.py
+++ b/tests/handlers/tasks/test_queue.py
@@ -1,0 +1,194 @@
+"""Tests for the public task queue handler."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.nomic.global_work_queue import WorkStatus, WorkType
+from aragora.server.handlers.tasks.queue import TaskQueueHandler
+
+
+def _body(result) -> dict:
+    raw = result.body
+    if isinstance(raw, (bytes, bytearray)):
+        return json.loads(raw.decode("utf-8"))
+    if isinstance(raw, str):
+        return json.loads(raw)
+    return raw
+
+
+@pytest.fixture
+def handler() -> TaskQueueHandler:
+    return TaskQueueHandler({})
+
+
+class TestCanHandle:
+    def test_task_queue_paths(self, handler: TaskQueueHandler):
+        assert handler.can_handle("/api/v1/tasks/queue")
+        assert handler.can_handle("/api/v1/tasks/queue/task:demo")
+        assert handler.can_handle("/api/v1/tasks/leases")
+        assert handler.can_handle("/api/v1/tasks/leases/lease-1/release")
+        assert handler.can_handle("/api/v1/tasks/salvage")
+        assert not handler.can_handle("/api/v2/tasks")
+
+
+class TestReads:
+    def test_list_queue_maps_status_and_work_type(self, handler: TaskQueueHandler):
+        queue = MagicMock()
+        item = MagicMock()
+        item.to_dict.return_value = {
+            "id": "task:demo",
+            "status": "pending",
+            "work_type": "custom",
+            "title": "Demo task",
+        }
+        queue.list_items.return_value = [item]
+
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "_get_queue", return_value=queue),
+        ):
+            result = handler.handle(
+                "/api/v1/tasks/queue",
+                {"status": "pending", "work_type": "custom", "limit": "5"},
+                MagicMock(),
+            )
+
+        assert result.status_code == 200
+        payload = _body(result)
+        assert payload["count"] == 1
+        queue.list_items.assert_called_once_with(
+            status=WorkStatus.PENDING,
+            work_type=WorkType.CUSTOM,
+            limit=5,
+        )
+
+    def test_invalid_queue_status_returns_400(self, handler: TaskQueueHandler):
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+        ):
+            result = handler.handle("/api/v1/tasks/queue", {"status": "bogus"}, MagicMock())
+
+        assert result.status_code == 400
+
+
+class TestWrites:
+    def test_claim_uses_task_metadata(self, handler: TaskQueueHandler):
+        queue = MagicMock()
+        item = MagicMock()
+        item.to_dict.return_value = {
+            "id": "task:demo",
+            "title": "Refactor queue API",
+            "metadata": {
+                "allowed_paths": ["aragora/nomic/dev_coordination.py"],
+                "acceptance_checks": ["pytest tests/nomic/test_dev_coordination.py -q"],
+            },
+        }
+        queue.get.return_value = item
+
+        lease = MagicMock()
+        lease.to_dict.return_value = {
+            "lease_id": "lease-1",
+            "task_id": "task:demo",
+            "status": "active",
+        }
+        store = MagicMock()
+        store.claim_lease.return_value = lease
+
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "_get_queue", return_value=queue),
+            patch.object(handler, "_get_store", return_value=store),
+            patch.object(handler, "read_json_body", return_value={"owner_agent": "codex"}),
+        ):
+            result = handler.handle_post("/api/v1/tasks/queue/task:demo/claim", {}, MagicMock())
+
+        assert result.status_code == 201
+        payload = _body(result)
+        assert payload["data"]["lease_id"] == "lease-1"
+        kwargs = store.claim_lease.call_args.kwargs
+        assert kwargs["task_id"] == "task:demo"
+        assert kwargs["title"] == "Refactor queue API"
+        assert kwargs["allowed_globs"] == ["aragora/nomic/dev_coordination.py"]
+        assert kwargs["expected_tests"] == ["pytest tests/nomic/test_dev_coordination.py -q"]
+
+    def test_release_is_lease_scoped(self, handler: TaskQueueHandler):
+        lease = MagicMock()
+        lease.to_dict.return_value = {"lease_id": "lease-1", "status": "released"}
+        store = MagicMock()
+        store.release_lease.return_value = lease
+
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "_get_store", return_value=store),
+            patch.object(handler, "read_json_body", return_value={}),
+        ):
+            result = handler.handle_post("/api/v1/tasks/leases/lease-1/release", {}, MagicMock())
+
+        assert result.status_code == 200
+        store.release_lease.assert_called_once_with("lease-1")
+
+    def test_complete_uses_active_lease_defaults(self, handler: TaskQueueHandler):
+        active_lease = SimpleNamespace(
+            lease_id="lease-1",
+            owner_agent="codex",
+            owner_session_id="session-1",
+            branch="codex/demo",
+            worktree_path="/tmp/wt",
+        )
+        receipt = MagicMock()
+        receipt.to_dict.return_value = {"receipt_id": "receipt-1", "lease_id": "lease-1"}
+        store = MagicMock()
+        store.list_active_leases.return_value = [active_lease]
+        store.record_completion.return_value = receipt
+
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "_get_store", return_value=store),
+            patch.object(
+                handler,
+                "read_json_body",
+                return_value={"head_sha": "abc123", "confidence": 0.9},
+            ),
+        ):
+            result = handler.handle_post("/api/v1/tasks/leases/lease-1/complete", {}, MagicMock())
+
+        assert result.status_code == 200
+        payload = _body(result)
+        assert payload["data"]["receipt_id"] == "receipt-1"
+        kwargs = store.record_completion.call_args.kwargs
+        assert kwargs["lease_id"] == "lease-1"
+        assert kwargs["owner_agent"] == "codex"
+        assert kwargs["owner_session_id"] == "session-1"
+        assert kwargs["branch"] == "codex/demo"
+        assert kwargs["worktree_path"] == "/tmp/wt"
+        assert kwargs["head_sha"] == "abc123"
+
+    def test_sync_projects_pending_and_developer_work(self, handler: TaskQueueHandler):
+        store = MagicMock()
+        store.sync_developer_task_queue.return_value = {"created": 2}
+        store.sync_pending_work_queue.return_value = {"updated": 1}
+        queue = MagicMock()
+
+        with (
+            patch.object(handler, "require_auth_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "require_permission_or_error", return_value=(MagicMock(), None)),
+            patch.object(handler, "_get_store", return_value=store),
+            patch.object(handler, "_get_queue", return_value=queue),
+            patch.object(handler, "read_json_body", return_value={}),
+        ):
+            result = handler.handle_post("/api/v1/tasks/queue/sync", {}, MagicMock())
+
+        assert result.status_code == 200
+        payload = _body(result)
+        assert payload["data"]["developer_tasks"]["created"] == 2
+        assert payload["data"]["pending"]["updated"] == 1

--- a/tests/server/handlers/test_rbac_coverage.py
+++ b/tests/server/handlers/test_rbac_coverage.py
@@ -125,6 +125,7 @@ EXEMPT_HANDLERS = frozenset(
         "EvolutionHandler",
         # Task execution (rate-limited, has internal validation)
         "TaskExecutionHandler",
+        "TaskQueueHandler",
         # Playground - intentionally public demo endpoint (rate-limited, mock agents only)
         "PlaygroundHandler",
         # Compliance reporting (uses internal auth or admin-only access)


### PR DESCRIPTION
## Summary
- add a public `aragora tasks` CLI for queue, lease, salvage, stats, and sync operations
- add `TaskQueueHandler` for `/api/v1/tasks/queue`, lease-scoped lifecycle endpoints, and explicit queue sync
- wire the new handler into parser/registry/stability metadata and cover the explicit task_id vs lease_id contract with tests

## Context
This is the clean follow-up to the closed backend tranche from #837. It rebuilds the missing public operator surface on top of current `dev_coordination` semantics instead of reviving the stale prototype's ambiguous ID handling.

## Verification
- `ruff check aragora/cli/commands/tasks.py aragora/cli/parser.py aragora/cli/commands/__init__.py aragora/server/handlers/tasks/__init__.py aragora/server/handlers/tasks/queue.py aragora/server/handlers/_lazy_imports.py aragora/server/handler_registry/admin.py aragora/server/handlers/__init__.py aragora/server/handlers/_stability.py tests/cli/test_tasks_command.py tests/handlers/tasks/test_queue.py tests/server/handlers/test_rbac_coverage.py`
- `python -m pytest tests/cli/test_tasks_command.py tests/handlers/tasks/test_queue.py tests/cli/test_swarm_command.py -q`

## Notes
A broader run including `tests/server/handlers/test_rbac_coverage.py` still fails on pre-existing unrelated handlers: `PipelineTelemetryHandler`, `MCPToolsHandler`, and `PublicDebateViewerHandler`. This PR only adds `TaskQueueHandler` to the exemption list so it doesn't introduce a new failure.