### PR TITLE
feat(swarm): add tranche queue harvest command

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -832,6 +832,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         )
         from aragora.swarm.tranche_queue import (
             compile_tranche_queue,
+            harvest_tranche_queue,
             reconcile_tranche_queue,
             run_tranche_queue,
         )
@@ -907,7 +908,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             else:
                 print(json.dumps(payload, indent=2))
             return
-        if subaction in {"run-queue", "reconcile-queue"}:
+        if subaction in {"run-queue", "reconcile-queue", "harvest-queue"}:
             queue_arg = str(getattr(args, "queue", "") or "").strip()
             if not queue_arg:
                 raise ValueError(f"tranche {subaction} requires --queue <path>")
@@ -935,6 +936,13 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                             getattr(args, "allow_same_model_review", False)
                         ),
                     )
+                )
+            elif subaction == "harvest-queue":
+                payload = harvest_tranche_queue(
+                    queue_path=queue_path,
+                    repo_root=repo_root,
+                    execute_merge=bool(getattr(args, "execute_merge", False)),
+                    allow_admin=bool(getattr(args, "allow_admin", False)),
                 )
             else:
                 payload = reconcile_tranche_queue(
@@ -1355,7 +1363,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             )
         else:
             raise ValueError(
-                "tranche action must be one of: submit, plan, inspect, watch, list, design-review, review, integrate, prepare, run, compile-queue, run-queue, reconcile-queue"
+                "tranche action must be one of: submit, plan, inspect, watch, list, design-review, review, integrate, prepare, run, compile-queue, run-queue, reconcile-queue, harvest-queue"
             )
         payload["action"] = subaction
         payload["manifest_path"] = str(manifest_path)

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2468,7 +2468,17 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "--queue",
         default=None,
