### PR TITLE
feat(tranche): add review preflight failover

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -1024,15 +1024,28 @@ class CampaignReviewer:
                 },
             )
         except ReviewRoutingError as exc:
+            logger.warning("review routing failed for project %s: %s", project.project_id, exc)
+            if exc.category == "billing_exhausted":
+                detail = (
+                    "CLI subscription usage exhausted. "
+                    "Run 'claude auth status' to check the active account, "
+                    "then 'claude auth logout && claude auth login' to switch "
+                    "to an account with available capacity."
+                )
+                findings = [f"Review blocked (billing): {detail}"]
+            else:
+                findings = [
+                    "Review blocked: no configured reviewer candidate succeeded. Check logs for detail."
+                ]
             return CampaignReviewGate(
                 required=True,
                 review_model=chosen_review_model,
                 status=CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value,
-                findings=[f"Review blocked: {str(exc)}"],
+                findings=findings,
                 reviewed_at=_now_iso(),
                 raw_review={
                     "error": type(exc).__name__,
-                    "detail": str(exc)[:500],
+                    "detail": exc.public_message,
                     "attempts": exc.attempts,
                 },
             )

--- a/aragora/swarm/review_routing.py
+++ b/aragora/swarm/review_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import shutil
 import socket
@@ -13,8 +14,11 @@ from typing import Any
 from aragora.agents.base import create_agent
 from aragora.agents.errors.exceptions import CLISubprocessError
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_REVIEW_PROVIDER_ORDER = ("codex", "claude", "openrouter")
 DEFAULT_CLAUDE_REVIEW_PROFILES = tuple(f"max-{index:02d}" for index in range(1, 13))
