### PR TITLE
feat(knowledge): wire debate outcome ingestion to KnowledgeMound

### DIFF
--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -1143,6 +1143,7 @@ async def handle_debate_completion(
             coordinator = PostDebateCoordinator(
                 config=effective_config,
                 settlement_tracker=settlement_tracker,
+                knowledge_mound=getattr(arena, "knowledge_mound", None),
             )
             task = getattr(ctx.env, "task", "") if ctx.env else ""
             confidence = getattr(ctx.result, "confidence", 0.0)

--- a/aragora/debate/post_debate_coordinator.py
+++ b/aragora/debate/post_debate_coordinator.py
@@ -96,6 +96,9 @@ class PostDebateConfig:
     auto_llm_judge: bool = True
     llm_judge_use_case: str = "debate"
     llm_judge_threshold: float = 4.0
+    # Knowledge Mound outcome ingestion: store high-confidence conclusions
+    auto_ingest_outcome: bool = True
+    ingest_outcome_min_confidence: float = 0.85
 
 
 @dataclass
@@ -127,6 +130,7 @@ class PostDebateResult:
     settlement_batch: dict[str, Any] | None = None
     staking_result: dict[str, Any] | None = None
     cost_breakdown: dict[str, Any] | None = None
+    outcome_ingested: bool = False
     errors: list[str] = field(default_factory=list)
 
     @property
@@ -152,9 +156,11 @@ class PostDebateCoordinator:
         self,
         config: PostDebateConfig | None = None,
         settlement_tracker: Any | None = None,
+        knowledge_mound: Any | None = None,
     ):
         self.config = config or PostDebateConfig()
         self._settlement_tracker = settlement_tracker
+        self._knowledge_mound = knowledge_mound
 
     @staticmethod
     def _run_async_callable(async_fn: Any, /, *args: Any, **kwargs: Any) -> Any:
@@ -317,6 +323,13 @@ class PostDebateCoordinator:
                 confidence,
                 cost_breakdown=result.cost_breakdown,
             )
+
+        # Step 6.5: Ingest debate outcome into Knowledge Mound (read-write feedback loop)
+        if (
+            self.config.auto_ingest_outcome
+            and confidence >= self.config.ingest_outcome_min_confidence
+        ):
+            result.outcome_ingested = self._step_ingest_outcome(debate_id, debate_result, task)
 
         # Step 7: Queue improvement suggestion
         if (
@@ -762,6 +775,49 @@ class PostDebateCoordinator:
             )
         )
         return receipt_persisted
