### PR TITLE
fix(debate): handle KnowledgeItem objects in KM outcome validation

### DIFF
--- a/aragora/debate/km_outcome_bridge.py
+++ b/aragora/debate/km_outcome_bridge.py
@@ -180,6 +180,54 @@ class KMOutcomeBridge:
         """Get KM items used in a debate."""
         return self._debate_km_usage.get(debate_id, [])
 
+    @staticmethod
+    def _item_get(item: Any, key: str, default: Any = None) -> Any:
+        """Read a field from KM items that may be dicts or dataclass-like objects."""
+        if isinstance(item, dict):
+            return item.get(key, default)
+
+        if hasattr(item, key):
+            return getattr(item, key)
+
+        if hasattr(item, "to_dict"):
+            try:
+                data = item.to_dict()
+            except Exception:  # pragma: no cover - defensive against third-party types
+                data = None
+            if isinstance(data, dict):
+                return data.get(key, default)
+
+        metadata = getattr(item, "metadata", None)
+        if isinstance(metadata, dict) and key in metadata:
+            return metadata.get(key, default)
+
+        return default
+
+    @staticmethod
+    def _coerce_confidence(raw_confidence: Any) -> float:
+        """Normalize confidence values from dicts, enums, or strings to floats."""
+        if raw_confidence is None:
+            return 0.5
+
+        if isinstance(raw_confidence, (int, float)):
+            return float(raw_confidence)
+
+        enum_value = getattr(raw_confidence, "value", None)
+        if isinstance(enum_value, str):
+            raw_confidence = enum_value
+
+        if isinstance(raw_confidence, str):
+            confidence_map = {
+                "verified": 0.95,
+                "high": 0.8,
+                "medium": 0.6,
+                "low": 0.4,
+                "unverified": 0.2,
+            }
+            return confidence_map.get(raw_confidence.lower(), 0.5)
+
+        return 0.5
+
     async def validate_knowledge_from_outcome(
         self,
         outcome: ConsensusOutcome,
@@ -283,17 +331,7 @@ class KMOutcomeBridge:
             logger.warning("KM item not found for validation: %s", item_id)
             return None
 
-        original_confidence = item.get("confidence", 0.5)
-        if isinstance(original_confidence, str):
-            # Convert confidence level to float if needed
-            confidence_map = {
-                "verified": 0.95,
-                "high": 0.8,
-                "medium": 0.6,
-                "low": 0.4,
-                "unverified": 0.2,
-            }
-            original_confidence = confidence_map.get(original_confidence.lower(), 0.5)
+        original_confidence = self._coerce_confidence(self._item_get(item, "confidence", 0.5))
 
         # Calculate adjustment based on outcome
         if was_successful:
@@ -377,16 +415,7 @@ class KMOutcomeBridge:
                     result.items_skipped += 1
                     continue
 
-                original_conf = item.get("confidence", 0.5)
-                if isinstance(original_conf, str):
-                    confidence_map = {
-                        "verified": 0.95,
-                        "high": 0.8,
-                        "medium": 0.6,
-                        "low": 0.4,
-                        "unverified": 0.2,
-                    }
-                    original_conf = confidence_map.get(original_conf.lower(), 0.5)
+                original_conf = self._coerce_confidence(self._item_get(item, "confidence", 0.5))
 
                 new_confidence = max(0.0, min(1.0, original_conf + decayed_adjustment))
 

--- a/tests/debate/test_km_outcome_bridge.py
+++ b/tests/debate/test_km_outcome_bridge.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from dataclasses import dataclass
+from datetime import datetime
 
 from aragora.debate.km_outcome_bridge import (
     KMOutcomeBridge,
@@ -17,6 +18,7 @@ from aragora.debate.km_outcome_bridge import (
     OutcomeValidation,
     PropagationResult,
 )
+from aragora.knowledge.mound.types import ConfidenceLevel, KnowledgeItem, KnowledgeSource
 
 
 @dataclass
@@ -264,6 +266,42 @@ class TestKMOutcomeBridgeValidation:
         assert len(validations) == 1
         assert 0.13 <= validations[0].confidence_adjustment <= 0.14
 
+    @pytest.mark.asyncio
+    async def test_validate_accepts_knowledge_item_objects(self):
+        """Validation should accept KnowledgeItem objects from live KM queries."""
+        mock_mound = MagicMock()
+        mock_mound.get = AsyncMock(
+            return_value=KnowledgeItem(
+                id="km_123",
+                content="Test content",
+                source=KnowledgeSource.FACT,
+                source_id="src_123",
+                confidence=ConfidenceLevel.HIGH,
+                created_at=datetime.now(),
+                updated_at=datetime.now(),
+                metadata={"workspace_id": "default"},
+            )
+        )
+        mock_mound.update_confidence = AsyncMock(return_value=True)
+        mock_mound.get_relationships = AsyncMock(return_value=[])
+
+        bridge = KMOutcomeBridge(knowledge_mound=mock_mound)
+        bridge.record_km_usage("debate_1", ["km_123"])
+
+        outcome = MockConsensusOutcome(
+            debate_id="debate_1",
+            consensus_text="Test",
+            consensus_confidence=0.85,
+            implementation_attempted=True,
+            implementation_succeeded=True,
+        )
+
+        validations = await bridge.validate_knowledge_from_outcome(outcome)
+
+        assert len(validations) == 1
+        assert validations[0].original_confidence == 0.8
+        mock_mound.update_confidence.assert_awaited_once()
+
 
 class TestKMOutcomeBridgePropagation:
     """Tests for validation propagation."""
@@ -353,6 +391,48 @@ class TestKMOutcomeBridgePropagation:
         for v in result.validations:
             # At depth 1, adjustment should be 0.1 * 0.5 = 0.05
             assert abs(v.confidence_adjustment) <= abs(validation.confidence_adjustment)
+
+    @pytest.mark.asyncio
+    async def test_propagate_validation_accepts_knowledge_item_objects(self):
+        """Propagation should accept KnowledgeItem objects from live KM queries."""
+
+        class MockMound:
+            def __init__(self) -> None:
+                self.update_confidence = AsyncMock(return_value=True)
+
+            async def get(self, _item_id: str) -> KnowledgeItem:
+                return KnowledgeItem(
+                    id="km_related",
+                    content="Related content",
+                    source=KnowledgeSource.FACT,
+                    source_id="src_related",
+                    confidence=ConfidenceLevel.MEDIUM,
+                    created_at=datetime.now(),
+                    updated_at=datetime.now(),
+                    metadata={},
+                )
+
+            async def get_relationships(self, _item_id: str) -> list[dict[str, str]]:
+                return [{"target_id": "km_related"}]
+
+        mock_mound = MockMound()
+        bridge = KMOutcomeBridge(knowledge_mound=mock_mound)
+        validation = OutcomeValidation(
+            km_item_id="km_root",
+            debate_id="debate_1",
+            was_successful=True,
+            confidence_adjustment=0.1,
+            validation_reason="test",
+        )
+
+        result = await bridge.propagate_validation(
+            km_item_id="km_root",
+            validation=validation,
+            depth=1,
+        )
+
+        assert result.items_updated == 1
+        assert result.validations[0].original_confidence == 0.6
 
 
 class TestKMOutcomeBridgeStats:


### PR DESCRIPTION
## Summary
- normalize KMOutcomeBridge item access for dict and KnowledgeItem returns
- coerce enum-backed confidence levels before applying validation math
- add focused bridge tests for real KnowledgeItem validation and propagation paths

## Testing
- python3 -m ruff check aragora/debate/km_outcome_bridge.py tests/debate/test_km_outcome_bridge.py
- python3 -m pytest tests/debate/test_km_outcome_bridge.py -q
- python3 -m pytest tests/cli/test_quickstart.py tests/debate/test_km_outcome_bridge.py -q
- env ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser
