### PR TITLE
docs(status): refresh canonical execution docs for March 23 state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,18 +1,19 @@
 # Aragora Product Roadmap
 
-**Last Updated:** March 2026
+**Last Updated:** March 23, 2026
 
 ---
 
 ## Current Status (March 2026)
 
-Aragora has shipped most of the closed-loop backbone (CLB) infrastructure and completed the 14/14 issue sprint, but the March 2026 product cohesion assessment found the product loop is still broken. Launch readiness is now gated first by PMF closure, not by enterprise certification.
+Aragora has shipped most of the closed-loop backbone (CLB) infrastructure and completed the 14/14 issue sprint, but the March 2026 product cohesion assessment still broadly holds: the product loop is not yet fully continuous for a new user. The March 21-23 merge stream, however, materially improved the state on `main`. Launch readiness is still gated first by PMF closure, not by enterprise certification.
 
 **By the numbers:**
-- 208,000+ tests across 5,000+ test files (0 failures on main)
-- 42 Knowledge Mound adapter specs registered (up from 34 in Q4 2025)
-- 3,100+ API operations across 2,600+ paths
-- 15 RBAC resource types, 8 actions, 420+ named permissions
+- 3,846 Python files under `aragora/`
+- 5,174 test files under `tests/`
+- 674 Markdown docs under `docs/`
+- 42 Knowledge Mound adapter specs registered
+- 43 agent types available across CLI, API, local, and proxy providers
 - SOC 2 controls framework: 98% implemented
 
 **Completed since January 2026:**
