### PR TITLE
fix(test): isolate pytest from user-site plugins

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,21 @@
+"""Repository-local Python startup customizations.
+
+Keep pytest runs isolated from user-site packages so local plugins installed
+outside the repo do not change or break the test environment.
+"""
+
+from __future__ import annotations
+
+import site
+import sys
+
+
+def _is_pytest_module_run() -> bool:
+    orig_argv = getattr(sys, "orig_argv", sys.argv)
+    return len(orig_argv) >= 3 and orig_argv[1] == "-m" and orig_argv[2] == "pytest"
+
+
+if _is_pytest_module_run():
+    user_site = site.getusersitepackages()
+    while user_site in sys.path:
+        sys.path.remove(user_site)


### PR DESCRIPTION
## Summary
- add a repository-local `sitecustomize.py` that removes the user-site path for `python -m pytest` runs
- keep local user-installed pytest plugins from silently changing or breaking Aragora's test environment

## Why
This was the last small, clearly useful slice left in the preserved integrations/status branch, and it stands on its own better than bundling it with the larger frontend diff.

## Validation
- `python3 -m py_compile sitecustomize.py`
