### PR TITLE
feat(debate): wire cross-verification and prover-estimator consensus

### DIFF
--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -227,6 +227,39 @@ async def _populate_result_cost(
         logger.debug("cost_population_failed (non-critical): %s", e)
 
 
+async def _run_cross_verification(
+    result: DebateResult,
+    agents: list[Any],
+) -> None:
+    """Run cross-verification on the final answer to detect hallucinations."""
+    try:
+        from aragora.debate.cross_verification import CrossVerificationEngine
+
+        if not agents:
+            return
+        engine = CrossVerificationEngine(verifier=agents[0])
+        task = getattr(result, "task", "") or ""
+        context = task
+        cv_result = await engine.verify(result.final_answer or "", context=context)
+
+        if result.metadata is None or not isinstance(result.metadata, dict):
+            result.metadata = {}
+        result.metadata["cross_verification"] = {
+            "grounding_delta": cv_result.grounding_delta,
+            "hallucination_risk": cv_result.hallucination_risk,
+            "adversarial_resistance": cv_result.adversarial_resistance,
+            "is_grounded": cv_result.is_grounded,
+        }
+        logger.info(
+            "cross_verification_complete grounding_delta=%.3f hallucination_risk=%.3f grounded=%s",
+            cv_result.grounding_delta,
+            cv_result.hallucination_risk,
+            cv_result.is_grounded,
+        )
+    except (ImportError, RuntimeError, ValueError, TypeError, AttributeError) as e:
+        logger.debug("cross_verification_skipped: %s", e)
+
+
 async def _populate_result_tokens_from_agents(
     result: DebateResult,
     agents: list[Any],
@@ -1247,6 +1280,13 @@ async def handle_debate_completion(
                 )
         except (AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.debug("Live explainability snapshot failed (non-critical): %s", e)
+
+    # Run cross-verification on final answer if explicitly enabled.
+    cross_verification_enabled = getattr(arena, "enable_cross_verification", False)
+    if not isinstance(cross_verification_enabled, bool):
+        cross_verification_enabled = False
+    if ctx.result and ctx.result.final_answer and cross_verification_enabled:
+        await _run_cross_verification(ctx.result, arena.agents)
 
     # Collect extended thinking traces from Anthropic agents
     if ctx.result and arena.agents:

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -478,6 +478,8 @@ class ConsensusPhase:
             await self._handle_judge_consensus(ctx)
         elif normalized == "byzantine":
             await self._handle_byzantine_consensus(ctx)
+        elif consensus_mode == "prover_estimator":
+            await self._handle_prover_estimator_consensus(ctx)
         else:
             logger.warning("Unknown consensus mode: %s, using none", consensus_mode)
             await self._handle_none_consensus(ctx)
@@ -1147,6 +1149,103 @@ class ConsensusPhase:
         except (RuntimeError, OSError, ConnectionError, TimeoutError) as e:  # noqa: BLE001 - phase isolation
             logger.error("byzantine_consensus_error: %s", e, exc_info=True)
             # Fall back to majority voting
+            await self._handle_majority_consensus(ctx)
+
+    async def _handle_prover_estimator_consensus(self, ctx: "DebateContext") -> None:
+        """Handle 'prover_estimator' consensus — structured truth-seeking protocol.
+
+        Uses the Prover-Estimator framework where claims are decomposed into
+        subclaims, probability-estimated, challenged with evidence, and aggregated
+        using importance-weighted geometric mean.
+        """
+        from aragora.debate.prover_estimator import ProverEstimatorEngine
+
+        result = ctx.result
+        proposals = ctx.proposals
+        agents = ctx.agents
+
+        if len(agents) < 2:
+            logger.warning(
+                "Prover-Estimator requires at least 2 agents, got %s. Falling back to majority.",
+                len(agents),
+            )
+            await self._handle_majority_consensus(ctx)
+            return
+
+        prover = agents[0]
+        estimator = agents[1] if len(agents) > 1 else agents[0]
+
+        max_rounds = getattr(self.protocol, "prover_estimator_max_rounds", 2)
+        pe_context = getattr(self.protocol, "prover_estimator_context", "")
+
+        claim = ctx.env.task if ctx.env else ""
+        if proposals:
+            best_proposal = next(iter(proposals.values()))
+            claim = f"{claim}\n\nProposal:\n{best_proposal}"
+
+        engine = ProverEstimatorEngine(
+            prover=prover,
+            estimator=estimator,
+            max_challenge_rounds=max_rounds,
+            context=pe_context,
+        )
+
+        logger.info(
+            "prover_estimator_start prover=%s estimator=%s rounds=%s",
+            getattr(prover, "name", "unknown"),
+            getattr(estimator, "name", "unknown"),
+            max_rounds,
+        )
+
+        if self._notify_spectator:
+            self._notify_spectator(
+                "prover_estimator",
+                details=f"Running Prover-Estimator with {len(agents)} agents",
+            )
+
+        try:
+            pe_result = await engine.run(claim)
+
+            result.confidence = pe_result.overall_confidence
+            result.consensus_reached = pe_result.overall_confidence >= 0.5
+
+            if proposals:
+                result.final_answer = next(iter(proposals.values()))
+            result.consensus_strength = (
+                "strong"
+                if pe_result.overall_confidence >= 0.8
+                else "medium"
+                if pe_result.overall_confidence >= 0.5
+                else "weak"
+            )
+
+            if result.formal_verification is None:
+                result.formal_verification = {}
+            result.formal_verification["prover_estimator"] = {
+                "overall_confidence": pe_result.overall_confidence,
+                "grounding_score": pe_result.grounding_score,
+                "obfuscation_detected": pe_result.obfuscation_detected,
+                "subclaim_count": len(pe_result.subclaims),
+                "challenge_count": len(pe_result.challenges),
+            }
+
+            logger.info(
+                "prover_estimator_complete confidence=%.3f grounding=%.3f obfuscation=%s subclaims=%s",
+                pe_result.overall_confidence,
+                pe_result.grounding_score,
+                pe_result.obfuscation_detected,
+                len(pe_result.subclaims),
+            )
+
+            if self._notify_spectator:
+                self._notify_spectator(
+                    "consensus",
+                    details=f"Prover-Estimator: confidence={pe_result.overall_confidence:.0%}, grounding={pe_result.grounding_score:.0%}",
+                    metric=pe_result.overall_confidence,
+                )
+
+        except (RuntimeError, ValueError, TypeError, AttributeError) as e:
+            logger.error("prover_estimator_error: %s", e, exc_info=True)
             await self._handle_majority_consensus(ctx)
 
     async def _collect_votes(self, ctx: "DebateContext") -> list["Vote"]:

--- a/tests/debate/phases/test_consensus_phase.py
+++ b/tests/debate/phases/test_consensus_phase.py
@@ -6,7 +6,7 @@ Tests cover:
 - ConsensusCallbacks dataclass
 - ConsensusPhase initialization (new style and legacy style)
 - execute method (timeout, error handling, cancellation, hooks)
-- _execute_consensus mode routing (none, majority, unanimous, judge, byzantine, unknown)
+- _execute_consensus mode routing (none, majority, unanimous, judge, byzantine, prover_estimator, unknown)
 - _handle_none_consensus method
 - _handle_fallback_consensus method
 - _handle_majority_consensus method
@@ -913,6 +913,21 @@ class TestExecuteConsensusRouting:
             mock.assert_called_once_with(ctx)
 
     @pytest.mark.asyncio
+    async def test_routes_prover_estimator_mode(self):
+        """Routes 'prover_estimator' mode to its handler."""
+        ctx, protocol = make_context()
+        deps = ConsensusDependencies(protocol=protocol)
+        phase = ConsensusPhase(deps=deps, callbacks=ConsensusCallbacks())
+
+        with patch.object(
+            phase,
+            "_handle_prover_estimator_consensus",
+            new_callable=AsyncMock,
+        ) as mock:
+            await phase._execute_consensus(ctx, "prover_estimator")
+            mock.assert_called_once_with(ctx)
+
+    @pytest.mark.asyncio
     async def test_unknown_mode_falls_back_to_none(self):
         """Unknown consensus mode falls back to none."""
         ctx, protocol = make_context()
@@ -1285,6 +1300,81 @@ class TestByzantineConsensus:
 
         # Should have processed some consensus
         assert ctx.result.final_answer is not None
+
+
+# =============================================================================
+# Additional Coverage: Prover-Estimator Consensus Tests
+# =============================================================================
+
+
+class TestProverEstimatorConsensus:
+    """Tests for prover-estimator consensus mode."""
+
+    @pytest.mark.asyncio
+    async def test_prover_estimator_populates_result(self):
+        """Prover-estimator records confidence and verification metadata."""
+        ctx, protocol = make_context(
+            proposals={"agent1": "Proposal A", "agent2": "Proposal B"},
+            agents=[MockAgent("agent1"), MockAgent("agent2")],
+            consensus_mode="prover_estimator",
+        )
+        deps = ConsensusDependencies(protocol=protocol)
+        phase = ConsensusPhase(deps=deps, callbacks=ConsensusCallbacks())
+
+        pe_result = MagicMock(
+            overall_confidence=0.82,
+            grounding_score=0.74,
+            obfuscation_detected=False,
+            subclaims=[object(), object()],
+            challenges=[object()],
+        )
+        engine = MagicMock()
+        engine.run = AsyncMock(return_value=pe_result)
+
+        with patch(
+            "aragora.debate.prover_estimator.ProverEstimatorEngine",
+            return_value=engine,
+        ) as engine_cls:
+            await phase._handle_prover_estimator_consensus(ctx)
+
+        engine_cls.assert_called_once()
+        engine.run.assert_awaited_once()
+        assert ctx.result.final_answer == "Proposal A"
+        assert ctx.result.consensus_reached is True
+        assert ctx.result.consensus_strength == "strong"
+        assert ctx.result.confidence == pytest.approx(0.82)
+        assert ctx.result.formal_verification["prover_estimator"] == {
+            "overall_confidence": 0.82,
+            "grounding_score": 0.74,
+            "obfuscation_detected": False,
+            "subclaim_count": 2,
+            "challenge_count": 1,
+        }
+
+    @pytest.mark.asyncio
+    async def test_prover_estimator_falls_back_to_majority_on_error(self):
+        """Engine failures fall back to majority consensus instead of aborting."""
+        ctx, protocol = make_context(consensus_mode="prover_estimator")
+        deps = ConsensusDependencies(protocol=protocol)
+        phase = ConsensusPhase(deps=deps, callbacks=ConsensusCallbacks())
+
+        engine = MagicMock()
+        engine.run = AsyncMock(side_effect=RuntimeError("boom"))
+
+        with (
+            patch(
+                "aragora.debate.prover_estimator.ProverEstimatorEngine",
+                return_value=engine,
+            ),
+            patch.object(
+                phase,
+                "_handle_majority_consensus",
+                new_callable=AsyncMock,
+            ) as mock_majority,
+        ):
+            await phase._handle_prover_estimator_consensus(ctx)
+
+        mock_majority.assert_awaited_once_with(ctx)
 
 
 # =============================================================================

--- a/tests/debate/test_orchestrator_runner.py
+++ b/tests/debate/test_orchestrator_runner.py
@@ -24,6 +24,7 @@ from aragora.core import DebateResult, Environment, TaskComplexity
 from aragora.debate.context import DebateContext
 from aragora.debate.orchestrator_runner import (
     _DebateExecutionState,
+    _run_cross_verification,
     initialize_debate_context,
     setup_debate_infrastructure,
     execute_debate_phases,
@@ -154,6 +155,7 @@ def mock_arena(
     arena.use_performance_selection = False
     arena.enable_auto_execution = False
     arena.enable_result_routing = False
+    arena.enable_cross_verification = False
     arena.phase_executor = mock_phase_executor
     arena.extensions = mock_extensions
 
@@ -837,6 +839,33 @@ class TestHandleDebateCompletion:
     """Tests for handle_debate_completion function."""
 
     @pytest.mark.asyncio
+    async def test_run_cross_verification_attaches_metadata(self, mock_agents):
+        """Cross-verification attaches grounding metadata to the result."""
+        result = DebateResult(task="Test task", final_answer="Test answer")
+        verification = MagicMock(
+            grounding_delta=0.42,
+            hallucination_risk=0.11,
+            adversarial_resistance=0.87,
+            is_grounded=True,
+        )
+        engine = MagicMock()
+        engine.verify = AsyncMock(return_value=verification)
+
+        with patch(
+            "aragora.debate.cross_verification.CrossVerificationEngine",
+            return_value=engine,
+        ):
+            await _run_cross_verification(result, mock_agents)
+
+        engine.verify.assert_awaited_once_with("Test answer", context="Test task")
+        assert result.metadata["cross_verification"] == {
+            "grounding_delta": 0.42,
+            "hallucination_risk": 0.11,
+            "adversarial_resistance": 0.87,
+            "is_grounded": True,
+        }
+
+    @pytest.mark.asyncio
     async def test_notifies_trackers_of_completion(self, mock_arena, execution_state):
         """Test that trackers are notified of debate completion."""
         await handle_debate_completion(mock_arena, execution_state)
@@ -970,6 +999,21 @@ class TestHandleDebateCompletion:
 
         # Should not raise
         await handle_debate_completion(mock_arena, execution_state)
+
+    @pytest.mark.asyncio
+    async def test_runs_cross_verification_when_enabled(self, mock_arena, execution_state):
+        """Debate completion runs cross-verification only when enabled."""
+        mock_arena.enable_cross_verification = True
+
+        with patch(
+            "aragora.debate.orchestrator_runner._run_cross_verification",
+            new_callable=AsyncMock,
+        ) as mock_cross_verification:
+            await handle_debate_completion(mock_arena, execution_state)
+
+        mock_cross_verification.assert_awaited_once_with(
+            execution_state.ctx.result, mock_arena.agents
+        )
 
     @pytest.mark.asyncio
     async def test_queues_for_supabase_sync(self, mock_arena, execution_state):


### PR DESCRIPTION
## Summary
- run cross-verification on final debate answers when explicitly enabled and attach grounding metadata to the result
- add concrete `prover_estimator` consensus handling for protocols that already advertise that mode
- cover the new orchestration and consensus behavior with focused tests

## Why
Current `main` already exposes `prover_estimator` in the debate protocol, but `ConsensusPhase` still routes it to the unknown-mode fallback. Separately, the preserved root-only debate patch contained a useful cross-verification hook that was never packaged into a lane. This re-homes both pieces cleanly onto current `main`.

## Validation
- `python3 -m ruff check aragora/debate/orchestrator_runner.py aragora/debate/phases/consensus_phase.py tests/debate/test_orchestrator_runner.py tests/debate/phases/test_consensus_phase.py`
- `python3 -m pytest tests/debate/test_orchestrator_runner.py tests/debate/phases/test_consensus_phase.py -q`
  - `169 passed`
  - includes a pre-existing pending KM background-task warning at teardown
