### PR TITLE
feat(debate): wire settlement hooks through outcome path

### DIFF
--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -1109,7 +1109,41 @@ async def handle_debate_completion(
         try:
             from aragora.debate.post_debate_coordinator import PostDebateCoordinator
 
-            coordinator = PostDebateCoordinator(config=effective_config)
+            settlement_tracker = None
+            if getattr(effective_config, "auto_settlement_tracking", False):
+                try:
+                    settlement_tracker = getattr(arena, "settlement_tracker", None)
+                    if settlement_tracker is None:
+                        from aragora.debate.settlement import SettlementTracker
+                        from aragora.debate.settlement_hooks import (
+                            EventBusSettlementHook,
+                            LoggingSettlementHook,
+                            SettlementHookRegistry,
+                        )
+
+                        hook_registry = SettlementHookRegistry()
+                        hook_registry.register(LoggingSettlementHook())
+                        event_bus = getattr(arena, "event_bus", None)
+                        if event_bus is not None:
+                            hook_registry.register(EventBusSettlementHook(event_bus))
+
+                        settlement_tracker = SettlementTracker(
+                            elo_system=getattr(arena, "elo_system", None),
+                            calibration_tracker=getattr(arena, "calibration_tracker", None),
+                            knowledge_mound=getattr(arena, "knowledge_mound", None),
+                            hooks=hook_registry,
+                        )
+                        setattr(arena, "settlement_tracker", settlement_tracker)
+                except ImportError:
+                    logger.debug("Settlement tracker wiring unavailable")
+                except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as st_err:
+                    logger.debug("Settlement tracker wiring unavailable: %s", st_err)
+                    settlement_tracker = None
+
+            coordinator = PostDebateCoordinator(
+                config=effective_config,
+                settlement_tracker=settlement_tracker,
+            )
             task = getattr(ctx.env, "task", "") if ctx.env else ""
             confidence = getattr(ctx.result, "confidence", 0.0)
             post_result = coordinator.run(

--- a/aragora/debate/post_debate_coordinator.py
+++ b/aragora/debate/post_debate_coordinator.py
@@ -147,8 +147,13 @@ class PostDebateCoordinator:
     records the error but doesn't prevent subsequent steps from running.
     """
 
-    def __init__(self, config: PostDebateConfig | None = None):
+    def __init__(
+        self,
+        config: PostDebateConfig | None = None,
+        settlement_tracker: Any | None = None,
+    ):
         self.config = config or PostDebateConfig()
+        self._settlement_tracker = settlement_tracker
 
     @staticmethod
     def _run_async_callable(async_fn: Any, /, *args: Any, **kwargs: Any) -> Any:
@@ -181,6 +186,22 @@ class PostDebateCoordinator:
         if "error" in error:
             raise error["error"]
         return result.get("value")
+
+    @staticmethod
+    def _coerce_receipt_id(candidate: Any) -> str | None:
+        """Normalize receipt IDs while ignoring mock objects and empty values."""
+        if not isinstance(candidate, str):
+            return None
+        normalized = candidate.strip()
+        return normalized or None
+
+    def _get_settlement_tracker(self) -> Any:
+        """Reuse an injected/shared settlement tracker when available."""
+        if self._settlement_tracker is None:
+            from aragora.debate.settlement import SettlementTracker
+
+            self._settlement_tracker = SettlementTracker()
+        return self._settlement_tracker
 
     def run(
         self,
@@ -325,7 +346,14 @@ class PostDebateCoordinator:
 
         # Step 7.9: Settlement tracking — extract verifiable claims for future resolution
         if self.config.auto_settlement_tracking:
-            result.settlement_batch = self._step_settlement_tracking(debate_id, debate_result)
+            result.settlement_batch = self._step_settlement_tracking(
+                debate_id,
+                debate_result,
+                receipt_id=(
+                    result.receipt_id
+                    or self._coerce_receipt_id(getattr(debate_result, "receipt_id", None))
+                ),
+            )
 
         # Step 8.5: Canvas pipeline — auto-trigger idea-to-execution visualization
         if self.config.auto_trigger_canvas and confidence >= self.config.canvas_min_confidence:
@@ -1389,21 +1417,22 @@ class PostDebateCoordinator:
         self,
         debate_id: str,
         debate_result: Any,
+        receipt_id: str | None = None,
     ) -> dict[str, Any] | None:
         """Step 7.9: Extract verifiable claims for future settlement.
 
         Scans the debate result for claims that contain measurable predictions,
-        registers them in the SettlementTracker for later resolution.
+        registers them in the SettlementTracker for later resolution, keeping
+        a truthful link to the persisted debate receipt when one exists.
         """
         try:
-            from aragora.debate.settlement import SettlementTracker
-
-            tracker = SettlementTracker()
+            tracker = self._get_settlement_tracker()
             batch = tracker.extract_verifiable_claims(
                 debate_id=debate_id,
                 debate_result=debate_result,
                 min_confidence=self.config.settlement_min_confidence,
                 domain=self.config.settlement_domain,
+                receipt_id=receipt_id,
             )
 
             if batch.settlements_created > 0:

--- a/aragora/debate/settlement.py
+++ b/aragora/debate/settlement.py
@@ -132,6 +132,7 @@ class SettlementBatch:
     settlements_created: int
     settlement_ids: list[str]
     claims_skipped: int = 0
+    receipt_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return asdict(self)
@@ -238,6 +239,7 @@ class SettlementTracker:
         *,
         min_confidence: float = 0.3,
         domain: str = "general",
+        receipt_id: str | None = None,
     ) -> SettlementBatch:
         """Extract verifiable claims from a debate result and register them.
 
@@ -249,11 +251,18 @@ class SettlementTracker:
             debate_result: The debate result object (has messages, claims, etc.).
             min_confidence: Minimum confidence to consider a claim verifiable.
             domain: Problem domain for calibration bucketing.
+            receipt_id: Persisted decision receipt ID for truthful linkage to
+                the debate outcome path, when available.
 
         Returns:
             SettlementBatch summarising what was created.
         """
-        claims = self._extract_claims_from_result(debate_result, debate_id, domain)
+        claims = self._extract_claims_from_result(
+            debate_result,
+            debate_id,
+            domain,
+            receipt_id=receipt_id,
+        )
 
         settlement_ids: list[str] = []
         skipped = 0
@@ -286,6 +295,7 @@ class SettlementTracker:
             settlements_created=len(settlement_ids),
             settlement_ids=settlement_ids,
             claims_skipped=skipped,
+            receipt_id=receipt_id,
         )
 
         if settlement_ids:
@@ -651,6 +661,9 @@ class SettlementTracker:
 
             confidence_level = ConfidenceLevel.from_float(record.claim.confidence)
             now = dt_cls.now(timezone.utc)
+            claim_metadata = (
+                record.claim.metadata if isinstance(record.claim.metadata, dict) else {}
+            )
 
             item = KnowledgeItem(
                 id=f"settlement:{record.settlement_id}",
@@ -675,6 +688,11 @@ class SettlementTracker:
                     "domain": record.claim.domain,
                     "settled_at": record.settled_at or "",
                     "brier_component": (record.claim.confidence - record.score) ** 2,
+                    **(
+                        {"receipt_id": str(claim_metadata["receipt_id"])}
+                        if claim_metadata.get("receipt_id")
+                        else {}
+                    ),
                 },
             )
 
@@ -703,11 +721,24 @@ class SettlementTracker:
     # Internal: claim extraction from debate result
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _with_receipt_link(
+        metadata: dict[str, Any] | None,
+        receipt_id: str | None,
+    ) -> dict[str, Any]:
+        """Attach a real receipt link without fabricating one."""
+        merged = dict(metadata or {})
+        if receipt_id:
+            merged["receipt_id"] = receipt_id
+        return merged
+
     def _extract_claims_from_result(
         self,
         debate_result: Any,
         debate_id: str,
         domain: str,
+        *,
+        receipt_id: str | None = None,
     ) -> list[VerifiableClaim]:
         """Extract VerifiableClaim objects from a debate result.
 
@@ -732,10 +763,13 @@ class SettlementTracker:
                             author=getattr(tc, "author", "unknown"),
                             confidence=getattr(tc, "confidence", 0.5),
                             domain=domain,
-                            metadata={
-                                "claim_type": getattr(tc, "claim_type", "assertion"),
-                                "round_num": getattr(tc, "round_num", 0),
-                            },
+                            metadata=self._with_receipt_link(
+                                {
+                                    "claim_type": getattr(tc, "claim_type", "assertion"),
+                                    "round_num": getattr(tc, "round_num", 0),
+                                },
+                                receipt_id,
+                            ),
                         )
                     )
             except (AttributeError, TypeError) as e:
