### PR TITLE
feat(receipts): surface provider labels in gauntlet receipts

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -423,6 +423,104 @@ def _maybe_add_vertical_specialist_local(
     return agents
 
 
+def _provider_display_name(provider: str | None) -> str:
+    """Convert provider keys into a stable user-facing label."""
+    raw = str(provider or "").strip()
+    if not raw:
+        return ""
+    key = raw.lower()
+    if "/" in key:
+        key = key.split("/", 1)[0]
+    aliases = {
+        "anthropic": "Anthropic",
+        "anthropic-api": "Anthropic",
+        "claude": "Anthropic",
+        "openai": "OpenAI",
+        "openai-api": "OpenAI",
+        "codex": "OpenAI",
+        "google": "Google",
+        "gemini": "Google",
+        "gemini-cli": "Google",
+        "xai": "xAI",
+        "grok": "xAI",
+        "grok-cli": "xAI",
+        "mistral": "Mistral",
+        "mistral-api": "Mistral",
+        "codestral": "Mistral",
+        "deepseek": "DeepSeek",
+        "deepseek-cli": "DeepSeek",
+        "openrouter": "OpenRouter",
+        "qwen": "Qwen",
+        "qwen-cli": "Qwen",
+        "ollama": "Ollama",
+        "lm-studio": "LM Studio",
+        "kimi": "Moonshot",
+        "kimi-thinking": "Moonshot",
+        "kilocode": "KiloCode",
+        "demo": "Demo",
+    }
+    if key in aliases:
+        return aliases[key]
+    if key.endswith("-api"):
+        key = key[:-4]
+    return " ".join(part.capitalize() for part in key.replace("_", "-").split("-") if part)
+
+
+def _detect_provider(model: str | None) -> str:
+    """Infer a provider from a model string when the agent doesn't expose one."""
+    candidate = str(model or "").strip()
+    if not candidate:
+        return ""
+    if "/" in candidate:
+        return candidate.split("/", 1)[0]
+    try:
+        from aragora.debate.provider_diversity import detect_provider
+
+        detected = detect_provider(candidate)
+    except ImportError:
+        detected = "unknown"
+    return "" if detected == "unknown" else detected
+
+
+def _format_llm_label(model: str | None, provider: str | None) -> str:
+    """Create the receipt label shown next to an agent response."""
+    model_name = str(model or "").strip()
+    provider_display = _provider_display_name(provider)
+    if model_name and provider_display:
+        return f"{model_name} via {provider_display}"
+    if model_name:
+        return model_name
+    return provider_display
+
+
+def _attach_agent_models_to_result(result: Any, agents: list[Any]) -> None:
+    """Persist agent provider/model metadata onto the debate result."""
+    metadata = getattr(result, "metadata", None)
+    if not isinstance(metadata, dict):
+        metadata = {}
+        setattr(result, "metadata", metadata)
+
+    agent_models = metadata.get("agent_models")
+    if not isinstance(agent_models, dict):
+        agent_models = {}
+        metadata["agent_models"] = agent_models
+
+    for agent in agents:
+        agent_name = str(getattr(agent, "name", "") or "").strip()
+        if not agent_name:
+            continue
+        provider = str(getattr(agent, "provider", "") or "").strip()
+        model = str(getattr(agent, "model", "") or "").strip()
+        if not provider and model:
+            provider = _detect_provider(model)
+        agent_models[agent_name] = {
+            "provider": provider,
+            "provider_display": _provider_display_name(provider),
+            "model": model,
+            "llm_label": _format_llm_label(model, provider),
+        }
+
+
 def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
     """Generate and persist a debate receipt to ~/.aragora/receipts/.
 
@@ -440,6 +538,28 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
         consensus_reached = getattr(result, "consensus_reached", False)
         confidence = getattr(result, "confidence", 0.0)
         final_answer = getattr(result, "final_answer", "") or ""
+        metadata = getattr(result, "metadata", None)
+        agent_models = metadata.get("agent_models", {}) if isinstance(metadata, dict) else {}
+        messages = list(getattr(result, "messages", []) or [])
+        agent_responses = []
+        for msg in messages[:40]:
+            agent_name = str(getattr(msg, "agent", "") or "").strip()
+            content = str(getattr(msg, "content", "") or "").strip()
+            if not agent_name or not content:
+                continue
+            model_meta = agent_models.get(agent_name, {}) if isinstance(agent_models, dict) else {}
+            agent_responses.append(
+                {
+                    "agent": agent_name,
+                    "role": str(getattr(msg, "role", "") or ""),
+                    "round": int(getattr(msg, "round", 0) or 0),
+                    "response": content[:2000],
+                    "provider": str(model_meta.get("provider", "") or ""),
+                    "provider_display": str(model_meta.get("provider_display", "") or ""),
+                    "model": str(model_meta.get("model", "") or ""),
+                    "llm_label": str(model_meta.get("llm_label", "") or ""),
+                }
+            )
 
         receipt = {
             "debate_id": debate_id,
@@ -448,9 +568,8 @@ def _persist_debate_receipt(result: Any, verbose: bool = False) -> str | None:
             "confidence": round(confidence, 4) if confidence else 0.0,
             "final_answer": final_answer[:2000],
             "rounds_used": getattr(result, "rounds_used", 0),
-            "agents": [
-                getattr(m, "agent", "unknown") for m in (getattr(result, "messages", []) or [])[:20]
-            ],
+            "agents": list(dict.fromkeys(response["agent"] for response in agent_responses)),
+            "agent_responses": agent_responses,
             "dissenting_views": [
                 str(v)[:500] for v in (getattr(result, "dissenting_views", []) or [])
             ],
@@ -1059,6 +1178,7 @@ async def run_debate(
         arena.extensions.auto_explain = True
 
     result = await arena.run()
+    _attach_agent_models_to_result(result, agents)
 
     # Store result
     if memory:

--- a/aragora/gauntlet/receipt_exporters.py
+++ b/aragora/gauntlet/receipt_exporters.py
@@ -114,6 +114,38 @@ def receipt_to_markdown(
     if receipt.cost_summary:
         lines.extend(_render_cost_summary_markdown(receipt.cost_summary))
 
+    if receipt.agent_responses:
+        lines.extend(
+            [
+                "---",
+                "",
+                "## Agent Responses",
+                "",
+            ]
+        )
+        for response in receipt.agent_responses[:12]:
+            label = (
+                response.llm_label or response.model or response.provider_display or "Unknown LLM"
+            )
+            lines.append(f"### {response.agent}")
+            meta_parts = [f"**LLM:** {label}"]
+            if response.role:
+                meta_parts.append(f"**Role:** {response.role}")
+            if response.round:
+                meta_parts.append(f"**Round:** {response.round}")
+            lines.append(" | ".join(meta_parts))
+            lines.append("")
+            text = response.response[:800]
+            if len(response.response) > 800:
+                text += "..."
+            lines.append(text)
+            lines.append("")
+        if len(receipt.agent_responses) > 12:
+            lines.append(
+                f"_Showing first 12 of {len(receipt.agent_responses)} recorded responses._"
+            )
+            lines.append("")
+
     if receipt.vulnerability_details:
         lines.append("---")
         lines.append("")
@@ -246,6 +278,33 @@ def receipt_to_html(
     findings_html = "".join(findings_parts)
 
     risk_summary = receipt.risk_summary or {}
+    agent_responses_html = ""
+    if receipt.agent_responses:
+        response_parts = ['<div class="section"><h2>Agent Responses</h2>']
+        for response in receipt.agent_responses[:12]:
+            label = (
+                response.llm_label or response.model or response.provider_display or "Unknown LLM"
+            )
+            role = escape(response.role) if response.role else "response"
+            round_label = (
+                f' <span class="meta">Round {response.round}</span>' if response.round else ""
+            )
+            response_text = escape(response.response[:1200])
+            if len(response.response) > 1200:
+                response_text += "..."
+            response_parts.append(
+                '<div class="finding">'
+                f"<strong>{escape(response.agent)}</strong>"
+                f' <span class="meta">{escape(label)} · {role}</span>{round_label}'
+                f"<p>{response_text}</p>"
+                "</div>"
+            )
+        if len(receipt.agent_responses) > 12:
+            response_parts.append(
+                f'<p class="meta">Showing first 12 of {len(receipt.agent_responses)} recorded responses.</p>'
+            )
+        response_parts.append("</div>")
+        agent_responses_html = "".join(response_parts)
 
     return f"""<!DOCTYPE html>
 <html>
@@ -318,6 +377,8 @@ def receipt_to_html(
     </div>
 
     {_render_cost_summary_html(receipt.cost_summary)}
+
+    {agent_responses_html}
 
     <div class="section">
         <h2>Findings</h2>

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -75,6 +75,32 @@ class ConsensusProof:
 
 
 @dataclass
+class AgentResponseRecord:
+    """A single agent response annotated with the producing LLM."""
+
+    agent: str
+    response: str
+    role: str = ""
+    round: int = 0
+    provider: str = ""
+    provider_display: str = ""
+    model: str = ""
+    llm_label: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "agent": self.agent,
+            "response": self.response,
+            "role": self.role,
+            "round": self.round,
+            "provider": self.provider,
+            "provider_display": self.provider_display,
+            "model": self.model,
+            "llm_label": self.llm_label,
+        }
+
+
+@dataclass
 class DecisionReceipt:
     """
     Audit-ready receipt for a Gauntlet validation.
@@ -116,6 +142,7 @@ class DecisionReceipt:
     dissenting_views: list[str] = field(default_factory=list)
     consensus_proof: ConsensusProof | None = None
     provenance_chain: list[ProvenanceRecord] = field(default_factory=list)
+    agent_responses: list[AgentResponseRecord] = field(default_factory=list)
 
     # Explainability (why the decision was made)
     explainability: dict[str, Any] | None = None  # Decision explanation from ExplanationBuilder
@@ -304,6 +331,296 @@ class DecisionReceipt:
     </div>
 """
 
+    @staticmethod
+    def _coerce_int(value: Any, default: int = 0) -> int:
+        """Best-effort integer coercion for receipt metadata."""
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _provider_display_name(provider: str | None) -> str:
+        """Convert provider keys into a user-facing display name."""
+        raw = str(provider or "").strip()
+        if not raw:
+            return ""
+        key = raw.lower()
+        if "/" in key:
+            key = key.split("/", 1)[0]
+        aliases = {
+            "anthropic": "Anthropic",
+            "anthropic-api": "Anthropic",
+            "claude": "Anthropic",
+            "openai": "OpenAI",
+            "openai-api": "OpenAI",
+            "codex": "OpenAI",
+            "google": "Google",
+            "gemini": "Google",
+            "gemini-cli": "Google",
+            "xai": "xAI",
+            "grok": "xAI",
+            "grok-cli": "xAI",
+            "mistral": "Mistral",
+            "mistral-api": "Mistral",
+            "codestral": "Mistral",
+            "deepseek": "DeepSeek",
+            "deepseek-cli": "DeepSeek",
+            "openrouter": "OpenRouter",
+            "qwen": "Qwen",
+            "qwen-cli": "Qwen",
+            "ollama": "Ollama",
+            "lm-studio": "LM Studio",
+            "kimi": "Moonshot",
+            "kimi-thinking": "Moonshot",
+            "kilocode": "KiloCode",
+            "demo": "Demo",
+        }
+        if key in aliases:
+            return aliases[key]
+        if key.endswith("-api"):
+            key = key[:-4]
+        return " ".join(part.capitalize() for part in key.replace("_", "-").split("-") if part)
+
+    @staticmethod
+    def _detect_provider(model: str | None) -> str:
+        """Infer a provider from a model identifier when not explicitly recorded."""
+        candidate = str(model or "").strip()
+        if not candidate:
+            return ""
+        if "/" in candidate:
+            return candidate.split("/", 1)[0]
+        try:
+            from aragora.debate.provider_diversity import detect_provider
+
+            detected = detect_provider(candidate)
+        except ImportError:
+            detected = "unknown"
+        return "" if detected == "unknown" else detected
+
+    @classmethod
+    def _format_llm_label(cls, model: str | None, provider: str | None) -> str:
+        """Create the receipt label shown next to an agent response."""
+        model_name = str(model or "").strip()
+        provider_display = cls._provider_display_name(provider)
+        if model_name and provider_display:
+            return f"{model_name} via {provider_display}"
+        if model_name:
+            return model_name
+        return provider_display
+
+    @classmethod
+    def _normalize_agent_model_entry(cls, entry: Any) -> dict[str, str]:
+        """Normalize agent/provider metadata from a variety of upstream shapes."""
+        provider = ""
+        provider_display = ""
+        model = ""
+        llm_label = ""
+
+        if isinstance(entry, str):
+            raw = entry.strip()
+            if "/" in raw:
+                provider, model = raw.split("/", 1)
+            else:
+                model = raw
+        elif isinstance(entry, dict):
+            provider = str(entry.get("provider") or entry.get("provider_name") or "").strip()
+            provider_display = str(entry.get("provider_display") or "").strip()
+            model = str(entry.get("model") or entry.get("model_name") or "").strip()
+            llm_label = str(entry.get("llm_label") or entry.get("label") or "").strip()
+
+        if not provider and model:
+            provider = cls._detect_provider(model)
+        provider_display = provider_display or cls._provider_display_name(provider)
+        llm_label = llm_label or cls._format_llm_label(model, provider)
+
+        return {
+            "provider": provider,
+            "provider_display": provider_display,
+            "model": model,
+            "llm_label": llm_label,
+        }
+
+    @classmethod
+    def _agent_metadata_from_cost_summary(
+        cls,
+        cost_summary: dict[str, Any] | None,
+    ) -> dict[str, dict[str, str]]:
+        """Extract per-agent provider/model metadata from a debate cost summary."""
+        if not isinstance(cost_summary, dict):
+            return {}
+
+        providers_by_model: dict[str, str] = {}
+        for model_data in (cost_summary.get("model_usage") or {}).values():
+            if not isinstance(model_data, dict):
+                continue
+            model_name = str(model_data.get("model") or "").strip()
+            provider = str(model_data.get("provider") or "").strip()
+            if model_name and provider and model_name not in providers_by_model:
+                providers_by_model[model_name] = provider
+
+        agent_metadata: dict[str, dict[str, str]] = {}
+        for agent_name, agent_data in (cost_summary.get("per_agent") or {}).items():
+            if not isinstance(agent_data, dict):
+                continue
+            normalized_name = str(agent_data.get("agent_name") or agent_name).strip()
+            if not normalized_name:
+                continue
+            models_used = agent_data.get("models_used") or {}
+            selected_model = ""
+            if isinstance(models_used, dict) and models_used:
+                selected_model = max(
+                    ((str(name), cls._coerce_int(count, 0)) for name, count in models_used.items()),
+                    key=lambda item: item[1],
+                )[0]
+            normalized = cls._normalize_agent_model_entry(
+                {
+                    "provider": providers_by_model.get(selected_model, ""),
+                    "model": selected_model,
+                }
+            )
+            if normalized["provider"] or normalized["model"]:
+                agent_metadata[normalized_name] = normalized
+
+        return agent_metadata
+
+    @classmethod
+    def _collect_agent_metadata(
+        cls,
+        result: Any,
+        cost_summary: dict[str, Any] | None = None,
+    ) -> dict[str, dict[str, str]]:
+        """Gather best-effort agent provider/model metadata from the result."""
+        collected: dict[str, dict[str, str]] = {}
+
+        metadata = getattr(result, "metadata", None)
+        if isinstance(metadata, dict):
+            raw_agent_models = metadata.get("agent_models")
+            if isinstance(raw_agent_models, dict):
+                for agent_name, entry in raw_agent_models.items():
+                    normalized_name = str(agent_name).strip()
+                    if normalized_name:
+                        collected[normalized_name] = cls._normalize_agent_model_entry(entry)
+
+            provider_routing = metadata.get("provider_routing")
+            if isinstance(provider_routing, dict):
+                provider_matches = provider_routing.get("provider_matches")
+                if isinstance(provider_matches, dict):
+                    for agent_name, entry in provider_matches.items():
+                        normalized_name = str(agent_name).strip()
+                        if normalized_name and normalized_name not in collected:
+                            collected[normalized_name] = cls._normalize_agent_model_entry(entry)
+
+                provider_names = provider_routing.get("provider_names")
+                participants = list(getattr(result, "participants", []))
+                if (
+                    isinstance(provider_names, list)
+                    and participants
+                    and len(provider_names) == len(participants)
+                ):
+                    for agent_name, entry in zip(participants, provider_names, strict=False):
+                        normalized_name = str(agent_name).strip()
+                        if normalized_name and normalized_name not in collected:
+                            collected[normalized_name] = cls._normalize_agent_model_entry(entry)
+
+        for agent_name, entry in cls._agent_metadata_from_cost_summary(cost_summary).items():
+            if agent_name not in collected:
+                collected[agent_name] = entry
+
+        return collected
+
+    @classmethod
+    def _build_agent_responses(
+        cls,
+        result: Any,
+        cost_summary: dict[str, Any] | None = None,
+    ) -> list[AgentResponseRecord]:
+        """Build per-response records annotated with provider/model metadata."""
+        agent_metadata = cls._collect_agent_metadata(result, cost_summary=cost_summary)
+        responses: list[AgentResponseRecord] = []
+
+        messages = list(getattr(result, "messages", []) or [])
+        for msg in messages:
+            agent_name = str(getattr(msg, "agent", "") or "").strip()
+            response_text = str(getattr(msg, "content", "") or "").strip()
+            if not agent_name or not response_text:
+                continue
+            model_meta = agent_metadata.get(agent_name, {})
+            responses.append(
+                AgentResponseRecord(
+                    agent=agent_name,
+                    response=response_text,
+                    role=str(getattr(msg, "role", "") or ""),
+                    round=cls._coerce_int(getattr(msg, "round", 0), 0),
+                    provider=model_meta.get("provider", ""),
+                    provider_display=model_meta.get("provider_display", ""),
+                    model=model_meta.get("model", ""),
+                    llm_label=model_meta.get("llm_label", ""),
+                )
+            )
+        if responses:
+            return responses
+
+        proposals = getattr(result, "proposals", None)
+        if isinstance(proposals, dict):
+            for agent_name, proposal in proposals.items():
+                normalized_name = str(agent_name).strip()
+                response_text = str(proposal or "").strip()
+                if not normalized_name or not response_text:
+                    continue
+                model_meta = agent_metadata.get(normalized_name, {})
+                responses.append(
+                    AgentResponseRecord(
+                        agent=normalized_name,
+                        response=response_text,
+                        role="proposal",
+                        provider=model_meta.get("provider", ""),
+                        provider_display=model_meta.get("provider_display", ""),
+                        model=model_meta.get("model", ""),
+                        llm_label=model_meta.get("llm_label", ""),
+                    )
+                )
+        if responses:
+            return responses
+
+        raw_responses = getattr(result, "agent_responses", None)
+        if isinstance(raw_responses, dict):
+            iterable = [
+                {"agent": agent_name, "response": response}
+                for agent_name, response in raw_responses.items()
+            ]
+        elif isinstance(raw_responses, list):
+            iterable = raw_responses
+        else:
+            iterable = []
+
+        for item in iterable:
+            if not isinstance(item, dict):
+                continue
+            agent_name = str(item.get("agent") or item.get("name") or "").strip()
+            response_text = str(item.get("response") or item.get("content") or "").strip()
+            if not agent_name or not response_text:
+                continue
+            merged_meta = cls._normalize_agent_model_entry(item)
+            if agent_name in agent_metadata:
+                for key, value in agent_metadata[agent_name].items():
+                    if not merged_meta.get(key):
+                        merged_meta[key] = value
+            responses.append(
+                AgentResponseRecord(
+                    agent=agent_name,
+                    response=response_text,
+                    role=str(item.get("role") or item.get("message_type") or ""),
+                    round=cls._coerce_int(item.get("round") or item.get("round_number"), 0),
+                    provider=merged_meta.get("provider", ""),
+                    provider_display=merged_meta.get("provider_display", ""),
+                    model=merged_meta.get("model", ""),
+                    llm_label=merged_meta.get("llm_label", ""),
+                )
+            )
+
+        return responses
+
     @classmethod
     def from_result(cls, result: GauntletResult) -> DecisionReceipt:
         """Create receipt from GauntletResult."""
@@ -374,6 +691,7 @@ class DecisionReceipt:
             dissenting_views=result.dissenting_views,
             consensus_proof=consensus,
             provenance_chain=provenance,
+            agent_responses=cls._build_agent_responses(result),
             config_used=result.config_used,
         )
 
