### PR TITLE
feat(knowledge): wire KnowledgeMound retrieval into debate factory

### DIFF
--- a/aragora/debate/arena_builder.py
+++ b/aragora/debate/arena_builder.py
@@ -198,6 +198,7 @@ class ArenaBuilder:
         self._trending_topic: TrendingTopic | None = None
         self._consensus_memory: Any = None
         self._tier_analytics_tracker: Any = None
+        self._knowledge_mound: Any | None = None
         self._enable_knowledge_retrieval: bool | None = None
         self._enable_knowledge_ingestion: bool | None = None
         self._enable_cross_debate_memory: bool | None = None
@@ -423,6 +424,18 @@ class ArenaBuilder:
             self._supermemory_max_context_items = supermemory_max_context_items
         if enable_belief_guidance is not None:
             self._enable_belief_guidance = enable_belief_guidance
+        return self
+
+    def with_knowledge_mound(self, knowledge_mound: Any) -> ArenaBuilder:
+        """Set the Knowledge Mound instance for debate context enrichment.
+
+        When provided, the Arena will use this KM for retrieving relevant
+        organizational knowledge during debates and ingesting outcomes afterward.
+
+        Args:
+            knowledge_mound: A KnowledgeMound instance (or compatible object)
+        """
+        self._knowledge_mound = knowledge_mound
         return self
 
     def with_feature_flags(
@@ -1196,6 +1209,8 @@ class ArenaBuilder:
             "mode_sequence": self._mode_sequence,
         }
 
+        if self._knowledge_mound is not None:
+            arena_kwargs["knowledge_mound"] = self._knowledge_mound
         if self._enable_knowledge_retrieval is not None:
             arena_kwargs["enable_knowledge_retrieval"] = self._enable_knowledge_retrieval
         if self._enable_knowledge_ingestion is not None:

--- a/aragora/server/debate_controller_mixin.py
+++ b/aragora/server/debate_controller_mixin.py
@@ -91,6 +91,7 @@ class DebateControllerMixin:
                 stream_emitter=self.stream_emitter,
                 document_store=getattr(self, "ctx", {}).get("document_store"),
                 evidence_store=getattr(self, "ctx", {}).get("evidence_store"),
+                knowledge_mound=getattr(self, "knowledge_mound", None),
             )
             cls._debate_factory = factory
 

--- a/aragora/server/debate_factory.py
+++ b/aragora/server/debate_factory.py
@@ -216,6 +216,7 @@ class DebateFactory:
         stream_emitter: SyncEventEmitter | None = None,
         document_store: Any | None = None,
         evidence_store: Any | None = None,
+        knowledge_mound: Any | None = None,
     ):
         """Initialize the debate factory.
 
@@ -229,6 +230,11 @@ class DebateFactory:
             dissent_retriever: Retrieves past dissent patterns
             moment_detector: Detects key debate moments
             stream_emitter: Event stream emitter for live updates
+            document_store: Document storage for uploaded documents
+            evidence_store: Evidence storage for debate evidence
+            knowledge_mound: KnowledgeMound instance for organizational knowledge
+                retrieval and outcome ingestion. If None, the Arena will attempt
+                auto-creation using the default singleton.
         """
         self.elo_system = elo_system
         self.persona_manager = persona_manager
@@ -241,6 +247,7 @@ class DebateFactory:
         self.stream_emitter = stream_emitter
         self.document_store = document_store
         self.evidence_store = evidence_store
+        self.knowledge_mound = knowledge_mound
 
     def create_agents(
         self,
@@ -363,6 +370,37 @@ class DebateFactory:
             )
         except (ValueError, TypeError, AttributeError, RuntimeError) as e:
             logger.warning("Failed to emit agent error event: %s", e)
