### PR TITLE
[codex] add tranche post-merge cascade handling

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -828,11 +828,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             render_tranche_inspection_text,
         )
         from aragora.swarm.tranche_integrate import (
-            assess_lane_integration,
-            classify_check_results,
-            discover_lane_pr,
-            record_lane_integration,
-            register_pr,
+            integrate_lane,
         )
         from aragora.swarm.tranche_review import review_lane, select_review_tier
         from aragora.swarm.tranche_submit import submit_intake_bundle
@@ -995,7 +991,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     repo_root=repo_root,
                 )
 
-            async def _watch_integrate_fn(*, manifest, lane_id, artifact, approve):
+            async def _watch_integrate_fn(*, manifest, lane_id, artifact, approve, run_state=None):
                 nonlocal github, registry
                 if artifact is None:
                     return {"recommendation": "needs_human", "executed": False}
@@ -1003,74 +999,21 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     github = GitHubControl(repo_root=repo_root)
                 if registry is None:
                     registry = PullRequestRegistry()
-                metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
-                review_payload = metadata.get("review", {})
-                if isinstance(review_payload, dict):
-                    review_status = str(review_payload.get("status", "") or "").strip() or "pending"
-                else:
-                    review_status = "pending"
-                if review_status == "pending":
-                    artifact_status = str(getattr(artifact, "status", "") or "").strip()
-                    if artifact_status == "review_passed":
-                        review_status = "passed"
-                    elif artifact_status == "changes_requested":
-                        review_status = "changes_requested"
-                    elif artifact_status == "review_blocked":
-                        review_status = "blocked_nonreviewable"
-
-                pr_url = discover_lane_pr(artifact, github=github, repo_root=repo_root)
-                branch = str(
-                    metadata.get("branch")
-                    or (
-                        metadata.get("deliverable", {}).get("branch")
-                        if isinstance(metadata.get("deliverable"), dict)
-                        else ""
-                    )
-                    or ""
-                ).strip()
-                if pr_url and branch:
-                    register_pr(pr_url, branch, registry)
-
-                checks = "checks_pending"
-                merge_result = None
-                if pr_url:
-                    snapshot = github.fetch_gate_snapshot(pr_url)
-                    checks = classify_check_results(
-                        list(getattr(snapshot, "required_checks", []))
-                        + list(getattr(snapshot, "advisory_checks", []))
-                    )
-                assessment = assess_lane_integration(
+                coord_store = DevCoordinationStore(repo_root=repo_root)
+                return await integrate_lane(
                     artifact=artifact,
-                    checks=checks,
-                    review_status=review_status,
-                    merge_policy=str(metadata.get("merge_policy", "confirm") or "confirm"),
-                    autonomy_mode=str(state.autonomy_mode or "adaptive"),
+                    manifest=manifest,
                     approve=bool(approve),
+                    repo_root=repo_root,
+                    github=github,
+                    registry=registry,
+                    store=coord_store,
+                    target_branch=str(getattr(args, "target_branch", "main") or "main"),
+                    decided_by="tranche-watch",
+                    rationale="Tranche watch approved merge after green checks and review.",
+                    run_state=run_state,
+                    autonomy_mode=str(state.autonomy_mode or "adaptive"),
                 )
-                if approve and assessment.get("recommendation") == "merge":
-                    coord_store = DevCoordinationStore(repo_root=repo_root)
-                    await record_lane_integration(
-                        artifact=artifact,
-                        decision="merge",
-                        rationale="Tranche watch approved merge after green checks and review.",
-                        decided_by="tranche-watch",
-                        store=coord_store,
-                        target_branch=str(getattr(args, "target_branch", "main") or "main"),
-                    )
-                    if pr_url and assessment.get("executed"):
-                        merge_call = github.merge_pr(
-                            pr_url,
-                            required_checks_green=checks == "checks_passed",
-                            allow_admin=False,
-                        )
-                        merge_result = (
-                            merge_call.to_dict() if hasattr(merge_call, "to_dict") else None
-                        )
-                        if isinstance(merge_result, dict):
-                            assessment["executed"] = bool(merge_result.get("merged", False))
-                if merge_result is not None:
-                    assessment["merge_result"] = merge_result
-                return assessment
 
             if driver_mode:
                 state = claim_driver(state, session_id=session_id)
@@ -1241,94 +1184,39 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             github = GitHubControl(repo_root=repo_root)
             registry = PullRequestRegistry()
             store = DevCoordinationStore(repo_root=repo_root) if approve else None
+            state_path = run_state_path_for_manifest(manifest_path)
+            run_state = None
+            try:
+                if state_path.exists():
+                    run_state = load_tranche_run_state(manifest_path)
+            except (OSError, ValueError):
+                run_state = None
             results: list[dict[str, object]] = []
             for artifact in selected_artifacts:
-                metadata = getattr(artifact, "metadata", {})
-                if not isinstance(metadata, dict):
-                    metadata = {}
-                review_payload = metadata.get("review", {})
-                if isinstance(review_payload, dict):
-                    review_status = str(review_payload.get("status", "") or "").strip() or "pending"
-                else:
-                    review_status = "pending"
-                if review_status == "pending":
-                    status_text = str(getattr(artifact, "status", "") or "").strip()
-                    if status_text == "review_passed":
-                        review_status = "passed"
-                    elif status_text == "changes_requested":
-                        review_status = "changes_requested"
-                    elif status_text == "review_blocked":
-                        review_status = "blocked_nonreviewable"
-
-                pr_url = discover_lane_pr(artifact, github=github, repo_root=repo_root)
-                branch = str(
-                    metadata.get("branch")
-                    or (
-                        metadata.get("deliverable", {}).get("branch")
-                        if isinstance(metadata.get("deliverable"), dict)
-                        else ""
-                    )
-                    or ""
-                ).strip()
-                if pr_url and branch:
-                    register_pr(pr_url, branch, registry)
-
-                gate_payload: dict[str, object] | None = None
-                checks = "checks_pending"
-                merge_result: dict[str, object] | None = None
-                if pr_url:
-                    snapshot = github.fetch_gate_snapshot(pr_url)
-                    gate_payload = snapshot.to_dict() if hasattr(snapshot, "to_dict") else None
-                    checks = classify_check_results(
-                        list(getattr(snapshot, "required_checks", []))
-                        + list(getattr(snapshot, "advisory_checks", []))
-                    )
-
-                assessment = assess_lane_integration(
-                    artifact=artifact,
-                    checks=checks,
-                    review_status=review_status,
-                    merge_policy=str(metadata.get("merge_policy", "confirm") or "confirm"),
-                    autonomy_mode=str(getattr(args, "autonomy", "adaptive") or "adaptive"),
-                    approve=approve,
-                )
-                if approve and assessment.get("recommendation") == "merge":
-                    awaitable = record_lane_integration(
+                result = asyncio.run(
+                    integrate_lane(
+                        manifest=manifest,
                         artifact=artifact,
-                        decision="merge",
+                        approve=approve,
+                        repo_root=repo_root,
+                        github=github,
+                        registry=registry,
+                        store=store,
+                        artifact_store=artifact_store,
+                        target_branch=str(getattr(args, "target_branch", "main") or "main"),
+                        decided_by=str(getattr(args, "decided_by", None) or "tranche-integrate"),
                         rationale=str(
                             getattr(args, "rationale", None)
                             or "Tranche integrate approved merge after green checks and review."
                         ),
-                        decided_by=str(getattr(args, "decided_by", None) or "tranche-integrate"),
-                        store=store,
-                        target_branch=str(getattr(args, "target_branch", "main") or "main"),
+                        run_state=run_state,
+                        autonomy_mode=str(getattr(args, "autonomy", "adaptive") or "adaptive"),
                     )
-                    asyncio.run(awaitable)
-                    if pr_url and assessment.get("executed"):
-                        merge_call = github.merge_pr(
-                            pr_url,
-                            required_checks_green=checks == "checks_passed",
-                            allow_admin=False,
-                        )
-                        merge_result = (
-                            merge_call.to_dict() if hasattr(merge_call, "to_dict") else None
-                        )
-                        if isinstance(merge_result, dict):
-                            assessment["executed"] = bool(merge_result.get("merged", False))
-
-                results.append(
-                    {
-                        "lane_id": artifact.lane_id,
-                        "status": getattr(artifact, "status", None),
-                        "pr_url": pr_url,
-                        "checks": checks,
-                        "review_status": review_status,
-                        "gate": gate_payload,
-                        "merge_result": merge_result,
-                        **assessment,
-                    }
                 )
+                results.append(result)
+
+            if run_state is not None:
+                run_state.save(state_path)
 
             payload = {
                 "mode": "tranche-integrate",

--- a/aragora/ralph/github_control.py
+++ b/aragora/ralph/github_control.py
@@ -141,6 +141,41 @@ class GitHubControl:
             raise GitHubControlError("gh pr create succeeded but returned no PR URL")
         return url
 
+    def retarget_pr_base(self, pr_ref: str, base_branch: str) -> dict[str, Any]:
+        normalized_pr_ref = str(pr_ref or "").strip()
+        normalized_base = str(base_branch or "").strip()
+        if not normalized_pr_ref:
+            return {
+                "retargeted": False,
+                "pr_url": None,
+                "base_branch": normalized_base or None,
+                "action": "retarget_failed",
+                "detail": "PR reference is required.",
+            }
+        if not normalized_base:
+            return {
+                "retargeted": False,
+                "pr_url": normalized_pr_ref,
+                "base_branch": None,
+                "action": "retarget_failed",
+                "detail": "Base branch is required.",
+            }
+
+        result = self._run_gh(
+            ["pr", "edit", normalized_pr_ref, "--base", normalized_base],
+            raise_on_error=False,
+            timeout=30,
+        )
+        detail = (result.stdout or result.stderr or "").strip()
+        return {
+            "retargeted": result.returncode == 0,
+            "pr_url": normalized_pr_ref,
+            "base_branch": normalized_base,
+            "action": "retarget" if result.returncode == 0 else "retarget_failed",
+            "detail": detail
+            or ("gh pr edit succeeded" if result.returncode == 0 else "gh pr edit failed"),
+        }
+
     def fetch_gate_snapshot(self, pr_ref: str) -> GitHubGateSnapshot:
         view = self._pr_view(pr_ref)
         pr_url = _optional_text(view.get("url")) or str(pr_ref).strip()

--- a/aragora/swarm/tranche_integrate.py
+++ b/aragora/swarm/tranche_integrate.py
@@ -11,6 +11,13 @@ from aragora.ralph.github_control import (
     _partition_checks,
 )
 from aragora.swarm.pr_registry import PullRequestRegistry
+from aragora.swarm.tranche import TrancheArtifactStore
+from aragora.swarm.tranche_state import (
+    LANE_STATUS_COMPLETED,
+    LANE_STATUS_NEEDS_HUMAN,
+    TRANCHE_STATUS_NEEDS_HUMAN,
+    _utcnow,
+)
 
 
 def discover_lane_pr(
@@ -143,6 +150,230 @@ def assess_lane_integration(
     }
 
 
+def execute_lane_merge(
+    pr_url: str,
+    *,
+    github: GitHubControl | Any,
+    branch: str | None,
+    registry: PullRequestRegistry | Any,
+    required_checks_green: bool,
+    allow_admin: bool = False,
+) -> dict[str, Any]:
+    merge_call = github.merge_pr(
+        pr_url,
+        required_checks_green=required_checks_green,
+        allow_admin=allow_admin,
+    )
+    result = merge_call.to_dict() if hasattr(merge_call, "to_dict") else dict(merge_call)
+    result["pr_url"] = str(pr_url or "").strip() or None
+    result["branch"] = _optional_text(branch)
+    if result.get("merged") and branch:
+        registry.close(str(branch).strip(), outcome="merged")
+    return result
+
+
+def cascade_after_merge(
+    manifest: Any,
+    merged_lane_id: str,
+    *,
+    artifact_store: TrancheArtifactStore | Any,
+    github: GitHubControl | Any,
+    registry: PullRequestRegistry | Any,
+    base_branch: str,
+    run_state: Any | None = None,
+) -> dict[str, Any]:
+    """Inspect dependent lane PRs after a merge.
+
+    Tranche lanes default to flat PRs against the manifest base branch. This
+    cascade only handles explicit lane-to-lane dependencies where downstream PRs
+    may need simple retargeting or manual restack after an upstream merge.
+    """
+
+    normalized_merged_lane_id = str(merged_lane_id or "").strip()
+    normalized_base_branch = str(base_branch or "main").strip() or "main"
+    lane_ids = {
+        str(getattr(lane, "lane_id", "") or "").strip()
+        for lane in getattr(manifest, "lanes", [])
+        if str(getattr(lane, "lane_id", "") or "").strip()
+    }
+    downstream: list[dict[str, Any]] = []
+
+    for lane in getattr(manifest, "lanes", []):
+        lane_id = str(getattr(lane, "lane_id", "") or "").strip()
+        dependencies = [
+            str(item).strip()
+            for item in getattr(lane, "dependencies", []) or []
+            if str(item).strip() in lane_ids
+        ]
+        if not lane_id or lane_id == normalized_merged_lane_id:
+            continue
+        if normalized_merged_lane_id not in dependencies:
+            continue
+
+        artifact = artifact_store.load(manifest.manifest_id, lane_id)
+        lane_branch = _lane_branch_hint(lane)
+        branch = _artifact_branch(artifact) or lane_branch
+        pr_url = discover_lane_pr(artifact, github=github) if artifact is not None else None
+        if not pr_url and branch:
+            pr_url = _optional_text(github.find_pr_for_branch(branch))
+        if pr_url and branch:
+            register_pr(pr_url, branch, registry)
+
+        action = "ok"
+        reason = "Downstream PR already targets the tranche base branch."
+
+        if artifact is None:
+            action = "missing_pr"
+            reason = "Downstream lane has no tranche artifact yet."
+        elif not pr_url:
+            action = "missing_pr"
+            reason = "Downstream lane has no discoverable PR."
+        else:
+            snapshot = github.fetch_gate_snapshot(pr_url)
+            state = str(getattr(snapshot, "state", "") or "").strip().upper()
+            current_base = _optional_text(getattr(snapshot, "base_branch", None))
+            merge_state = str(getattr(snapshot, "merge_state_status", "") or "").strip().upper()
+
+            if state != "OPEN":
+                action = "needs_restack"
+                reason = f"Downstream PR is {state.lower() or 'closed'} after the upstream merge."
+            elif current_base and current_base != normalized_base_branch:
+                retarget = github.retarget_pr_base(pr_url, normalized_base_branch)
+                if retarget.get("retargeted"):
+                    action = "retargeted"
+                    reason = (
+                        f"Retargeted downstream PR from {current_base} to {normalized_base_branch}."
+                    )
+                else:
+                    action = "needs_restack"
+                    reason = str(retarget.get("detail", "") or "Failed to retarget downstream PR.")
+            elif not current_base:
+                action = "needs_restack"
+                reason = "Downstream PR base branch could not be determined."
+            elif merge_state == "DIRTY":
+                action = "needs_restack"
+                reason = "Downstream PR has merge conflicts after the upstream merge."
+
+        downstream.append(
+            {
+                "lane_id": lane_id,
+                "pr_url": pr_url,
+                "action": action,
+                "reason": reason,
+            }
+        )
+
+    report = {
+        "merged_lane_id": normalized_merged_lane_id,
+        "downstream": downstream,
+        "clean": all(item["action"] in {"ok", "retargeted"} for item in downstream),
+        "needs_human": any(
+            item["action"] in {"needs_restack", "missing_pr"} for item in downstream
+        ),
+    }
+    if run_state is not None:
+        _apply_cascade_to_run_state(run_state, report)
+    return report
+
+
+async def integrate_lane(
+    *,
+    manifest: Any,
+    artifact: Any,
+    approve: bool,
+    repo_root: Path | None = None,
+    github: GitHubControl | Any | None = None,
+    registry: PullRequestRegistry | Any | None = None,
+    store: DevCoordinationStore | Any | None = None,
+    artifact_store: TrancheArtifactStore | Any | None = None,
+    target_branch: str = "main",
+    decided_by: str = "tranche-integrate",
+    rationale: str | None = None,
+    allow_admin: bool = False,
+    run_state: Any | None = None,
+    autonomy_mode: str = "adaptive",
+) -> dict[str, Any]:
+    repo = (repo_root or Path.cwd()).resolve()
+    github_obj = github or GitHubControl(repo_root=repo)
+    registry_obj = registry or PullRequestRegistry()
+    artifact_store_obj = artifact_store or TrancheArtifactStore(repo_root=repo)
+
+    review_status = _artifact_review_status(artifact)
+    pr_url = discover_lane_pr(artifact, github=github_obj, repo_root=repo)
+    branch = _artifact_branch(artifact)
+    if pr_url and branch:
+        register_pr(pr_url, branch, registry_obj)
+
+    gate_payload: dict[str, Any] | None = None
+    checks = "checks_pending"
+    if pr_url:
+        snapshot = github_obj.fetch_gate_snapshot(pr_url)
+        gate_payload = snapshot.to_dict() if hasattr(snapshot, "to_dict") else None
+        checks = classify_check_results(
+            list(getattr(snapshot, "required_checks", []))
+            + list(getattr(snapshot, "advisory_checks", []))
+        )
+
+    metadata = getattr(artifact, "metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+    assessment = assess_lane_integration(
+        artifact=artifact,
+        checks=checks,
+        review_status=review_status,
+        merge_policy=str(metadata.get("merge_policy", "confirm") or "confirm"),
+        autonomy_mode=str(autonomy_mode or "adaptive").strip() or "adaptive",
+        approve=approve,
+    )
+
+    merge_result: dict[str, Any] | None = None
+    cascade_report: dict[str, Any] | None = None
+    if approve and assessment.get("recommendation") == "merge":
+        coord_store = store or DevCoordinationStore(repo_root=repo)
+        await record_lane_integration(
+            artifact=artifact,
+            decision="merge",
+            rationale=str(
+                rationale or "Tranche integrate approved merge after green checks and review."
+            ).strip(),
+            decided_by=str(decided_by or "tranche-integrate").strip() or "tranche-integrate",
+            store=coord_store,
+            target_branch=str(target_branch or "main").strip() or "main",
+        )
+        if pr_url and assessment.get("executed"):
+            merge_result = execute_lane_merge(
+                pr_url,
+                github=github_obj,
+                branch=branch,
+                registry=registry_obj,
+                required_checks_green=checks == "checks_passed",
+                allow_admin=allow_admin,
+            )
+            assessment["executed"] = bool(merge_result.get("merged", False))
+            if merge_result.get("merged"):
+                cascade_report = cascade_after_merge(
+                    manifest,
+                    str(getattr(artifact, "lane_id", "") or "").strip(),
+                    artifact_store=artifact_store_obj,
+                    github=github_obj,
+                    registry=registry_obj,
+                    base_branch=str(target_branch or "main").strip() or "main",
+                    run_state=run_state,
+                )
+
+    return {
+        "lane_id": str(getattr(artifact, "lane_id", "") or "").strip() or None,
+        "status": getattr(artifact, "status", None),
+        "pr_url": pr_url,
+        "checks": checks,
+        "review_status": review_status,
+        "gate": gate_payload,
+        "merge_result": merge_result,
+        "cascade_report": cascade_report,
+        **assessment,
+    }
+
+
 async def record_lane_integration(
     *,
     artifact: Any,
@@ -216,6 +447,80 @@ def _check_is_failed(check: GitHubCheck) -> bool:
 
 def _looks_like_pr_url(value: str) -> bool:
     return value.startswith("https://github.com/") and "/pull/" in value
+
+
+def _artifact_review_status(artifact: Any) -> str:
+    metadata = getattr(artifact, "metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+    review_payload = metadata.get("review", {})
+    if isinstance(review_payload, dict):
+        review_status = str(review_payload.get("status", "") or "").strip() or "pending"
+    else:
+        review_status = "pending"
+    if review_status != "pending":
+        return review_status
+
+    artifact_status = str(getattr(artifact, "status", "") or "").strip()
+    if artifact_status == "review_passed":
+        return "passed"
+    if artifact_status == "changes_requested":
+        return "changes_requested"
+    if artifact_status == "review_blocked":
+        return "blocked_nonreviewable"
+    return "pending"
+
+
+def _artifact_branch(artifact: Any) -> str | None:
+    metadata = getattr(artifact, "metadata", {})
+    if not isinstance(metadata, dict):
+        metadata = {}
+    deliverable = metadata.get("deliverable", {})
+    if not isinstance(deliverable, dict):
+        deliverable = {}
+    return _optional_text(
+        deliverable.get("branch") or metadata.get("branch") or getattr(artifact, "branch", None)
+    )
+
+
+def _lane_branch_hint(lane: Any) -> str | None:
+    branch = getattr(lane, "branch", {})
+    if isinstance(branch, dict):
+        return _optional_text(branch.get("current"))
+    return None
+
+
+def _apply_cascade_to_run_state(run_state: Any, report: dict[str, Any]) -> None:
+    if not hasattr(run_state, "lane_states") or not isinstance(run_state.lane_states, dict):
+        return
+
+    merged_lane_id = _optional_text(report.get("merged_lane_id"))
+    now = _utcnow()
+    if merged_lane_id:
+        merged_lane = run_state.lane_states.get(merged_lane_id)
+        if merged_lane is not None:
+            merged_lane.status = LANE_STATUS_COMPLETED
+            merged_lane.last_updated = now
+
+    needs_human = False
+    for item in report.get("downstream", []):
+        if not isinstance(item, dict):
+            continue
+        lane_id = _optional_text(item.get("lane_id"))
+        action = str(item.get("action", "") or "").strip()
+        if not lane_id:
+            continue
+        if action not in {"needs_restack", "missing_pr"}:
+            continue
+        needs_human = True
+        lane_state = run_state.lane_states.get(lane_id)
+        if lane_state is not None:
+            lane_state.status = LANE_STATUS_NEEDS_HUMAN
+            lane_state.last_updated = now
+
+    if needs_human:
+        run_state.status = TRANCHE_STATUS_NEEDS_HUMAN
+    run_state.updated_at = now
 
 
 def _optional_text(value: Any, *, upper: bool = False) -> str | None:

--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -241,7 +241,13 @@ async def watch_tick(
                     lane_id=lane_id,
                     artifact=artifact,
                     approve=(mode == "fire_and_forget"),
+                    run_state=refreshed,
                 )
+                if isinstance(integrate_payload, dict):
+                    _apply_cascade_report_to_state(
+                        refreshed,
+                        integrate_payload.get("cascade_report"),
+                    )
                 lane_state.status = _watch_integrate_status(
                     lane_state.status,
                     integrate_payload if isinstance(integrate_payload, dict) else {},
@@ -541,6 +547,39 @@ def _watch_integrate_status(current_status: str, payload: dict[str, Any]) -> str
     if recommendation in {"request_changes", "blocked", "needs_human"}:
         return LANE_STATUS_NEEDS_HUMAN
     return current_status
+
+
+def _apply_cascade_report_to_state(
+    state: TrancheRunState,
+    report: dict[str, Any] | None,
+) -> None:
+    if not isinstance(report, dict):
+        return
+    now = _utcnow()
+    merged_lane_id = _optional_text(report.get("merged_lane_id"))
+    if merged_lane_id and merged_lane_id in state.lane_states:
+        state.lane_states[merged_lane_id].status = LANE_STATUS_COMPLETED
+        state.lane_states[merged_lane_id].last_updated = now
+
+    needs_human = False
+    for item in report.get("downstream", []):
+        if not isinstance(item, dict):
+            continue
+        lane_id = _optional_text(item.get("lane_id"))
+        action = str(item.get("action", "") or "").strip()
+        if not lane_id or action not in {"needs_restack", "missing_pr"}:
+            continue
+        lane_state = state.lane_states.get(lane_id)
+        if lane_state is None:
+            lane_state = LaneRunState(lane_id=lane_id, status=LANE_STATUS_NEEDS_HUMAN)
+            state.lane_states[lane_id] = lane_state
+        lane_state.status = LANE_STATUS_NEEDS_HUMAN
+        lane_state.last_updated = now
+        needs_human = True
+
+    if needs_human:
+        state.status = TRANCHE_STATUS_NEEDS_HUMAN
+    state.updated_at = now
 
 
 def _close_session_history(state: TrancheRunState, session_id: str, *, now: Any) -> None:

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -602,43 +602,48 @@ class TestSwarmCommand:
                 "lease_id": "lease-123",
             },
         )
+        fake_state = SimpleNamespace(save=lambda _path: None)
         with (
             patch("pathlib.Path.exists", return_value=True),
             patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
             patch("aragora.swarm.tranche.load_tranche_manifest", return_value=fake_manifest),
             patch("aragora.swarm.tranche.TrancheArtifactStore") as store_cls,
-            patch("aragora.swarm.tranche_integrate.discover_lane_pr") as mock_discover_pr,
-            patch("aragora.swarm.tranche_integrate.register_pr") as mock_register_pr,
-            patch("aragora.swarm.tranche_integrate.classify_check_results") as mock_classify,
-            patch("aragora.swarm.tranche_integrate.assess_lane_integration") as mock_assess,
+            patch("aragora.swarm.tranche_watch.load_tranche_run_state", return_value=fake_state),
             patch(
-                "aragora.swarm.tranche_integrate.record_lane_integration", new_callable=AsyncMock
-            ) as mock_record,
-            patch("aragora.ralph.github_control.GitHubControl") as github_cls,
+                "aragora.swarm.tranche_integrate.integrate_lane",
+                new_callable=AsyncMock,
+            ) as mock_integrate,
         ):
             store_cls.return_value.load.return_value = fake_artifact
-            mock_discover_pr.return_value = "https://github.com/org/repo/pull/42"
-            mock_classify.return_value = "checks_passed"
-            mock_assess.return_value = {
+            mock_integrate.return_value = {
+                "lane_id": "lane_a",
                 "recommendation": "merge",
                 "executed": False,
                 "checks": "checks_passed",
                 "review_status": "passed",
+                "cascade_report": {
+                    "merged_lane_id": "lane_a",
+                    "downstream": [
+                        {
+                            "lane_id": "lane_b",
+                            "pr_url": "https://github.com/org/repo/pull/99",
+                            "action": "retargeted",
+                            "reason": "Retargeted downstream PR from stack-base to main.",
+                        }
+                    ],
+                    "clean": True,
+                    "needs_human": False,
+                },
             }
-            github_cls.return_value.fetch_gate_snapshot.return_value = SimpleNamespace(
-                required_checks=[],
-                advisory_checks=[],
-                required_checks_green=True,
-                to_dict=lambda: {"required_checks_green": True},
-            )
             cmd_swarm(args)
 
         out = capsys.readouterr().out
         assert '"mode": "tranche-integrate"' in out
         assert '"recommendation": "merge"' in out
         assert '"action": "integrate"' in out
-        mock_register_pr.assert_called_once()
-        mock_record.assert_not_called()
+        assert '"cascade_report"' in out
+        assert '"action": "retargeted"' in out
+        mock_integrate.assert_awaited_once()
 
     def test_cmd_swarm_tranche_watch_json(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_tranche_integrate.py
+++ b/tests/swarm/test_tranche_integrate.py
@@ -7,23 +7,66 @@ import pytest
 
 from aragora.nomic.dev_coordination import IntegrationDecisionType
 from aragora.swarm.pr_registry import PullRequestRegistry
+from aragora.swarm.tranche import TrancheLane, TrancheLaneArtifact
 from aragora.swarm.tranche_integrate import (
     assess_lane_integration,
+    cascade_after_merge,
     classify_check_results,
     discover_lane_pr,
+    execute_lane_merge,
+    integrate_lane,
     record_lane_integration,
     register_pr,
+)
+from aragora.swarm.tranche_state import (
+    LANE_STATUS_NEEDS_HUMAN,
+    LANE_STATUS_WAITING_FOR_MERGE,
+    LaneRunState,
+    TrancheRunState,
 )
 
 
 def _make_artifact(
-    *, metadata: dict | None = None, urls: list[str] | None = None
-) -> SimpleNamespace:
-    return SimpleNamespace(
-        lane_id="lane-a",
+    *,
+    lane_id: str = "lane-a",
+    status: str = "review_passed",
+    metadata: dict | None = None,
+    urls: list[str] | None = None,
+) -> TrancheLaneArtifact:
+    return TrancheLaneArtifact(
+        lane_id=lane_id,
+        source_ref=f"lane:{lane_id}",
+        status=status,
         metadata=metadata or {},
         urls=urls or [],
     )
+
+
+def _make_lane(
+    lane_id: str,
+    *,
+    dependencies: list[str] | None = None,
+    branch: dict | None = None,
+) -> TrancheLane:
+    return TrancheLane(
+        lane_id=lane_id,
+        owner_role="critical_path_engineer",
+        branch=branch or {},
+        dependencies=dependencies or [],
+    )
+
+
+def _make_manifest(*lanes: TrancheLane) -> SimpleNamespace:
+    return SimpleNamespace(manifest_id="m1", lanes=list(lanes))
+
+
+class _FakeArtifactStore:
+    def __init__(self, artifacts: dict[str, TrancheLaneArtifact]) -> None:
+        self._artifacts = dict(artifacts)
+
+    def load(self, manifest_id: str, lane_id: str) -> TrancheLaneArtifact | None:
+        assert manifest_id == "m1"
+        return self._artifacts.get(lane_id)
 
 
 def test_discover_pr_from_artifact_metadata():
@@ -201,3 +244,341 @@ def test_assess_fire_and_forget_confirm_policy_still_waits() -> None:
 
     assert result["recommendation"] == "merge"
     assert result["executed"] is False
+
+
+def test_execute_lane_merge_reuses_github_control_and_closes_registry() -> None:
+    github = MagicMock()
+    github.merge_pr.return_value = SimpleNamespace(
+        to_dict=lambda: {
+            "merged": True,
+            "action": "merge",
+            "used_admin": False,
+            "detail": "merged",
+        }
+    )
+    registry = MagicMock(spec=PullRequestRegistry)
+
+    result = execute_lane_merge(
+        "https://github.com/org/repo/pull/42",
+        github=github,
+        branch="feat-branch",
+        registry=registry,
+        required_checks_green=True,
+    )
+
+    github.merge_pr.assert_called_once_with(
+        "https://github.com/org/repo/pull/42",
+        required_checks_green=True,
+        allow_admin=False,
+    )
+    registry.close.assert_called_once_with("feat-branch", outcome="merged")
+    assert result["merged"] is True
+
+
+def test_cascade_retargets_open_downstream_prs_and_ignores_reference_dependencies() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["lane-a"]),
+        _make_lane("lane-c", dependencies=["issue_123"]),
+    )
+    artifact_store = _FakeArtifactStore(
+        {
+            "lane-b": _make_artifact(
+                lane_id="lane-b",
+                metadata={
+                    "branch": "feat-b",
+                    "deliverable": {"pr_url": "https://github.com/org/repo/pull/99"},
+                },
+            )
+        }
+    )
+    github = MagicMock()
+    github.fetch_gate_snapshot.return_value = SimpleNamespace(
+        state="OPEN",
+        base_branch="stack-base",
+        merge_state_status="CLEAN",
+    )
+    github.retarget_pr_base.return_value = {
+        "retargeted": True,
+        "pr_url": "https://github.com/org/repo/pull/99",
+        "base_branch": "main",
+        "action": "retarget",
+    }
+    registry = MagicMock(spec=PullRequestRegistry)
+    run_state = TrancheRunState(
+        manifest_id="m1",
+        status="integrating",
+        autonomy_mode="adaptive",
+        lane_states={
+            "lane-b": LaneRunState(lane_id="lane-b", status=LANE_STATUS_WAITING_FOR_MERGE)
+        },
+    )
+
+    report = cascade_after_merge(
+        manifest,
+        "lane-a",
+        artifact_store=artifact_store,
+        github=github,
+        registry=registry,
+        base_branch="main",
+        run_state=run_state,
+    )
+
+    assert [item["lane_id"] for item in report["downstream"]] == ["lane-b"]
+    assert report["downstream"][0]["action"] == "retargeted"
+    assert report["clean"] is True
+    assert report["needs_human"] is False
+    assert run_state.lane_states["lane-b"].status == LANE_STATUS_WAITING_FOR_MERGE
+    github.retarget_pr_base.assert_called_once_with(
+        "https://github.com/org/repo/pull/99",
+        "main",
+    )
+
+
+def test_cascade_flags_closed_downstream_pr_for_restack_and_updates_run_state() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["lane-a"]),
+    )
+    artifact_store = _FakeArtifactStore(
+        {
+            "lane-b": _make_artifact(
+                lane_id="lane-b",
+                metadata={
+                    "branch": "feat-b",
+                    "deliverable": {"pr_url": "https://github.com/org/repo/pull/99"},
+                },
+            )
+        }
+    )
+    github = MagicMock()
+    github.fetch_gate_snapshot.return_value = SimpleNamespace(
+        state="CLOSED",
+        base_branch="stack-base",
+        merge_state_status="CLEAN",
+    )
+    registry = MagicMock(spec=PullRequestRegistry)
+    run_state = TrancheRunState(
+        manifest_id="m1",
+        status="integrating",
+        autonomy_mode="adaptive",
+        lane_states={"lane-b": LaneRunState(lane_id="lane-b", status="waiting_for_merge")},
+    )
+
+    report = cascade_after_merge(
+        manifest,
+        "lane-a",
+        artifact_store=artifact_store,
+        github=github,
+        registry=registry,
+        base_branch="main",
+        run_state=run_state,
+    )
+
+    assert report["downstream"][0]["action"] == "needs_restack"
+    assert report["needs_human"] is True
+    assert run_state.lane_states["lane-b"].status == LANE_STATUS_NEEDS_HUMAN
+    assert run_state.status == "needs_human"
+
+
+def test_cascade_flags_conflicting_prs_for_restack() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["lane-a"]),
+    )
+    artifact_store = _FakeArtifactStore(
+        {
+            "lane-b": _make_artifact(
+                lane_id="lane-b",
+                metadata={
+                    "branch": "feat-b",
+                    "deliverable": {"pr_url": "https://github.com/org/repo/pull/99"},
+                },
+            )
+        }
+    )
+    github = MagicMock()
+    github.fetch_gate_snapshot.return_value = SimpleNamespace(
+        state="OPEN",
+        base_branch="main",
+        merge_state_status="DIRTY",
+    )
+
+    report = cascade_after_merge(
+        manifest,
+        "lane-a",
+        artifact_store=artifact_store,
+        github=github,
+        registry=MagicMock(spec=PullRequestRegistry),
+        base_branch="main",
+    )
+
+    assert report["downstream"][0]["action"] == "needs_restack"
+    assert report["needs_human"] is True
+
+
+def test_cascade_flags_missing_pr_without_recreating() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["lane-a"]),
+    )
+    artifact_store = _FakeArtifactStore({"lane-b": _make_artifact(lane_id="lane-b")})
+    github = MagicMock()
+
+    report = cascade_after_merge(
+        manifest,
+        "lane-a",
+        artifact_store=artifact_store,
+        github=github,
+        registry=MagicMock(spec=PullRequestRegistry),
+        base_branch="main",
+    )
+
+    assert report["downstream"][0]["action"] == "missing_pr"
+    github.fetch_gate_snapshot.assert_not_called()
+    github.retarget_pr_base.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_integrate_lane_returns_merge_and_cascade_payload() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["lane-a"]),
+    )
+    artifact = _make_artifact(
+        metadata={
+            "branch": "feat-a",
+            "review": {"status": "passed"},
+            "merge_policy": "auto",
+            "receipt_id": "receipt-a",
+            "lease_id": "lease-a",
+            "deliverable": {"pr_url": "https://github.com/org/repo/pull/42"},
+        }
+    )
+    downstream_artifact = _make_artifact(
+        lane_id="lane-b",
+        status="waiting_for_merge",
+        metadata={
+            "branch": "feat-b",
+            "deliverable": {"pr_url": "https://github.com/org/repo/pull/99"},
+        },
+    )
+    artifact_store = _FakeArtifactStore({"lane-b": downstream_artifact})
+    github = MagicMock()
+    github.fetch_gate_snapshot.side_effect = [
+        SimpleNamespace(
+            required_checks=[{"name": "lint", "conclusion": "SUCCESS", "required": True}],
+            advisory_checks=[],
+            required_checks_green=True,
+            to_dict=lambda: {"required_checks_green": True},
+            state="OPEN",
+            base_branch="main",
+            merge_state_status="CLEAN",
+        ),
+        SimpleNamespace(
+            state="OPEN",
+            base_branch="stack-base",
+            merge_state_status="CLEAN",
+        ),
+    ]
+    github.merge_pr.return_value = SimpleNamespace(
+        to_dict=lambda: {
+            "merged": True,
+            "action": "merge",
+            "used_admin": False,
+            "detail": "merged",
+        }
+    )
+    github.retarget_pr_base.return_value = {
+        "retargeted": True,
+        "pr_url": "https://github.com/org/repo/pull/99",
+        "base_branch": "main",
+        "action": "retarget",
+        "detail": "retargeted",
+    }
+    registry = MagicMock(spec=PullRequestRegistry)
+    store = MagicMock()
+    run_state = TrancheRunState(
+        manifest_id="m1",
+        status="integrating",
+        autonomy_mode="adaptive",
+        lane_states={
+            "lane-a": LaneRunState(lane_id="lane-a", status="review_passed"),
+            "lane-b": LaneRunState(lane_id="lane-b", status="waiting_for_merge"),
+        },
+    )
+
+    result = await integrate_lane(
+        manifest=manifest,
+        artifact=artifact,
+        approve=True,
+        github=github,
+        registry=registry,
+        store=store,
+        artifact_store=artifact_store,
+        target_branch="main",
+        run_state=run_state,
+    )
+
+    assert result["recommendation"] == "merge"
+    assert result["executed"] is True
+    assert result["merge_result"]["merged"] is True
+    assert result["cascade_report"]["downstream"][0]["action"] == "retargeted"
+    store.record_integration_decision.assert_called_once()
+    registry.close.assert_called_once_with("feat-a", outcome="merged")
+    assert run_state.lane_states["lane-a"].status == "completed"
+    assert run_state.lane_states["lane-b"].status == "waiting_for_merge"
+
+
+@pytest.mark.asyncio
+async def test_integrate_lane_flat_default_skips_cascade_without_downstream_lane_deps() -> None:
+    manifest = _make_manifest(
+        _make_lane("lane-a"),
+        _make_lane("lane-b", dependencies=["issue_123"]),
+    )
+    artifact = _make_artifact(
+        metadata={
+            "branch": "feat-a",
+            "review": {"status": "passed"},
+            "merge_policy": "auto",
+            "receipt_id": "receipt-a",
+            "lease_id": "lease-a",
+            "deliverable": {"pr_url": "https://github.com/org/repo/pull/42"},
+        }
+    )
+    github = MagicMock()
+    github.fetch_gate_snapshot.return_value = SimpleNamespace(
+        required_checks=[{"name": "lint", "conclusion": "SUCCESS", "required": True}],
+        advisory_checks=[],
+        required_checks_green=True,
+        to_dict=lambda: {"required_checks_green": True},
+        state="OPEN",
+        base_branch="main",
+        merge_state_status="CLEAN",
+    )
+    github.merge_pr.return_value = SimpleNamespace(
+        to_dict=lambda: {
+            "merged": True,
+            "action": "merge",
+            "used_admin": False,
+            "detail": "merged",
+        }
+    )
+
+    result = await integrate_lane(
+        manifest=manifest,
+        artifact=artifact,
+        approve=True,
+        github=github,
+        registry=MagicMock(spec=PullRequestRegistry),
+        store=MagicMock(),
+        artifact_store=_FakeArtifactStore({}),
+        target_branch="main",
+    )
+
+    assert result["cascade_report"] == {
+        "merged_lane_id": "lane-a",
+        "downstream": [],
+        "clean": True,
+        "needs_human": False,
+    }

