### PR TITLE
feat(swarm): add tranche inspection and artifact receipts

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -35,6 +35,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "reconcile",
         "campaign",
         "integrator",
+        "tranche",
     }:
         return str(first), second
     return "run", first
@@ -786,6 +787,33 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     )
             else:
                 print(json.dumps(payload, indent=2))
+        return
+
+    if action == "tranche":
+        from aragora.swarm.tranche import (
+            TrancheInspector,
+            load_tranche_manifest,
+            render_tranche_inspection_text,
+        )
+
+        subaction = str(goal or "inspect").strip().lower() or "inspect"
+        if subaction != "inspect":
+            raise ValueError("tranche action must be 'inspect'")
+        manifest_arg = str(getattr(args, "manifest", "") or "").strip()
+        if not manifest_arg:
+            raise ValueError("tranche inspect requires --manifest <path>")
+        manifest_path = Path(manifest_arg).resolve()
+        if not manifest_path.exists():
+            raise ValueError(f"tranche manifest not found: {manifest_path}")
+        manifest = load_tranche_manifest(manifest_path)
+        repo_root = resolve_repo_root(Path.cwd())
+        payload = TrancheInspector(repo_root=repo_root).inspect(manifest)
+        payload["action"] = subaction
+        payload["manifest_path"] = str(manifest_path)
+        if as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(render_tranche_inspection_text(payload))
         return
 
     if boss_mode:

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2130,7 +2130,7 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "swarm_action_or_goal",
         nargs="?",