@@ -762,6 +796,7 @@ class SettlementTracker:
                                 author=ec.get("author", "unknown"),
                                 confidence=ec.get("confidence", 0.5),
                                 domain=domain,
+                                metadata=self._with_receipt_link(None, receipt_id),
                             )
                         )
             except ImportError:
@@ -785,6 +820,7 @@ class SettlementTracker:
                             author="consensus",
                             confidence=getattr(debate_result, "confidence", 0.5),
                             domain=domain,
+                            metadata=self._with_receipt_link(None, receipt_id),
                         )
                     )
             except ImportError:

--- a/aragora/debate/settlement_hooks.py
+++ b/aragora/debate/settlement_hooks.py
@@ -36,6 +36,15 @@ from aragora.debate.settlement import (
 logger = logging.getLogger(__name__)
 
 
+def _linked_receipt_id(record: SettlementRecord) -> str | None:
+    """Return the persisted receipt ID linked to a settlement claim, if any."""
+    metadata = record.claim.metadata if isinstance(record.claim.metadata, dict) else {}
+    receipt_id = metadata.get("receipt_id")
+    if not receipt_id:
+        return None
+    return str(receipt_id)
+
+
 # ---------------------------------------------------------------------------
 # Hook protocol
 # ---------------------------------------------------------------------------
@@ -149,6 +158,7 @@ class ERC8004SettlementHook:
             return
 
         agent = record.claim.author
+        receipt_id = _linked_receipt_id(record)
         brier_component = (record.claim.confidence - record.score) ** 2
         # Convert Brier component to reputation: 0=worst, 100=perfect
         reputation = max(0, min(100, int((1.0 - brier_component) * 100)))
@@ -180,6 +190,7 @@ class ERC8004SettlementHook:
                         "brier_component": round(brier_component, 4),
                         "confidence": record.claim.confidence,
                         "content_hash": content_hash,
+                        **({"receipt_id": receipt_id} if receipt_id else {}),
                     },
                 )
                 logger.info(
@@ -233,13 +244,15 @@ class EventBusSettlementHook:
         if self._event_bus is None:
             return
         try:
-            self._event_bus.emit(
-                "settlement_claims_extracted",
-                debate_id=batch.debate_id,
-                settlements_created=batch.settlements_created,
-                settlement_ids=batch.settlement_ids,
-                claims_skipped=batch.claims_skipped,
-            )
+            payload: dict[str, Any] = {
+                "debate_id": batch.debate_id,
+                "settlements_created": batch.settlements_created,
+                "settlement_ids": batch.settlement_ids,
+                "claims_skipped": batch.claims_skipped,
+            }
+            if batch.receipt_id:
+                payload["receipt_id"] = batch.receipt_id
+            self._event_bus.emit("settlement_claims_extracted", **payload)
         except (ValueError, TypeError, AttributeError, RuntimeError) as e:
             logger.debug("EventBus emit failed for claims_extracted: %s", e)
 
@@ -247,16 +260,19 @@ class EventBusSettlementHook:
         if self._event_bus is None:
             return
         try:
-            self._event_bus.emit(
-                "settlement_resolved",
-                settlement_id=record.settlement_id,
-                debate_id=record.claim.debate_id,
-                agent=record.claim.author,
-                outcome=result.outcome.value,
-                score=result.score,
-                elo_updates=result.elo_updates,
-                calibration_recorded=result.calibration_recorded,
-            )
+            payload: dict[str, Any] = {
+                "settlement_id": record.settlement_id,
+                "debate_id": record.claim.debate_id,
+                "agent": record.claim.author,
+                "outcome": result.outcome.value,
+                "score": result.score,
+                "elo_updates": result.elo_updates,
+                "calibration_recorded": result.calibration_recorded,
+            }
+            receipt_id = _linked_receipt_id(record)
+            if receipt_id:
+                payload["receipt_id"] = receipt_id
+            self._event_bus.emit("settlement_resolved", **payload)
         except (ValueError, TypeError, AttributeError, RuntimeError) as e:
             logger.debug("EventBus emit failed for settlement_resolved: %s", e)
 

--- a/tests/debate/test_settlement_hooks.py
+++ b/tests/debate/test_settlement_hooks.py
@@ -10,10 +10,12 @@ Validates that:
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from aragora.debate.post_debate_coordinator import PostDebateConfig, PostDebateCoordinator
 from aragora.debate.settlement import (
     SettlementBatch,
     SettlementOutcome,
@@ -41,6 +43,7 @@ def _make_claim(
     statement: str = "Revenue will increase by 20%",
     author: str = "claude",
     confidence: float = 0.8,
+    metadata: dict[str, Any] | None = None,
 ) -> VerifiableClaim:
     return VerifiableClaim(
         claim_id="clm-1",
@@ -48,6 +51,7 @@ def _make_claim(
         statement=statement,
         author=author,
         confidence=confidence,
+        metadata=metadata or {},
     )
 
 
@@ -75,12 +79,13 @@ def _make_settle_result() -> SettleResult:
     )
 
 
-def _make_batch() -> SettlementBatch:
+def _make_batch(receipt_id: str | None = None) -> SettlementBatch:
     return SettlementBatch(
         debate_id="d-1",
         settlements_created=2,
         settlement_ids=["stl-abc123", "stl-def456"],
         claims_skipped=1,
+        receipt_id=receipt_id,
     )
 
 
@@ -192,6 +197,32 @@ class TestSettlementTrackerHooks:
         batch = tracker.extract_verifiable_claims("d-1", debate_result)
         assert batch.settlements_created == 0
         hook.on_claims_extracted.assert_not_called()
+
+    def test_extract_preserves_receipt_linkage(self):
+        hooks = SettlementHookRegistry()
+        hook = MagicMock()
+        hooks.register(hook)
+
+        tracker = SettlementTracker(hooks=hooks)
+        debate_result = _make_debate_result()
+
+        with patch(
+            "aragora.reasoning.claims.fast_extract_claims",
+            return_value=[
+                {"text": "Revenue will increase by 20%", "author": "claude", "confidence": 0.8}
+            ],
+        ):
+            batch = tracker.extract_verifiable_claims(
+                "d-1",
+                debate_result,
+                receipt_id="rcpt-123",
+            )
+
+        assert batch.receipt_id == "rcpt-123"
+        pending = tracker.get_pending(debate_id="d-1")
+        assert pending[0].claim.metadata["receipt_id"] == "rcpt-123"
+        fired_batch = hook.on_claims_extracted.call_args[0][0]
+        assert fired_batch.receipt_id == "rcpt-123"
 
     def test_settle_fires_hook(self):
         hooks = SettlementHookRegistry()
@@ -309,6 +340,21 @@ class TestEventBusSettlementHook:
             claims_skipped=1,
         )
 
+    def test_on_claims_extracted_emits_receipt_id_when_present(self):
+        bus = MagicMock()
+        hook = EventBusSettlementHook(bus)
+
+        hook.on_claims_extracted(_make_batch(receipt_id="rcpt-123"))
+
+        bus.emit.assert_called_once_with(
+            "settlement_claims_extracted",
+            debate_id="d-1",
+            settlements_created=2,
+            settlement_ids=["stl-abc123", "stl-def456"],
+            claims_skipped=1,
+            receipt_id="rcpt-123",
+        )
+
     def test_on_settled_emits_event(self):
         bus = MagicMock()
         hook = EventBusSettlementHook(bus)
@@ -326,6 +372,25 @@ class TestEventBusSettlementHook:
             score=1.0,
             elo_updates={"claude": 12.5},
             calibration_recorded=True,
+        )
+
+    def test_on_settled_emits_receipt_id_when_present(self):
+        bus = MagicMock()
+        hook = EventBusSettlementHook(bus)
+
+        claim = _make_claim(metadata={"receipt_id": "rcpt-123"})
+        hook.on_settled(_make_record(claim=claim), _make_settle_result())
+
+        bus.emit.assert_called_once_with(
+            "settlement_resolved",
+            settlement_id="stl-abc123",
+            debate_id="d-1",
+            agent="claude",
+            outcome="correct",
+            score=1.0,
+            elo_updates={"claude": 12.5},
+            calibration_recorded=True,
+            receipt_id="rcpt-123",
         )
 
     def test_none_bus_does_not_error(self):
