### PR TITLE
fix(cli): use insight store for quickstart analytics

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -434,7 +434,7 @@ async def _run_live_debate(
     from aragora.agents.base import AgentType, create_agent
     from aragora.core import Environment
     from aragora.debate.orchestrator import Arena, DebateProtocol
-    from aragora.memory.store import CritiqueStore
+    from aragora.insights.store import InsightStore
 
     agents_list = await _filter_reachable_live_agents(agents_list)
 
@@ -454,7 +454,7 @@ async def _run_live_debate(
         enable_llm_question_classification=False,
         enable_llm_synthesis=False,
     )
-    store = CritiqueStore()
+    store = InsightStore()
 
     agents = []
     agent_names = []

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -541,6 +541,7 @@ class TestCmdQuickstart:
         mock_agent = MagicMock()
         mock_agent.name = "openai-api"
         mock_result = argparse.Namespace()
+        mock_insight_store = MagicMock()
 
         with (
             patch(
@@ -548,6 +549,7 @@ class TestCmdQuickstart:
                 return_value=[("openai-api", "gpt-4o")],
             ),
             patch("aragora.agents.base.create_agent", return_value=mock_agent),
+            patch("aragora.insights.store.InsightStore", return_value=mock_insight_store),
             patch(
                 "aragora.cli.commands.quickstart._build_live_receipt",
                 return_value={"mode": "live", "rounds": 1},
@@ -576,6 +578,7 @@ class TestCmdQuickstart:
         assert protocol.enable_llm_synthesis is False
 
         arena_kwargs = mock_arena_cls.call_args.kwargs
+        assert arena_kwargs["insight_store"] is mock_insight_store
         assert arena_kwargs["knowledge_mound"] is None
         assert arena_kwargs["auto_create_knowledge_mound"] is False
         assert arena_kwargs["enable_knowledge_retrieval"] is False


### PR DESCRIPTION
## Summary
- use the proper InsightStore for quickstart live debates instead of CritiqueStore
- keep the bounded quickstart profile unchanged apart from the analytics-store wiring
- cover the Arena insight_store wiring in focused quickstart tests

## Proof
- python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py
- python3 -m pytest tests/cli/test_quickstart.py -q
- CERT=$(python3 -c 'import certifi; print(certifi.where())') && env SSL_CERT_FILE="$CERT" ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser
