### PR TITLE
feat(tranche): dispatch ready lanes from watch driver

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -941,9 +941,32 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             session_id = str(
                 getattr(args, "owner_session_id", None) or f"cli-watch-{os.getpid()}"
             ).strip()
+            executor = TrancheExecutor(repo_root=repo_root) if driver_mode else None
             supervisor = None
             github = None
             registry = None
+
+            async def _watch_run_fn(*, manifest):
+                if executor is None:
+                    return None
+                try:
+                    return await executor.run(
+                        manifest,
+                        owner_session_id=session_id,
+                        target_branch=str(getattr(args, "target_branch", "main") or "main"),
+                        max_ticks=int(getattr(args, "max_ticks", 360) or 360),
+                        wait_for_completion=False,
+                        skip_review=True,
+                    )
+                except ValueError as exc:
+                    detail = str(exc or "").strip()
+                    if (
+                        "No ready claimable lanes found" in detail
+                        or "Tranche is not ready to run." in detail
+                        or detail.endswith("is not ready.")
+                    ):
+                        return None
+                    raise
 
             async def _watch_review_fn(*, manifest, lane_id, artifact):
                 nonlocal supervisor
@@ -1025,8 +1048,10 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     interval_seconds=interval_seconds,
                     max_ticks=max_ticks,
                     state_path=state_path,
+                    driver_session_id=session_id if driver_mode else None,
                     artifact_store=artifact_store,
                     repo_root=repo_root,
+                    run_fn=_watch_run_fn if driver_mode else None,
                     review_fn=_watch_review_fn if driver_mode else None,
                     integrate_fn=_watch_integrate_fn if driver_mode else None,
                 )

--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -195,10 +195,14 @@ async def watch_tick(
     artifacts: dict[str, TrancheLaneArtifact] | None = None,
     store: DevCoordinationStore | Any | None = None,
     repo_root: Path | None = None,
+    run_fn: Any | None = None,
     review_fn: Any | None = None,
     integrate_fn: Any | None = None,
 ) -> TrancheRunState:
     mode = str(autonomy_mode or state.autonomy_mode or "adaptive").strip().lower() or "adaptive"
