### PR TITLE
fix(memory): demote expected embedding rate-limit fallback noise

### DIFF
--- a/aragora/memory/embeddings.py
+++ b/aragora/memory/embeddings.py
@@ -68,6 +68,30 @@ _API_TIMEOUT = aiohttp.ClientTimeout(total=30)
 _embedding_cache_registered = False
 
 
+def _is_rate_limited_embedding_error(exc: BaseException) -> bool:
+    """Return True when an embedding failure is an expected rate-limit fallback."""
+    return "rate limited" in str(exc).lower()
+
+
+def _log_embedding_fallback(
+    provider_name: str,
+    exc: BaseException,
+    *,
+    batch: bool = False,
+) -> None:
+    """Log degraded embedding fallback at the appropriate severity.
+
+    Rate-limit degradation is expected fail-soft behavior and should not surface as a
+    founder-loop warning. Other connectivity/runtime failures remain warnings.
+    """
+    subject = "batch embedding" if batch else "embedding"
+    message = "%s %s failed (%s), using hash fallback"
+    if _is_rate_limited_embedding_error(exc):
+        logger.info(message, provider_name, subject, exc)
+    else:
+        logger.warning(message, provider_name, subject, exc)
+
+
 def _register_embedding_cache() -> None:
     """Register embedding cache with ServiceRegistry for observability."""
     global _embedding_cache_registered
@@ -202,7 +226,7 @@ class OpenAIEmbedding(EmbeddingProvider):
         try:
             embedding = await _retry_with_backoff(_call)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            logger.warning("OpenAI embedding failed (%s), using hash fallback", e)
+            _log_embedding_fallback("OpenAI", e)
             fallback = EmbeddingProvider(dimension=self.dimension)
             embedding = await fallback.embed(text)
         _get_embedding_cache().set(text, embedding)
@@ -233,7 +257,7 @@ class OpenAIEmbedding(EmbeddingProvider):
         try:
             return await _retry_with_backoff(_call)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            logger.warning("OpenAI batch embedding failed (%s), using hash fallback", e)
+            _log_embedding_fallback("OpenAI", e, batch=True)
             fallback = EmbeddingProvider(dimension=self.dimension)
             return await fallback.embed_batch(texts)
 
@@ -277,7 +301,7 @@ class GeminiEmbedding(EmbeddingProvider):
         try:
             embedding = await _retry_with_backoff(_call)
         except (aiohttp.ClientError, asyncio.TimeoutError) as e:
-            logger.warning("Gemini embedding failed (%s), using hash fallback", e)
+            _log_embedding_fallback("Gemini", e)
             fallback = EmbeddingProvider(dimension=self.dimension)
             embedding = await fallback.embed(text)
         _get_embedding_cache().set(text, embedding)

--- a/tests/memory/test_embeddings.py
+++ b/tests/memory/test_embeddings.py
@@ -14,6 +14,7 @@ Tests cover:
 from __future__ import annotations
 
 import asyncio
+import logging
 import struct
 import tempfile
 from pathlib import Path
@@ -383,6 +384,69 @@ class TestOpenAIEmbedding:
         fallback_embed.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_embed_logs_rate_limit_fallback_at_info(self, caplog):
