### PR TITLE
fix(cli): clamp quickstart confidence to valid bounds

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -325,6 +325,15 @@ def _default_receipt_path(mode: str, fmt: str) -> Path:
     return receipts_dir / f"quickstart-{normalized_mode}-receipt{suffix}"
 
 
+def _clamp_confidence(raw_confidence: Any) -> float:
+    """Normalize confidence values into the expected [0.0, 1.0] range."""
+    try:
+        confidence = float(raw_confidence or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, confidence))
+
+
 def _save_receipt(receipt_data: dict[str, Any], path: str | Path, fmt: str) -> Path:
     """Save receipt to file in the specified format."""
     output_path = Path(path)
@@ -404,7 +413,7 @@ async def _run_demo_debate(question: str, rounds: int) -> dict[str, Any]:
         else str(result.verdict)
         if hasattr(result, "verdict")
         else "consensus",
-        "confidence": result.confidence if hasattr(result, "confidence") else 0.85,
+        "confidence": _clamp_confidence(getattr(result, "confidence", 0.85)),
         "rounds": rounds,
         "agents": [a.name for a in agents],
         "summary": result.receipt.to_markdown() if hasattr(result, "receipt") else str(result),
@@ -575,7 +584,7 @@ def _build_live_receipt(
         participants = [str(agent["name"]) for agent in team]
 
     final_answer = str(getattr(result, "final_answer", "") or "")
-    confidence = float(getattr(result, "confidence", 0.0) or 0.0)
+    confidence = _clamp_confidence(getattr(result, "confidence", 0.0))
     consensus_reached = bool(getattr(result, "consensus_reached", False))
     verdict = (
         "PASS"

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -418,6 +418,30 @@ class TestLiveQuickstartHelpers:
         assert receipt["receipt"]["artifact_hash"] == receipt["artifact_hash"]
         assert DecisionReceipt.from_dict(receipt).verify_integrity() is True
 
+    def test_build_live_receipt_clamps_confidence_into_unit_interval(self):
+        result = argparse.Namespace(
+            debate_id="debate-123",
+            participants=["alpha"],
+            final_answer="Ship it",
+            confidence=1.2,
+            consensus_reached=True,
+            rounds_used=1,
+            dissenting_views=[],
+            proposals={},
+            votes=[],
+        )
+
+        receipt = _build_live_receipt(
+            result,
+            "Should we ship?",
+            1,
+            [{"name": "alpha", "provider": "openai-api"}],
+        )
+
+        assert receipt["confidence"] == 1.0
+        assert receipt["receipt"]["confidence"] == 1.0
+        assert receipt["consensus_proof"]["confidence"] == 1.0
+
     @pytest.mark.asyncio
     async def test_can_reach_provider_tls_normalizes_wrapped_cert_errors(self):
         with patch(


### PR DESCRIPTION
## Summary
- clamp quickstart-exported confidence into the valid [0.0, 1.0] range
- cover the >1.0 regression in the focused quickstart receipt tests
- keep the founder-loop behavior unchanged aside from the invalid confidence display

## Proof
- python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py
- python3 -m pytest tests/cli/test_quickstart.py -q
- CERT=$(python3 -c 'import certifi; print(certifi.where())') && /usr/bin/time -p env SSL_CERT_FILE="$CERT" ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser
