### PR TITLE
feat(dashboard): add live debates section with active debate tracking

### DIFF
--- a/aragora/live/src/app/(app)/dashboard/page.tsx
+++ b/aragora/live/src/app/(app)/dashboard/page.tsx
@@ -13,7 +13,8 @@ import { CostSummaryWidget } from '@/components/costs/CostSummaryWidget';
 import { TrialStatusWidget } from '@/components/billing/TrialStatusWidget';
 import { TemplateMarketplace } from '@/components/templates/TemplateMarketplace';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
-import { useSWRFetch } from '@/hooks/useSWRFetch';
+import { useSWRFetch, useActiveDebates } from '@/hooks/useSWRFetch';
+import type { ActiveDebate } from '@/hooks/useSWRFetch';
 import { useDashboardEvents } from '@/hooks/useDashboardEvents';
 
 // Backend API response shape for debates list
@@ -170,6 +171,93 @@ function SystemStatusPanel({ refreshInterval = 30000 }: { refreshInterval?: numb
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function formatElapsed(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const hrs = Math.floor(mins / 60);
+  if (hrs > 0) return `${hrs}h ${mins % 60}m`;
+  if (mins > 0) return `${mins}m`;
+  return `${Math.floor(seconds)}s`;
+}
+
+function LiveDebatesPanel() {
+  const { data, isLoading } = useActiveDebates();
+  const debates: ActiveDebate[] = data?.debates ?? [];
+
+  return (
+    <div className="bg-[var(--surface)] border border-[var(--border)]">
+      <div className="flex items-center justify-between p-4 border-b border-[var(--border)]">
+        <h3 className="text-sm font-mono text-[var(--acid-green)] flex items-center gap-2">
+          {'>'} LIVE DEBATES
+          {debates.length > 0 && (
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+            </span>
+          )}
+        </h3>
+        {debates.length > 0 && (
+          <span className="px-2 py-0.5 text-[10px] font-mono bg-green-500/20 text-green-400 border border-green-500/30">
+            {debates.length} ACTIVE
+          </span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="p-4 text-center text-[var(--text-muted)] font-mono text-sm animate-pulse">
+          Checking...
+        </div>
+      ) : debates.length === 0 ? (
+        <div className="p-4 text-center text-[var(--text-muted)] font-mono text-sm">
+          No debates running.{' '}
+          <Link href="/arena" className="text-[var(--acid-green)] hover:underline">
+            Start one
+          </Link>
+        </div>
+      ) : (
+        <div className="divide-y divide-[var(--border)]">
+          {debates.map((debate) => (
+            <Link
+              key={debate.id}
+              href={`/debate/${debate.id}`}
+              className="block p-4 hover:bg-[var(--bg)] transition-colors"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-mono text-[var(--text)] truncate">
+                    {debate.topic || 'Untitled debate'}
+                  </p>
+                  <div className="flex items-center gap-2 mt-1">
+                    <span className="text-[10px] font-mono text-[var(--text-muted)]">
+                      {debate.agents.length} agents
+                    </span>
+                    <span className="text-[10px] font-mono text-[var(--text-muted)]">
+                      Round {debate.round}/{debate.total_rounds}
+                    </span>
+                  </div>
+                </div>
+                <div className="text-right flex-shrink-0">
+                  <div className="flex items-center gap-1">
+                    <span className="relative flex h-1.5 w-1.5">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-green-500" />
+                    </span>
+                    <span className="text-[10px] font-mono text-green-400 uppercase">
+                      {debate.status}
+                    </span>
+                  </div>
+                  <div className="text-[10px] text-[var(--text-muted)] font-mono mt-1">
+                    {formatElapsed(debate.elapsed_seconds)}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -337,6 +425,13 @@ export default function DashboardPage() {
           <div className="mt-6">
             <PanelErrorBoundary panelName="Settlement Panel">
               <SettlementPanel refreshInterval={pollInterval} />
+            </PanelErrorBoundary>
+          </div>
+
+          {/* Live Debates */}
+          <div className="mt-6">
+            <PanelErrorBoundary panelName="Live Debates">
+              <LiveDebatesPanel />
             </PanelErrorBoundary>
           </div>
 

--- a/aragora/live/src/hooks/useSWRFetch.ts
+++ b/aragora/live/src/hooks/useSWRFetch.ts
@@ -255,6 +255,28 @@ export function useDebates(options?: UseSWRFetchOptions<unknown>) {
   });
 }
 
+export interface ActiveDebate {
+  id: string;
+  topic: string;
+  status: string;
+  started_at: string;
+  agents: string[];
+  round: number;
+  total_rounds: number;
+  elapsed_seconds: number;
+}
+
+export interface ActiveDebatesResponse {
+  debates: ActiveDebate[];
+}
+
+export function useActiveDebates(options?: UseSWRFetchOptions<ActiveDebatesResponse>) {
+  return useSWRFetch<ActiveDebatesResponse>('/api/v1/debates/active', {
+    refreshInterval: 5000, // Refresh every 5 seconds for live data
+    ...options,
+  });
+}
+
 export function useDebate(debateId: string | null, options?: UseSWRFetchOptions<unknown>) {
   return useSWRFetch(debateId ? `/api/debates/${debateId}` : null, options);
 }

--- a/aragora/server/handlers/debates/crud.py
+++ b/aragora/server/handlers/debates/crud.py
@@ -53,6 +53,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _epoch_to_iso(epoch: float) -> str:
+    """Convert a Unix epoch timestamp to ISO 8601 string."""
+    from datetime import datetime, timezone
+
+    if not epoch:
+        return ""
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
 class _DebatesHandlerProtocol(Protocol):
     """Protocol defining the interface expected by CrudOperationsMixin.
 
@@ -129,6 +138,76 @@ class CrudOperationsMixin:
             for d in debates
         ]
         return json_response({"debates": debates_list, "count": len(debates_list)})
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/debates/active",
+        summary="List currently running debates",
+        description="Returns debates that are currently in-progress (running or paused).",
+        tags=["Debates"],
+        responses={
+            "200": {
+                "description": "Active debates returned",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "debates": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "id": {"type": "string"},
+                                            "topic": {"type": "string"},
+                                            "status": {"type": "string"},
+                                            "started_at": {"type": "string", "format": "date-time"},
+                                            "agents": {
+                                                "type": "array",
+                                                "items": {"type": "string"},
+                                            },
+                                            "round": {"type": "integer"},
+                                            "total_rounds": {"type": "integer"},
+                                            "elapsed_seconds": {"type": "number"},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    )
+    @handle_errors("list active debates")
+    def _get_active_debates(self: _DebatesHandlerProtocol) -> HandlerResult:
+        """List currently running debates from the server state manager.
+
+        Returns debates tracked in StateManager that have status 'running' or 'paused'.
+        These are debates actively being processed, not yet completed/persisted.
+        """
+        from aragora.server.state import get_state_manager
+
+        state_mgr = get_state_manager()
+        active = state_mgr.get_active_debates()
+
+        debates_list = []
+        for debate_id, debate_state in active.items():
+            info = debate_state.to_dict()
+            debates_list.append(
+                {
+                    "id": info.get("debate_id", debate_id),
+                    "topic": info.get("task", ""),
+                    "status": info.get("status", "running"),
+                    "started_at": _epoch_to_iso(info.get("start_time", 0)),
+                    "agents": info.get("agents", []),
+                    "round": info.get("current_round", 0),
+                    "total_rounds": info.get("total_rounds", 3),
+                    "elapsed_seconds": info.get("elapsed_seconds", 0),
+                }
+            )
+
+        return json_response({"debates": debates_list})
 
     @api_endpoint(
         method="GET",

--- a/aragora/server/handlers/debates/handler.py
+++ b/aragora/server/handlers/debates/handler.py
@@ -187,6 +187,10 @@ class DebatesHandler(
         if normalized.startswith("/api/debates/export/batch"):
             return self._handle_batch_export(normalized, query_params, handler)
 
+        # Active (in-progress) debates
+        if normalized == "/api/debates/active":
+            return self._get_active_debates()
+
         # Exact path matches - list debates
         if normalized in ("/api/debates", "/api/debates/"):
             limit = min(get_int_param(query_params, "limit", 20), 100)

--- a/aragora/server/handlers/debates/routing.py
+++ b/aragora/server/handlers/debates/routing.py
@@ -34,6 +34,7 @@ ROUTES = [
     "/api/v1/debate",  # POST - create new debate (legacy endpoint)
     "/api/v1/debates",
     "/api/v1/debates/",  # With trailing slash
+    "/api/v1/debates/active",  # GET - currently running debates
     "/api/v1/debates/estimate-cost",  # GET - pre-debate cost estimation
     "/api/v1/debates/batch",  # POST - batch debate submission
     "/api/v1/debates/batch/",

--- a/tests/server/handlers/debates/test_active_debates.py
+++ b/tests/server/handlers/debates/test_active_debates.py
@@ -1,0 +1,211 @@
+"""
+Tests for GET /api/v1/debates/active endpoint.
+
+Covers:
+- Returns empty list when no debates are running
+- Returns active debates with correct fields
+- Correct ISO timestamp conversion
+- Multiple concurrent debates
+- Route dispatch from DebatesHandler.handle()
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.server.handlers.debates.crud import CrudOperationsMixin, _epoch_to_iso
+from aragora.server.handlers.base import HandlerResult
+from aragora.server.state import DebateState
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _parse_result(result: HandlerResult) -> tuple[dict, int]:
+    """Extract parsed JSON body and status code from HandlerResult."""
+    body = json.loads(result.body) if isinstance(result.body, bytes) else result.body
+    return body, result.status_code
+
+
+class _FakeHandler(CrudOperationsMixin):
+    """Minimal concrete class mixing in CrudOperationsMixin for testing."""
+
+    def __init__(self):
+        self.ctx = {}
+
+    def get_storage(self):
+        return MagicMock()
+
+    def read_json_body(self, handler, max_size=None):
+        return {}
+
+    def get_current_user(self, handler):
+        return None
+
+
+# ============================================================================
+# Tests: _epoch_to_iso helper
+# ============================================================================
+
+
+class TestEpochToIso:
+    def test_zero_returns_empty(self):
+        assert _epoch_to_iso(0) == ""
+
+    def test_valid_epoch(self):
+        # 2026-01-01T00:00:00+00:00
+        result = _epoch_to_iso(1767225600)
+        assert "2026" in result
+        assert "T" in result
+
+    def test_falsy_returns_empty(self):
+        assert _epoch_to_iso(0.0) == ""
+
+
+# ============================================================================
+# Tests: _get_active_debates endpoint
+# ============================================================================
+
+
+class TestGetActiveDebates:
+    @pytest.fixture
+    def handler(self):
+        return _FakeHandler()
+
+    @pytest.fixture
+    def mock_state_manager(self):
+        mgr = MagicMock()
+        mgr.get_active_debates.return_value = {}
+        return mgr
+
+    def test_empty_when_no_debates(self, handler, mock_state_manager):
+        with patch(
+            "aragora.server.state.get_state_manager",
+            return_value=mock_state_manager,
+        ):
+            result = handler._get_active_debates()
+
+        assert isinstance(result, HandlerResult)
+        body, status = _parse_result(result)
+        assert status == 200
+        assert "debates" in body
+        assert body["debates"] == []
+
+    def test_returns_running_debate(self, handler, mock_state_manager):
+        now = time.time()
+        debate_state = DebateState(
+            debate_id="debate-abc",
+            task="Should we refactor the API?",
+            agents=["claude", "gemini", "grok"],
+            start_time=now - 120,  # started 2 minutes ago
+            status="running",
+            current_round=2,
+            total_rounds=5,
+        )
+        mock_state_manager.get_active_debates.return_value = {
+            "debate-abc": debate_state,
+        }
+
+        with patch(
+            "aragora.server.state.get_state_manager",
+            return_value=mock_state_manager,
+        ):
+            result = handler._get_active_debates()
+
+        body, status = _parse_result(result)
+        assert status == 200
+        debates = body["debates"]
+        assert len(debates) == 1
+
+        d = debates[0]
+        assert d["id"] == "debate-abc"
+        assert d["topic"] == "Should we refactor the API?"
+        assert d["status"] == "running"
+        assert d["agents"] == ["claude", "gemini", "grok"]
+        assert d["round"] == 2
+        assert d["total_rounds"] == 5
+        assert d["elapsed_seconds"] > 0
+        assert d["started_at"] != ""  # non-empty ISO string
+
+    def test_multiple_active_debates(self, handler, mock_state_manager):
+        now = time.time()
+        debates = {
+            "debate-1": DebateState(
+                debate_id="debate-1",
+                task="Topic A",
+                agents=["claude"],
+                start_time=now - 60,
+                status="running",
+                current_round=1,
+                total_rounds=3,
+            ),
+            "debate-2": DebateState(
+                debate_id="debate-2",
+                task="Topic B",
+                agents=["gemini", "grok"],
+                start_time=now - 300,
+                status="paused",
+                current_round=3,
+                total_rounds=3,
+            ),
+        }
+        mock_state_manager.get_active_debates.return_value = debates
+
+        with patch(
+            "aragora.server.state.get_state_manager",
+            return_value=mock_state_manager,
+        ):
+            result = handler._get_active_debates()
+
+        body, status = _parse_result(result)
+        assert status == 200
+        assert len(body["debates"]) == 2
+
+        ids = {d["id"] for d in body["debates"]}
+        assert ids == {"debate-1", "debate-2"}
+
+        # Verify paused debate has correct status
+        paused = next(d for d in body["debates"] if d["id"] == "debate-2")
+        assert paused["status"] == "paused"
+
+
+# ============================================================================
+# Tests: Route dispatch
+# ============================================================================
+
+
+class TestActiveDebatesRouteDispatch:
+    """Test that DebatesHandler.handle() dispatches to _get_active_debates."""
+
+    @pytest.fixture
+    def debates_handler(self):
+        from aragora.server.handlers.debates.handler import DebatesHandler
+
+        return DebatesHandler(ctx={})
+
+    def test_route_dispatches_active(self, debates_handler):
+        """Verify /api/v1/debates/active dispatches to _get_active_debates."""
+        mock_state_manager = MagicMock()
+        mock_state_manager.get_active_debates.return_value = {}
+
+        with patch(
+            "aragora.server.state.get_state_manager",
+            return_value=mock_state_manager,
+        ):
+            result = debates_handler.handle("/api/v1/debates/active", {}, None)
+
+        assert result is not None
+        assert isinstance(result, HandlerResult)
+        body, status = _parse_result(result)
+        assert status == 200
+        assert "debates" in body
+
+    def test_can_handle_active_route(self, debates_handler):
+        """Verify can_handle returns True for the active debates route."""
+        assert debates_handler.can_handle("/api/v1/debates/active")


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/debates/active` endpoint returning currently running debates
- Dashboard shows "Live Debates" panel with pulsing green indicators, agent count, round progress, elapsed time
- Links to `/debate/{id}` for streaming view; "No debates running" state with CTA
- SWR polling every 5 seconds for real-time updates

## Test plan
- [x] 8 backend tests pass (epoch helper, active debates, route dispatch)
- [ ] Verify live panel updates when debates are running
- [ ] Verify empty state displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)