### PR TITLE
fix(cli): keep quickstart demo fallback inside Aragora

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -399,29 +399,22 @@ def _open_receipt_in_browser(
 
 async def _run_demo_debate(question: str, rounds: int) -> dict[str, Any]:
     """Run a debate with mock agents (no API keys needed)."""
-    from aragora_debate.arena import Arena
-    from aragora_debate.styled_mock import StyledMockAgent
-    from aragora_debate.types import Agent as DebateAgent, DebateConfig
+    from aragora.agents.demo_agent import DemoAgent
 
-    agents: list[DebateAgent] = [
-        StyledMockAgent("analyst", style="supportive"),
-        StyledMockAgent("critic", style="critical"),
-        StyledMockAgent("synthesizer", style="balanced"),
+    agents = [
+        DemoAgent("analyst", role="proposer"),
+        DemoAgent("critic", role="critic"),
+        DemoAgent("synthesizer", role="synthesizer"),
     ]
-    arena = Arena(question=question, agents=agents, config=DebateConfig(rounds=rounds))
-    result = await arena.run()
+    summary = await agents[-1].generate(f"Task: {question}")
 
     return {
         "question": question,
-        "verdict": result.verdict.value
-        if hasattr(result, "verdict") and hasattr(result.verdict, "value")
-        else str(result.verdict)
-        if hasattr(result, "verdict")
-        else "consensus",
-        "confidence": _clamp_confidence(getattr(result, "confidence", 0.85)),
+        "verdict": "consensus",
+        "confidence": 0.85,
         "rounds": rounds,
         "agents": [a.name for a in agents],
-        "summary": result.receipt.to_markdown() if hasattr(result, "receipt") else str(result),
+        "summary": summary,
         "dissent": [],
         "mode": "demo",
     }

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -26,6 +26,7 @@ from aragora.cli.commands.quickstart import (
     _normalize_provider,
     _open_receipt_in_browser,
     _resolve_rounds,
+    _run_demo_debate,
     _run_live_debate,
     _save_receipt,
     add_quickstart_parser,
@@ -478,6 +479,16 @@ class TestLiveQuickstartHelpers:
 
 
 class TestCmdQuickstart:
+    @pytest.mark.asyncio
+    async def test_run_demo_debate_uses_builtin_demo_agents(self):
+        result = await _run_demo_debate("Should we ship the fallback fix?", rounds=2)
+
+        assert result["mode"] == "demo"
+        assert result["verdict"] == "consensus"
+        assert result["confidence"] == 0.85
+        assert result["agents"] == ["analyst", "critic", "synthesizer"]
+        assert "Demo synthesis for: Should we ship the fallback fix?" in result["summary"]
+
     @pytest.mark.asyncio
     async def test_run_live_debate_raises_when_arena_returns_none(self):
         """Live quickstart should fail closed when Arena produces no result."""
@@ -1029,3 +1040,44 @@ class TestCmdQuickstart:
         output = capsys.readouterr().out
         assert "Falling back to demo" in output
         assert "RESULT" in output  # Demo result was displayed
+
+    def test_live_mode_real_demo_fallback_survives_without_legacy_demo_package(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        monkeypatch.chdir(tmp_path)
+        args = argparse.Namespace(
+            question="Should we keep the real fallback path working?",
+            demo=False,
+            provider=None,
+            api_key=None,
+            save_key=False,
+            output=None,
+            format="json",
+            rounds=2,
+            no_browser=True,
+        )
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._detect_agents",
+                return_value=[("gemini", "gemini-3.1-pro")],
+            ),
+            patch(
+                "aragora.cli.commands.quickstart._run_live_debate",
+                side_effect=RuntimeError("Live debate timed out after 120s"),
+            ),
+        ):
+            cmd_quickstart(args)
+
+        artifact_path = tmp_path / ".aragora" / "receipts" / "quickstart-demo-receipt.json"
+        assert artifact_path.exists()
+        saved = json.loads(artifact_path.read_text())
+        assert saved["mode"] == "demo"
+        assert saved["agents"] == ["analyst", "critic", "synthesizer"]
+        assert (
+            "Demo synthesis for: Should we keep the real fallback path working?" in saved["summary"]
+        )
+
+        output = capsys.readouterr().out
+        assert "Live debate failed: Live debate timed out after 120s" in output
+        assert "Mode:       Demo" in output


### PR DESCRIPTION
## Summary
- keep quickstart demo fallback inside Aragora instead of importing the removed `aragora_debate` package
- add direct coverage for `_run_demo_debate()` and the real live-to-demo fallback path
- preserve a deterministic offline receipt so users still get a truthful result when live quickstart fails

## Root cause
`aragora.cli.commands.quickstart._run_demo_debate()` still imported `aragora_debate.*`, which is not importable on current `main`. When live quickstart failed and fell back to demo mode, the fallback crashed instead of returning a receipt.

## Verification
- `python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- `python3 -m aragora.cli.main quickstart --demo --question "Should we keep the real fallback path working?" --no-browser`
