### PR TITLE
fix(cli): restore bounded live quickstart profile

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -72,22 +72,18 @@ _PROVIDER_TLS_HOSTS: dict[str, str] = {
 _PROVIDER_SPECS: dict[str, dict[str, Any]] = {
     "anthropic": {
         "agent_type": "anthropic-api",
-        "model": "claude-opus-4-6",
+        "model": "claude-haiku-4-5-20251001",
         "env_vars": ("ANTHROPIC_API_KEY",),
-        # Falls back to OpenRouter when credits exhausted
-        "openrouter_fallback": "anthropic/claude-opus-4-6",
     },
     "openai": {
         "agent_type": "openai-api",
-        "model": "gpt-5.4",
+        "model": "gpt-4o-mini",
         "env_vars": ("OPENAI_API_KEY",),
-        "openrouter_fallback": "openai/gpt-5.4",
     },
     "gemini": {
         "agent_type": "gemini",
-        "model": "gemini-3.1-pro",
+        "model": "gemini-2.0-flash",
         "env_vars": ("GEMINI_API_KEY",),
-        "openrouter_fallback": "google/gemini-3.1-pro",
     },
     "mistral": {
         "agent_type": "mistral",
@@ -526,14 +522,6 @@ def _build_live_team(
                 "api_key": None,
             }
         )
-
-    # Always include OpenRouter as a fallback provider when available.
-    # This ensures at least one agent can complete even when primary
-    # providers are rate-limited or out of credits.
-    openrouter_available = os.environ.get("OPENROUTER_API_KEY")
-    primary_provider = provider_configs[0]["provider"]
-    if openrouter_available and primary_provider != "deepseek":
-        provider_configs.append({"provider": "deepseek", "model": None, "api_key": None})
 
     team: list[dict[str, Any]] = []
     for index, (role, role_label) in enumerate(_LIVE_ROLES):

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -146,7 +146,7 @@ class TestDetectAgents:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-anthropic")
         agents = _detect_agents("openai")
-        assert agents == [("openai-api", "gpt-5.4")]
+        assert agents == [("openai-api", "gpt-4o-mini")]
 
     def test_invalid_preferred_provider_raises(self):
         with pytest.raises(ValueError, match="Unsupported provider"):
@@ -362,7 +362,7 @@ class TestLiveQuickstartHelpers:
         assert team[0]["provider"] == "openai-api"
         assert team[0]["api_key"] == "sk-inline"
 
-    def test_build_live_team_includes_openrouter_fallback(self):
+    def test_build_live_team_stays_single_provider_even_with_openrouter_available(self):
         team = _build_live_team(
             [
                 ("anthropic-api", "claude-sonnet-4-5-20250929"),
@@ -373,11 +373,7 @@ class TestLiveQuickstartHelpers:
 
         providers = [agent["provider"] for agent in team]
         assert providers[0] == "openai-api"
-        # OpenRouter fallback included when OPENROUTER_API_KEY is set
-        if os.environ.get("OPENROUTER_API_KEY"):
-            assert "deepseek" in providers
-        else:
-            assert providers == ["openai-api"] * 3
+        assert providers == ["openai-api"] * 3
 
     def test_build_live_receipt_surfaces_consensus_dissent_and_receipt(self):
         from aragora.gauntlet.receipt_models import DecisionReceipt


### PR DESCRIPTION
## Summary
- restore quickstart's bounded fast-path models
- keep the live quickstart team on a single provider instead of adding an extra OpenRouter participant
- preserve the previously merged demo fallback fix on top of current `main`

## Root cause
Quickstart regressed into the full live timeout path on current `main`. The bounded founder-loop profile was widened in two ways: it started using frontier models (`gpt-5.4`, `gemini-3.1-pro`, `claude-opus-4-6`) and it mixed in an extra `deepseek` participant when OpenRouter was available. On this machine, the real CLI path then spent the full 120s budget inside round 1 and died in `debate_rounds._revision_phase()` before a result was produced.

## Verification
- `python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- `SSL_CERT_FILE="$(python3 -c 'import certifi; print(certifi.where())')" ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser`
  - before: timed out after 120s in round 1 revision
  - after: completed in ~45s with a live receipt
