### PR TITLE
docs(review): require remote PR head inspection

### DIFF
--- a/aragora/compat/openclaw/skills/pr-reviewer/SKILL.md
+++ b/aragora/compat/openclaw/skills/pr-reviewer/SKILL.md
@@ -51,6 +51,27 @@ Unlike single-model code review, Aragora uses adversarial consensus:
 - **Split opinions** = documented with majority/minority positions
 - An **agreement score** (0-1) measures overall consensus
 
+## Remote Head Discipline
+
+Always review the pull request's remote head, not the ambient local worktree.
+
+Required practice:
+
+1. Fetch the PR branch or use GitHub's diff API before reading file contents.
+2. Treat `gh pr diff`, `gh pr view --json`, `git diff origin/<base>...origin/<head>`,
+   and `git show origin/<head>:<path>` as the source of truth.
+3. When quoting or inspecting a file in a finding, confirm it against the PR
+   head SHA or remote branch ref first.
+
+Do not:
+
+- read the current checkout and assume it matches the PR branch
+- review against a stale local branch snapshot
+- issue blocking findings that are not reproducible from the remote PR head
+
+If the remote branch cannot be fetched, report `blocked_nonreviewable` instead
+of silently falling back to local workspace files.
+
 ## Output Format
 
 Each review produces:

--- a/docs/runbooks/PR_REVIEW_REMOTE_HEAD_DISCIPLINE.md
+++ b/docs/runbooks/PR_REVIEW_REMOTE_HEAD_DISCIPLINE.md
@@ -1,0 +1,45 @@
+# PR Review Remote-Head Discipline
+
+Use this rule for every manual or agentic PR review:
+
+**Review the remote PR head, not the ambient local worktree.**
+
+## Why
+
+We hit repeated false findings because review agents inspected whatever branch
+their local worktree happened to be on rather than the actual PR branch under
+review. That produces stale-snapshot reviews, blocks valid PRs, and erodes
+operator trust.
+
+## Required Commands
+
+Fetch the PR metadata and branch first:
+
+```bash
+gh pr view <pr-number> --repo synaptent/aragora \
+  --json headRefName,headRefOid,baseRefName
+git fetch origin <headRefName> --quiet
+```
+
+Use remote diff or remote file reads as the source of truth:
+
+```bash
+gh pr diff <pr-number> --repo synaptent/aragora
+git diff origin/<baseRefName>...origin/<headRefName>
+git show origin/<headRefName>:<path>
+```
+
+## Review Rules
+
+- A review finding must be reproducible from the remote PR head.
+- If the local worktree disagrees with the remote branch, the remote branch
+  wins.
+- If the remote branch cannot be fetched or inspected safely, mark the review
+  `blocked_nonreviewable` instead of relying on local files.
+
+## Minimal Checklist
+
+1. Confirm `headRefOid`.
+2. Inspect the PR diff from GitHub or `git diff origin/<base>...origin/<head>`.
+3. Inspect any cited file with `git show origin/<head>:<path>`.
+4. Only then write findings or approval.


### PR DESCRIPTION
## Summary
- require PR reviews to inspect the remote PR head rather than ambient local worktrees
- document the exact remote-head commands to use for file and diff inspection
- encode the same rule in the built-in PR reviewer skill

## Why
Repeated stale-snapshot review mistakes came from reading local branches that did not match the PR branch under review.