### PR TITLE
docs(strategy): clarify positioning and runtime visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Aragora
 
-Aragora orchestrates 43 AI agents to adversarially vet decisions through structured debate, delivering audit-ready decision receipts. Built for enterprises where AI decisions carry real consequences.
+Aragora is an auditable execution control plane for AI-assisted work. It uses
+structured multi-model debate, review, receipts, and truthful gates to govern
+consequential decisions and execution flows.
 
-### The Decision Integrity Platform
+### Auditable Execution Control Plane
 
 [![PyPI](https://img.shields.io/pypi/v/aragora)](https://pypi.org/project/aragora/)
 [![Tests](https://github.com/an0mium/aragora/actions/workflows/test.yml/badge.svg)](https://github.com/an0mium/aragora/actions/workflows/test.yml)
@@ -12,7 +14,7 @@ Aragora orchestrates 43 AI agents to adversarially vet decisions through structu
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a deeper overview, see [Start Here](docs/START_HERE.md).
+**New here?** Start with the [Quickstart Guide](docs/quickstart.md) -- you'll have a working debate in under a minute. For a deeper overview, see [Start Here](docs/START_HERE.md). For strategic framing, see [Competitive Positioning (March 2026)](docs/strategy/COMPETITIVE_POSITIONING_2026_03.md) and [When To Use Aragora Vs Execution Substrates](docs/strategy/WHEN_TO_USE_ARAGORA_VS_EXECUTION_SUBSTRATES.md).
 
 | I want to... | Install |
 |--------------|---------|
@@ -20,9 +22,9 @@ Aragora orchestrates 43 AI agents to adversarially vet decisions through structu
 | Call the Aragora API from Python | `pip install aragora-sdk` |
 | Self-host the full platform | `docker compose -f deploy/demo/docker-compose.yml up` |
 
-**Individual LLMs are unreliable. Their personas shift with context, their confidence doesn't correlate with accuracy, and they say what you want to hear. For consequential decisions, you need infrastructure that treats this as a feature to be engineered around, not a problem to be ignored.**
+**Individual LLMs are unreliable. Their personas shift with context, their confidence does not correlate with accuracy, and they often optimize for plausible agreement instead of truth.**
 
-Aragora orchestrates 43 agent types in structured adversarial debates -- forcing models to challenge each other's reasoning, surface blind spots, and produce decisions with complete audit trails showing where they agreed, where they disagreed, and why.
+Aragora treats that as a systems problem. It coordinates heterogeneous models through structured debate and review, preserves receipts and provenance, and stops truthfully when evidence is insufficient. The goal is not just faster AI output, but governed AI-assisted execution you can actually inspect.
 
 ## Try It Now
 
@@ -114,7 +116,7 @@ aragora self-improve "Maximize utility for SME businesses" --dry-run
 aragora self-improve "Harden security" --require-approval --budget-limit 20 --receipt
 ```
 
-Each subtask gets an isolated git worktree, cross-agent code review, sandbox validation, and a cryptographic decision receipt before merge.
+Each subtask gets an isolated git worktree, cross-agent review, sandbox validation, and a receipt trail before merge or truthful escalation.
 
 ### Add to Your CI Pipeline (1 minute)
 
@@ -169,7 +171,7 @@ The Nomic Loop is Aragora's autonomous self-improvement system: agents debate im
 
 A single LLM will confidently give you a wrong answer and you won't know it. Research shows that LLM personas are context-dependent, fragile under adversarial pressure, and prone to sycophantic agreement with whoever is asking. [Stanford's taxonomy of LLM reasoning failures](https://arxiv.org/abs/2602.06176) documents systematic breakdowns in formal logic, unfaithful chain-of-thought, and robustness failures under minor prompt variations -- exactly the failure modes that structured adversarial debate is designed to surface. When the decision matters -- hiring, architecture, compliance, strategy -- one model's opinion is insufficient.
 
-Aragora treats each model as an **unreliable witness** and uses structured debate protocols to extract signal from their disagreements:
+Aragora treats each model as an **unreliable witness** and uses structured debate, review, and receipts to extract signal from disagreement instead of hiding it behind a single routed answer:
 
 | What you get | How it works |
 |---|---|

--- a/aragora/pipeline/unified_orchestrator.py
+++ b/aragora/pipeline/unified_orchestrator.py
@@ -247,6 +247,10 @@ class UnifiedOrchestrator:
                 consensus_threshold=consensus_threshold,
                 provider_hints=provider_hints,
             )
+            self._annotate_provider_metadata(
+                result.debate_result,
+                provider_hints=provider_hints,
+            )
             result.stages_completed.append("debate")
 
             # Update phase ELO from debate
@@ -508,6 +512,35 @@ class UnifiedOrchestrator:
         if provider_hints:
             return [str(item) for item in provider_hints if str(item)]
         return []
+
+    @staticmethod
+    def _annotate_provider_metadata(
+        debate_result: Any,
+        *,
+        provider_hints: list[str] | None = None,
+    ) -> None:
+        """Persist routed provider choices into debate metadata when available.
+
+        Some injected arena factories already surface provider routing in their
+        result metadata, while others only consume ``provider_hints`` during
+        selection. Stamping the selected providers here makes routing decisions
+        observable to downstream receipts and telemetry without overwriting
+        richer metadata from the debate runtime itself.
+        """
+        if debate_result is None or not provider_hints:
+            return
+        metadata = getattr(debate_result, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            try:
+                setattr(debate_result, "metadata", metadata)
+            except (AttributeError, TypeError):
+                return
+        provider_names = [str(item) for item in provider_hints if str(item)]
+        if not provider_names:
+            return
+        metadata.setdefault("provider_hints", list(provider_names))
+        metadata.setdefault("provider_names", list(provider_names))
 
     def _update_phase_elo(self, debate_result: Any, domain: str) -> None:
         """Update phase ELO ratings from debate results."""

--- a/docs/strategy/COMPETITIVE_POSITIONING_2026_03.md
+++ b/docs/strategy/COMPETITIVE_POSITIONING_2026_03.md
@@ -1,0 +1,182 @@
+# Aragora Competitive Positioning — March 2026
+
+> This document augments, not replaces, the broader vision in
+> [CANONICAL_GOALS](../CANONICAL_GOALS.md),
+> [WHY_ARAGORA](../WHY_ARAGORA.md), and
+> [COMMERCIAL_OVERVIEW](../COMMERCIAL_OVERVIEW.md). It adds competitive
+> context and priority ordering based on the current agent-tool landscape.
+
+## The Landscape Shift
+
+Multi-model orchestration is now commodity.
+
+Tools like OpenCode, Pi, and model-routing plugin ecosystems already provide:
+
+- provider-agnostic model access
+- task-type-based routing
+- terminal and IDE-native execution
+- extensible tool/plugin surfaces
+- lightweight multi-agent coordination
+
+Aragora should not try to win on those dimensions alone.
+
+## What Aragora Should Actually Be
+
+Aragora is best framed as an **auditable execution control plane for
+AI-assisted work**.
+
+That means:
+
+- multiple models can contribute
+- disagreement is surfaced, not hidden
+- review and approval gates stay explicit
+- receipts and provenance are first-class outputs
+- automation stops truthfully when evidence is insufficient
+
+This is a different category from "AI coding assistant" or "agent shell."
+
+## Where Aragora Has A Real Wedge
+
+### 1. Adversarial disagreement as evidence
+
+Most tools treat model disagreement as a nuisance to route around.
+Aragora should treat disagreement as data:
+
+- where models converge after challenge, confidence is stronger
+- where they diverge, the dissent trail tells the human where judgment is still needed
+
+### 2. Receipts, provenance, and truthful gates
+
+Aragora's strongest product distinction is not "many models" but:
+
+- receipts
+- provenance
+- review outcomes
+- merge gates
+- truthful blocker handling
+
+The system should always be able to answer:
+
+- who said what
+- what evidence was used
+- why the system advanced or stopped
+- what the next human action actually is
+
+### 3. Control-plane coordination above worker runtimes
+
+OpenCode, Pi, Codex, Claude Code, and similar tools can be excellent worker
+runtimes. Aragora does not need to replace them.
+
+The better strategy is to own the layer above them:
+
+- policy
+- routing
+- bounded delegation
+- review
+- receipts
+- publish and merge truthfulness
+
+### 4. Long-term calibrated accountability
+
+Aragora already has the ingredients for a deeper moat:
+
+- ELO and calibration tracking
+- receipts
+- historical outcomes
+- heterogeneous model comparison
+
+That creates the foundation for evidence-based trust weighting and, later,
+cryptoeconomic accountability.
+
+## What Is Table Stakes Now
+
+These are necessary, but no longer differentiators:
+
+- multi-provider support
+- plugin/extensibility stories
+- generic "43 agent types" breadth
+- broad connector counts
+- generic workflow orchestration
+
+If Aragora leads with these, it will sound interchangeable with stronger,
+larger ecosystems.
+
+## Beachhead
+
+The most credible near-term beachhead is:
+
+**auditable multi-model execution and review for consequential engineering work**
+
+Why this works:
+
+- engineering teams already use AI tooling
+- PR review and execution quality are measurable
+- receipts and blocker truthfulness are valuable immediately
+- the repo now contains real evidence from queue-produced work, not just demos
+
+## ERC-8004 And Cryptoeconomic Accountability
+
+This is not a sideshow, but it is not the beachhead.
+
+ERC-8004-style staking and identity become strategically valuable only after
+Aragora has enough real decision volume to justify:
+
+- per-model, per-domain track records
+- durable outcome labeling
+- reputation weighting
+- stronger external trust guarantees
+
+So the correct sequence is:
+
+1. generate real decision and execution data
+2. preserve receipts and outcomes truthfully
+3. calibrate model reliability empirically
+4. later, make that accountability economically meaningful
+
+## Current Priority Order
+
+### P0
+
+- make the product surface reflect the real wedge
+- keep unattended execution truthful
+- make `aragora review` / execution flows feel like product, not internal plumbing
+
+### P1
+
+- strengthen audit-ready PR and review workflows
+- expose routing, review, and blocker evidence cleanly to operators
+- validate with real external users on consequential tasks
+
+### P2
+
+- unify the full idea-to-execution workbench
+- turn upstream ideas/goals/actions into the default shell around the control plane
+
+## What This Means For Development
+
+Build product surface and control-plane truthfulness, not more generic substrate.
+
+The right next steps are things like:
+
+- clearer review and receipt UX
+- stronger publish / merge visibility
+- truthful stage transitions
+- better operator-facing summaries
+
+The wrong next steps are:
+
+- more generic orchestration infrastructure without user pull
+- selling provider breadth as if it were a moat
+- building huge agent orchestras before the control plane is unquestionably truthful
+
+## Simple Strategic Test
+
+If a user asks, "Why not just use OpenCode or Pi plus plugins?" the answer
+should not be "because Aragora supports more models."
+
+The answer should be:
+
+**Because Aragora governs AI-assisted execution with receipts, review, provenance,
+and truthful stopping behavior.**
+
+That is the category worth owning.

--- a/docs/strategy/WHEN_TO_USE_ARAGORA_VS_EXECUTION_SUBSTRATES.md
+++ b/docs/strategy/WHEN_TO_USE_ARAGORA_VS_EXECUTION_SUBSTRATES.md
@@ -1,0 +1,110 @@
+# When To Use Aragora Vs Execution Substrates
+
+This is the practical decision table for operating Aragora alongside tools like
+Codex, Claude Code, OpenCode, and Pi.
+
+## Default Rule
+
+Use the **simplest layer that preserves the needed truthfulness**.
+
+If the task only needs raw execution, use a worker runtime.
+If the task needs receipts, review, provenance, or truthful blocker handling,
+use Aragora.
+
+## Decision Table
+
+| Situation | Best default | Why |
+|---|---|---|
+| Small code edit with clear scope | Single strong coding agent | Lowest coordination overhead |
+| One owner, 2-4 bounded parallel subtasks | Lead agent plus bounded subagents | Keeps ownership clear while getting real parallelism |
+| Vague natural-language request | Lead agent first | Someone has to frame, slice, and own integration |
+| High-stakes review or merge decision | Aragora | Receipts, dissent, gates, and blocker truth matter |
+| Unattended multi-step execution | Aragora | Queue, watch, integrate, and truthful terminalization are the point |
+| Pure terminal productivity for one developer | Codex / Claude Code / OpenCode / Pi | Fastest path, lowest ceremony |
+| Model-routing experiments | OpenCode/Pi or direct worker harnesses | Good substrate for worker-level routing |
+| Building Aragora itself | Lead agent plus bounded subagents, optionally under Aragora for proof runs | Orchestration overhead must stay bounded |
+
+## Recommended Operating Modes
+
+### 1. Single-agent mode
+
+Use when:
+
+- the task is small
+- scope is obvious
+- integration risk is low
+
+Best tools:
+
+- Codex
+- Claude Code
+- other direct coding agents
+
+### 2. Lead agent plus bounded subagents
+
+Use when:
+
+- the prompt is vague
+- you need a decomposition pass
+- there are a few independent sidecar tasks
+
+This is the default mode for building Aragora itself.
+
+Why:
+
+- one agent owns framing and integration
+- a few workers handle isolated slices
+- coordination stays legible
+
+### 3. Aragora control-plane mode
+
+Use when:
+
+- the work is consequential
+- a receipt is valuable
+- review and publish behavior must be explicit
+- unattended execution needs truthful stopping behavior
+
+Why:
+
+- Aragora's value starts where worker runtimes stop
+- it owns governance, not just execution
+
+### 4. Worker-runtime mode
+
+Use OpenCode, Pi, Codex, Claude Code, or similar tools directly when:
+
+- you mainly need execution speed
+- auditability is not the main bottleneck
+- the task does not need a control plane
+
+These tools are better treated as substrates than as strategic enemies.
+
+## A Note On "Whole Orchestras"
+
+Large heterogeneous swarms sound appealing, but they fail quickly when:
+
+- the prompt is vague
+- scopes overlap
+- state propagation lies
+- verification evidence is weak
+- no one clearly owns integration
+
+So the default should not be "spawn a huge orchestra."
+
+The better sequence is:
+
+1. one lead agent frames the task
+2. a few bounded workers handle independent slices
+3. Aragora governs when the work becomes consequential enough to need receipts, gates, and truthfulness
+
+## Strategic Implication
+
+Aragora should not try to beat OpenCode or Pi at being execution substrates.
+
+Aragora should sit above them:
+
+- selecting when deeper governance is needed
+- preserving receipts and provenance
+- making disagreement useful
+- turning "needs human" into a precise, low-cost next action

--- a/tests/pipeline/test_provider_routing_integration.py
+++ b/tests/pipeline/test_provider_routing_integration.py
@@ -49,6 +49,17 @@ async def test_provider_router_selects_before_debate(mock_arena_factory, mock_pr
     call_kwargs = mock_arena_factory.call_args
     assert call_kwargs is not None
     assert "provider_hints" in (call_kwargs.kwargs or {})
+    assert result.debate_result is not None
+    assert result.debate_result.metadata["provider_hints"] == [
+        "claude-sonnet-4",
+        "gpt-4o",
+        "deepseek-r1",
+    ]
+    assert result.debate_result.metadata["provider_names"] == [
+        "claude-sonnet-4",
+        "gpt-4o",
+        "deepseek-r1",
+    ]
 
 
 @pytest.mark.asyncio
@@ -95,6 +106,48 @@ async def test_provider_router_does_not_break_factory_without_provider_hints_kwa
 
     assert "debate" in result.stages_completed
     assert result.errors == []
+    assert result.debate_result is not None
+    assert result.debate_result.metadata["provider_names"] == [
+        "claude-sonnet-4",
+        "gpt-4o",
+        "deepseek-r1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_provider_router_does_not_overwrite_existing_provider_metadata(
+    mock_provider_router,
+):
+    """If the debate runtime already stamps provider metadata, preserve it."""
+
+    async def arena_factory(
+        prompt: str,
+        agents=None,
+        rounds: int = 3,
+        agent_count: int = 3,
+        consensus_threshold: float = 0.6,
+        provider_hints=None,
+    ):
+        result = MagicMock()
+        result.final_answer = "Use approach A"
+        result.participants = ["agent-claude", "agent-gpt"]
+        result.consensus_reached = True
+        result.metadata = {
+            "provider_names": ["preexisting-provider"],
+            "provider_hints": ["preexisting-provider"],
+        }
+        return result
+
+    orch = UnifiedOrchestrator(
+        arena_factory=arena_factory,
+        provider_router=mock_provider_router,
+    )
+
+    result = await orch.run("Design a rate limiter")
+
+    assert result.debate_result is not None
+    assert result.debate_result.metadata["provider_names"] == ["preexisting-provider"]
+    assert result.debate_result.metadata["provider_hints"] == ["preexisting-provider"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a March 2026 competitive positioning memo
- add a practical decision table for Aragora vs execution substrates
- refresh the README framing around auditable execution control plane
- stamp routed provider choices into debate metadata for downstream receipts and telemetry

## Validation
- python3 -m pytest tests/pipeline/test_provider_routing_integration.py tests/debate/test_provider_routing_integration.py tests/pipeline/test_unified_orchestrator.py -q
- python3 -m ruff check aragora/pipeline/unified_orchestrator.py tests/pipeline/test_provider_routing_integration.py tests/debate/test_provider_routing_integration.py