### PR TITLE
fix(tranche): recover queue worker deliverables

### DIFF
--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -1435,6 +1435,8 @@ def _lane_spec_from_manifest(manifest: TrancheManifest, lane: TrancheLane) -> An
     prompt = _optional_text(lane.metadata.get("prompt"))
     if not prompt:
         raise ValueError(f"Lane {lane.lane_id} is missing prompt metadata.")
+    target_agent = _lane_target_agent(lane, fallback="codex")
+    review_model = _lane_review_model(lane, target_agent=target_agent)
     acceptance = _metadata_string_list(lane, "acceptance_criteria") or [
         f"Run and satisfy: {item}" for item in lane.verification_commands
     ]
@@ -1443,6 +1445,26 @@ def _lane_spec_from_manifest(manifest: TrancheManifest, lane: TrancheLane) -> An
     file_scope_hints = _metadata_string_list(lane, "file_scope_hints") or list(
         lane.allowed_write_scope
     )
+    explicit_work_order = {
+        "work_order_id": lane.lane_id,
+        "title": _lane_title(lane),
+        "description": prompt,
+        "file_scope": list(dict.fromkeys(file_scope_hints)),
+        "target_agent": target_agent,
+        "reviewer_agent": review_model,
+        "expected_tests": list(lane.verification_commands),
+        "success_criteria": {
+            "acceptance_criteria": list(dict.fromkeys(acceptance)),
+            "tests": list(lane.verification_commands),
+        },
+        "estimated_complexity": str(lane.metadata.get("estimated_complexity", "medium")).strip()
+        or "medium",
+        "approval_required": bool(lane.metadata.get("requires_approval", True)),
+        "metadata": {
+            "tranche_manifest_id": manifest.manifest_id,
+            "tranche_lane_id": lane.lane_id,
+        },
+    }
     return SwarmSpec(
         raw_goal=_lane_execution_prompt(manifest, lane, prompt=prompt),
         refined_goal=_lane_execution_prompt(manifest, lane, prompt=prompt),
@@ -1450,6 +1472,7 @@ def _lane_spec_from_manifest(manifest: TrancheManifest, lane: TrancheLane) -> An
         constraints=list(dict.fromkeys(constraints)),
         budget_limit_usd=_lane_budget_limit_usd(lane),
         file_scope_hints=list(dict.fromkeys(file_scope_hints)),
+        work_orders=[explicit_work_order],
         requires_approval=bool(lane.metadata.get("requires_approval", True)),
         user_expertise="developer",
         estimated_complexity=str(lane.metadata.get("estimated_complexity", "medium")).strip()

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -1679,9 +1679,9 @@ class TrancheQueueExecutor:
         item_state.events = _truncate_events(events)
 
         pr_urls = [
-            str(lane_state.pr_url).strip()
+            url
             for lane_state in current.lane_states.values()
-            if str(getattr(lane_state, "pr_url", "")).strip()
+            if (url := _optional_text(getattr(lane_state, "pr_url", None)))
         ]
         item_state.pr_urls = list(dict.fromkeys(pr_urls))
         for finding in self._findings_from_events(events):

--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -210,6 +210,7 @@ async def watch_tick(
         state,
         store=resolved_store,
         repo_root=repo_root,
+        artifact_store=artifact_store,
     )
     artifact_map = _resolve_artifacts(
         state.manifest_id,
@@ -395,6 +396,7 @@ async def _collect_and_refresh_supervisor_runs(
     *,
     store: Any | None,
     repo_root: Path | None,
+    artifact_store: TrancheArtifactStore | Any | None = None,
 ) -> None:
     if store is None or repo_root is None:
         return
@@ -420,11 +422,17 @@ async def _collect_and_refresh_supervisor_runs(
                 exc,
             )
         try:
-            supervisor.refresh_run(run_id)
+            refreshed = supervisor.refresh_run(run_id)
         except KeyError:
             continue
         except Exception as exc:
             logger.warning("watch_tick failed refreshing run %s: %s", run_id, exc)
+            continue
+        _sync_artifacts_from_supervisor_run(
+            state,
+            run_dict=refreshed.to_dict() if hasattr(refreshed, "to_dict") else {},
+            artifact_store=artifact_store,
+        )
 
 
 def _apply_artifact_projection(lane_state: LaneRunState, artifact: TrancheLaneArtifact) -> None:
@@ -439,11 +447,28 @@ def _apply_artifact_projection(lane_state: LaneRunState, artifact: TrancheLaneAr
 
 def _apply_run_projection(lane_state: LaneRunState, run_dict: dict[str, Any]) -> None:
     run_status = str(run_dict.get("status", "")).strip().lower()
+    has_deliverable = False
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        has_deliverable = has_deliverable or _work_order_has_deliverable(work_order)
+        lane_state.worktree_path = _prefer_text(
+            lane_state.worktree_path, work_order.get("worktree_path")
+        )
+        lane_state.receipt_id = _prefer_text(lane_state.receipt_id, work_order.get("receipt_id"))
+        lane_state.lease_id = _prefer_text(lane_state.lease_id, work_order.get("lease_id"))
+        lane_state.pr_url = _prefer_text(
+            lane_state.pr_url,
+            work_order.get("pr_url") or work_order.get("adopted_pr"),
+        )
+        if lane_state.run_id:
+            break
+
     mapped = {
         "planned": LANE_STATUS_PENDING,
         "active": LANE_STATUS_RUNNING,
         "completed": lane_state.status,
-        "needs_human": LANE_STATUS_NEEDS_HUMAN,
+        "needs_human": (LANE_STATUS_COMPLETED if has_deliverable else LANE_STATUS_NEEDS_HUMAN),
     }.get(run_status)
     if mapped and lane_state.status in {
         LANE_STATUS_PENDING,
@@ -451,17 +476,6 @@ def _apply_run_projection(lane_state: LaneRunState, run_dict: dict[str, Any]) ->
         LANE_STATUS_RUNNING,
     }:
         lane_state.status = mapped
-
-    for work_order in run_dict.get("work_orders", []):
-        if not isinstance(work_order, dict):
-            continue
-        lane_state.worktree_path = _prefer_text(
-            lane_state.worktree_path, work_order.get("worktree_path")
-        )
-        lane_state.receipt_id = _prefer_text(lane_state.receipt_id, work_order.get("receipt_id"))
-        lane_state.lease_id = _prefer_text(lane_state.lease_id, work_order.get("lease_id"))
-        if lane_state.run_id:
-            break
 
 
 def _apply_lease_projection(lane_state: LaneRunState, lease: Any) -> None:
@@ -608,6 +622,107 @@ def _prefer_text(current: Any, candidate: Any) -> str | None:
 def _optional_text(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _work_order_has_deliverable(work_order: dict[str, Any]) -> bool:
+    if _optional_text(work_order.get("pr_url")) or _optional_text(work_order.get("adopted_pr")):
+        return True
+    branch = _optional_text(work_order.get("branch"))
+    commit_shas = [
+        str(item).strip() for item in work_order.get("commit_shas", []) if str(item).strip()
+    ]
+    return bool(branch and commit_shas)
+
+
+def _sync_artifacts_from_supervisor_run(
+    state: TrancheRunState,
+    *,
+    run_dict: dict[str, Any],
+    artifact_store: TrancheArtifactStore | Any | None,
+) -> None:
+    if artifact_store is None or not isinstance(run_dict, dict):
+        return
+    work_orders = [item for item in run_dict.get("work_orders", []) if isinstance(item, dict)]
+    if not work_orders:
+        return
+    for work_order in work_orders:
+        lane_id = _work_order_lane_id(state, work_order)
+        if not lane_id:
+            continue
+        artifact = _load_artifact_for_lane(artifact_store, state.manifest_id, lane_id)
+        if artifact is None:
+            continue
+        metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+        deliverable = metadata.get("deliverable", {})
+        if not isinstance(deliverable, dict):
+            deliverable = {}
+        branch = _optional_text(work_order.get("branch"))
+        pr_url = _optional_text(work_order.get("pr_url")) or _optional_text(
+            work_order.get("adopted_pr")
+        )
+        commit_shas = [
+            str(item).strip() for item in work_order.get("commit_shas", []) if str(item).strip()
+        ]
+        if branch:
+            metadata["branch"] = branch
+            deliverable["branch"] = branch
+        if pr_url:
+            metadata["pr_url"] = pr_url
+            deliverable["pr_url"] = pr_url
+            if pr_url not in artifact.urls:
+                artifact.urls = [*artifact.urls, pr_url]
+        if commit_shas:
+            deliverable["commit_shas"] = list(commit_shas)
+        receipt_id = _optional_text(work_order.get("receipt_id"))
+        if receipt_id:
+            metadata["receipt_id"] = receipt_id
+        lease_id = _optional_text(work_order.get("lease_id"))
+        if lease_id:
+            metadata["lease_id"] = lease_id
+        if deliverable:
+            metadata["deliverable"] = deliverable
+        artifact.metadata = metadata
+        artifact.run_id = _prefer_text(artifact.run_id, run_dict.get("run_id"))
+        artifact.worktree_path = _prefer_text(
+            artifact.worktree_path, work_order.get("worktree_path")
+        )
+        if _work_order_has_deliverable(work_order):
+            artifact.status = "completed"
+            artifact.residual_risk = (
+                "Lane delivered a concrete branch/commit and is ready for review."
+            )
+            artifact.next_actions = ["Run tranche review/integrate for this lane."]
+        elif str(work_order.get("status", "")).strip().lower() == "needs_human":
+            artifact.status = "needs_human"
+            artifact.residual_risk = "Worker reached needs_human state."
+            artifact.next_actions = ["Worker reached needs_human state."]
+        artifact.timestamp = _utcnow().isoformat()
+        artifact_store.save(state.manifest_id, artifact)
+
+
+def _work_order_lane_id(state: TrancheRunState, work_order: dict[str, Any]) -> str | None:
+    work_order_id = _optional_text(work_order.get("work_order_id"))
+    if work_order_id and work_order_id in state.lane_states:
+        return work_order_id
+    if len(state.lane_states) == 1:
+        return next(iter(state.lane_states))
+    return None
+
+
+def _load_artifact_for_lane(
+    artifact_store: TrancheArtifactStore | Any,
+    manifest_id: str,
+    lane_id: str,
+) -> TrancheLaneArtifact | None:
+    if hasattr(artifact_store, "load"):
+        artifact = artifact_store.load(manifest_id, lane_id)
+        if artifact is not None:
+            return artifact
+    if hasattr(artifact_store, "list"):
+        for artifact in artifact_store.list(manifest_id):
+            if getattr(artifact, "lane_id", None) == lane_id:
+                return artifact
+    return None
 
 
 def _watch_review_status(status: str) -> str:

--- a/docs/examples/overnight-sources.yaml
+++ b/docs/examples/overnight-sources.yaml
@@ -18,6 +18,8 @@ sources:
     objective: Refresh the design partner program materials with current V14 benchmark evidence, keeping the tranche bounded to documentation and supporting reference updates only.
     allowed_write_scope:
       - docs/**
+    verification_commands:
+      - python3 -m pytest tests/swarm/test_tranche_queue.py -q
 
   - id: product-loop-cli-slice
     kind: issue
@@ -32,6 +34,8 @@ sources:
       - aragora/cli/**
       - tests/cli/**
       - docs/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
 
   - id: core-pages-functional-slice
     kind: issue
@@ -47,6 +51,8 @@ sources:
       - tests/e2e/**
       - tests/handlers/**
       - docs/**
+    verification_commands:
+      - python3 -m pytest tests/swarm/test_tranche_e2e.py -q
 
   - id: knowledge-mound-enrichment-slice
     kind: issue
@@ -64,6 +70,8 @@ sources:
       - tests/debate/**
       - tests/handlers/**
       - docs/**
+    verification_commands:
+      - python3 -m pytest tests/rlm/test_knowledge_mound_adapter.py -q
 
   - id: integrations-ui-truthful-status-slice
     kind: issue
@@ -80,3 +88,5 @@ sources:
       - tests/e2e/**
       - tests/handlers/**
       - docs/**
+    verification_commands:
+      - python3 -m pytest tests/handlers/features/test_integrations.py -q

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -804,6 +804,49 @@ async def test_artifact_from_run_result_persists_receipt_and_lease_ids(tmp_path:
     assert artifact.metadata["lease_id"] == "lease-abc"
 
 
+def test_lane_spec_from_manifest_emits_explicit_single_work_order() -> None:
+    from aragora.swarm.tranche import TrancheManifest, _lane_spec_from_manifest
+
+    manifest = TrancheManifest.from_dict(
+        {
+            "manifest_id": "overnight",
+            "repo": {
+                "name": "synaptent/aragora",
+                "root": "/tmp/repo",
+                "base_ref": "origin/main",
+            },
+            "objective": "Ship one bounded overnight slice.",
+            "lanes": [
+                {
+                    "lane_id": "product-loop-cli-slice",
+                    "owner_role": "implementation_engineer",
+                    "allowed_write_scope": ["aragora/cli/**", "tests/cli/**"],
+                    "verification_commands": [
+                        "python3 -m pytest tests/cli/test_api_key_command.py -q"
+                    ],
+                    "prompt": "Implement one bounded CLI slice.",
+                    "title": "Product loop CLI slice",
+                    "target_agent": "codex",
+                    "review_model": "claude",
+                }
+            ],
+            "terminal_outcomes": {"success": {"definition": "done"}},
+        }
+    )
+
+    spec = _lane_spec_from_manifest(manifest, manifest.lane("product-loop-cli-slice"))
+
+    assert len(spec.work_orders) == 1
+    work_order = spec.work_orders[0]
+    assert work_order["work_order_id"] == "product-loop-cli-slice"
+    assert work_order["file_scope"] == ["aragora/cli/**", "tests/cli/**"]
+    assert work_order["expected_tests"] == [
+        "python3 -m pytest tests/cli/test_api_key_command.py -q"
+    ]
+    assert work_order["target_agent"] == "codex"
+    assert work_order["reviewer_agent"] == "claude"
+
+
 @pytest.mark.asyncio
 async def test_run_reprepares_failed_artifact_before_dispatch(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)

--- a/tests/swarm/test_tranche_watch.py
+++ b/tests/swarm/test_tranche_watch.py
@@ -65,6 +65,10 @@ class _FakeArtifactStore:
         assert manifest_id == "m1"
         return list(self._artifacts.values())
 
+    def load(self, manifest_id: str, lane_id: str) -> TrancheLaneArtifact | None:
+        assert manifest_id == "m1"
+        return self._artifacts.get(lane_id)
+
     def save(self, manifest_id: str, artifact: TrancheLaneArtifact) -> None:
         assert manifest_id == "m1"
         self._artifacts[artifact.lane_id] = artifact
@@ -500,6 +504,91 @@ async def test_watch_tick_collects_finished_supervisor_results_before_projection
 
     assert new_state.lane_states["a"].status == "needs_human"
     assert new_state.status == "needs_human"
+
+
+@pytest.mark.asyncio
+async def test_watch_tick_promotes_deliverable_from_needs_human_run_and_syncs_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aragora.swarm.tranche_watch import watch_tick
+
+    state = _make_state(lane_statuses={"a": "running"})
+    state.lane_states["a"].run_id = "run-1"
+    artifact_store = _FakeArtifactStore(
+        {
+            "a": _make_artifact(
+                lane_id="a",
+                status="running",
+                run_id="run-1",
+                metadata={"branch": "codex/tranche-old"},
+            )
+        }
+    )
+    store = _FakeCoordinationStore(
+        runs={
+            "run-1": {
+                "run_id": "run-1",
+                "status": "active",
+                "work_orders": [{"work_order_id": "a"}],
+            }
+        }
+    )
+
+    class _FakeSupervisor:
+        def __init__(self, repo_root=None, store=None, **kwargs) -> None:
+            self.store = store
+
+        async def collect_finished_results(self, run_id: str):
+            self.store._runs[run_id] = {
+                "run_id": run_id,
+                "status": "needs_human",
+                "work_orders": [
+                    {
+                        "work_order_id": "a",
+                        "status": "needs_human",
+                        "branch": "codex/swarm-a",
+                        "commit_shas": ["abc123"],
+                        "worktree_path": "/tmp/worker-a",
+                        "lease_id": "lease-a",
+                    }
+                ],
+            }
+            return []
+
+        def refresh_run(self, run_id: str):
+            return SimpleNamespace(to_dict=lambda: dict(self.store._runs[run_id]))
+
+    review_fn = AsyncMock(return_value={"status": "passed"})
+    integrate_fn = AsyncMock(
+        return_value={
+            "recommendation": "awaiting_checks",
+            "pr_url": "https://github.com/org/repo/pull/42",
+        }
+    )
+
+    monkeypatch.setattr("aragora.swarm.supervisor.SwarmSupervisor", _FakeSupervisor)
+
+    new_state = await watch_tick(
+        state,
+        manifest=SimpleNamespace(manifest_id="m1"),
+        autonomy_mode="adaptive",
+        artifact_store=artifact_store,
+        store=store,
+        repo_root=tmp_path,
+        review_fn=review_fn,
+        integrate_fn=integrate_fn,
+    )
+
+    assert new_state.lane_states["a"].status == "waiting_for_merge"
+    saved_artifact = artifact_store.load("m1", "a")
+    assert saved_artifact is not None
+    assert saved_artifact.status == "review_passed"
+    assert saved_artifact.metadata["branch"] == "codex/swarm-a"
+    assert saved_artifact.metadata["deliverable"]["branch"] == "codex/swarm-a"
+    assert saved_artifact.metadata["deliverable"]["commit_shas"] == ["abc123"]
+    assert review_fn.await_count == 1
+    assert integrate_fn.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- emit a single explicit supervisor work order for curated tranche lanes so queue items stay single-lane end to end
- sync supervisor deliverables back into tranche artifacts and promote deliverable-bearing needs_human runs into review/publish instead of dropping them
- fix queue PR URL serialization and add default verification commands to the overnight manifest example

## Testing
- python3 -m pytest tests/swarm/test_tranche_e2e.py tests/swarm/test_tranche.py tests/swarm/test_tranche_watch.py tests/swarm/test_tranche_queue.py tests/swarm/test_supervisor.py -q
- python3 -m pytest tests/swarm/test_tranche_queue.py tests/cli/test_setup.py tests/rlm/test_knowledge_mound_adapter.py tests/handlers/features/test_integrations.py -q
- python3 -m ruff check aragora/swarm/tranche.py aragora/swarm/tranche_watch.py aragora/swarm/tranche_queue.py tests/swarm/test_tranche.py tests/swarm/test_tranche_watch.py
- python3 -m aragora.cli.main swarm tranche compile-queue --sources docs/examples/overnight-sources.yaml --output /tmp/overnight-curated-v3.yaml