### PR TITLE
feat(debate): wire KM retrieval into standalone debate prompts (#1048)

### DIFF
--- a/aragora/debate/knowledge_mound_ops.py
+++ b/aragora/debate/knowledge_mound_ops.py
@@ -57,6 +57,42 @@ class KnowledgeMoundOperations:
         self._last_km_item_ids: list[str] = []  # IDs of KM items used in last fetch
         self._warned_missing_query_capability = False
 
+    @staticmethod
+    def _extract_query_items(results: Any) -> list[Any] | None:
+        """Normalize the different query result envelopes returned by KM implementations."""
+        if results is None:
+            return None
+
+        if isinstance(results, list):
+            return results
+
+        if isinstance(results, dict):
+            dict_items = results.get("items")
+            if isinstance(dict_items, list):
+                return dict_items
+            dict_nodes = results.get("nodes")
+            if isinstance(dict_nodes, list):
+                return dict_nodes
+            return None
+
+        for attr in ("items", "nodes"):
+            value = getattr(results, attr, None)
+            if isinstance(value, list):
+                return value
+
+        return None
+
+    @staticmethod
+    def _get_item_value(item: Any, *names: str, default: Any = None) -> Any:
+        """Read a field from object-style or dict-style KM items."""
+        for name in names:
+            if isinstance(item, dict) and name in item:
+                return item[name]
+            value = getattr(item, name, None)
+            if value is not None:
+                return value
+        return default
+
     def _has_query_capability(self) -> bool:
         """Check whether the configured KM object supports retrieval operations."""
         return bool(self.knowledge_mound) and any(
@@ -157,11 +193,7 @@ class KnowledgeMoundOperations:
                 else:
                     raise
 
-            items = None
-            if isinstance(results, list):
-                items = results
-            elif hasattr(results, "items"):
-                items = results.items
+            items = self._extract_query_items(results)
 
             if not items:
                 self._last_km_item_ids = []
@@ -169,9 +201,9 @@ class KnowledgeMoundOperations:
 
             # Track item IDs for outcome validation feedback loop
             self._last_km_item_ids = [
-                getattr(item, "id", None) or getattr(item, "item_id", "")
+                self._get_item_value(item, "id", "item_id", default="")
                 for item in items[:limit]
-                if getattr(item, "id", None) or getattr(item, "item_id", "")
+                if self._get_item_value(item, "id", "item_id", default="")
             ]
 
             # Format knowledge for agent context
@@ -196,9 +228,13 @@ class KnowledgeMoundOperations:
                 return 0.5
 
             for item in items[:limit]:
-                source = getattr(item, "source", "unknown")
-                confidence = _confidence_to_float(getattr(item, "confidence", 0.0))
-                content = getattr(item, "content", str(item))[:300]
+                source = self._get_item_value(item, "source", "node_type", default="unknown")
+                if hasattr(source, "value"):
+                    source = source.value
+                confidence = _confidence_to_float(
+                    self._get_item_value(item, "confidence", default=0.0)
+                )
+                content = str(self._get_item_value(item, "content", default=item))[:300]
                 lines.append(f"**[{source}]** (confidence: {confidence:.0%})")
                 lines.append(f"{content}")
                 lines.append("")

--- a/aragora/debate/orchestrator.py
+++ b/aragora/debate/orchestrator.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import logging
 from typing import Any
 
 from aragora.core import Critique, DebateResult, Environment, Message, Vote
+from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
 from aragora.debate.protocol import DebateProtocol, resolve_default_protocol
+
+logger = logging.getLogger(__name__)
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -50,6 +54,10 @@ class Arena:
         environment: Environment,
         agents: list[Any],
         protocol: DebateProtocol | None = None,
+        *,
+        knowledge_mound: Any | None = None,
+        enable_knowledge_retrieval: bool = True,
+        enable_knowledge_ingestion: bool = True,
         **_: Any,
     ) -> None:
         if not agents:
@@ -57,6 +65,23 @@ class Arena:
         self.env = environment
         self.agents = agents
         self.protocol = resolve_default_protocol(protocol)
+        self.knowledge_mound = knowledge_mound
+        self.enable_knowledge_retrieval = enable_knowledge_retrieval
+        self.enable_knowledge_ingestion = enable_knowledge_ingestion
+        self._knowledge_ops = KnowledgeMoundOperations(
+            knowledge_mound=knowledge_mound,
+            enable_retrieval=enable_knowledge_retrieval,
+            enable_ingestion=enable_knowledge_ingestion,
+        )
+        self._last_knowledge_context: str = ""
+
+    async def _fetch_knowledge_context(self, task: str, limit: int = 10) -> str | None:
+        """Fetch debate background evidence from the Knowledge Mound."""
+        return await self._knowledge_ops.fetch_knowledge_context(task, limit=limit)
+
+    async def _ingest_debate_outcome(self, result: DebateResult) -> None:
+        """Feed the debate outcome back into the Knowledge Mound."""
+        await self._knowledge_ops.ingest_debate_outcome(result, env=self.env)
 
     @classmethod
     def from_config(
@@ -101,11 +126,18 @@ class Arena:
         critiques: list[Critique] = []
         votes: list[Vote] = []
         proposals: dict[str, str] = {}
+        knowledge_context = await self._fetch_knowledge_context(self.env.task, limit=5)
+        self._last_knowledge_context = knowledge_context or ""
+        prompt = self.env.task
+        if knowledge_context:
+            prompt = (
+                f"{self.env.task}\n\nBackground evidence from Knowledge Mound:\n{knowledge_context}"
+            )
 
         for round_number in range(1, self.protocol.rounds + 1):
             for agent in self.agents:
                 name = getattr(agent, "name", f"agent_{len(proposals) + 1}")
-                content = await _maybe_await(agent.generate(self.env.task))
+                content = await _maybe_await(agent.generate(prompt))
                 content_text = str(content)
                 proposals[name] = content_text
                 messages.append(
@@ -172,7 +204,7 @@ class Arena:
                 )
                 confidence = winner_counts[final_answer] / len(votes)
 
-        return DebateResult(
+        result = DebateResult(
             debate_id="standalone-debate",
             task=self.env.task,
             final_answer=final_answer,
@@ -187,6 +219,23 @@ class Arena:
             critiques=critiques,
             votes=votes,
         )
+        km_item_ids = list(self._knowledge_ops._last_km_item_ids)
+        result.metadata.update(
+            {
+                "knowledge_mound_context_applied": bool(knowledge_context),
+                "knowledge_mound_read_hits": len(km_item_ids),
+                "knowledge_mound_item_ids": km_item_ids,
+            }
+        )
+        if knowledge_context:
+            result.metadata["knowledge_mound_context_chars"] = len(knowledge_context)
+
+        try:
+            await self._ingest_debate_outcome(result)
+        except Exception as exc:  # noqa: BLE001 - standalone wedge should not fail closed on KM
+            logger.debug("Knowledge Mound outcome ingestion failed: %s", exc)
+
+        return result
 
     async def _gather_trending_context(self) -> None:
         """Compatibility stub for integration-test fixtures."""

--- a/tests/debate/test_knowledge_mound_ops.py
+++ b/tests/debate/test_knowledge_mound_ops.py
@@ -163,6 +163,20 @@ class TestFetchKnowledgeContext:
         assert "KNOWLEDGE MOUND CONTEXT" in result
 
     @pytest.mark.asyncio
+    async def test_results_with_nodes_attribute(self):
+        items = [_make_item(source="fact", item_id="node-1")]
+        results_obj = SimpleNamespace(nodes=items)
+        mound = _make_mound()
+        mound.query_semantic.return_value = results_obj
+
+        ops = KnowledgeMoundOperations(knowledge_mound=mound)
+        result = await ops.fetch_knowledge_context("task")
+
+        assert result is not None
+        assert "**[fact]**" in result
+        assert ops._last_km_item_ids == ["node-1"]
+
+    @pytest.mark.asyncio
     async def test_empty_results_returns_none(self):
         mound = _make_mound()
         mound.query_semantic.return_value = []

--- a/tests/debate/test_orchestrator_knowledge_mound_path.py
+++ b/tests/debate/test_orchestrator_knowledge_mound_path.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aragora.core import Environment
+from aragora.debate.orchestrator import Arena
+from aragora.debate.protocol import DebateProtocol
+
+
+class CaptureAgent:
+    def __init__(self, name: str, response: str) -> None:
+        self.name = name
+        self.role = "proposer"
+        self._response = response
+        self.prompts: list[str] = []
+
+    async def generate(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_arena_run_enriches_prompt_and_closes_knowledge_loop():
+    node = SimpleNamespace(
+        id="km-node-1",
+        node_type="fact",
+        confidence=0.91,
+        content="Rate limiters need tenant-aware burst controls.",
+    )
+    knowledge_mound = AsyncMock()
+    knowledge_mound.workspace_id = "ws-debate"
+    knowledge_mound.query_semantic = AsyncMock(return_value=SimpleNamespace(nodes=[node]))
+    knowledge_mound.store = AsyncMock(return_value=SimpleNamespace(node_id="stored-node"))
+
+    agent = CaptureAgent("agent-1", "Use a token bucket with tenant-aware burst limits.")
+    arena = Arena(
+        Environment(task="Design a rate limiter for multi-tenant APIs"),
+        [agent],
+        DebateProtocol(rounds=1, consensus="none"),
+        knowledge_mound=knowledge_mound,
+        enable_knowledge_retrieval=True,
+        enable_knowledge_ingestion=True,
+    )
+
+    result = await arena.run()
+
+    knowledge_mound.query_semantic.assert_awaited_once_with(
+        text="Design a rate limiter for multi-tenant APIs",
+        limit=5,
+        min_confidence=0.5,
+    )
+    knowledge_mound.store.assert_awaited_once()
+    assert "Background evidence from Knowledge Mound" in agent.prompts[0]
+    assert "Rate limiters need tenant-aware burst controls." in agent.prompts[0]
+    assert result.metadata["knowledge_mound_context_applied"] is True
+    assert result.metadata["knowledge_mound_read_hits"] == 1
+    assert result.metadata["knowledge_mound_item_ids"] == ["km-node-1"]


### PR DESCRIPTION
## Summary
Wire Knowledge Mound retrieval into standalone debate prompt building so debates are enriched with organizational knowledge.

🤖 Generated by Aragora tranche queue (queue-v3, item: knowledge-mound-enrichment-slice)