### PR TITLE
fix(pmf): 4 surgical fixes for the canonical founder loop

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -423,6 +423,59 @@ def _maybe_add_vertical_specialist_local(
     return agents
 
 
+def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
+    """Generate and persist a debate receipt to ~/.aragora/receipts/.
+
+    Returns the receipt file path, or None if receipt generation fails.
+    """
+    try:
+        import hashlib
+        import json
+        from pathlib import Path
+
+        receipts_dir = Path.home() / ".aragora" / "receipts"
+        receipts_dir.mkdir(parents=True, exist_ok=True)
+
+        debate_id = getattr(result, "debate_id", None) or "unknown"
+        consensus_reached = getattr(result, "consensus_reached", False)
+        confidence = getattr(result, "confidence", 0.0)
+        final_answer = getattr(result, "final_answer", "") or ""
+
+        receipt = {
+            "debate_id": debate_id,
+            "task": getattr(result, "task", ""),
+            "consensus_reached": consensus_reached,
+            "confidence": round(confidence, 4) if confidence else 0.0,
+            "final_answer": final_answer[:2000],
+            "rounds_used": getattr(result, "rounds_used", 0),
+            "agents": [
+                getattr(m, "agent", "unknown") for m in (getattr(result, "messages", []) or [])[:20]
+            ],
+            "dissenting_views": [
+                str(v)[:500] for v in (getattr(result, "dissenting_views", []) or [])
+            ],
+        }
+
+        content_hash = hashlib.sha256(
+            json.dumps(receipt, sort_keys=True, default=str).encode()
+        ).hexdigest()[:16]
+        receipt["content_hash"] = content_hash
+
+        filename = f"{debate_id}_{content_hash}.json"
+        receipt_path = receipts_dir / filename
+        receipt_path.write_text(json.dumps(receipt, indent=2, default=str), encoding="utf-8")
+
+        if verbose:
+            print(f"[receipt] persisted debate_id={debate_id} hash={content_hash}", file=sys.stderr)
+
+        return str(receipt_path)
+
+    except (OSError, TypeError, ValueError, AttributeError) as e:
+        if verbose:
+            print(f"[receipt] failed to persist: {e}", file=sys.stderr)
+        return None
+
+
 def _print_debate_result(debate: Any, verbose: bool = False) -> None:
     """Print a standard debate result summary."""
     final_answer = None
@@ -2101,6 +2154,13 @@ def cmd_ask(args: argparse.Namespace) -> None:
         print("DISSENTING VIEWS:")
         for view in result.dissenting_views:
             print(f"\n{view}")
+
+    # Auto-persist receipt for audit trail
+    receipt_path = _persist_debate_receipt(result, verbose=args.verbose)
+    if receipt_path:
+        print(f"\nReceipt saved: {receipt_path}")
+        print(f"  View:   aragora receipt view {receipt_path}")
+        print(f"  Verify: aragora receipt verify {receipt_path}")
 
     if decision_integrity:
         if di_execution_mode and di_execution_mode != "plan_only":

--- a/aragora/debate/arena_config.py
+++ b/aragora/debate/arena_config.py
@@ -431,7 +431,7 @@ class ArenaConfig:
         # Protocol-level flags (stored for preset passthrough to Arena/Protocol)
         enable_adaptive_consensus: bool = False,
         enable_synthesis: bool = False,
-        enable_knowledge_injection: bool = False,
+        enable_knowledge_injection: bool = True,
         enable_meta_learning: bool = False,
         # RLM (Recursive Language Models): context compression for long debates
         enable_rlm: bool = False,

--- a/aragora/debate/protocol.py
+++ b/aragora/debate/protocol.py
@@ -560,7 +560,7 @@ class DebateProtocol:
 
     # Knowledge injection flywheel: Injects past debate receipts from KM into context
     # Completes the loop: Debate → Receipt → KM (persist) → KM (query) → Next Debate
-    enable_knowledge_injection: bool = False  # Opt-in: requires Knowledge Mound
+    enable_knowledge_injection: bool = True  # On by default to close the knowledge flywheel
     knowledge_injection_max_receipts: int = 3  # Max past receipts to inject
 
     # Codebase grounding: Inject codebase structure into debate context

--- a/aragora/server/debate_factory.py
+++ b/aragora/server/debate_factory.py
@@ -691,6 +691,9 @@ class DebateFactory:
         # Enable position ledger auto-creation for truth grounding
         builder = builder.with_enable_position_ledger(True)
 
+        # Enable performance-aware agent selection (integrates ProviderRouter hints)
+        builder = builder.with_performance_selection(use_performance_selection=True)
+
         # Pass feature flags from config if specified
         if any(
             v is not None

--- a/aragora/server/handler_registry/__init__.py
+++ b/aragora/server/handler_registry/__init__.py
@@ -538,6 +538,26 @@ class HandlerRegistryMixin:
                 self.end_headers()
                 self.wfile.write(result.body)
                 return True
+        except ImportError as e:
+            # Subsystem not available — return 503 not 500
+            logger.warning(
+                "[handlers] Subsystem unavailable in %s: %s", handler.__class__.__name__, e
+            )
+            body_503 = json.dumps(
+                {
+                    "error": "Feature temporarily unavailable",
+                    "code": "subsystem_unavailable",
+                }
+            ).encode()
+            self.send_response(503)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body_503)))
+            self._add_cors_headers()
+            self._add_security_headers()
+            self._add_trace_headers()
+            self.end_headers()
+            self.wfile.write(body_503)
+            return True
         except (
             RuntimeError,
             OSError,


### PR DESCRIPTION
## Summary

4 small, zero-conflict fixes targeting the canonical founder loop acceptance criteria:

1. **KM flywheel default-on** — `enable_knowledge_injection=True` in DebateProtocol and ArenaConfig
2. **ImportError→503** — Handler dispatch returns structured JSON 503 instead of opaque 500
3. **Receipt auto-persistence** — `_persist_debate_receipt()` saves to `~/.aragora/receipts/` after every `aragora ask`
4. **Performance selection in factory** — DebateFactory enables `use_performance_selection=True`

## Test plan
- [ ] `python -c "import ast; ast.parse(open('aragora/debate/protocol.py').read())"` — syntax check
- [ ] Existing orchestrator tests pass (no regressions expected — additive changes only)
- [ ] Handler registry test covers ImportError path

5 files changed, 85 insertions(+), 2 deletions(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)