### PR TITLE
fix(swarm): close stdin on non-detached workers and guard script(1) PTY

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -187,6 +187,7 @@ class WorkerLauncher:
             proc = await asyncio.create_subprocess_exec(
                 *cmd,
                 cwd=worktree_path,
+                stdin=asyncio.subprocess.DEVNULL,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env=worker_env,

--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -334,7 +334,7 @@ PY
 }
 trap cleanup_lock EXIT INT TERM
 
-if command -v script >/dev/null 2>&1; then
+if command -v script >/dev/null 2>&1 && [ -t 0 ]; then
     if [[ $# -eq 0 ]]; then
         script -q "${LOG_FILE}" codex
     else

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -278,6 +278,62 @@ class TestLaunch:
         assert worker.is_running
 
     @pytest.mark.asyncio
+    async def test_launch_non_detached_sets_stdin_devnull(self, tmp_path: Path):
+        """Non-detached workers must close stdin to prevent PTY/interactive stalls."""
+        launcher = WorkerLauncher(LaunchConfig(detach=False))
+        mock_proc = AsyncMock()
+        mock_proc.pid = 99
+        worktree = tmp_path / "wt"
+        (worktree / "scripts").mkdir(parents=True)
+        (worktree / "scripts" / "codex_session.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+
+        wo = {
+            "work_order_id": "wo-stdin",
+            "target_agent": "claude",
+            "title": "Stdin guard test",
+        }
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch.object(WorkerLauncher, "_git_output", return_value=""),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await launcher.launch(wo, worktree_path=str(worktree), branch="feat")
+
+        call_kwargs = mock_exec.call_args
+        assert call_kwargs.kwargs.get("stdin") == asyncio.subprocess.DEVNULL
+
+    @pytest.mark.asyncio
+    async def test_launch_detached_sets_stdin_devnull(self, tmp_path: Path):
+        """Detached workers also close stdin."""
+        launcher = WorkerLauncher(LaunchConfig(detach=True))
+        mock_proc = AsyncMock()
+        mock_proc.pid = 100
+        worktree = tmp_path / "wt"
+        (worktree / "scripts").mkdir(parents=True)
+        (worktree / "scripts" / "codex_session.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+
+        wo = {
+            "work_order_id": "wo-stdin-detach",
+            "target_agent": "codex",
+            "title": "Stdin guard detached",
+        }
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/codex"),
+            patch.object(WorkerLauncher, "_git_output", return_value=""),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await launcher.launch(wo, worktree_path=str(worktree), branch="feat")
+
+        call_kwargs = mock_exec.call_args
+        assert call_kwargs.kwargs.get("stdin") == asyncio.subprocess.DEVNULL
+
+    @pytest.mark.asyncio
     async def test_launch_raises_on_missing_cli(self):
         launcher = WorkerLauncher()
         wo = {"work_order_id": "wo-1", "target_agent": "claude"}


### PR DESCRIPTION
## Summary
- Add `stdin=asyncio.subprocess.DEVNULL` to the non-detached worker subprocess path in `worker_launcher.py`, matching the existing detached path
- Guard `script(1)` usage in `codex_session.sh` with `[ -t 0 ]` so PTY allocation only happens when stdin is a real terminal
- Add 2 focused tests asserting both launch paths close stdin

## Context
Follow-up to PR #1061 which fixed the operator-facing boss-loop hang. That fix accidentally sidestepped this deeper issue because `max_iterations=1` uses detached mode (which already had `stdin=DEVNULL`). For multi-tick runs (`max_iterations>1`), workers launch non-detached — and the missing stdin closure combined with `script(1)` PTY allocation could cause worker stalls.

## Test plan
- [x] 46/46 worker_launcher tests pass
- [x] 588/588 swarm tests pass (excluding 13 pre-existing dead model-selection tests from #1060 and 4 pre-existing merge-gate failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)