### PR TITLE
fix(cli): keep quickstart off crux webhook dispatch

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -53,6 +53,7 @@ _LIVE_ARENA_KWARGS: dict[str, Any] = {
     "auto_create_knowledge_mound": False,
     "enable_knowledge_retrieval": False,
     "enable_knowledge_ingestion": False,
+    "enable_belief_guidance": False,
     "enable_cross_debate_memory": False,
     "use_rlm_limiter": False,
     "enable_ml_delegation": False,

--- a/aragora/debate/arena_phases.py
+++ b/aragora/debate/arena_phases.py
@@ -439,7 +439,11 @@ def init_phases(arena: Arena) -> None:
         notify_spectator=arena._notify_spectator,
         drain_user_events=arena._drain_user_events,
         extract_debate_domain=arena._extract_debate_domain,
-        get_belief_analyzer=OptionalImports.get_belief_analyzer,
+        get_belief_analyzer=(
+            OptionalImports.get_belief_analyzer
+            if getattr(arena, "enable_belief_guidance", True)
+            else None
+        ),
         user_vote_multiplier=user_vote_multiplier,
         # Verification callback for claim verification during consensus
         # When protocol.verify_claims_during_consensus is True, this callback

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.agents.base import create_agent as create_real_agent
 from aragora.cli.commands.quickstart import (
     _build_live_receipt,
     _build_live_team,
@@ -583,6 +584,7 @@ class TestCmdQuickstart:
         assert arena_kwargs["auto_create_knowledge_mound"] is False
         assert arena_kwargs["enable_knowledge_retrieval"] is False
         assert arena_kwargs["enable_knowledge_ingestion"] is False
+        assert arena_kwargs["enable_belief_guidance"] is False
         assert arena_kwargs["enable_cross_debate_memory"] is False
         assert arena_kwargs["use_rlm_limiter"] is False
         assert arena_kwargs["enable_ml_delegation"] is False
@@ -590,6 +592,41 @@ class TestCmdQuickstart:
         assert arena_kwargs["enable_consensus_estimation"] is False
         assert arena_kwargs["disable_post_debate_pipeline"] is True
         assert mock_arena.enable_introspection is False
+
+    @pytest.mark.asyncio
+    async def test_run_live_debate_skips_crux_event_dispatch_in_bounded_profile(self):
+        """Bounded quickstart should not emit crux events through the webhook dispatcher."""
+
+        def fake_create_agent(
+            agent_type: str,
+            *,
+            name: str,
+            role: str,
+            model: str | None = None,
+            api_key: str | None = None,
+        ):
+            del agent_type, model, api_key
+            return create_real_agent("demo", name=name, role=role)
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._filter_reachable_live_agents",
+                return_value=[("openai-api", "gpt-4o")],
+            ),
+            patch("aragora.agents.base.create_agent", side_effect=fake_create_agent),
+            patch(
+                "aragora.events.dispatcher.dispatch_event",
+                side_effect=AssertionError("bounded quickstart should not dispatch crux events"),
+            ),
+        ):
+            result = await _run_live_debate(
+                "Should we ship the quickstart path?",
+                [("openai-api", "gpt-4o")],
+                rounds=1,
+            )
+
+        assert result["mode"] == "live"
+        assert result["rounds"] == 1
 
     @pytest.mark.asyncio
     async def test_filter_reachable_live_agents_returns_empty_on_tls_failure(self):


### PR DESCRIPTION
## Summary
- keep bounded quickstart off belief/crux event dispatch
- disable belief guidance in the quickstart live arena profile
- gate consensus-phase belief analysis on `arena.enable_belief_guidance`
- add a regression test that fails if bounded quickstart dispatches crux events

## Root cause
Quickstart's bounded live path still ran consensus-phase belief crux analysis. `CruxDetector.detect_cruxes()` emits `dispatch_event("crux_detected", ...)`, and the global event dispatcher lazily opens the webhook store. In a running event loop that forces `webhook_config` through the asyncpg fallback path and logs:

`[webhook_config] Cannot initialize PostgreSQL from async context ... Falling back to SQLite.`

That warning was not a webhook hook problem. The actual call chain was:
`winner_selector -> crux_detector -> events.dispatcher -> server.handlers.webhooks.get_webhook_store() -> get_webhook_config_store()`.

## Verification
- `python3 -m ruff check aragora/cli/commands/quickstart.py aragora/debate/arena_phases.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- live quickstart log before patch contained the `webhook_config` async fallback warning
- live quickstart log after patch no longer contains that warning

## Residual risk
- This PR removes the warning path for bounded quickstart only.
- A separate live run later timed out at 120s and then hit a missing `aragora_debate` demo fallback import on this machine. That is unrelated to this warning fix and should be handled separately.