-        help="Queue manifest path for 'swarm tranche run-queue' and 'reconcile-queue'",
+        help="Queue manifest path for 'swarm tranche run-queue', 'reconcile-queue', and 'harvest-queue'",
+    )
+    swarm_parser.add_argument(
+        "--execute-merge",
+        action="store_true",
+        help="For 'swarm tranche harvest-queue', execute merges for PRs whose GitHub gate disposition is merge_now",
+    )
+    swarm_parser.add_argument(
+        "--allow-admin",
+        action="store_true",
+        help="Allow admin merge fallback for eligible harvest-queue merges when GitHub reports a policy/admin override candidate",
     )
     swarm_parser.add_argument(
         "--sources",

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -2008,3 +2008,98 @@ def reconcile_tranche_queue(
         repo_root=repo_root,
     )
     return executor.reconcile()
+
+
+def harvest_tranche_queue(
+    *,
+    queue_path: str | Path,
+    repo_root: str | Path,
+    execute_merge: bool = False,
+    allow_admin: bool = False,
+) -> dict[str, Any]:
+    resolved_queue_path = Path(queue_path).resolve()
+    resolved_repo_root = Path(repo_root).resolve()
+    reconciled = reconcile_tranche_queue(
+        queue_path=resolved_queue_path, repo_root=resolved_repo_root
+    )
+    manifest = TrancheQueueManifest.load(resolved_queue_path)
+    state_path = queue_state_path_for_queue(resolved_queue_path)
+    state = TrancheQueueRunState.load(state_path, manifest=manifest)
+    github = GitHubControl(repo_root=resolved_repo_root)
+
+    pr_counts: dict[str, int] = {}
+    executed_merges: list[dict[str, Any]] = []
+    items: list[dict[str, Any]] = []
+
+    for item in manifest.items:
+        item_state = state.item_states[item.item_id]
+        pr_records: list[dict[str, Any]] = []
+        for pr_url in item_state.pr_urls:
+            normalized_pr_url = str(pr_url or "").strip()
+            if not normalized_pr_url:
+                continue
+            try:
+                snapshot = github.fetch_gate_snapshot(normalized_pr_url)
+                pr_record = snapshot.to_dict()
+                pr_record["snapshot_disposition"] = snapshot.disposition
+                disposition = snapshot.disposition
+                if execute_merge and snapshot.disposition == "merge_now":
+                    merge_result = github.merge_pr(
+                        normalized_pr_url,
+                        required_checks_green=snapshot.required_checks_green,
+                        allow_admin=allow_admin,
+                    )
+                    pr_record["merge_result"] = merge_result.to_dict()
+                    disposition = "merged" if merge_result.merged else "merge_failed"
+                    pr_record["disposition"] = disposition
+                    if merge_result.merged:
+                        executed_merges.append(
+                            {
+                                "item_id": item.item_id,
+                                "pr_url": normalized_pr_url,
+                                "branch": snapshot.head_branch,
+                                "action": merge_result.action,
+                                "used_admin": merge_result.used_admin,
+                            }
+                        )
+                pr_counts[disposition] = pr_counts.get(disposition, 0) + 1
+            except Exception as exc:
+                pr_record = {
+                    "pr_url": normalized_pr_url,
+                    "disposition": "error",
+                    "error_type": type(exc).__name__,
+                    "detail": str(exc).strip() or type(exc).__name__,
+                }
+                pr_counts["error"] = pr_counts.get("error", 0) + 1
+            pr_records.append(pr_record)
+
+        items.append(
+            {
+                "item_id": item.item_id,
+                "kind": item.kind,
+                "source": item.source,
+                "status": item_state.status,
+                "merge_class": item.merge_class,
+                "tranche_status": item_state.tranche_status,
+                "pr_urls": list(item_state.pr_urls),
+                "findings": list(item_state.findings),
+                "stop_reason": item_state.stop_reason,
+                "prs": pr_records,
+            }
+        )
+
+    return {
+        "mode": "tranche-queue-harvest",
+        "queue_id": manifest.queue_id,
+        "queue_path": str(resolved_queue_path),
+        "state_path": str(state_path),
+        "status": state.status,
+        "stop_reason": state.stop_reason,
+        "current_item_id": state.current_item_id,
+        "counts": dict(reconciled.get("counts") or {}),
+        "pr_counts": pr_counts,
+        "execute_merge": bool(execute_merge),
+        "allow_admin": bool(allow_admin),
+        "executed_merges": executed_merges,
+        "items": items,
+    }

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -61,6 +61,8 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "no_wait": False,
         "manifest": ".aragora/campaign_manifest.yaml",
         "queue": None,
+        "execute_merge": False,
+        "allow_admin": False,
         "intake": None,
         "rounds": 2,
         "all_completed": False,
@@ -399,6 +401,30 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "tranche"
         assert args.swarm_goal == "reconcile-queue"
         assert args.queue == "docs/examples/overnight-queue.yaml"
+        assert args.json is True
+
+    def test_swarm_tranche_harvest_queue_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "tranche",
+                "harvest-queue",
+                "--queue",
+                "docs/examples/overnight-queue.yaml",
+                "--execute-merge",
+                "--allow-admin",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "tranche"
+        assert args.swarm_goal == "harvest-queue"
+        assert args.queue == "docs/examples/overnight-queue.yaml"
+        assert args.execute_merge is True
+        assert args.allow_admin is True
         assert args.json is True
 
     def test_swarm_tranche_compile_queue_parser(self):
@@ -906,6 +932,40 @@ class TestSwarmCommand:
         assert '"queue_id": "overnight"' in out
         assert '"action": "compile-queue"' in out
         mock_compile_queue.assert_called_once()
+
+    def test_cmd_swarm_tranche_harvest_queue_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="tranche",
+            swarm_goal="harvest-queue",
+            queue="/tmp/overnight-queue.yaml",
+            execute_merge=True,
+            allow_admin=True,
+            json=True,
+        )
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.swarm.tranche_queue.harvest_tranche_queue") as mock_harvest_queue,
+        ):
+            mock_harvest_queue.return_value = {
+                "mode": "tranche-queue-harvest",
+                "queue_id": "overnight",
+                "status": "completed",
+                "pr_counts": {"merge_now": 1},
+                "executed_merges": [],
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"mode": "tranche-queue-harvest"' in out
+        assert '"queue_id": "overnight"' in out
+        assert '"action": "harvest-queue"' in out
+        mock_harvest_queue.assert_called_once_with(
+            queue_path=Path("/tmp/overnight-queue.yaml").resolve(),
+            repo_root=Path("/tmp/repo"),
+            execute_merge=True,
+            allow_admin=True,
+        )
 
     def test_cmd_swarm_tranche_prepare_json(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from aragora.swarm.tranche_queue import (
+    QUEUE_STATUS_PENDING,
     QUEUE_ITEM_STATUS_COMPLETED,
     QUEUE_ITEM_STATUS_NEEDS_HUMAN,
     QUEUE_ITEM_STATUS_PENDING,
@@ -21,6 +22,7 @@ from aragora.swarm.tranche_queue import (
     TrancheQueueManifest,
     TrancheQueueRunState,
     compile_tranche_queue,
+    harvest_tranche_queue,
     _queue_merge_policy,
     _resolve_queue_autonomy_mode,
     queue_state_path_for_queue,
@@ -90,6 +92,115 @@ sources:
     bundle = bundle_path.read_text(encoding="utf-8")
     assert "Ship the roadmap tranche work." in bundle
     assert "merge_policy: manual" in bundle
+
+
+def test_harvest_queue_executes_merge_for_merge_now_pr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = TrancheQueueManifest.from_dict(
+        {
+            "queue_id": "overnight",
+            "items": [
+                {
+                    "id": "issue-1046",
+                    "kind": "issue",
+                    "source": "1046",
+                    "merge_class": "manual",
+                }
+            ],
+        }
+    )
+    queue_path.write_text(manifest.to_yaml(), encoding="utf-8")
+
+    state = TrancheQueueRunState(queue_id="overnight", status=QUEUE_STATUS_PENDING)
+    state.ensure_manifest(manifest)
+    item_state = state.item_states["issue-1046"]
+    item_state.status = QUEUE_ITEM_STATUS_NEEDS_HUMAN
+    item_state.pr_urls = ["https://github.com/org/repo/pull/42"]
+    state.save(queue_state_path_for_queue(queue_path))
+
+    class _FakeSnapshot:
+        disposition = "merge_now"
+        required_checks_green = True
+        head_branch = "codex/example-branch"
+
+        def to_dict(self) -> dict[str, object]:
+            return {
+                "pr_url": "https://github.com/org/repo/pull/42",
+                "state": "OPEN",
+                "draft": False,
+                "head_branch": self.head_branch,
+                "base_branch": "main",
+                "review_decision": "APPROVED",
+                "merge_state_status": "CLEAN",
+                "merge_commit_sha": None,
+                "required_checks": [],
+                "advisory_checks": [],
+                "required_checks_green": True,
+                "required_checks_known": True,
+                "required_checks_source": "ruleset",
+                "disposition": "merge_now",
+                "blocker_detail": None,
+            }
+
+    class _FakeMergeResult:
+        merged = True
+        action = "merge"
+        used_admin = False
+
+        def to_dict(self) -> dict[str, object]:
+            return {
+                "merged": True,
+                "action": "merge",
+                "used_admin": False,
+                "detail": "merged",
+            }
+
+    class _FakeGitHubControl:
+        def __init__(self, *, repo_root: Path) -> None:
+            self.repo_root = repo_root
+
+        def fetch_gate_snapshot(self, pr_ref: str) -> _FakeSnapshot:
+            assert pr_ref == "https://github.com/org/repo/pull/42"
+            return _FakeSnapshot()
+
+        def merge_pr(
+            self,
+            pr_ref: str,
+            *,
+            required_checks_green: bool,
+            allow_admin: bool,
+        ) -> _FakeMergeResult:
+            assert pr_ref == "https://github.com/org/repo/pull/42"
+            assert required_checks_green is True
+            assert allow_admin is True
+            return _FakeMergeResult()
+
+    monkeypatch.setattr("aragora.swarm.tranche_queue.GitHubControl", _FakeGitHubControl)
+
+    payload = harvest_tranche_queue(
+        queue_path=queue_path,
+        repo_root=tmp_path,
+        execute_merge=True,
+        allow_admin=True,
+    )
+
+    assert payload["mode"] == "tranche-queue-harvest"
+    assert payload["queue_id"] == "overnight"
+    assert payload["pr_counts"] == {"merged": 1}
+    assert payload["executed_merges"] == [
+        {
+            "item_id": "issue-1046",
+            "pr_url": "https://github.com/org/repo/pull/42",
+            "branch": "codex/example-branch",
+            "action": "merge",
+            "used_admin": False,
+        }
+    ]
+    assert payload["items"][0]["prs"][0]["snapshot_disposition"] == "merge_now"
+    assert payload["items"][0]["prs"][0]["disposition"] == "merged"
 
 
 def test_compile_queue_records_proposal_for_synthesize_doc_source(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a `swarm tranche harvest-queue` command for post-run PR harvesting
- report live PR gate dispositions from a saved queue state and optionally execute eligible merges
- cover the CLI/parser wiring and merge-now harvest path with tests

## Validation
- `python3 -m pytest tests/cli/test_swarm_command.py tests/swarm/test_tranche_queue.py -q`
- `python3 -m aragora.cli.main swarm tranche harvest-queue --queue /Users/armand/Development/aragora/.worktrees/codex-auto/queue-v10-sleep-20260322/.aragora/overnight/queue-v10-sleep-batch-20260322.yaml --json`
