### PR TITLE
fix(cli): wire spec command to prompt conductor

### DIFF
--- a/aragora/cli/commands/spec.py
+++ b/aragora/cli/commands/spec.py
@@ -31,32 +31,43 @@ async def _run_spec_pipeline(
     output_format: str = "text",
 ) -> dict[str, Any]:
     """Run the prompt-to-spec pipeline and return the result."""
-    from aragora.prompt_engine.conductor import SpecConductor
-    from aragora.prompt_engine.types import InterrogationDepth, UserProfile
+    from aragora.prompt_engine.conductor import ConductorConfig, PromptConductor
+    from aragora.prompt_engine.types import InterrogationDepth
 
     depth_map = {
         "quick": InterrogationDepth.QUICK,
         "thorough": InterrogationDepth.THOROUGH,
         "exhaustive": InterrogationDepth.EXHAUSTIVE,
     }
-    profile_map = {
-        "founder": UserProfile.FOUNDER,
-        "cto": UserProfile.CTO,
-        "business": UserProfile.BUSINESS,
-        "team": UserProfile.TEAM,
+
+    config = ConductorConfig.from_profile(profile)
+    config.interrogation_depth = depth_map.get(depth, InterrogationDepth.QUICK)
+    config.skip_research = skip_research
+    config.skip_interrogation = skip_interrogation
+
+    # Use a fast agent for CLI to keep latency bounded
+    try:
+        from aragora.agents.api_agents.openai import OpenAIAPIAgent
+
+        agent = OpenAIAPIAgent(name="spec-agent", model="gpt-4o-mini", role="proposer")
+    except (ImportError, RuntimeError, ValueError):
+        agent = None
+
+    conductor = PromptConductor(config=config, agent=agent)
+    result = await conductor.run(prompt)
+
+    return {
+        "specification": result.specification.to_dict()
+        if hasattr(result.specification, "to_dict")
+        else result.specification,
+        "intent": result.intent.to_dict() if hasattr(result.intent, "to_dict") else result.intent,
+        "research": result.research.to_dict()
+        if result.research and hasattr(result.research, "to_dict")
+        else result.research,
+        "questions": [q.to_dict() if hasattr(q, "to_dict") else q for q in result.questions],
+        "stages_completed": result.stages_completed,
+        "auto_approved": result.auto_approved,
     }
-
-    conductor = SpecConductor(
-        interrogation_depth=depth_map.get(depth, InterrogationDepth.QUICK),
-        user_profile=profile_map.get(profile, UserProfile.FOUNDER),
-    )
-
-    result = await conductor.run(
-        prompt,
-        skip_research=skip_research,
-        skip_interrogation=skip_interrogation,
-    )
-    return result
 
 
 def _print_spec_result(result: dict[str, Any], output_format: str = "text") -> None:

--- a/tests/cli/test_spec_command.py
+++ b/tests/cli/test_spec_command.py
@@ -11,32 +11,72 @@ from aragora.cli.commands.spec import _run_spec_pipeline, cmd_spec
 from aragora.cli.parser import build_parser
 
 
-class _FakeSpecConductor:
+class _FakeConductorConfig:
+    last_profile: str | None = None
+
+    def __init__(self) -> None:
+        self.interrogation_depth = None
+        self.skip_research = False
+        self.skip_interrogation = False
+
+    @classmethod
+    def from_profile(cls, profile: str):
+        cls.last_profile = profile
+        return cls()
+
+
+class _FakeOpenAIAPIAgent:
+    last_run: dict[str, object] | None = None
+
+    def __init__(self, *, name, model, role) -> None:
+        type(self).last_run = {
+            "name": name,
+            "model": model,
+            "role": role,
+        }
+
+
+class _FakeRecord:
+    def __init__(self, **data) -> None:
+        self._data = data
+        for key, value in data.items():
+            setattr(self, key, value)
+
+    def to_dict(self) -> dict[str, object]:
+        return dict(self._data)
+
+
+class _FakePromptConductor:
     last_init: dict[str, object] | None = None
     last_run: dict[str, object] | None = None
 
-    def __init__(self, *, interrogation_depth, user_profile) -> None:
+    def __init__(self, *, config, agent) -> None:
         type(self).last_init = {
-            "interrogation_depth": interrogation_depth,
-            "user_profile": user_profile,
+            "interrogation_depth": config.interrogation_depth,
+            "skip_research": config.skip_research,
+            "skip_interrogation": config.skip_interrogation,
+            "agent": agent,
         }
 
-    async def run(self, prompt: str, *, skip_research: bool, skip_interrogation: bool):
+    async def run(self, prompt: str):
         type(self).last_run = {
             "prompt": prompt,
-            "skip_research": skip_research,
-            "skip_interrogation": skip_interrogation,
         }
-        return {
-            "specification": {
-                "problem_statement": "Need a better onboarding flow.",
-                "proposed_solution": "Add a guided setup sequence.",
-                "success_criteria": [{"description": "Users finish setup faster."}],
-                "risks": [{"description": "Higher implementation complexity."}],
-                "estimated_effort": "medium",
-                "confidence": 0.8,
-            }
-        }
+        return _FakeRecord(
+            specification=_FakeRecord(
+                problem_statement="Need a better onboarding flow.",
+                proposed_solution="Add a guided setup sequence.",
+                success_criteria=[_FakeRecord(description="Users finish setup faster.")],
+                risks=[_FakeRecord(description="Higher implementation complexity.")],
+                estimated_effort="medium",
+                confidence=0.8,
+            ),
+            intent=_FakeRecord(intent_type="feature", scope_estimate="medium"),
+            research=_FakeRecord(evidence_links=["km://onboarding"]),
+            questions=[_FakeRecord(question="What should improve first?")],
+            stages_completed=["decompose", "specify"],
+            auto_approved=False,
+        )
 
 
 class TestSpecParser:
@@ -94,7 +134,11 @@ class TestRunSpecPipeline:
             "sys.modules",
             {
                 "aragora.prompt_engine.conductor": SimpleNamespace(
-                    SpecConductor=_FakeSpecConductor
+                    ConductorConfig=_FakeConductorConfig,
+                    PromptConductor=_FakePromptConductor,
+                ),
+                "aragora.agents.api_agents.openai": SimpleNamespace(
+                    OpenAIAPIAgent=_FakeOpenAIAPIAgent
                 ),
                 "aragora.prompt_engine.types": fake_types,
             },
@@ -107,16 +151,25 @@ class TestRunSpecPipeline:
                 profile="cto",
             )
 
