### PR TITLE
[codex] preserve tests workflow conclusion on prioritized PRs

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -36,13 +36,15 @@ jobs:
             const sweeps = 4;
             const sweepDelayMs = 10000;
 
-            // Required checks are currently produced by these workflows.
-            // Keep this list in sync with branch protection required contexts.
+            // Required checks are produced by these workflows, and we also keep
+            // Tests so PR CI reflects real test outcomes instead of looking
+            // cancelled after prioritization sweeps.
             const alwaysKeepWorkflowPaths = new Set([
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/lint.yml',
               '.github/workflows/sdk-parity.yml',
               '.github/workflows/sdk-test.yml',
+              '.github/workflows/test.yml',
               '.github/workflows/openapi.yml',
               '.github/workflows/self-host-readiness.yml',
               '.github/workflows/required-check-priority.yml',
@@ -53,6 +55,7 @@ jobs:
               'Lint',
               'SDK Parity Check',
               'SDK Tests',
+              'Tests',
               'OpenAPI Spec',
               'Self-Host Readiness',
             ]);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1942,13 +1942,38 @@ jobs:
 
   # Test Analytics - Generate flakiness report
   quality-gates:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always())
     name: Quality Gates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [test-fast, test-summary, epistemic-settlement-gate, v1-scope-lock-gate]
 
     steps:
+      - name: Check prerequisite results
+        shell: bash
+        run: |
+          check_result() {
+            local label="$1"
+            local result="$2"
+            case "$result" in
+              success)
+                echo "$label passed."
+                ;;
+              skipped|cancelled)
+                echo "::warning::$label was $result; continuing quality gates without failing the workflow."
+                ;;
+              *)
+                echo "::error::$label completed with result: $result"
+                exit 1
+                ;;
+            esac
+          }
+
+          check_result "test-fast" "${{ needs.test-fast.result }}"
+          check_result "test-summary" "${{ needs.test-summary.result }}"
+          check_result "epistemic-settlement-gate" "${{ needs.epistemic-settlement-gate.result }}"
+          check_result "v1-scope-lock-gate" "${{ needs.v1-scope-lock-gate.result }}"
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -22,6 +22,7 @@ REQUIRED_KEEP_WORKFLOW_PATHS = {
     ".github/workflows/lint.yml",
     ".github/workflows/sdk-parity.yml",
     ".github/workflows/sdk-test.yml",
+    ".github/workflows/test.yml",
     ".github/workflows/openapi.yml",
     ".github/workflows/required-check-priority.yml",
 }
@@ -32,6 +33,7 @@ REQUIRED_KEEP_WORKFLOW_NAMES = {
     "Lint",
     "SDK Parity Check",
     "SDK Tests",
+    "Tests",
     "OpenAPI Spec",
 }
 


### PR DESCRIPTION
## Summary
This PR fixes a misleading CI outcome on pull requests where the top-level `Tests` workflow can end in `cancelled` even though the actually executed test jobs succeeded. The regression surfaced immediately after landing the tranche post-merge cascade work: `Test Analytics` and `Test Summary` were both green, but the overall workflow still looked non-green because prioritized PR CI cancelled the wrapper path that GitHub used for the workflow-level conclusion.

The change is intentionally small. It preserves the `Tests` workflow in required-check prioritization so the real PR test workflow is not swept away, and it hardens the `Quality Gates` wrapper job so cancelled or skipped prerequisite jobs are treated as warnings instead of poisoning the whole workflow result.

## User Impact
Before this change, PR authors and reviewers could see a `Tests` workflow conclusion of `cancelled` even when the substantive executed jobs had passed. That creates merge friction, hides the real signal, and encourages manual triage of workflow noise instead of product regressions.

After this change:
- `Required Check Priority` will preserve the `Tests` workflow on PRs
- `Quality Gates` will run under `always()`
- cancelled or skipped upstream fast-path jobs will surface as warnings instead of self-cancelling the workflow wrapper
- the keep-list policy guard will enforce this behavior so it does not drift back silently

## Root Cause
The issue had two layers:
1. [required-check-priority.yml](.github/workflows/required-check-priority.yml) did not keep the `Tests` workflow in its allowlist, so PR prioritization could cancel the workflow that should have been preserved for test truth.
2. [test.yml](.github/workflows/test.yml) defined `Quality Gates` as a normal `needs` wrapper instead of an `always()` summary path, so cancelled or skipped prerequisite jobs could cause the wrapper to end `cancelled` and leave the whole workflow looking non-green.

## Fix
This PR:
- adds `.github/workflows/test.yml` and `Tests` to the required-check-priority keep-lists
- updates `quality-gates` in `.github/workflows/test.yml` to run with `always()`
- adds an explicit prerequisite-result step that treats `cancelled` and `skipped` as warnings, while still failing on real errors
- updates `scripts/check_required_check_priority_policy.py` so the keep-list enforcement matches the workflow behavior

## Validation
I ran:
- `python3 scripts/check_required_check_priority_policy.py`
- YAML parse checks for `.github/workflows/required-check-priority.yml` and `.github/workflows/test.yml`
- `python3 -m ruff check scripts/check_required_check_priority_policy.py`

Results:
- policy guard passed
- workflow YAML parsed successfully
- lint clean
