### PR TITLE
feat(surfaces): productize Wave 2 — spectate, onboarding, conditional endpoints

### DIFF
--- a/aragora/server/auth_requirements.py
+++ b/aragora/server/auth_requirements.py
@@ -114,6 +114,33 @@ PUBLIC_ENDPOINTS = [
         AuthLevel.PUBLIC,
         description="Playground health check",
     ),
+    # Spectate - public read-only live observation (debate IDs redacted for unauthenticated)
+    EndpointAuth(
+        "/api/v1/spectate/recent",
+        "get",
+        AuthLevel.PUBLIC,
+        description="Recent spectate events",
+    ),
+    EndpointAuth(
+        "/api/v1/spectate/status",
+        "get",
+        AuthLevel.PUBLIC,
+        description="Spectate bridge status (redacted for unauthenticated)",
+    ),
+    # Onboarding - public for first-time users
+    EndpointAuth(
+        "/api/v1/onboarding/templates",
+        "get",
+        AuthLevel.PUBLIC,
+        description="Onboarding starter templates",
+    ),
+    # Public surface discovery
+    EndpointAuth(
+        "/api/v1/public/surfaces",
+        "get",
+        AuthLevel.PUBLIC,
+        description="List available public API surfaces",
+    ),
 ]
 
 # =============================================================================

--- a/aragora/server/handlers/public/__init__.py
+++ b/aragora/server/handlers/public/__init__.py
@@ -2,12 +2,13 @@
 Public-facing handlers that don't require authentication.
 
 Includes:
