### PR TITLE
docs(partners): refresh design partner brief with March 2026 evidence

### DIFF
--- a/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
+++ b/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
@@ -1,17 +1,19 @@
-# Aragora: Design Partner Program
+# Aragora: Design Partner Brief
 
 **Stop shipping decisions you can't explain.**
+
+Last updated: 2026-03-23
 
 ---
 
 ## The Problem
 
-Your team uses AI every day — generating code, drafting plans, evaluating options.
+Your team uses AI every day -- generating code, drafting plans, evaluating options.
 But when something goes wrong, nobody can answer: *why did we decide that?*
 
 - **No audit trail.** AI outputs are ephemeral. Decisions evaporate.
 - **Single-model blind spots.** One LLM = one perspective. No adversarial vetting.
-- **Compliance gaps.** Regulators want explainability. You have chat logs.
+- **Compliance gaps.** Regulators want explainability. You have chat logs. EU AI Act enforcement begins August 2, 2026.
 
 ## What Aragora Does
 
@@ -20,98 +22,101 @@ to adversarially vet decisions, then delivers audit-ready **decision receipts**
 to any channel.
 
 ```
-Your question → 43 agents debate → Consensus + receipt → Slack / GitHub / API
+Your input -> multi-agent debate -> consensus + receipt -> KM feedback -> Slack / GitHub / API
 ```
 
-**Three things that make it different:**
+**What makes it different:**
 
-1. **Multi-agent consensus.** Claude, GPT-4, Mistral, Gemini debate each decision.
+1. **Multi-agent consensus.** Claude, GPT-4, Mistral, Gemini, Grok debate each decision.
    Disagreements surface blind spots before they become incidents.
 
 2. **Cryptographic receipts.** Every decision produces a SHA-256 signed receipt
    with agent votes, agreement scores, and provenance chains.
 
-3. **Zero-config autonomous actions.** Point it at your GitHub repo and it
-   reviews PRs, identifies next steps, and posts findings — no setup required.
+3. **Self-improving knowledge loop.** Debate outcomes feed back into a Knowledge Mound
+   (45 adapters), so the platform learns from every decision it vets.
 
-## What You Get Today
+4. **Autonomous bounded execution.** Supervisor-backed work orders with receipt gates,
+   lease-based coordination, and explicit merge policy -- not unguarded autonomy.
 
-| Capability | Status |
-|------------|--------|
-| Multi-agent debate engine (43 agent types) | Production |
-| PR code review (`aragora openclaw review --pr <url>`) | Production |
-| Next-steps scanner (`aragora openclaw next-steps`) | Production |
-| Decision receipts with SHA-256 audit trail | Production |
-| SARIF export for GitHub Security tab | Production |
-| WebSocket real-time streaming (190+ events) | Production |
-| Python + TypeScript SDKs | Production |
-| Docker one-command deployment | Production |
-| EU AI Act compliance artifacts (Art. 12/13/14) | Production |
-| RBAC with 360+ permissions | Production |
-| OpenTelemetry observability | Production |
+## What Works End-to-End Today (March 23, 2026)
 
-## Quick Demo (60 seconds)
+The product loop is **structurally closed** on `main`. The complete path:
 
