### PR TITLE
fix(tests): make nomic wiring checks portable

### DIFF
--- a/tests/nomic/test_self_improve_wiring.py
+++ b/tests/nomic/test_self_improve_wiring.py
@@ -31,6 +31,10 @@ from aragora.nomic.hardened_orchestrator import (
 )
 from aragora.nomic.task_decomposer import SubTask
 
+_IDEA_TO_EXECUTION_PATH = (
+    Path(__file__).resolve().parents[2] / "aragora" / "pipeline" / "idea_to_execution.py"
+)
+
 
 # ---------------------------------------------------------------------------
 # Fixtures & helpers
@@ -593,22 +597,15 @@ class TestIdeaToExecutionPipelineWiring:
         # This tests that the StrategicMemoryStore import exists in from_ideas
         # (line 484). It's used for goal enrichment, not for pipeline outcome
         # recording. The feedback loop is closed by PipelineKMBridge instead.
-        import ast
+        source = _IDEA_TO_EXECUTION_PATH.read_text()
 
-        with open("/Users/armand/Development/aragora/aragora/pipeline/idea_to_execution.py") as f:
-            source = f.read()
-
-        tree = ast.parse(source)
         # Check that StrategicMemoryStore is imported somewhere in the file
         # (it's used for enrichment in from_ideas and _advance_to_goals)
         assert "StrategicMemoryStore" in source
 
     def test_pipeline_km_bridge_used_for_feedback_loop(self):
         """PipelineKMBridge is used (not StrategicMemoryStore) for pipeline result storage."""
-        import ast
-
-        with open("/Users/armand/Development/aragora/aragora/pipeline/idea_to_execution.py") as f:
-            source = f.read()
+        source = _IDEA_TO_EXECUTION_PATH.read_text()
 
         # PipelineKMBridge.store_pipeline_result should be called
         assert "bridge.store_pipeline_result(result)" in source

--- a/tests/nomic/test_shift_controller.py
+++ b/tests/nomic/test_shift_controller.py
@@ -17,7 +17,7 @@ import pytest
 
 def _run(coro):
     """Run an async coroutine synchronously."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- replace the shift-controller test helper's deprecated event-loop usage with `asyncio.run()` for Python 3.13
- make self-improve wiring source inspections repo-relative instead of hardcoding a local `/Users/armand/...` path

## Why
Current `main` reproduces a large cluster of nomic test failures that are portability issues rather than product regressions:
- `tests/nomic/test_shift_controller.py` uses `asyncio.get_event_loop().run_until_complete(...)`
- `tests/nomic/test_self_improve_wiring.py` opens `aragora/pipeline/idea_to_execution.py` via a machine-specific absolute path

## Validation
- `python3 -m ruff check tests/nomic/test_shift_controller.py tests/nomic/test_self_improve_wiring.py`
- `python3 -m pytest tests/nomic/test_shift_controller.py tests/nomic/test_self_improve_wiring.py -q`