+
+    def _step_ingest_outcome(
+        self,
+        debate_id: str,
+        debate_result: Any,
+        task: str,
+    ) -> bool:
+        """Step 6.5: Ingest debate outcome into Knowledge Mound.
+
+        Stores the consensus conclusion and metadata from high-confidence
+        debates into the Knowledge Mound for future retrieval, closing the
+        read-write feedback loop.
+
+        Args:
+            debate_id: Unique identifier for the debate.
+            debate_result: The debate result object.
+            task: The debate task/question.
+        """
+        if not self._knowledge_mound:
+            return False
+
+        try:
+            from aragora.core import Environment
+            from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+            ops = KnowledgeMoundOperations(
+                knowledge_mound=self._knowledge_mound,
+                enable_ingestion=True,
+            )
+            env = Environment(task=task) if task else None
+            self._run_async_callable(ops.ingest_debate_outcome, debate_result, env=env)
+            logger.info(
+                "post_debate_outcome_ingested debate_id=%s",
+                debate_id,
+            )
+            return True
+        except (ImportError, RuntimeError, ValueError, TypeError, AttributeError, OSError) as e:
+            logger.warning(
+                "post_debate_outcome_ingestion_failed debate_id=%s error=%s",
+                debate_id,
+                type(e).__name__,
+            )
+            return False
 
     def _step_persist_signed_receipt(
         self,
@@ -1872,6 +1928,7 @@ DEFAULT_POST_DEBATE_CONFIG = PostDebateConfig(
     auto_push_calibration=True,
     auto_queue_improvement=True,
     auto_outcome_feedback=True,
+    auto_ingest_outcome=True,
 )
 
 

--- a/aragora/debate/presets.py
+++ b/aragora/debate/presets.py
@@ -45,12 +45,13 @@ _PRESETS: dict[str, dict[str, Any]] = {
         "enable_position_ledger": True,
         # Compliance
         "enable_compliance_artifacts": True,
-        # Post-debate pipeline (explanation + receipt persistence + gauntlet)
+        # Post-debate pipeline (explanation + receipt persistence + gauntlet + KM ingestion)
         "_post_debate_preset": {
             "auto_explain": True,
             "auto_persist_receipt": True,
             "auto_gauntlet_validate": True,
             "auto_push_calibration": True,
+            "auto_ingest_outcome": True,
         },
     },
     "enterprise": {
@@ -87,6 +88,7 @@ _PRESETS: dict[str, dict[str, Any]] = {
             "auto_gauntlet_validate": True,
             "auto_queue_improvement": True,
             "auto_push_calibration": True,
+            "auto_ingest_outcome": True,
         },
     },
     "minimal": {

--- a/tests/debate/test_outcome_ingestion_wiring.py
+++ b/tests/debate/test_outcome_ingestion_wiring.py
@@ -1,0 +1,294 @@
+"""Tests for debate outcome ingestion to KnowledgeMound.
+
+Verifies that:
+1. Outcome ingestion is called after successful debate when KM is configured
+2. Ingestion failure does not affect debate result
+3. Ingestion is skipped when KM is not configured
+4. Ingestion is skipped when confidence is below threshold
+5. Ingestion is opt-in via PostDebateConfig.auto_ingest_outcome
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.debate.post_debate_coordinator import (
+    PostDebateConfig,
+    PostDebateCoordinator,
+)
+
+
+def _make_debate_result(
+    confidence: float = 0.9,
+    final_answer: str = "The consensus conclusion",
+    consensus_reached: bool = True,
+) -> MagicMock:
+    """Create a mock debate result."""
+    result = MagicMock()
+    result.confidence = confidence
+    result.final_answer = final_answer
+    result.consensus_reached = consensus_reached
+    result.id = "debate-123"
+    result.rounds_used = 3
+    result.participants = ["claude", "gpt4"]
+    result.winner = "claude"
+    result.messages = []
+    result.debate_cruxes = None
+    result.metadata = {}
+    return result
+
+
+class TestOutcomeIngestionInCoordinator:
+    """Test outcome ingestion step in PostDebateCoordinator."""
+
+    def test_ingestion_called_when_km_configured(self):
+        """Outcome ingestion fires when knowledge_mound is provided."""
+        km = MagicMock()
+        km.workspace_id = "default"
+        km.store = AsyncMock(return_value=MagicMock(node_id="node-1", success=True))
+
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_gauntlet_validate=False,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_trigger_canvas=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_ingest_outcome=True,
+        )
+        coordinator = PostDebateCoordinator(config=config, knowledge_mound=km)
+
+        result = coordinator.run(
+            debate_id="d-1",
+            debate_result=_make_debate_result(),
+            confidence=0.9,
+            task="Design a rate limiter",
+        )
+
+        assert result.outcome_ingested is True
+
+    def test_ingestion_skipped_when_km_not_configured(self):
+        """Outcome ingestion is skipped when no knowledge_mound."""
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_gauntlet_validate=False,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_trigger_canvas=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_ingest_outcome=True,
+        )
+        coordinator = PostDebateCoordinator(config=config, knowledge_mound=None)
+
+        result = coordinator.run(
+            debate_id="d-2",
+            debate_result=_make_debate_result(),
+            confidence=0.9,
+            task="Test task",
+        )
+
+        assert result.outcome_ingested is False
+
+    def test_ingestion_skipped_when_disabled(self):
+        """Outcome ingestion is skipped when auto_ingest_outcome=False."""
+        km = MagicMock()
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_gauntlet_validate=False,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_trigger_canvas=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_ingest_outcome=False,
+        )
+        coordinator = PostDebateCoordinator(config=config, knowledge_mound=km)
+
+        result = coordinator.run(
+            debate_id="d-3",
+            debate_result=_make_debate_result(),
+            confidence=0.9,
+            task="Test task",
+        )
+
+        assert result.outcome_ingested is False
+
+    def test_ingestion_skipped_below_confidence_threshold(self):
+        """Outcome ingestion is skipped when confidence < threshold."""
+        km = MagicMock()
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_gauntlet_validate=False,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_trigger_canvas=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_ingest_outcome=True,
+            ingest_outcome_min_confidence=0.85,
+        )
+        coordinator = PostDebateCoordinator(config=config, knowledge_mound=km)
+
+        result = coordinator.run(
+            debate_id="d-4",
+            debate_result=_make_debate_result(confidence=0.5),
+            confidence=0.5,
+            task="Low confidence task",
+        )
+
+        assert result.outcome_ingested is False
+
+    def test_ingestion_failure_does_not_affect_result(self):
+        """Ingestion error is caught and does not block pipeline."""
+        km = MagicMock()
+        km.workspace_id = "default"
+        km.store = AsyncMock(side_effect=RuntimeError("KM unavailable"))
+
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_gauntlet_validate=False,
+            auto_queue_improvement=False,
+            auto_outcome_feedback=False,
+            auto_trigger_canvas=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            auto_ingest_outcome=True,
+        )
+        coordinator = PostDebateCoordinator(config=config, knowledge_mound=km)
+
+        result = coordinator.run(
+            debate_id="d-5",
+            debate_result=_make_debate_result(),
+            confidence=0.9,
+            task="Error task",
+        )
+
+        # Pipeline completes successfully even if ingestion fails
+        assert result.success is True
+
+    def test_config_defaults(self):
+        """auto_ingest_outcome defaults to True."""
+        config = PostDebateConfig()
+        assert config.auto_ingest_outcome is True
+        assert config.ingest_outcome_min_confidence == 0.85
+
+
+class TestOutcomeIngestionOps:
+    """Test KnowledgeMoundOperations.ingest_debate_outcome directly."""
+
+    @pytest.mark.asyncio
+    async def test_ingest_stores_high_confidence_result(self):
+        """High-confidence results are stored in KM."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        km = MagicMock()
+        km.workspace_id = "ws-1"
+        km.store = AsyncMock(return_value=MagicMock(node_id="n-1", success=True))
+
+        ops = KnowledgeMoundOperations(knowledge_mound=km, enable_ingestion=True)
+        result = _make_debate_result(confidence=0.9)
+
+        await ops.ingest_debate_outcome(result)
+
+        km.store.assert_called_once()
+        call_args = km.store.call_args
+        request = call_args[0][0]
+        assert "Debate Conclusion" in request.content
+
+    @pytest.mark.asyncio
+    async def test_ingest_skips_low_confidence(self):
+        """Low-confidence results are not stored."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        km = MagicMock()
+        km.workspace_id = "ws-1"
+        km.store = AsyncMock()
+
+        ops = KnowledgeMoundOperations(knowledge_mound=km, enable_ingestion=True)
+        result = _make_debate_result(confidence=0.5)
+
+        await ops.ingest_debate_outcome(result)
+
+        km.store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ingest_skips_no_final_answer(self):
+        """Results without final_answer are not stored."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        km = MagicMock()
+        km.workspace_id = "ws-1"
+        km.store = AsyncMock()
+
+        ops = KnowledgeMoundOperations(knowledge_mound=km, enable_ingestion=True)
+        result = _make_debate_result(final_answer="")
+
+        await ops.ingest_debate_outcome(result)
+
+        km.store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ingest_skips_when_disabled(self):
+        """Ingestion is skipped when enable_ingestion=False."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        km = MagicMock()
+        km.workspace_id = "ws-1"
+        km.store = AsyncMock()
+
+        ops = KnowledgeMoundOperations(knowledge_mound=km, enable_ingestion=False)
+        result = _make_debate_result(confidence=0.9)
+
+        await ops.ingest_debate_outcome(result)
+
+        km.store.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ingest_skips_when_no_km(self):
+        """Ingestion is skipped when knowledge_mound is None."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        ops = KnowledgeMoundOperations(knowledge_mound=None, enable_ingestion=True)
+        result = _make_debate_result(confidence=0.9)
+
+        await ops.ingest_debate_outcome(result)
+        # No error, just silently skipped
+
+    @pytest.mark.asyncio
+    async def test_ingest_handles_store_error_gracefully(self):
+        """Store errors are caught and logged, not raised."""
+        from aragora.debate.knowledge_mound_ops import KnowledgeMoundOperations
+
+        km = MagicMock()
+        km.workspace_id = "ws-1"
+        km.store = AsyncMock(side_effect=RuntimeError("DB down"))
+
+        ops = KnowledgeMoundOperations(knowledge_mound=km, enable_ingestion=True)
+        result = _make_debate_result(confidence=0.9)
+
+        # Should not raise
+        await ops.ingest_debate_outcome(result)


### PR DESCRIPTION
## Summary
- Wires `KnowledgeMoundOperations.ingest_debate_outcome()` into the PostDebateCoordinator pipeline
- Runs as step 6.5 (between receipt persistence and improvement queueing)
- Opt-in via `PostDebateConfig.auto_ingest_outcome` (defaults to True)
- Confidence threshold: 0.85 (debates below this skip ingestion)
- Fire-and-forget: errors logged at WARNING, never block post-debate pipeline
- Closes the KM read-write feedback loop: debates enrich KM, future debates retrieve that knowledge

## Test plan
- [x] 12 new tests + 288 existing pass (300 total)
- [ ] Verify outcome ingestion runs after high-confidence debate
- [ ] Verify ingestion is skipped for low-confidence results

🤖 Generated with [Claude Code](https://claude.com/claude-code)