### PR TITLE
feat(pipeline): productize DAG workbench with real stage transitions

### DIFF
--- a/aragora/server/handlers/canvas_pipeline.py
+++ b/aragora/server/handlers/canvas_pipeline.py
@@ -391,12 +391,14 @@ class CanvasPipelineHandler:
     """HTTP handler for the idea-to-execution canvas pipeline."""
 
     ROUTES = [
+        "GET /api/v1/canvas/pipeline",
         "POST /api/v1/canvas/pipeline/from-debate",
         "POST /api/v1/canvas/pipeline/from-ideas",
         "POST /api/v1/canvas/pipeline/from-braindump",
         "POST /api/v1/canvas/pipeline/from-template",
         "POST /api/v1/canvas/pipeline/demo",
         "POST /api/v1/canvas/pipeline/advance",
+        "POST /api/v1/canvas/pipeline/approve-transition",
         "POST /api/v1/canvas/pipeline/run",
         "POST /api/v1/canvas/pipeline/{id}/approve-transition",
         "POST /api/v1/canvas/pipeline/{id}/execute",
@@ -578,6 +580,10 @@ class CanvasPipelineHandler:
         """Dispatch GET requests to the appropriate handler method."""
         self._get_request_body(handler)
 
+        # GET /api/v1/canvas/pipeline — list pipelines or return latest
+        if path in ("/api/v1/canvas/pipeline", "/api/v1/canvas/pipeline/"):
+            return self.handle_list_or_latest(query_params)
+
         # GET /api/v1/canvas/pipeline/templates
         if path.endswith("/pipeline/templates"):
             return self.handle_list_templates(query_params)
@@ -723,6 +729,7 @@ class CanvasPipelineHandler:
             return self.handle_execute(m.group(1), body)
 
         # Check for transition approval: /api/v1/canvas/pipeline/{id}/approve-transition
+        # Also supports root path with pipeline_id in body (frontend pattern)
         if "/approve-transition" in path:
             auth_error = self._check_permission(handler, "pipeline:write")
             if auth_error:
@@ -731,6 +738,12 @@ class CanvasPipelineHandler:
             m = re.match(r".*/pipeline/([a-zA-Z0-9_-]+)/approve-transition$", path)
             if m:
                 return self.handle_approve_transition(m.group(1), body)
+            # Fallback: root-path approve-transition with pipeline_id in body
+            if path.endswith("/pipeline/approve-transition"):
+                pipeline_id = body.get("pipeline_id")
+                if not pipeline_id:
+                    return error_response("Missing pipeline_id in request body", 400)
+                return self.handle_approve_transition(str(pipeline_id), body)
             return None
 
         target = None
@@ -1130,6 +1143,40 @@ class CanvasPipelineHandler:
         except (ImportError, ValueError, TypeError) as e:
             logger.warning("Pipeline advance failed: %s", e)
             return error_response("Pipeline advance failed", 500)
+
+    async def handle_list_or_latest(self, query_params: dict[str, Any]) -> HandlerResult:
+        """GET /api/v1/canvas/pipeline
+
+        Returns the most recent pipeline result (for SWR auto-load on the
+        pipeline page).  Pass ``?list=true`` to get a list of pipeline summaries
+        instead.
+        """
+        store = _get_store()
+
+        # List mode
+        list_mode = query_params.get("list")
+        if list_mode and str(list_mode).lower() in ("1", "true", "yes"):
+            status_filter = query_params.get("status")
+            limit = 50
+            try:
+                limit = int(query_params.get("limit", 50))
+            except (ValueError, TypeError):
+                pass
+            pipelines = store.list_pipelines(status=status_filter, limit=limit)
+            return json_response({"pipelines": pipelines, "count": len(pipelines)})
+
+        # Default: return the latest pipeline
+        pipelines = store.list_pipelines(limit=1)
+        if not pipelines:
+            # No pipelines exist -- return empty so the frontend shows the
+            # empty state (brain dump input) rather than an error.
+            return json_response(None)
+
+        latest_id = pipelines[0]["id"]
+        result = store.get(latest_id)
+        if not result:
+            return json_response(None)
+        return json_response(attach_unified_live_state(result))
 
     async def handle_get_pipeline(self, pipeline_id: str) -> HandlerResult:
         """GET /api/v1/canvas/pipeline/{id}"""
@@ -1989,7 +2036,10 @@ class CanvasPipelineHandler:
 
         from_stage = request_data.get("from_stage", "")
         to_stage = request_data.get("to_stage", "")
-        approved = request_data.get("approved", False)
+        # Default to True when "approved" is not explicitly provided --
+        # the frontend calls approve-transition without this field to
+        # approve, and sets approved=false to reject.
+        approved = request_data.get("approved", True)
         comment = request_data.get("comment", "")
 
         if not from_stage or not to_stage:
@@ -2039,6 +2089,7 @@ class CanvasPipelineHandler:
                 "to_stage": to_stage,
                 "status": "approved" if approved else "rejected",
                 "comment": comment,
+                "result": existing,
             }
         )
 

--- a/tests/server/handlers/test_canvas_pipeline_endpoints.py
+++ b/tests/server/handlers/test_canvas_pipeline_endpoints.py
@@ -483,3 +483,150 @@ class TestHandleConvertWorkflow:
         body = _body(result)
         assert "nodes" in body
         assert "edges" in body
