### PR TITLE
fix(debates): fix backend pagination and response shape for debates list

### DIFF
--- a/aragora/protocols/storage_protocols.py
+++ b/aragora/protocols/storage_protocols.py
@@ -164,7 +164,7 @@ class DebateStorageProtocol(Protocol):
         """Get debate by slug (alias)."""
         ...
 
-    def list_recent(self, limit: int = 20, org_id: str | None = None) -> list[Any]:
+    def list_recent(self, limit: int = 20, org_id: str | None = None, offset: int = 0) -> list[Any]:
         """List recent debates."""
         ...
 

--- a/aragora/server/handlers/debates/crud.py
+++ b/aragora/server/handlers/debates/crud.py
@@ -91,8 +91,12 @@ class CrudOperationsMixin:
         method="GET",
         path="/api/v1/debates",
         summary="List all debates",
-        description="List recent debates with optional organization filtering. Requires authentication.",
+        description="List recent debates with optional organization filtering and pagination.",
         tags=["Debates"],
+        parameters=[
+            {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 20}},
+            {"name": "offset", "in": "query", "schema": {"type": "integer", "default": 0}},
+        ],
         responses={
             "200": {
                 "description": "List of debates returned",
@@ -103,6 +107,10 @@ class CrudOperationsMixin:
                             "properties": {
                                 "debates": {"type": "array", "items": {"type": "object"}},
                                 "count": {"type": "integer"},
+                                "total": {"type": "integer"},
+                                "has_more": {"type": "boolean"},
+                                "offset": {"type": "integer"},
+                                "limit": {"type": "integer"},
                             },
                         },
                     },
@@ -117,7 +125,7 @@ class CrudOperationsMixin:
     @ttl_cache(ttl_seconds=CACHE_TTL_DEBATES_LIST, key_prefix="debates_list", skip_first=True)
     @handle_errors("list debates")
     def _list_debates(
-        self: _DebatesHandlerProtocol, limit: int, org_id: str | None = None
+        self: _DebatesHandlerProtocol, limit: int, org_id: str | None = None, offset: int = 0
     ) -> HandlerResult:
         """List recent debates, optionally filtered by organization.
 
@@ -125,11 +133,12 @@ class CrudOperationsMixin:
             limit: Maximum number of debates to return
             org_id: If provided, only return debates for this organization.
                     If None, returns all debates (backwards compatible).
+            offset: Number of debates to skip (for pagination).
 
         Cached for 30 seconds. Cache key includes org_id for per-org isolation.
         """
         storage = self.get_storage()
-        debates = storage.list_recent(limit=limit, org_id=org_id)
+        debates = storage.list_recent(limit=limit, org_id=org_id, offset=offset)
         # Convert DebateMetadata objects to dicts and normalize for SDK compatibility
         debates_list = [
             normalize_debate_response(
@@ -137,7 +146,35 @@ class CrudOperationsMixin:
             )  # DebateMetadata may be dict-like at runtime
             for d in debates
         ]
