### PR TITLE
feat(tranche): add state refresh from authoritative stores

### DIFF
--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -56,7 +56,6 @@ def refresh_tranche_state(
         repo_root=repo_root,
     )
 
-    lease_map = _lease_map(resolved_store)
     for lane_id, lane_state in list(refreshed.lane_states.items()):
         artifact = artifact_map.get(lane_id)
         if artifact is not None:
@@ -66,6 +65,15 @@ def refresh_tranche_state(
         if run_dict is not None:
             _apply_run_projection(lane_state, run_dict)
 
+    lease_map = _lease_map(
+        resolved_store,
+        lease_ids={
+            lease_id
+            for lane_state in refreshed.lane_states.values()
+            if (lease_id := _optional_text(lane_state.lease_id)) is not None
+        },
+    )
+    for lane_state in refreshed.lane_states.values():
         lease = lease_map.get(str(lane_state.lease_id or "").strip())
         if lease is not None:
             _apply_lease_projection(lane_state, lease)
@@ -246,13 +254,16 @@ def _artifact_pr_url(artifact: TrancheLaneArtifact) -> str | None:
     return None
 
 
-def _lease_map(store: Any | None) -> dict[str, Any]:
+def _lease_map(store: Any | None, *, lease_ids: set[str] | None = None) -> dict[str, Any]:
     if store is None or not hasattr(store, "list_leases"):
+        return {}
+    relevant_lease_ids = {item for item in (lease_ids or set()) if _optional_text(item)}
+    if not relevant_lease_ids:
         return {}
     return {
         str(item.lease_id): item
         for item in store.list_leases(limit=None)
-        if getattr(item, "lease_id", None)
+        if getattr(item, "lease_id", None) and str(item.lease_id) in relevant_lease_ids
     }
 
 

--- a/tests/swarm/test_tranche_watch.py
+++ b/tests/swarm/test_tranche_watch.py
@@ -59,6 +59,7 @@ class _FakeCoordinationStore:
         self._leases = leases or []
         self._receipts = receipts or {}
         self._decisions = decisions or {}
+        self.list_leases_calls = 0
 
     def get_supervisor_run(self, run_id: str) -> dict | None:
         return self._runs.get(run_id)
@@ -66,6 +67,7 @@ class _FakeCoordinationStore:
     def list_leases(
         self, *, statuses: list[str] | None = None, limit: int | None = 500
     ) -> list[WorkLease]:
+        self.list_leases_calls += 1
         items = list(self._leases)
         if statuses is None:
             return items
@@ -102,6 +104,30 @@ def test_refresh_updates_lane_status_from_artifact_store():
 
     assert refreshed.lane_states["a"].status == "completed"
     assert refreshed.lane_states["a"].run_id == "run-1"
+
+
+def test_refresh_skips_lease_lookup_without_known_lease_ids() -> None:
+    state = _make_state(lane_statuses={"a": "completed"})
+    artifact = _make_artifact(lane_id="a", status="completed", run_id="run-1")
+    store = _FakeCoordinationStore(
+        leases=[
+            WorkLease(
+                lease_id="lease-1",
+                task_id="task-1",
+                title="task-1",
+                owner_agent="codex",
+                owner_session_id="sess-1",
+                branch="feat-branch",
+                worktree_path="/tmp/worktree",
+                status="active",
+            )
+        ]
+    )
+
+    refreshed = refresh_tranche_state(state, artifacts={"a": artifact}, store=store)
+
+    assert refreshed.lane_states["a"].lease_id is None
+    assert store.list_leases_calls == 0
 
 
 def test_refresh_uses_receipt_and_integration_state_for_waiting_for_merge():


### PR DESCRIPTION
## Summary
- add the initial tranche watch projection module with refresh from artifacts, runs, leases, receipts, and integration decisions
- project lane-level status updates into `LaneRunState` and derive aggregate tranche status
- cover refresh behavior with dedicated tranche watch tests

## Verification
- python3 -m pytest tests/swarm/test_tranche_watch.py -q
- python3 -m pytest tests/swarm/test_tranche_watch.py tests/swarm/test_tranche_state.py -q
- python3 -m ruff check aragora/swarm/tranche_watch.py tests/swarm/test_tranche_watch.py