+
+    def _resolve_knowledge_mound(self) -> Any | None:
+        """Resolve the Knowledge Mound instance for debate enrichment.
+
+        Uses the explicitly provided instance if available, otherwise attempts
+        to retrieve the global singleton. Returns None on failure so debates
+        can proceed without knowledge grounding.
+
+        Returns:
+            A KnowledgeMound instance, or None if unavailable.
+        """
+        if self.knowledge_mound is not None:
+            return self.knowledge_mound
+
+        try:
+            from aragora.knowledge.mound import get_knowledge_mound
+
+            km = get_knowledge_mound()
+            logger.debug("Resolved KnowledgeMound singleton for debate enrichment")
+            return km
+        except ImportError:
+            logger.debug(
+                "KnowledgeMound module not available; debates will run without knowledge grounding"
+            )
+        except (RuntimeError, ConnectionError, OSError, ValueError, TypeError, AttributeError) as e:
+            logger.debug(
+                "Could not resolve KnowledgeMound singleton: %s; "
+                "debates will run without knowledge grounding",
+                e,
+            )
+        return None
 
     def _maybe_add_vertical_specialist(
         self,
@@ -643,6 +681,12 @@ class DebateFactory:
             builder = builder.with_document_store(self.document_store)
         if self.evidence_store:
             builder = builder.with_evidence_store(self.evidence_store)
+
+        # Wire Knowledge Mound for debate context enrichment and outcome ingestion.
+        # Use explicitly provided instance, or attempt to resolve the singleton.
+        km = self._resolve_knowledge_mound()
+        if km is not None:
+            builder = builder.with_knowledge_mound(km)
 
         # Enable position ledger auto-creation for truth grounding
         builder = builder.with_enable_position_ledger(True)

--- a/tests/test_debate_factory.py
+++ b/tests/test_debate_factory.py
@@ -501,3 +501,103 @@ class TestDebateFactoryResetCircuitBreakers:
         factory.reset_circuit_breakers(arena)
 
         arena.circuit_breaker.reset.assert_not_called()
+
+
+class TestDebateFactoryKnowledgeMound:
+    """Tests for KnowledgeMound wiring in DebateFactory."""
+
+    def test_factory_accepts_knowledge_mound(self):
+        """Factory stores the knowledge_mound parameter."""
+        km = Mock()
+        factory = DebateFactory(knowledge_mound=km)
+        assert factory.knowledge_mound is km
+
+    def test_factory_defaults_knowledge_mound_to_none(self):
+        """Factory defaults knowledge_mound to None."""
+        factory = DebateFactory()
+        assert factory.knowledge_mound is None
+
+    def test_resolve_knowledge_mound_returns_explicit_instance(self):
+        """_resolve_knowledge_mound returns the explicitly provided instance."""
+        km = Mock()
+        factory = DebateFactory(knowledge_mound=km)
+        assert factory._resolve_knowledge_mound() is km
+
+    def test_resolve_knowledge_mound_falls_back_to_singleton(self):
+        """_resolve_knowledge_mound tries the singleton when no explicit instance."""
+        singleton_km = Mock()
+        factory = DebateFactory()
+
+        with patch("aragora.knowledge.mound.get_knowledge_mound", return_value=singleton_km):
+            result = factory._resolve_knowledge_mound()
+            assert result is singleton_km
+
+    def test_resolve_knowledge_mound_returns_none_on_import_error(self):
+        """_resolve_knowledge_mound returns None when KM module is unavailable."""
+        factory = DebateFactory()
+
+        with patch(
+            "aragora.knowledge.mound.get_knowledge_mound",
+            side_effect=ImportError("No module"),
+        ):
+            result = factory._resolve_knowledge_mound()
+            assert result is None
+
+    def test_resolve_knowledge_mound_returns_none_on_runtime_error(self):
+        """_resolve_knowledge_mound returns None on infrastructure failure."""
+        factory = DebateFactory()
+
+        with patch(
+            "aragora.knowledge.mound.get_knowledge_mound",
+            side_effect=RuntimeError("DB unavailable"),
+        ):
+            result = factory._resolve_knowledge_mound()
+            assert result is None
+
+    def test_create_arena_passes_km_to_builder(self):
+        """create_arena passes the resolved KM to ArenaBuilder."""
+        import aragora.server.debate_factory as factory_module
+
+        km = Mock()
+        mock_agent1 = Mock()
+        mock_agent2 = Mock()
+
+        with patch.object(factory_module, "create_agent", side_effect=[mock_agent1, mock_agent2]):
+            factory = DebateFactory(knowledge_mound=km)
+            config = DebateConfig(
+                question="Test question",
+                agents_str="anthropic-api,openai-api",
+                rounds=3,
+                auto_trim_unavailable=False,
+            )
+
+            arena = factory.create_arena(config)
+
+            # The arena should have been created; verify the KM was resolved
+            assert factory.knowledge_mound is km
+
+    def test_create_arena_works_without_km(self):
+        """create_arena works when KM is not available (graceful fallback)."""
+        import aragora.server.debate_factory as factory_module
+
+        mock_agent1 = Mock()
+        mock_agent2 = Mock()
+
+        with (
+            patch.object(factory_module, "create_agent", side_effect=[mock_agent1, mock_agent2]),
+            patch(
+                "aragora.knowledge.mound.get_knowledge_mound",
+                side_effect=ImportError("No KM module"),
+            ),
+        ):
+            factory = DebateFactory()
+            config = DebateConfig(
+                question="Test question",
+                agents_str="anthropic-api,openai-api",
+                rounds=3,
+                auto_trim_unavailable=False,
+            )
+
+            # Should not raise
+            arena = factory.create_arena(config)
+            assert arena is not None


### PR DESCRIPTION
## Summary
- Wires KnowledgeMound retrieval into `DebateFactory.create_arena()` so debates are enriched with organizational knowledge
- Adds `with_knowledge_mound()` to `ArenaBuilder`
- Factory resolves KM from explicit instance → singleton fallback → None (graceful)
- Debate outcome ingestion already works once KM is passed through

## Test plan
- [x] 8 new tests covering explicit, singleton fallback, and error paths
- [ ] Verify debates still work without KM configured
- [ ] Verify KM enrichment appears in debate context when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)