### PR TITLE
fix(tranche): propagate verification_commands through queue compile

### DIFF
--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -183,6 +183,7 @@ class TrancheQueueItem:
     max_lanes: int = 1
     allowed_write_scope: list[str] = field(default_factory=list)
     autonomy_mode: str | None = None
+    verification_commands: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         payload: dict[str, Any] = {
@@ -198,6 +199,8 @@ class TrancheQueueItem:
             payload["allowed_write_scope"] = list(self.allowed_write_scope)
         if self.autonomy_mode:
             payload["autonomy_mode"] = self.autonomy_mode
+        if self.verification_commands:
+            payload["verification_commands"] = list(self.verification_commands)
         return payload
 
     @classmethod
@@ -224,6 +227,7 @@ class TrancheQueueItem:
             max_lanes=max_lanes,
             allowed_write_scope=_normalize_scope(_string_list(data.get("allowed_write_scope"))),
             autonomy_mode=_optional_text(data.get("autonomy_mode")),
+            verification_commands=_string_list(data.get("verification_commands")),
         )
 
 
@@ -786,6 +790,7 @@ def _compile_issue_source(
                 max_lanes=source.max_lanes,
                 allowed_write_scope=list(source.allowed_write_scope),
                 autonomy_mode=source.autonomy_mode,
+                verification_commands=list(source.verification_commands),
             )
         ],
         [],
@@ -813,6 +818,7 @@ def _compile_issue_query_source(
                 max_lanes=source.max_lanes,
                 allowed_write_scope=list(source.allowed_write_scope),
                 autonomy_mode=source.autonomy_mode,
+                verification_commands=list(source.verification_commands),
             )
         )
     if items:
@@ -843,7 +849,9 @@ def _fallback_issue_lane(item: TrancheQueueItem, *, objective: str, context: str
         "prompt": context,
         "owner_role": "implementation_engineer",
         "allowed_write_scope": list(scope),
-        "verification_commands": [],
+        "verification_commands": list(item.verification_commands)
+        if item.verification_commands
+        else [],
         "merge_class": item.merge_class,
         "merge_policy": "manual",
         "queue_item_id": item.item_id,
@@ -1469,6 +1477,8 @@ class TrancheQueueExecutor:
             updated["merge_class"] = item.merge_class
             updated["merge_policy"] = _queue_merge_policy(merge_class=item.merge_class)
             updated["queue_item_id"] = item.item_id
+            if item.verification_commands and not updated.get("verification_commands"):
+                updated["verification_commands"] = list(item.verification_commands)
             normalized_lanes.append(updated)
         return {
             "objective": objective,

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -146,6 +146,40 @@ sources:
     assert output_path.exists() is False
 
 
+def test_compile_queue_propagates_verification_commands_to_items(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verification commands from sources must flow through to compiled queue items."""
+    sources_path = tmp_path / "sources.yaml"
+    output_path = tmp_path / "overnight.yaml"
+    sources_path.write_text(
+        """
+queue_id: overnight
+sources:
+  - id: test-issue
+    kind: issue
+    mode: execute
+    url: https://github.com/org/repo/issues/42
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+    merge_class: manual
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = compile_tranche_queue(
+        sources_path=sources_path,
+        output_path=output_path,
+        repo_root=tmp_path,
+    )
+
+    assert payload["item_count"] == 1
+    manifest = TrancheQueueManifest.load(output_path)
+    item = manifest.items[0]
+    assert item.verification_commands == ["python3 -m pytest tests/cli/test_setup.py -q"]
+
+
 def test_compile_queue_expands_issue_query_sources(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
Fix three breaks in the verification command propagation chain that caused the supervisor merge gate to reject real worker deliverables with `missing_verification_plan` during overnight queue runs.

### Root Cause
`verification_commands` were defined on `TrancheQueueSource` but never reached the compiled `TrancheQueueItem`, the fallback issue lane, or the intake bundle normalization loop. The supervisor's merge gate requires `expected_tests` to be non-empty, and those come from `lane.verification_commands` in the spec. Empty verification → merge gate rejection → `needs_human` even though the worker committed real code.

### Fixes
1. Added `verification_commands` field to `TrancheQueueItem` dataclass (was missing entirely)
2. `_compile_issue_source` and `_compile_issue_query_source` now copy `verification_commands` from source to item
3. `_fallback_issue_lane` uses `item.verification_commands` instead of hardcoded `[]`
4. `_bundle_from_issue_item` normalization loop copies `verification_commands` from item to lane when the lane doesn't already have them

### Test
- Added `test_compile_queue_propagates_verification_commands_to_items` — verifies end-to-end: source YAML → compiled queue item → item field populated
- Full tranche suite: 77 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>