### PR TITLE
feat(auth): add versioned API key management endpoints

### DIFF
--- a/aragora/live/src/components/settings-panel/index.tsx
+++ b/aragora/live/src/components/settings-panel/index.tsx
@@ -31,6 +31,7 @@ interface ApiKeyListResponse {
   count?: number;
   keys?: Array<{
     prefix: string;
+    name?: string;
     created_at?: string | null;
     expires_at?: string | null;
   }>;
@@ -38,11 +39,13 @@ interface ApiKeyListResponse {
 
 interface GenerateApiKeyResponse {
   api_key?: string;
+  prefix?: string;
+  name?: string;
 }
 
 function mapBackendApiKey(key: NonNullable<ApiKeyListResponse['keys']>[number]): ApiKey {
   return {
-    name: 'Active key',
+    name: key.name || 'Active key',
     prefix: key.prefix,
     created_at: key.created_at ?? null,
     last_used: null,
@@ -173,7 +176,7 @@ export function SettingsPanel() {
     setApiKeyError(null);
 
     try {
-      const data = await authFetch<ApiKeyListResponse>(`${backendConfig.api}/api/auth/api-keys`);
+      const data = await authFetch<ApiKeyListResponse>(`${backendConfig.api}/api/v1/api-keys`);
       const apiKeys = (data?.keys ?? []).map(mapBackendApiKey);
       setPreferences(prev => ({ ...prev, api_keys: apiKeys }));
     } catch (error) {
@@ -193,9 +196,9 @@ export function SettingsPanel() {
     setApiKeyError(null);
 
     try {
-      const data = await authFetch<GenerateApiKeyResponse>(`${backendConfig.api}/api/auth/api-keys`, {
+      const data = await authFetch<GenerateApiKeyResponse>(`${backendConfig.api}/api/v1/api-keys`, {
         method: 'POST',
-        body: JSON.stringify({}),
+        body: JSON.stringify({ name: 'Personal API Key' }),
       });
 
       if (!data?.api_key) {
@@ -220,7 +223,7 @@ export function SettingsPanel() {
 
     try {
       await authFetch<Record<string, unknown>>(
-        `${backendConfig.api}/api/auth/api-keys/${encodeURIComponent(prefix)}`,
+        `${backendConfig.api}/api/v1/api-keys/${encodeURIComponent(prefix)}`,
         { method: 'DELETE' }
       );
       await fetchApiKeys();

--- a/aragora/server/handlers/auth/api_keys.py
+++ b/aragora/server/handlers/auth/api_keys.py
@@ -98,17 +98,24 @@ def handle_generate_api_key(handler_instance: AuthHandler, handler) -> HandlerRe
         if org and not org.limits.api_access:
             return error_response("API access requires Professional tier or higher", 403)
 
+    # Read optional name from request body
+    key_name = "Active key"
+    body = handler_instance.read_json_body(handler)
+    if body and isinstance(body, dict):
+        key_name = body.get("name", "Active key") or "Active key"
+
     # Generate new API key using secure hash-based storage
     # The plaintext key is only returned once; we store the hash
     api_key = user.generate_api_key(expires_days=365)
 
-    # Persist the hashed key fields (api_key_hash, api_key_prefix, expiry)
+    # Persist the hashed key fields (api_key_hash, api_key_prefix, expiry, name)
     user_store.update_user(
         user.id,
         api_key_hash=user.api_key_hash,
         api_key_prefix=user.api_key_prefix,
         api_key_created_at=user.api_key_created_at,
         api_key_expires_at=user.api_key_expires_at,
+        api_key_name=key_name,
     )
 
     logger.info("API key generated for user_id=%s (prefix: %s)", user.id, user.api_key_prefix)
@@ -128,6 +135,10 @@ def handle_generate_api_key(handler_instance: AuthHandler, handler) -> HandlerRe
         {
             "api_key": api_key,
             "prefix": user.api_key_prefix,
+            "name": key_name,
+            "created_at": (
+                user.api_key_created_at.isoformat() if user.api_key_created_at else None
+            ),
             "expires_at": (
                 user.api_key_expires_at.isoformat() if user.api_key_expires_at else None
             ),
@@ -240,6 +251,7 @@ def handle_list_api_keys(handler_instance: AuthHandler, handler) -> HandlerResul
         keys.append(
             {
                 "prefix": user.api_key_prefix,
+                "name": getattr(user, "api_key_name", None) or "Active key",
                 "created_at": (
                     user.api_key_created_at.isoformat() if user.api_key_created_at else None
                 ),

--- a/aragora/server/handlers/auth/handler.py
+++ b/aragora/server/handlers/auth/handler.py
@@ -13,6 +13,9 @@ Endpoints:
 - POST /api/auth/password - Change password
 - POST /api/auth/api-key - Generate API key
 - DELETE /api/auth/api-key - Revoke API key
+- GET /api/v1/api-keys - List API keys (alias)
+- POST /api/v1/api-keys - Generate API key (alias)
+- DELETE /api/v1/api-keys/:prefix - Revoke API key by prefix (alias)
 - GET /api/auth/sessions - List active sessions for current user
 - DELETE /api/auth/sessions/:id - Revoke a specific session
 """
@@ -172,6 +175,9 @@ class AuthHandler(SecureHandler):
         # SDK aliases for API key management
         "/api/keys",
         "/api/keys/*",
+        # Versioned alias: /api/v1/api-keys -> /api/api-keys (after strip_version_prefix)
+        "/api/api-keys",
+        "/api/api-keys/*",
     ]
 
     def can_handle(self, path: str) -> bool:
@@ -186,6 +192,9 @@ class AuthHandler(SecureHandler):
             return True
         # SDK alias: /api/keys/* -> /api/auth/api-keys/*
         if normalized.startswith("/api/keys/"):
+            return True
+        # Versioned alias: /api/api-keys/* -> /api/auth/api-keys/*
+        if normalized.startswith("/api/api-keys"):
             return True
         return False
 
@@ -208,6 +217,12 @@ class AuthHandler(SecureHandler):
             path = "/api/auth/api-keys"
         elif path.startswith("/api/keys/"):
             path = "/api/auth/api-keys/" + path[len("/api/keys/") :]
+
+        # Normalize versioned alias: /api/api-keys -> /api/auth/api-keys
+        if path == "/api/api-keys":
+            path = "/api/auth/api-keys"
+        elif path.startswith("/api/api-keys/"):
+            path = "/api/auth/api-keys/" + path[len("/api/api-keys/") :]
 
         # Determine HTTP method from handler
         method = method or (getattr(handler, "command", "GET") if handler else "GET")

--- a/tests/server/handlers/auth/test_api_keys.py
+++ b/tests/server/handlers/auth/test_api_keys.py
@@ -814,6 +814,213 @@ class TestApiKeyErrorHandling:
         assert result.status_code == 503
 
 
+# ============================================================================
+# Test: Route Aliases (/api/v1/api-keys -> /api/auth/api-keys)
+# ============================================================================
+
+
+class TestApiKeyRouteAliases:
+    """Tests for /api/v1/api-keys route alias support."""
+
+    def test_can_handle_versioned_api_keys_path(self):
+        """Test that AuthHandler.can_handle accepts /api/v1/api-keys."""
+        from aragora.server.handlers.auth.handler import AuthHandler
+
+        auth_handler = AuthHandler(server_context={})
+        assert auth_handler.can_handle("/api/v1/api-keys") is True
+
+    def test_can_handle_versioned_api_keys_prefix_path(self):
+        """Test that AuthHandler.can_handle accepts /api/v1/api-keys/<prefix>."""
+        from aragora.server.handlers.auth.handler import AuthHandler
+
+        auth_handler = AuthHandler(server_context={})
+        assert auth_handler.can_handle("/api/v1/api-keys/ara_abcd1234") is True
+
+    def test_versioned_api_keys_list_routes_correctly(
+        self, mock_handler_instance, mock_http_handler, mock_user_with_key, mock_user_store
+    ):
+        """Test that GET /api/v1/api-keys returns the key list."""
+        from aragora.server.handlers.auth.api_keys import handle_list_api_keys
+
+        mock_user_store.get_user_by_id.return_value = mock_user_with_key
+
+        http = mock_http_handler(method="GET")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user_with_key.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_list_api_keys(mock_handler_instance, http)
+
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert "keys" in body
+        assert body["count"] >= 1
+
+    def test_can_handle_non_versioned_api_keys_path(self):
+        """Test that AuthHandler.can_handle accepts /api/api-keys."""
+        from aragora.server.handlers.auth.handler import AuthHandler
+
+        auth_handler = AuthHandler(server_context={})
+        assert auth_handler.can_handle("/api/api-keys") is True
+
+
+# ============================================================================
+# Test: Name Field Support
+# ============================================================================
+
+
+class TestApiKeyNameField:
+    """Tests for API key name field in create and list responses."""
+
+    def test_generate_api_key_with_name(
+        self, mock_handler_instance, mock_http_handler, mock_user, mock_user_store
+    ):
+        """Test that name is included in generate response."""
+        from aragora.server.handlers.auth.api_keys import handle_generate_api_key
+
+        # Mock read_json_body to return body with name
+        mock_handler_instance.read_json_body.return_value = {"name": "My Test Key"}
+
+        http = mock_http_handler(method="POST")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_generate_api_key(mock_handler_instance, http)
+
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert body["name"] == "My Test Key"
+
+    def test_generate_api_key_default_name(
+        self, mock_handler_instance, mock_http_handler, mock_user, mock_user_store
+    ):
+        """Test that default name is used when none provided."""
+        from aragora.server.handlers.auth.api_keys import handle_generate_api_key
+
+        # Mock read_json_body to return empty body
+        mock_handler_instance.read_json_body.return_value = {}
+
+        http = mock_http_handler(method="POST")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_generate_api_key(mock_handler_instance, http)
+
+        assert result.status_code == 200
+        body = parse_handler_response(result)
+        assert body["name"] == "Active key"
+
+    def test_generate_api_key_persists_name(
+        self, mock_handler_instance, mock_http_handler, mock_user, mock_user_store
+    ):
+        """Test that name is persisted via update_user."""
+        from aragora.server.handlers.auth.api_keys import handle_generate_api_key
+
+        mock_handler_instance.read_json_body.return_value = {"name": "Production Key"}
+
+        http = mock_http_handler(method="POST")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user.id
+            mock_extract.return_value = mock_ctx
+
+            handle_generate_api_key(mock_handler_instance, http)
+
+        mock_user_store.update_user.assert_called_once()
+        call_kwargs = mock_user_store.update_user.call_args[1]
+        assert call_kwargs.get("api_key_name") == "Production Key"
+
+    def test_list_api_keys_includes_name(
+        self, mock_handler_instance, mock_http_handler, mock_user_with_key, mock_user_store
+    ):
+        """Test that list response includes name field."""
+        from aragora.server.handlers.auth.api_keys import handle_list_api_keys
+
+        mock_user_with_key.api_key_name = "My Key"
+        mock_user_store.get_user_by_id.return_value = mock_user_with_key
+
+        http = mock_http_handler(method="GET")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user_with_key.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_list_api_keys(mock_handler_instance, http)
+
+        body = parse_handler_response(result)
+        key_info = body["keys"][0]
+        assert key_info["name"] == "My Key"
+
+    def test_list_api_keys_default_name_when_not_set(
+        self, mock_handler_instance, mock_http_handler, mock_user_with_key, mock_user_store
+    ):
+        """Test that list returns default name when user has no api_key_name attribute."""
+        from aragora.server.handlers.auth.api_keys import handle_list_api_keys
+
+        # Simulate user without api_key_name attribute
+        if hasattr(mock_user_with_key, "api_key_name"):
+            delattr(mock_user_with_key, "api_key_name")
+        mock_user_store.get_user_by_id.return_value = mock_user_with_key
+
+        http = mock_http_handler(method="GET")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user_with_key.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_list_api_keys(mock_handler_instance, http)
+
+        body = parse_handler_response(result)
+        key_info = body["keys"][0]
+        assert key_info["name"] == "Active key"
+
+    def test_generate_api_key_includes_created_at(
+        self, mock_handler_instance, mock_http_handler, mock_user, mock_user_store
+    ):
+        """Test that generate response includes created_at timestamp."""
+        from aragora.server.handlers.auth.api_keys import handle_generate_api_key
+
+        mock_handler_instance.read_json_body.return_value = {}
+
+        http = mock_http_handler(method="POST")
+
+        with patch(
+            "aragora.server.handlers.auth.api_keys.extract_user_from_request"
+        ) as mock_extract:
+            mock_ctx = MagicMock()
+            mock_ctx.user_id = mock_user.id
+            mock_extract.return_value = mock_ctx
+
+            result = handle_generate_api_key(mock_handler_instance, http)
+
+        body = parse_handler_response(result)
+        assert "created_at" in body
+        assert body["created_at"] is not None
+
+
 __all__ = [
     "TestGenerateApiKey",
     "TestRevokeApiKey",
@@ -821,4 +1028,6 @@ __all__ = [
     "TestRevokeApiKeyByPrefix",
     "TestApiKeySecurityProperties",
     "TestApiKeyErrorHandling",
+    "TestApiKeyRouteAliases",
+    "TestApiKeyNameField",
 ]


### PR DESCRIPTION
## Summary
- Adds `/api/v1/api-keys` route alias to existing auth handler (maps to `/api/auth/api-keys`)
- Adds `name` field support to API key generation and listing
- Wires frontend `ApiKeysTab` to use versioned `/api/v1/api-keys` endpoints instead of unversioned paths
- Backend already had SHA-256 hashing, one-time display, RBAC — this PR closes the frontend gap

## Test plan
- [x] 10 new tests (route aliases + name field) + 30 existing pass (40 total)
- [ ] Verify API key creation from Settings UI shows real key
- [ ] Verify key listing shows name and prefix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)