### PR TITLE
fix(dev): keep Codex sessions off billable shell API keys

### DIFF
--- a/scripts/codex_session.sh
+++ b/scripts/codex_session.sh
@@ -334,20 +334,30 @@ PY
 }
 trap cleanup_lock EXIT INT TERM
 
+run_sanitized_session() {
+    # Keep billable Anthropic/OpenAI API keys out of managed Codex sessions so
+    # local fixed-cost CLI auth remains authoritative unless the child process
+    # explicitly hydrates its own keys (for example via Aragora secure store).
+    env \
+        -u ANTHROPIC_API_KEY \
+        -u OPENAI_API_KEY \
+        "$@"
+}
+
 if command -v script >/dev/null 2>&1 && [ -t 0 ]; then
     if [[ $# -eq 0 ]]; then
-        script -q "${LOG_FILE}" codex
+        script -q "${LOG_FILE}" env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY codex
     else
-        script -q "${LOG_FILE}" "$@"
+        script -q "${LOG_FILE}" env -u ANTHROPIC_API_KEY -u OPENAI_API_KEY "$@"
     fi
     exit $?
 fi
 
 # Fallback when script(1) is unavailable.
 if [[ $# -eq 0 ]]; then
-    codex 2>&1 | tee -a "${LOG_FILE}"
+    run_sanitized_session codex 2>&1 | tee -a "${LOG_FILE}"
     exit ${PIPESTATUS[0]}
 fi
 
-"$@" 2>&1 | tee -a "${LOG_FILE}"
+run_sanitized_session "$@" 2>&1 | tee -a "${LOG_FILE}"
 exit ${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- strip `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` from managed `codex_session.sh` launches
- keep fixed-cost Codex CLI auth authoritative for Codex sessions unless the child process explicitly hydrates its own keys
- apply the same sanitization in both the `script(1)` and fallback execution paths

## Why
The preserved `codex/local-cli-key-coexistence` branch still had one worthwhile dev-safety fix: avoid leaking billable shell API keys into Codex sessions started through Aragora's managed session wrapper.

## Validation
- `bash -n scripts/codex_session.sh`
