### PR TITLE
feat(receipts): add Ralph and boss-loop operational provenance

### DIFF
--- a/aragora/ralph/supervisor.py
+++ b/aragora/ralph/supervisor.py
@@ -283,6 +283,33 @@ class RalphSupervisor:
             self._pr_registry = PullRequestRegistry(state_dir=state_dir)
         return self._pr_registry
 
+    def _emit_operational_receipt(
+        self,
+        *,
+        state: SupervisorState,
+        action: str,
+        verdict: str,
+        outputs: dict[str, Any],
+    ) -> None:
+        try:
+            from aragora.receipts.provenance import emit_operational_receipt
+
+            emit_operational_receipt(
+                source="ralph",
+                action=action,
+                actor=state.supervisor_id or "ralph-supervisor",
+                inputs={
+                    "campaign_id": state.campaign_id,
+                    "campaign_manifest_path": state.campaign_manifest_path,
+                    "supervisor_id": state.supervisor_id,
+                    "current_step": state.current_step,
+                },
+                outputs=outputs,
+                verdict=verdict,
+            )
+        except Exception as exc:
+            logger.debug("Ralph operational receipt skipped: %s", exc)
+
     # -- public API --
 
     @classmethod
@@ -576,6 +603,17 @@ class RalphSupervisor:
 
         if stop_reason == "campaign_complete":
             state.status = SupervisorStatus.COMPLETED.value
