### PR TITLE
style(demo): tighten standalone result presentation

### DIFF
--- a/aragora/live/src/app/(standalone)/demo/page.tsx
+++ b/aragora/live/src/app/(standalone)/demo/page.tsx
@@ -326,116 +326,122 @@ function LiveResultCard({
 
   return (
     <section className="space-y-5 rounded-[20px] border border-[var(--border)] bg-[var(--surface)] p-6 shadow-[var(--shadow-elevated)] md:p-7">
-      <div className="flex flex-col gap-4 border-b border-[var(--border)] pb-5 md:flex-row md:items-start md:justify-between">
-        <div className="space-y-3">
-          <StatusBadge label={resultLabel} tone={resultTone} />
-          <div className="space-y-1">
-            <p className="text-base font-semibold text-[var(--text)]">
-              {result.topic}
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_320px]">
+        <div className="space-y-5">
+          <div className="space-y-3 border-b border-[var(--border)] pb-5">
+            <StatusBadge label={resultLabel} tone={resultTone} />
+            <div className="space-y-2">
+              <p className="max-w-3xl text-[21px] font-semibold leading-9 text-[var(--text)] text-balance">
+                {result.topic}
+              </p>
+              <p className="max-w-2xl text-sm leading-7 text-[var(--text-muted)] text-pretty">
+                {resultTone === 'live'
+                  ? 'Fresh result from the public playground backend.'
+                  : `The backend returned a non-live fallback${result.mock_fallback_reason ? `: ${result.mock_fallback_reason}` : '.'}`}
+              </p>
+            </div>
+          </div>
+          <div className="space-y-4 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-6 shadow-[var(--shadow-panel)]">
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
+              Verdict
+            </h3>
+            <p className="max-w-2xl text-[17px] leading-8 text-[var(--text)] text-pretty">
+              {summary}
             </p>
-            <p className="max-w-2xl text-sm leading-7 text-[var(--text-muted)] text-pretty">
-            {resultTone === 'live'
-              ? 'Fresh result from the public playground backend.'
-              : `The backend returned a non-live fallback${result.mock_fallback_reason ? `: ${result.mock_fallback_reason}` : '.'}`}
-            </p>
           </div>
-        </div>
-        <div className="grid min-w-[220px] grid-cols-2 gap-3 text-sm text-[var(--text-muted)] md:text-right">
-          <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 shadow-[var(--shadow-panel)]">
-            <div className="text-[11px] uppercase tracking-[0.14em]">Runtime</div>
-            <div className="mt-1 font-semibold text-[var(--text)]">{result.duration_seconds.toFixed(1)}s</div>
-          </div>
-          <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 shadow-[var(--shadow-panel)]">
-            <div className="text-[11px] uppercase tracking-[0.14em]">Started</div>
-            <div className="mt-1 font-semibold text-[var(--text)]">{runStartedAt ?? 'Just now'}</div>
-          </div>
-          <div className="col-span-2 rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-3 py-2 shadow-[var(--shadow-panel)]">
-            <div className="text-[11px] uppercase tracking-[0.14em]">Result ID</div>
-            <div className="mt-1 font-mono text-xs text-[var(--text)]">{result.id}</div>
-          </div>
-        </div>
-      </div>
 
-      <div className="space-y-3">
-        <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
-          Returned agents
-        </h3>
-        <AgentRoster agents={result.participants} />
-      </div>
-
-      <ConsensusBar confidence={result.confidence} />
-
-      <div className="space-y-4 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-6 shadow-[var(--shadow-panel)]">
-        <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
-          Verdict
-        </h3>
-        <p className="max-w-3xl text-[17px] leading-8 text-[var(--text)] text-pretty">
-          {summary}
-        </p>
-      </div>
-
-      {proposalEntries.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
-            Agent positions
-          </h3>
-          <div className="grid grid-cols-1 gap-4">
-            {proposalEntries.map(([agent, proposal]) => {
-              const accent = accentForAgent(agent);
-              return (
-                <div
-                  key={agent}
-                  className="space-y-3 rounded-[18px] border bg-[var(--surface)] p-5 shadow-[var(--shadow-panel)]"
-                  style={{ borderColor: `${accent}28`, boxShadow: `inset 3px 0 0 ${accent}` }}
-                >
-                  <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="text-lg font-bold uppercase tracking-[0.08em]" style={{ color: accent }}>
-                      {formatAgentName(agent)}
-                    </div>
-                    <span
-                      className="rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]"
-                      style={{ color: accent, backgroundColor: `${accent}10` }}
+          {proposalEntries.length > 0 && (
+            <div className="space-y-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
+                Agent positions
+              </h3>
+              <div className="grid grid-cols-1 gap-4">
+                {proposalEntries.map(([agent, proposal]) => {
+                  const accent = accentForAgent(agent);
+                  return (
+                    <div
+                      key={agent}
+                      className="space-y-3 rounded-[18px] border bg-[var(--surface)] p-5 shadow-[var(--shadow-panel)]"
+                      style={{ borderColor: `${accent}28`, boxShadow: `inset 3px 0 0 ${accent}` }}
                     >
-                      Position
-                    </span>
-                  </div>
-                  <p className="max-w-3xl text-[15px] leading-7 text-[var(--text)] text-pretty">
-                    {proposal}
-                  </p>
-                </div>
-              );
-            })}
-          </div>
+                      <div className="flex flex-wrap items-center justify-between gap-3">
+                        <div className="text-lg font-bold uppercase tracking-[0.08em]" style={{ color: accent }}>
+                          {formatAgentName(agent)}
+                        </div>
+                        <span
+                          className="rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em]"
+                          style={{ color: accent, backgroundColor: `${accent}10` }}
+                        >
+                          Position
+                        </span>
+                      </div>
+                      <p className="max-w-2xl text-[15px] leading-7 text-[var(--text)] text-pretty">
+                        {proposal}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </div>
-      )}
 
-      <div className="flex flex-wrap items-center gap-4 border-t border-[var(--border)] pt-3 text-sm text-[var(--text-muted)]">
-        <span className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 shadow-[var(--shadow-panel)]">
-          Rounds {result.rounds_used}
-        </span>
-        <span className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 shadow-[var(--shadow-panel)]">
-          Status {result.status}
-        </span>
-        {result.receipt_hash && (
-          <span className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 font-mono text-xs shadow-[var(--shadow-panel)]">
-            Receipt {result.receipt_hash.slice(0, 16)}...
-          </span>
-        )}
-      </div>
+        <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
+          <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3 shadow-[var(--shadow-panel)]">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Runtime</div>
+              <div className="mt-1 text-lg font-semibold text-[var(--text)]">{result.duration_seconds.toFixed(1)}s</div>
+            </div>
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3 shadow-[var(--shadow-panel)]">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Started</div>
+              <div className="mt-1 text-sm font-semibold text-[var(--text)]">{runStartedAt ?? 'Just now'}</div>
+            </div>
+            <div className="rounded-2xl border border-[var(--border)] bg-[var(--surface-elevated)] px-4 py-3 shadow-[var(--shadow-panel)] sm:col-span-3 xl:col-span-1">
+              <div className="text-[11px] uppercase tracking-[0.14em] text-[var(--text-muted)]">Result ID</div>
+              <div className="mt-1 break-all font-mono text-xs text-[var(--text)]">{result.id}</div>
+            </div>
+          </div>
 
-      <div className="flex flex-wrap gap-3">
-        <Link
-          href={shareHref}
-          className="rounded-full bg-[var(--acid-green)] px-5 py-2.5 text-sm font-semibold text-white transition-opacity hover:opacity-90"
-        >
-          View Shareable Result
-        </Link>
-        <Link
-          href={`/try?topic=${encodeURIComponent(result.topic)}`}
-          className="rounded-full border border-[var(--border)] px-5 py-2.5 text-sm font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--acid-green)]/50 hover:text-[var(--acid-green)]"
-        >
-          Ask This in /try
-        </Link>
+          <div className="space-y-3 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[var(--acid-green)]">
+              Returned agents
+            </h3>
+            <AgentRoster agents={result.participants} />
+          </div>
+
+          <div className="space-y-3 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <ConsensusBar confidence={result.confidence} />
+          </div>
+
+          <div className="flex flex-wrap gap-2 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 text-sm text-[var(--text-muted)] shadow-[var(--shadow-panel)]">
+            <span className="rounded-full bg-[var(--surface)] px-3 py-1 shadow-[var(--shadow-panel)]">
+              Rounds {result.rounds_used}
+            </span>
+            <span className="rounded-full bg-[var(--surface)] px-3 py-1 shadow-[var(--shadow-panel)]">
+              Status {result.status}
+            </span>
+            {result.receipt_hash && (
+              <span className="rounded-full bg-[var(--surface)] px-3 py-1 font-mono text-xs shadow-[var(--shadow-panel)]">
+                Receipt {result.receipt_hash.slice(0, 16)}...
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-3">
+            <Link
+              href={shareHref}
+              className="rounded-full bg-[var(--acid-green)] px-5 py-2.5 text-center text-sm font-semibold text-white transition-opacity hover:opacity-90"
+            >
+              View Shareable Result
+            </Link>
+            <Link
+              href={`/try?topic=${encodeURIComponent(result.topic)}`}
+              className="rounded-full border border-[var(--border)] bg-[var(--surface)] px-5 py-2.5 text-center text-sm font-medium text-[var(--text-muted)] transition-colors hover:border-[var(--acid-green)]/50 hover:text-[var(--acid-green)]"
+            >
+              Ask This in /try
+            </Link>
+          </div>
+        </aside>
       </div>
     </section>
   );
@@ -443,74 +449,89 @@ function LiveResultCard({
 
 function RecordedSampleCard({ sample }: { sample: RecordedDebate }) {
   return (
-    <section className="space-y-5 rounded-[20px] border border-sky-500/18 bg-[var(--surface)] p-6 shadow-[var(--shadow-elevated)] md:p-7">
-      <div className="space-y-2">
-        <StatusBadge label="Recorded sample" tone="sample" />
-        <p className="max-w-2xl text-sm leading-7 text-[var(--text-muted)]">
-          This is a captured example for zero-latency browsing. It is illustrative only and is
-          never presented as a fresh run.
-        </p>
-      </div>
+    <section className="rounded-[20px] border border-sky-500/18 bg-[var(--surface)] p-6 shadow-[var(--shadow-elevated)] md:p-7">
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.6fr)_320px]">
+        <div className="space-y-5">
+          <div className="space-y-2 border-b border-[var(--border)] pb-5">
+            <StatusBadge label="Recorded sample" tone="sample" />
+            <p className="max-w-2xl text-sm leading-7 text-[var(--text-muted)]">
+              This is a captured example for zero-latency browsing. It is illustrative only and is
+              never presented as a fresh run.
+            </p>
+          </div>
 
-      <AgentRoster agents={sample.agents} />
-      <ConsensusBar confidence={sample.confidence} />
+          <div className="space-y-4 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-6 shadow-[var(--shadow-panel)]">
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-700">
+              Recorded verdict
+            </h3>
+            <p className="max-w-2xl text-[17px] leading-8 text-[var(--text)] text-pretty">{sample.verdict}</p>
+          </div>
 
-      <div className="space-y-4 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-6 shadow-[var(--shadow-panel)]">
-        <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-700">
-          Recorded verdict
-        </h3>
-        <p className="max-w-3xl text-[17px] leading-8 text-[var(--text)] text-pretty">{sample.verdict}</p>
-      </div>
+          <div className="grid grid-cols-1 gap-4">
+            {sample.events.map((event, index) => {
+              const accent = accentForAgent(event.agent);
+              const badgeColor =
+                event.type === 'proposal'
+                  ? 'text-blue-400'
+                  : event.type === 'critique'
+                    ? 'text-red-400'
+                    : event.type === 'vote'
+                      ? 'text-green-400'
+                      : 'text-[var(--acid-green)]';
 
-      <div className="grid grid-cols-1 gap-4">
-        {sample.events.map((event, index) => {
-          const accent = accentForAgent(event.agent);
-          const badgeColor =
-            event.type === 'proposal'
-              ? 'text-blue-400'
-              : event.type === 'critique'
-                ? 'text-red-400'
-                : event.type === 'vote'
-                  ? 'text-green-400'
-                  : 'text-[var(--acid-green)]';
-
-          return (
-            <div
-              key={`${event.agent}-${index}`}
-              className="border p-5 bg-[var(--surface)] space-y-3 rounded-lg shadow-sm"
-              style={{ borderColor: `${accent}30` }}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-lg font-bold uppercase tracking-[0.08em]" style={{ color: accent }}>
-                    {event.model}
-                  </span>
-                  <span className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] font-semibold ${badgeColor} bg-current/5`}>
-                    {event.type}
-                  </span>
+              return (
+                <div
+                  key={`${event.agent}-${index}`}
+                  className="border p-5 bg-[var(--surface)] space-y-3 rounded-lg shadow-sm"
+                  style={{ borderColor: `${accent}30` }}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      <span className="text-lg font-bold uppercase tracking-[0.08em]" style={{ color: accent }}>
+                        {event.model}
+                      </span>
+                      <span className={`rounded-full px-2.5 py-1 text-[11px] uppercase tracking-[0.16em] font-semibold ${badgeColor} bg-current/5`}>
+                        {event.type}
+                      </span>
+                    </div>
+                    <div className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--text-muted)] shadow-[var(--shadow-panel)]">
+                      Round {event.round}
+                      {event.confidence !== undefined
+                        ? ` · ${Math.round(event.confidence * 100)}%`
+                        : ''}
+                    </div>
+                  </div>
+                  <p className="max-w-2xl text-[15px] leading-7 text-[var(--text)] text-pretty">
+                    {event.content}
+                  </p>
+                  {event.vote && (
+                    <div className="text-sm font-semibold text-[var(--acid-green)]">
+                      Vote: {event.vote}
+                    </div>
+                  )}
                 </div>
-                <div className="rounded-full bg-[var(--surface-elevated)] px-3 py-1 text-sm text-[var(--text-muted)] shadow-[var(--shadow-panel)]">
-                  Round {event.round}
-                  {event.confidence !== undefined
-                    ? ` · ${Math.round(event.confidence * 100)}%`
-                    : ''}
-                </div>
-              </div>
-              <p className="max-w-3xl text-[15px] leading-7 text-[var(--text)] text-pretty">
-                {event.content}
-              </p>
-              {event.vote && (
-                <div className="text-sm font-semibold text-[var(--acid-green)]">
-                  Vote: {event.vote}
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
+              );
+            })}
+          </div>
+        </div>
 
-      <div className="border-t border-[var(--border)] pt-3 text-xs text-[var(--text-muted)]">
-        Receipt sample (not cryptographic): <span className="font-mono">{sample.receiptHash}</span>
+        <aside className="space-y-4 xl:sticky xl:top-6 xl:self-start">
+          <div className="space-y-3 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <h3 className="text-[11px] font-semibold uppercase tracking-[0.22em] text-sky-700">
+              Sample agents
+            </h3>
+            <AgentRoster agents={sample.agents} />
+          </div>
+
+          <div className="space-y-3 rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 shadow-[var(--shadow-panel)]">
+            <ConsensusBar confidence={sample.confidence} />
+          </div>
+
+          <div className="rounded-[18px] border border-[var(--border)] bg-[var(--surface-elevated)] p-5 text-xs text-[var(--text-muted)] shadow-[var(--shadow-panel)]">
+            Receipt sample (not cryptographic):{' '}
+            <span className="break-all font-mono">{sample.receiptHash}</span>
+          </div>
+        </aside>
       </div>
     </section>
   );
@@ -626,8 +647,8 @@ export default function PublicDemoPage() {
   const recordedSampleVisible = showRecordedSample || recordedSamplePinned;
 
   return (
-    <main className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
-      <nav className="flex items-center justify-between border-b border-[var(--border)] bg-[var(--surface)]/90 px-4 py-3 backdrop-blur">
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(21,128,61,0.08),_transparent_32%),var(--bg)] text-[var(--text)]">
+      <nav className="sticky top-0 z-20 flex items-center justify-between border-b border-[var(--border)] bg-[var(--surface)]/92 px-4 py-3 backdrop-blur">
         <Link
           href="/landing"
           className="text-sm font-semibold tracking-[0.14em] text-[var(--acid-green)] transition-opacity hover:opacity-80"
@@ -650,7 +671,7 @@ export default function PublicDemoPage() {
         </div>
       </nav>
 
-      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-8">
+      <div className="mx-auto flex max-w-[1120px] flex-col gap-8 px-4 py-8 md:px-6">
         <header className="space-y-3 text-center">
           <h1 className="text-3xl font-bold tracking-tight text-[var(--acid-green)] sm:text-4xl text-balance">
             Live Demo


### PR DESCRIPTION
## Summary
- tighten the standalone live result layout into a clearer two-column presentation
- restructure the recorded sample card to separate sample agents, verdict, and receipt metadata
- add a sticky top nav and more deliberate page spacing without changing backend behavior

## Validation
- `PATH="/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH" NODE_PATH="/Users/armand/Development/aragora/aragora/live/node_modules" tsc -p aragora/live/tsconfig.json --pretty false --noEmit`