@@ -468,6 +786,19 @@ class DecisionReceipt:
             if f.severity_level in ("CRITICAL", "HIGH")
         ]
 
+        config_used = getattr(result, "config_used", None)
+        if not isinstance(config_used, dict):
+            config_used = {}
+        result_config = getattr(result, "config", None)
+        if not config_used and result_config is not None and hasattr(result_config, "to_dict"):
+            try:
+                config_used = result_config.to_dict()
+            except (AttributeError, TypeError, ValueError):
+                config_used = {}
+
+        raw_cost_summary = getattr(result, "cost_summary", None)
+        cost_summary = raw_cost_summary if isinstance(raw_cost_summary, dict) else None
+
         return cls(
             receipt_id=receipt_id,
             gauntlet_id=result.gauntlet_id,
@@ -495,6 +826,9 @@ class DecisionReceipt:
             dissenting_views=dissenting,
             consensus_proof=consensus,
             provenance_chain=provenance,
+            agent_responses=cls._build_agent_responses(result, cost_summary=cost_summary),
+            cost_summary=cost_summary,
+            config_used=config_used,
         )
 
     @classmethod
@@ -719,6 +1053,8 @@ class DecisionReceipt:
 
         verdict_reasoning = ". ".join(reasoning_parts)
 
+        agent_responses = cls._build_agent_responses(result, cost_summary=cost_summary)
+
         return cls(
             receipt_id=receipt_id,
             gauntlet_id=debate_id,  # Use debate_id for gauntlet_id field
@@ -744,6 +1080,7 @@ class DecisionReceipt:
             dissenting_views=dissenting_views,
             consensus_proof=consensus,
             provenance_chain=provenance,
+            agent_responses=agent_responses,
             cost_summary=cost_summary,
             settlement_metadata=settlement_metadata,
             config_used={
@@ -1271,6 +1608,7 @@ class DecisionReceipt:
             "dissenting_views": self.dissenting_views,
             "consensus_proof": self.consensus_proof.to_dict() if self.consensus_proof else None,
             "provenance_chain": [p.to_dict() for p in self.provenance_chain],
+            "agent_responses": [response.to_dict() for response in self.agent_responses],
             "cost_summary": self.cost_summary,
             "settlement_metadata": self.settlement_metadata,
             "settlement_status": self.settlement_status,
@@ -1297,6 +1635,11 @@ class DecisionReceipt:
             ProvenanceRecord(**record) if isinstance(record, dict) else record
             for record in provenance_data
         ]
+        agent_response_data = data.get("agent_responses") or []
+        agent_responses = [
+            AgentResponseRecord(**record) if isinstance(record, dict) else record
+            for record in agent_response_data
+        ]
 
         return cls(
             receipt_id=data.get("receipt_id", ""),
@@ -1317,6 +1660,7 @@ class DecisionReceipt:
             dissenting_views=data.get("dissenting_views", []) or [],
             consensus_proof=consensus,
             provenance_chain=provenance,
+            agent_responses=agent_responses,
             schema_version=data.get("schema_version", "1.0"),
             artifact_hash=data.get("artifact_hash", ""),
             cost_summary=data.get("cost_summary"),

--- a/aragora/live/src/components/GauntletRunner.tsx
+++ b/aragora/live/src/components/GauntletRunner.tsx
@@ -512,7 +512,17 @@ function ReceiptView({ receipt }: { receipt: GauntletReceipt }) {
     approved: 'bg-green-600 text-white',
     rejected: 'bg-red-600 text-white',
     needs_review: 'bg-yellow-600 text-black',
+    pass: 'bg-green-600 text-white',
+    conditional: 'bg-yellow-600 text-black',
+    fail: 'bg-red-600 text-white',
   };
+  const verdictKey = String(receipt.verdict || '').toLowerCase();
+  const verdictClass =
+    verdictColors[verdictKey as keyof typeof verdictColors] || 'bg-slate-700 text-white';
+  const summaryText = receipt.input_summary || receipt.decision || 'Receipt summary unavailable.';
+  const riskFactors = receipt.risk_factors || [];
+  const signatures = receipt.signatures || [];
+  const agentResponses = receipt.agent_responses || [];
 
   return (
     <div className="space-y-4">
@@ -520,14 +530,12 @@ function ReceiptView({ receipt }: { receipt: GauntletReceipt }) {
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-medium text-white">Decision Receipt</h3>
           <span
-            className={`px-3 py-1 rounded font-medium ${
-              verdictColors[receipt.verdict]
-            }`}
+            className={`px-3 py-1 rounded font-medium ${verdictClass}`}
           >
-            {receipt.verdict.replace('_', ' ').toUpperCase()}
+            {String(receipt.verdict || 'unknown').replace('_', ' ').toUpperCase()}
           </span>
         </div>
-        <p className="text-slate-300">{receipt.decision}</p>
+        <p className="text-slate-300">{summaryText}</p>
         <div className="mt-4">
           <span className="text-slate-400">Confidence:</span>
           <span className="text-white ml-2 font-semibold">
@@ -536,39 +544,68 @@ function ReceiptView({ receipt }: { receipt: GauntletReceipt }) {
         </div>
       </div>
 
-      <div className="bg-slate-800 rounded-lg p-4">
-        <h4 className="text-sm font-medium text-slate-300 mb-3">Risk Factors</h4>
-        <div className="space-y-2">
-          {receipt.risk_factors.map((factor, i) => (
-            <div
-              key={i}
-              className="flex items-center justify-between p-2 bg-slate-900 rounded"
-            >
-              <div>
-                <p className="text-white text-sm">{factor.factor}</p>
-                <p className="text-xs text-slate-400">{factor.assessment}</p>
+      {riskFactors.length > 0 && (
+        <div className="bg-slate-800 rounded-lg p-4">
+          <h4 className="text-sm font-medium text-slate-300 mb-3">Risk Factors</h4>
+          <div className="space-y-2">
+            {riskFactors.map((factor, i) => (
+              <div
+                key={i}
+                className="flex items-center justify-between p-2 bg-slate-900 rounded"
+              >
+                <div>
+                  <p className="text-white text-sm">{factor.factor}</p>
+                  <p className="text-xs text-slate-400">{factor.assessment}</p>
+                </div>
+                <span className="text-sm text-slate-300">
+                  Weight: {(factor.weight * 100).toFixed(0)}%
+                </span>
               </div>
-              <span className="text-sm text-slate-300">
-                Weight: {(factor.weight * 100).toFixed(0)}%
-              </span>
-            </div>
-          ))}
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
-      <div className="bg-slate-800 rounded-lg p-4">
-        <h4 className="text-sm font-medium text-slate-300 mb-2">Signatures</h4>
-        <div className="flex flex-wrap gap-2">
-          {receipt.signatures.map((sig, i) => (
-            <span
-              key={i}
-              className="px-2 py-1 bg-slate-700 rounded text-xs font-mono text-slate-300"
-            >
-              {sig}
-            </span>
-          ))}
+      {agentResponses.length > 0 && (
+        <div className="bg-slate-800 rounded-lg p-4">
+          <h4 className="text-sm font-medium text-slate-300 mb-3">Agent Responses</h4>
+          <div className="space-y-3">
+            {agentResponses.map((response, i) => (
+              <div key={i} className="p-3 bg-slate-900 rounded border border-slate-700">
+                <div className="flex flex-wrap items-center gap-2 mb-2">
+                  <span className="text-sm font-medium text-white">{response.agent}</span>
+                  {response.llm_label && (
+                    <span className="text-xs font-mono text-cyan-300">{response.llm_label}</span>
+                  )}
+                  {response.role && (
+                    <span className="text-xs text-slate-400 uppercase">{response.role}</span>
+                  )}
+                  {response.round ? (
+                    <span className="text-xs text-slate-500">Round {response.round}</span>
+                  ) : null}
+                </div>
+                <p className="text-sm text-slate-300 whitespace-pre-wrap">{response.response}</p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
+
+      {signatures.length > 0 && (
+        <div className="bg-slate-800 rounded-lg p-4">
+          <h4 className="text-sm font-medium text-slate-300 mb-2">Signatures</h4>
+          <div className="flex flex-wrap gap-2">
+            {signatures.map((sig, i) => (
+              <span
+                key={i}
+                className="px-2 py-1 bg-slate-700 rounded text-xs font-mono text-slate-300"
+              >
+                {sig}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/aragora/live/src/lib/aragora-client.ts
+++ b/aragora/live/src/lib/aragora-client.ts
@@ -1722,15 +1722,26 @@ export interface GauntletResult {
 
 export interface GauntletReceipt {
   gauntlet_id: string;
-  decision: string;
-  verdict: 'approved' | 'rejected' | 'needs_review';
+  decision?: string;
+  input_summary?: string;
+  verdict: 'approved' | 'rejected' | 'needs_review' | 'PASS' | 'CONDITIONAL' | 'FAIL' | string;
   confidence: number;
-  risk_factors: Array<{
+  risk_factors?: Array<{
     factor: string;
     weight: number;
     assessment: string;
   }>;
-  signatures: string[];
+  signatures?: string[];
+  agent_responses?: Array<{
+    agent: string;
+    response: string;
+    role?: string;
+    round?: number;
+    provider?: string;
+    provider_display?: string;
+    model?: string;
+    llm_label?: string;
+  }>;
 }
 
 export interface GauntletHeatmap {

--- a/aragora/server/handlers/gauntlet/receipts.py
+++ b/aragora/server/handlers/gauntlet/receipts.py
@@ -229,6 +229,11 @@ class GauntletReceiptsMixin:
                 verdict=result.get("verdict", "UNKNOWN").upper(),
                 confidence=result.get("confidence", 0),
                 robustness_score=result.get("robustness_score", 0),
+                agent_responses=result.get("agent_responses", [])
+                if isinstance(result, dict)
+                else [],
+                cost_summary=result.get("cost_summary") if isinstance(result, dict) else None,
+                config_used=result.get("config_used", {}) if isinstance(result, dict) else {},
             )
 
         # Return format based on query param

--- a/tests/handlers/gauntlet/test_receipts.py
+++ b/tests/handlers/gauntlet/test_receipts.py
@@ -20,6 +20,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.core_types import DebateResult, Message
+from aragora.gauntlet.receipt_models import DecisionReceipt
 from aragora.server.handlers.gauntlet.receipts import GauntletReceiptsMixin
 from aragora.server.handlers.gauntlet.storage import get_gauntlet_runs
 from aragora.server.handlers.utils.responses import HandlerResult
@@ -81,6 +83,7 @@ class FakeReceipt:
     signature_key_id: str | None = None
     signed_at: str | None = None
     vulnerability_details: list = field(default_factory=list)
+    agent_responses: list = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -98,6 +101,7 @@ class FakeReceipt:
             "confidence": self.confidence,
             "robustness_score": self.robustness_score,
             "artifact_hash": self.artifact_hash,
+            "agent_responses": self.agent_responses,
         }
 
     def sign(self, signer=None):
@@ -270,6 +274,16 @@ class TestGetReceiptJSON:
     @pytest.mark.asyncio
     async def test_returns_receipt_from_memory_completed(self, mixin, mock_receipt):
         """In-memory completed run returns receipt JSON."""
+        mock_receipt.agent_responses = [
+            {
+                "agent": "claude",
+                "response": "Use Redis for coordination.",
+                "provider": "anthropic",
+                "provider_display": "Anthropic",
+                "model": "claude-sonnet-4",
+                "llm_label": "claude-sonnet-4 via Anthropic",
+            }
+        ]
         runs = get_gauntlet_runs()
         runs["g-001"] = {
             "status": "completed",
@@ -286,6 +300,7 @@ class TestGetReceiptJSON:
         assert _status(result) == 200
         data = _parse(result)
         assert data["receipt_id"] == "receipt-abc123"
+        assert data["agent_responses"][0]["llm_label"] == "claude-sonnet-4 via Anthropic"
 
     @pytest.mark.asyncio
     async def test_returns_receipt_with_result_obj(self, mixin, mock_receipt):
@@ -678,6 +693,87 @@ class TestGetReceiptConstruction:
         assert captured["input_summary"] == "Stored decision"
         assert captured["input_hash"] == "stored-hash"
         assert captured["verdict"] == "PASS"
+
+    @pytest.mark.asyncio
+    async def test_receipt_from_storage_preserves_agent_responses(self, mixin, mock_storage):
+        """Stored provider/model labels are preserved in the JSON receipt."""
+        mock_storage.get.return_value = {
+            "total_findings": 1,
+            "verdict": "pass",
+            "confidence": 0.95,
+            "robustness_score": 0.9,
+            "input_summary": "Stored decision",
+            "input_hash": "stored-hash",
+            "agent_responses": [
+                {
+                    "agent": "claude",
+                    "response": "Use Redis for coordination.",
+                    "provider": "anthropic",
+                    "provider_display": "Anthropic",
+                    "model": "claude-sonnet-4",
+                    "llm_label": "claude-sonnet-4 via Anthropic",
+                }
+            ],
+        }
+
+        captured = {}
+
+        def fake_init(**kwargs):
+            captured.update(kwargs)
+            return FakeReceipt(**{k: v for k, v in kwargs.items() if hasattr(FakeReceipt, k)})
+
+        with patch(_DR, side_effect=fake_init):
+            result = await mixin._get_receipt("g-stored", {"signed": "false"})
+
+        assert _status(result) == 200
+        assert captured["agent_responses"][0]["llm_label"] == "claude-sonnet-4 via Anthropic"
+
+
+class TestDecisionReceiptAgentResponses:
+    """Tests for provider/model labels in canonical decision receipts."""
+
+    def test_from_debate_result_includes_llm_labels(self):
+        debate_result = DebateResult(
+            debate_id="debate-123",
+            task="Pick a database",
+            final_answer="Use Postgres.",
+            confidence=0.92,
+            consensus_reached=True,
+            rounds_used=1,
+            participants=["claude", "gpt"],
+            messages=[
+                Message(
+                    role="proposer",
+                    agent="claude",
+                    content="Use Postgres with read replicas.",
+                    round=1,
+                ),
+                Message(
+                    role="critic",
+                    agent="gpt",
+                    content="Postgres fits if we shard later.",
+                    round=1,
+                ),
+            ],
+            metadata={
+                "agent_models": {
+                    "claude": {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4",
+                    },
+                    "gpt": {
+                        "provider": "openai",
+                        "model": "gpt-4.1",
+                    },
+                }
+            },
+        )
+
+        receipt = DecisionReceipt.from_debate_result(debate_result)
+
+        assert [response.agent for response in receipt.agent_responses] == ["claude", "gpt"]
+        assert receipt.agent_responses[0].llm_label == "claude-sonnet-4 via Anthropic"
+        assert receipt.agent_responses[1].llm_label == "gpt-4.1 via OpenAI"
 
     @pytest.mark.asyncio
     async def test_receipt_defaults_for_missing_fields(self, mixin, mock_storage):


### PR DESCRIPTION
## Summary
- surface provider labels and richer provider metadata in gauntlet receipt models and exporters
- carry the new receipt fields through the debate CLI, gauntlet API handler, and live gauntlet runner client
- add focused backend coverage for the receipt surface

## Validation
- `python3 -m ruff check aragora/cli/commands/debate.py aragora/gauntlet/receipt_exporters.py aragora/gauntlet/receipt_models.py aragora/server/handlers/gauntlet/receipts.py tests/handlers/gauntlet/test_receipts.py`
- `python3 -m pytest tests/handlers/gauntlet/test_receipts.py -q`
