### PR TITLE
fix(cli): make live quickstart use a bounded fast path

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -31,13 +31,35 @@ from typing import Any, cast
 logger = logging.getLogger(__name__)
 
 _DEFAULT_QUESTION = "Should we adopt microservices or keep our monolith?"
+_DEMO_DEFAULT_ROUNDS = 2
+_LIVE_DEFAULT_ROUNDS = 1
 _LIVE_PRECHECK_TIMEOUT_SECONDS = 3.0
-_LIVE_DEBATE_TIMEOUT_SECONDS = 75.0
+_LIVE_DEBATE_TIMEOUT_SECONDS = 120.0
 _LIVE_ROLES: tuple[tuple[str, str], ...] = (
     ("proposer", "proposer"),
     ("critic", "critic"),
     ("synthesizer", "synthesizer"),
 )
+_LIVE_PROVIDER_PRIORITY: tuple[str, ...] = (
+    "openai-api",
+    "gemini",
+    "anthropic-api",
+    "mistral",
+    "grok",
+    "deepseek",
+)
+_LIVE_ARENA_KWARGS: dict[str, Any] = {
+    "knowledge_mound": None,
+    "auto_create_knowledge_mound": False,
+    "enable_knowledge_retrieval": False,
+    "enable_knowledge_ingestion": False,
+    "enable_cross_debate_memory": False,
+    "use_rlm_limiter": False,
+    "enable_ml_delegation": False,
+    "enable_quality_gates": False,
+    "enable_consensus_estimation": False,
+    "disable_post_debate_pipeline": True,
+}
 _PROVIDER_TLS_HOSTS: dict[str, str] = {
     "anthropic-api": "api.anthropic.com",
     "openai-api": "api.openai.com",
@@ -49,17 +71,17 @@ _PROVIDER_TLS_HOSTS: dict[str, str] = {
 _PROVIDER_SPECS: dict[str, dict[str, Any]] = {
     "anthropic": {
         "agent_type": "anthropic-api",
-        "model": "claude-sonnet-4-5-20250929",
+        "model": "claude-haiku-4-5-20251001",
         "env_vars": ("ANTHROPIC_API_KEY",),
     },
     "openai": {
         "agent_type": "openai-api",
-        "model": "gpt-4o",
+        "model": "gpt-4o-mini",
         "env_vars": ("OPENAI_API_KEY",),
     },
     "gemini": {
         "agent_type": "gemini",
-        "model": None,
+        "model": "gemini-2.0-flash",
         "env_vars": ("GEMINI_API_KEY",),
     },
     "mistral": {
@@ -92,10 +114,10 @@ def add_quickstart_parser(subparsers: Any) -> None:
         "quickstart",
         help="Guided zero-to-receipt first debate (new user onboarding)",
         description="""
-Run your first adversarial debate in under 60 seconds.
+Run your first adversarial debate with a bounded live onboarding path.
 
 Automatically detects available API keys, picks agents, runs a fast
-2-round debate, and opens the decision receipt in your browser.
+live debate, and opens the decision receipt in your browser.
 No configuration needed.
 
 Examples:
@@ -142,8 +164,8 @@ Examples:
         "--rounds",
         "-r",
         type=int,
-        default=2,
-        help="Number of debate rounds (default: 2)",
+        default=None,
+        help="Number of debate rounds (default: 2 for demo, 1 for live quickstart)",
     )
     qs_parser.add_argument(
         "--format",
@@ -267,6 +289,13 @@ def _get_question(args: argparse.Namespace) -> str | None:
         return None
 
 
+def _resolve_rounds(requested_rounds: int | None, *, use_demo: bool) -> int:
+    """Resolve quickstart rounds with mode-specific defaults."""
+    if requested_rounds is not None:
+        return requested_rounds
+    return _DEMO_DEFAULT_ROUNDS if use_demo else _LIVE_DEFAULT_ROUNDS
+
+
 def _default_receipt_path(mode: str, fmt: str) -> Path:
     """Return the default saved artifact path for quickstart results."""
     receipts_dir = Path.cwd() / ".aragora" / "receipts"
@@ -388,7 +417,17 @@ async def _run_live_debate(
         raise RuntimeError("No live debate team could be assembled for quickstart")
 
     env = Environment(task=question)
-    protocol = DebateProtocol(rounds=rounds, consensus="majority")
+    protocol = DebateProtocol(
+        rounds=rounds,
+        consensus="majority",
+        convergence_detection=False,
+        vote_grouping=False,
+        enable_trickster=False,
+        enable_research=False,
+        enable_trending_injection=False,
+        enable_llm_question_classification=False,
+        enable_llm_synthesis=False,
+    )
     store = CritiqueStore()
 
     agents = []
@@ -405,7 +444,9 @@ async def _run_live_debate(
         agents.append(agent)
         agent_names.append(agent.name)
 
-    arena = Arena(env, agents, protocol, insight_store=store)
+    # Quickstart is a bounded onboarding lane, not the full debate control plane.
+    arena = Arena(env, agents, protocol, insight_store=store, **_LIVE_ARENA_KWARGS)
+    arena.enable_introspection = False
     try:
         result = await asyncio.wait_for(arena.run(), timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
     except TimeoutError as exc:
@@ -445,8 +486,22 @@ def _build_live_team(
             }
         )
     else:
-        for agent_type, model in agents_list[:4]:
-            provider_configs.append({"provider": agent_type, "model": model, "api_key": None})
+        selected_provider = next(
+            (
+                (agent_type, model)
+                for preferred in _LIVE_PROVIDER_PRIORITY
+                for agent_type, model in agents_list[:4]
+                if agent_type == preferred
+            ),
+            agents_list[0],
+        )
+        provider_configs.append(
+            {
+                "provider": selected_provider[0],
+                "model": selected_provider[1],
+                "api_key": None,
+            }
+        )
 
     team: list[dict[str, Any]] = []
     for index, (role, role_label) in enumerate(_LIVE_ROLES):
@@ -702,7 +757,7 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
 
     # Step 3: Detect agents
     use_demo = getattr(args, "demo", False)
-    rounds = getattr(args, "rounds", 2)
+    rounds = _resolve_rounds(getattr(args, "rounds", None), use_demo=use_demo)
     provider = getattr(args, "provider", None)
     inline_api_key = getattr(args, "api_key", None)
     try:
@@ -737,7 +792,12 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
             print("    Agents: analyst (supportive), critic (critical), synthesizer (balanced)")
             use_demo = True
         else:
-            providers = [p for p, _ in detected[:4]]
+            preview_team = _build_live_team(
+                detected[:4],
+                provider=normalized_provider,
+                api_key=inline_api_key,
+            )
+            providers = list(dict.fromkeys(str(member["provider"]) for member in preview_team))
             print("\n[+] Run mode: live")
             print(f"    Agents: {', '.join(providers)}")
 

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -23,6 +23,7 @@ from aragora.cli.commands.quickstart import (
     _load_dotenv,
     _normalize_provider,
     _open_receipt_in_browser,
+    _resolve_rounds,
     _run_live_debate,
     _save_receipt,
     add_quickstart_parser,
@@ -142,7 +143,7 @@ class TestDetectAgents:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic")
         agents = _detect_agents("openai")
-        assert agents == [("openai-api", "gpt-4o")]
+        assert agents == [("openai-api", "gpt-4o-mini")]
 
     def test_invalid_preferred_provider_raises(self):
         with pytest.raises(ValueError, match="Unsupported provider"):
@@ -206,6 +207,17 @@ class TestGetQuestion:
         monkeypatch.setattr("builtins.input", lambda _: "")
         args = argparse.Namespace(question=None, demo=False)
         assert _get_question(args) is None
+
+
+class TestResolveRounds:
+    def test_demo_defaults_to_two_rounds(self):
+        assert _resolve_rounds(None, use_demo=True) == 2
+
+    def test_live_defaults_to_one_round(self):
+        assert _resolve_rounds(None, use_demo=False) == 1
+
+    def test_explicit_rounds_win(self):
+        assert _resolve_rounds(4, use_demo=False) == 4
 
 
 # =============================================================================
@@ -346,6 +358,17 @@ class TestLiveQuickstartHelpers:
         assert [agent["provider"] for agent in team] == ["openai-api"] * 3
         assert [agent["api_key"] for agent in team] == ["sk-inline"] * 3
 
+    def test_build_live_team_defaults_to_single_preferred_provider(self):
+        team = _build_live_team(
+            [
+                ("anthropic-api", "claude-sonnet-4-5-20250929"),
+                ("openai-api", "gpt-4o"),
+                ("gemini", None),
+            ]
+        )
+
+        assert [agent["provider"] for agent in team] == ["openai-api"] * 3
+
     def test_build_live_receipt_surfaces_consensus_dissent_and_receipt(self):
         from aragora.gauntlet.receipt_models import DecisionReceipt
 
@@ -453,6 +476,59 @@ class TestCmdQuickstart:
                 )
 
     @pytest.mark.asyncio
+    async def test_run_live_debate_uses_bounded_quickstart_profile(self):
+        """Live quickstart should disable heavyweight debate subsystems by default."""
+        mock_agent = MagicMock()
+        mock_agent.name = "openai-api"
+        mock_result = argparse.Namespace()
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._filter_reachable_live_agents",
+                return_value=[("openai-api", "gpt-4o")],
+            ),
+            patch("aragora.agents.base.create_agent", return_value=mock_agent),
+            patch(
+                "aragora.cli.commands.quickstart._build_live_receipt",
+                return_value={"mode": "live", "rounds": 1},
+            ),
+            patch("aragora.debate.orchestrator.Arena") as mock_arena_cls,
+        ):
+            mock_arena = MagicMock()
+            mock_arena.run = AsyncMock(return_value=mock_result)
+            mock_arena_cls.return_value = mock_arena
+
+            await _run_live_debate(
+                "Should we ship the quickstart path?",
+                [("openai-api", "gpt-4o")],
+                rounds=1,
+            )
+
+        protocol = mock_arena_cls.call_args.args[2]
+        assert protocol.rounds == 1
+        assert protocol.consensus == "majority"
+        assert protocol.convergence_detection is False
+        assert protocol.vote_grouping is False
+        assert protocol.enable_trickster is False
+        assert protocol.enable_research is False
+        assert protocol.enable_trending_injection is False
+        assert protocol.enable_llm_question_classification is False
+        assert protocol.enable_llm_synthesis is False
+
+        arena_kwargs = mock_arena_cls.call_args.kwargs
+        assert arena_kwargs["knowledge_mound"] is None
+        assert arena_kwargs["auto_create_knowledge_mound"] is False
+        assert arena_kwargs["enable_knowledge_retrieval"] is False
+        assert arena_kwargs["enable_knowledge_ingestion"] is False
+        assert arena_kwargs["enable_cross_debate_memory"] is False
+        assert arena_kwargs["use_rlm_limiter"] is False
+        assert arena_kwargs["enable_ml_delegation"] is False
+        assert arena_kwargs["enable_quality_gates"] is False
+        assert arena_kwargs["enable_consensus_estimation"] is False
+        assert arena_kwargs["disable_post_debate_pipeline"] is True
+        assert mock_arena.enable_introspection is False
+
+    @pytest.mark.asyncio
     async def test_filter_reachable_live_agents_raises_clean_tls_error(self):
         """Quickstart should stop before debate startup when TLS verification fails."""
         with patch(
@@ -513,6 +589,72 @@ class TestCmdQuickstart:
         output = capsys.readouterr().out
         assert "QUICKSTART" in output
         assert "consensus" in output.lower()
+
+    def test_live_mode_defaults_to_one_round_when_unspecified(self, capsys):
+        args = argparse.Namespace(
+            question="Should we use the live default?",
+            demo=False,
+            provider=None,
+            api_key=None,
+            save_key=False,
+            output=None,
+            format="json",
+            rounds=None,
+            no_browser=True,
+        )
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._detect_agents",
+                return_value=[("openai-api", "gpt-4o")],
+            ),
+            patch(
+                "aragora.cli.commands.quickstart._run_live_debate",
+                return_value={
+                    "question": "Should we use the live default?",
+                    "verdict": "approve",
+                    "confidence": 0.8,
+                    "rounds": 1,
+                    "agents": ["openai-api"],
+                    "summary": "Use the bounded live default.",
+                    "dissent": [],
+                    "mode": "live",
+                },
+            ) as run_live_debate,
+        ):
+            cmd_quickstart(args)
+
+        assert run_live_debate.call_args.args[2] == 1
+
+    def test_demo_mode_defaults_to_two_rounds_when_unspecified(self, capsys):
+        args = argparse.Namespace(
+            question="Should we use the demo default?",
+            demo=True,
+            provider=None,
+            api_key=None,
+            save_key=False,
+            output=None,
+            format="json",
+            rounds=None,
+            no_browser=True,
+        )
+
+        with patch(
+            "aragora.cli.commands.quickstart._run_demo_debate",
+            return_value={
+                "question": "Should we use the demo default?",
+                "verdict": "consensus",
+                "confidence": 0.85,
+                "rounds": 2,
+                "agents": ["analyst", "critic", "synthesizer"],
+                "summary": "Keep demo defaults stable.",
+                "dissent": [],
+                "mode": "demo",
+            },
+        ) as run_demo_debate:
+            cmd_quickstart(args)
+
+        assert run_demo_debate.call_args.args[1] == 2
 
     def test_no_question_exits(self):
         """Test that missing question causes exit."""
@@ -608,6 +750,7 @@ class TestCmdQuickstart:
 
         output = capsys.readouterr().out
         assert "Run mode: live" in output
+        assert "Agents: openai-api" in output
         assert "Mode:       Live" in output
         assert str(artifact_path.resolve()) in output
 


### PR DESCRIPTION
## Summary
- make live quickstart use a bounded 1-round profile by default
- keep the live onboarding lane on a single preferred provider instead of a mixed-provider team
- disable semantic convergence, vote grouping, and trickster in live quickstart so it does not cold-load the local sentence-transformers/NLI stack
- add focused quickstart coverage for mode-specific round defaults and the bounded live profile

## Root Cause
The founder-loop timeout was not a single external provider failure. Quickstart was still invoking debate features that lazily initialize the shared semantic similarity backend. That backend cold-loads `cross-encoder/nli-deberta-v3-small`, which adds substantial local startup cost before the live debate can finish.

For the bounded quickstart lane, those features were not required to produce a truthful receipt:
- semantic convergence detection
- semantic vote grouping
- trickster-driven novelty checks

## Verification
- `python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- live proof:
  - `SSL_CERT_FILE="$(python3 -c 'import certifi; print(certifi.where())')" ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser`

## Live Proof Result
- return code: `0`
- duration: `53.45s`
- receipt emitted: yes
- selected agent surface: `Agents: openai-api`
- `DebertaV2ForSequenceClassification` no longer appears in the log for the successful default path

## Residual Risk
- quickstart still emits pre-existing warnings from unrelated subsystems:
  - `python3-saml` / `xmlsec` mismatch warning
  - async PostgreSQL fallback warning
  - `CritiqueStore` insight extraction warning
- the receipt currently reports confidence values over 100%; that pre-existing formatting/data issue is not changed here
