### PR TITLE
feat(swarm): allow boss-loop to target one issue

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -534,6 +534,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             freshness_ttl_seconds=float(getattr(args, "freshness_ttl", 3600.0) or 3600.0),
             repo=getattr(args, "boss_repo", None),
             label_filter=getattr(args, "boss_label_filter", None),
+            issue_number=getattr(args, "boss_issue_number", None),
             target_branch=target_branch,
             budget_limit_usd=budget_limit,
             max_consecutive_failures=int(getattr(args, "max_consecutive_failures", 3) or 3),

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2344,6 +2344,12 @@ def _add_swarm_parser(subparsers) -> None:
         help="Only consider issues with this label in boss-loop",
     )
     swarm_parser.add_argument(
+        "--boss-issue-number",
+        type=int,
+        default=None,
+        help="Target one specific GitHub issue number in boss-loop instead of selecting from the feed",
+    )
+    swarm_parser.add_argument(
         "--max-consecutive-failures",
         type=int,
         default=3,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -498,6 +498,7 @@ class BossLoopConfig:
     # Issue feed
     repo: str | None = None
     label_filter: str | None = None
+    issue_number: int | None = None
     issue_limit: int = 25
     skip_labels: set[str] = field(default_factory=lambda: {"wontfix", "duplicate", "invalid"})
     require_labels: set[str] | None = None
@@ -959,14 +960,42 @@ class BossLoop:
             if count >= self.config.max_retries_per_issue
         }
         candidate_issues = [i for i in issues if i.number not in already_maxed]
-
-        selected = select_eligible_issue(
-            candidate_issues,
-            skip_labels=self.config.skip_labels,
-            require_labels=self.config.require_labels,
-        )
+        if self.config.issue_number is not None:
+            target_issue = next(
+                (issue for issue in candidate_issues if issue.number == self.config.issue_number),
+                None,
+            )
+            selected = (
+                select_eligible_issue(
+                    [target_issue],
+                    skip_labels=self.config.skip_labels,
+                    require_labels=self.config.require_labels,
+                )
+                if target_issue is not None
+                else None
+            )
+        else:
+            selected = select_eligible_issue(
+                candidate_issues,
+                skip_labels=self.config.skip_labels,
+                require_labels=self.config.require_labels,
+            )
 
         if selected is None:
+            if self.config.issue_number is not None:
+                needs_human_reasons = [
+                    f"Target issue #{self.config.issue_number} was not found in the issue feed or is not eligible under current filters/retry state."
+                ]
+                next_actions = [
+                    f"Verify issue #{self.config.issue_number} is still open, eligible, and has not exceeded retry limits.",
+                    "Remove --boss-issue-number to return to feed-driven selection.",
+                ]
+            else:
+                needs_human_reasons = ["No suitable open issue found in the GitHub feed."]
+                next_actions = [
+                    "Create a new issue with actionable scope, or adjust label filters.",
+                    f"Issues checked: {len(issues)}, already maxed retries: {len(already_maxed)}",
+                ]
             return BossIterationStatus(
                 iteration=iteration,
                 run_id=self.run_id,
@@ -975,11 +1004,8 @@ class BossLoop:
                 selected_issue=None,
                 worker_status="idle",
                 stop_reason=BossStopReason.NO_SUITABLE_ISSUE.value,
-                needs_human_reasons=["No suitable open issue found in the GitHub feed."],
-                next_actions=[
-                    "Create a new issue with actionable scope, or adjust label filters.",
-                    f"Issues checked: {len(issues)}, already maxed retries: {len(already_maxed)}",
-                ],
+                needs_human_reasons=needs_human_reasons,
+                next_actions=next_actions,
                 elapsed_seconds=time.monotonic() - iter_start,
             )
 

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -462,6 +462,46 @@ class TestBossLoop:
         assert len(result.issues_attempted) == 0
         assert "No suitable open issue" in result.needs_human_reasons[0]
 
+    def test_specific_issue_number_selects_target_issue(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [
+            _make_issue(909, "Meta benchmark issue"),
+            _make_issue(873, "Bounded execution issue"),
+        ]
+
+        config = _boss_config(max_iterations=1, issue_number=873)
+
+        async def _complete(issue, freshness):
+            assert issue.number == 873
+            return {"status": "completed"}
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _complete
+
+        result = asyncio.run(loop.run())
+
+        assert result.iterations_completed == 1
+        assert result.issues_attempted[0]["number"] == 873
+
+    def test_specific_issue_number_missing_stops_truthfully(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(909, "Meta benchmark issue")]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1, issue_number=873),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        assert "Target issue #873" in result.needs_human_reasons[0]
+
     def test_bounded_iteration_limit(self):
         """Loop respects max_iterations even when issues keep flowing."""
         feed = MagicMock(spec=GitHubIssueFeed)
@@ -846,6 +886,7 @@ class TestBossLoopCLI:
             "freshness_ttl": 3600.0,
             "boss_repo": None,
             "boss_label_filter": None,
+            "boss_issue_number": None,
             "max_consecutive_failures": 3,
         }
         defaults.update(overrides)
@@ -924,6 +965,8 @@ class TestBossLoopCLI:
                 "synaptent/aragora",
                 "--boss-label-filter",
                 "boss-ready",
+                "--boss-issue-number",
+                "873",
                 "--max-consecutive-failures",
                 "5",
                 "--allow-missing-validation-contract",
@@ -936,6 +979,7 @@ class TestBossLoopCLI:
         assert args.freshness_ttl == 1800.0
         assert args.boss_repo == "synaptent/aragora"
         assert args.boss_label_filter == "boss-ready"
+        assert args.boss_issue_number == 873
         assert args.max_consecutive_failures == 5
         assert args.allow_missing_validation_contract is True
         assert args.json is True


### PR DESCRIPTION
## Summary
- add `--boss-issue-number` so Boss loop can target one bounded issue instead of selecting the first eligible item from the feed
- fail closed with a specific reason when the targeted issue is missing or no longer eligible
- cover the new selection and parser behavior in the existing Boss-loop test suite

## Verification
- `ruff check aragora/swarm/boss_loop.py aragora/cli/commands/swarm.py aragora/cli/parser.py tests/swarm/test_boss_loop.py`
- `python -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py -q`
- `ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop --boss-label-filter boss-loop-test --boss-issue-number 873 --no-dispatch --max-ticks 1 --json`

## Operational note
The targeted preview selected live issue #873 as intended. A concurrent one-tick live run was also started from the managed worktree and may still be executing while this PR is reviewed.

Advances #871.