### PR TITLE
fix(debate): respect RLM limiter flag in context gatherer

### DIFF
--- a/aragora/debate/arena_phases.py
+++ b/aragora/debate/arena_phases.py
@@ -266,6 +266,8 @@ def init_phases(arena: Arena) -> None:
         knowledge_mound=getattr(arena, "knowledge_mound", None),
         knowledge_workspace_id=getattr(arena, "loop_id", None) or "debate",
         enable_trending_context=getattr(arena.protocol, "enable_trending_injection", True),
+        enable_rlm_compression=getattr(arena, "enable_rlm", True)
+        and getattr(arena, "use_rlm_limiter", True),
         document_store=getattr(arena, "document_store", None),
         evidence_store=getattr(arena, "evidence_store", None),
         document_ids=getattr(arena.env, "documents", None),

--- a/tests/debate/test_arena_phases.py
+++ b/tests/debate/test_arena_phases.py
@@ -152,6 +152,19 @@ class TestInitPhases:
 
         assert mock_arena.context_gatherer is not None
 
+    def test_init_phases_passes_rlm_flag_to_context_gatherer(self):
+        """ContextGatherer should respect arena-level RLM disablement."""
+        mock_arena = self._create_mock_arena()
+        mock_arena.enable_rlm = True
+        mock_arena.use_rlm_limiter = False
+
+        with patch("aragora.debate.arena_phases.ContextGatherer") as mock_gatherer_cls:
+            init_phases(mock_arena)
+
+        assert mock_gatherer_cls.called
+        _, kwargs = mock_gatherer_cls.call_args
+        assert kwargs["enable_rlm_compression"] is False
+
     def test_init_phases_sets_context_initializer(self):
         """init_phases sets context_initializer attribute."""
         mock_arena = self._create_mock_arena()


### PR DESCRIPTION
## Summary
- pass the arena-level RLM toggle through to `ContextGatherer` as `enable_rlm_compression`
- add focused coverage proving `init_phases()` disables compression when `use_rlm_limiter` is false

## Why
`init_phases()` already reads other arena-level feature flags, but it was not wiring the RLM limiter toggle into the context gathering path. That left a mismatch between arena configuration and the phase subsystem.

## Validation
- `python3 -m ruff check aragora/debate/arena_phases.py tests/debate/test_arena_phases.py`
- `python3 -m pytest tests/debate/test_arena_phases.py -q`
  - `43 passed`
