### PR TITLE
fix(cli): quickstart falls back to demo on TLS/provider failure

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -725,14 +725,18 @@ async def _filter_reachable_live_agents(
     if reachable:
         return reachable
 
+    # All providers failed TLS — return empty list instead of crashing.
+    # The caller falls back to demo mode when no live agents are available.
     if certificate_failure:
         providers = ", ".join(provider for provider, _ in limited_agents)
-        raise RuntimeError(
-            f"Provider TLS verification failed for {providers}. Check the local CA trust store."
+        logger.warning(
+            "Provider TLS verification failed for %s. Check the local CA trust store.", providers
         )
+    else:
+        failure_summary = "; ".join(failures) if failures else "no providers available"
+        logger.warning("No live providers passed connectivity preflight: %s", failure_summary)
 
-    failure_summary = "; ".join(failures) if failures else "no providers available"
-    raise RuntimeError(f"No live providers passed connectivity preflight: {failure_summary}")
+    return []
 
 
 def cmd_quickstart(args: argparse.Namespace) -> None:
@@ -819,12 +823,23 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
                 )
             )
     except (OSError, ConnectionError, RuntimeError, ValueError, TypeError) as e:
-        logger.debug("Debate failed: %s", e)
-        print(f"\n[!] Debate failed: {e}")
-        if "CERTIFICATE_VERIFY_FAILED" in str(e):
-            print("    Provider TLS verification failed. Check the local CA trust store.")
-        print("    Try: aragora quickstart --demo")
-        sys.exit(1)
+        logger.debug("Live debate failed, falling back to demo: %s", e)
+        error_str = str(e)
+        if "TLS" in error_str or "CERTIFICATE" in error_str:
+            print("\n[!] Provider TLS check failed. Falling back to demo mode.")
+            print("    Check the local CA trust store for live debates.")
+        elif "No live" in error_str or "no live" in error_str:
+            print("\n[!] No live providers available. Falling back to demo mode.")
+        else:
+            print(f"\n[!] Live debate failed: {e}")
+            print("    Falling back to demo mode.")
+        # Fall back to demo — the user should always get a result
+        try:
+            result = asyncio.run(_run_demo_debate(question, rounds))
+        except (OSError, RuntimeError, ValueError) as demo_err:
+            logger.debug("Demo debate also failed: %s", demo_err)
+            print(f"\n[!] Demo debate also failed: {demo_err}")
+            sys.exit(1)
 
     elapsed = time.monotonic() - start_time
     result["elapsed_seconds"] = elapsed

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -529,14 +529,16 @@ class TestCmdQuickstart:
         assert mock_arena.enable_introspection is False
 
     @pytest.mark.asyncio
-    async def test_filter_reachable_live_agents_raises_clean_tls_error(self):
-        """Quickstart should stop before debate startup when TLS verification fails."""
+    async def test_filter_reachable_live_agents_returns_empty_on_tls_failure(self):
+        """When all providers fail TLS, return empty list for demo fallback."""
         with patch(
             "aragora.cli.commands.quickstart._can_reach_provider_tls",
             new=AsyncMock(return_value=(False, "CERTIFICATE_VERIFY_FAILED")),
         ):
-            with pytest.raises(RuntimeError, match="CA trust store"):
-                await _filter_reachable_live_agents([("openai-api", "gpt-4o"), ("gemini", None)])
+            result = await _filter_reachable_live_agents(
+                [("openai-api", "gpt-4o"), ("gemini", None)]
+            )
+            assert result == []
 
     @pytest.mark.asyncio
     async def test_filter_reachable_live_agents_keeps_healthy_subset(self):
@@ -868,8 +870,8 @@ class TestCmdQuickstart:
         output = capsys.readouterr().out
         assert "Falling back to demo mode" in output
 
-    def test_live_mode_exits_cleanly_on_tls_failure(self, capsys):
-        """TLS/provider failures should surface a clear operator hint."""
+    def test_live_mode_falls_back_to_demo_on_tls_failure(self, capsys):
+        """TLS/provider failures should fall back to demo mode, not exit."""
         args = argparse.Namespace(
             question="Should we use the live path?",
             demo=False,
@@ -882,6 +884,17 @@ class TestCmdQuickstart:
             no_browser=True,
         )
 
+        mock_demo_result = {
+            "question": "Should we use the live path?",
+            "verdict": "consensus",
+            "confidence": 0.85,
+            "rounds": 2,
+            "agents": ["analyst", "critic", "synthesizer"],
+            "summary": "Demo result",
+            "dissent": [],
+            "mode": "demo",
+        }
+
         with (
             patch(
                 "aragora.cli.commands.quickstart._detect_agents",
@@ -889,15 +902,15 @@ class TestCmdQuickstart:
             ),
             patch(
                 "aragora.cli.commands.quickstart._run_live_debate",
-                side_effect=RuntimeError(
-                    "Live debate failed before producing a result: CERTIFICATE_VERIFY_FAILED"
-                ),
+                side_effect=RuntimeError("Live debate failed: CERTIFICATE_VERIFY_FAILED"),
+            ),
+            patch(
+                "aragora.cli.commands.quickstart._run_demo_debate",
+                return_value=mock_demo_result,
             ),
         ):
-            with pytest.raises(SystemExit):
-                cmd_quickstart(args)
+            cmd_quickstart(args)
 
         output = capsys.readouterr().out
-        assert "Debate failed" in output
-        assert "CA trust store" in output
-        assert "quickstart --demo" in output
+        assert "Falling back to demo" in output
+        assert "RESULT" in output  # Demo result was displayed


### PR DESCRIPTION
## Summary

Quickstart no longer crashes when all providers fail TLS preflight. Instead it falls back to demo mode automatically. The user always gets a result.

Changes:
- `_filter_reachable_live_agents()` returns `[]` instead of raising RuntimeError
- `cmd_quickstart` catches live debate failure and runs `_run_demo_debate` as fallback
- Updated 2 tests to expect demo fallback instead of SystemExit

50/50 quickstart tests passing.

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)