@@ -351,3 +416,50 @@ class TestLoggingSettlementHook:
         with caplog.at_level("INFO"):
             hook.on_settled(_make_record(), _make_settle_result())
         assert "settled as correct" in caplog.text
+
+
+class TestPostDebateCoordinatorSettlementHooks:
+    def test_real_post_debate_path_fires_hooks_with_receipt_linkage(self):
+        hooks = SettlementHookRegistry()
+        hook = MagicMock()
+        hooks.register(hook)
+
+        tracker = SettlementTracker(hooks=hooks)
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_persist_receipt=True,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_settlement_tracking=True,
+            auto_llm_judge=False,
+            auto_trigger_canvas=False,
+        )
+        coordinator = PostDebateCoordinator(config=config, settlement_tracker=tracker)
+
+        with patch.object(coordinator, "_step_persist_signed_receipt", return_value="rcpt-789"):
+            with patch(
+                "aragora.reasoning.claims.fast_extract_claims",
+                return_value=[
+                    {
+                        "text": "Revenue will increase by 20%",
+                        "author": "claude",
+                        "confidence": 0.8,
+                    }
+                ],
+            ):
+                result = coordinator.run("d-1", _make_debate_result(), confidence=0.8)
+
+        assert result.receipt_id == "rcpt-789"
+        assert result.settlement_batch is not None
+        assert result.settlement_batch["receipt_id"] == "rcpt-789"
+
+        hook.on_claims_extracted.assert_called_once()
+        fired_batch = hook.on_claims_extracted.call_args[0][0]
+        assert fired_batch.receipt_id == "rcpt-789"
+
+        pending = tracker.get_pending(debate_id="d-1")
+        assert pending[0].claim.metadata["receipt_id"] == "rcpt-789"


### PR DESCRIPTION
Queue-v9 salvage for issue #1049.

## Summary
- fire settlement tracking from the canonical post-debate outcome path
- preserve receipt linkage through extracted claims and settlement hook payloads
- add focused settlement-hook coverage for the coordinator path

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/debate/test_settlement_hooks.py -q

## Notes
- The queue worker's original pytest invocation hit a local plugin socket restriction; disabling plugin autoload validated the targeted code path cleanly in this environment.