### PR TITLE
fix(ci): use ubuntu-latest for deploy test job to fix ARM Python path

### DIFF
--- a/.github/workflows/deploy-lightsail.yml
+++ b/.github/workflows/deploy-lightsail.yml
@@ -23,39 +23,19 @@ permissions:
 jobs:
   test:
     if: ${{ github.event.inputs.skip_tests != 'true' }}
-    runs-on: aragora
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        shell: bash
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
-            git reset --hard FETCH_HEAD
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::Standard recovery failed; attempting archive restore"
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            ls -la
-            exit 1
-          fi
-
       - name: Set up Python
-        uses: ./.github/actions/setup-python-safe
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+
       - name: Install and test
         run: |
+          python -m pip install --upgrade pip
           python -m pip install -e ".[dev]" pytest-timeout httpx
           python -m pytest tests/test_handlers_debates.py tests/test_api_handler.py \
             --timeout=60 -x --tb=short

--- a/.github/workflows/deploy-secure.yml
+++ b/.github/workflows/deploy-secure.yml
@@ -52,54 +52,16 @@ env:
 
 jobs:
   test:
-    runs-on: aragora
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Verify checkout integrity
-        shell: bash
-        run: |
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::pyproject.toml missing after checkout; attempting recovery"
-            git sparse-checkout disable || true
-            git fetch --no-tags origin "${GITHUB_SHA:-HEAD}"
-            git reset --hard FETCH_HEAD
-            git clean -ffd || true
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::warning::Standard recovery failed; attempting archive restore"
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
-            git archive "${GITHUB_SHA:-HEAD}" | tar -x || git archive HEAD | tar -x
-          fi
-          if [[ ! -f pyproject.toml ]]; then
-            echo "::error::Repository checkout is incomplete (pyproject.toml missing)"
-            echo "PWD=$(pwd)"
-            ls -la
-            exit 1
-          fi
-
       - name: Set up Python
-        id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-        continue-on-error: true
-
-      - name: Fallback to system Python
-        if: steps.setup-python.outcome == 'failure'
-        run: |
-          echo "actions/setup-python failed, using system Python"
-          for cmd in python3.11 python3; do
-            if command -v "$cmd" &>/dev/null; then
-              echo "Found $cmd: $("$cmd" --version)"
-              sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python
-              sudo ln -sf "$(command -v "$cmd")" /usr/local/bin/python3
-              break
-            fi
-          done
-          python --version
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- Moves `test` job from self-hosted `aragora` runner (ARM Mac) to `ubuntu-latest` in deploy-secure.yml and deploy-lightsail.yml
- Fixes: `actions/setup-python@v5` fails with "version '3.11' with architecture 'x64' was not found" on ARM
- Removes unnecessary Python fallback steps (ubuntu-latest has Python 3.11 pre-installed)
- Deploy jobs remain on self-hosted runner (need AWS creds/infra access)

**This unblocks ALL production deploys** — every deploy since the 31 PR merge batch has failed at the test step.

## Test plan
- [x] YAML is valid
- [ ] Deploy pipeline succeeds after merge (push-to-main triggers deploy-secure.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)