+    resolved_store = store
+    if resolved_store is None and repo_root is not None:
+        resolved_store = DevCoordinationStore(repo_root=Path(repo_root).resolve())
     artifact_map = _resolve_artifacts(
         state.manifest_id,
         artifacts=artifacts,
@@ -209,14 +213,34 @@ async def watch_tick(
         state,
         artifacts=artifact_map,
         artifact_store=artifact_store,
-        store=store,
+        store=resolved_store,
         repo_root=repo_root,
     )
 
     if mode in {"adaptive", "fire_and_forget"}:
+        if run_fn is not None and _should_attempt_dispatch(refreshed, store=resolved_store):
+            dispatch_payload = await run_fn(manifest=manifest)
+            _apply_dispatch_payload(refreshed, dispatch_payload)
+            artifact_map = _resolve_artifacts(
+                state.manifest_id,
+                artifacts=artifacts,
+                artifact_store=artifact_store,
+                repo_root=repo_root,
+            )
+            refreshed = refresh_tranche_state(
+                refreshed,
+                artifacts=artifact_map,
+                artifact_store=artifact_store,
+                store=resolved_store,
+                repo_root=repo_root,
+            )
         for lane_id, lane_state in refreshed.lane_states.items():
             artifact = artifact_map.get(lane_id)
-            if lane_state.status == LANE_STATUS_COMPLETED and review_fn is not None:
+            if (
+                lane_state.status == LANE_STATUS_COMPLETED
+                and review_fn is not None
+                and not _completed_lane_is_terminal(lane_state, store=resolved_store)
+            ):
                 lane_state.status = LANE_STATUS_REVIEWING
                 review_payload = await review_fn(
                     manifest=manifest,
@@ -267,6 +291,7 @@ async def watch_loop(
     interval_seconds: float = 10.0,
     max_ticks: int | None = None,
     state_path: str | Path | None = None,
+    driver_session_id: str | None = None,
     **kwargs: Any,
 ) -> TrancheRunState:
     current = TrancheRunState.from_dict(state.to_dict())
@@ -274,7 +299,11 @@ async def watch_loop(
         return current
     ticks = 0
     while True:
+        if driver_session_id:
+            current = heartbeat_driver(current, session_id=driver_session_id)
         current = await watch_tick(current, manifest=manifest, **kwargs)
+        if driver_session_id:
+            current = heartbeat_driver(current, session_id=driver_session_id)
         if state_path is not None:
             current.save(state_path)
         if current.status in {
@@ -423,6 +452,8 @@ def _apply_receipt_projection(lane_state: LaneRunState, receipt: Any) -> None:
 def _apply_integration_projection(lane_state: LaneRunState, decision: Any) -> None:
     value = str(getattr(decision, "decision", "")).strip()
     if value in {IntegrationDecisionType.MERGE.value, IntegrationDecisionType.CHERRY_PICK.value}:
+        if lane_state.status == LANE_STATUS_COMPLETED:
+            return
         lane_state.status = (
             LANE_STATUS_WAITING_FOR_MERGE if lane_state.pr_url else LANE_STATUS_WAITING_FOR_PR
         )
@@ -547,6 +578,90 @@ def _watch_integrate_status(current_status: str, payload: dict[str, Any]) -> str
     if recommendation in {"request_changes", "blocked", "needs_human"}:
         return LANE_STATUS_NEEDS_HUMAN
     return current_status
+
+
+def _should_attempt_dispatch(
+    state: TrancheRunState,
+    *,
+    store: Any | None,
+) -> bool:
+    lane_states = list(state.lane_states.values())
+    if not any(str(item.status).strip() == LANE_STATUS_PENDING for item in lane_states):
+        return False
+    return not any(_lane_blocks_dispatch(item, store=store) for item in lane_states)
+
+
+def _lane_blocks_dispatch(
+    lane_state: LaneRunState,
+    *,
+    store: Any | None,
+) -> bool:
+    status = str(lane_state.status or "").strip()
+    if status == LANE_STATUS_PENDING:
+        return False
+    if status == LANE_STATUS_COMPLETED:
+        return not _completed_lane_is_terminal(lane_state, store=store)
+    return status not in {
+        LANE_STATUS_ABORTED,
+        LANE_STATUS_NEEDS_HUMAN,
+        LANE_STATUS_REVIEW_FAILED,
+    }
+
+
+def _completed_lane_is_terminal(
+    lane_state: LaneRunState,
+    *,
+    store: Any | None,
+) -> bool:
+    if str(lane_state.status or "").strip() != LANE_STATUS_COMPLETED:
+        return False
+    decision = _latest_integration_decision(store, lane_state.receipt_id)
+    value = str(getattr(decision, "decision", "") or "").strip()
+    return value in {
+        IntegrationDecisionType.MERGE.value,
+        IntegrationDecisionType.CHERRY_PICK.value,
+    }
+
+
+def _apply_dispatch_payload(state: TrancheRunState, payload: Any) -> None:
+    if not isinstance(payload, dict):
+        return
+    results = payload.get("results")
+    if not isinstance(results, list):
+        return
+    now = _utcnow()
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        lane_id = _optional_text(item.get("lane_id"))
+        if not lane_id:
+            continue
+        lane_state = state.lane_states.get(lane_id)
+        if lane_state is None:
+            lane_state = LaneRunState(lane_id=lane_id, status=LANE_STATUS_PENDING)
+            state.lane_states[lane_id] = lane_state
+        lane_state.status = _watch_dispatch_status(item)
+        lane_state.run_id = _prefer_text(lane_state.run_id, item.get("run_id"))
+        lane_state.worktree_path = _prefer_text(
+            lane_state.worktree_path,
+            item.get("worktree_path"),
+        )
+        metadata = item.get("metadata") if isinstance(item.get("metadata"), dict) else {}
+        lane_state.receipt_id = _prefer_text(lane_state.receipt_id, metadata.get("receipt_id"))
+        lane_state.lease_id = _prefer_text(lane_state.lease_id, metadata.get("lease_id"))
+        lane_state.pr_url = _prefer_text(lane_state.pr_url, metadata.get("pr_url"))
+        lane_state.last_updated = now
+
+
+def _watch_dispatch_status(payload: dict[str, Any]) -> str:
+    lowered = str(payload.get("status", "") or "").strip().lower()
+    if lowered == "running":
+        return LANE_STATUS_RUNNING
+    if lowered == "completed":
+        return LANE_STATUS_COMPLETED
+    if lowered in {"needs_human", "failed"}:
+        return LANE_STATUS_NEEDS_HUMAN
+    return LANE_STATUS_DISPATCHED
 
 
 def _apply_cascade_report_to_state(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -659,6 +659,7 @@ class TestSwarmCommand:
             swarm_goal="watch",
             manifest="docs/examples/boss-lane-manifest-2026-03-19.yaml",
             driver=True,
+            owner_session_id="sess-1",
             interval_seconds=3.0,
             max_ticks=2,
             json=True,
@@ -724,6 +725,8 @@ class TestSwarmCommand:
         assert '"action": "watch"' in out
         mock_claim.assert_called_once()
         mock_watch_loop.assert_awaited_once()
+        assert mock_watch_loop.await_args.kwargs["driver_session_id"] == "sess-1"
+        assert callable(mock_watch_loop.await_args.kwargs["run_fn"])
 
     def test_cmd_swarm_tranche_list_json(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_tranche_watch.py
+++ b/tests/swarm/test_tranche_watch.py
@@ -352,6 +352,97 @@ async def test_watch_tick_triggers_review_when_lane_completes():
 
 
 @pytest.mark.asyncio
+async def test_watch_tick_dispatches_pending_lane_when_idle() -> None:
+    from aragora.swarm.tranche_watch import watch_tick
+
+    state = _make_state(lane_statuses={"a": "pending"})
+    mock_run = AsyncMock(
+        return_value={
+            "results": [
+                {
+                    "lane_id": "a",
+                    "status": "running",
+                    "run_id": "run-1",
+                    "worktree_path": "/tmp/worktree-a",
+                }
+            ]
+        }
+    )
+
+    new_state = await watch_tick(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        autonomy_mode="adaptive",
+        run_fn=mock_run,
+    )
+
+    mock_run.assert_awaited_once()
+    lane = new_state.lane_states["a"]
+    assert lane.status == "running"
+    assert lane.run_id == "run-1"
+    assert lane.worktree_path == "/tmp/worktree-a"
+
+
+@pytest.mark.asyncio
+async def test_watch_tick_skips_dispatch_when_lane_is_already_active() -> None:
+    from aragora.swarm.tranche_watch import watch_tick
+
+    state = _make_state(lane_statuses={"a": "running", "b": "pending"})
+    mock_run = AsyncMock()
+
+    new_state = await watch_tick(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        autonomy_mode="adaptive",
+        run_fn=mock_run,
+    )
+
+    mock_run.assert_not_awaited()
+    assert new_state.lane_states["b"].status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_watch_tick_skips_rereview_for_terminal_completed_lane_and_dispatches_next() -> None:
+    from aragora.swarm.tranche_watch import watch_tick
+
+    state = _make_state(lane_statuses={"a": "completed", "b": "pending"})
+    state.lane_states["a"].receipt_id = "receipt-a"
+    state.lane_states["a"].pr_url = "https://github.com/org/repo/pull/42"
+    store = _FakeCoordinationStore(
+        decisions={
+            "receipt-a": [
+                IntegrationDecision(
+                    decision_id="decision-a",
+                    lease_id="lease-a",
+                    receipt_id="receipt-a",
+                    decision=IntegrationDecisionType.MERGE.value,
+                    target_branch="main",
+                    rationale="merged",
+                )
+            ]
+        }
+    )
+    mock_review = AsyncMock()
+    mock_run = AsyncMock(
+        return_value={"results": [{"lane_id": "b", "status": "running", "run_id": "run-b"}]}
+    )
+
+    new_state = await watch_tick(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        autonomy_mode="adaptive",
+        run_fn=mock_run,
+        review_fn=mock_review,
+        store=store,
+    )
+
+    mock_run.assert_awaited_once()
+    mock_review.assert_not_awaited()
+    assert new_state.lane_states["a"].status == "completed"
+    assert new_state.lane_states["b"].status == "running"
+
+
+@pytest.mark.asyncio
 async def test_watch_tick_marks_tranche_completed_when_all_lanes_done():
     from aragora.swarm.tranche_watch import watch_tick
 
@@ -493,3 +584,26 @@ async def test_watch_loop_exits_on_aborted_status() -> None:
     )
 
     assert result.status == "aborted"
+
+
+@pytest.mark.asyncio
+async def test_watch_loop_refreshes_driver_heartbeat() -> None:
+    from aragora.swarm.tranche_watch import watch_loop
+
+    state = claim_driver(
+        TrancheRunState(manifest_id="m1", status="running", autonomy_mode="adaptive"),
+        session_id="sess-1",
+    )
+    before = state.driver_heartbeat
+
+    result = await watch_loop(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        interval_seconds=0,
+        max_ticks=1,
+        driver_session_id="sess-1",
+    )
+
+    assert before is not None
+    assert result.driver_heartbeat is not None
+    assert result.driver_heartbeat >= before


### PR DESCRIPTION
## Summary
- let watch driver dispatch one ready pending lane when the tranche is idle
- keep watch loop responsive by running lane execution without waiting for completion
- add coverage for driver dispatch, terminal-lane skip behavior, and heartbeat refresh

## Validation
- python3 -m pytest tests/swarm/test_tranche_watch.py tests/cli/test_swarm_command.py -q
- python3 -m ruff check aragora/swarm/tranche_watch.py aragora/cli/commands/swarm.py tests/swarm/test_tranche_watch.py tests/cli/test_swarm_command.py