-- StatusPageHandler: Public status page for service health visibility
+- StatusPageHandler: Public status page and surface discovery
 """
 
 from .status_page import (
     ComponentHealth,
     Incident,
+    PublicSurfaceReadiness,
     ServiceStatus,
     StatusPageHandler,
 )
@@ -17,4 +18,5 @@ __all__ = [
     "ServiceStatus",
     "ComponentHealth",
     "Incident",
+    "PublicSurfaceReadiness",
 ]

--- a/aragora/server/handlers/public/status_page.py
+++ b/aragora/server/handlers/public/status_page.py
@@ -119,6 +119,8 @@ class StatusPageHandler(BaseHandler):
         "/api/v1/status/components",
         "/api/v1/status/incidents",
         "/api/v1/status/uptime",
+        # Public surface discovery
+        "/api/v1/public/surfaces",
     ]
 
     # Component definitions with health check functions
@@ -151,6 +153,7 @@ class StatusPageHandler(BaseHandler):
         "/api/v1/status/components",
         "/api/v1/status/incidents",
         "/api/v1/status/uptime",
+        "/api/v1/public/surfaces",
     }
 
     def can_handle(self, path: str) -> bool:
@@ -159,6 +162,7 @@ class StatusPageHandler(BaseHandler):
             path in self.ROUTES
             or path.startswith("/api/status/")
             or path.startswith("/api/v1/status")
+            or path == "/api/v1/public/surfaces"
         )
 
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
@@ -176,6 +180,8 @@ class StatusPageHandler(BaseHandler):
             "/api/v1/status/components": self._v1_components,
             "/api/v1/status/incidents": self._v1_incidents,
             "/api/v1/status/uptime": self._v1_uptime,
+            # Public surface discovery
+            "/api/v1/public/surfaces": self._v1_public_surfaces,
         }
 
         endpoint_handler = handlers.get(path)
@@ -306,6 +312,18 @@ class StatusPageHandler(BaseHandler):
                     },
                     "periods": sla_uptime,
                     "timestamp": now.isoformat(),
+                }
+            }
+        )
+
+    def _v1_public_surfaces(self) -> HandlerResult:
+        """GET /api/v1/public/surfaces - List available public surfaces."""
+        surfaces = self._get_public_surface_readiness()
+        return json_response(
+            {
+                "data": {
+                    "surfaces": [self._serialize_public_surface(s) for s in surfaces],
+                    "summary": self._summarize_public_surfaces(surfaces),
                 }
             }
         )
@@ -863,9 +881,120 @@ class StatusPageHandler(BaseHandler):
                 ],
                 message="Public health and uptime endpoints are backed by this handler.",
             ),
+            PublicSurfaceReadiness(
+                id="health",
+                name="Health checks",
+                readiness="live",
+                paths=[
+                    "/api/health",
+                    "/api/healthz",
+                    "/api/readyz",
+                    "/api/health/detailed",
+                ],
+                message="Health endpoints are public for load balancers and onboarding connection checks.",
+            ),
+            self._get_spectate_surface_readiness(),
+            self._get_onboarding_surface_readiness(),
             self._get_openapi_surface_readiness(),
             self._get_memory_surface_readiness(),
         ]
+
+    def _get_spectate_surface_readiness(self) -> PublicSurfaceReadiness:
+        """Assess whether the spectate bridge is wired and serving events."""
+        try:
+            from aragora.spectate.ws_bridge import get_spectate_bridge
+
+            bridge = get_spectate_bridge()
+            if bridge.running:
+                return PublicSurfaceReadiness(
+                    id="spectate",
+                    name="Spectate (live debate observation)",
+                    readiness="live",
+                    paths=[
+                        "/api/v1/spectate/recent",
+                        "/api/v1/spectate/status",
+                        "/api/v1/spectate/stream",
+                    ],
+                    message=(
+                        "Spectate bridge is running. Live debate events are "
+                        "available via polling and WebSocket. Unauthenticated "
+                        "callers receive redacted status (debate IDs hidden)."
+                    ),
+                    backend_conditional=True,
+                    details={
+                        "bridge_running": True,
+                        "subscribers": bridge.subscriber_count,
+                        "buffer_size": bridge.buffer_size,
+                    },
+                )
+            return PublicSurfaceReadiness(
+                id="spectate",
+                name="Spectate (live debate observation)",
+                readiness="partial",
+                paths=[
+                    "/api/v1/spectate/recent",
+                    "/api/v1/spectate/status",
+                    "/api/v1/spectate/stream",
+                ],
+                message=(
+                    "Spectate bridge is initialized but not running. "
+                    "Endpoints return empty results until a debate starts."
+                ),
+                backend_conditional=True,
+                details={"bridge_running": False},
+            )
+        except ImportError:
+            return PublicSurfaceReadiness(
+                id="spectate",
+                name="Spectate (live debate observation)",
+                readiness="partial",
+                paths=[
+                    "/api/v1/spectate/recent",
+                    "/api/v1/spectate/status",
+                    "/api/v1/spectate/stream",
+                ],
+                message=(
+                    "Spectate module not available. Endpoints return empty fallback responses."
+                ),
+                backend_conditional=True,
+                details={"bridge_running": False},
+            )
+
+    def _get_onboarding_surface_readiness(self) -> PublicSurfaceReadiness:
+        """Assess whether the onboarding wizard endpoints are wired."""
+        try:
+            from aragora.onboarding import OnboardingWizard  # noqa: F401
+
+            return PublicSurfaceReadiness(
+                id="onboarding",
+                name="SME onboarding wizard",
+                readiness="live",
+                paths=[
+                    "/api/v1/onboarding/flow",
+                    "/api/v1/onboarding/templates",
+                    "/api/v1/onboarding/first-debate",
+                    "/api/v1/onboarding/quick-start",
+                ],
+                message=(
+                    "Onboarding wizard is wired: 3-step get-started flow, "
+                    "SME-specific templates, and quick-start profiles are "
+                    "served by the backend handler."
+                ),
+            )
+        except ImportError:
+            return PublicSurfaceReadiness(
+                id="onboarding",
+                name="SME onboarding wizard",
+                readiness="partial",
+                paths=[
+                    "/api/v1/onboarding/flow",
+                    "/api/v1/onboarding/templates",
+                    "/api/v1/onboarding/first-debate",
+                    "/api/v1/onboarding/quick-start",
+                ],
+                message="Onboarding module not importable. Endpoints may return 500.",
+                backend_conditional=True,
+            )
 
     def _get_openapi_surface_readiness(self) -> PublicSurfaceReadiness:
         """Assess whether the documented OpenAPI surface is fully hardened."""

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -38,6 +38,14 @@ These build on earlier March 21-22 work:
 - **Dashboard shows live state** (was: historical only).
 - **Boss loop can run unattended** with label-scoped dispatch.
 
+### Wave 2 Surface Productization
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| **Spectate** | productized | Frontend wired to real WebSocket + polling. Conditional auth redacts debate IDs for unauthenticated callers. |
+| **SME Onboarding** | productized | 3-step wizard wired to backend. 9 starter templates including SME-specific profiles. |
+| **Conditional Public Endpoints** | productized | `GET /api/v1/public/surfaces` lists all public surfaces with readiness. Auth manifest declares spectate + onboarding as public. |
+
 ### Current Frontier
 
 The frontier has shifted from "close the product loop" to:

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -37,6 +37,16 @@ Earlier March 21-23 work that these build on:
 6. continuity/path-truthfulness improved via [#1146](https://github.com/synaptent/aragora/pull/1146), [#1147](https://github.com/synaptent/aragora/pull/1147), [#1148](https://github.com/synaptent/aragora/pull/1148), [#1150](https://github.com/synaptent/aragora/pull/1150), and [#1151](https://github.com/synaptent/aragora/pull/1151)
 7. queue throughput/harvest support improved via [#1141](https://github.com/synaptent/aragora/pull/1141) and [#1164](https://github.com/synaptent/aragora/pull/1164)
 
+### Wave 2 Surface Productization
+
+Three surfaces productized and inventoried:
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| **Spectate** | productized | Frontend wired to `useSpectate` hook (polls `/api/v1/spectate/recent` + `/api/v1/spectate/status`). Per-debate WebSocket stream at `/spectate/{debateId}` with feed/timeline/summary views. Conditional auth: unauthenticated callers get redacted status (debate IDs hidden). |
+| **SME Onboarding** | productized | 3-step get-started page (check connection, run debate, view results) wired to backend. Onboarding handler serves flow management, 9 starter templates (including SME-specific), quick-start profiles, and funnel analytics. |
+| **Conditional Public Endpoints** | productized | `GET /api/v1/public/surfaces` lists all public surfaces with readiness (live/partial), paths, and backend-conditional flags. Auth requirements manifest declares spectate and onboarding templates as public. Spectate status auto-redacts debate IDs for unauthenticated callers. |
+
 ### Current Frontier
 
 The frontier is no longer "close the product loop." It is:


### PR DESCRIPTION
## Summary
- Inventoried all 3 Wave 2 surfaces: spectate, SME onboarding, conditional endpoints
- All found to be already implemented — added public surface registry endpoint
- `GET /api/v1/public/surfaces` returns all public surfaces with readiness state
- Declared spectate + onboarding as AuthLevel.PUBLIC in auth_requirements.py
- Updated status docs with Wave 2 productization table

Closes #820

## Test plan
- [x] 393 tests pass across affected components
- [ ] Verify /api/v1/public/surfaces returns correct surface inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)