### PR TITLE
fix(cli): prefer healthy default provider for quickstart

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -41,11 +41,11 @@ _LIVE_ROLES: tuple[tuple[str, str], ...] = (
     ("synthesizer", "synthesizer"),
 )
 _LIVE_PROVIDER_PRIORITY: tuple[str, ...] = (
-    "openai-api",
     "gemini",
+    "openai-api",
     "anthropic-api",
-    "mistral",
     "grok",
+    "mistral",
     "deepseek",
 )
 _LIVE_ARENA_KWARGS: dict[str, Any] = {

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -372,8 +372,8 @@ class TestLiveQuickstartHelpers:
         )
 
         providers = [agent["provider"] for agent in team]
-        assert providers[0] == "openai-api"
-        assert providers == ["openai-api"] * 3
+        assert providers[0] == "gemini"
+        assert providers == ["gemini"] * 3
 
     def test_build_live_receipt_surfaces_consensus_dissent_and_receipt(self):
         from aragora.gauntlet.receipt_models import DecisionReceipt


### PR DESCRIPTION
## Summary
- prefer Gemini ahead of OpenAI in the automatic quickstart provider priority
- keep explicit `--provider` behavior unchanged
- cover the default single-provider team selection order in quickstart tests

## Why
On this machine the automatic quickstart path was selecting `openai-api`, then immediately hitting HTTP 429 fallback churn before timing out. The bounded onboarding lane should prefer the provider that can actually complete a live run instead of the one that only looks available from env/key presence.

## Testing
- python3 -m ruff check aragora/cli/commands/quickstart.py tests/cli/test_quickstart.py
- python3 -m pytest tests/cli/test_quickstart.py -q
- python3 -m aragora.cli.main quickstart --provider gemini --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser
- python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser
