### PR TITLE
fix(ci): surface Redis self-host auth diagnostics

### DIFF
--- a/scripts/check_self_host_runtime.py
+++ b/scripts/check_self_host_runtime.py
@@ -233,6 +233,67 @@ def _get_container_ip(container_id: str) -> str:
     return ip_address
 
 
+def _get_container_env(container_id: str) -> dict[str, str]:
+    inspect_result = _run(
+        [
+            "docker",
+            "inspect",
+            "-f",
+            "{{range .Config.Env}}{{println .}}{{end}}",
+            container_id,
+        ],
+        check=False,
+    )
+    if inspect_result.returncode != 0:
+        details = inspect_result.stderr.strip() or inspect_result.stdout.strip() or "unknown error"
+        raise RuntimeCheckError(f"Failed to inspect environment for {container_id}: {details}")
+
+    env_map: dict[str, str] = {}
+    for raw_line in inspect_result.stdout.splitlines():
+        line = raw_line.strip()
+        if not line or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        env_map[key] = value
+    return env_map
+
+
+def _print_container_env_subset(base_cmd: list[str], service: str, keys: list[str]) -> None:
+    print(f"\n=== {service} env subset ===")
+    try:
+        container_id = _get_primary_container_id(base_cmd, service)
+        env_map = _get_container_env(container_id)
+    except RuntimeCheckError as exc:
+        print(f"[warn] unable to inspect {service} env: {exc}", file=sys.stderr)
+        return
+
+    for key in keys:
+        value = env_map.get(key)
+        if value is None:
+            print(f"{key}=<unset>")
+            continue
+        if "PASSWORD" in key or "SECRET" in key or key.endswith("_TOKEN"):
+            print(f"{key}=<set len={len(value)}>")
+        else:
+            print(f"{key}={value}")
+
+
+def _print_service_exec_output(
+    base_cmd: list[str],
+    service: str,
+    title: str,
+    shell_command: str,
+) -> None:
+    print(f"\n=== {title} ===")
+    result = _compose(base_cmd, ["exec", "-T", service, "sh", "-lc", shell_command], check=False)
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    if result.returncode != 0 and not result.stdout and not result.stderr:
+        print(f"[warn] {service} exec failed with exit={result.returncode}", file=sys.stderr)
+
+
 def _parse_compose_port(raw_output: str) -> tuple[str, int] | None:
     """Parse docker compose port output into (host, port)."""
     for raw_line in raw_output.splitlines():
@@ -495,6 +556,33 @@ def _print_diagnostics(base_cmd: list[str], services: list[str]) -> None:
         print(logs_result.stdout)
     if logs_result.stderr:
         print(logs_result.stderr, file=sys.stderr)
+
+    _print_container_env_subset(
+        base_cmd,
+        "aragora",
+        [
+            "ARAGORA_REDIS_MODE",
+            "ARAGORA_REDIS_SENTINEL_HOSTS",
+            "ARAGORA_REDIS_SENTINEL_MASTER",
+            "ARAGORA_REDIS_PASSWORD",
+            "ARAGORA_REDIS_SENTINEL_PASSWORD",
+            "ARAGORA_REDIS_URL",
+            "REDIS_URL",
+            "REDIS_PASSWORD",
+        ],
+    )
+    _print_service_exec_output(
+        base_cmd,
+        "redis-master",
+        "redis-master rendered auth config",
+        "grep -nE '^(requirepass|masterauth)' /data/redis.conf || true",
+    )
+    _print_service_exec_output(
+        base_cmd,
+        "sentinel-1",
+        "sentinel-1 rendered auth config",
+        "grep -nE '^sentinel (monitor|auth-pass)' /data/sentinel.conf || true",
+    )
 
 
 def main() -> int:

--- a/tests/scripts/test_check_self_host_runtime.py
+++ b/tests/scripts/test_check_self_host_runtime.py
@@ -175,6 +175,59 @@ def test_resolve_runtime_base_url_uses_container_ip_when_no_host_port() -> None:
     assert resolved == "http://172.18.0.9:8080"
 
 
+def test_get_container_env_parses_inspect_output() -> None:
+    module = _load_script_module()
+
+    with patch.object(
+        module,
+        "_run",
+        return_value=_proc("ARAGORA_REDIS_MODE=sentinel\nARAGORA_REDIS_PASSWORD=secret\n"),
+    ):
+        env_map = module._get_container_env("aragora-container")
+
+    assert env_map == {
+        "ARAGORA_REDIS_MODE": "sentinel",
+        "ARAGORA_REDIS_PASSWORD": "secret",
+    }
+
+
+def test_print_diagnostics_includes_redis_env_and_rendered_auth(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _load_script_module()
+
+    compose_outputs = [
+        _proc("NAME   STATUS\naragora healthy\n"),
+        _proc("aragora logs\n"),
+        _proc("1:requirepass secret\n"),
+        _proc("1:sentinel monitor mymaster redis-master 6379 2\n"),
+    ]
+    with (
+        patch.object(module, "_compose", side_effect=compose_outputs),
+        patch.object(module, "_get_primary_container_id", return_value="aragora-container"),
+        patch.object(
+            module,
+            "_get_container_env",
+            return_value={
+                "ARAGORA_REDIS_MODE": "sentinel",
+                "ARAGORA_REDIS_SENTINEL_HOSTS": "sentinel-1:26379",
+                "ARAGORA_REDIS_SENTINEL_MASTER": "mymaster",
+                "ARAGORA_REDIS_PASSWORD": "secret",
+            },
+        ),
+    ):
+        module._print_diagnostics(["docker", "compose"], ["aragora"])
+
+    output = capsys.readouterr().out
+    assert "=== aragora env subset ===" in output
+    assert "ARAGORA_REDIS_MODE=sentinel" in output
+    assert "ARAGORA_REDIS_PASSWORD=<set len=6>" in output
+    assert "=== redis-master rendered auth config ===" in output
+    assert "requirepass secret" in output
+    assert "=== sentinel-1 rendered auth config ===" in output
+    assert "sentinel monitor mymaster redis-master 6379 2" in output
+
+
 def test_resolve_runtime_base_url_keeps_requested_when_port_is_published() -> None:
     module = _load_script_module()
 


### PR DESCRIPTION
## Summary
- add runtime diagnostics for Redis auth mode in the self-host readiness checker
- surface mismatches between compose/env expectations and the live Redis/Sentinel config
- add focused coverage for the new runtime diagnostics output

## Why
The unpublished follow-up on top of #1228 still had value, but it was sitting on a stale stacked branch that also replayed already-merged self-host auth changes. This PR carries only the net-new diagnostics commit on top of current `main`.

## Validation
- `python3 -m ruff check scripts/check_self_host_runtime.py tests/scripts/test_check_self_host_runtime.py`
- `python3 -m pytest tests/scripts/test_check_self_host_runtime.py -q`
