### PR TITLE
fix(swarm): harvest summary uses item-level completed count

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -71,7 +71,7 @@ def _render_tranche_queue_harvest_table(payload: dict[str, object]) -> None:
     rows = [
         ("total items", int(summary.get("total_items", 0) or 0)),
         ("PRs created", int(summary.get("prs_created", 0) or 0)),
-        ("merged", int(summary.get("merged", 0) or 0)),
+        ("completed", int(summary.get("completed", 0) or 0)),
         ("needs_human", int(summary.get("needs_human", 0) or 0)),
         ("failed", int(summary.get("failed", 0) or 0)),
     ]

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -2255,18 +2255,17 @@ def _harvest_summary(items: list[dict[str, Any]]) -> dict[str, int]:
     summary = {
         "total_items": len(items),
         "prs_created": 0,
-        "merged": 0,
+        "completed": 0,
         "needs_human": 0,
         "failed": 0,
     }
     for item in items:
         pr_records = [entry for entry in item.get("prs", []) if isinstance(entry, dict)]
         summary["prs_created"] += len(pr_records)
-        summary["merged"] += sum(
-            1 for entry in pr_records if str(entry.get("disposition", "")).strip() == "merged"
-        )
         outcome = _harvest_item_outcome(item)
-        if outcome == "needs_human":
+        if outcome == "merged" or outcome == QUEUE_ITEM_STATUS_COMPLETED:
+            summary["completed"] += 1
+        elif outcome == "needs_human":
             summary["needs_human"] += 1
         elif outcome == "failed":
             summary["failed"] += 1

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -204,7 +204,7 @@ def test_harvest_queue_executes_merge_for_merge_now_pr(
     assert payload["summary"] == {
         "total_items": 1,
         "prs_created": 1,
-        "merged": 1,
+        "completed": 1,
         "needs_human": 0,
         "failed": 0,
     }
@@ -278,7 +278,7 @@ def test_harvest_queue_summary_counts_needs_human_and_failed(
     assert payload["summary"] == {
         "total_items": 3,
         "prs_created": 2,
-        "merged": 1,
+        "completed": 1,
         "needs_human": 1,
         "failed": 1,
     }
@@ -299,7 +299,7 @@ def test_render_harvest_queue_summary_table_prints_counts(
             "summary": {
                 "total_items": 3,
                 "prs_created": 2,
-                "merged": 1,
+                "completed": 1,
                 "needs_human": 1,
                 "failed": 1,
             },
@@ -316,13 +316,13 @@ def test_render_harvest_queue_summary_table_prints_counts(
         if len(parts) != 2:
             continue
         label, value = parts
-        if label in {"total items", "PRs created", "merged", "needs_human", "failed"}:
+        if label in {"total items", "PRs created", "completed", "needs_human", "failed"}:
             metrics[label] = value
 
     assert metrics == {
         "total items": "3",
         "PRs created": "2",
-        "merged": "1",
+        "completed": "1",
         "needs_human": "1",
         "failed": "1",
     }


### PR DESCRIPTION
Follow-up to #1227. Replaces mixed-unit 'merged' (PR count) with 'completed' (item count). 3 tests updated.