### PR TITLE
fix(self-host): render Redis passwords without newline corruption

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -231,7 +231,7 @@ services:
     command: >
       -c "cp /etc/redis/redis.conf.template /data/redis.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/redis.conf;
           else
             sed -i '/^requirepass REDIS_PASSWORD_PLACEHOLDER$/d' /data/redis.conf;
@@ -267,7 +267,7 @@ services:
     command: >
       -c "cp /etc/redis/redis.conf.template /data/redis.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/redis.conf;
           else
             sed -i '/^requirepass REDIS_PASSWORD_PLACEHOLDER$/d' /data/redis.conf &&
@@ -307,7 +307,7 @@ services:
     command: >
       -c "cp /etc/redis/redis.conf.template /data/redis.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/redis.conf;
           else
             sed -i '/^requirepass REDIS_PASSWORD_PLACEHOLDER$/d' /data/redis.conf &&
@@ -347,7 +347,7 @@ services:
     command: >
       -c "cp /etc/redis/sentinel.conf.template /data/sentinel.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/sentinel.conf;
           else
             sed -i '/^sentinel auth-pass mymaster REDIS_PASSWORD_PLACEHOLDER$/d' /data/sentinel.conf;
@@ -386,7 +386,7 @@ services:
     command: >
       -c "cp /etc/redis/sentinel.conf.template /data/sentinel.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/sentinel.conf;
           else
             sed -i '/^sentinel auth-pass mymaster REDIS_PASSWORD_PLACEHOLDER$/d' /data/sentinel.conf;
@@ -425,7 +425,7 @@ services:
     command: >
       -c "cp /etc/redis/sentinel.conf.template /data/sentinel.conf &&
           if [ -n \"$$REDIS_PASSWORD\" ]; then
-            escaped_password=$$(printf '%s\n' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
+            escaped_password=$$(printf '%s' \"$$REDIS_PASSWORD\" | sed 's/[|&]/\\\\&/g') &&
             sed -i \"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\" /data/sentinel.conf;
           else
             sed -i '/^sentinel auth-pass mymaster REDIS_PASSWORD_PLACEHOLDER$/d' /data/sentinel.conf;

--- a/scripts/check_self_host_compose.py
+++ b/scripts/check_self_host_compose.py
@@ -136,6 +136,14 @@ def _contains_required_runbook_markers(path: Path) -> list[str]:
     return missing
 
 
+def _has_broken_redis_password_render(service: dict[str, object]) -> bool:
+    """Detect newline-corrupting REDIS_PASSWORD render commands."""
+    command = service.get("command")
+    if not isinstance(command, str):
+        return False
+    return "REDIS_PASSWORD_PLACEHOLDER" in command and "printf '%s\\n'" in command
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Validate production self-host compose configuration"
@@ -292,6 +300,10 @@ def main() -> int:
             service_env = _parse_service_env(service)
             if "REDIS_PASSWORD" not in service_env:
                 errors.append(f"{service_name} service missing REDIS_PASSWORD env wiring")
+            if _has_broken_redis_password_render(service):
+                errors.append(
+                    f"{service_name} service uses newline-appending REDIS_PASSWORD render logic"
+                )
 
     missing_markers = _contains_required_runbook_markers(runbook_path)
     if missing_markers:

--- a/tests/scripts/test_check_self_host_compose.py
+++ b/tests/scripts/test_check_self_host_compose.py
@@ -281,6 +281,28 @@ def test_fails_when_sentinel_service_missing_redis_password_wiring(tmp_path: Pat
     assert "redis-master service missing redis_password env wiring" in result.stdout.lower()
 
 
+def test_fails_when_sentinel_service_uses_newline_password_render(tmp_path: Path):
+    compose, env, runbook = _write_valid_fixture(tmp_path)
+    compose.write_text(
+        compose.read_text(encoding="utf-8").replace(
+            "  redis-master:\n    environment:\n      - REDIS_PASSWORD=${REDIS_PASSWORD:-}\n"
+            '    healthcheck:\n      test: ["CMD", "true"]\n',
+            "  redis-master:\n"
+            "    environment:\n"
+            "      - REDIS_PASSWORD=${REDIS_PASSWORD:-}\n"
+            "    command: >\n"
+            "      -c \"escaped_password=$$(printf '%s\\n' \\\"$$REDIS_PASSWORD\\\" | sed 's/[|&]/\\\\\\\\&/g') && "
+            'sed -i \\"s|REDIS_PASSWORD_PLACEHOLDER|$$escaped_password|g\\" /data/redis.conf"\n'
+            '    healthcheck:\n      test: ["CMD", "true"]\n',
+        ),
+        encoding="utf-8",
+    )
+
+    result = _run("--compose", str(compose), "--env-example", str(env), "--runbook", str(runbook))
+    assert result.returncode == 1
+    assert "newline-appending redis_password render logic" in result.stdout.lower()
+
+
 def test_standalone_redis_topology_passes(tmp_path: Path):
     compose, env, runbook = _write_valid_standalone_fixture(tmp_path)
 


### PR DESCRIPTION
## Summary
- fix Redis/Sentinel password rendering in `docker-compose.production.yml`
- add a static self-host validator guard for newline-corrupting password render commands
- add a regression test for the validator

## Root cause
The production compose render commands used `printf '%s\n'` when substituting `REDIS_PASSWORD` into the Redis and Sentinel templates.
In the rendered configs this produced a literal trailing `n`, so Redis expected:
- `aragora-ci-redis-password-0123456789n`

while the Aragora app authenticated with:
- `aragora-ci-redis-password-0123456789`

That mismatch caused the self-host readiness failure:
- `invalid username-password pair or user is disabled`

## Evidence
Rendered configs before the fix:
- `requirepass aragora-ci-redis-password-0123456789n`
- `sentinel auth-pass mymaster aragora-ci-redis-password-0123456789n`

After the fix:
- rendered configs match the exact password
- sync Redis Sentinel client ping succeeds
- async Redis Sentinel client ping succeeds

## Verification
- `python3 scripts/check_self_host_compose.py`
- `python3 -m pytest tests/scripts/test_check_self_host_compose.py -q`
- `python3 -m ruff check scripts/check_self_host_compose.py tests/scripts/test_check_self_host_compose.py`
- direct Docker Redis/Sentinel repro before fix: auth failed
- direct Docker Redis/Sentinel repro after fix: sync + async `PING True`

## Notes
I started a full local `check_self_host_runtime.py` rerun as well, but the bottleneck was the full Aragora image build. The decisive Redis auth boundary is already reproduced and fixed here; the PR self-host workflow is the clean end-to-end confirmation.
