### PR TITLE
fix(cli): fail quickstart fast on broken live provider TLS

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import ssl
 import sys
 import tempfile
 import time
@@ -27,6 +28,16 @@ from typing import Any, cast
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUESTION = "Should we adopt microservices or keep our monolith?"
+_LIVE_PRECHECK_TIMEOUT_SECONDS = 3.0
+_LIVE_DEBATE_TIMEOUT_SECONDS = 75.0
+_PROVIDER_TLS_HOSTS: dict[str, str] = {
+    "anthropic-api": "api.anthropic.com",
+    "openai-api": "api.openai.com",
+    "gemini": "generativelanguage.googleapis.com",
+    "mistral": "api.mistral.ai",
+    "grok": "api.x.ai",
+    "deepseek": "openrouter.ai",
+}
 
 
 def add_quickstart_parser(subparsers: Any) -> None:
@@ -260,6 +271,8 @@ async def _run_live_debate(
     from aragora.debate.orchestrator import Arena, DebateProtocol
     from aragora.memory.store import CritiqueStore
 
+    agents_list = await _filter_reachable_live_agents(agents_list)
+
     env = Environment(task=question)
     protocol = DebateProtocol(rounds=rounds, consensus="majority")
     store = CritiqueStore()
@@ -272,7 +285,18 @@ async def _run_live_debate(
         agent_names.append(provider)
 
     arena = Arena(env, agents, protocol, insight_store=store)
-    result = await arena.run()
+    try:
+        result = await asyncio.wait_for(arena.run(), timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        raise RuntimeError(
+            f"Live debate timed out after {_LIVE_DEBATE_TIMEOUT_SECONDS:.0f}s"
+        ) from exc
+    except Exception as exc:
+        detail = str(exc).strip() or type(exc).__name__
+        raise RuntimeError(f"Live debate failed before producing a result: {detail}") from exc
+
+    if result is None:
+        raise RuntimeError("Live debate returned no result")
 
     verdict = "consensus"
     confidence = 0.0
@@ -299,6 +323,71 @@ async def _run_live_debate(
         "dissent": dissent,
         "mode": "live",
     }
+
+
+async def _can_reach_provider_tls(provider: str) -> tuple[bool, str | None]:
+    """Return whether the provider host passes a basic TLS handshake."""
+    host = _PROVIDER_TLS_HOSTS.get(provider)
+    if not host:
+        return True, None
+
+    try:
+        reader, writer = await asyncio.wait_for(
+            asyncio.open_connection(
+                host,
+                443,
+                ssl=ssl.create_default_context(),
+                server_hostname=host,
+            ),
+            timeout=_LIVE_PRECHECK_TIMEOUT_SECONDS,
+        )
+    except ssl.SSLCertVerificationError:
+        return False, "CERTIFICATE_VERIFY_FAILED"
+    except Exception as exc:
+        detail = str(exc).strip() or type(exc).__name__
+        return False, detail
+
+    writer.close()
+    await writer.wait_closed()
+    return True, None
+
+
+async def _filter_reachable_live_agents(
+    agents_list: list[tuple[str, str | None]],
+) -> list[tuple[str, str | None]]:
+    """Keep only providers that pass a fast TLS preflight.
+
+    Fail closed before entering the debate engine when no detected live providers
+    can establish a verified TLS connection.
+    """
+    limited_agents = agents_list[:4]
+    probe_results = await asyncio.gather(
+        *(_can_reach_provider_tls(provider) for provider, _ in limited_agents)
+    )
+
+    reachable: list[tuple[str, str | None]] = []
+    failures: list[str] = []
+    certificate_failure = False
+    for agent_spec, (ok, detail) in zip(limited_agents, probe_results, strict=False):
+        if ok:
+            reachable.append(agent_spec)
+            continue
+        provider = agent_spec[0]
+        if detail == "CERTIFICATE_VERIFY_FAILED":
+            certificate_failure = True
+        failures.append(f"{provider}: {detail}")
+
+    if reachable:
+        return reachable
+
+    if certificate_failure:
+        providers = ", ".join(provider for provider, _ in limited_agents)
+        raise RuntimeError(
+            f"Provider TLS verification failed for {providers}. Check the local CA trust store."
+        )
+
+    failure_summary = "; ".join(failures) if failures else "no providers available"
+    raise RuntimeError(f"No live providers passed connectivity preflight: {failure_summary}")
 
 
 def cmd_quickstart(args: argparse.Namespace) -> None:
@@ -350,9 +439,11 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
             result = asyncio.run(_run_demo_debate(question, rounds))
         else:
             result = asyncio.run(_run_live_debate(question, detected[:4], rounds))
-    except (OSError, ConnectionError, RuntimeError, ValueError) as e:
+    except (OSError, ConnectionError, RuntimeError, ValueError, TypeError) as e:
         logger.debug("Debate failed: %s", e)
         print(f"\n[!] Debate failed: {e}")
+        if "CERTIFICATE_VERIFY_FAILED" in str(e):
+            print("    Provider TLS verification failed. Check the local CA trust store.")
         print("    Try: aragora quickstart --demo")
         sys.exit(1)
 

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import builtins
 import json
 import os
@@ -12,10 +13,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aragora.cli.commands.quickstart import (
+    _can_reach_provider_tls,
     _detect_agents,
+    _filter_reachable_live_agents,
     _get_question,
     _load_dotenv,
     _open_receipt_in_browser,
+    _run_live_debate,
     _save_receipt,
     add_quickstart_parser,
     cmd_quickstart,
@@ -257,6 +261,93 @@ class TestReceiptFormatting:
 
 
 class TestCmdQuickstart:
+    @pytest.mark.asyncio
+    async def test_run_live_debate_raises_when_arena_returns_none(self):
+        """Live quickstart should fail closed when Arena produces no result."""
+        mock_agent = MagicMock()
+        mock_agent.name = "openai-api"
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._filter_reachable_live_agents",
+                return_value=[("openai-api", "gpt-4o")],
+            ),
+            patch("aragora.agents.base.create_agent", return_value=mock_agent),
+            patch("aragora.debate.orchestrator.Arena") as mock_arena_cls,
+        ):
+            mock_arena = MagicMock()
+            mock_arena.run = AsyncMock(return_value=None)
+            mock_arena_cls.return_value = mock_arena
+
+            with pytest.raises(RuntimeError, match="Live debate returned no result"):
+                await _run_live_debate(
+                    "Should we ship the quickstart path?",
+                    [("openai-api", "gpt-4o")],
+                    rounds=2,
+                )
+
+    @pytest.mark.asyncio
+    async def test_run_live_debate_times_out_cleanly(self, monkeypatch):
+        """Live quickstart should bound long-running onboarding debates."""
+        mock_agent = MagicMock()
+        mock_agent.name = "openai-api"
+
+        async def slow_run():
+            await asyncio.sleep(0.05)
+            return MagicMock()
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._filter_reachable_live_agents",
+                return_value=[("openai-api", "gpt-4o")],
+            ),
+            patch("aragora.agents.base.create_agent", return_value=mock_agent),
+            patch("aragora.debate.orchestrator.Arena") as mock_arena_cls,
+        ):
+            mock_arena = MagicMock()
+            mock_arena.run = slow_run
+            mock_arena_cls.return_value = mock_arena
+            monkeypatch.setattr(
+                "aragora.cli.commands.quickstart._LIVE_DEBATE_TIMEOUT_SECONDS",
+                0.01,
+            )
+
+            with pytest.raises(RuntimeError, match="Live debate timed out"):
+                await _run_live_debate(
+                    "Should we ship the quickstart path?",
+                    [("openai-api", "gpt-4o")],
+                    rounds=2,
+                )
+
+    @pytest.mark.asyncio
+    async def test_filter_reachable_live_agents_raises_clean_tls_error(self):
+        """Quickstart should stop before debate startup when TLS verification fails."""
+        with patch(
+            "aragora.cli.commands.quickstart._can_reach_provider_tls",
+            new=AsyncMock(return_value=(False, "CERTIFICATE_VERIFY_FAILED")),
+        ):
+            with pytest.raises(RuntimeError, match="CA trust store"):
+                await _filter_reachable_live_agents([("openai-api", "gpt-4o"), ("gemini", None)])
+
+    @pytest.mark.asyncio
+    async def test_filter_reachable_live_agents_keeps_healthy_subset(self):
+        """Providers that pass preflight should still be used."""
+
+        async def fake_probe(provider: str) -> tuple[bool, str | None]:
+            if provider == "openai-api":
+                return True, None
+            return False, "connection refused"
+
+        with patch(
+            "aragora.cli.commands.quickstart._can_reach_provider_tls",
+            side_effect=fake_probe,
+        ):
+            reachable = await _filter_reachable_live_agents(
+                [("openai-api", "gpt-4o"), ("gemini", None)]
+            )
+
+        assert reachable == [("openai-api", "gpt-4o")]
+
     def test_demo_mode(self, capsys):
         """Test quickstart runs in demo mode with mock agents."""
         args = argparse.Namespace(
@@ -418,6 +509,34 @@ class TestCmdQuickstart:
 
         output = capsys.readouterr().out
         assert "Falling back to demo mode" in output
-        assert "local mock agents, not live model calls" in output
-        assert "Mode:       Demo" in output
-        assert str(artifact_path.resolve()) in output
+
+    def test_live_mode_exits_cleanly_on_tls_failure(self, capsys):
+        """TLS/provider failures should surface a clear operator hint."""
+        args = argparse.Namespace(
+            question="Should we use the live path?",
+            demo=False,
+            output=None,
+            format="json",
+            rounds=2,
+            no_browser=True,
+        )
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._detect_agents",
+                return_value=[("gemini", None)],
+            ),
+            patch(
+                "aragora.cli.commands.quickstart._run_live_debate",
+                side_effect=RuntimeError(
+                    "Live debate failed before producing a result: CERTIFICATE_VERIFY_FAILED"
+                ),
+            ),
+        ):
+            with pytest.raises(SystemExit):
+                cmd_quickstart(args)
+
+        output = capsys.readouterr().out
+        assert "Debate failed" in output
+        assert "CA trust store" in output
+        assert "quickstart --demo" in output


### PR DESCRIPTION
## Summary
- add a fast TLS preflight before quickstart enters the live debate engine
- fail closed with a direct CA trust store hint when no detected live provider passes the preflight
- keep the existing debate timeout guard and extend focused CLI coverage for the preflight path

## Why
The default founder-demo proof on current `main` exposed a real onboarding bug: `aragora quickstart` would detect live providers from `.env`, enter the debate engine, then churn through provider retries and circuit-breaker noise for ~90 seconds before surfacing a user-facing failure. The local environment problem was a broken CA trust store, but the command path was still wrong because it did not fail early or truthfully.

## Validation
- `python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- `python3 -m aragora.cli.main quickstart --question "Should Aragora use the integrated quickstart path as the default founder demo?" --no-browser`
  - before: exited after ~89s with internal agent failure cascade
  - after: exits in ~2s with `Provider TLS verification failed ... Check the local CA trust store.`

## Scope
- `aragora/cli/commands/quickstart.py`
- `tests/cli/test_quickstart.py`