+_BILLING_MARKERS = ("credit balance", "billing", "payment required", "purchase credits")
 _MODEL_FAMILY_OVERRIDES = {
     "anthropic-api": "claude",
     "claude": "claude",
@@ -42,13 +46,19 @@ class ReviewCandidate:
 
 
 class ReviewRoutingError(RuntimeError):
-    def __init__(self, attempts: list[dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        attempts: list[dict[str, Any]],
+        *,
+        category: str = "unavailable",
+        public_message: str | None = None,
+    ) -> None:
         self.attempts = attempts
-        summary = "; ".join(
-            f"{item.get('candidate', 'unknown')}: {item.get('detail', 'unavailable')}"
-            for item in attempts
+        self.category = str(category or "unavailable").strip() or "unavailable"
+        self.public_message = str(public_message or "").strip() or _review_routing_public_message(
+            self.category
         )
-        super().__init__(summary or "No review candidate succeeded.")
+        super().__init__(self.public_message)
 
 
 def resolve_review_candidates(
@@ -130,13 +140,24 @@ async def generate_review_response(
             continue
         try:
             response = await _run_review_candidate(candidate, prompt, repo_root=repo_root)
-        except Exception as exc:
+        except CLISubprocessError as exc:
+            logger.warning("review candidate %s failed: %s", candidate.label, exc)
             attempts.append(
-                {
-                    "candidate": candidate.label,
-                    "stage": "generate",
-                    "detail": _candidate_failure_detail(exc),
-                }
+                _failure_attempt(
+                    candidate.label,
+                    stage="generate",
+                    exc=exc,
+                )
+            )
+            continue
+        except Exception as exc:
+            logger.warning("review candidate %s failed: %s", candidate.label, exc)
+            attempts.append(
+                _failure_attempt(
+                    candidate.label,
+                    stage="generate",
+                    exc=exc,
+                )
             )
             continue
         attempts.append(
@@ -151,7 +172,10 @@ async def generate_review_response(
             "response": response,
             "attempts": attempts,
         }
-    raise ReviewRoutingError(attempts)
+    raise ReviewRoutingError(
+        attempts,
+        category=_review_routing_category(attempts),
+    )
 
 
 async def _run_review_candidate(
@@ -284,12 +308,35 @@ def _strip_claude_profile_wrapper(output: str) -> str:
     return "\n".join(lines).strip()
 
 
-def _candidate_failure_detail(exc: Exception) -> str:
+def _candidate_failure_detail(exc: Exception) -> tuple[str, str]:
     if isinstance(exc, CLISubprocessError):
-        detail = str(exc.stderr or exc).strip()
-        return detail or exc.__class__.__name__
-    text = str(exc).strip()
-    return text or exc.__class__.__name__
+        raw = str(exc.stderr or exc).strip().lower()
+        if any(marker in raw for marker in _BILLING_MARKERS):
+            return ("billing_exhausted", "Reviewer credits are exhausted.")
+        return ("cli_failure", "Reviewer CLI command failed.")
+    return (exc.__class__.__name__, exc.__class__.__name__)
+
+
+def _failure_attempt(candidate: str, *, stage: str, exc: Exception) -> dict[str, Any]:
+    kind, detail = _candidate_failure_detail(exc)
+    return {
+        "candidate": candidate,
+        "stage": stage,
+        "kind": kind,
+        "detail": detail,
+    }
+
+
+def _review_routing_category(attempts: list[dict[str, Any]]) -> str:
+    if any(str(item.get("kind", "")).strip() == "billing_exhausted" for item in attempts):
+        return "billing_exhausted"
+    return "unavailable"
+
+
+def _review_routing_public_message(category: str) -> str:
+    if category == "billing_exhausted":
+        return "Reviewer capacity is exhausted. Check the active reviewer account and available credits."
+    return "No configured review candidate succeeded. Check logs for detail."
 
 
 def _review_provider_order() -> list[str]:

--- a/tests/swarm/test_campaign_reviewer_diff.py
+++ b/tests/swarm/test_campaign_reviewer_diff.py
@@ -383,10 +383,19 @@ class TestReviewerBillingErrorDetection:
         run_dict = _make_run_dict()
         routing_error = ReviewRoutingError(
             [
-                {"candidate": "codex", "detail": "codex CLI not found"},
-                {"candidate": "claude:max-01", "detail": "Credit balance is too low"},
-                {"candidate": "openrouter", "detail": "OpenRouter TLS check failed"},
-            ]
+                {"candidate": "codex", "detail": "codex CLI not found", "kind": "preflight"},
+                {
+                    "candidate": "claude:max-01",
+                    "detail": "Reviewer credits are exhausted.",
+                    "kind": "billing_exhausted",
+                },
+                {
+                    "candidate": "openrouter",
+                    "detail": "OpenRouter TLS check failed",
+                    "kind": "preflight",
+                },
+            ],
+            category="billing_exhausted",
         )
 
         with patch(
@@ -401,8 +410,7 @@ class TestReviewerBillingErrorDetection:
             )
 
         assert gate.status == CampaignReviewStatus.BLOCKED_NONREVIEWABLE.value
-        assert gate.findings == [
-            "Review blocked: codex: codex CLI not found; claude:max-01: Credit balance is too low; openrouter: OpenRouter TLS check failed"
-        ]
+        assert any("billing" in item.lower() for item in gate.findings)
+        assert any("claude auth status" in item.lower() for item in gate.findings)
         assert gate.raw_review["error"] == "ReviewRoutingError"
         assert len(gate.raw_review["attempts"]) == 3

--- a/tests/swarm/test_review_routing.py
+++ b/tests/swarm/test_review_routing.py
@@ -73,6 +73,7 @@ async def test_generate_review_response_fails_over_to_next_candidate() -> None:
 
     assert result["candidate"]["label"] == "claude:max-01"
     assert result["attempts"][0]["candidate"] == "codex"
+    assert result["attempts"][0]["kind"] == "cli_failure"
     assert result["attempts"][1]["candidate"] == "claude:max-01"
 
 
@@ -102,8 +103,7 @@ async def test_generate_review_response_raises_with_attempt_history() -> None:
                 repo_root=Path("/tmp/repo"),
             )
 
-    assert "codex: codex CLI not found" in str(exc_info.value)
-    assert "openrouter: OpenRouter TLS check failed" in str(exc_info.value)
+    assert str(exc_info.value) == "No configured review candidate succeeded. Check logs for detail."
     assert exc_info.value.attempts == [
         {
             "candidate": "codex",
@@ -115,4 +115,51 @@ async def test_generate_review_response_raises_with_attempt_history() -> None:
             "stage": "preflight",
             "detail": "OpenRouter TLS check failed",
         },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generate_review_response_marks_billing_exhaustion() -> None:
+    with (
+        patch(
+            "aragora.swarm.review_routing.resolve_review_candidates",
+            return_value=[
+                ReviewCandidate(provider="claude", label="claude:max-01", profile="max-01")
+            ],
+        ),
+        patch(
+            "aragora.swarm.review_routing.preflight_review_candidate",
+            return_value={"ok": True, "detail": "claude available"},
+        ),
+        patch(
+            "aragora.swarm.review_routing._run_review_candidate",
+            new=AsyncMock(
+                side_effect=CLISubprocessError(
+                    message="CLI command failed with return code 1",
+                    agent_name="claude:max-01",
+                    returncode=1,
+                    stderr="Credit balance is too low",
+                )
+            ),
+        ),
+    ):
+        with pytest.raises(ReviewRoutingError) as exc_info:
+            await generate_review_response(
+                "review this",
+                worker_model="codex",
+                preferred_review_model="claude",
+                repo_root=Path("/tmp/repo"),
+            )
+
+    assert exc_info.value.category == "billing_exhausted"
+    assert str(exc_info.value) == (
+        "Reviewer capacity is exhausted. Check the active reviewer account and available credits."
+    )
+    assert exc_info.value.attempts == [
+        {
+            "candidate": "claude:max-01",
+            "stage": "generate",
+            "kind": "billing_exhausted",
+            "detail": "Reviewer credits are exhausted.",
+        }
     ]


### PR DESCRIPTION
## Summary
- add review routing with provider-order failover across codex, claude profiles, and openrouter
- preflight reviewer candidates before attempting generation and surface precise blocked reasons
- record routing attempts in campaign review metadata for tranche/watch visibility

## Testing
- python3 -m pytest tests/swarm/test_campaign.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_tranche_review.py tests/swarm/test_review_routing.py -q
- python3 -m ruff check aragora/swarm/review_routing.py aragora/swarm/campaign.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_review_routing.py tests/swarm/test_tranche_review.py
