### PR TITLE
fix(test): sync debates handler expectations with offset pagination

### DIFF
--- a/tests/test_handlers_debates.py
+++ b/tests/test_handlers_debates.py
@@ -227,14 +227,14 @@ class TestListDebatesEndpoint:
         result = debates_handler.handle("/api/v1/debates", {"limit": "10"}, None)
 
         assert result.status_code == 200
-        mock_storage.list_recent.assert_called_with(limit=10, org_id="test-org-001")
+        mock_storage.list_recent.assert_called_with(limit=10, org_id="test-org-001", offset=0)
 
     def test_list_caps_limit_at_100(self, debates_handler, mock_storage):
         """Should cap limit at 100."""
         result = debates_handler.handle("/api/v1/debates", {"limit": "500"}, None)
 
         assert result.status_code == 200
-        mock_storage.list_recent.assert_called_with(limit=100, org_id="test-org-001")
+        mock_storage.list_recent.assert_called_with(limit=100, org_id="test-org-001", offset=0)
 
     def test_list_unavailable_returns_503(self):
         """Should return 503 when storage not available."""


### PR DESCRIPTION
## Summary
- update the two stale `list_recent` expectations in `tests/test_handlers_debates.py`
- align the tests with current handler behavior, which passes `offset=0` into paginated debate listing
- restore the `Deploy (Secure)` quick-test slice on current `main`

## Failure
Current `main` at `4e79bd866` fails the secure deploy quick tests with:
- `Expected: list_recent(limit=100, org_id='test-org-001')`
- `Actual: list_recent(limit=100, org_id='test-org-001', offset=0)`

## Validation
- `python3 -m ruff check tests/test_handlers_debates.py`
- `python3 -m pytest -q tests/test_handlers_debates.py`
- `python3 -m pytest -q tests/test_handlers_debates.py tests/test_api_handler.py`
