### PR TITLE
fix(ci): surface /readyz failure reasons in self-host smoke

### DIFF
--- a/scripts/check_self_host_runtime.py
+++ b/scripts/check_self_host_runtime.py
@@ -353,16 +353,58 @@ def _http_request(
         raise RuntimeCheckError(f"HTTP request failed for {url}: {exc}") from exc
 
 
+def _summarize_http_body(body: str, *, max_length: int = 240) -> str:
+    """Summarize an HTTP response body for diagnostics."""
+    stripped = body.strip()
+    if not stripped:
+        return ""
+
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return stripped.replace("\n", " ")[:max_length]
+
+    if not isinstance(payload, dict):
+        return stripped.replace("\n", " ")[:max_length]
+
+    details: list[str] = []
+    for key in ("reason", "status", "message", "error", "degraded_reason"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            details.append(f"{key}={value.strip()[:80]}")
+
+    degraded = payload.get("degraded")
+    if isinstance(degraded, dict):
+        for key in ("error_code", "reason", "recovery_hint"):
+            value = degraded.get(key)
+            if isinstance(value, str) and value.strip():
+                details.append(f"degraded.{key}={value.strip()[:80]}")
+
+    checks = payload.get("checks")
+    if isinstance(checks, dict):
+        failing_checks = [name for name, value in checks.items() if value is False]
+        if failing_checks:
+            details.append(f"failed_checks={','.join(failing_checks[:6])}")
+
+    summary = "; ".join(details)
+    if summary:
+        return summary[:max_length]
+
+    return stripped.replace("\n", " ")[:max_length]
+
+
 def _wait_for_http_200(base_url: str, path: str, timeout_seconds: int) -> None:
     deadline = time.monotonic() + timeout_seconds
     url = urllib.parse.urljoin(base_url, path)
     last_status = 0
     last_error = ""
+    last_body = ""
 
     while time.monotonic() < deadline:
         try:
-            status, _ = _http_request(url, method="GET", timeout_seconds=5)
+            status, body = _http_request(url, method="GET", timeout_seconds=5)
             last_status = status
+            last_body = _summarize_http_body(body)
             if status == 200:
                 print(f"[ok] {path} returned 200")
                 return
@@ -372,7 +414,12 @@ def _wait_for_http_200(base_url: str, path: str, timeout_seconds: int) -> None:
             last_status = 0
         time.sleep(2)
 
-    extra = f", last_error={last_error}" if last_error else ""
+    extra_parts = []
+    if last_error:
+        extra_parts.append(f"last_error={last_error}")
+    if last_body:
+        extra_parts.append(f"last_body={last_body}")
+    extra = f", {', '.join(extra_parts)}" if extra_parts else ""
     raise RuntimeCheckError(
         f"Timed out waiting for {path} to return 200 (last_status={last_status}{extra})"
     )

--- a/tests/scripts/test_check_self_host_runtime.py
+++ b/tests/scripts/test_check_self_host_runtime.py
@@ -230,6 +230,34 @@ def test_wait_for_http_200_reports_last_connection_error_on_timeout() -> None:
             module._wait_for_http_200("http://127.0.0.1:8080", "/healthz", timeout_seconds=1)
 
 
+def test_wait_for_http_200_reports_last_http_body_on_timeout() -> None:
+    module = _load_script_module()
+
+    with (
+        patch.object(
+            module,
+            "_http_request",
+            return_value=(
+                503,
+                (
+                    '{"status":"not_ready","reason":"Server in degraded mode",'
+                    '"checks":{"degraded_mode":false,"startup_complete":true}}'
+                ),
+            ),
+        ),
+        patch.object(module.time, "monotonic", side_effect=[0.0, 0.1, 1.1]),
+        patch.object(module.time, "sleep", return_value=None),
+    ):
+        with pytest.raises(
+            module.RuntimeCheckError,
+            match=(
+                "last_status=503.*last_body=reason=Server in degraded mode; "
+                "status=not_ready; failed_checks=degraded_mode"
+            ),
+        ):
+            module._wait_for_http_200("http://127.0.0.1:8080", "/readyz", timeout_seconds=1)
+
+
 def test_main_builds_services_before_waiting_for_health(tmp_path: Path) -> None:
     module = _load_script_module()
     compose_path = tmp_path / "docker-compose.production.yml"


### PR DESCRIPTION
## Summary
- preserve the existing self-host readiness polling behavior
- include the last `/readyz` response body summary when readiness times out
- surface degraded-mode reason and failed checks in CI output

## Why
The prior self-host compose smoke failure only reported `last_status=503`, which was not enough to tell whether the stack was in degraded mode or failing a specific readiness check.

## Verification
- `python3 -m ruff check scripts/check_self_host_runtime.py tests/scripts/test_check_self_host_runtime.py`
- `python3 -m pytest tests/scripts/test_check_self_host_runtime.py -q`

## Notes
- I could not reproduce the full Docker compose runtime locally in this lane because the local Docker daemon was unavailable.
- This PR does not change readiness semantics; it makes the next failure actionable.