+        """Rate-limit fallback should not surface as a warning."""
+        fallback_embedding = [0.42] * 1536
+        with (
+            patch(
+                "aragora.memory.embeddings._retry_with_backoff",
+                new=AsyncMock(side_effect=aiohttp.ClientError("Rate limited")),
+            ),
+            patch.object(
+                EmbeddingProvider,
+                "embed",
+                new=AsyncMock(return_value=fallback_embedding),
+            ),
+            caplog.at_level(logging.INFO, logger="aragora.memory.embeddings"),
+        ):
+            provider = OpenAIEmbedding(api_key="test-key")
+            from aragora.memory.embeddings import _get_embedding_cache
+
+            _get_embedding_cache()._cache.clear()
+            result = await provider.embed("rate-limited openai text")
+
+        assert result == fallback_embedding
+        assert any(
+            record.levelno == logging.INFO
+            and "OpenAI embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and "OpenAI embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_embed_logs_non_rate_limit_fallback_at_warning(self, caplog):
+        """Non-rate embedding failures should stay visible as warnings."""
+        fallback_embedding = [0.42] * 1536
+        with (
+            patch(
+                "aragora.memory.embeddings._retry_with_backoff",
+                new=AsyncMock(side_effect=aiohttp.ClientError("tls failure")),
+            ),
+            patch.object(
+                EmbeddingProvider,
+                "embed",
+                new=AsyncMock(return_value=fallback_embedding),
+            ),
+            caplog.at_level(logging.INFO, logger="aragora.memory.embeddings"),
+        ):
+            provider = OpenAIEmbedding(api_key="test-key")
+            from aragora.memory.embeddings import _get_embedding_cache
+
+            _get_embedding_cache()._cache.clear()
+            result = await provider.embed("tls-failure openai text")
+
+        assert result == fallback_embedding
+        assert any(
+            record.levelno == logging.WARNING
+            and "OpenAI embedding failed (tls failure)" in record.message
+            for record in caplog.records
+        )
+
+    @pytest.mark.asyncio
     async def test_embed_batch_uses_hash_fallback_on_client_error(self):
         """Batch failures should degrade without breaking list alignment."""
         fallback_embeddings = [[0.42] * 1536, [0.24] * 1536]
@@ -402,6 +466,37 @@ class TestOpenAIEmbedding:
 
         assert result == fallback_embeddings
         fallback_embed_batch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_embed_batch_logs_rate_limit_fallback_at_info(self, caplog):
+        """Batch rate-limit fallback should not surface as a warning."""
+        fallback_embeddings = [[0.42] * 1536, [0.24] * 1536]
+        with (
+            patch(
+                "aragora.memory.embeddings._retry_with_backoff",
+                new=AsyncMock(side_effect=aiohttp.ClientError("Rate limited")),
+            ),
+            patch.object(
+                EmbeddingProvider,
+                "embed_batch",
+                new=AsyncMock(return_value=fallback_embeddings),
+            ),
+            caplog.at_level(logging.INFO, logger="aragora.memory.embeddings"),
+        ):
+            provider = OpenAIEmbedding(api_key="test-key")
+            result = await provider.embed_batch(["text1", "text2"])
+
+        assert result == fallback_embeddings
+        assert any(
+            record.levelno == logging.INFO
+            and "OpenAI batch embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and "OpenAI batch embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
 
 
 # ===========================================================================
@@ -475,6 +570,40 @@ class TestGeminiEmbedding:
 
         assert result == fallback_embedding
         fallback_embed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_embed_logs_rate_limit_fallback_at_info(self, caplog):
+        """Gemini rate-limit fallback should not surface as a warning."""
+        fallback_embedding = [0.42] * 768
+        with (
+            patch(
+                "aragora.memory.embeddings._retry_with_backoff",
+                new=AsyncMock(side_effect=aiohttp.ClientError("Rate limited")),
+            ),
+            patch.object(
+                EmbeddingProvider,
+                "embed",
+                new=AsyncMock(return_value=fallback_embedding),
+            ),
+            caplog.at_level(logging.INFO, logger="aragora.memory.embeddings"),
+        ):
+            provider = GeminiEmbedding(api_key="test-key")
+            from aragora.memory.embeddings import _get_embedding_cache
+
+            _get_embedding_cache()._cache.clear()
+            result = await provider.embed("rate-limited gemini text")
+
+        assert result == fallback_embedding
+        assert any(
+            record.levelno == logging.INFO
+            and "Gemini embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
+        assert not any(
+            record.levelno >= logging.WARNING
+            and "Gemini embedding failed (Rate limited)" in record.message
+            for record in caplog.records
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- demote expected embedding rate-limit fallbacks from warnings to info
- keep non-rate-limit embedding failures at warning severity
- add regression coverage for OpenAI and Gemini fallback logging

## Why
Quickstart's lightweight Knowledge Mound retrieval already degrades safely when embedding providers rate-limit. The remaining founder-loop issue was user-facing warning noise from the embedding layer itself, not a debate failure.

## Verification
- `python3 -m ruff check aragora/memory/embeddings.py tests/memory/test_embeddings.py`
- `python3 -m pytest tests/memory/test_embeddings.py -q`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- `ARAGORA_USER_ID=an0mium PYTHONUNBUFFERED=1 python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser`
