### PR TITLE
[codex] fix(tranche): persist prepared lane artifacts

### DIFF
--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -525,6 +525,7 @@ class TrancheExecutor:
                 owner_session_id=owner_session_id,
                 base_branch=base_branch,
             )
+            self.artifact_store.save(manifest.manifest_id, artifact)
             prepared.append(artifact.to_dict())
         return {
             "mode": "tranche-prepare",

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -541,6 +541,10 @@ def test_prepare_creates_workspace_artifact_for_ready_lane(tmp_path: Path) -> No
     assert prepared["status"] == "prepared"
     assert prepared["metadata"]["branch"].startswith("codex/")
     assert prepared["worktree_path"].endswith("/lane-1")
+    saved = executor.artifact_store.load(manifest.manifest_id, "pmf_impl")
+    assert saved is not None
+    assert saved.status == "prepared"
+    assert saved.worktree_path == f"{repo}/.worktrees/codex-auto/lane-1"
 
 
 def test_prepare_preserves_nested_base_branch_names(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
The first real bounded tranche dogfood run exposed a prepare/run handoff bug in `TrancheExecutor`.

`swarm tranche prepare` successfully created the lane worktree, but `TrancheExecutor.prepare()` did not persist the prepared artifact into `TrancheArtifactStore`. On the next `swarm tranche run`, `run()` loaded no prepared artifact, assumed the lane still needed preparation, and tried to create the same branch/worktree again. In a real dogfood run that failed with Git reporting the branch was already in use by an existing worktree.

This change persists the prepared lane artifact at prepare time so `run()` can reuse the real prepared state instead of re-preparing.

## Root Cause
`TrancheExecutor.prepare()` returned the artifact produced by `_prepare_lane_workspace(...)`, but never saved it through `self.artifact_store.save(...)`.

`TrancheExecutor.run()` correctly consults the artifact store before deciding whether it must prepare a lane. Because the prepare step had not saved anything, the run step saw an empty store and duplicated workspace preparation.

## Fix
- save the prepared lane artifact during `TrancheExecutor.prepare()`
- extend the existing prepare regression test to assert that the artifact is actually persisted and reloadable from the store

## Validation
- `python3 -m pytest tests/swarm/test_tranche.py -q -k 'prepare_creates_workspace_artifact_for_ready_lane or run_dispatches_prepared_lane_and_records_review or run_reprepares_failed_artifact_before_dispatch'`
- `python3 -m ruff check aragora/swarm/tranche.py tests/swarm/test_tranche.py`

The focused tranche slice passes locally (`3 passed`) and lint is clean.