+
+
+# =========================================================================
+# Route registration for new endpoints
+# =========================================================================
+
+
+class TestNewRouteRegistration:
+    def test_list_pipelines_route(self, handler):
+        assert "GET /api/v1/canvas/pipeline" in handler.ROUTES
+
+    def test_approve_transition_root_route(self, handler):
+        assert "POST /api/v1/canvas/pipeline/approve-transition" in handler.ROUTES
+
+
+# =========================================================================
+# handle_list_or_latest
+# =========================================================================
+
+
+class TestHandleListOrLatest:
+    @pytest.fixture(autouse=True)
+    def _fresh_db(self):
+        """Delete all pipelines from the store for a clean slate."""
+        store = _get_store()
+        for p in store.list_pipelines(limit=1000):
+            store.delete(p["id"])
+        yield
+        for p in store.list_pipelines(limit=1000):
+            store.delete(p["id"])
+
+    @pytest.mark.asyncio
+    async def test_empty_store_returns_null(self, handler):
+        """When no pipelines exist, returns null so frontend shows empty state."""
+        result = await handler.handle_list_or_latest({})
+        body = _body(result)
+        assert body is None
+
+    @pytest.mark.asyncio
+    async def test_returns_latest_pipeline(self, handler, sample_cartographer_data):
+        """After creating a pipeline, list_or_latest returns it."""
+        create_result = await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        pipeline_id = _body(create_result)["pipeline_id"]
+
+        result = await handler.handle_list_or_latest({})
+        body = _body(result)
+        assert body is not None
+        assert body["pipeline_id"] == pipeline_id
+
+    @pytest.mark.asyncio
+    async def test_list_mode(self, handler, sample_cartographer_data):
+        """?list=true returns a list of pipeline summaries."""
+        await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        result = await handler.handle_list_or_latest({"list": "true"})
+        body = _body(result)
+        assert "pipelines" in body
+        assert "count" in body
+        assert body["count"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_latest_has_live_state(self, handler, sample_cartographer_data):
+        """Latest pipeline includes unified live state."""
+        await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        result = await handler.handle_list_or_latest({})
+        body = _body(result)
+        assert body is not None
+        assert "live_state" in body
+
+
+# =========================================================================
+# handle_approve_transition — root path with pipeline_id in body
+# =========================================================================
+
+
+class TestHandleApproveTransitionRootPath:
+    @pytest.mark.asyncio
+    async def test_approve_transition_defaults_to_approved(self, handler, sample_cartographer_data):
+        """Calling approve-transition without 'approved' field should default to True."""
+        create_result = await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        pipeline_id = _body(create_result)["pipeline_id"]
+
+        result = await handler.handle_approve_transition(
+            pipeline_id,
+            {
+                "from_stage": "ideas",
+                "to_stage": "goals",
+            },
+        )
+        body = _body(result)
+        assert body["status"] == "approved"
+
+    @pytest.mark.asyncio
+    async def test_reject_transition(self, handler, sample_cartographer_data):
+        """Calling approve-transition with approved=false should reject."""
+        create_result = await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        pipeline_id = _body(create_result)["pipeline_id"]
+
+        result = await handler.handle_approve_transition(
+            pipeline_id,
+            {
+                "from_stage": "ideas",
+                "to_stage": "goals",
+                "approved": False,
+                "comment": "Not ready",
+            },
+        )
+        body = _body(result)
+        assert body["status"] == "rejected"
+        assert body["comment"] == "Not ready"
+
+    @pytest.mark.asyncio
+    async def test_approve_transition_returns_updated_pipeline(
+        self, handler, sample_cartographer_data
+    ):
+        """Approve-transition should include the updated pipeline data in result."""
+        create_result = await handler.handle_from_debate(
+            {"cartographer_data": sample_cartographer_data, "auto_advance": True}
+        )
+        pipeline_id = _body(create_result)["pipeline_id"]
+
+        result = await handler.handle_approve_transition(
+            pipeline_id,
+            {"from_stage": "ideas", "to_stage": "goals"},
+        )
+        body = _body(result)
+        assert "result" in body
+        assert body["result"]["pipeline_id"] == pipeline_id
+
+    @pytest.mark.asyncio
+    async def test_approve_transition_missing_pipeline(self, handler):
+        """Approving a non-existent pipeline returns 404."""
+        result = await handler.handle_approve_transition(
+            "nonexistent-pipe",
+            {"from_stage": "ideas", "to_stage": "goals"},
+        )
+        body = _body(result)
+        assert "error" in body


### PR DESCRIPTION
## Summary
- Fixes 3 backend gaps preventing the pipeline page from functioning:
  1. `GET /api/v1/canvas/pipeline` now returns latest pipeline (auto-load on page mount)
  2. `POST /api/v1/canvas/pipeline/approve-transition` supports root-path body pattern
  3. Approve-transition default fixed (was silently rejecting all approvals)
- Pipeline page now loads real data, transitions work, and approvals update state

Closes #993

## Test plan
- [x] 10 new tests + 154 existing pass (164 total)
- [ ] Verify pipeline page loads and shows real pipeline data
- [ ] Verify stage transitions (approve/reject) work from UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)