### PR TITLE
fix(queue): publish completed lane deliverables after watch exit

### DIFF
--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -1797,6 +1797,22 @@ class TrancheQueueExecutor:
             except Exception as exc:
                 logger.warning("tranche queue release driver failed for %s: %s", item.item_id, exc)
 
+        if current.status in {
+            TRANCHE_STATUS_ABORTED,
+            TRANCHE_STATUS_COMPLETED,
+            TRANCHE_STATUS_NEEDS_HUMAN,
+        }:
+            await self._publish_terminal_lane_deliverables(
+                current=current,
+                tranche_manifest=tranche_manifest,
+                artifact_store=artifact_store,
+                github=github,
+                registry=registry,
+                state_path=state_path,
+                item_state=item_state,
+                events=events,
+            )
+
         if item_state.status not in _QUEUE_ITEM_TERMINAL_STATUSES:
             if current.status == TRANCHE_STATUS_COMPLETED:
                 item_state.status = QUEUE_ITEM_STATUS_COMPLETED
@@ -1825,6 +1841,84 @@ class TrancheQueueExecutor:
         }
 
         return systemic_reason or self._classify_systemic_reason(events, item_state)
+
+    async def _publish_terminal_lane_deliverables(
+        self,
+        *,
+        current: Any,
+        tranche_manifest: Any,
+        artifact_store: TrancheArtifactStore | Any,
+        github: Any,
+        registry: Any,
+        state_path: Path,
+        item_state: TrancheQueueItemRunState,
+        events: list[dict[str, Any]],
+    ) -> None:
+        updated = False
+        for lane_id, lane_state in current.lane_states.items():
+            if _optional_text(getattr(lane_state, "pr_url", None)):
+                continue
+            artifact = self._load_artifact_for_lane(artifact_store, current.manifest_id, lane_id)
+            if artifact is None or not self._artifact_has_publishable_deliverable(artifact):
+                continue
+            payload = await integrate_lane(
+                artifact=artifact,
+                manifest=tranche_manifest,
+                approve=False,
+                repo_root=self.repo_root,
+                github=github,
+                registry=registry,
+                store=DevCoordinationStore(repo_root=self.repo_root),
+                target_branch=self.target_branch,
+                decided_by="tranche-queue-terminal-publish",
+                rationale=(
+                    "Tranche queue published a completed lane deliverable after watch "
+                    "terminated without recording a PR."
+                ),
+                run_state=current,
+                autonomy_mode=str(item_state.effective_autonomy_mode or "adaptive"),
+            )
+            if not isinstance(payload, dict):
+                continue
+            payload = {"lane_id": lane_id, **payload}
+            events.append(_event_summary("integrate", payload))
+            pr_url = _optional_text(payload.get("pr_url"))
+            if pr_url:
+                lane_state.pr_url = pr_url
+                updated = True
+        if updated:
+            current.updated_at = _utcnow()
+            current.save(state_path)
+
+    @staticmethod
+    def _artifact_has_publishable_deliverable(artifact: Any) -> bool:
+        metadata = getattr(artifact, "metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+        deliverable = metadata.get("deliverable", {})
+        if not isinstance(deliverable, dict):
+            deliverable = {}
+        branch = _optional_text(deliverable.get("branch")) or _optional_text(metadata.get("branch"))
+        commit_shas = [
+            str(item).strip() for item in deliverable.get("commit_shas", []) if str(item).strip()
+        ]
+        return bool(branch and commit_shas)
+
+    @staticmethod
+    def _load_artifact_for_lane(
+        artifact_store: TrancheArtifactStore | Any,
+        manifest_id: str,
+        lane_id: str,
+    ) -> Any | None:
+        if hasattr(artifact_store, "load"):
+            artifact = artifact_store.load(manifest_id, lane_id)
+            if artifact is not None:
+                return artifact
+        if hasattr(artifact_store, "list"):
+            for artifact in artifact_store.list(manifest_id):
+                if getattr(artifact, "lane_id", None) == lane_id:
+                    return artifact
+        return None
 
     def _classify_systemic_reason(
         self,

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -26,6 +26,13 @@ from aragora.swarm.tranche_queue import (
     queue_state_path_for_queue,
     reconcile_tranche_queue,
 )
+from aragora.swarm.tranche import TrancheLaneArtifact
+from aragora.swarm.tranche_state import (
+    LANE_STATUS_NEEDS_HUMAN,
+    TRANCHE_STATUS_NEEDS_HUMAN,
+    LaneRunState,
+    TrancheRunState,
+)
 
 
 def _write_queue(queue_path: Path) -> TrancheQueueManifest:
@@ -823,3 +830,107 @@ async def test_run_queue_stops_on_systemic_reasons(
     assert result["status"] == QUEUE_STATUS_STOPPED
     assert result["stop_reason"] == expected_stop_reason
     assert result["counts"] == {"stopped": 1, "pending": 2}
+
+
+@pytest.mark.asyncio
+async def test_drive_manifest_publishes_terminal_deliverable_without_recorded_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    _write_queue(queue_path)
+    executor = TrancheQueueExecutor(queue_path=queue_path, repo_root=tmp_path)
+    manifest_path = tmp_path / "tranche.yaml"
+    manifest_path.write_text("manifest_id: tranche-test\n", encoding="utf-8")
+    item = TrancheQueueItem(
+        item_id="issue-1046",
+        kind="issue",
+        source="1046",
+        merge_class="manual",
+    )
+    item_state = TrancheQueueItemRunState(
+        item_id=item.item_id,
+        status=QUEUE_ITEM_STATUS_RUNNING,
+        effective_autonomy_mode="adaptive",
+    )
+    current = TrancheRunState(
+        manifest_id="tranche-test",
+        status=TRANCHE_STATUS_NEEDS_HUMAN,
+        autonomy_mode="adaptive",
+        lane_states={
+            "lane-a": LaneRunState(
+                lane_id="lane-a",
+                status=LANE_STATUS_NEEDS_HUMAN,
+                run_id="run-123",
+            )
+        },
+    )
+    artifact = TrancheLaneArtifact(
+        lane_id="lane-a",
+        source_ref="issue-1046",
+        status="completed",
+        run_id="run-123",
+        metadata={
+            "deliverable": {
+                "branch": "codex/swarm-lane-a",
+                "commit_shas": ["abc123"],
+            }
+        },
+    )
+
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.load_tranche_run_state",
+        lambda _: current,
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.claim_driver",
+        lambda state, **kwargs: state,
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.release_driver",
+        lambda state, **kwargs: state,
+    )
+
+    async def fake_watch_loop(state, **kwargs):
+        return state
+
+    monkeypatch.setattr("aragora.swarm.tranche_queue.watch_loop", fake_watch_loop)
+    monkeypatch.setattr(
+        TrancheQueueExecutor,
+        "_load_artifact_for_lane",
+        staticmethod(lambda *args, **kwargs: artifact),
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.DevCoordinationStore",
+        lambda repo_root: object(),
+    )
+
+    async def fake_integrate_lane(**kwargs):
+        return {
+            "pr_url": "https://example.test/pr/42",
+            "publish_result": {"action": "pr_created"},
+            "recommendation": "needs_human",
+            "executed": False,
+        }
+
+    monkeypatch.setattr("aragora.swarm.tranche_queue.integrate_lane", fake_integrate_lane)
+
+    tranche_manifest = SimpleNamespace(manifest_id="tranche-test")
+    deadline = datetime.now(UTC) + timedelta(minutes=5)
+
+    result = await executor._drive_manifest(
+        item=item,
+        item_state=item_state,
+        manifest_path=manifest_path,
+        tranche_manifest=tranche_manifest,
+        deadline=deadline,
+    )
+
+    assert result is None
+    assert item_state.status == QUEUE_ITEM_STATUS_NEEDS_HUMAN
+    assert item_state.pr_urls == ["https://example.test/pr/42"]
+    assert current.lane_states["lane-a"].pr_url == "https://example.test/pr/42"
+    assert any(
+        event.get("type") == "integrate" and event.get("pr_url") == "https://example.test/pr/42"
+        for event in item_state.events
+    )


### PR DESCRIPTION
This reduces manual salvage during overnight queue runs.

## Summary
- add a terminal fallback publish pass in the queue driver for lanes that already have a concrete branch/commit but no recorded PR
- backfill the lane PR URL into tranche state so queue items expose the published deliverable
- cover the regression where watch exits `needs_human` before integrate records the PR

## Validation
- python3 -m pytest tests/swarm/test_tranche_queue.py -q
- python3 -m ruff check aragora/swarm/tranche_queue.py tests/swarm/test_tranche_queue.py