### PR TITLE
fix(nomic): preserve subtasks when scope hints are empty

### DIFF
--- a/aragora/nomic/task_decomposer.py
+++ b/aragora/nomic/task_decomposer.py
@@ -1520,7 +1520,10 @@ class TaskDecomposer:
         - Empty file_scope → backfilled from hints
         - Non-overlapping file_scope → overridden with hints
         - Overlapping file_scope → preserved (decomposer correctly narrowed)
+        - Empty hints → no changes (nothing to constrain against)
         """
+        if not hints:
+            return subtasks
         for subtask in subtasks:
             if not subtask.file_scope:
                 subtask.file_scope = list(hints)


### PR DESCRIPTION
## Summary
- return subtasks unchanged when `_constrain_scopes_to_hints` receives no file-scope hints
- align the later overriding implementation with the documented and previously tested behavior
- keep the bounded-issues decomposition path from dropping or rewriting scopes when there is nothing to constrain against

## Why
Current `main` had two implementations of `_constrain_scopes_to_hints`. The later overriding version was missing the empty-hints fast path, so `tests/nomic/test_decomposer_bounded_issues.py::TestConstrainScopesToHints::test_no_hints_passthrough` regressed even though the earlier implementation and docstring implied passthrough behavior.

## Validation
- `python3 -m ruff check aragora/nomic/task_decomposer.py tests/nomic/test_decomposer_bounded_issues.py`
- `python3 -m pytest -q tests/nomic/test_decomposer_bounded_issues.py::TestConstrainScopesToHints::test_no_hints_passthrough tests/nomic/test_decomposer_bounded_issues.py`
