### PR TITLE
fix(swarm): default worker agent to claude instead of codex

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -515,7 +515,7 @@ class SwarmSupervisor:
         for item in work_orders:
             if str(item.get("status", "")) != "leased":
                 continue
-            target_agent = str(item.get("target_agent", "codex")).strip().lower() or "codex"
+            target_agent = str(item.get("target_agent", "claude")).strip().lower() or "claude"
             if self._worker_type_circuit_breaker_is_open(
                 worker_type_circuit_breakers,
                 target_agent,


### PR DESCRIPTION
## Summary

Changes the supervisor's default `target_agent` from `"codex"` to `"claude"`.

## Root Cause

The PMF queue run produced 7 PRs from 10 items, but 3 items failed to create PRs. Investigation revealed that ALL workers ran under Codex's `--full-auto` network sandbox, which blocks DNS resolution for `git push`. Workers committed code locally but couldn't push to GitHub.

The supervisor at line 518 defaulted `target_agent` to `"codex"` even though the queue manifest didn't specify an agent. Claude Code has no network sandbox restriction and can push to GitHub normally.

## Fix

One-line change: `"codex"` → `"claude"` in the supervisor's default target_agent.

## Test plan
- [ ] Next queue run should use Claude Code workers by default
- [ ] Workers should be able to `git push` without DNS failures

1 file changed, 1 insertion(+), 1 deletion(-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)