### PR TITLE
test(tranche): use timezone.utc in queue review deadline

### DIFF
--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -902,7 +902,7 @@ async def test_process_item_records_design_review_blocker_when_confirmation_requ
         manifest=manifest,
         item=item,
         item_state=item_state,
-        deadline=datetime.now(UTC) + timedelta(minutes=10),
+        deadline=datetime.now(timezone.utc) + timedelta(minutes=10),
     )
 
     assert result is None


### PR DESCRIPTION
## Summary
- replace the undefined `UTC` symbol in the tranche queue test with `timezone.utc`
- keep the test behavior unchanged while fixing the current failure on `main`

## Why
Current `origin/main` imports `datetime`, `timedelta`, and `timezone` in `tests/swarm/test_tranche_queue.py`, but the test still calls `datetime.now(UTC)`. That produces a `NameError` in the focused tranche queue suite.

## Validation
- `python3 -m ruff check tests/swarm/test_tranche_queue.py`
- `python3 -m pytest tests/swarm/test_tranche_queue.py -q`
