### PR TITLE
fix(dev): keep Codex sessions off billable shell API keys

### DIFF
--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -334,20 +334,30 @@ PY
 }
 trap cleanup_lock EXIT INT TERM
 
+run_sanitized_session() {
+    # Keep billable Anthropic/OpenAI API keys out of managed Codex sessions so
+    # local fixed-cost CLI auth remains authoritative unless the child process
+    # explicitly hydrates its own keys (for example via Aragora secure store).
+    env \
+        -u ANTHROPIC_API_KEY \
+        -u OPENAI_API_KEY \
+        "$@"
+}
+
 if command -v script >/dev/null 2>&1 && [ -t 0 ]; then
     if [[ $# -eq 0 ]]; then
-        script -q "${LOG_FILE}" codex
+        script -q "${LOG_FILE}" env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY codex
     else
-        script -q "${LOG_FILE}" "$@"
+        script -q "${LOG_FILE}" env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY "$@"
     fi
     exit $?
 fi
 
 # Fallback when script(1) is unavailable.
 if [[ $# -eq 0 ]]; then
-    codex 2>&1 | tee -a "${LOG_FILE}"
+    run_sanitized_session codex 2>&1 | tee -a "${LOG_FILE}"
     exit ${PIPESTATUS[0]}
 fi
 
-"$@" 2>&1 | tee -a "${LOG_FILE}"
+run_sanitized_session "$@" 2>&1 | tee -a "${LOG_FILE}"
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- strip `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from managed Codex session children
- keep local fixed-cost Codex and Claude CLI auth authoritative inside `scripts/codex_session.sh`
- leave Aragora secure-store and AWS Secrets Manager hydration paths unchanged

## Why
Local direnv shell exports can override fixed-cost Claude/Codex subscription profiles and accidentally route local work through billable API keys. Aragora itself already supports process-local key hydration via `hydrate_env_from_secure_store()` and production Secrets Manager hydration, but the managed Codex session wrapper was still inheriting shell keys unchanged.

## Validation
- `bash -n scripts/codex_session.sh`
- `env ANTHROPIC_API_KEY=parent-anthropic OPENAI_API_KEY=parent-openai ./scripts/codex_session.sh --managed-dir .worktrees/codex-auto-keytest2 --no-maintain --no-reconcile -- python3 - <<'PY' ...`
  - verified child process sees both vars as `null`

## Notes
- The matching `.envrc` change is intentionally local-only because `.envrc` is gitignored in this repo.
