### PR TITLE
fix(quickstart): restore founder-loop KM ingestion and token accounting

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -49,16 +49,6 @@ _LIVE_PROVIDER_PRIORITY: tuple[str, ...] = (
     "deepseek",
 )
 _LIVE_ARENA_KWARGS: dict[str, Any] = {
-    "knowledge_mound": None,
-    "auto_create_knowledge_mound": False,
-    "enable_knowledge_retrieval": False,
-    "enable_knowledge_ingestion": False,
-    "enable_belief_guidance": False,
-    "enable_cross_debate_memory": False,
-    "use_rlm_limiter": False,
-    "enable_ml_delegation": False,
-    "enable_quality_gates": False,
-    "enable_consensus_estimation": False,
     "disable_post_debate_pipeline": True,
 }
 _PROVIDER_TLS_HOSTS: dict[str, str] = {
@@ -465,7 +455,38 @@ async def _run_live_debate(
         agent_names.append(agent.name)
 
     # Quickstart is a bounded onboarding lane, not the full debate control plane.
-    arena = Arena(env, agents, protocol, insight_store=store, **_LIVE_ARENA_KWARGS)
+    # Use config objects to avoid deprecation warnings from individual kwargs.
+    from aragora.debate.arena_primary_configs import KnowledgeConfig, MemoryConfig, MLConfig
+
+    memory_config = MemoryConfig(
+        enable_knowledge_retrieval=True,
+        enable_knowledge_ingestion=True,
+        auto_create_knowledge_mound=True,
+        enable_belief_guidance=False,
+        enable_cross_debate_memory=False,
+        use_rlm_limiter=False,
+    )
+    knowledge_config = KnowledgeConfig(
+        auto_create_knowledge_mound=True,
+        enable_knowledge_retrieval=True,
+        enable_knowledge_ingestion=True,
+        enable_belief_guidance=False,
+    )
+    ml_config = MLConfig(
+        enable_ml_delegation=False,
+        enable_quality_gates=False,
+        enable_consensus_estimation=False,
+    )
+    arena = Arena(
+        env,
+        agents,
+        protocol,
+        insight_store=store,
+        memory_config=memory_config,
+        knowledge_config=knowledge_config,
+        ml_config=ml_config,
+        **_LIVE_ARENA_KWARGS,
+    )
     arena.enable_introspection = False
     try:
         result = await asyncio.wait_for(arena.run(), timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
@@ -482,6 +503,10 @@ async def _run_live_debate(
 
     live_receipt = _build_live_receipt(result, question, rounds, team)
     live_receipt["agents"] = agent_names
+    live_receipt["km_ingested"] = bool(
+        getattr(arena, "knowledge_mound", None)
+        and getattr(arena, "enable_knowledge_ingestion", False)
+    )
     return live_receipt
 
 
@@ -610,8 +635,9 @@ def _build_live_receipt(
         elif vote_agent:
             dissenting_agents.append(vote_agent)
 
-    if not vote_records and consensus_reached:
+    if not supporting_agents and consensus_reached:
         supporting_agents = participants[:]
+        dissenting_agents = []
 
     rounds_used = int(getattr(result, "rounds_used", 0) or rounds)
     receipt = DecisionReceipt(
@@ -894,7 +920,15 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
         print(f"  Artifact:   {str(result['artifact_hash'])[:16]}...")
 
     if result.get("summary"):
-        print(f"\n  Summary:\n  {result['summary'][:500]}")
+        summary_text = result["summary"]
+        if len(summary_text) > 800:
+            # Truncate at sentence boundary to avoid mid-sentence clipping
+            cutoff = summary_text[:800].rfind(".")
+            if cutoff > 200:
+                summary_text = summary_text[: cutoff + 1] + "\n  [... truncated]"
+            else:
+                summary_text = summary_text[:800] + "..."
+        print(f"\n  Summary:\n  {summary_text}")
 
     if result.get("dissent"):
         print("\n  Dissent:")
@@ -913,6 +947,15 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
     )
     artifact_format = saved_artifact.suffix.lstrip(".") or fmt
     print(f"\nResult artifact ({result.get('mode', 'demo')}/{artifact_format}): {saved_artifact}")
+
+    # Step 6b: Report KM ingestion status truthfully
+    if result.get("mode") == "live":
+        km_ingested = result.get("km_ingested", False)
+        if km_ingested:
+            print("[+] Knowledge Mound: outcome ingested")
+        else:
+            print("[*] Knowledge Mound: ingestion skipped (quickstart uses lightweight KM)")
+            print("    Use 'aragora ask' or 'aragora decide' for full KM writeback.")
 
     # Step 7: Open receipt in browser
     no_browser = getattr(args, "no_browser", False)

--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -227,6 +227,20 @@ async def _populate_result_cost(
         logger.debug("cost_population_failed (non-critical): %s", e)
 
 
+async def _populate_result_tokens_from_agents(
+    result: DebateResult,
+    agents: list[Any],
+) -> None:
+    """Fallback: sum per-agent token counters when cost tracker has no data."""
+    if getattr(result, "total_tokens", 0):
+        return
+    total = 0
+    for agent in agents:
+        total += getattr(agent, "total_tokens_in", 0) + getattr(agent, "total_tokens_out", 0)
+    if total > 0:
+        result.total_tokens = total
+
+
 def _persist_debate_cost_to_km(debate_id: str, extensions: Any) -> None:
     """Persist debate cost summary to Knowledge Mound via CostAdapter.
 
@@ -879,6 +893,7 @@ async def handle_debate_completion(
     # Populate DebateResult cost fields from cost tracker
     if ctx.result:
         await _populate_result_cost(ctx.result, state.debate_id, arena.extensions)
+        await _populate_result_tokens_from_agents(ctx.result, arena.agents)
 
     # Persist debate cost summary to Knowledge Mound via CostAdapter
     if ctx.result:

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -587,18 +587,27 @@ class TestCmdQuickstart:
 
         arena_kwargs = mock_arena_cls.call_args.kwargs
         assert arena_kwargs["insight_store"] is mock_insight_store
-        assert arena_kwargs["knowledge_mound"] is None
-        assert arena_kwargs["auto_create_knowledge_mound"] is False
-        assert arena_kwargs["enable_knowledge_retrieval"] is False
-        assert arena_kwargs["enable_knowledge_ingestion"] is False
-        assert arena_kwargs["enable_belief_guidance"] is False
-        assert arena_kwargs["enable_cross_debate_memory"] is False
-        assert arena_kwargs["use_rlm_limiter"] is False
-        assert arena_kwargs["enable_ml_delegation"] is False
-        assert arena_kwargs["enable_quality_gates"] is False
-        assert arena_kwargs["enable_consensus_estimation"] is False
         assert arena_kwargs["disable_post_debate_pipeline"] is True
         assert mock_arena.enable_introspection is False
+
+        # Quickstart now uses config objects instead of individual kwargs
+        memory_config = arena_kwargs["memory_config"]
+        assert memory_config.enable_knowledge_retrieval is True
+        assert memory_config.enable_knowledge_ingestion is True
+        assert memory_config.auto_create_knowledge_mound is True
+        assert memory_config.enable_belief_guidance is False
+        assert memory_config.enable_cross_debate_memory is False
+        assert memory_config.use_rlm_limiter is False
+
+        knowledge_config = arena_kwargs["knowledge_config"]
+        assert knowledge_config.enable_knowledge_retrieval is True
+        assert knowledge_config.enable_knowledge_ingestion is True
+        assert knowledge_config.enable_belief_guidance is False
+
+        ml_config = arena_kwargs["ml_config"]
+        assert ml_config.enable_ml_delegation is False
+        assert ml_config.enable_quality_gates is False
+        assert ml_config.enable_consensus_estimation is False
 
     @pytest.mark.asyncio
     async def test_run_live_debate_skips_crux_event_dispatch_in_bounded_profile(self):


### PR DESCRIPTION
## Summary
- replace deprecated per-flag Arena kwargs with `MemoryConfig`, `KnowledgeConfig`, and `MLConfig` in the quickstart founder loop
- restore truthful quickstart founder-loop behavior for KM retrieval/ingestion and supporting agent reporting
- add token fallback accounting from per-agent counters when the cost tracker summary is empty

## Why
A local unpublished commit on `main` had real founder-loop behavior fixes that were not on `origin/main`. This PR preserves that value on a clean `origin/main` base instead of leaving it stranded in the root checkout.

## Validation
- `python3 -m ruff check aragora/cli/commands/quickstart.py aragora/debate/orchestrator_runner.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
  - result: `57 passed`
