### PR TITLE
feat(dev): add isolated Codex profile wrapper

### DIFF
--- a/scripts/codex_profile.sh
+++ b/scripts/codex_profile.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# Explicit Codex CLI profile selector for local Aragora runs.
+#
+# This helper isolates Codex auth state via CODEX_HOME so local fixed-cost
+# Codex subscriptions can coexist with Aragora's own secure-store/API-key paths.
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  codex_profile.sh home <profile-name-or-home>
+  codex_profile.sh status <profile-name-or-home>
+  codex_profile.sh login <profile-name-or-home> [extra codex login args...]
+  codex_profile.sh logout <profile-name-or-home>
+  codex_profile.sh exec <profile-name-or-home> -- <command...>
+
+Examples:
+  scripts/codex_profile.sh status pro-01
+  scripts/codex_profile.sh login pro-02 --device-auth
+  scripts/codex_profile.sh exec pro-01 -- codex
+  scripts/codex_profile.sh exec pro-01 -- \
+    python3 -m aragora.cli.main quickstart --demo --no-browser
+
+Conventions:
+  Bare profile names resolve under ~/.aragora-codex by default.
+  <profile-home> is a directory used as CODEX_HOME for the command it runs.
+EOF
+}
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+if [[ $# -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+MODE="$1"
+PROFILE_HOME="$2"
+shift 2
+
+require_command codex
+
+ORIGINAL_HOME="$HOME"
+PROFILE_ROOT="${CODEX_PROFILE_ROOT:-${ORIGINAL_HOME}/.aragora-codex}"
+
+resolve_profile_home() {
+  local raw_path="$1"
+
+  case "$raw_path" in
+    "~") raw_path="${HOME}" ;;
+    "~"/*) raw_path="${HOME}${raw_path#"~"}" ;;
+    /*) ;;
+    ./*|../*)
+      raw_path="$(cd "$(dirname "$raw_path")" && pwd)/$(basename "$raw_path")"
+      ;;
+    *)
+      raw_path="${PROFILE_ROOT}/${raw_path}"
+      ;;
+  esac
+
+  local raw_parent
+  raw_parent="$(dirname "$raw_path")"
+  mkdir -p "$raw_parent"
+  raw_path="$(cd "$raw_parent" && pwd)/$(basename "$raw_path")"
+  mkdir -p "$raw_path"
+  printf '%s\n' "$raw_path"
+}
+
+PROFILE_HOME="$(resolve_profile_home "$PROFILE_HOME")"
+
+run_with_profile() {
+  CODEX_HOME="${PROFILE_HOME}" \
+  PATH="${PATH}" \
+  env \
+    -u ANTHROPIC_API_KEY \
+    -u OPENAI_API_KEY \
+    "$@"
+}
+
+case "$MODE" in
+  home)
+    if [[ $# -ne 0 ]]; then
+      die "home does not take extra arguments"
+    fi
+    printf '%s\n' "$PROFILE_HOME"
+    ;;
+  status)
+    if [[ $# -ne 0 ]]; then
+      die "status does not take extra arguments"
+    fi
+    run_with_profile codex login status
+    ;;
+  login)
+    echo "Using CODEX_HOME: ${PROFILE_HOME}"
+    run_with_profile codex login "$@"
+    ;;
+  logout)
+    if [[ $# -ne 0 ]]; then
+      die "logout does not take extra arguments"
+    fi
+    run_with_profile codex logout
+    ;;
+  exec)
+    if [[ $# -lt 2 || "$1" != "--" ]]; then
+      die "exec requires '-- <command...>'"
+    fi
+    shift
+    echo "Using CODEX_HOME: ${PROFILE_HOME}"
+    echo "Command: $*"
+    run_with_profile "$@"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/tests/scripts/test_codex_profile.py
+++ b/tests/scripts/test_codex_profile.py
@@ -1,0 +1,83 @@
+"""Tests for scripts/codex_profile.sh."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "codex_profile.sh"
+
+
+def _write_codex_stub(tmp_path: Path) -> Path:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "codex"
+    stub.write_text(
+        """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+print(json.dumps({
+    "argv": sys.argv[1:],
+    "CODEX_HOME": os.environ.get("CODEX_HOME"),
+    "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY"),
+    "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY"),
+}))
+""",
+        encoding="utf-8",
+    )
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    return bin_dir
+
+
+def _run(
+    tmp_path: Path,
+    *args: str,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    bin_dir = _write_codex_stub(tmp_path)
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    env["HOME"] = str(tmp_path / "home")
+    env["OPENAI_API_KEY"] = "parent-openai"
+    env["ANTHROPIC_API_KEY"] = "parent-anthropic"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        [str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_home_returns_default_profile_dir(tmp_path: Path):
+    result = _run(tmp_path, "home", "pro-01")
+    assert result.returncode == 0
+    assert result.stdout.strip() == str((tmp_path / "home" / ".aragora-codex" / "pro-01").resolve())
+
+
+def test_status_uses_isolated_codex_home_and_strips_shell_keys(tmp_path: Path):
+    result = _run(tmp_path, "status", "pro-02")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["argv"] == ["login", "status"]
+    assert payload["CODEX_HOME"] == str((tmp_path / "home" / ".aragora-codex" / "pro-02").resolve())
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["ANTHROPIC_API_KEY"] is None
+
+
+def test_exec_sanitizes_keys_for_arbitrary_child_command(tmp_path: Path):
+    result = _run(tmp_path, "exec", "pro-03", "--", "codex", "exec", "hello")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["argv"] == ["exec", "hello"]
+    assert payload["CODEX_HOME"] == str((tmp_path / "home" / ".aragora-codex" / "pro-03").resolve())
+    assert payload["OPENAI_API_KEY"] is None
+    assert payload["ANTHROPIC_API_KEY"] is None


### PR DESCRIPTION
## Summary
- add `scripts/codex_profile.sh` for explicit per-profile Codex auth isolation
- use `CODEX_HOME` to keep local Codex subscriptions and Aragora API-key workflows separate
- add focused tests covering profile path resolution, `status`, and `exec` key stripping

## Why
The repo already had a Claude-side helper for keeping subscription auth separate from billable API keys. Codex had no equivalent tracked helper. This wrapper gives a first-class path for direct Codex use without relying on ambient `OPENAI_API_KEY` in the shell.

## Validation
- `bash -n scripts/codex_profile.sh`
- `python3 -m pytest tests/scripts/test_codex_profile.py -q`
- `scripts/codex_profile.sh status <empty-profile-dir>`
  - returns `Not logged in`, proving profile isolation via `CODEX_HOME`

## Notes
- `#1191` already landed the managed-session side via `scripts/codex_session.sh`
- the local `.envrc` change remains intentionally local-only because `.envrc` is gitignored
