### PR TITLE
feat(cli): wire swarm tranche integrate command

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -814,6 +814,9 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         return
 
     if action == "tranche":
+        from aragora.nomic.dev_coordination import DevCoordinationStore
+        from aragora.ralph.github_control import GitHubControl
+        from aragora.swarm.pr_registry import PullRequestRegistry
         from aragora.swarm.tranche import (
             TrancheArtifactStore,
             TrancheExecutor,
@@ -821,6 +824,13 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             TranchePlanner,
             load_tranche_manifest,
             render_tranche_inspection_text,
+        )
+        from aragora.swarm.tranche_integrate import (
+            assess_lane_integration,
+            classify_check_results,
+            discover_lane_pr,
+            record_lane_integration,
+            register_pr,
         )
         from aragora.swarm.tranche_review import review_lane, select_review_tier
         from aragora.swarm.tranche_submit import submit_intake_bundle
@@ -1018,6 +1028,131 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 print(json.dumps(payload, indent=2))
             return
 
+        if subaction == "integrate":
+            artifact_store = TrancheArtifactStore(repo_root=repo_root)
+            lane_id = str(getattr(args, "lane_id", "") or "").strip()
+            all_mergeable = bool(getattr(args, "all_mergeable", False))
+            approve = bool(getattr(args, "approve", False))
+            if lane_id:
+                artifact = artifact_store.load(manifest.manifest_id, lane_id)
+                selected_artifacts = [artifact] if artifact is not None else []
+            elif all_mergeable:
+                selected_artifacts = [
+                    item
+                    for item in artifact_store.list(manifest.manifest_id)
+                    if str(item.status).strip() in {"review_passed", "completed"}
+                ]
+            else:
+                raise ValueError("tranche integrate requires --lane-id <id> or --all-mergeable")
+            if not selected_artifacts:
+                raise ValueError("No matching tranche artifacts found for integrate.")
+
+            github = GitHubControl(repo_root=repo_root)
+            registry = PullRequestRegistry()
+            store = DevCoordinationStore(repo_root=repo_root) if approve else None
+            results: list[dict[str, object]] = []
+            for artifact in selected_artifacts:
+                metadata = getattr(artifact, "metadata", {})
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                review_payload = metadata.get("review", {})
+                if isinstance(review_payload, dict):
+                    review_status = str(review_payload.get("status", "") or "").strip() or "pending"
+                else:
+                    review_status = "pending"
+                if review_status == "pending":
+                    status_text = str(getattr(artifact, "status", "") or "").strip()
+                    if status_text == "review_passed":
+                        review_status = "passed"
+                    elif status_text == "changes_requested":
+                        review_status = "changes_requested"
+                    elif status_text == "review_blocked":
+                        review_status = "blocked_nonreviewable"
+
+                pr_url = discover_lane_pr(artifact, github=github, repo_root=repo_root)
+                branch = str(
+                    metadata.get("branch")
+                    or (
+                        metadata.get("deliverable", {}).get("branch")
+                        if isinstance(metadata.get("deliverable"), dict)
+                        else ""
+                    )
+                    or ""
+                ).strip()
+                if pr_url and branch:
+                    register_pr(pr_url, branch, registry)
+
+                gate_payload: dict[str, object] | None = None
+                checks = "checks_pending"
+                merge_result: dict[str, object] | None = None
+                if pr_url:
+                    snapshot = github.fetch_gate_snapshot(pr_url)
+                    gate_payload = snapshot.to_dict() if hasattr(snapshot, "to_dict") else None
+                    checks = classify_check_results(
+                        list(getattr(snapshot, "required_checks", []))
+                        + list(getattr(snapshot, "advisory_checks", []))
+                    )
+
+                assessment = assess_lane_integration(
+                    artifact=artifact,
+                    checks=checks,
+                    review_status=review_status,
+                    merge_policy=str(metadata.get("merge_policy", "confirm") or "confirm"),
+                    autonomy_mode=str(getattr(args, "autonomy", "adaptive") or "adaptive"),
+                    approve=approve,
+                )
+                if approve and assessment.get("recommendation") == "merge":
+                    awaitable = record_lane_integration(
+                        artifact=artifact,
+                        decision="merge",
+                        rationale=str(
+                            getattr(args, "rationale", None)
+                            or "Tranche integrate approved merge after green checks and review."
+                        ),
+                        decided_by=str(getattr(args, "decided_by", None) or "tranche-integrate"),
+                        store=store,
+                        target_branch=str(getattr(args, "target_branch", "main") or "main"),
+                    )
+                    asyncio.run(awaitable)
+                    if pr_url and assessment.get("executed"):
+                        merge_call = github.merge_pr(
+                            pr_url,
+                            required_checks_green=checks == "checks_passed",
+                            allow_admin=False,
+                        )
+                        merge_result = (
+                            merge_call.to_dict() if hasattr(merge_call, "to_dict") else None
+                        )
+                        if isinstance(merge_result, dict):
+                            assessment["executed"] = bool(merge_result.get("merged", False))
+
+                results.append(
+                    {
+                        "lane_id": artifact.lane_id,
+                        "status": getattr(artifact, "status", None),
+                        "pr_url": pr_url,
+                        "checks": checks,
+                        "review_status": review_status,
+                        "gate": gate_payload,
+                        "merge_result": merge_result,
+                        **assessment,
+                    }
+                )
+
+            payload = {
+                "mode": "tranche-integrate",
+                "action": subaction,
+                "manifest_id": manifest.manifest_id,
+                "manifest_path": str(manifest_path),
+                "approve": approve,
+                "results": results,
+            }
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                print(json.dumps(payload, indent=2))
+            return
+
         executor = TrancheExecutor(repo_root=repo_root)
         lane_id = str(getattr(args, "lane_id", "") or "").strip()
         all_ready = bool(getattr(args, "all_ready", False))