-        assert _FakeSpecConductor.last_init == {
+        assert _FakeConductorConfig.last_profile == "cto"
+        assert _FakePromptConductor.last_init == {
             "interrogation_depth": "thorough-depth",
-            "user_profile": "cto-profile",
-        }
-        assert _FakeSpecConductor.last_run == {
-            "prompt": "Design a better onboarding flow",
             "skip_research": True,
             "skip_interrogation": True,
+            "agent": _FakePromptConductor.last_init["agent"],
         }
-        assert "specification" in result
+        assert _FakeOpenAIAPIAgent.last_run == {
+            "name": "spec-agent",
+            "model": "gpt-4o-mini",
+            "role": "proposer",
+        }
+        assert _FakePromptConductor.last_run == {
+            "prompt": "Design a better onboarding flow",
+        }
+        assert result["intent"]["intent_type"] == "feature"
+        assert result["specification"]["problem_statement"] == "Need a better onboarding flow."
+        assert result["questions"] == [{"question": "What should improve first?"}]
+        assert result["stages_completed"] == ["decompose", "specify"]
 
 
 class TestCmdSpec:


### PR DESCRIPTION
## Summary
- switch `aragora spec` from the stale `SpecConductor` path to the current `PromptConductor` interface
- keep CLI latency bounded by preferring a lightweight OpenAI API agent when available
- update the focused CLI tests to validate the current conductor/config contract and serialized result shape

## Validation
- `python3 -m ruff check aragora/cli/commands/spec.py tests/cli/test_spec_command.py`
- `python3 -m pytest tests/cli/test_spec_command.py -q`