@@ -32,8 +33,17 @@ Aragora has shipped most of the closed-loop backbone (CLB) infrastructure and co
 - Ralph observability dashboard (7 Prometheus metrics, 10 REST API endpoints, YAML state data service)
 - File-scope propagation fix for swarm work orders (#884)
 - LLM-first vague-goal expansion replacing keyword templates (#888)
+- Live settings/API-key tab wiring to backend auth endpoints ([#1146](https://github.com/synaptent/aragora/pull/1146))
+- Live debate creation from the debates page ([#1147](https://github.com/synaptent/aragora/pull/1147))
+- Truthful partial-public status surface ([#1148](https://github.com/synaptent/aragora/pull/1148))
+- Refresh-aware pipeline feedback scoping ([#1149](https://github.com/synaptent/aragora/pull/1149))
+- Visible pipeline golden-path summary ([#1150](https://github.com/synaptent/aragora/pull/1150))
+- `PipelineKMBridge` precedent loading before debate ([#1151](https://github.com/synaptent/aragora/pull/1151))
+- Queue max-parallel-two safety slice ([#1141](https://github.com/synaptent/aragora/pull/1141))
+- Queue harvest command ([#1164](https://github.com/synaptent/aragora/pull/1164))
 
 **Remaining tracked priority work:**
+- Rationalize and merge the active PMF stack as one coherent lane instead of merging overlapping slices blindly; current recommended order is [#1167](https://github.com/synaptent/aragora/pull/1167) -> [#1168](https://github.com/synaptent/aragora/pull/1168) -> [#1169](https://github.com/synaptent/aragora/pull/1169) -> [#1170](https://github.com/synaptent/aragora/pull/1170), then harvest or close [#1166](https://github.com/synaptent/aragora/pull/1166)
 - Wire provider routing into Arena agent selection ([#813](https://github.com/synaptent/aragora/issues/813))
 - Complete one end-to-end user journey from setup to value delivery ([#1046](https://github.com/synaptent/aragora/issues/1046))
 - Feed Knowledge Mound reads into debate context so memory is not write-only ([#1048](https://github.com/synaptent/aragora/issues/1048))
@@ -201,7 +211,7 @@ Aragora is the control plane for multi-agent vetted decisionmaking across organi
 This section captures the prioritized forward roadmap as of March 2026, organized by quarter and theme.
 Execution priority source of truth: [docs/status/NEXT_STEPS_CANONICAL.md](docs/status/NEXT_STEPS_CANONICAL.md). This roadmap summarizes quarter-level themes and does not supersede canonical execution priorities.
 
-The March 2026 product cohesion assessment found ~25% effective feature completeness for actual use, no complete user journey, provider routing still not wired to Arena, Knowledge Mound retrieval not enriching debates, and roughly 140 of 149 frontend pages still acting as shells. The near-term roadmap therefore prioritizes closing the product loop before widening enterprise-readiness work.
+The March 2026 product cohesion assessment found ~25% effective feature completeness for actual use, no complete user journey, provider routing still not wired to Arena, Knowledge Mound retrieval not enriching debates, and a shell-heavy frontend surface. The March 21-23 merge stream improved continuity on `main`, but the near-term roadmap still prioritizes closing the product loop before widening enterprise-readiness work.
 
 **EU AI Act enforcement: August 2, 2026.** This remains a real forcing function, but the compliance package only matters commercially if the core PMF loop is usable enough to demo and adopt.
 
@@ -211,6 +221,7 @@ The March 2026 product cohesion assessment found ~25% effective feature complete
 - [ ] Feed Knowledge Mound reads into debate context ([#1048](https://github.com/synaptent/aragora/issues/1048))
 - [ ] OpenClaw dispatch completion ([#814](https://github.com/synaptent/aragora/issues/814))
 - [ ] Productize five functional frontend paths instead of expanding shell coverage ([#1047](https://github.com/synaptent/aragora/issues/1047))
+- [ ] Resolve the overlapping PMF PR stack into one truthful merge lane before widening surface work ([#1166](https://github.com/synaptent/aragora/pull/1166), [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), [#1170](https://github.com/synaptent/aragora/pull/1170))
 - [x] Agent-first beta: OpenClaw fleet deployed on 3 machines, running `aragora review` on real PRs via REST API
 - [x] GitHub Actions pre-merge gate (`aragora-review-gate.yml` shipped)
 - [x] Public demo at aragora.ai/demo (PR #705; standalone demo page live)

--- a/docs/FEATURE_GAP_LIST.md
+++ b/docs/FEATURE_GAP_LIST.md
@@ -2,7 +2,7 @@
 
 > **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
 > Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md) and the linked GitHub issues. This file remains the capability and productization backlog truth.
-> Last updated: March 2026
+> Last updated: March 23, 2026
 > March 2026 priority reframe: product cohesion and PMF proof come before certification. Pentest / SOC 2 stay tracked, but they are no longer the first blocker lane.
 
 ## How to Read This List
@@ -20,9 +20,9 @@
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Smart provider routing | **Phase 1 shipped** | PR #724: Pareto optimizer, 8-model pricing database, ProviderRouter. Runtime integration with Arena agent selection remains the first product-loop blocker. Tracked in [#813](https://github.com/synaptent/aragora/issues/813). |
-| Complete one working user journey | Not started end-to-end | No truthful path yet from setup / API key to real debate execution to visible results. Tracked in [#1046](https://github.com/synaptent/aragora/issues/1046). |
-| Knowledge Mound reads enrich debate context | Write path shipped; retrieval not wired | KM remains effectively write-only in default product flows. Debate context is not enriched by accumulated knowledge. Tracked in [#1048](https://github.com/synaptent/aragora/issues/1048). |
+| Smart provider routing | **Phase 1 shipped; runtime integration under active review** | PR #724 shipped the Pareto optimizer, pricing database, and `ProviderRouter`. The next merge decision is the runtime `DebateFactory`/Arena lane in [#1167](https://github.com/synaptent/aragora/pull/1167) versus overlapping umbrella [#1166](https://github.com/synaptent/aragora/pull/1166). Tracked in [#813](https://github.com/synaptent/aragora/issues/813). |
+| Complete one working user journey | Partial slices on `main`; end-to-end proof still open | The base user-journey slice is merged via [#1110](https://github.com/synaptent/aragora/pull/1110), with live settings/API-key wiring in [#1146](https://github.com/synaptent/aragora/pull/1146) and live debate creation in [#1147](https://github.com/synaptent/aragora/pull/1147). The remaining gap is one repeatable setup -> debate -> result proof, with active continuity slices in [#1169](https://github.com/synaptent/aragora/pull/1169), [#1170](https://github.com/synaptent/aragora/pull/1170), and overlapping umbrella [#1166](https://github.com/synaptent/aragora/pull/1166). Tracked in [#1046](https://github.com/synaptent/aragora/issues/1046). |
+| Knowledge Mound reads enrich debate context | Partial: retrieval/writeback groundwork shipped; default flow still closing | Retrieval and writeback groundwork landed via [#1111](https://github.com/synaptent/aragora/pull/1111), [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), [#1134](https://github.com/synaptent/aragora/pull/1134), and pre-debate precedent loading in [#1151](https://github.com/synaptent/aragora/pull/1151). The remaining default-flow wiring is under active review in [#1168](https://github.com/synaptent/aragora/pull/1168) and overlapping umbrella [#1166](https://github.com/synaptent/aragora/pull/1166). Tracked in [#1048](https://github.com/synaptent/aragora/issues/1048). |
 | Debate output quality | **VALIDATED — moved to Completed** | Run 012 (Mar 5): composite 8.38-9.39/10. Diverse benchmark (10 domains): 100% pass, avg composite 0.938. |
 
 ---
@@ -32,7 +32,7 @@
 | Feature | Status | Notes |
 |---------|--------|-------|
 | OpenClaw end-to-end demo | **Core loop shipped** | PR #727: CodeImplementationTask, SpecExtractor, ComputerUseActionBundle, receipt linkage. Production validation with live agents remaining. Tracked in [#814](https://github.com/synaptent/aragora/issues/814). |
-| Functional frontend paths (5 that matter) | Shell-heavy (~140/149 pages remain scaffolding) | Focus the frontend on five truthful surfaces: debate creation, results, knowledge, settings, and receipts. Current page count overstates usability. Tracked in [#1047](https://github.com/synaptent/aragora/issues/1047). |
+| Functional frontend paths (5 that matter) | Still shell-heavy, but continuity slices are landing on `main` | Recent merged slices improved the real surface: settings/API-key wiring ([#1146](https://github.com/synaptent/aragora/pull/1146)), debate creation ([#1147](https://github.com/synaptent/aragora/pull/1147)), public status truthfulness ([#1148](https://github.com/synaptent/aragora/pull/1148)), and pipeline golden-path visibility ([#1150](https://github.com/synaptent/aragora/pull/1150)). The remaining gap is continuity across debate creation, results, knowledge, settings, and receipts, not raw page count. Tracked in [#1047](https://github.com/synaptent/aragora/issues/1047). |
 | 10+ agent coordinated debates | Scaffolding | Current practical limit: 2-6 agents. Coordination infrastructure exists; scale testing needed after the core loop works. Tracked in [#815](https://github.com/synaptent/aragora/issues/815). |
 | Agent-first beta via REST API | **Fleet deployed (12 runners)** | `aragora openclaw watch` polls repos, runs multi-agent review, posts findings. 3 Hetzner + 6 EC2 + 3 local Macs. PR watch daemon on Mac Studio via launchd. Shared operator productization is tracked in [#817](https://github.com/synaptent/aragora/issues/817) and [#819](https://github.com/synaptent/aragora/issues/819). |
 | GitHub Actions pre-merge gate | **Workflow created** | `aragora-review-gate.yml` manual-only (workflow_dispatch). Re-enable pull_request trigger when ready. |

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-03-22
+Last updated: 2026-03-23
 
 This document links Aragora's current execution program to the live GitHub issue tracker.
 
@@ -18,6 +18,13 @@ This document links Aragora's current execution program to the live GitHub issue
 6. Idea-to-execution workbench
 7. Enterprise readiness stays warm, not the main product lane
 
+Immediate merge discipline for step 1:
+
+- `main` already contains supporting PMF slices through `#1164`.
+- The active merge gate is the overlapping open PR stack [#1166](https://github.com/synaptent/aragora/pull/1166), [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), and [#1170](https://github.com/synaptent/aragora/pull/1170).
+- `#1166` overlaps the narrower `#1167-#1170` slices; merge order must choose one coherent lane instead of landing overlapping PMF work twice.
+- Recommended sequence: merge the narrow runtime/user-journey slices first ([#1167](https://github.com/synaptent/aragora/pull/1167) -> [#1168](https://github.com/synaptent/aragora/pull/1168) -> [#1169](https://github.com/synaptent/aragora/pull/1169) -> [#1170](https://github.com/synaptent/aragora/pull/1170)), then either harvest the remaining net-new pieces from [#1166](https://github.com/synaptent/aragora/pull/1166) or close it as superseded.
+
 ## Current PMF Proof Reality
 
 The March 19-22 tranche/live-proof cycle generated real output and several merged proof-surface closures:
@@ -25,9 +32,9 @@ The March 19-22 tranche/live-proof cycle generated real output and several merge
 | Issue | Current reality | Output / note |
 |------|-----------------|---------------|
 | [#1011](https://github.com/synaptent/aragora/issues/1011) | First queue artifact recovered and published | [#1108](https://github.com/synaptent/aragora/pull/1108) merged |
-| [#1046](https://github.com/synaptent/aragora/issues/1046) | First user-journey slice is merged on `main` | [#1110](https://github.com/synaptent/aragora/pull/1110) merged; remaining gap is full end-to-end continuity |
-| [#1048](https://github.com/synaptent/aragora/issues/1048) | First KM retrieval slice is merged on `main` | [#1111](https://github.com/synaptent/aragora/pull/1111) merged; later KM writeback/settlement closures landed via [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), and [#1134](https://github.com/synaptent/aragora/pull/1134) |
-| [#1047](https://github.com/synaptent/aragora/issues/1047) | Active reduced proof lane | Latest `queue-v4b` attempt is truthfully `needs_human` / review-blocked |
+| [#1046](https://github.com/synaptent/aragora/issues/1046) | Multiple user-journey support slices are now merged on `main` | [#1110](https://github.com/synaptent/aragora/pull/1110), [#1146](https://github.com/synaptent/aragora/pull/1146), and [#1147](https://github.com/synaptent/aragora/pull/1147) are merged; remaining gap is one repeatable end-to-end default proof and an explicit decision on `#1166` vs `#1169`/`#1170` |
+| [#1048](https://github.com/synaptent/aragora/issues/1048) | Retrieval and writeback slices are partially merged on `main` | [#1111](https://github.com/synaptent/aragora/pull/1111) merged; KM writeback/settlement closures landed via [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), and [#1134](https://github.com/synaptent/aragora/pull/1134); pre-debate precedent loading landed in [#1151](https://github.com/synaptent/aragora/pull/1151); default debate-factory wiring remains the active merge decision in `#1168` / `#1166` |
+| [#1047](https://github.com/synaptent/aragora/issues/1047) | Still active, but the frontier changed | Partial-public status landed in [#1148](https://github.com/synaptent/aragora/pull/1148) and visible golden-path summary landed in [#1150](https://github.com/synaptent/aragora/pull/1150); the gap is now continuity across five truthful pages, not just page-shell diagnosis |
 | [#818](https://github.com/synaptent/aragora/issues/818) | Truthful public proof slice is merged on `main` | [#1136](https://github.com/synaptent/aragora/pull/1136) merged; remaining gap is repeated external use |
 | [#819](https://github.com/synaptent/aragora/issues/819) | First truthful integrations slice is merged on `main` | [#1119](https://github.com/synaptent/aragora/pull/1119) merged; broader integrations trustworthiness still active |
 
@@ -40,6 +47,7 @@ Current tranche:
 - the queue runs and follow-on merges now directly underpin the real PMF surfaces
 - `#1046`, `#1048`, `#818`, and `#819` now all have at least one merged truthful slice on `main`
 - `#1047` remains the active page-truthfulness/core-loop proof lane, not because nothing landed, but because the merged slices still do not add up to one complete default journey
+- March 23 added live get-started/debate/settings/status/pipeline support on `main`, which means the immediate work is continuity and merge discipline rather than broadening page count
 
 | Issue | State | Priority | Owner | Milestone | Scope |
 |------|-------|----------|-------|-----------|-------|
@@ -53,14 +61,16 @@ Current tranche:
 This is a cross-epic tranche front-loaded ahead of broader control-plane and workbench expansion.
 
 - [#813](https://github.com/synaptent/aragora/issues/813) is the provider-routing blocker inside the first truthful loop.
-- [#1046](https://github.com/synaptent/aragora/issues/1046) and [#1048](https://github.com/synaptent/aragora/issues/1048) already have queue-generated candidate outputs open as PRs.
+- [#1046](https://github.com/synaptent/aragora/issues/1046) and [#1048](https://github.com/synaptent/aragora/issues/1048) already have merged base slices on `main` plus a new overlapping PR stack on top.
 - The current goal is not more breadth. It is one default flow that truthfully routes agents, completes the user journey, and reads Knowledge Mound context back into debates.
+- The active merge problem is explicit: [#1166](https://github.com/synaptent/aragora/pull/1166) overlaps [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), and [#1170](https://github.com/synaptent/aragora/pull/1170). Treat it as a lane-selection problem, not a queue-more-work problem.
+- Working recommendation: do not merge [#1166](https://github.com/synaptent/aragora/pull/1166) ahead of the narrower slices. Use [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), and [#1170](https://github.com/synaptent/aragora/pull/1170) as the mainline sequence, then reassess what remains unique in [#1166](https://github.com/synaptent/aragora/pull/1166).
 
 | Issue | Why it is first | Current reality |
 |------|------------------|-----------------|
-| [#813](https://github.com/synaptent/aragora/issues/813) | Provider routing blocks the first truthful product loop | ProviderRouter Phase 1 shipped on `main`, but runtime agent-selection integration is still open |
-| [#1046](https://github.com/synaptent/aragora/issues/1046) | One working user journey is the first PMF proof | Preferred queue artifact is [#1110](https://github.com/synaptent/aragora/pull/1110); alternate is [#1113](https://github.com/synaptent/aragora/pull/1113) |
-| [#1048](https://github.com/synaptent/aragora/issues/1048) | Knowledge retrieval must become a default read path | Preferred queue artifact is [#1111](https://github.com/synaptent/aragora/pull/1111); alternate is [#1114](https://github.com/synaptent/aragora/pull/1114) |
+| [#813](https://github.com/synaptent/aragora/issues/813) | Provider routing blocks the first truthful product loop | ProviderRouter Phase 1 shipped on `main`; the active runtime agent-selection integration lane is [#1167](https://github.com/synaptent/aragora/pull/1167), with overlapping umbrella coverage in [#1166](https://github.com/synaptent/aragora/pull/1166) |
+| [#1046](https://github.com/synaptent/aragora/issues/1046) | One working user journey is the first PMF proof | Base slices are merged on `main` via [#1110](https://github.com/synaptent/aragora/pull/1110), [#1146](https://github.com/synaptent/aragora/pull/1146), and [#1147](https://github.com/synaptent/aragora/pull/1147); the active continuity/onboarding lanes are [#1169](https://github.com/synaptent/aragora/pull/1169), [#1170](https://github.com/synaptent/aragora/pull/1170), and overlapping umbrella [#1166](https://github.com/synaptent/aragora/pull/1166) |
+| [#1048](https://github.com/synaptent/aragora/issues/1048) | Knowledge retrieval must become a default read path | Base retrieval and writeback slices are merged on `main` via [#1111](https://github.com/synaptent/aragora/pull/1111), [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), [#1134](https://github.com/synaptent/aragora/pull/1134), and [#1151](https://github.com/synaptent/aragora/pull/1151); the default debate-factory lane is [#1168](https://github.com/synaptent/aragora/pull/1168), with overlapping umbrella [#1166](https://github.com/synaptent/aragora/pull/1166) |
 
 ## Demonstrate The Value Prop (Q2 2026)
 
@@ -102,6 +112,7 @@ Recent reality on `main`:
 - file-scope ownership and canonical PR tracking landed earlier via [#840](https://github.com/synaptent/aragora/issues/840) and [#841](https://github.com/synaptent/aragora/issues/841)
 - March 19-20 hardening added queue compile and run, dead-worker recovery, deliverable sync, verification propagation, stale fleet-claim reaping, and queue-state persistence through merged PRs `#1109`, `#1112`, `#1115`, `#1116`, and `#1117`
 - March 21-22 closure added preserved verification evidence, terminal tranche reconciliation, authoritative lane view, completed-lane publish, and remote-head PR review through `#1124`, `#1126`, `#1127`, `#1133`, and `#1138`
+- March 23 added queue harvest support on `main` through [#1164](https://github.com/synaptent/aragora/pull/1164) and left two active supporting PRs open: [#1157](https://github.com/synaptent/aragora/pull/1157) for blocker-context persistence and [#1165](https://github.com/synaptent/aragora/pull/1165) for tranche queue Claude worker routing
 - this work remains active, but it now serves the PMF slices above rather than defining the first execution lane by itself
 - the current active proof lane is no longer "can a queue dispatch?" but "can every blocker and deliverable carry forward canonical receipts, review evidence, and operator-grade state?"
 
@@ -170,3 +181,4 @@ When the execution program changes:
 1. update the GitHub issues first
 2. update [NEXT_STEPS_CANONICAL](NEXT_STEPS_CANONICAL.md)
 3. update this issue map and any linked summary docs
+4. if multiple open PRs cover the same PMF slice, choose a single merge lane and close or supersede the rest with proof

--- a/docs/status/DOC_RECONCILE_REPORT.md
+++ b/docs/status/DOC_RECONCILE_REPORT.md
@@ -1,11 +1,17 @@
 # Status Document Reconciliation Report
-Generated: 2026-03-05
+Generated: 2026-03-23
 
-## Summary: 0 critical, 0 warnings, 2 info
+## Summary: 0 critical, 1 warnings, 4 info
 
-### INFO (2)
+### WARNING (1)
 
-  - [GA_CHECKLIST.md] GA checklist references 4 blocker mentions
-  - [connectors/STATUS.md] Connectors: ~151 production, ~0 beta, ~0 stub mentions
+  ! [connectors/STATUS.md] Connector status has 2 stub references (target: 0)
+
+### INFO (4)
+
+  - [GA_CHECKLIST.md] GA checklist references 3 blocker mentions
+  - [connectors/STATUS.md] Connectors: ~149 production, ~0 beta, ~2 stub mentions
+  - [docs/api/openapi_generated.json] Generated OpenAPI counts: 3168 operations across 2679 paths
+  - [status/ACTIVE_EXECUTION_ISSUES.md] Execution issue map links 20 required issues
 
 Result: PASS

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-03-22
+Last updated: 2026-03-23
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -10,9 +10,12 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Reality
 
-- The March 18 product cohesion assessment is still directionally right about shell-heavy pages and the lack of one complete user journey, but `main` moved materially again on March 21-22.
+- The March 18 product cohesion assessment is still directionally right about shell-heavy pages and the lack of one complete user journey, but `main` moved materially again on March 23.
 - `main` now contains more than queue hardening through [#1117](https://github.com/synaptent/aragora/pull/1117): it also includes the first merged API-key/user-journey slice ([#1110](https://github.com/synaptent/aragora/pull/1110)), default KM retrieval and later writeback/settlement wiring ([#1111](https://github.com/synaptent/aragora/pull/1111), [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), [#1134](https://github.com/synaptent/aragora/pull/1134)), truthful integrations/public/operator surfaces ([#1118](https://github.com/synaptent/aragora/pull/1118), [#1119](https://github.com/synaptent/aragora/pull/1119), [#1127](https://github.com/synaptent/aragora/pull/1127), [#1136](https://github.com/synaptent/aragora/pull/1136), [#1137](https://github.com/synaptent/aragora/pull/1137)), and real OpenClaw dispatch ([#1135](https://github.com/synaptent/aragora/pull/1135)).
+- March 23 also landed continuity work that the older docs do not mention: queue max-parallel-two safety ([#1141](https://github.com/synaptent/aragora/pull/1141)), exposed KM-backed knowledge search ([#1144](https://github.com/synaptent/aragora/pull/1144)), live settings/API-key wiring ([#1146](https://github.com/synaptent/aragora/pull/1146)), live debate creation from the debates page ([#1147](https://github.com/synaptent/aragora/pull/1147)), truthful partial-public status surfaces ([#1148](https://github.com/synaptent/aragora/pull/1148)), refresh-aware pipeline feedback scoping ([#1149](https://github.com/synaptent/aragora/pull/1149)), a visible pipeline golden-path summary ([#1150](https://github.com/synaptent/aragora/pull/1150)), pre-debate precedent loading via `PipelineKMBridge` ([#1151](https://github.com/synaptent/aragora/pull/1151)), the roadmap execution-map doc ([#1152](https://github.com/synaptent/aragora/pull/1152)), and queue harvest support ([#1164](https://github.com/synaptent/aragora/pull/1164)).
 - Because of that, the immediate priority is not broad platform breadth. It is stitching the merged slices into three repeatable wedges: trust wedge, truthful default/public debate surfaces, and bounded repo execution.
+- The immediate merge discipline problem is the active PMF stack itself: [#1166](https://github.com/synaptent/aragora/pull/1166) overlaps [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), and [#1170](https://github.com/synaptent/aragora/pull/1170). All are open and mergeable. Only one coherent lane should be merged.
+- Recommended merge order: land the narrow runtime/user-journey slices in sequence ([#1167](https://github.com/synaptent/aragora/pull/1167) -> [#1168](https://github.com/synaptent/aragora/pull/1168) -> [#1169](https://github.com/synaptent/aragora/pull/1169) -> [#1170](https://github.com/synaptent/aragora/pull/1170)), then harvest any truly net-new value from [#1166](https://github.com/synaptent/aragora/pull/1166) or close it as redundant.
 - Queue and control-plane work still matter, but only insofar as they help close those PMF slices truthfully and without hidden operator repair.
 - GitHub issues remain the live backlog. These docs summarize the active order and capability posture.
 - The product strategy narrative is now maintained in [ARAGORA_IDEA_TO_EXECUTION_STRATEGY](../plans/ARAGORA_IDEA_TO_EXECUTION_STRATEGY.md).
@@ -22,17 +25,17 @@ This is the single source of truth for short-horizon execution priorities.
 ### 1) Close The Product Loop (Immediate)
 - Tracking: [#813](https://github.com/synaptent/aragora/issues/813), [#1046](https://github.com/synaptent/aragora/issues/1046), [#1047](https://github.com/synaptent/aragora/issues/1047), [#1048](https://github.com/synaptent/aragora/issues/1048), [#819](https://github.com/synaptent/aragora/issues/819)
 - Goal: make one truthful default loop work end to end: credentials/provider routing, one complete user journey, KM-enriched debate context, receipt, and visible result.
-- Current tranche: the first `#1046` and `#1048` slices are merged on `main`, but provider routing, surface continuity, and the shell-heavy frontend still prevent a genuinely complete default journey.
+- Current tranche: the first `#1046` and `#1048` slices are merged on `main`, and March 23 added more continuity support on `main` (`#1146`, `#1147`, `#1148`, `#1150`, `#1151`). The remaining gap is no longer "missing pieces exist nowhere"; it is choosing one merge lane for the overlapping PMF stack (`#1166` vs `#1167`/`#1168`/`#1169`/`#1170`) and then proving the full default journey without hidden operator repair.
 
 ### 2) Demonstrate The Value Prop (Q2 2026)
 - Tracking: [#806](https://github.com/synaptent/aragora/issues/806), [#814](https://github.com/synaptent/aragora/issues/814), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
 - Goal: prove Aragora on three bounded user-visible surfaces: trust wedge, truthful public/default debate surface, and swarm/OpenClaw execution.
-- Current tranche: trust wedge core is real, public proof is materially truthful, and OpenClaw dispatch is real on `main`; the remaining gap is repeatable partner usage and five actually functional frontend paths.
+- Current tranche: trust wedge core is real, public proof is materially truthful, and OpenClaw dispatch is real on `main`; March 23 added truthful partial-public status and pipeline summary surfaces. The remaining gap is repeatable partner usage and five actually functional frontend paths that add up to one continuous experience instead of adjacent truthful slices.
 
 ### 3) Developer Swarm Control Plane And Truthful Execution
 - Tracking: [#836](https://github.com/synaptent/aragora/issues/836), [#837](https://github.com/synaptent/aragora/issues/837), [#840](https://github.com/synaptent/aragora/issues/840), [#841](https://github.com/synaptent/aragora/issues/841), [#842](https://github.com/synaptent/aragora/issues/842), [#843](https://github.com/synaptent/aragora/issues/843), [#871](https://github.com/synaptent/aragora/issues/871), [#990](https://github.com/synaptent/aragora/issues/990), [#1036](https://github.com/synaptent/aragora/issues/1036), [#1037](https://github.com/synaptent/aragora/issues/1037), [#1038](https://github.com/synaptent/aragora/issues/1038)
 - Goal: make unattended repo-improvement lanes truthful by keeping queue state, lane ownership, receipts, review outcomes, publish behavior, and operator visibility canonical.
-- Current tranche: queue-backed execution is real on `main`; authoritative lane view, preserved review evidence, completed-lane publish, and remote-head review are now merged. The remaining gap is universal per-lane receipts/provenance and a canonical claim/integrator contract across all lanes.
+- Current tranche: queue-backed execution is real on `main`; authoritative lane view, preserved review evidence, completed-lane publish, and remote-head review are now merged. March 23 added queue harvest support on `main` and left two active supporting fixes open: [#1157](https://github.com/synaptent/aragora/pull/1157) for blocker context persistence and [#1165](https://github.com/synaptent/aragora/pull/1165) for Claude worker routing. The remaining gap is universal per-lane receipts/provenance and a canonical claim/integrator contract across all lanes.
 
 ### 4) Decision Integrity Kernel Scale-Out
 - Tracking: [#805](https://github.com/synaptent/aragora/issues/805), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812)
@@ -42,7 +45,7 @@ This is the single source of truth for short-horizon execution priorities.
 ### 5) Idea-to-Execution Workbench
 - Tracking: [#989](https://github.com/synaptent/aragora/issues/989)
 - Goal: unify ideas, goals, actions, and orchestration into one local-first product shell with auditable stage transitions.
-- Why later: live state and one transition-review slice are now worth extending, but the first obligation is still to make the current wedges repeatable before widening the shell.
+- Why later: live state and one transition-review slice are now worth extending, and March 23 improved the visible golden path and precedent loading, but the first obligation is still to make the current wedges repeatable before widening the shell.
 
 ### 6) Truthfulness And Documentation Hygiene
 - Tracking: [#804](https://github.com/synaptent/aragora/issues/804), [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809)

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -1,38 +1,46 @@
 # Aragora Project Status
 
-*Last updated: March 22, 2026*
+*Last updated: March 23, 2026*
 
 > See [README](../README.md) for the five pillars framework. See [Documentation Index](../INDEX.md) for the curated technical reference map.
 > For roadmap extraction, doc drift, and partial-feature tracking, see [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md).
 
-## March 21-22, 2026 — Current State
+## March 23, 2026 — Current State
 
 ### Canonical Current Reality
 
-- `main` now contains the tranche queue / overnight autonomy hardening through [#1117](https://github.com/synaptent/aragora/pull/1117) plus March 21-22 proof-surface closures through [#1138](https://github.com/synaptent/aragora/pull/1138).
-- The system has moved beyond "candidate PMF PRs are open." The first user-journey slice, default KM retrieval slice, truthful integrations/public state slices, real OpenClaw dispatch, and stronger operator/integrator surfaces are all now merged on `main`.
+- `main` now contains the tranche queue / overnight autonomy hardening through [#1117](https://github.com/synaptent/aragora/pull/1117), the March 21-22 proof-surface closures through [#1138](https://github.com/synaptent/aragora/pull/1138), and the March 23 continuity/support slices through [#1164](https://github.com/synaptent/aragora/pull/1164).
+- The system has moved beyond "candidate PMF PRs are open." The first user-journey slice, default KM retrieval slice, truthful integrations/public state slices, real OpenClaw dispatch, stronger operator/integrator surfaces, live settings/API-key wiring, live debate creation, partial-public status truthfulness, pipeline golden-path visibility, and queue harvest support are all now merged on `main`.
 - The first real queue artifact remains [#1108](https://github.com/synaptent/aragora/pull/1108), but it is no longer the only proof worth citing.
 
 ### What Recently Landed On `main`
 
-The March 21-22 cycle closed several important gaps:
+The March 21-23 cycle closed several important gaps:
 
 1. API-key / first-user-journey slice merged via [#1110](https://github.com/synaptent/aragora/pull/1110)
 2. default KM retrieval, later KM writeback, and settlement-hook wiring merged via [#1111](https://github.com/synaptent/aragora/pull/1111), [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), and [#1134](https://github.com/synaptent/aragora/pull/1134)
 3. truthful receipts/integrations/public state improved via [#1118](https://github.com/synaptent/aragora/pull/1118), [#1119](https://github.com/synaptent/aragora/pull/1119), [#1136](https://github.com/synaptent/aragora/pull/1136), and [#1137](https://github.com/synaptent/aragora/pull/1137)
 4. bounded execution operator surfaces improved via [#1124](https://github.com/synaptent/aragora/pull/1124), [#1126](https://github.com/synaptent/aragora/pull/1126), [#1127](https://github.com/synaptent/aragora/pull/1127), [#1133](https://github.com/synaptent/aragora/pull/1133), and [#1138](https://github.com/synaptent/aragora/pull/1138)
 5. real OpenClaw action dispatch landed via [#1135](https://github.com/synaptent/aragora/pull/1135)
+6. continuity/path-truthfulness improved via [#1146](https://github.com/synaptent/aragora/pull/1146), [#1147](https://github.com/synaptent/aragora/pull/1147), [#1148](https://github.com/synaptent/aragora/pull/1148), [#1150](https://github.com/synaptent/aragora/pull/1150), and [#1151](https://github.com/synaptent/aragora/pull/1151)
+7. queue throughput/harvest support improved via [#1141](https://github.com/synaptent/aragora/pull/1141) and [#1164](https://github.com/synaptent/aragora/pull/1164)
 
 ### Current Frontier
 
-The reduced `queue-v4b` proof is still the active frontier for unresolved product slices:
+The frontier is no longer just "get another proof candidate out of the queue." It is the merge-order and continuity problem around the active PMF stack:
 
-- [#1047](https://github.com/synaptent/aragora/issues/1047): latest queue attempt is truthfully `needs_human` / review-blocked
-- [#819](https://github.com/synaptent/aragora/issues/819): first truthful status/edit slice is merged, but the broader integrations surface still needs to become trustworthy by default
+- [#1166](https://github.com/synaptent/aragora/pull/1166): umbrella PMF integration branch covering routing, user-journey, and get-started continuity
+- [#1167](https://github.com/synaptent/aragora/pull/1167): narrow ProviderRouter -> `DebateFactory` runtime integration
+- [#1168](https://github.com/synaptent/aragora/pull/1168): narrow Knowledge Mound retrieval -> `DebateFactory` default integration
+- [#1169](https://github.com/synaptent/aragora/pull/1169): versioned API-key management endpoints
+- [#1170](https://github.com/synaptent/aragora/pull/1170): interactive onboarding / get-started flow
+- [#1165](https://github.com/synaptent/aragora/pull/1165): separate swarm-routing fix supporting the unattended execution substrate
+- Recommended path: merge [#1167](https://github.com/synaptent/aragora/pull/1167), [#1168](https://github.com/synaptent/aragora/pull/1168), [#1169](https://github.com/synaptent/aragora/pull/1169), and [#1170](https://github.com/synaptent/aragora/pull/1170) in that order, then decide whether [#1166](https://github.com/synaptent/aragora/pull/1166) still contains anything worth harvesting.
 
 This means the current problem is no longer "can the queue dispatch?" It is:
 
 - can the default product loop feel continuous from setup to visible result
+- can the overlapping PMF stack be merged as one truthful lane instead of duplicating slices
 - can every lane preserve canonical provenance, review evidence, and explicit blocked next steps
 - can the proof surfaces stay truthful under partial/live states instead of falling back to shell behavior
 
@@ -43,6 +51,7 @@ The strategy document is now [ARAGORA_IDEA_TO_EXECUTION_STRATEGY](../plans/ARAGO
 - close one truthful default product loop,
 - make the existing proof surfaces operator-grade and partner-repeatable,
 - then invest in the unified idea-to-execution GUI and stage-transition UX.
+- near-term execution discipline is merge-order discipline: prefer a coherent PMF lane over overlapping "everything stack" merges.
 
 ## March 2026 Sprint — Closed-Loop Backbone, Trust Wedge & Infrastructure
 


### PR DESCRIPTION
## Summary
- refresh the canonical status and roadmap docs to match the current March 23 `main` reality
- make the PMF-stack merge recommendation explicit: prefer `#1167 -> #1168 -> #1169 -> #1170`, then harvest or close `#1166`
- regenerate `docs/status/DOC_RECONCILE_REPORT.md` so the generated artifact matches the current doc sources

## Verification
- `python3 scripts/reconcile_status_docs.py --output docs/status/DOC_RECONCILE_REPORT.md`
- `python3 scripts/reconcile_status_docs.py --strict --json`

## Notes
- The remaining reconciliation warning is truthful and unchanged in substance: `docs/connectors/STATUS.md` still reports 2 stub connectors.
- This PR is docs-only.