-        help="Action (run/status/reconcile/campaign/integrator) or your goal in plain language",
+        help="Action (run/status/reconcile/campaign/integrator/tranche) or your goal in plain language",
     )
     swarm_parser.add_argument(
         "swarm_goal",
@@ -2411,7 +2411,7 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "--manifest",
         default=DEFAULT_CAMPAIGN_MANIFEST,
-        help="Campaign manifest path (default: .aragora/campaign_manifest.yaml)",
+        help="Campaign or tranche manifest path (default: .aragora/campaign_manifest.yaml)",
     )
     swarm_parser.add_argument(
         "--output",

--- a/aragora/swarm/__init__.py
+++ b/aragora/swarm/__init__.py
@@ -35,6 +35,16 @@ from aragora.swarm.reconciler import SwarmReconciler, SwarmReconcilerConfig
 from aragora.swarm.reporter import SwarmReport, SwarmReporter
 from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.supervisor import SupervisorRun, SwarmApprovalPolicy, SwarmSupervisor
+from aragora.swarm.tranche import (
+    TrancheArtifactStore,
+    TrancheGate,
+    TrancheInspector,
+    TrancheLane,
+    TrancheLaneArtifact,
+    TrancheManifest,
+    load_tranche_manifest,
+    save_tranche_manifest,
+)
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
 
 __all__ = [
@@ -48,6 +58,12 @@ __all__ = [
     "LaunchConfig",
     "SwarmCommander",
     "SwarmCommanderConfig",
+    "TrancheArtifactStore",
+    "TrancheGate",
+    "TrancheInspector",
+    "TrancheLane",
+    "TrancheLaneArtifact",
+    "TrancheManifest",
     "SwarmReconciler",
     "SwarmReconcilerConfig",
     "SupervisorRun",
@@ -58,4 +74,6 @@ __all__ = [
     "SwarmSupervisor",
     "WorkerLauncher",
     "WorkerProcess",
+    "load_tranche_manifest",
+    "save_tranche_manifest",
 ]

--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -1,0 +1,932 @@
+"""Manifest-driven tranche inspection and artifact persistence for swarm work."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.nomic.dev_coordination import DevCoordinationStore, WorkLease
+from aragora.swarm.campaign import locked_manifest_path
+
+UTC = timezone.utc
+DEFAULT_TRANCHE_ARTIFACT_ROOT = ".aragora/tranche_artifacts"
+_GITHUB_REF_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/(pull|issues)/(\d+)$")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _string_list(value: Any, *, field_name: str) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise ValueError(f"{field_name} must be a list.")
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _dict_value(value: Any, *, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise ValueError(f"{field_name} must be an object.")
+    return dict(value)
+
+
+def _normalize_scope(value: str) -> str:
+    return value.replace("\\", "/").strip().strip("/")
+
+
+def _scope_prefix(value: str) -> str:
+    normalized = _normalize_scope(value)
+    if normalized.endswith("/**"):
+        normalized = normalized[:-3]
+    return normalized.rstrip("/")
+
+
+def _scope_patterns_overlap(left: str, right: str) -> bool:
+    left_norm = _normalize_scope(left)
+    right_norm = _normalize_scope(right)
+    if not left_norm or not right_norm:
+        return False
+    if left_norm == right_norm:
+        return True
+    left_recursive = left_norm.endswith("/**")
+    right_recursive = right_norm.endswith("/**")
+    left_prefix = _scope_prefix(left_norm)
+    right_prefix = _scope_prefix(right_norm)
+    if left_recursive and (
+        right_prefix == left_prefix or right_prefix.startswith(left_prefix + "/")
+    ):
+        return True
+    if right_recursive and (
+        left_prefix == right_prefix or left_prefix.startswith(right_prefix + "/")
+    ):
+        return True
+    if left_prefix == right_prefix:
+        return True
+    return False
+
+
+def _paths_overlap(left: list[str], right: list[str]) -> bool:
+    return any(
+        _scope_patterns_overlap(left_item, right_item) for left_item in left for right_item in right
+    )
+
+
+@dataclass(slots=True)
+class TrancheReference:
+    kind: str
+    url: str
+    state: str = ""
+    meaning: str = ""
+    label: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "kind": self.kind,
+            "url": self.url,
+            "state": self.state,
+            "meaning": self.meaning,
+        }
+        if self.label:
+            payload["label"] = self.label
+        payload.update(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrancheReference:
+        kind = str(data.get("kind", "")).strip()
+        url = str(data.get("url", "")).strip()
+        if not kind:
+            raise ValueError("Tranche reference kind is required.")
+        if not url:
+            raise ValueError("Tranche reference url is required.")
+        metadata = {
+            key: value
+            for key, value in data.items()
+            if key not in {"kind", "url", "state", "meaning", "label"}
+        }
+        return cls(
+            kind=kind,
+            url=url,
+            state=str(data.get("state", "")).strip(),
+            meaning=str(data.get("meaning", "")).strip(),
+            label=_optional_text(data.get("label")),
+            metadata=metadata,
+        )
+
+
+@dataclass(slots=True)
+class TrancheGate:
+    source_ref: str
+    state: str
+    required_for: list[str] = field(default_factory=list)
+    satisfy_when: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "source_ref": self.source_ref,
+            "state": self.state,
+            "required_for": list(self.required_for),
+            "satisfy_when": self.satisfy_when,
+        }
+        payload.update(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrancheGate:
+        source_ref = str(data.get("source_ref", "")).strip()
+        state = str(data.get("state", "")).strip()
+        if not source_ref:
+            raise ValueError("Tranche gate source_ref is required.")
+        if not state:
+            raise ValueError("Tranche gate state is required.")
+        metadata = {
+            key: value
+            for key, value in data.items()
+            if key not in {"source_ref", "state", "required_for", "satisfy_when"}
+        }
+        return cls(
+            source_ref=source_ref,
+            state=state,
+            required_for=_string_list(data.get("required_for"), field_name="required_for"),
+            satisfy_when=str(data.get("satisfy_when", "")).strip(),
+            metadata=metadata,
+        )
+
+
+@dataclass(slots=True)
+class TrancheLane:
+    lane_id: str
+    owner_role: str
+    branch: dict[str, Any] = field(default_factory=dict)
+    worktree: dict[str, Any] = field(default_factory=dict)
+    allowed_write_scope: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+    verification_commands: list[str] = field(default_factory=list)
+    stop_conditions: list[str] = field(default_factory=list)
+    expected_receipts_artifacts: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = {
+            "lane_id": self.lane_id,
+            "owner_role": self.owner_role,
+            "branch": dict(self.branch),
+            "worktree": dict(self.worktree),
+            "allowed_write_scope": list(self.allowed_write_scope),
+            "dependencies": list(self.dependencies),
+            "verification_commands": list(self.verification_commands),
+            "stop_conditions": list(self.stop_conditions),
+            "expected_receipts_artifacts": list(self.expected_receipts_artifacts),
+        }
+        payload.update(self.metadata)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrancheLane:
+        lane_id = str(data.get("lane_id", "")).strip()
+        owner_role = str(data.get("owner_role", "")).strip()
+        if not lane_id:
+            raise ValueError("Tranche lane lane_id is required.")
+        if not owner_role:
+            raise ValueError("Tranche lane owner_role is required.")
+        metadata = {
+            key: value
+            for key, value in data.items()
+            if key
+            not in {
+                "lane_id",
+                "owner_role",
+                "branch",
+                "worktree",
+                "allowed_write_scope",
+                "dependencies",
+                "verification_commands",
+                "stop_conditions",
+                "expected_receipts_artifacts",
+            }
+        }
+        return cls(
+            lane_id=lane_id,
+            owner_role=owner_role,
+            branch=_dict_value(data.get("branch"), field_name="branch"),
+            worktree=_dict_value(data.get("worktree"), field_name="worktree"),
+            allowed_write_scope=_string_list(
+                data.get("allowed_write_scope"), field_name="allowed_write_scope"
+            ),
+            dependencies=_string_list(data.get("dependencies"), field_name="dependencies"),
+            verification_commands=_string_list(
+                data.get("verification_commands"), field_name="verification_commands"
+            ),
+            stop_conditions=_string_list(data.get("stop_conditions"), field_name="stop_conditions"),
+            expected_receipts_artifacts=_string_list(
+                data.get("expected_receipts_artifacts"),
+                field_name="expected_receipts_artifacts",
+            ),
+            metadata=metadata,
+        )
+
+    @property
+    def claimable(self) -> bool:
+        return bool(self.allowed_write_scope)
+
+
+@dataclass(slots=True)
+class TrancheManifest:
+    manifest_id: str
+    repo: dict[str, Any]
+    references: dict[str, dict[str, TrancheReference]]
+    gates: dict[str, TrancheGate]
+    lanes: list[TrancheLane]
+    terminal_outcomes: dict[str, Any]
+    manifest_version: int = 1
+    generated_on: str | None = None
+    objective: str = ""
+    shared_constraints: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest_version": self.manifest_version,
+            "manifest_id": self.manifest_id,
+            "generated_on": self.generated_on,
+            "repo": dict(self.repo),
+            "objective": self.objective,
+            "shared_constraints": dict(self.shared_constraints),
+            "references": {
+                group: {ref_id: ref.to_dict() for ref_id, ref in refs.items()}
+                for group, refs in self.references.items()
+            },
+            "gates": {gate_id: gate.to_dict() for gate_id, gate in self.gates.items()},
+            "lanes": [lane.to_dict() for lane in self.lanes],
+            "terminal_outcomes": dict(self.terminal_outcomes),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrancheManifest:
+        manifest_id = str(data.get("manifest_id", "")).strip()
+        if not manifest_id:
+            raise ValueError("Tranche manifest manifest_id is required.")
+        repo = _dict_value(data.get("repo"), field_name="repo")
+        if not repo:
+            raise ValueError("Tranche manifest repo is required.")
+        references_raw = _dict_value(data.get("references"), field_name="references")
+        gates_raw = _dict_value(data.get("gates"), field_name="gates")
+        lanes_raw = data.get("lanes")
+        if not isinstance(lanes_raw, list):
+            raise ValueError("Tranche manifest lanes must be a list.")
+        terminal_outcomes = _dict_value(
+            data.get("terminal_outcomes"), field_name="terminal_outcomes"
+        )
+        if not terminal_outcomes:
+            raise ValueError("Tranche manifest terminal_outcomes is required.")
+        references: dict[str, dict[str, TrancheReference]] = {}
+        for group, items in references_raw.items():
+            if not isinstance(items, dict):
+                raise ValueError(f"Tranche references group {group!r} must be an object.")
+            references[str(group)] = {
+                str(ref_id): TrancheReference.from_dict(dict(ref_data))
+                for ref_id, ref_data in items.items()
+                if isinstance(ref_data, dict)
+            }
+        gates = {
+            str(gate_id): TrancheGate.from_dict(dict(gate_data))
+            for gate_id, gate_data in gates_raw.items()
+            if isinstance(gate_data, dict)
+        }
+        lanes = [TrancheLane.from_dict(dict(item)) for item in lanes_raw if isinstance(item, dict)]
+        return cls(
+            manifest_version=int(data.get("manifest_version", 1) or 1),
+            manifest_id=manifest_id,
+            generated_on=_optional_text(data.get("generated_on")),
+            repo=repo,
+            objective=str(data.get("objective", "")).strip(),
+            shared_constraints=_dict_value(
+                data.get("shared_constraints"), field_name="shared_constraints"
+            ),
+            references=references,
+            gates=gates,
+            lanes=lanes,
+            terminal_outcomes=terminal_outcomes,
+        )
+
+    def reference(self, ref_id: str) -> tuple[str, TrancheReference] | None:
+        for group, refs in self.references.items():
+            if ref_id in refs:
+                return group, refs[ref_id]
+        return None
+
+    def lane(self, lane_id: str) -> TrancheLane:
+        for lane in self.lanes:
+            if lane.lane_id == lane_id:
+                return lane
+        raise KeyError(f"Unknown tranche lane: {lane_id}")
+
+    def to_yaml(self) -> str:
+        try:
+            import yaml
+
+            return yaml.safe_dump(self.to_dict(), sort_keys=False, allow_unicode=False)
+        except ImportError:
+            return json.dumps(self.to_dict(), indent=2, sort_keys=False)
+
+    @classmethod
+    def from_text(cls, text: str) -> TrancheManifest:
+        try:
+            import yaml
+
+            payload = yaml.safe_load(text) or {}
+        except ImportError:
+            payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError("Tranche manifest must deserialize to an object.")
+        return cls.from_dict(payload)
+
+
+@dataclass(slots=True)
+class TrancheLaneArtifact:
+    lane_id: str
+    source_ref: str
+    status: str
+    commands: list[str] = field(default_factory=list)
+    urls: list[str] = field(default_factory=list)
+    run_id: str | None = None
+    worktree_path: str | None = None
+    residual_risk: str = ""
+    timestamp: str = field(default_factory=lambda: _utcnow().isoformat())
+    next_actions: list[str] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "lane_id": self.lane_id,
+            "source_ref": self.source_ref,
+            "status": self.status,
+            "commands": list(self.commands),
+            "urls": list(self.urls),
+            "run_id": self.run_id,
+            "worktree_path": self.worktree_path,
+            "residual_risk": self.residual_risk,
+            "timestamp": self.timestamp,
+            "next_actions": list(self.next_actions),
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TrancheLaneArtifact:
+        lane_id = str(data.get("lane_id", "")).strip()
+        source_ref = str(data.get("source_ref", "")).strip()
+        status = str(data.get("status", "")).strip()
+        if not lane_id:
+            raise ValueError("Tranche lane artifact lane_id is required.")
+        if not source_ref:
+            raise ValueError("Tranche lane artifact source_ref is required.")
+        if not status:
+            raise ValueError("Tranche lane artifact status is required.")
+        return cls(
+            lane_id=lane_id,
+            source_ref=source_ref,
+            status=status,
+            commands=_string_list(data.get("commands"), field_name="commands"),
+            urls=_string_list(data.get("urls"), field_name="urls"),
+            run_id=_optional_text(data.get("run_id")),
+            worktree_path=_optional_text(data.get("worktree_path")),
+            residual_risk=str(data.get("residual_risk", "")).strip(),
+            timestamp=str(data.get("timestamp", "")).strip() or _utcnow().isoformat(),
+            next_actions=_string_list(data.get("next_actions"), field_name="next_actions"),
+            metadata=_dict_value(data.get("metadata"), field_name="metadata"),
+        )
+
+
+class TrancheArtifactStore:
+    """File-backed lane artifact store for tranche proofs and runbooks."""
+
+    def __init__(self, repo_root: Path, root: str | Path = DEFAULT_TRANCHE_ARTIFACT_ROOT) -> None:
+        self.repo_root = repo_root.resolve()
+        root_path = Path(root)
+        self.root = root_path if root_path.is_absolute() else (self.repo_root / root_path).resolve()
+
+    def path_for(self, manifest_id: str, lane_id: str) -> Path:
+        return self.root / manifest_id / f"{lane_id}.yaml"
+
+    def save(self, manifest_id: str, artifact: TrancheLaneArtifact) -> Path:
+        path = self.path_for(manifest_id, artifact.lane_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with locked_manifest_path(path):
+            path.write_text(_dump_yaml_like(artifact.to_dict()), encoding="utf-8")
+        return path
+
+    def load(self, manifest_id: str, lane_id: str) -> TrancheLaneArtifact | None:
+        path = self.path_for(manifest_id, lane_id)
+        if not path.exists():
+            return None
+        return TrancheLaneArtifact.from_dict(_load_yaml_like(path))
+
+    def list(self, manifest_id: str) -> list[TrancheLaneArtifact]:
+        root = self.root / manifest_id
+        if not root.exists():
+            return []
+        artifacts = [
+            TrancheLaneArtifact.from_dict(_load_yaml_like(path))
+            for path in sorted(root.glob("*.yaml"))
+        ]
+        return sorted(artifacts, key=lambda item: item.timestamp, reverse=True)
+
+
+@dataclass(slots=True)
+class GitHubReferenceTarget:
+    owner: str
+    repo: str
+    kind: str
+    number: int
+
+
+class GhReferenceClient:
+    """Minimal GitHub reference resolver backed by the gh CLI."""
+
+    def _run_json(self, args: list[str]) -> dict[str, Any]:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh command failed")
+        payload = json.loads(proc.stdout or "{}")
+        if not isinstance(payload, dict):
+            raise RuntimeError("gh command did not return a JSON object")
+        return payload
+
+    def get_issue(self, repo: str, number: int) -> dict[str, Any]:
+        return self._run_json(
+            [
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,state,closedAt,title,url,labels",
+            ]
+        )
+
+    def get_pr(self, repo: str, number: int) -> dict[str, Any]:
+        return self._run_json(
+            [
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,state,mergedAt,title,url,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName",
+            ]
+        )
+
+
+class TrancheInspector:
+    """Read-only tranche inspection against live GitHub and local scope rules."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        reference_client: GhReferenceClient | None = None,
+        artifact_store: TrancheArtifactStore | None = None,
+        coordination_store: DevCoordinationStore | None = None,
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.reference_client = reference_client or GhReferenceClient()
+        self.artifact_store = artifact_store or TrancheArtifactStore(self.repo_root)
+        self.coordination_store = coordination_store
+
+    def inspect(self, manifest: TrancheManifest) -> dict[str, Any]:
+        references = self._resolve_references(manifest)
+        gates = self._resolve_gates(manifest, references)
+        scope_conflicts = self._declared_scope_conflicts(manifest)
+        artifacts = self.artifact_store.list(manifest.manifest_id)
+        lanes = self._resolve_lanes(manifest, references, gates, artifacts, scope_conflicts)
+        blockers = []
+        blockers.extend(
+            item["reason"]
+            for item in references.values()
+            if item["group"] == "live_target" and item["status"] in {"blocked", "stale"}
+        )
+        blockers.extend(
+            f"Declared write-scope overlap between {item['left_lane_id']} and {item['right_lane_id']}"
+            for item in scope_conflicts
+        )
+        recommended = self._recommended_action(gates, lanes, blockers)
+        return {
+            "mode": "tranche-inspect",
+            "generated_at": _utcnow().isoformat(),
+            "manifest_id": manifest.manifest_id,
+            "manifest_version": manifest.manifest_version,
+            "repo": dict(manifest.repo),
+            "preflight_status": "blocked" if blockers else "ok",
+            "preflight_blockers": blockers,
+            "references": references,
+            "gates": gates,
+            "lanes": lanes,
+            "scope_conflicts": scope_conflicts,
+            "artifacts": [item.to_dict() for item in artifacts],
+            "recommended_action": recommended,
+        }
+
+    def prepare_lane_claim(
+        self,
+        manifest: TrancheManifest,
+        *,
+        lane_id: str,
+        task_id: str,
+        title: str,
+        owner_agent: str,
+        owner_session_id: str,
+        branch: str,
+        worktree_path: str,
+        expected_tests: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkLease:
+        lane = manifest.lane(lane_id)
+        if not lane.claimable:
+            raise ValueError(f"Lane {lane_id} is read-only and cannot claim a write lease.")
+        store = self.coordination_store or DevCoordinationStore(repo_root=self.repo_root)
+        return store.claim_lease(
+            task_id=task_id,
+            title=title or lane_id,
+            owner_agent=owner_agent,
+            owner_session_id=owner_session_id,
+            branch=branch,
+            worktree_path=worktree_path,
+            allowed_globs=list(lane.allowed_write_scope),
+            claimed_paths=[],
+            expected_tests=list(expected_tests or lane.verification_commands),
+            metadata={
+                "tranche_manifest_id": manifest.manifest_id,
+                "tranche_lane_id": lane_id,
+                **dict(metadata or {}),
+            },
+        )
+
+    def _resolve_references(self, manifest: TrancheManifest) -> dict[str, dict[str, Any]]:
+        resolved: dict[str, dict[str, Any]] = {}
+        for group, refs in manifest.references.items():
+            for ref_id, ref in refs.items():
+                target = parse_github_reference_url(ref.url)
+                repo = f"{target.owner}/{target.repo}"
+                payload = (
+                    self.reference_client.get_pr(repo, target.number)
+                    if target.kind == "pull_request"
+                    else self.reference_client.get_issue(repo, target.number)
+                )
+                observed_state = _observed_reference_state(target.kind, payload)
+                status = self._classify_reference_status(
+                    group=group,
+                    kind=target.kind,
+                    declared_state=ref.state,
+                    observed_state=observed_state,
+                )
+                resolved[ref_id] = {
+                    "group": group,
+                    "kind": target.kind,
+                    "repo": repo,
+                    "number": target.number,
+                    "url": ref.url,
+                    "title": str(payload.get("title", "")).strip(),
+                    "declared_state": ref.state,
+                    "observed_state": observed_state,
+                    "status": status,
+                    "actionable": target.kind == "issue" and observed_state == "open",
+                    "drifted": bool(ref.state) and ref.state.lower() != observed_state.lower(),
+                    "meaning": ref.meaning,
+                    "label": ref.label,
+                    "labels": [
+                        str(item.get("name", "")).strip()
+                        for item in payload.get("labels", [])
+                        if isinstance(item, dict) and str(item.get("name", "")).strip()
+                    ],
+                    "closed_at": payload.get("closedAt"),
+                    "merged_at": payload.get("mergedAt"),
+                    "mergeable": payload.get("mergeable"),
+                    "merge_state_status": payload.get("mergeStateStatus"),
+                    "review_decision": payload.get("reviewDecision"),
+                    "reason": _reference_reason(group, target.kind, observed_state, status),
+                }
+        return resolved
+
+    def _classify_reference_status(
+        self,
+        *,
+        group: str,
+        kind: str,
+        declared_state: str,
+        observed_state: str,
+    ) -> str:
+        declared = declared_state.lower()
+        observed = observed_state.lower()
+        if group == "retired_targets":
+            return "stale" if observed in {"closed", "merged"} else "unexpectedly_open"
+        if group == "live_target":
+            if kind == "issue":
+                return "actionable" if observed == "open" else "blocked"
+            return "actionable" if observed == "open" else "blocked"
+        if observed == "merged":
+            return "satisfied"
+        if observed == "open":
+            return "pending" if declared not in {"merged", "closed"} else "drifted"
+        if observed == "closed":
+            return "resolved" if declared == "closed" else "stale"
+        return observed
+
+    def _resolve_gates(
+        self,
+        manifest: TrancheManifest,
+        references: dict[str, dict[str, Any]],
+    ) -> dict[str, dict[str, Any]]:
+        resolved: dict[str, dict[str, Any]] = {}
+        for gate_id, gate in manifest.gates.items():
+            ref = references.get(gate.source_ref)
+            if ref is None:
+                state = "blocked"
+                reason = f"Missing reference {gate.source_ref}"
+            else:
+                state, reason = self._evaluate_gate(gate, ref)
+            resolved[gate_id] = {
+                "source_ref": gate.source_ref,
+                "declared_state": gate.state,
+                "state": state,
+                "required_for": list(gate.required_for),
+                "satisfy_when": gate.satisfy_when,
+                "reason": reason,
+            }
+        return resolved
+
+    def _evaluate_gate(
+        self,
+        gate: TrancheGate,
+        reference: dict[str, Any],
+    ) -> tuple[str, str]:
+        observed = str(reference.get("observed_state", "")).lower()
+        declared = gate.state.lower()
+        satisfy_when = gate.satisfy_when.lower()
+        if observed == "merged":
+            if "merged" in satisfy_when or declared in {"pending", "satisfied"}:
+                return "satisfied", f"{gate.source_ref} merged"
+            return "blocked", f"{gate.source_ref} merged unexpectedly"
+        if observed == "open":
+            if declared == "pending":
+                return "pending", f"{gate.source_ref} still open"
+            return "blocked", f"{gate.source_ref} still open"
+        if observed == "closed":
+            if (
+                declared == "satisfied"
+                and str(reference.get("declared_state", "")).lower() == "closed"
+            ):
+                return "satisfied", f"{gate.source_ref} reached declared closed state"
+            return "blocked", f"{gate.source_ref} closed without satisfying gate"
+        return "blocked", f"{gate.source_ref} resolved to unsupported state {observed}"
+
+    def _declared_scope_conflicts(self, manifest: TrancheManifest) -> list[dict[str, Any]]:
+        conflicts: list[dict[str, Any]] = []
+        writable = [lane for lane in manifest.lanes if lane.allowed_write_scope]
+        for index, left in enumerate(writable):
+            for right in writable[index + 1 :]:
+                if not _paths_overlap(left.allowed_write_scope, right.allowed_write_scope):
+                    continue
+                conflicts.append(
+                    {
+                        "left_lane_id": left.lane_id,
+                        "right_lane_id": right.lane_id,
+                        "left_scope": list(left.allowed_write_scope),
+                        "right_scope": list(right.allowed_write_scope),
+                    }
+                )
+        return conflicts
+
+    def _resolve_lanes(
+        self,
+        manifest: TrancheManifest,
+        references: dict[str, dict[str, Any]],
+        gates: dict[str, dict[str, Any]],
+        artifacts: list[TrancheLaneArtifact],
+        scope_conflicts: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        artifacts_by_lane: dict[str, list[dict[str, Any]]] = {}
+        for artifact in artifacts:
+            artifacts_by_lane.setdefault(artifact.lane_id, []).append(artifact.to_dict())
+        conflicting_lanes = {item["left_lane_id"] for item in scope_conflicts}.union(
+            {item["right_lane_id"] for item in scope_conflicts}
+        )
+        lanes: list[dict[str, Any]] = []
+        for lane in manifest.lanes:
+            blockers: list[str] = []
+            dependency_status: list[dict[str, Any]] = []
+            for dependency in lane.dependencies:
+                if dependency in gates:
+                    gate = gates[dependency]
+                    satisfied = gate["state"] == "satisfied"
+                    dependency_status.append(
+                        {
+                            "dependency": dependency,
+                            "kind": "gate",
+                            "state": gate["state"],
+                            "satisfied": satisfied,
+                            "reason": gate["reason"],
+                        }
+                    )
+                    if not satisfied:
+                        blockers.append(gate["reason"])
+                    continue
+                ref = references.get(dependency)
+                if ref is None:
+                    dependency_status.append(
+                        {
+                            "dependency": dependency,
+                            "kind": "unknown",
+                            "state": "missing",
+                            "satisfied": False,
+                            "reason": f"Unknown dependency {dependency}",
+                        }
+                    )
+                    blockers.append(f"Unknown dependency {dependency}")
+                    continue
+                satisfied = ref["status"] in {"actionable", "satisfied", "resolved"}
+                dependency_status.append(
+                    {
+                        "dependency": dependency,
+                        "kind": "reference",
+                        "state": ref["status"],
+                        "satisfied": satisfied,
+                        "reason": ref["reason"],
+                    }
+                )
+                if not satisfied:
+                    blockers.append(ref["reason"])
+            if lane.lane_id in conflicting_lanes:
+                blockers.append("Lane has declared write-scope overlap with another writable lane.")
+            readiness = "ready" if not blockers else "blocked"
+            lanes.append(
+                {
+                    "lane_id": lane.lane_id,
+                    "owner_role": lane.owner_role,
+                    "claimable": lane.claimable,
+                    "readiness": readiness,
+                    "allowed_write_scope": list(lane.allowed_write_scope),
+                    "dependencies": dependency_status,
+                    "blockers": blockers,
+                    "artifacts": artifacts_by_lane.get(lane.lane_id, []),
+                    "branch": dict(lane.branch),
+                    "worktree": dict(lane.worktree),
+                    "verification_commands": list(lane.verification_commands),
+                    "stop_conditions": list(lane.stop_conditions),
+                    "expected_receipts_artifacts": list(lane.expected_receipts_artifacts),
+                }
+            )
+        return lanes
+
+    def _recommended_action(
+        self,
+        gates: dict[str, dict[str, Any]],
+        lanes: list[dict[str, Any]],
+        blockers: list[str],
+    ) -> dict[str, Any]:
+        if blockers:
+            return {
+                "kind": "stop_and_replan",
+                "reason": blockers[0],
+            }
+        for gate_id, gate in gates.items():
+            if gate["state"] == "pending":
+                affected = [
+                    lane["lane_id"]
+                    for lane in lanes
+                    if gate_id in {dep["dependency"] for dep in lane["dependencies"]}
+                ]
+                return {
+                    "kind": "resolve_gate",
+                    "gate_id": gate_id,
+                    "source_ref": gate["source_ref"],
+                    "reason": gate["reason"],
+                    "affected_lanes": affected,
+                }
+        for lane in lanes:
+            if lane["readiness"] == "ready":
+                return {
+                    "kind": "run_lane",
+                    "lane_id": lane["lane_id"],
+                    "reason": "All dependencies satisfied",
+                }
+        return {
+            "kind": "idle",
+            "reason": "No ready lane found",
+        }
+
+
+def parse_github_reference_url(url: str) -> GitHubReferenceTarget:
+    match = _GITHUB_REF_RE.match(str(url).strip())
+    if match is None:
+        raise ValueError(f"Unsupported GitHub reference URL: {url}")
+    owner, repo, raw_kind, number_text = match.groups()
+    return GitHubReferenceTarget(
+        owner=owner,
+        repo=repo,
+        kind="pull_request" if raw_kind == "pull" else "issue",
+        number=int(number_text),
+    )
+
+
+def load_tranche_manifest(path: Path) -> TrancheManifest:
+    return TrancheManifest.from_text(path.read_text(encoding="utf-8"))
+
+
+def save_tranche_manifest(path: Path, manifest: TrancheManifest) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with locked_manifest_path(path):
+        path.write_text(manifest.to_yaml(), encoding="utf-8")
+
+
+def render_tranche_inspection_text(payload: dict[str, Any]) -> str:
+    lines = [
+        f"manifest_id={payload.get('manifest_id', '')}",
+        f"preflight={payload.get('preflight_status', '')}",
+    ]
+    recommended = payload.get("recommended_action", {})
+    if isinstance(recommended, dict):
+        lines.append(
+            "recommended={kind} {detail}".format(
+                kind=recommended.get("kind", ""),
+                detail=recommended.get("lane_id") or recommended.get("gate_id") or "",
+            ).strip()
+        )
+    blockers = [str(item) for item in payload.get("preflight_blockers", []) if str(item).strip()]
+    for blocker in blockers[:3]:
+        lines.append(f"blocker: {blocker}")
+    for gate_id, gate in list((payload.get("gates") or {}).items())[:5]:
+        if not isinstance(gate, dict):
+            continue
+        lines.append(f"gate {gate_id}: {gate.get('state')} ({gate.get('reason', '')})")
+    for lane in [item for item in payload.get("lanes", []) if isinstance(item, dict)][:5]:
+        lines.append(
+            "lane {lane_id}: {readiness} claimable={claimable}".format(
+                lane_id=lane.get("lane_id", ""),
+                readiness=lane.get("readiness", ""),
+                claimable=lane.get("claimable", False),
+            )
+        )
+        for blocker in [item for item in lane.get("blockers", []) if str(item).strip()][:2]:
+            lines.append(f"  blocker: {blocker}")
+    return "\n".join(lines)
+
+
+def _dump_yaml_like(data: dict[str, Any]) -> str:
+    try:
+        import yaml
+
+        return yaml.safe_dump(data, sort_keys=False, allow_unicode=False)
+    except ImportError:
+        return json.dumps(data, indent=2, sort_keys=False)
+
+
+def _load_yaml_like(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except ImportError:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected object payload in {path}")
+    return payload
+
+
+def _observed_reference_state(kind: str, payload: dict[str, Any]) -> str:
+    state = str(payload.get("state", "")).strip().lower()
+    if kind == "pull_request" and _optional_text(payload.get("mergedAt")):
+        return "merged"
+    return state or "unknown"
+
+
+def _reference_reason(group: str, kind: str, observed_state: str, status: str) -> str:
+    if group == "retired_targets":
+        return f"Retired {kind} is {observed_state}"
+    if group == "live_target" and status == "actionable":
+        return f"Live target is {observed_state}"
+    if group == "live_target":
+        return f"Live target is {observed_state}; dispatch should not proceed"
+    return f"Reference is {observed_state}"

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -498,7 +498,7 @@ aragora skills list
 
 **Purpose:** Launch the full swarm lifecycle: interrogate a goal → generate a spec → dispatch to agents → report results. Supervisor-backed with lease coordination, managed worktrees, and periodic reconciliation.
 
-**Usage:** `aragora swarm [run|status|reconcile] "<goal>" [options]`
+**Usage:** `aragora swarm [run|status|reconcile|campaign|integrator|tranche] "<goal>" [options]`
 
 **Subcommands:**
 - `run "<goal>"` — decompose goal, provision worktrees, dispatch workers (default)
@@ -556,6 +556,24 @@ aragora swarm campaign plan --source-file roadmap.md --json
 ```
 
 See `docs/guides/CAMPAIGN_OPERATOR.md` for the full operator guide including Ralph loop usage, prebuilt manifest workflow, and stop-reason semantics.
+
+#### `aragora swarm tranche`
+
+**Purpose:** Inspect a manifest-captured boss tranche against live GitHub and local repo state without mutating worktrees or dispatching agents.
+
+**Subcommands:**
+- `inspect` — resolve reference freshness, gate satisfaction, lane readiness, scope overlap, and the recommended next action
+
+**Key options:**
+- `--manifest <path>` — tranche manifest path
+- `--json` — emit machine-readable inspection payload
+
+**Example:**
+```bash
+aragora swarm tranche inspect \
+  --manifest docs/examples/boss-lane-manifest-2026-03-19.yaml \
+  --json
+```
 
 ---
 

--- a/docs/briefs/boss-loop-live-proof-runbook.md
+++ b/docs/briefs/boss-loop-live-proof-runbook.md
@@ -1,0 +1,81 @@
+# Boss-Loop Live Proof Runbook
+
+Historical note: this runbook captures the bounded execution contract used for the first live Boss-loop proof on 2026-03-19. Current `main` has since absorbed `#1065` and `#1066`, and issue `#1064` is closed. Use this as the template for future bounded live proofs, not as a literal instruction to rerun `#1064`.
+
+## Preconditions
+
+- `#1061` is merged so `--max-ticks 1` returns after dispatch instead of waiting for full worker completion.
+- The target issue is labeled `boss-loop-test`, still open, and has an explicit validation contract.
+- The runner is registered and fresh.
+- The repo is synced to current `origin/main`.
+
+## Launch Contract
+
+Run a single bounded live tick:
+
+```bash
+ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop \
+  --boss-label-filter boss-loop-test \
+  --boss-issue-number <ISSUE_NUMBER> \
+  --max-ticks 1 \
+  --target-branch main \
+  --json
+```
+
+Expected result:
+
+- `stop_reason: "max_iterations"`
+- exactly one iteration completed
+- `worker_status: "running"`
+- `worker_outcome: "dispatched"`
+- `next_actions[0]` references the active supervisor run id
+
+The command returning promptly is the point. The worker continues detached and must be monitored separately.
+
+## Monitor Contract
+
+After launch, inspect the active run:
+
+```bash
+python -m aragora.cli.main swarm status --json
+```
+
+Check for:
+
+- the active `run_id`
+- work order branch / worktree metadata
+- terminal outcome (`completed`, `needs_human`, `failed`)
+- any `receipt_id`, `pr_url`, or commit metadata
+
+If the run becomes terminal, preserve the JSON output as part of the evidence bundle.
+
+## Stop Conditions
+
+Stop and mark `needs_human` when any of the following occurs:
+
+- the target issue is closed, stale, or missing explicit validation commands
+- the worker edits outside the declared file scope
+- the worker reaches `needs_human`, `failed`, or `blocked`
+- the launch JSON is non-terminal in a way that contradicts the one-tick contract
+
+Do not widen scope during a live proof. Do not remove the explicit issue number. Do not increase `--max-ticks` beyond `1` for the first proof pattern.
+
+## Evidence Bundle
+
+For acceptance evidence on `#871`, `#990`, and `#1036`, preserve:
+
+- the boss-loop dispatch JSON
+- the final supervisor status JSON
+- the resulting PR URL or branch and commit metadata
+- the bounded validation commands run for the deliverable issue
+- the exact `origin/main` SHA used at launch time
+
+## Current Historical Outcome
+
+The first bounded tranche completed through these milestones:
+
+- `#1061` merged the one-tick return-shape fix
+- `#1065` merged the stdin / PTY hardening
+- `#1066` merged the concrete `#1064` deliverable
+
+That sequence is the reference pattern this runbook is meant to preserve.

--- a/docs/examples/boss-lane-manifest-2026-03-19.yaml
+++ b/docs/examples/boss-lane-manifest-2026-03-19.yaml
@@ -1,0 +1,218 @@
+manifest_version: 1
+manifest_id: boss-live-proof-tranche-2026-03-19
+generated_on: 2026-03-19
+repo:
+  name: synaptent/aragora
+  root: /Users/armand/Development/aragora
+  base_ref: origin/main
+  base_sha: 1eb030814
+objective: >-
+  Captured pre-execution tranche snapshot for the first bounded Boss-loop live
+  proof. Current main has since advanced; use `swarm tranche inspect` to detect
+  drift from this snapshot instead of assuming the declared states still match.
+shared_constraints:
+  start_from_fresh_worktree: true
+  worktree_convention: .worktrees/{agent}-auto/<session-id>
+  ignore_untracked_paths:
+    - /Users/armand/Development/aragora/Aragora Idea-to-Execution Strategy.docx
+  root_main_policy: do_not_use_as_work_lane
+  report_requirements:
+    - exact commands run
+    - url list for PRs, issues, or docs touched
+    - residual risk
+references:
+  gates:
+    pr_1061:
+      kind: pull_request
+      url: https://github.com/synaptent/aragora/pull/1061
+      state: merged
+      meaning: Base one-tick Boss-loop live-stop fix landed on main.
+    pr_1065:
+      kind: pull_request
+      url: https://github.com/synaptent/aragora/pull/1065
+      state: open
+      meaning: Follow-up worker-launch and PTY/stdin hardening.
+    pr_1060:
+      kind: pull_request
+      url: https://github.com/synaptent/aragora/pull/1060
+      state: closed
+      meaning: Treat as superseded; do not merge unchanged.
+  live_target:
+    issue_1064:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/1064
+      state: open
+      label: boss-loop-test
+      meaning: First bounded live Boss-loop proof target.
+  retired_targets:
+    issue_873:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/873
+      state: closed
+      label: boss-loop-test
+      meaning: "Stale after PR #857 merged."
+    issue_909:
+      kind: issue
+      url: https://github.com/synaptent/aragora/issues/909
+      state: closed
+      label: boss-loop-test
+      meaning: "Stale benchmark issue tied to #873 and the closed #907 contract."
+gates:
+  gate_1061:
+    source_ref: pr_1061
+    state: satisfied
+    required_for:
+      - codex_a_live_gate
+      - claude_a_runtime_verifier
+    satisfy_when: merged_to_main
+  gate_1065:
+    source_ref: pr_1065
+    state: pending
+    required_for:
+      - codex_a_live_gate
+      - codex_b_gatekeeper
+      - claude_a_runtime_verifier
+      - claude_b_operator_brief
+    satisfy_when: >-
+      merged to main or explicitly superseded by a narrower swarm runtime fix
+      that preserves the same intent
+  replace_1060:
+    source_ref: pr_1060
+    state: satisfied
+    required_for:
+      - codex_b_gatekeeper
+    satisfy_when: closed without merge and excluded from the live-proof critical path
+lanes:
+  - lane_id: codex_a_live_gate
+    owner_role: critical_path_engineer
+    branch:
+      current: codex/worker-launch-followup
+      convention: codex/<swarm-fix-or-live-proof>
+    worktree:
+      convention: .worktrees/codex-auto/<session-id>
+    allowed_write_scope:
+      - aragora/swarm/**
+      - aragora/swarm/worker_launcher.py
+      - tests/swarm/**
+    dependencies:
+      - gate_1061
+      - gate_1065
+      - issue_1064
+    success_criteria:
+      - "PR #1065 is merged or replaced by a narrower equivalent fix"
+      - "A live boss-loop run against #1064 terminates with truthful terminal JSON"
+      - Any created deliverable includes branch and commit metadata or a PR URL
+    verification_commands:
+      - gh -R synaptent/aragora pr view 1065 --json state,mergeable,url
+      - >-
+        ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop
+        --boss-label-filter boss-loop-test --boss-issue-number 1064
+        --no-dispatch --max-ticks 1 --json
+      - >-
+        ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop
+        --boss-label-filter boss-loop-test --boss-issue-number 1064
+        --max-ticks 1 --json
+    stop_conditions:
+      - The live run returns non-terminal output or hangs past the bounded observation window
+      - "Issue #1064 lacks an explicit validation contract or becomes stale"
+      - needs_human is returned without deliverable metadata and without a new truthful next action
+    expected_receipts_artifacts:
+      - Boss-loop terminal JSON containing run_id, stop_reason, needs_human_reasons, next_actions
+      - Operational receipt emission with source=boss_loop and action=run_completed
+      - Worker receipt_id if dispatch produces a worker run
+      - Worker worktree_path and branch metadata if a deliverable lane is created
+  - lane_id: codex_b_gatekeeper
+    owner_role: pr_gate_and_repo_ops
+    branch:
+      current: none_required
+      convention: codex/<repo-ops-or-gate-task>
+    worktree:
+      convention: .worktrees/codex-auto/<session-id>
+    allowed_write_scope: []
+    allowed_operations:
+      - GitHub PR review and merge decisions outside Codex A's write scope
+      - Root fast-forward after merge
+      - Safe worktree cleanup outside active lanes
+    dependencies:
+      - gate_1065
+      - replace_1060
+    success_criteria:
+      - "Gate status for #1065 is recorded accurately and root main is synced after merge"
+      - "#1060 remains excluded from merge flow"
+      - Cleanup touches only provably safe inactive worktrees and merged branches
+    verification_commands:
+      - gh -R synaptent/aragora pr view 1065 --json state,mergeable,url,statusCheckRollup
+      - git -C /Users/armand/Development/aragora fetch origin --prune --quiet
+      - git -C /Users/armand/Development/aragora rev-parse --short main
+      - git -C /Users/armand/Development/aragora rev-parse --short origin/main
+    stop_conditions:
+      - "#1065 has unresolved failing required checks or reviewer blockers"
+      - Cleanup candidate contains unmerged commits not proven superseded
+    expected_receipts_artifacts:
+      - "Merge or hold decision summary for #1065"
+      - Root-sync command transcript
+      - Keep/delete ledger for worktrees and branches touched
+  - lane_id: claude_a_runtime_verifier
+    owner_role: read_only_runtime_forensics
+    branch:
+      current: none_required
+      convention: claude/<forensics-task>
+    worktree:
+      convention: .worktrees/claude-auto/<session-id>
+    allowed_write_scope: []
+    dependencies:
+      - gate_1061
+      - gate_1065
+      - issue_1064
+    success_criteria:
+      - "Independent confirmation of where the first live #1064 run stops"
+      - Clear attribution of any wait point to worker routing, PTY, GitHub/API, or issue hygiene
+    verification_commands:
+      - gh -R synaptent/aragora pr view 1065 --json state,mergeable,url
+      - >-
+        ARAGORA_USER_ID=an0mium python -m aragora.cli.main swarm boss-loop
+        --boss-label-filter boss-loop-test --boss-issue-number 1064
+        --max-ticks 1 --json
+    stop_conditions:
+      - Another active session owns the live process and cannot be safely observed
+      - "The run target changes from #1064 before observation starts"
+    expected_receipts_artifacts:
+      - Read-only memo with exact command, wait point, likely root cause, and implicated file/function
+      - Captured terminal JSON if the run terminates
+  - lane_id: claude_b_operator_brief
+    owner_role: read_only_target_readiness
+    branch:
+      current: none_required
+      convention: claude/<brief-task>
+    worktree:
+      convention: .worktrees/claude-auto/<session-id>
+    allowed_write_scope: []
+    dependencies:
+      - gate_1065
+      - issue_1064
+    success_criteria:
+      - "Operator brief for #1064 is current and bounded"
+      - Acceptance evidence required for #871, #990, and #1036 is explicit
+    verification_commands:
+      - gh -R synaptent/aragora issue view 1064 --json state,title,url,body,labels
+      - sed -n '1,220p' aragora/live/package.json
+      - rg -n '"@supabase/supabase-js"|node_modules/@supabase/supabase-js' aragora/live/package-lock.json
+    stop_conditions:
+      - "Validation commands in #1064 drift from the current package surface"
+      - The issue stops being a single-package bounded lane
+    expected_receipts_artifacts:
+      - Short operator brief or comment-ready memo
+      - Validation command list and bounded file-scope confirmation
+terminal_outcomes:
+  success:
+    definition: >-
+      Gate #1065 is resolved and a live boss-loop run against #1064 completes
+      with truthful terminal output and captured artifacts.
+  needs_human:
+    definition: >-
+      Any lane returns explicit needs_human reasons or blocked gate state without
+      a safe automated next action.
+  stop_and_replan:
+    definition: >-
+      #1065 changes scope materially, #1064 becomes stale, or live-proof runtime
+      behavior falls outside the bounded one-tick contract.

--- a/docs/plans/2026-03-19-boss-lane-manifest-prototype.md
+++ b/docs/plans/2026-03-19-boss-lane-manifest-prototype.md
@@ -1,0 +1,41 @@
+# Boss Lane Manifest Prototype
+
+This document preserves the first tranche manifest that was assembled by hand while Boss-loop dogfooding was still being operated manually.
+
+The machine-readable example is [docs/examples/boss-lane-manifest-2026-03-19.yaml](../examples/boss-lane-manifest-2026-03-19.yaml). It captures the exact planning shape that was needed for the first bounded live proof:
+
+- `#1061` as the already-landed one-tick dispatch fix
+- `#1065` as the runtime hardening gate
+- `#1060` as an explicitly replaced PR, not something to merge unchanged
+- `#1064` as the bounded `boss-loop-test` issue
+- `#873` and `#909` as retired stale targets
+
+Current main has since moved past that snapshot: `#1065` and `#1066` are merged, and `#1064` is closed. That is intentional. The manifest remains useful because `swarm tranche inspect` can now compare the captured tranche snapshot against live GitHub and local repo state and report the drift explicitly.
+
+## Why This Shape
+
+The prototype is intentionally narrow:
+
+- `references` records the external PR and issue facts the tranche depends on
+- `gates` turns those references into explicit prerequisites
+- `lanes` records ownership, write scope, verification commands, stop conditions, and expected artifacts
+
+That is enough to make the current boss process reproducible without jumping straight to full autonomous multi-lane execution.
+
+## Current Use
+
+The first tranche-v1 implementation uses this artifact in three ways:
+
+1. loader and validation for the manifest structure
+2. read-only tranche inspection against live GitHub state
+3. artifact persistence for lane-level proofs, forensics, and runbooks
+
+## Next Increment
+
+The next useful step after this prototype is not auto-dispatch. It is a narrow claim/prepare capability that:
+
+1. refuses read-only lanes
+2. creates a managed worktree for a writable lane
+3. records write-scope ownership through the existing coordination lease store
+
+That keeps the control plane honest before any broader automation is attempted.

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -59,6 +59,7 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "all_runs": False,
         "dispatch_only": False,
         "no_wait": False,
+        "manifest": ".aragora/campaign_manifest.yaml",
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -172,6 +173,26 @@ class TestSwarmParser:
         assert args.lane_id == "lane-1"
         assert args.rationale == "Ship it"
 
+    def test_swarm_tranche_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "tranche",
+                "inspect",
+                "--manifest",
+                "docs/examples/boss-lane-manifest-2026-03-19.yaml",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "tranche"
+        assert args.swarm_goal == "inspect"
+        assert args.manifest == "docs/examples/boss-lane-manifest-2026-03-19.yaml"
+        assert args.json is True
+
     def test_swarm_parser_accepts_spec_dispatch_options(self):
         from aragora.cli.parser import build_parser
 
@@ -218,8 +239,34 @@ class TestSwarmCommand:
         assert '"runner_id": "codex-runner-123"' in out
         assert '"auth_mode": "chatgpt_login"' in out
         assert '"availability": "available"' in out
+
+    def test_cmd_swarm_tranche_inspect_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="tranche",
+            swarm_goal="inspect",
+            manifest="docs/examples/boss-lane-manifest-2026-03-19.yaml",
+            json=True,
+        )
+
+        fake_manifest = object()
+        with (
+            patch("aragora.swarm.tranche.load_tranche_manifest", return_value=fake_manifest),
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.swarm.tranche.TrancheInspector") as inspector_cls,
+        ):
+            inspector_cls.return_value.inspect.return_value = {
+                "mode": "tranche-inspect",
+                "manifest_id": "boss-live-proof-tranche-2026-03-19",
+                "preflight_status": "ok",
+                "recommended_action": {"kind": "run_lane", "lane_id": "codex_a_live_gate"},
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"mode": "tranche-inspect"' in out
+        assert '"manifest_id": "boss-live-proof-tranche-2026-03-19"' in out
+        assert '"lane_id": "codex_a_live_gate"' in out
         assert '"action": "inspect"' in out
-        assert '"freshness_status": "fresh"' in out
 
     def test_cmd_swarm_runner_register_rejects_unknown_auth(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from aragora.nomic.dev_coordination import LeaseConflictError
+from aragora.swarm.tranche import (
+    TrancheArtifactStore,
+    TrancheInspector,
+    TrancheLaneArtifact,
+    TrancheManifest,
+    load_tranche_manifest,
+    parse_github_reference_url,
+)
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", "README.md")
+    _run(repo, "git", "commit", "-m", "initial")
+    _run(repo, "git", "remote", "add", "origin", str(repo))
+    _run(repo, "git", "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+class _FakeReferenceClient:
+    def __init__(
+        self,
+        *,
+        pulls: dict[int, dict] | None = None,
+        issues: dict[int, dict] | None = None,
+    ) -> None:
+        self.pulls = pulls or {}
+        self.issues = issues or {}
+
+    def get_pr(self, repo: str, number: int) -> dict:
+        payload = dict(self.pulls[number])
+        payload.setdefault("url", f"https://github.com/{repo}/pull/{number}")
+        return payload
+
+    def get_issue(self, repo: str, number: int) -> dict:
+        payload = dict(self.issues[number])
+        payload.setdefault("url", f"https://github.com/{repo}/issues/{number}")
+        return payload
+
+
+def _historical_manifest() -> TrancheManifest:
+    return TrancheManifest.from_dict(
+        {
+            "manifest_version": 1,
+            "manifest_id": "boss-live-proof-tranche-2026-03-19",
+            "repo": {
+                "name": "synaptent/aragora",
+                "root": "/tmp/repo",
+                "base_ref": "origin/main",
+                "base_sha": "1eb030814",
+            },
+            "references": {
+                "gates": {
+                    "pr_1061": {
+                        "kind": "pull_request",
+                        "url": "https://github.com/synaptent/aragora/pull/1061",
+                        "state": "merged",
+                    },
+                    "pr_1065": {
+                        "kind": "pull_request",
+                        "url": "https://github.com/synaptent/aragora/pull/1065",
+                        "state": "open",
+                    },
+                    "pr_1060": {
+                        "kind": "pull_request",
+                        "url": "https://github.com/synaptent/aragora/pull/1060",
+                        "state": "closed",
+                    },
+                },
+                "live_target": {
+                    "issue_1064": {
+                        "kind": "issue",
+                        "url": "https://github.com/synaptent/aragora/issues/1064",
+                        "state": "open",
+                        "label": "boss-loop-test",
+                    }
+                },
+                "retired_targets": {
+                    "issue_873": {
+                        "kind": "issue",
+                        "url": "https://github.com/synaptent/aragora/issues/873",
+                        "state": "closed",
+                    },
+                    "issue_909": {
+                        "kind": "issue",
+                        "url": "https://github.com/synaptent/aragora/issues/909",
+                        "state": "closed",
+                    },
+                },
+            },
+            "gates": {
+                "gate_1061": {
+                    "source_ref": "pr_1061",
+                    "state": "satisfied",
+                    "required_for": ["codex_a_live_gate"],
+                    "satisfy_when": "merged_to_main",
+                },
+                "gate_1065": {
+                    "source_ref": "pr_1065",
+                    "state": "pending",
+                    "required_for": ["codex_a_live_gate", "codex_b_gatekeeper"],
+                    "satisfy_when": "merged to main",
+                },
+                "replace_1060": {
+                    "source_ref": "pr_1060",
+                    "state": "satisfied",
+                    "required_for": ["codex_b_gatekeeper"],
+                    "satisfy_when": "closed without merge",
+                },
+            },
+            "lanes": [
+                {
+                    "lane_id": "codex_a_live_gate",
+                    "owner_role": "critical_path_engineer",
+                    "branch": {"convention": "codex/<swarm-fix-or-live-proof>"},
+                    "worktree": {"convention": ".worktrees/codex-auto/<session-id>"},
+                    "allowed_write_scope": ["aragora/swarm/**"],
+                    "dependencies": ["gate_1061", "gate_1065", "issue_1064"],
+                    "verification_commands": ["python -m aragora.cli.main swarm boss-loop --json"],
+                    "stop_conditions": ["needs_human returned"],
+                    "expected_receipts_artifacts": ["boss loop JSON"],
+                },
+                {
+                    "lane_id": "codex_b_gatekeeper",
+                    "owner_role": "pr_gate_and_repo_ops",
+                    "branch": {"convention": "codex/<repo-ops-or-gate-task>"},
+                    "worktree": {"convention": ".worktrees/codex-auto/<session-id>"},
+                    "allowed_write_scope": [],
+                    "dependencies": ["gate_1065", "replace_1060"],
+                    "verification_commands": ["gh pr view 1065 --json state"],
+                    "stop_conditions": ["required check blocking"],
+                    "expected_receipts_artifacts": ["gate summary"],
+                },
+            ],
+            "terminal_outcomes": {
+                "success": {"definition": "proof completed"},
+                "needs_human": {"definition": "blocked safely"},
+                "stop_and_replan": {"definition": "target stale"},
+            },
+        }
+    )
+
+
+def _historical_client(*, gate_1065_state: str = "OPEN") -> _FakeReferenceClient:
+    pulls = {
+        1061: {
+            "number": 1061,
+            "state": "MERGED",
+            "mergedAt": "2026-03-19T15:27:39Z",
+            "title": "fix(swarm): stop one-tick boss-loop live runs after dispatch",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+            "reviewDecision": "APPROVED",
+        },
+        1065: {
+            "number": 1065,
+            "state": gate_1065_state,
+            "mergedAt": "2026-03-19T17:22:00Z" if gate_1065_state == "MERGED" else None,
+            "title": "fix(swarm): close stdin on non-detached workers and guard script(1) PTY",
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN" if gate_1065_state == "MERGED" else "BLOCKED",
+            "reviewDecision": "APPROVED" if gate_1065_state == "MERGED" else "REVIEW_REQUIRED",
+        },
+        1060: {
+            "number": 1060,
+            "state": "CLOSED",
+            "mergedAt": None,
+            "title": "stale boss-model cleanup",
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
+            "reviewDecision": "",
+        },
+    }
+    issues = {
+        1064: {
+            "number": 1064,
+            "state": "OPEN",
+            "closedAt": None,
+            "title": "Boss-loop execution: bump @supabase/supabase-js from 2.99.1 to 2.99.3 in /aragora/live",
+            "labels": [{"name": "boss-loop-test"}],
+        },
+        873: {
+            "number": 873,
+            "state": "CLOSED",
+            "closedAt": "2026-03-19T15:00:00Z",
+            "title": "stale dependency lane",
+            "labels": [{"name": "boss-loop-test"}],
+        },
+        909: {
+            "number": 909,
+            "state": "CLOSED",
+            "closedAt": "2026-03-19T15:00:00Z",
+            "title": "stale benchmark issue",
+            "labels": [{"name": "boss-loop-test"}],
+        },
+    }
+    return _FakeReferenceClient(pulls=pulls, issues=issues)
+
+
+def test_parse_github_reference_url() -> None:
+    ref = parse_github_reference_url("https://github.com/synaptent/aragora/pull/1065")
+    assert ref.owner == "synaptent"
+    assert ref.repo == "aragora"
+    assert ref.kind == "pull_request"
+    assert ref.number == 1065
+
+
+def test_load_tracked_example_manifest() -> None:
+    path = Path("docs/examples/boss-lane-manifest-2026-03-19.yaml")
+    manifest = load_tranche_manifest(path)
+    assert manifest.manifest_id == "boss-live-proof-tranche-2026-03-19"
+    assert "retired_targets" in manifest.references
+    assert "issue_873" in manifest.references["retired_targets"]
+
+
+def test_manifest_validation_rejects_missing_fields() -> None:
+    with pytest.raises(ValueError, match="manifest_id"):
+        TrancheManifest.from_dict(
+            {
+                "repo": {"name": "synaptent/aragora"},
+                "references": {},
+                "gates": {},
+                "lanes": [],
+                "terminal_outcomes": {},
+            }
+        )
+
+
+def test_inspect_reports_historical_gate_states_and_stale_targets(tmp_path: Path) -> None:
+    manifest = _historical_manifest()
+    artifact_store = TrancheArtifactStore(tmp_path)
+    artifact_store.save(
+        manifest.manifest_id,
+        TrancheLaneArtifact(
+            lane_id="claude_a_runtime_verifier",
+            source_ref="issue_1064",
+            status="approved_with_risk",
+            commands=["gh pr view 1065 --json state"],
+            urls=["https://github.com/synaptent/aragora/pull/1065"],
+            run_id="run-873",
+            worktree_path="/tmp/worktree",
+            residual_risk="multi-tick path still unmerged",
+            next_actions=["Merge #1065"],
+        ),
+    )
+    inspector = TrancheInspector(
+        repo_root=tmp_path,
+        reference_client=_historical_client(gate_1065_state="OPEN"),
+        artifact_store=artifact_store,
+    )
+
+    payload = inspector.inspect(manifest)
+
+    assert payload["gates"]["gate_1061"]["state"] == "satisfied"
+    assert payload["gates"]["gate_1065"]["state"] == "pending"
+    assert payload["references"]["issue_1064"]["status"] == "actionable"
+    assert payload["references"]["issue_873"]["status"] == "stale"
+    assert payload["references"]["issue_909"]["status"] == "stale"
+    assert payload["recommended_action"]["kind"] == "resolve_gate"
+    assert payload["recommended_action"]["source_ref"] == "pr_1065"
+    verifier_lane = next(
+        lane for lane in payload["lanes"] if lane["lane_id"] == "codex_b_gatekeeper"
+    )
+    assert verifier_lane["claimable"] is False
+    assert payload["artifacts"][0]["lane_id"] == "claude_a_runtime_verifier"
+
+
+def test_inspect_recommends_lane_once_pending_gate_is_satisfied(tmp_path: Path) -> None:
+    manifest = _historical_manifest()
+    inspector = TrancheInspector(
+        repo_root=tmp_path,
+        reference_client=_historical_client(gate_1065_state="MERGED"),
+        artifact_store=TrancheArtifactStore(tmp_path),
+    )
+
+    payload = inspector.inspect(manifest)
+
+    assert payload["gates"]["gate_1065"]["state"] == "satisfied"
+    assert payload["recommended_action"] == {
+        "kind": "run_lane",
+        "lane_id": "codex_a_live_gate",
+        "reason": "All dependencies satisfied",
+    }
+
+
+def test_declared_scope_conflict_blocks_only_writable_lanes(tmp_path: Path) -> None:
+    manifest = _historical_manifest()
+    manifest.lanes.append(
+        manifest.lane("codex_a_live_gate").__class__.from_dict(
+            {
+                "lane_id": "codex_c_overlap",
+                "owner_role": "supporting_engineer",
+                "branch": {"convention": "codex/<support>"},
+                "worktree": {"convention": ".worktrees/codex-auto/<session-id>"},
+                "allowed_write_scope": ["aragora/swarm/worker_launcher.py"],
+                "dependencies": ["gate_1061"],
+                "verification_commands": ["pytest tests/swarm/test_worker_launcher.py -q"],
+                "stop_conditions": ["scope leak"],
+                "expected_receipts_artifacts": ["worker receipt"],
+            }
+        )
+    )
+    inspector = TrancheInspector(
+        repo_root=tmp_path,
+        reference_client=_historical_client(gate_1065_state="MERGED"),
+        artifact_store=TrancheArtifactStore(tmp_path),
+    )
+
+    payload = inspector.inspect(manifest)
+
+    assert len(payload["scope_conflicts"]) == 1
+    conflict = payload["scope_conflicts"][0]
+    assert {conflict["left_lane_id"], conflict["right_lane_id"]} == {
+        "codex_a_live_gate",
+        "codex_c_overlap",
+    }
+    assert "codex_b_gatekeeper" not in {conflict["left_lane_id"], conflict["right_lane_id"]}
+
+
+def test_prepare_lane_claim_rejects_read_only_lane(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    manifest = _historical_manifest()
+    inspector = TrancheInspector(
+        repo_root=repo,
+        reference_client=_historical_client(gate_1065_state="MERGED"),
+        artifact_store=TrancheArtifactStore(repo),
+    )
+
+    with pytest.raises(ValueError, match="read-only"):
+        inspector.prepare_lane_claim(
+            manifest,
+            lane_id="codex_b_gatekeeper",
+            task_id="task-1",
+            title="gatekeeper",
+            owner_agent="codex",
+            owner_session_id="sess-1",
+            branch="codex/gatekeeper",
+            worktree_path=str(repo),
+        )
+
+
+def test_prepare_lane_claim_detects_scope_conflicts(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    manifest = _historical_manifest()
+    manifest.lanes.append(
+        manifest.lane("codex_a_live_gate").__class__.from_dict(
+            {
+                "lane_id": "codex_c_overlap",
+                "owner_role": "supporting_engineer",
+                "branch": {"convention": "codex/<support>"},
+                "worktree": {"convention": ".worktrees/codex-auto/<session-id>"},
+                "allowed_write_scope": ["aragora/swarm/worker_launcher.py"],
+                "dependencies": ["gate_1061"],
+                "verification_commands": ["pytest tests/swarm/test_worker_launcher.py -q"],
+                "stop_conditions": ["scope leak"],
+                "expected_receipts_artifacts": ["worker receipt"],
+            }
+        )
+    )
+    inspector = TrancheInspector(
+        repo_root=repo,
+        reference_client=_historical_client(gate_1065_state="MERGED"),
+        artifact_store=TrancheArtifactStore(repo),
+    )
+
+    inspector.prepare_lane_claim(
+        manifest,
+        lane_id="codex_a_live_gate",
+        task_id="task-a",
+        title="primary lane",
+        owner_agent="codex",
+        owner_session_id="sess-a",
+        branch="codex/primary-lane",
+        worktree_path=str(repo),
+    )
+
+    with pytest.raises(LeaseConflictError):
+        inspector.prepare_lane_claim(
+            manifest,
+            lane_id="codex_c_overlap",
+            task_id="task-c",
+            title="overlap lane",
+            owner_agent="codex",
+            owner_session_id="sess-c",
+            branch="codex/overlap-lane",
+            worktree_path=str(repo),
+        )
+
+
+def test_lane_artifact_round_trip_preserves_receipt_fields(tmp_path: Path) -> None:
+    store = TrancheArtifactStore(tmp_path)
+    artifact = TrancheLaneArtifact(
+        lane_id="codex_a_live_gate",
+        source_ref="issue_1064",
+        status="running",
+        commands=["python -m aragora.cli.main swarm boss-loop --json"],
+        urls=[
+            "https://github.com/synaptent/aragora/issues/1064",
+            "https://github.com/synaptent/aragora/pull/1065",
+        ],
+        run_id="8c06b6cc-a1f",
+        worktree_path="/tmp/repo/.worktrees/swarm-8c06b6cc-subtask_1",
+        residual_risk="worker still executing npm install",
+        next_actions=["Inspect the active supervisor run before starting another tick."],
+        metadata={"worker_status": "running"},
+    )
+
+    store.save("boss-live-proof-tranche-2026-03-19", artifact)
+    loaded = store.load("boss-live-proof-tranche-2026-03-19", "codex_a_live_gate")
+
+    assert loaded is not None
+    assert loaded.lane_id == artifact.lane_id
+    assert loaded.urls == artifact.urls
+    assert loaded.run_id == artifact.run_id
+    assert loaded.worktree_path == artifact.worktree_path
+    assert loaded.next_actions == artifact.next_actions


### PR DESCRIPTION
## Summary
- add a first-class tranche manifest model/loader and lane artifact store
- add `aragora swarm tranche inspect --manifest ... [--json]` for read-only gate and lane inspection
- preserve the first live boss-loop tranche artifacts as tracked docs
- add focused tests for manifest validation, stale-target detection, lane readiness, write-scope leasing, and artifact round-trip

## What Changed
- new `aragora.swarm.tranche` module for manifest parsing, GitHub reference resolution, lane inspection, artifact persistence, and narrow lease preparation
- `swarm` CLI now accepts the `tranche inspect` action
- tracked artifacts added under `docs/examples/`, `docs/plans/`, and `docs/briefs/`
- CLI reference updated with the new `swarm tranche` surface

## Verification
- `python3 -m ruff check aragora/swarm/tranche.py aragora/cli/commands/swarm.py aragora/cli/parser.py tests/swarm/test_tranche.py tests/cli/test_swarm_command.py`
- `python3 -m pytest tests/swarm/test_tranche.py tests/cli/test_swarm_command.py -q`
- `python3 -m pytest tests/swarm/test_campaign.py -q`
- `python3 -m aragora.cli.main swarm tranche inspect --manifest docs/examples/boss-lane-manifest-2026-03-19.yaml --json`

## Tranche Context
The current tranche has already advanced beyond the preserved snapshot:
- `#1061` merged the one-tick boss-loop return-shape fix
- `#1065` merged the worker-launch stdin / PTY hardening
- `#1066` merged the concrete `#1064` deliverable

The tracked example manifest intentionally captures the pre-execution snapshot so `swarm tranche inspect` can report drift against live GitHub state.
