### PR TITLE
fix(ci): use legacy dependency shim in test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1100,7 +1100,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,research,test]"
+          bash scripts/ci_install_project.sh --extras dev,research,test
           python -m pip install pytest-cov pytest-timeout pytest-xdist
 
       - name: Run tests – shard ${{ matrix.shard.name }} (parallel with xdist)


### PR DESCRIPTION
## Summary
- switch the full `test` matrix install step to `scripts/ci_install_project.sh --extras dev,research,test`
- align the full matrix with the already-working `test-fast` install path
- restore legacy control-plane runtime deps like `pydantic` during CI bootstrap

## Why
Recent PR failures across #1111, #1118, #1119, and #1120 were not caused by PR-local code. The full test matrix was bypassing the repo's legacy dependency shim and installing from a `pyproject.toml` that currently declares no runtime dependencies, which made every shard fail immediately with `ModuleNotFoundError: No module named 'pydantic'` while importing `tests/conftest.py`.

## Validation
- created a clean virtualenv
- ran `bash scripts/ci_install_project.sh --extras dev,research,test --project-dir /tmp/aragora-ci-fix`
- verified `import pydantic` and `from aragora.config import settings` both succeed in that clean env