### PR TITLE
feat(swarm): gate boss-loop dispatch on validation contract

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -537,6 +537,10 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             target_branch=target_branch,
             budget_limit_usd=budget_limit,
             max_consecutive_failures=int(getattr(args, "max_consecutive_failures", 3) or 3),
+            require_validation_contract=not bool(
+                getattr(args, "allow_missing_validation_contract", False)
+            ),
+            dispatch_enabled=not no_dispatch,
         )
         loop = BossLoop(config=boss_loop_config)
 

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2350,6 +2350,11 @@ def _add_swarm_parser(subparsers) -> None:
         help="Stop boss-loop after N consecutive worker failures (default: 3)",
     )
     swarm_parser.add_argument(
+        "--allow-missing-validation-contract",
+        action="store_true",
+        help="Allow boss-loop dispatch even when the issue body lacks explicit validation criteria",
+    )
+    swarm_parser.add_argument(
         "--source-file",
         help="Campaign planner input markdown/text file",
     )

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 import time
 import uuid
@@ -170,6 +171,96 @@ def select_eligible_issue(
             continue
         return issue
     return None
+
+
+_VALIDATION_SECTION_PREFIXES = (
+    "acceptance criteria",
+    "validation",
+    "validation contract",
+    "definition of done",
+    "done when",
+    "test plan",
+)
+_VALIDATION_INLINE_PREFIXES = (
+    "acceptance",
+    "acceptance criteria",
+    "validation",
+    "validation contract",
+    "definition of done",
+    "done when",
+    "test plan",
+)
+_VALIDATION_BULLET_RE = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(?:\[(?: |x|X)\]\s*)?(?P<text>.+?)\s*$")
+
+
+def _ordered_unique_strings(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+def extract_issue_validation_contract(issue_body: str) -> list[str]:
+    """Extract an explicit validation contract from a GitHub issue body.
+
+    Supported forms:
+    - bullets/checklists under headings such as "Acceptance Criteria" or "Validation"
+    - inline markers such as "Validation: pytest -q ..."
+    - standalone pytest commands anywhere in the issue body
+    """
+    lines = [str(line).rstrip() for line in str(issue_body or "").splitlines()]
+    criteria: list[str] = []
+    in_validation_section = False
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        normalized = stripped.lstrip("#").strip()
+        normalized_lower = normalized.rstrip(":").strip().lower()
+
+        if any(
+            normalized_lower == prefix or normalized_lower.startswith(f"{prefix} ")
+            for prefix in _VALIDATION_SECTION_PREFIXES
+        ):
+            in_validation_section = True
+            continue
+
+        inline_prefix, _, inline_value = normalized.partition(":")
+        if inline_value and inline_prefix.strip().lower() in _VALIDATION_INLINE_PREFIXES:
+            criteria.append(inline_value.strip())
+            in_validation_section = False
+            continue
+
+        if stripped.startswith("pytest ") or stripped.startswith("python -m pytest"):
+            criteria.append(stripped)
+            continue
+
+        if not in_validation_section:
+            continue
+
+        if stripped.startswith("#"):
+            in_validation_section = False
+            continue
+
+        bullet_match = _VALIDATION_BULLET_RE.match(stripped)
+        if bullet_match:
+            criteria.append(bullet_match.group("text"))
+            continue
+
+        if not stripped:
+            continue
+
+        if normalized.endswith(":"):
+            in_validation_section = False
+            continue
+
+        criteria.append(stripped)
+
+    return _ordered_unique_strings(criteria)
 
 
 # ---------------------------------------------------------------------------
@@ -410,6 +501,7 @@ class BossLoopConfig:
     issue_limit: int = 25
     skip_labels: set[str] = field(default_factory=lambda: {"wontfix", "duplicate", "invalid"})
     require_labels: set[str] | None = None
+    require_validation_contract: bool = True
 
     # Retry / self-correction
     max_consecutive_failures: int = 3
@@ -418,6 +510,7 @@ class BossLoopConfig:
     # Dispatch
     target_branch: str = "main"
     budget_limit_usd: float = 5.0
+    dispatch_enabled: bool = True
 
     # Reporting
     status_report_interval: int = 5  # every N iterations
@@ -919,6 +1012,11 @@ class BossLoop:
 
         if worker_result.get("status") == "needs_human":
             self._failed_issues.append(issue_dict)
+            next_actions = [
+                str(item).strip()
+                for item in worker_result.get("next_actions", [])
+                if str(item).strip()
+            ] or ["Review the worker output and decide next steps."]
             return BossIterationStatus(
                 iteration=iteration,
                 run_id=self.run_id,
@@ -928,7 +1026,7 @@ class BossLoop:
                 worker_status="needs_human",
                 stop_reason=BossStopReason.NEEDS_HUMAN.value,
                 needs_human_reasons=worker_result.get("reasons", ["Worker requires human input."]),
-                next_actions=["Review the worker output and decide next steps."],
+                next_actions=next_actions,
                 elapsed_seconds=elapsed,
             )
 
@@ -996,12 +1094,45 @@ class BossLoop:
             requires_approval=True,
             user_expertise="developer",
         )
+        validation_contract = extract_issue_validation_contract(issue.body)
+        if validation_contract:
+            spec.acceptance_criteria = list(validation_contract)
+
+        if self.config.require_validation_contract and not bool(
+            getattr(spec, "acceptance_criteria", None)
+        ):
+            return {
+                "status": "needs_human",
+                "reasons": [
+                    f"Issue #{issue.number} lacks an explicit validation contract or acceptance criteria."
+                ],
+                "next_actions": [
+                    "Add an Acceptance Criteria, Validation, Definition of Done, or Test Plan section to the issue body.",
+                    "Include at least one concrete verification step such as a pytest command or observable success criterion.",
+                ],
+            }
 
         if not spec.is_dispatch_bounded():
             return {
-                "status": "failed",
-                "error": f"Issue #{issue.number} produced an under-specified spec: "
-                f"{spec.dispatch_gate_reason()}",
+                "status": "needs_human",
+                "reasons": [
+                    f"Issue #{issue.number} is not safely dispatchable: {spec.dispatch_gate_reason()}"
+                ],
+                "next_actions": [
+                    "Add file-scope hints, constraints, acceptance criteria, or explicit work orders before dispatch.",
+                ],
+            }
+
+        if not self.config.dispatch_enabled:
+            return {
+                "status": "needs_human",
+                "reasons": [
+                    f"No-dispatch preview only for issue #{issue.number}; supervised execution was intentionally skipped."
+                ],
+                "next_actions": [
+                    "Review the selected issue and derived validation contract.",
+                    "Rerun without --no-dispatch to execute the bounded Boss loop lane.",
+                ],
             }
 
         result = await dispatch_bounded_spec(
@@ -1046,6 +1177,9 @@ class BossLoop:
                 "Investigate the last failures before resuming.",
             ]
         if self._stop_reason == BossStopReason.NEEDS_HUMAN.value:
+            for status in reversed(self._iteration_statuses):
+                if status.stop_reason == BossStopReason.NEEDS_HUMAN.value and status.next_actions:
+                    return list(status.next_actions)
             return [
                 "Worker reached a decision boundary requiring human input.",
                 "Review the worker output and decide next steps.",

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -33,6 +33,7 @@ from aragora.swarm.boss_loop import (
     RunnerFreshnessResult,
     check_runner_freshness,
     dispatch_bounded_spec,
+    extract_issue_validation_contract,
     select_eligible_issue,
 )
 
@@ -47,7 +48,12 @@ UTC = timezone.utc
 def _make_issue(
     number: int = 1,
     title: str = "Fix the dashboard",
-    body: str = "The dashboard is slow, improve query performance in aragora/analytics/dashboard.py",
+    body: str = (
+        "The dashboard is slow, improve query performance in aragora/analytics/dashboard.py\n\n"
+        "Acceptance Criteria:\n"
+        "- pytest -q tests/swarm/test_boss_loop.py\n"
+        "- Dashboard query path remains bounded to aragora/analytics/dashboard.py\n"
+    ),
     labels: list[str] | None = None,
     state: str = "OPEN",
 ) -> GitHubIssue:
@@ -220,6 +226,34 @@ class TestSelectEligibleIssue:
         selected = select_eligible_issue(issues, require_labels={"boss-ready"})
         assert selected is not None
         assert selected.number == 2
+
+
+class TestValidationContractExtraction:
+    def test_extracts_bullets_from_acceptance_section(self):
+        body = """
+Summary text.
+
+Acceptance Criteria:
+- pytest -q tests/swarm/test_boss_loop.py
+- No files outside aragora/swarm/ are changed
+"""
+
+        assert extract_issue_validation_contract(body) == [
+            "pytest -q tests/swarm/test_boss_loop.py",
+            "No files outside aragora/swarm/ are changed",
+        ]
+
+    def test_extracts_inline_validation_and_pytest_lines(self):
+        body = """
+Validation: verify JSON output includes stop_reason
+
+python -m pytest tests/swarm/test_boss_loop.py -q
+"""
+
+        assert extract_issue_validation_contract(body) == [
+            "verify JSON output includes stop_reason",
+            "python -m pytest tests/swarm/test_boss_loop.py -q",
+        ]
 
     def test_returns_none_when_no_eligible_issue(self):
         issues = [_make_issue(1, "Invalid", labels=["wontfix"])]
@@ -596,6 +630,43 @@ class TestBossLoop:
         assert len(result.issues_completed) == 2
         assert len(result.issues_failed) == 1
 
+    def test_missing_validation_contract_stops_with_needs_human(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [
+            _make_issue(
+                7,
+                "Issue missing validation",
+                body="Tighten the boss loop selection logic in aragora/swarm/boss_loop.py",
+            )
+        ]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
+        assert "lacks an explicit validation contract" in result.needs_human_reasons[0]
+
+    def test_no_dispatch_preview_stops_truthfully(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(8, "Preview only issue")]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1, dispatch_enabled=False),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
+        assert "No-dispatch preview only" in result.needs_human_reasons[0]
+        assert "Rerun without --no-dispatch" in result.next_actions[1]
+
 
 # ---------------------------------------------------------------------------
 # Status payload shape tests
@@ -855,6 +926,7 @@ class TestBossLoopCLI:
                 "boss-ready",
                 "--max-consecutive-failures",
                 "5",
+                "--allow-missing-validation-contract",
                 "--json",
             ]
         )
@@ -865,6 +937,7 @@ class TestBossLoopCLI:
         assert args.boss_repo == "synaptent/aragora"
         assert args.boss_label_filter == "boss-ready"
         assert args.max_consecutive_failures == 5
+        assert args.allow_missing_validation_contract is True
         assert args.json is True
 
 


### PR DESCRIPTION
## Summary
- require Boss loop issues to carry an explicit validation contract or acceptance criteria before dispatch
- preserve issue-specific next actions for missing-contract and `--no-dispatch` preview stop paths
- wire `--no-dispatch` into boss-loop as a truthful preview mode and add an explicit opt-out flag for missing validation contracts

## Verification
- `ruff check aragora/swarm/boss_loop.py aragora/cli/commands/swarm.py aragora/cli/parser.py tests/swarm/test_boss_loop.py`
- `python -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py -q`
- bounded CLI preview run with patched fresh runner + fixture issue feed

Notes:
- `tests/swarm/test_boss_model_selection.py` is already failing on current `main` due unrelated pre-existing model-wiring drift and was not changed in this lane.

Advances #871.