-        return json_response({"debates": debates_list, "count": len(debates_list)})
+
+        # Get total count for pagination metadata
+        total = -1
+        try:
+            count_fn = getattr(storage, "count_debates", None)
+            if callable(count_fn):
+                raw_total = count_fn(org_id=org_id)
+                if isinstance(raw_total, int):
+                    total = raw_total
+        except Exception:  # noqa: BLE001
+            logger.debug("count_debates not available, estimating from results")
+
+        # If count_debates isn't available, estimate has_more from result size
+        if total >= 0:
+            has_more = (offset + len(debates_list)) < total
+        else:
+            has_more = len(debates_list) == limit
+            total = offset + len(debates_list) + (1 if has_more else 0)
+
+        return json_response(
+            {
+                "debates": debates_list,
+                "count": len(debates_list),
+                "total": total,
+                "has_more": has_more,
+                "offset": offset,
+                "limit": limit,
+            }
+        )
 
     @api_endpoint(
         method="GET",

--- a/aragora/server/handlers/debates/handler.py
+++ b/aragora/server/handlers/debates/handler.py
@@ -194,10 +194,11 @@ class DebatesHandler(
         # Exact path matches - list debates
         if normalized in ("/api/debates", "/api/debates/"):
             limit = min(get_int_param(query_params, "limit", 20), 100)
+            offset = max(get_int_param(query_params, "offset", 0), 0)
             # Get authenticated user for org-scoped results
             user = self.get_current_user(handler)
             org_id = user.org_id if user else None
-            return self._list_debates(limit, org_id)
+            return self._list_debates(limit, org_id, offset)
 
         if normalized.startswith("/api/debates/slug/"):
             slug = normalized.split("/")[-1]

--- a/aragora/server/handlers/debates/response_formatting.py
+++ b/aragora/server/handlers/debates/response_formatting.py
@@ -134,6 +134,12 @@ def normalize_debate_response(debate: dict | None) -> dict | None:
     elif "final_answer" in debate and "conclusion" not in debate:
         debate["conclusion"] = debate["final_answer"]
 
+    # winning_proposal alias for final_answer (used by frontend debates list)
+    if "winning_proposal" not in debate:
+        winning = debate.get("final_answer") or debate.get("conclusion")
+        if winning:
+            debate["winning_proposal"] = winning
+
     return debate
 
 

--- a/aragora/server/postgres_storage.py
+++ b/aragora/server/postgres_storage.py
@@ -166,9 +166,11 @@ class PostgresDebateStorage(PostgresStore):
         """Get debate by ID (sync wrapper)."""
         return run_async(self.get_by_id_async(debate_id, org_id, verify_ownership))
 
-    def list_recent(self, limit: int = 20, org_id: str | None = None) -> list[DebateMetadata]:
+    def list_recent(
+        self, limit: int = 20, org_id: str | None = None, offset: int = 0
+    ) -> list[DebateMetadata]:
         """List recent debates (sync wrapper)."""
-        return run_async(self.list_recent_async(limit, org_id))
+        return run_async(self.list_recent_async(limit, org_id, offset))
 
     def search(
         self,
@@ -385,7 +387,7 @@ class PostgresDebateStorage(PostgresStore):
         return None
 
     async def list_recent_async(
-        self, limit: int = 20, org_id: str | None = None
+        self, limit: int = 20, org_id: str | None = None, offset: int = 0
     ) -> list[DebateMetadata]:
         """List recent debates."""
         async with self.connection() as conn:
@@ -397,10 +399,11 @@ class PostgresDebateStorage(PostgresStore):
                     FROM debates
                     WHERE org_id = $1
                     ORDER BY created_at DESC
-                    LIMIT $2
+                    LIMIT $2 OFFSET $3
                     """,
                     org_id,
                     limit,
+                    offset,
                 )
             else:
                 rows = await conn.fetch(
@@ -409,12 +412,29 @@ class PostgresDebateStorage(PostgresStore):
                            confidence, created_at, view_count, is_public
                     FROM debates
                     ORDER BY created_at DESC
-                    LIMIT $1
+                    LIMIT $1 OFFSET $2
                     """,
                     limit,
+                    offset,
                 )
 
             return [self._row_to_metadata(row) for row in rows]
+
+    async def count_debates_async(self, org_id: str | None = None) -> int:
+        """Count total number of debates, optionally filtered by organization."""
+        async with self.connection() as conn:
+            if org_id:
+                row = await conn.fetchrow(
+                    "SELECT COUNT(*) FROM debates WHERE org_id = $1",
+                    org_id,
+                )
+            else:
+                row = await conn.fetchrow("SELECT COUNT(*) FROM debates")
+            return row[0] if row else 0
+
+    def count_debates(self, org_id: str | None = None) -> int:
+        """Count total debates (sync wrapper)."""
+        return run_async(self.count_debates_async(org_id))
 
     async def search_async(
         self,

--- a/aragora/server/storage.py
+++ b/aragora/server/storage.py
@@ -436,7 +436,9 @@ class DebateStorage(SQLiteStore):
             row = cursor.fetchone()
         return json.loads(row[0]) if row else None
 
-    def list_recent(self, limit: int = 20, org_id: str | None = None) -> list[DebateMetadata]:
+    def list_recent(
+        self, limit: int = 20, org_id: str | None = None, offset: int = 0
+    ) -> list[DebateMetadata]:
         """
         List recent debates, optionally filtered by organization.
 
@@ -444,6 +446,7 @@ class DebateStorage(SQLiteStore):
             limit: Maximum number of debates to return
             org_id: If provided, only return debates for this organization.
                     If None, returns all debates (for backwards compatibility).
+            offset: Number of debates to skip (for pagination).
 
         Returns:
             List of DebateMetadata ordered by creation date (newest first)
@@ -457,9 +460,9 @@ class DebateStorage(SQLiteStore):
                     FROM debates
                     WHERE org_id = ?
                     ORDER BY created_at DESC
-                    LIMIT ?
+                    LIMIT ? OFFSET ?
                 """,
-                    (org_id, limit),
+                    (org_id, limit, offset),
                 )
             else:
                 cursor = conn.execute(
@@ -468,9 +471,9 @@ class DebateStorage(SQLiteStore):
                            confidence, created_at, view_count, is_public
                     FROM debates
                     ORDER BY created_at DESC
-                    LIMIT ?
+                    LIMIT ? OFFSET ?
                 """,
-                    (limit,),
+                    (limit, offset),
                 )
 
             results = []
@@ -495,6 +498,19 @@ class DebateStorage(SQLiteStore):
                 )
 
         return results
+
+    def count_debates(self, org_id: str | None = None) -> int:
+        """Count total number of debates, optionally filtered by organization."""
+        with self.connection() as conn:
+            if org_id:
+                cursor = conn.execute(
+                    "SELECT COUNT(*) FROM debates WHERE org_id = ?",
+                    (org_id,),
+                )
+            else:
+                cursor = conn.execute("SELECT COUNT(*) FROM debates")
+            row = cursor.fetchone()
+        return row[0] if row else 0
 
     def search(
         self,

--- a/tests/handlers/debates/test_crud.py
+++ b/tests/handlers/debates/test_crud.py
@@ -189,7 +189,7 @@ class TestListDebates:
         h = _make_handler(storage=storage)
         result = h._list_debates(limit=5, org_id="org-123")
         assert _status(result) == 200
-        storage.list_recent.assert_called_once_with(limit=5, org_id="org-123")
+        storage.list_recent.assert_called_once_with(limit=5, org_id="org-123", offset=0)
 
     def test_list_debates_no_storage(self):
         h = _make_handler(storage=None)
@@ -224,14 +224,14 @@ class TestListDebates:
         storage.list_recent.return_value = []
         h = _make_handler(storage=storage)
         h._list_debates(limit=25)
-        storage.list_recent.assert_called_once_with(limit=25, org_id=None)
+        storage.list_recent.assert_called_once_with(limit=25, org_id=None, offset=0)
 
     def test_list_debates_no_org_id_default(self):
         storage = MagicMock()
         storage.list_recent.return_value = []
         h = _make_handler(storage=storage)
         h._list_debates(limit=10)
-        storage.list_recent.assert_called_once_with(limit=10, org_id=None)
+        storage.list_recent.assert_called_once_with(limit=10, org_id=None, offset=0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/handlers/debates/test_handler.py
+++ b/tests/handlers/debates/test_handler.py
@@ -363,14 +363,14 @@ class TestHandleListDebates:
         handler = _make_handler(storage=mock_storage)
         result = handler.handle("/api/debates", {"limit": "5"}, mock_http_handler)
         assert _status(result) == 200
-        mock_storage.list_recent.assert_called_with(limit=5, org_id="test-org-001")
+        mock_storage.list_recent.assert_called_with(limit=5, org_id="test-org-001", offset=0)
 
     def test_list_debates_limit_capped(self, mock_storage, mock_http_handler):
         mock_storage.list_recent.return_value = []
         handler = _make_handler(storage=mock_storage)
         result = handler.handle("/api/debates", {"limit": "500"}, mock_http_handler)
         assert _status(result) == 200
-        mock_storage.list_recent.assert_called_with(limit=100, org_id="test-org-001")
+        mock_storage.list_recent.assert_called_with(limit=100, org_id="test-org-001", offset=0)
 
     def test_list_debates_v1_path(self, mock_storage, mock_http_handler):
         mock_storage.list_recent.return_value = []


### PR DESCRIPTION
## Summary
- Adds `offset` parameter to debate list storage layer (SQLite + Postgres)
- Returns `{debates, count, total, has_more, offset, limit}` from API
- Promotes `winning_proposal` from `final_answer`/`conclusion` in response formatting
- Frontend was already correctly coded — just needed the backend to match

## Test plan
- [x] 1815 debate handler tests pass
- [ ] Verify pagination works on debates page (page 1, 2, etc.)