### PR TITLE
feat(swarm): add label filter to boss-loop CLI for unattended dispatch

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -553,12 +553,24 @@ def cmd_swarm(args: argparse.Namespace) -> None:
     if action == "boss-loop":
         from aragora.swarm.boss_loop import BossLoop, BossLoopConfig
 
+        # Merge --label (repeatable) with legacy --boss-label-filter (single string).
+        cli_labels: list[str] = list(getattr(args, "labels", None) or [])
+        legacy_label = getattr(args, "boss_label_filter", None)
+        if legacy_label and legacy_label not in cli_labels:
+            cli_labels.insert(0, legacy_label)
+
+        # Use the first label for gh CLI pre-filtering (server-side), and the
+        # full set as require_labels for Python-side ALL-match filtering.
+        label_filter = cli_labels[0] if cli_labels else None
+        require_labels = set(cli_labels) if cli_labels else None
+
         boss_loop_config = BossLoopConfig(
             max_iterations=int(getattr(args, "max_ticks", None) or 50),
             iteration_interval_seconds=float(getattr(args, "interval_seconds", 30.0) or 30.0),
             freshness_ttl_seconds=float(getattr(args, "freshness_ttl", 3600.0) or 3600.0),
             repo=getattr(args, "boss_repo", None),
-            label_filter=getattr(args, "boss_label_filter", None),
+            label_filter=label_filter,
+            require_labels=require_labels,
             issue_number=getattr(args, "boss_issue_number", None),
             target_branch=target_branch,
             budget_limit_usd=budget_limit,

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2393,7 +2393,14 @@ def _add_swarm_parser(subparsers) -> None:
         "--boss-label-filter",
         type=str,
         default=None,
-        help="Only consider issues with this label in boss-loop",
+        help="Only consider issues with this label in boss-loop (deprecated: use --label)",
+    )
+    swarm_parser.add_argument(
+        "--label",
+        action="append",
+        default=None,
+        dest="labels",
+        help="Only consider issues with ALL specified labels (repeatable: --label P0 --label queue-eligible)",
     )
     swarm_parser.add_argument(
         "--boss-issue-number",

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -155,7 +155,7 @@ def select_eligible_issue(
     - Must be in ``open`` state
     - Must have a non-empty title
     - Must not carry any label in ``skip_labels``
-    - If ``require_labels`` is set, must carry at least one
+    - If ``require_labels`` is set, must carry ALL of them
 
     Returns ``None`` with no improvisation if nothing qualifies.
     """
@@ -167,7 +167,7 @@ def select_eligible_issue(
             continue
         if _skip & set(issue.labels):
             continue
-        if require_labels and not (require_labels & set(issue.labels)):
+        if require_labels and not require_labels.issubset(set(issue.labels)):
             continue
         return issue
     return None

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -227,6 +227,35 @@ class TestSelectEligibleIssue:
         assert selected is not None
         assert selected.number == 2
 
+    def test_require_labels_all_match(self):
+        """When multiple labels are required, ALL must be present on the issue."""
+        issues = [
+            _make_issue(1, "Only one label", labels=["P0"]),
+            _make_issue(2, "Both labels", labels=["P0", "queue-eligible"]),
+            _make_issue(3, "Extra labels too", labels=["P0", "queue-eligible", "enhancement"]),
+        ]
+        selected = select_eligible_issue(issues, require_labels={"P0", "queue-eligible"})
+        assert selected is not None
+        assert selected.number == 2
+
+    def test_require_labels_rejects_partial_match(self):
+        """An issue with only some of the required labels is rejected."""
+        issues = [
+            _make_issue(1, "Partial", labels=["P0"]),
+        ]
+        selected = select_eligible_issue(issues, require_labels={"P0", "queue-eligible"})
+        assert selected is None
+
+    def test_no_require_labels_means_no_filtering(self):
+        """When require_labels is None, all issues are eligible (label-wise)."""
+        issues = [
+            _make_issue(1, "No labels"),
+            _make_issue(2, "Has labels", labels=["P0"]),
+        ]
+        selected = select_eligible_issue(issues, require_labels=None)
+        assert selected is not None
+        assert selected.number == 1
+
 
 class TestValidationContractExtraction:
     def test_extracts_bullets_from_acceptance_section(self):
@@ -918,6 +947,8 @@ class TestBossLoopCLI:
             "boss_label_filter": None,
             "boss_issue_number": None,
             "max_consecutive_failures": 3,
+            "labels": None,
+            "allow_missing_validation_contract": False,
         }
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
@@ -1013,6 +1044,130 @@ class TestBossLoopCLI:
         assert args.max_consecutive_failures == 5
         assert args.allow_missing_validation_contract is True
         assert args.json is True
+
+    def test_boss_loop_parser_accepts_label_repeatable(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "boss-loop",
+                "--label",
+                "P0",
+                "--label",
+                "queue-eligible",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "boss-loop"
+        assert args.labels == ["P0", "queue-eligible"]
+        assert args.json is True
+
+    def test_boss_loop_parser_no_labels_defaults_to_none(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["swarm", "boss-loop"])
+        assert args.labels is None
+
+    def test_boss_loop_label_filter_wired_to_config(self):
+        """--label args are wired to BossLoopConfig.require_labels as a set."""
+        from aragora.cli.commands.swarm import cmd_swarm
+
+        args = self._swarm_args(
+            json=True,
+            max_ticks=1,
+            labels=["P0", "queue-eligible"],
+        )
+
+        with patch(
+            "aragora.swarm.boss_loop.check_runner_freshness",
+            return_value=_fresh_result(fresh=False, blocked_reason="missing_owner_context"),
+        ) as _:
+            cmd_swarm(args)
+
+        # The loop ran (and stopped because no fresh runner). We verify that
+        # the config was constructed with the right require_labels by checking
+        # that it didn't crash and produced valid output.  A more direct test
+        # of the wiring follows below.
+
+    def test_boss_loop_label_filter_wired_require_labels_all_match(self, capsys):
+        """Issues must carry ALL --label values to be selected."""
+        from aragora.cli.commands.swarm import cmd_swarm
+
+        # Issue only has P0, not queue-eligible
+        fixture_issues = [
+            _make_issue(1, "Partial match", labels=["P0"]),
+        ]
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = fixture_issues
+
+        args = self._swarm_args(
+            json=True,
+            max_ticks=1,
+            labels=["P0", "queue-eligible"],
+        )
+
+        with (
+            patch(
+                "aragora.swarm.boss_loop.check_runner_freshness",
+                return_value=_fresh_result(fresh=True),
+            ),
+            patch(
+                "aragora.swarm.boss_loop.GitHubIssueFeed",
+                return_value=feed,
+            ),
+        ):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["stop_reason"] == "no_suitable_issue"
+
+    def test_boss_loop_label_filter_passes_with_all_labels(self, capsys):
+        """Issues carrying ALL required labels pass the filter."""
+        from aragora.cli.commands.swarm import cmd_swarm
+
+        fixture_issues = [
+            _make_issue(
+                1,
+                "Full match",
+                labels=["P0", "queue-eligible", "enhancement"],
+                body=(
+                    "Fix the thing\n\n"
+                    "Acceptance Criteria:\n"
+                    "- pytest -q tests/swarm/test_boss_loop.py\n"
+                ),
+            ),
+        ]
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = fixture_issues
+
+        args = self._swarm_args(
+            json=True,
+            max_ticks=1,
+            labels=["P0", "queue-eligible"],
+            no_dispatch=True,
+        )
+
+        with (
+            patch(
+                "aragora.swarm.boss_loop.check_runner_freshness",
+                return_value=_fresh_result(fresh=True),
+            ),
+            patch(
+                "aragora.swarm.boss_loop.GitHubIssueFeed",
+                return_value=feed,
+            ),
+        ):
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        # The issue was selected (didn't stop with no_suitable_issue)
+        assert parsed["stop_reason"] != "no_suitable_issue"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds repeatable `--label` argument to boss-loop CLI: `aragora swarm boss-loop --label queue-eligible --label P0`
- Changed `require_labels` semantics from OR to AND (all specified labels must be present)
- Backward-compatible `--boss-label-filter` kept (deprecated)
- Enables truly unattended operation: `aragora swarm boss-loop --label queue-eligible`

## Test plan
- [x] 8 new tests + 52 existing pass (60 total in test_boss_loop.py)
- [ ] Verify `aragora swarm boss-loop --label queue-eligible` filters correctly against real issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)