### PR TITLE
fix(knowledge): fall back when semantic embedding requests are rate limited

### DIFF
--- a/aragora/knowledge/mound/api/query.py
+++ b/aragora/knowledge/mound/api/query.py
@@ -17,6 +17,7 @@ comments suppress mypy warnings that are expected for this mixin pattern.
 
 from __future__ import annotations
 
+import aiohttp
 import asyncio
 import logging
 import time
@@ -526,7 +527,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                     if node:
                         items.append(node)
                 return items
-            except (RuntimeError, ValueError, OSError) as e:
+            except (RuntimeError, ValueError, OSError, aiohttp.ClientError) as e:
                 logger.warning("Semantic store search failed: %s, falling back", e)
 
         if not allow_fallback:

--- a/tests/knowledge/test_mound_facade.py
+++ b/tests/knowledge/test_mound_facade.py
@@ -1,5 +1,6 @@
 """Tests for enhanced Knowledge Mound facade."""
 
+import aiohttp
 import asyncio
 import pytest
 import tempfile
@@ -642,6 +643,37 @@ class TestKnowledgeMoundAdvanced:
 
         # Results depend on embedding availability
         assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_query_semantic_falls_back_on_embedding_rate_limit(self, mound):
+        """Semantic search should fail soft when embedding generation is rate-limited."""
+        fallback_item = MagicMock()
+        mound._vector_store = None
+        mound._semantic_store = MagicMock()
+        mound._semantic_store.search_similar = AsyncMock(
+            side_effect=aiohttp.ClientError("Rate limited")
+        )
+        mound.query = AsyncMock(
+            return_value=QueryResult(
+                items=[fallback_item],
+                total_count=1,
+                query="ML classification",
+                execution_time_ms=1.0,
+            )
+        )
+
+        results = await mound.query_semantic(
+            text="ML classification",
+            limit=3,
+            workspace_id="test_workspace",
+        )
+
+        assert results == [fallback_item]
+        mound.query.assert_awaited_once_with(
+            "ML classification",
+            limit=3,
+            workspace_id="test_workspace",
+        )
 
     @pytest.mark.asyncio
     async def test_query_graph(self, mound):


### PR DESCRIPTION
## Summary
- catch `aiohttp.ClientError` in Knowledge Mound semantic search so embedding rate limits fail soft into keyword fallback
- add a regression test covering the rate-limited embedding path
- preserve the founder-loop investigation by narrowing the next blocker instead of letting KM retrieval abort semantic query

## Verification
- `python3 -m ruff check aragora/knowledge/mound/api/query.py tests/knowledge/test_mound_facade.py`
- `python3 -m pytest tests/knowledge/test_mound_facade.py -q`
- live proof with TLS certifi workaround:
  - before patch: quickstart hit `aiohttp.client_exceptions.ClientError: Rate limited` in KM semantic retrieval and ended with `Live debate timed out after 75s`
  - after patch: live run logs `Semantic store search failed: Rate limited, falling back` and continues far enough to expose the next blocker (`pulse.ingestor` retries / Reddit `403 Blocked`)

## Notes
- refs #1200
- this does not claim full founder-loop success; it removes one concrete blocker and exposes the next one truthfully
