### PR TITLE
fix(playground): fix mistral agent type and add mock fallback

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -1861,16 +1861,21 @@ class PlaygroundHandler(BaseHandler):
                     )
                 logger.info("Multi-perspective call failed — trying live debate")
 
-        # Run a real live debate (no mock fallback)
+        # Run a real live debate, fall back to mock if it fails
         try:
             live_result = self._run_live_debate(question or topic, rounds, agent_count)
-            return self._persist_and_respond(live_result, topic, source, **_cache_kw)
-        except (TimeoutError, ValueError, RuntimeError, OSError) as exc:
-            logger.warning("Live debate failed: %s", exc)
-            return error_response(
-                "Debate temporarily unavailable. Please try again in a moment.",
-                503,
+            # Check if live debate returned an error response (status >= 400)
+            if live_result.status_code < 400:
+                return self._persist_and_respond(live_result, topic, source, **_cache_kw)
+            logger.info(
+                "Live debate returned status %d, falling back to mock", live_result.status_code
             )
+        except (TimeoutError, ValueError, RuntimeError, OSError) as exc:
+            logger.warning("Live debate failed, falling back to mock: %s", exc)
+
+        # Mock fallback -- always works, no external dependencies
+        mock_data = _run_inline_mock_debate(topic, rounds, agent_count, question=question)
+        return self._persist_and_respond(json_response(mock_data), topic, source, **_cache_kw)
 
     @staticmethod
     def _persist_and_respond(
@@ -2327,7 +2332,7 @@ def _get_available_live_agents(count: int) -> list[str]:
     if _get_api_key("OPENAI_API_KEY"):
         candidates.append("openai-api")
     if _get_api_key("MISTRAL_API_KEY"):
-        candidates.append("mistral-api")
+        candidates.append("mistral")
 
     # If we have enough primary agents, use them
     if len(candidates) >= count:

--- a/tests/server/handlers/test_playground.py
+++ b/tests/server/handlers/test_playground.py
@@ -433,14 +433,33 @@ class TestRateLimiting:
 
 
 class TestGracefulDegradation:
-    def test_no_live_debate_returns_503(self, handler, mock_http_handler):
-        """When live debate is unavailable, returns 503 instead of mock."""
+    def test_live_debate_failure_falls_back_to_mock(self, handler, mock_http_handler):
+        """When live debate fails, falls back to inline mock debate."""
         with patch.object(
             handler,
             "_run_live_debate",
             side_effect=RuntimeError("Live debate unavailable"),
         ):
-            result = handler._run_debate("test", 1, 2)
+            result = handler._run_debate("test topic", 1, 2)
             data, status = _parse_result(result)
-            assert status == 503
-            assert "unavailable" in data.get("error", "").lower()
+            assert status == 200
+            assert "id" in data
+            assert "proposals" in data
+            assert "participants" in data
+            assert len(data["participants"]) == 2
+
+    def test_live_debate_error_response_falls_back_to_mock(self, handler, mock_http_handler):
+        """When live debate returns an error status, falls back to mock."""
+        from aragora.server.handlers.base import error_response as _er
+
+        with patch.object(
+            handler,
+            "_run_live_debate",
+            return_value=_er("Live debate failed", 500),
+        ):
+            result = handler._run_debate("test topic", 1, 3)
+            data, status = _parse_result(result)
+            assert status == 200
+            assert "id" in data
+            assert data["topic"] == "test topic"
+            assert len(data["participants"]) == 3

--- a/tests/server/handlers/test_playground_openrouter_agents.py
+++ b/tests/server/handlers/test_playground_openrouter_agents.py
@@ -88,7 +88,7 @@ class TestGetAvailableLiveAgentsAllPrimary:
         )
         agents = _get_available_live_agents(3)
 
-        assert agents == ["anthropic-api", "openai-api", "mistral-api"]
+        assert agents == ["anthropic-api", "openai-api", "mistral"]
 
     @patch("aragora.server.handlers.playground._get_api_key")
     def test_no_openrouter_tags_when_primary_sufficient(self, mock_key):


### PR DESCRIPTION
## Summary
- Fixes `"mistral-api"` → `"mistral"` in `_get_available_live_agents()` (invalid agent type caused ValueError)
- Adds mock fallback in `_run_debate()`: if live debate fails, falls back to `_run_inline_mock_debate()` instead of returning 500
- The playground demo endpoint now ALWAYS returns a response, even if LLM providers are down

**This fixes the production 500 on POST /api/v1/playground/debate**

Root cause: `AgentSpec.__post_init__` rejected `"mistral-api"` — the valid type is `"mistral"`. With the mock fallback, even if future agent issues arise, the demo endpoint stays functional.

## Test plan
- [x] 71 playground tests pass (including updated degradation test)
- [ ] Verify api.aragora.ai/api/v1/playground/debate returns a debate after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)