+            self._emit_operational_receipt(
+                state=state,
+                action=SupervisorAction.CAMPAIGN_COMPLETED.value,
+                verdict="pass",
+                outputs={
+                    "status": SupervisorStatus.COMPLETED.value,
+                    "stop_reason": stop_reason,
+                    "budget_spent_usd": state.budget_spent_usd,
+                    "merge_ready_projects": len(merge_ready_projects),
+                },
+            )
             return StepResult(
                 action=SupervisorAction.CAMPAIGN_COMPLETED.value,
                 status=SupervisorStatus.COMPLETED.value,
@@ -1293,6 +1331,17 @@ class RalphSupervisor:
         state.status = SupervisorStatus.ESCALATED.value
         state.escalation_reason = reason
         logger.warning("Ralph supervisor escalating: %s", reason)
+        self._emit_operational_receipt(
+            state=state,
+            action=SupervisorAction.ESCALATED.value,
+            verdict="escalated",
+            outputs={
+                "status": SupervisorStatus.ESCALATED.value,
+                "reason": reason,
+                "active_blocker": state.active_blocker,
+                "repair_attempts": state.repair_attempts,
+            },
+        )
         return StepResult(
             action=SupervisorAction.ESCALATED.value,
             status=SupervisorStatus.ESCALATED.value,

--- a/aragora/receipts/__init__.py
+++ b/aragora/receipts/__init__.py
@@ -1,0 +1,5 @@
+"""Operational receipt helpers."""
+
+from .provenance import emit_operational_receipt
+
+__all__ = ["emit_operational_receipt"]

--- a/aragora/receipts/provenance.py
+++ b/aragora/receipts/provenance.py
@@ -1,0 +1,143 @@
+"""Best-effort provenance receipt emission for autonomous loops."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _get_facade() -> Any | None:
+    try:
+        from aragora.pipeline.receipt_store_facade import get_receipt_store_facade
+
+        return get_receipt_store_facade()
+    except (ImportError, RuntimeError, OSError, ValueError) as exc:
+        logger.debug("Receipt facade unavailable: %s", exc)
+        return None
+
+
+def _get_signer() -> Any | None:
+    try:
+        from aragora.gauntlet.signing import get_default_signer
+
+        return get_default_signer()
+    except (ImportError, RuntimeError, OSError, ValueError, TypeError) as exc:
+        logger.debug("Receipt signer unavailable: %s", exc)
+        return None
+
+
+def emit_operational_receipt(
+    *,
+    source: str,
+    action: str,
+    actor: str,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    verdict: str,
+    confidence: float = 0.0,
+    duration_seconds: float = 0.0,
+    receipt_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> str | None:
+    """Persist a best-effort signed receipt and never raise to the caller."""
+
+    facade = _get_facade()
+    if facade is None:
+        return None
+
+    receipt_id = receipt_id or f"op-{uuid.uuid4().hex[:12]}"
+    receipt_data = {
+        "receipt_id": receipt_id,
+        "receipt_type": "operational",
+        "source": source,
+        "action": action,
+        "actor": actor,
+        "inputs": inputs,
+        "outputs": outputs,
+        "verdict": verdict,
+        "confidence": confidence,
+        "duration_seconds": duration_seconds,
+        "metadata": dict(metadata or {}),
+        "generated_at": datetime.now(UTC).isoformat(),
+        "content_hash": _content_hash(
+            receipt_id=receipt_id,
+            source=source,
+            action=action,
+            actor=actor,
+            inputs=inputs,
+            outputs=outputs,
+            verdict=verdict,
+            confidence=confidence,
+        ),
+    }
+
+    signature = None
+    signature_key_id = None
+    signed_at = None
+    signature_algorithm = None
+
+    signer = _get_signer()
+    if signer is not None:
+        try:
+            signed = signer.sign(receipt_data)
+            metadata_obj = getattr(signed, "signature_metadata", None)
+            signature = getattr(signed, "signature", None)
+            signature_key_id = getattr(metadata_obj, "key_id", None)
+            signed_at = getattr(metadata_obj, "timestamp", None)
+            signature_algorithm = getattr(metadata_obj, "algorithm", None)
+        except (RuntimeError, ValueError, TypeError, AttributeError) as exc:
+            logger.debug("Receipt signing skipped for %s: %s", receipt_id, exc)
+
+    try:
+        facade.persist_and_save(
+            receipt_id,
+            receipt_data,
+            signature=signature,
+            signature_key_id=signature_key_id,
+            signed_at=signed_at,
+            signature_algorithm=signature_algorithm,
+            state="CREATED",
+        )
+    except (RuntimeError, OSError, ValueError, TypeError) as exc:
+        logger.debug("Receipt emission failed for %s: %s", receipt_id, exc)
+        return None
+
+    logger.info("Operational receipt emitted: %s (%s/%s)", receipt_id, source, action)
+    return receipt_id
+
+
+def _content_hash(
+    *,
+    receipt_id: str,
+    source: str,
+    action: str,
+    actor: str,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+    verdict: str,
+    confidence: float,
+) -> str:
+    content = json.dumps(
+        {
+            "receipt_id": receipt_id,
+            "source": source,
+            "action": action,
+            "actor": actor,
+            "inputs": inputs,
+            "outputs": outputs,
+            "verdict": verdict,
+            "confidence": confidence,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+__all__ = ["emit_operational_receipt"]

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -688,6 +688,53 @@ class BossLoop:
         self._issue_attempt_counts: dict[int, int] = {}
         self._stop_reason: str | None = None
 
+    def _emit_terminal_receipt(self, result: BossLoopResult) -> None:
+        try:
+            from aragora.receipts.provenance import emit_operational_receipt
+
+            attempted = len(result.issues_attempted)
+            completed = len(result.issues_completed)
+            failed = len(result.issues_failed)
+            if completed > 0:
+                verdict = "pass"
+            elif result.stop_reason in {
+                BossStopReason.NO_FRESH_RUNNER.value,
+                BossStopReason.NO_SUITABLE_ISSUE.value,
+                BossStopReason.NEEDS_HUMAN.value,
+            }:
+                verdict = "blocked"
+            else:
+                verdict = "fail"
+
+            emit_operational_receipt(
+                source="boss_loop",
+                action="run_completed",
+                actor="boss-loop",
+                inputs={
+                    "run_id": self.run_id,
+                    "repo": self.config.repo,
+                    "label_filter": self.config.label_filter,
+                    "max_iterations": self.config.max_iterations,
+                    "max_retries_per_issue": self.config.max_retries_per_issue,
+                    "max_consecutive_failures": self.config.max_consecutive_failures,
+                    "budget_limit_usd": self.config.budget_limit_usd,
+                },
+                outputs={
+                    "iterations_completed": result.iterations_completed,
+                    "stop_reason": result.stop_reason,
+                    "issues_attempted": attempted,
+                    "issues_completed": completed,
+                    "issues_failed": failed,
+                    "needs_human_reasons": list(result.needs_human_reasons),
+                    "next_actions": list(result.next_actions),
+                },
+                verdict=verdict,
+                confidence=(completed / attempted) if attempted else 0.0,
+                duration_seconds=result.total_elapsed_seconds,
+            )
+        except Exception as exc:
+            logger.debug("Boss loop operational receipt skipped: %s", exc)
+
     async def run(
         self,
         *,
@@ -742,7 +789,7 @@ class BossLoop:
             self._stop_reason = BossStopReason.MAX_ITERATIONS.value
 
         total_elapsed = time.monotonic() - start_time
-        return BossLoopResult(
+        result = BossLoopResult(
             run_id=self.run_id,
             iterations_completed=iteration,
             total_elapsed_seconds=total_elapsed,
@@ -754,6 +801,8 @@ class BossLoop:
             needs_human_reasons=self._collect_needs_human_reasons(),
             next_actions=self._derive_next_actions(),
         )
+        self._emit_terminal_receipt(result)
+        return result
 
     async def _run_iteration(self, iteration: int) -> BossIterationStatus:
         """Execute a single Boss loop iteration."""

--- a/tests/ralph/test_supervisor_receipts.py
+++ b/tests/ralph/test_supervisor_receipts.py
@@ -1,0 +1,121 @@
+"""Focused tests for Ralph operational receipt emission."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import yaml
+
+from aragora.ralph.classifier import BlockerKind
+from aragora.ralph.supervisor import (
+    RalphSupervisor,
+    SupervisorState,
+    SupervisorStatus,
+    load_supervisor_state,
+    save_supervisor_state,
+)
+
+
+def _write_manifest(path: Path, campaign_id: str = "test-campaign") -> Path:
+    manifest = {
+        "campaign_id": campaign_id,
+        "created_at": "2026-03-10T00:00:00Z",
+        "source_kind": "manual",
+        "source_ref": "test",
+        "worker_model": "codex",
+        "review_model": "claude",
+        "max_parallel_ready_projects": 1,
+        "max_retries_per_project": 2,
+        "budget_limit_usd": 20.0,
+        "time_limit_hours": 4.0,
+        "projects": [],
+        "execution_state": {"total_cost_usd": 3.5},
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(manifest), encoding="utf-8")
+    return path
+
+
+def _write_state(path: Path, **overrides: object) -> SupervisorState:
+    state = SupervisorState(
+        supervisor_id="ralph-test123",
+        campaign_manifest_path=str(overrides.pop("campaign_manifest_path", "/tmp/manifest.yaml")),
+        campaign_id="test-campaign",
+        **overrides,
+    )
+    save_supervisor_state(path, state)
+    return state
+
+
+class TestRalphOperationalReceipts:
+    def test_campaign_complete_emits_receipt(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+        )
+
+        with (
+            patch(
+                "aragora.swarm.campaign.CampaignExecutor.execute_once",
+                new=AsyncMock(
+                    return_value={"stop_reason": "campaign_complete", "dispatched_projects": []}
+                ),
+            ),
+            patch("aragora.receipts.provenance.emit_operational_receipt") as emit_receipt,
+        ):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.COMPLETED.value
+        emit_receipt.assert_called_once()
+        kwargs = emit_receipt.call_args.kwargs
+        assert kwargs["source"] == "ralph"
+        assert kwargs["action"] == "campaign_completed"
+        assert kwargs["inputs"]["campaign_id"] == "test-campaign"
+        assert kwargs["outputs"]["status"] == "completed"
+        state = load_supervisor_state(state_path)
+        assert state.status == SupervisorStatus.COMPLETED.value
+
+    def test_escalation_emits_receipt(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.BUDGET_EXHAUSTION.value,
+        )
+
+        with patch("aragora.receipts.provenance.emit_operational_receipt") as emit_receipt:
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.ESCALATED.value
+        emit_receipt.assert_called_once()
+        kwargs = emit_receipt.call_args.kwargs
+        assert kwargs["action"] == "escalated"
+        assert kwargs["verdict"] == "escalated"
+        assert kwargs["outputs"]["reason"].startswith("Non-deterministic blocker:")
+
+    def test_receipt_failures_do_not_block_escalation(self, tmp_path: Path) -> None:
+        manifest_path = _write_manifest(tmp_path / "manifest.yaml")
+        state_path = tmp_path / "state.yaml"
+        _write_state(
+            state_path,
+            campaign_manifest_path=str(manifest_path),
+            status=SupervisorStatus.RUNNING.value,
+            active_blocker=BlockerKind.BUDGET_EXHAUSTION.value,
+        )
+
+        with patch(
+            "aragora.receipts.provenance.emit_operational_receipt",
+            side_effect=RuntimeError("receipt path unavailable"),
+        ):
+            supervisor = RalphSupervisor(state_path=state_path, repo_root=tmp_path)
+            result = supervisor.step()
+
+        assert result.status == SupervisorStatus.ESCALATED.value

--- a/tests/receipts/test_provenance.py
+++ b/tests/receipts/test_provenance.py
@@ -1,0 +1,110 @@
+"""Tests for best-effort operational provenance receipts."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class TestEmitOperationalReceipt:
+    def test_persists_signed_receipt_when_dependencies_available(self) -> None:
+        from aragora.receipts.provenance import emit_operational_receipt
+
+        facade = MagicMock()
+        signer = MagicMock()
+        signed = MagicMock()
+        signed.signature = "sig-123"
+        signed.signature_metadata.key_id = "key-1"
+        signed.signature_metadata.timestamp = "2026-03-19T00:00:00+00:00"
+        signed.signature_metadata.algorithm = "hmac-sha256"
+        signer.sign.return_value = signed
+
+        with (
+            patch("aragora.receipts.provenance._get_facade", return_value=facade),
+            patch("aragora.receipts.provenance._get_signer", return_value=signer),
+        ):
+            receipt_id = emit_operational_receipt(
+                source="boss_loop",
+                action="run_completed",
+                actor="boss-loop",
+                inputs={"run_id": "boss-123"},
+                outputs={"stop_reason": "no_suitable_issue"},
+                verdict="blocked",
+                confidence=0.5,
+            )
+
+        assert receipt_id is not None
+        facade.persist_and_save.assert_called_once()
+        persisted_receipt_id, payload = facade.persist_and_save.call_args.args[:2]
+        assert persisted_receipt_id == receipt_id
+        assert payload["receipt_type"] == "operational"
+        assert payload["source"] == "boss_loop"
+        assert payload["action"] == "run_completed"
+        assert payload["verdict"] == "blocked"
+        kwargs = facade.persist_and_save.call_args.kwargs
+        assert kwargs["signature"] == "sig-123"
+        assert kwargs["signature_key_id"] == "key-1"
+        assert kwargs["state"] == "CREATED"
+
+    def test_returns_none_when_facade_is_unavailable(self) -> None:
+        from aragora.receipts.provenance import emit_operational_receipt
+
+        with patch("aragora.receipts.provenance._get_facade", return_value=None):
+            receipt_id = emit_operational_receipt(
+                source="ralph",
+                action="campaign_completed",
+                actor="ralph-123",
+                inputs={},
+                outputs={},
+                verdict="pass",
+            )
+
+        assert receipt_id is None
+
+    def test_signing_failure_does_not_block_persistence(self) -> None:
+        from aragora.receipts.provenance import emit_operational_receipt
+
+        facade = MagicMock()
+        signer = MagicMock()
+        signer.sign.side_effect = RuntimeError("no signer")
+
+        with (
+            patch("aragora.receipts.provenance._get_facade", return_value=facade),
+            patch("aragora.receipts.provenance._get_signer", return_value=signer),
+        ):
+            receipt_id = emit_operational_receipt(
+                source="ralph",
+                action="escalated",
+                actor="ralph-123",
+                inputs={"campaign_id": "camp-1"},
+                outputs={"reason": "budget"},
+                verdict="escalated",
+            )
+
+        assert receipt_id is not None
+        assert facade.persist_and_save.call_args.kwargs["signature"] is None
+
+    def test_content_hash_changes_when_payload_changes(self) -> None:
+        from aragora.receipts.provenance import _content_hash
+
+        first = _content_hash(
+            receipt_id="r-1",
+            source="ralph",
+            action="campaign_completed",
+            actor="ralph-123",
+            inputs={"campaign_id": "camp-1"},
+            outputs={"status": "completed"},
+            verdict="pass",
+            confidence=1.0,
+        )
+        second = _content_hash(
+            receipt_id="r-1",
+            source="ralph",
+            action="campaign_completed",
+            actor="ralph-123",
+            inputs={"campaign_id": "camp-1"},
+            outputs={"status": "escalated"},
+            verdict="escalated",
+            confidence=0.0,
+        )
+
+        assert first != second

--- a/tests/swarm/test_boss_loop_receipts.py
+++ b/tests/swarm/test_boss_loop_receipts.py
@@ -1,0 +1,63 @@
+"""Focused tests for BossLoop operational receipt emission."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+from aragora.swarm.boss_loop import BossLoop, BossLoopConfig, BossStopReason, RunnerFreshnessResult
+
+UTC = timezone.utc
+
+
+def _fresh_result(
+    *, fresh: bool = True, blocked_reason: str | None = None
+) -> RunnerFreshnessResult:
+    return RunnerFreshnessResult(
+        fresh=fresh,
+        runner_ids=["codex-runner-1"] if fresh else [],
+        checked_at=datetime.now(UTC).isoformat(),
+        blocked_reason=blocked_reason,
+    )
+
+
+class TestBossLoopOperationalReceipts:
+    def test_run_emits_terminal_receipt(self) -> None:
+        feed = MagicMock()
+        feed.fetch.return_value = []
+
+        loop = BossLoop(
+            config=BossLoopConfig(max_iterations=1, iteration_interval_seconds=0.0),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        with patch("aragora.receipts.provenance.emit_operational_receipt") as emit_receipt:
+            result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        emit_receipt.assert_called_once()
+        kwargs = emit_receipt.call_args.kwargs
+        assert kwargs["source"] == "boss_loop"
+        assert kwargs["action"] == "run_completed"
+        assert kwargs["inputs"]["run_id"] == result.run_id
+        assert kwargs["outputs"]["stop_reason"] == BossStopReason.NO_SUITABLE_ISSUE.value
+
+    def test_receipt_failures_do_not_block_run_completion(self) -> None:
+        feed = MagicMock()
+        feed.fetch.return_value = []
+
+        loop = BossLoop(
+            config=BossLoopConfig(max_iterations=1, iteration_interval_seconds=0.0),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        with patch(
+            "aragora.receipts.provenance.emit_operational_receipt",
+            side_effect=RuntimeError("receipt store unavailable"),
+        ):
+            result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value


### PR DESCRIPTION
## Summary
- add a small best-effort operational provenance helper backed by the canonical receipt facade
- emit operational receipts from Ralph terminal completion/escalation paths and BossLoop terminal summaries
- cover the helper and both integrations with focused tests

## Verification
- ruff check aragora/receipts/provenance.py aragora/ralph/supervisor.py aragora/swarm/boss_loop.py tests/receipts/test_provenance.py tests/ralph/test_supervisor_receipts.py tests/swarm/test_boss_loop_receipts.py
- python -m pytest tests/receipts/test_provenance.py tests/ralph/test_supervisor_receipts.py tests/swarm/test_boss_loop_receipts.py tests/swarm/test_boss_loop.py -q

## Notes
- This is the remaining follow-up sliver after the broader #842 work was closed on main.
- I did not revive the stale SwarmSupervisor duplicate receipt path because main already has canonical completion receipts there.
