### PR TITLE
fix(swarm): stop one-tick boss-loop live runs after dispatch

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -586,6 +586,7 @@ async def dispatch_bounded_spec(
     target_branch: str = "main",
     budget_limit_usd: float = 5.0,
     max_ticks: int = 360,
+    wait_for_completion: bool = True,
     repo_path: Any | None = None,
     default_target_agent: str | None = None,
     default_reviewer_agent: str | None = None,
@@ -623,7 +624,7 @@ async def dispatch_bounded_spec(
                 require_external_action_approval=True,
             ),
             dispatch=True,
-            wait=True,
+            wait=wait_for_completion,
             interval_seconds=5.0,
             max_ticks=max_ticks,
             force_collect_on_max_ticks=True,
@@ -632,6 +633,14 @@ async def dispatch_bounded_spec(
             use_managed_session_script=use_managed_session_script,
         )
         run_dict = run.to_dict()
+        run_status = str(run_dict.get("status", "")).strip().lower()
+        if not wait_for_completion and run_status not in {"completed", "needs_human"}:
+            return {
+                "status": "running",
+                "outcome": "dispatched",
+                "run": run_dict,
+                "run_id": run_dict.get("run_id"),
+            }
         outcome = _classify_terminal_run_outcome(run_dict)
         deliverable = _extract_deliverable(run_dict)
         if outcome in {"deliverable_created", "pr_adopted"}:
@@ -1020,6 +1029,35 @@ class BossLoop:
 
         elapsed = time.monotonic() - iter_start
 
+        if worker_result.get("status") == "running":
+            self._consecutive_failures = 0
+            worker_run_id = str(worker_result.get("run_id", "")).strip()
+            next_actions = [
+                (
+                    f"Supervisor run {worker_run_id} is active for issue #{selected.number}; "
+                    "the boss loop returned after this bounded dispatch tick."
+                )
+                if worker_run_id
+                else (
+                    f"Issue #{selected.number} dispatched successfully; "
+                    "the boss loop returned after this bounded dispatch tick."
+                ),
+                "Inspect the active supervisor run before starting another live boss-loop tick.",
+            ]
+            return BossIterationStatus(
+                iteration=iteration,
+                run_id=self.run_id,
+                timestamp=now,
+                runner_freshness=freshness_dict,
+                selected_issue=issue_dict,
+                worker_status="running",
+                stop_reason=None,
+                needs_human_reasons=[],
+                next_actions=next_actions,
+                elapsed_seconds=elapsed,
+                worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
+            )
+
         if worker_result.get("status") == "completed":
             self._completed_issues.append(issue_dict)
             self._consecutive_failures = 0
@@ -1166,6 +1204,7 @@ class BossLoop:
             target_branch=self.config.target_branch,
             budget_limit_usd=self.config.budget_limit_usd,
             max_ticks=360,
+            wait_for_completion=self.config.max_iterations > 1,
         )
         if result.get("status") == "failed":
             error = str(result.get("error", "")).strip()
@@ -1183,6 +1222,9 @@ class BossLoop:
     def _derive_next_actions(self) -> list[str]:
         """Derive final next actions based on stop reason."""
         if self._stop_reason == BossStopReason.MAX_ITERATIONS.value:
+            for status in reversed(self._iteration_statuses):
+                if status.worker_status == "running" and status.next_actions:
+                    return list(status.next_actions)
             return [
                 f"Boss loop completed {len(self._iteration_statuses)} iterations.",
                 "Review completed and failed issues, then restart if needed.",

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -707,6 +707,36 @@ class TestBossLoop:
         assert "No-dispatch preview only" in result.needs_human_reasons[0]
         assert "Rerun without --no-dispatch" in result.next_actions[1]
 
+    def test_single_tick_live_dispatch_returns_after_launch(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(873, "Bounded live issue")]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        async def _running_dispatch(issue, freshness):
+            return {
+                "status": "running",
+                "outcome": "dispatched",
+                "run_id": "run-873",
+            }
+
+        loop._dispatch_issue = _running_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert result.iterations_completed == 1
+        assert len(result.issues_attempted) == 1
+        assert len(result.issues_completed) == 0
+        assert len(result.issues_failed) == 0
+        assert "Supervisor run run-873 is active" in result.next_actions[0]
+        assert result.iteration_statuses[0]["worker_status"] == "running"
+        assert result.iteration_statuses[0]["worker_outcome"] == "dispatched"
+
 
 # ---------------------------------------------------------------------------
 # Status payload shape tests
@@ -1011,6 +1041,38 @@ async def test_dispatch_bounded_spec_enables_force_collect_on_max_ticks() -> Non
     kwargs = mock_commander_cls.return_value.run_supervised_from_spec.await_args.kwargs
     assert kwargs["max_ticks"] == 7
     assert kwargs["force_collect_on_max_ticks"] is True
+
+
+@pytest.mark.asyncio
+async def test_dispatch_bounded_spec_wait_false_returns_running_after_launch() -> None:
+    spec = MagicMock()
+    spec.is_dispatch_bounded.return_value = True
+
+    active_run = MagicMock()
+    active_run.to_dict.return_value = {
+        "status": "active",
+        "run_id": "run-873",
+        "work_orders": [
+            {
+                "status": "dispatched",
+                "branch": "",
+                "commit_shas": [],
+            }
+        ],
+    }
+
+    with patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls:
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(
+            return_value=active_run
+        )
+
+        result = await dispatch_bounded_spec(spec, wait_for_completion=False)
+
+    kwargs = mock_commander_cls.return_value.run_supervised_from_spec.await_args.kwargs
+    assert kwargs["wait"] is False
+    assert result["status"] == "running"
+    assert result["outcome"] == "dispatched"
+    assert result["run_id"] == "run-873"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- stop single-tick live boss-loop runs from blocking on full supervisor completion
- return a truthful running/dispatched result after launch for the bounded live path
- add focused regression coverage for the non-blocking dispatch path and one-tick boss-loop result shaping

## Root cause
`boss-loop --max-ticks 1` was selecting the right issue, then calling `dispatch_bounded_spec(..., wait=True, max_ticks=360)`.
That pushed the CLI into the supervisor watch loop for up to 30 minutes after dispatch, so a one-tick live run looked hung even though the worker had already launched.

## What changed
- `dispatch_bounded_spec()` now supports `wait_for_completion=False`
- in that mode, a launched non-terminal supervisor run returns `{status: "running", outcome: "dispatched"}` with the supervisor `run_id`
- the boss loop uses that non-blocking path only for single-iteration live runs
- the final boss-loop result stays truthful by ending on `max_iterations` and surfacing that the supervisor run is still active

## Verification
- `python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `python3 -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py tests/cli/test_swarm_command.py -q`
- live proof:
  - `ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop --boss-label-filter boss-loop-test --boss-issue-number 873 --max-ticks 1 --json`
  - exits in ~4s with `worker_status: "running"`, `worker_outcome: "dispatched"`, and supervisor run `0eb0ba94-d81`

## Residual risk
Multi-iteration live boss-loop runs keep the existing wait-for-completion behavior. This PR fixes the proven bounded live blocker without changing the broader long-running semantics.