@@ -1048,7 +1183,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             )
         else:
             raise ValueError(
-                "tranche action must be one of: submit, plan, inspect, design-review, review, prepare, run"
+                "tranche action must be one of: submit, plan, inspect, design-review, review, integrate, prepare, run"
             )
         payload["action"] = subaction
         payload["manifest_path"] = str(manifest_path)

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2448,6 +2448,11 @@ def _add_swarm_parser(subparsers) -> None:
         help="Operate on all completed tranche lanes instead of one lane",
     )
     swarm_parser.add_argument(
+        "--all-mergeable",
+        action="store_true",
+        help="Operate on all mergeable tranche lanes instead of one lane",
+    )
+    swarm_parser.add_argument(
         "--owner-agent",
         default=None,
         help="Owner agent recorded for tranche prepare/run (defaults to lane target agent)",
@@ -2473,6 +2478,11 @@ def _add_swarm_parser(subparsers) -> None:
         choices=("auto", "1", "2", "3"),
         default="auto",
         help="Review tier for tranche review (default: auto)",
+    )
+    swarm_parser.add_argument(
+        "--approve",
+        action="store_true",
+        help="Allow tranche integrate to record and execute the recommended integration action",
     )
     swarm_parser.add_argument(
         "--max-parallel-ready-projects",

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -63,6 +63,8 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "intake": None,
         "rounds": 2,
         "all_completed": False,
+        "all_mergeable": False,
+        "approve": False,
         "tier": "auto",
         "from_prompts": None,
         "all_ready": False,
@@ -295,6 +297,30 @@ class TestSwarmParser:
         assert args.tier == "1"
         assert args.json is True
 
+    def test_swarm_tranche_integrate_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "tranche",
+                "integrate",
+                "--manifest",
+                "docs/examples/boss-lane-manifest-2026-03-19.yaml",
+                "--lane-id",
+                "lane_a",
+                "--approve",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "tranche"
+        assert args.swarm_goal == "integrate"
+        assert args.lane_id == "lane_a"
+        assert args.approve is True
+        assert args.json is True
+
     def test_swarm_parser_accepts_spec_dispatch_options(self):
         from aragora.cli.parser import build_parser
 
@@ -521,6 +547,63 @@ class TestSwarmCommand:
         assert '"mode": "tranche-review"' in out
         assert '"status": "passed"' in out
         assert '"action": "review"' in out
+
+    def test_cmd_swarm_tranche_integrate_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="tranche",
+            swarm_goal="integrate",
+            manifest="docs/examples/boss-lane-manifest-2026-03-19.yaml",
+            lane_id="lane_a",
+            json=True,
+        )
+        fake_manifest = SimpleNamespace(manifest_id="pmf-tranche")
+        fake_artifact = SimpleNamespace(
+            lane_id="lane_a",
+            status="review_passed",
+            metadata={
+                "branch": "feat-branch",
+                "review": {"status": "passed"},
+                "receipt_id": "receipt-123",
+                "lease_id": "lease-123",
+            },
+        )
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.swarm.tranche.load_tranche_manifest", return_value=fake_manifest),
+            patch("aragora.swarm.tranche.TrancheArtifactStore") as store_cls,
+            patch("aragora.swarm.tranche_integrate.discover_lane_pr") as mock_discover_pr,
+            patch("aragora.swarm.tranche_integrate.register_pr") as mock_register_pr,
+            patch("aragora.swarm.tranche_integrate.classify_check_results") as mock_classify,
+            patch("aragora.swarm.tranche_integrate.assess_lane_integration") as mock_assess,
+            patch(
+                "aragora.swarm.tranche_integrate.record_lane_integration", new_callable=AsyncMock
+            ) as mock_record,
+            patch("aragora.ralph.github_control.GitHubControl") as github_cls,
+        ):
+            store_cls.return_value.load.return_value = fake_artifact
+            mock_discover_pr.return_value = "https://github.com/org/repo/pull/42"
+            mock_classify.return_value = "checks_passed"
+            mock_assess.return_value = {
+                "recommendation": "merge",
+                "executed": False,
+                "checks": "checks_passed",
+                "review_status": "passed",
+            }
+            github_cls.return_value.fetch_gate_snapshot.return_value = SimpleNamespace(
+                required_checks=[],
+                advisory_checks=[],
+                required_checks_green=True,
+                to_dict=lambda: {"required_checks_green": True},
+            )
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"mode": "tranche-integrate"' in out
+        assert '"recommendation": "merge"' in out
+        assert '"action": "integrate"' in out
+        mock_register_pr.assert_called_once()
+        mock_record.assert_not_called()
 
     def test_cmd_swarm_tranche_prepare_json(self, capsys):
         args = _swarm_args(


### PR DESCRIPTION
## Summary
- add `swarm tranche integrate` with lane selection, `--all-mergeable`, and `--approve`
- assess tranche PR readiness from live GitHub gate snapshots plus recorded review state
- keep integrate assess-first by default and only record decisions when explicitly approved

## Verification
- python3 -m pytest tests/cli/test_swarm_command.py -q -k tranche_integrate
- python3 -m pytest tests/swarm/test_tranche_integrate.py tests/swarm/test_tranche_review.py tests/cli/test_swarm_command.py -q -k "tranche_integrate or tranche_review or integrate or review"
- python3 -m ruff check aragora/cli/commands/swarm.py aragora/cli/parser.py tests/cli/test_swarm_command.py aragora/swarm/tranche_integrate.py tests/swarm/test_tranche_integrate.py