-```bash
-# Install
-pip install aragora
-
-# Review a PR
-aragora openclaw review --pr https://github.com/your-org/repo/pull/123 --dry-run
-
-# Scan for next steps
-aragora openclaw next-steps --path /your/repo
-
-# Start the full platform
-docker compose -f deploy/demo/docker-compose.yml up
-# Open http://localhost:3000
+```
+Onboarding wizard -> API key setup -> ProviderRouter-backed debate
+  -> KM-enriched context -> consensus + receipt -> KM writeback
+  -> live dashboard -> demo surface
 ```
 
-## Who This Is For
+23 PRs merged March 21-23 closing 15 issues to wire this loop shut:
 
-We're looking for **3-5 design partners** who:
+| Capability | Status | Evidence |
+|------------|--------|----------|
+| Multi-agent debate engine (43 agent types, 10+ concurrent) | Production | PR #1182 |
+| Smart provider routing (cost/quality/latency Pareto) | Wired | PR #1167 |
+| KM-enriched debate context + outcome writeback | Wired | PRs #1168, #1176 |
+| Interactive onboarding wizard (landing to first debate) | Shipped | PR #1170 |
+| API key management (real backend, no client-side fakes) | Shipped | PR #1169 |
+| Live dashboard with active debate tracking | Shipped | PR #1175 |
+| Demo surface hitting real backend | Shipped | PR #1177 |
+| Decision receipts with SHA-256 audit trail | Production | |
+| Autonomous repo improvement (Ralph loop) | Validated | V14 benchmark |
+| Swarm orchestration (supervisor, leases, receipts) | Production | |
+| Inbox trust wedge (Gmail -> debate -> receipt -> action) | Shipped | |
+| EU AI Act compliance artifacts (85/100 score) | Production | |
+| 210,000+ tests across 5,000+ test files | CI | |
 
-- Ship software with AI assistance (Copilot, Claude, Cursor, etc.)
-- Need to explain AI-assisted decisions to stakeholders or regulators
-- Want autonomous code review beyond what a single LLM provides
-- Are willing to give candid feedback in exchange for early access
+## Three Proof Surfaces for Partners
 
-**Ideal verticals:** FinTech, HealthTech, Legal Tech, GovTech, or any
-regulated industry where decision provenance matters.
+**1. Decision Review.** Run any artifact (spec, PR, architecture proposal) through
+multi-agent debate. Get a receipt with consensus, dissent, confidence, and provenance.
+Share it on Slack, export as PDF/MD/JSON.
 
-## What We're Asking
+**2. Autonomous Repo Improvement.** Point Aragora at bounded engineering work.
+The Ralph loop: spec -> deliverable -> cross-model review -> repair -> PR -> merge.
+Zero operator intervention on the validated benchmark path.
+
+**3. Inbox Trust Wedge.** Gmail -> adversarial debate -> signed receipt -> CLI approval
+-> action (archive/star/label). Receipt-before-action is non-negotiable.
+
+## What Partners Get
+
+- A self-improving platform that learns from every decision it vets
+- Autonomous repo maintenance under explicit policy and receipt gates
+- Audit-ready decision receipts (SHA-256 signed, exportable, verifiable)
+- Priority support, roadmap influence, and direct access to the team
+- Early access to enterprise features (OIDC/SAML SSO, RBAC, multi-tenancy)
+
+## What We Need From Partners
 
 | From You | From Us |
 |----------|---------|
-| 30 min onboarding call | Free access during partner period |
-| Run on 1-2 real repos | Priority feature requests |
-| 15 min feedback call every 2 weeks | Direct Slack access to the team |
-| Permission to use anonymized case study | Co-marketing opportunity |
+| One bounded recurring workflow with a clear trigger | Free access during partner period |
+| 30 min onboarding + weekly 30 min check-in for 4-6 weeks | Hands-on onboarding to first receipt |
+| Real artifacts (sanitized OK): inbox batch, design doc, bounded backlog | Priority feature requests and weekly iteration |
+| Candid feedback on quality, friction, and trust | Co-marketing opportunity (anonymized case studies OK) |
 
-## How It Works (Architecture)
+## Who This Is For
 
-```
-┌─────────────┐     ┌──────────────┐     ┌─────────────────┐
-│  Your Repo  │────▶│  Aragora CLI │────▶│  Debate Engine   │
-│  or PR URL  │     │  / SDK / API │     │  (43 agent types)│
-└─────────────┘     └──────────────┘     └────────┬────────┘
-                                                   │
-                          ┌────────────────────────┼────────────────────┐
-                          │                        │                    │
-                    ┌─────▼─────┐          ┌──────▼──────┐    ┌───────▼───────┐
-                    │ Consensus │          │   Receipt    │    │  Connectors   │
-                    │  Engine   │          │  Generator   │    │ Slack/GitHub/ │
-                    │           │          │ (SHA-256)    │    │ Teams/Email   │
-                    └───────────┘          └─────────────┘    └───────────────┘
-```
+We are looking for **3-5 design partners** who:
+
+- Feel real pain from review latency, manual triage, audit evidence work, or bounded engineering backlog throughput
+- Have one recurring workflow with a clear trigger, owner, and success/failure outcome
+- Can start narrow (one receipt-gated workflow) before expanding
+- Have a champion who can provide artifacts, review receipts, and join a weekly loop
+
+**Best-fit segments:** Regulated SaaS, FinTech, HealthTech, platform/security teams,
+founder-led teams with painful inbox triage, AI-native teams frustrated by single-model trust gaps.
 
 ## Numbers
 
-- **129,000+ tests** across 3,000+ test files
-- **3,000+ API operations** across 2,900+ handler routes
-- **33 knowledge adapters** for cross-system learning
+- **210,000+ tests** across 5,000+ test files
+- **3,700+ Python modules** | **3,000+ API operations**
+- **45 knowledge adapters** for cross-system learning
+- **43 agent types** across 6+ LLM providers
 - **190+ WebSocket event types** for real-time streaming
-- **Python + TypeScript SDKs** with 100% route coverage
+- **Python + TypeScript SDKs** (186 Py / 185 TS namespaces)
 
 ## Next Step
 
@@ -119,7 +124,7 @@ regulated industry where decision provenance matters.
 
 - Email: [your-email]
 - Calendar: [booking-link]
-- GitHub: https://github.com/an0mium/aragora
+- GitHub: https://github.com/synaptent/aragora
 
 ---
 

--- a/docs/status/DESIGN_PARTNER_PROGRAM.md
+++ b/docs/status/DESIGN_PARTNER_PROGRAM.md
@@ -1,38 +1,65 @@
 # Design Partner Program (Q2 2026)
 
-Last updated: 2026-03-20
+Last updated: 2026-03-23
 
-This document defines the Q2 2026 design partner program for achieving product-market fit (PMF) around Aragora's receipt-gated decision kernel. The partner motion should now be anchored to the product surfaces that are real on `main`: the inbox trust wedge, the Ralph autonomous loop, and supervisor-backed swarm orchestration. The SME Starter Pack remains a useful activation target, but it is no longer enough to describe the whole program.
+This document defines the Q2 2026 design partner program for achieving product-market fit (PMF) around Aragora's receipt-gated decision kernel. As of March 23, the default product loop is **structurally closed** on `main`. The partner motion is now anchored to four proof surfaces: the decision review loop (the default), the inbox trust wedge, the Ralph autonomous loop, and supervisor-backed swarm orchestration.
 
 Related:
 - Current status: `docs/STATUS.md`, `docs/status/STATUS.md`
+- Design partner brief (one-pager): `docs/outreach/DESIGN_PARTNER_ONEPAGER.md`
 - Capability/backlog truth: `docs/FEATURE_GAP_LIST.md`
 - Canonical execution order: `docs/status/NEXT_STEPS_CANONICAL.md`
 - PMF scoring rubric: `docs/status/PMF_SCORECARD.md`
 - Inbox trust wedge dogfood plan: `docs/plans/2026-03-06-openrouter-inbox-dogfood-plan.md`
 - Ralph benchmark evidence: `docs/experiments/phase0b_role_benchmark/results.json`
+- Strategy: `docs/plans/ARAGORA_IDEA_TO_EXECUTION_STRATEGY.md`
 
 ---
 
-## Current Product Truth
+## Current Product Truth (March 23, 2026)
 
-Aragora's core kernel is now:
+The default product loop is structurally closed. 23 PRs merged March 21-23 closing 15 issues wired the remaining gaps. The complete path:
+
+```
+Onboarding wizard -> API key management -> ProviderRouter-backed debate
+  -> KM-enriched context -> consensus + receipt -> KM writeback
+  -> live dashboard -> real demo surface
+```
+
+Key March 23 merge evidence:
+- **ProviderRouter wired into DebateFactory** ([#1167](https://github.com/synaptent/aragora/pull/1167)) -- debates use cost/quality/latency routing
+- **KnowledgeMound retrieval wired into DebateFactory** ([#1168](https://github.com/synaptent/aragora/pull/1168)) -- debates enriched with org knowledge by default
+- **Debate outcome ingestion to KM** ([#1176](https://github.com/synaptent/aragora/pull/1176)) -- closes the read-write feedback loop
+- **API key management endpoints** ([#1169](https://github.com/synaptent/aragora/pull/1169)) -- real backend auth
+- **Interactive onboarding wizard** ([#1170](https://github.com/synaptent/aragora/pull/1170)) -- first complete user journey
+- **Live dashboard** ([#1175](https://github.com/synaptent/aragora/pull/1175)) -- shows active debates, not just historical
+- **Demo wired to real backend** ([#1177](https://github.com/synaptent/aragora/pull/1177)) -- demo is no longer static
+- **Boss-loop label filter** ([#1172](https://github.com/synaptent/aragora/pull/1172)) -- unattended dispatch scoped by label
+- **Fresh queue v5** ([#1171](https://github.com/synaptent/aragora/pull/1171)) -- 5 new workbench/integrator issues seeded
+- **E2E user journey smoke test** ([#1179](https://github.com/synaptent/aragora/pull/1179)) -- product loop validated in CI
+
+Aragora's core kernel:
 
 `prompt/spec -> adversarial debate -> consensus/dissent -> signed receipt -> policy/approval gate -> execution`
 
 Current partner-facing proof surfaces:
 
-### 1. Inbox Trust Wedge
+### 1. Decision Review (Default Surface)
+- The default activation path: run any artifact through multi-agent debate, get a receipt
+- Complete loop on `main`: onboarding -> credentials -> debate with KM context -> receipt -> KM writeback -> dashboard
+- Core claim: Aragora turns any decision into an auditable, shareable receipt with consensus, dissent, and provenance
+
+### 2. Inbox Trust Wedge
 - Real path: `Gmail -> adversarial debate -> signed receipt -> CLI approval -> gmail.modify`
 - Narrow allowed actions are already defined: `ARCHIVE`, `STAR`, `LABEL`, `IGNORE`
 - Core claim: Aragora can take low-risk operational actions only after a persisted receipt and an explicit approval policy
 
-### 2. Ralph Autonomous Loop
+### 3. Ralph Autonomous Loop
 - Supervisor-backed repo improvement loop for bounded tasks
 - Current loop shape: `spec -> deliverable -> review -> blocker classification -> repair -> PR -> merge`
 - Core claim: Aragora can autonomously complete bounded engineering work, recover from critique, and advance toward merge under explicit policy
 
-### 3. Swarm Orchestration
+### 4. Swarm Orchestration
 - Supervisor, worker launcher, reconciler, work leases, and completion receipts are shipped
 - Current posture: bounded work orders, isolated worktrees, one PR-or-blocker stop condition, integrator-controlled merge authority
 - Core claim: Aragora can coordinate multi-lane execution while preserving ownership, receipts, and operator visibility
@@ -48,6 +75,15 @@ The strongest current proof point for design partners is the Ralph V14 benchmark
 - The benchmark closed the loop for `merge_policy=admin_merge_allowed`
 
 Use this as proof that Aragora can autonomously execute bounded work under policy. Do not pitch it as proof of unrestricted autonomy across broad external actions.
+
+### Platform Evidence
+
+- **210,000+ tests** across 5,000+ test files
+- **3,700+ Python modules** | **3,000+ API operations**
+- **45 KM adapters** for cross-system learning
+- **43 agent types** across 6+ LLM providers
+- **EU AI Act compliance: 85/100 score**
+- **Python + TypeScript SDKs** (186 Py / 185 TS namespaces)
 
 ---
 
@@ -157,10 +193,10 @@ Use the ICP checklist in `docs/status/POSITIONING.md` as the base, but apply the
 
 ## Timeline (Calendar Dates)
 
-Current date: 2026-03-20.
+Current date: 2026-03-23. Product loop structurally closed on `main` as of this date.
 
 Recommended Q2 2026 cadence:
-- Weeks of 2026-04-06 and 2026-04-13: outreach, qualification, and surface mapping
+- Weeks of 2026-04-06 and 2026-04-13: outreach, qualification, and surface mapping (lead with the decision review surface and live demo)
 - Weeks of 2026-04-20 and 2026-04-27: select 3-5 design partners, kickoff, and reach first receipt
 - Weeks of 2026-05-04 through 2026-06-12: weekly operating loop, PMF scorecards, and proof capture
 - Weeks of 2026-06-15 and 2026-06-22: case study drafting, pricing/procurement closure, and Q3 scope decision


### PR DESCRIPTION
## Summary
- Updates DESIGN_PARTNER_ONEPAGER.md with Mar 23 product-loop closure milestone
- Updates DESIGN_PARTNER_PROGRAM.md with specific PR evidence and current metrics
- Adds fourth proof surface (Decision Review) and updated platform evidence
- Fixes GitHub URL from an0mium/aragora to synaptent/aragora

Closes #1011

## Test plan
- [x] Docs are internally consistent with current codebase state

🤖 Generated with [Claude Code](https://claude.com/claude-code)