--- a/tests/swarm/test_tranche_watch.py
+++ b/tests/swarm/test_tranche_watch.py
@@ -434,6 +434,51 @@ async def test_watch_tick_integrates_when_receipt_projection_precedes_integrate(
 
 
 @pytest.mark.asyncio
+async def test_watch_tick_marks_tranche_needs_human_when_cascade_flags_manual_repair() -> None:
+    from aragora.swarm.tranche_watch import watch_tick
+
+    state = _make_state(lane_statuses={"a": "review_passed", "b": "waiting_for_merge"})
+    artifact_store = _FakeArtifactStore(
+        {
+            "a": _make_artifact(lane_id="a", status="review_passed"),
+            "b": _make_artifact(lane_id="b", status="waiting_for_merge"),
+        }
+    )
+    mock_integrate = AsyncMock(
+        return_value={
+            "recommendation": "merge",
+            "executed": True,
+            "cascade_report": {
+                "merged_lane_id": "a",
+                "downstream": [
+                    {
+                        "lane_id": "b",
+                        "pr_url": "https://github.com/org/repo/pull/99",
+                        "action": "needs_restack",
+                        "reason": "Downstream PR was closed after the upstream merge.",
+                    }
+                ],
+                "clean": False,
+                "needs_human": True,
+            },
+        }
+    )
+
+    new_state = await watch_tick(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        autonomy_mode="fire_and_forget",
+        integrate_fn=mock_integrate,
+        artifact_store=artifact_store,
+    )
+
+    mock_integrate.assert_awaited_once()
+    assert new_state.lane_states["a"].status == "completed"
+    assert new_state.lane_states["b"].status == "needs_human"
+    assert new_state.status == "needs_human"
+
+
+@pytest.mark.asyncio
 async def test_watch_loop_exits_on_aborted_status() -> None:
     from aragora.swarm.tranche_watch import watch_loop
 


### PR DESCRIPTION
## Summary
This PR adds post-merge cascade handling for tranche-generated multi-PR flows. The tranche stack incident exposed that Aragora could assess and execute a single merge, but it had no control-plane behavior for the downstream aftermath when one lane merge affected other open lane PRs. The result was manual restacking and repair work outside the tranche lifecycle.

This change keeps Aragora's intended flat PR topology intact and makes the merge path reusable from both the CLI and the watch loop. `tranche integrate` now goes through a shared `integrate_lane()` orchestration helper instead of keeping merge execution inline in the CLI command. After a successful merge, the same path can inspect downstream dependent lanes, retarget simple open PRs back to `main`, and flag harder cases for human repair.

## User Impact
Before this change, a successful lane merge ended the automateable part of the workflow. If downstream tranche lanes had dependent PR state, Aragora did not surface that state in a structured way and did not perform any repair. Operators had to detect the fallout manually and restack branches themselves.

After this change, Aragora can:
- execute merges through the shared tranche integration path
- detect downstream lane PRs that are fine, retargetable, missing, or require restack
- retarget simple open downstream PRs to `main`
- project manual-repair cases into tranche run state so watch/CLI surfaces them as `needs_human`

## Root Cause
The original tranche integrate implementation split responsibility across layers. `swarm.py` contained the merge execution path inline, while `tranche_integrate.py` only handled assessment and recording. That made it difficult to reuse the same integration behavior from `watch_tick()`, and there was no place to attach downstream cascade handling after merge execution.

## Fix
This PR:
- adds `GitHubControl.retarget_pr_base()` for `gh pr edit --base`
- adds `execute_lane_merge()` and `integrate_lane()` in `aragora/swarm/tranche_integrate.py`
- adds `cascade_after_merge()` to classify downstream lane PRs as `ok`, `retargeted`, `needs_restack`, or `missing_pr`
- moves tranche integrate orchestration out of the CLI-inline path and into the shared helper
- wires the same integration path into tranche watch so automatic merges and cascade handling share one implementation
- updates run-state projection so downstream `needs_restack` and missing-PR cases become `needs_human`
- keeps the default flat-to-main behavior intact; this PR does not add stacked PR topology as a first-class default

## Validation
I ran:
- `python3 -m pytest tests/swarm/test_tranche_integrate.py -q`
- `python3 -m pytest tests/swarm/test_tranche_watch.py -q`
- `python3 -m pytest tests/cli/test_swarm_command.py -q -k 'tranche_integrate or tranche_watch'`
- `python3 -m pytest tests/swarm/test_tranche*.py tests/cli/test_swarm_command.py -q`
- `python3 -m ruff check aragora/swarm/tranche_integrate.py aragora/swarm/tranche_watch.py aragora/cli/commands/swarm.py aragora/ralph/github_control.py tests/swarm/test_tranche_integrate.py tests/swarm/test_tranche_watch.py tests/cli/test_swarm_command.py`

Results:
- `132 passed`
- lint clean
