### PR TITLE
feat(demo): make public proof surface truthful

### DIFF
--- a/aragora/live/src/app/try/page.tsx
+++ b/aragora/live/src/app/try/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect, Suspense } from 'react';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { TeaserResult } from '@/components/try/TeaserResult';
@@ -101,7 +102,7 @@ function TryPageInner() {
       const response = await fetch(`${API_BASE_URL}/api/v1/playground/debate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ question: question.trim(), source: 'landing' }),
+        body: JSON.stringify({ question: question.trim(), source: 'try' }),
         signal: abortRef.current.signal,
       });
 
@@ -211,12 +212,23 @@ function TryPageInner() {
         <div className="max-w-2xl mx-auto px-4 py-12">
           {/* Headline */}
           <div className="text-center mb-10">
+            <div className="mb-4 inline-flex items-center rounded-full border border-[var(--acid-cyan)]/30 bg-[var(--acid-cyan)]/8 px-3 py-1 text-[11px] font-mono font-bold uppercase tracking-[0.2em] text-[var(--acid-cyan)]">
+              Public beta
+            </div>
             <h1 className="text-3xl md:text-4xl font-mono text-[var(--acid-green)] mb-4">
-              Test a decision with AI experts
+              Try Aragora Beta
             </h1>
             <p className="text-sm font-mono text-[var(--text-muted)] max-w-lg mx-auto">
-              Pose any question and watch multiple AI models debate it from different angles.
-              Get a consensus verdict in seconds.
+              Ask your own question through the public beta flow. `/try` keeps rate limiting,
+              persistence, and replay/share behavior intact while `/demo` stays focused on the
+              canonical live proof.
+            </p>
+            <p className="text-xs font-mono text-[var(--text-muted)]/70 max-w-lg mx-auto mt-3">
+              Need the product proof surface first?{' '}
+              <Link href="/demo" className="text-[var(--acid-green)] hover:underline">
+                Open /demo
+              </Link>
+              .
             </p>
           </div>
 

--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -296,6 +296,37 @@ def _normalize_public_debate_payload(data: dict[str, Any]) -> dict[str, Any]:
     return data
 
 
+def _is_live_public_result(data: dict[str, Any]) -> bool:
+    """Return True when a public result explicitly came from a live backend path."""
+    return data.get("is_live") is True
+
+
+def _annotate_mock_fallback(
+    data: dict[str, Any],
+    *,
+    reason: str,
+) -> dict[str, Any]:
+    """Attach explicit fallback provenance to a public debate payload."""
+    annotated = dict(data)
+    annotated["is_live"] = False
+    annotated["mock_fallback"] = True
+    annotated["mock_fallback_reason"] = reason
+    return annotated
+
+
+def _build_live_demo_unavailable_response(message: str) -> HandlerResult:
+    """Return an explicit failure when the public demo cannot prove a live result."""
+    return json_response(
+        {
+            "error": message,
+            "code": "live_demo_unavailable",
+            "is_live": False,
+            "show_recorded_sample": True,
+        },
+        status=503,
+    )
+
+
 # Keep static versions for backward compat
 _MOCK_CRITIQUE_ISSUES = _build_mock_critiques(_DEFAULT_TOPIC)["issues"]
 _MOCK_CRITIQUE_SUGGESTIONS = _build_mock_critiques(_DEFAULT_TOPIC)["suggestions"]
@@ -1744,10 +1775,25 @@ class PlaygroundHandler(BaseHandler):
             cached = store.get_by_cache_key(cache_key)
             if cached is not None:
                 cached = _normalize_public_debate_payload(cached)
-                cached["cached"] = True
-                cached["cached_at"] = time.time()
-                logger.info("Cache hit for debate key %.12s…", cache_key)
-                return json_response(cached)
+                cached.setdefault("source", source)
+
+                # /demo is a truthful proof surface: it may replay persisted live runs,
+                # but it must not surface unlabeled fallback debates as if they were live.
+                if source == "demo" and not _is_live_public_result(cached):
+                    logger.info(
+                        "Skipping cached debate %.12s… for demo: no live provenance",
+                        cache_key,
+                    )
+                else:
+                    if not _is_live_public_result(cached) and not cached.get("mock_fallback"):
+                        cached = _annotate_mock_fallback(
+                            cached,
+                            reason="Served from a persisted fallback result.",
+                        )
+                    cached["cached"] = True
+                    cached["cached_at"] = time.time()
+                    logger.info("Cache hit for debate key %.12s…", cache_key)
+                    return json_response(cached)
         except (ImportError, RuntimeError, OSError, ValueError):
             logger.debug("Cache lookup unavailable, proceeding to debate", exc_info=True)
         except Exception:  # noqa: BLE001
@@ -1873,8 +1919,17 @@ class PlaygroundHandler(BaseHandler):
         except (TimeoutError, ValueError, RuntimeError, OSError) as exc:
             logger.warning("Live debate failed, falling back to mock: %s", exc)
 
+        if source == "demo":
+            return _build_live_demo_unavailable_response(
+                "The live demo could not produce a real backend result right now. "
+                "Use the labeled recorded example or retry for a fresh proof run."
+            )
+
         # Mock fallback -- always works, no external dependencies
-        mock_data = _run_inline_mock_debate(topic, rounds, agent_count, question=question)
+        mock_data = _annotate_mock_fallback(
+            _run_inline_mock_debate(topic, rounds, agent_count, question=question),
+            reason="Live agents were unavailable, so the public beta returned a deterministic fallback.",
+        )
         return self._persist_and_respond(json_response(mock_data), topic, source, **_cache_kw)
 
     @staticmethod

--- a/tests/server/handlers/test_demo_live_proof_surface.py
+++ b/tests/server/handlers/test_demo_live_proof_surface.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from aragora.server.handlers.base import error_response
+from aragora.server.handlers.playground import PlaygroundHandler, _reset_rate_limits
+
+
+class _MockHeaders:
+    def __init__(self, raw_len: int):
+        self._data = {
+            "Content-Type": "application/json",
+            "Content-Length": str(raw_len),
+        }
+
+    def get(self, key: str, default: str = "") -> str:
+        return self._data.get(key, default)
+
+
+def _make_http_handler(body: dict[str, Any], client_ip: str = "10.0.0.1"):
+    raw = json.dumps(body).encode()
+    handler = type("MockHandler", (), {})()
+    handler.client_address = (client_ip, 12345)
+    handler.headers = _MockHeaders(len(raw))
+    handler.rfile = io.BytesIO(raw)
+    return handler
+
+
+def _parse_result(result) -> tuple[dict[str, Any], int]:
+    assert result is not None
+    return json.loads(result.body), result.status_code
+
+
+@pytest.fixture(autouse=True)
+def _clean_rate_limits():
+    _reset_rate_limits()
+    yield
+    _reset_rate_limits()
+
+
+@pytest.fixture()
+def handler(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_DATA_DIR", str(tmp_path))
+    import aragora.storage.debate_store as debate_store_mod
+
+    monkeypatch.setattr(debate_store_mod, "_store", None)
+    return PlaygroundHandler({})
+
+
+def _live_result(debate_id: str) -> dict[str, Any]:
+    return {
+        "id": debate_id,
+        "topic": "Should we require AI code review in CI?",
+        "status": "completed",
+        "rounds_used": 1,
+        "consensus_reached": True,
+        "confidence": 0.74,
+        "verdict": "needs_review",
+        "duration_seconds": 2.4,
+        "participants": ["claude", "gpt"],
+        "proposals": {
+            "claude": "Treat AI review as a structured advisory layer.",
+            "gpt": "Gate only high-risk paths while false-positive rates stabilize.",
+        },
+        "critiques": [],
+        "votes": [],
+        "dissenting_views": [],
+        "final_answer": "Adopt tiered enforcement and measure it.",
+        "is_live": True,
+        "receipt_hash": "abc123",
+    }
+
+
+@patch("aragora.storage.debate_store.DebateResultStore.get_by_cache_key", return_value=None)
+def test_demo_source_requires_live_proof_when_backend_cannot_deliver(
+    _mock_cache,
+    handler,
+):
+    request = _make_http_handler(
+        {
+            "topic": "Should we require AI code review in CI?",
+            "question": "Should we require AI code review in CI?",
+            "source": "demo",
+        }
+    )
+
+    with (
+        patch("aragora.server.handlers.playground._try_oracle_tentacles", return_value=None),
+        patch.object(
+            handler,
+            "_run_live_debate",
+            return_value=error_response("Live playground unavailable", 503),
+        ),
+    ):
+        result = handler.handle_post("/api/v1/playground/debate", {}, request)
+
+    body, status = _parse_result(result)
+    assert status == 503
+    assert body["code"] == "live_demo_unavailable"
+    assert body["show_recorded_sample"] is True
+    assert body["is_live"] is False
+
+
+def test_demo_source_skips_cached_results_without_live_provenance(handler):
+    request = _make_http_handler(
+        {
+            "topic": "Should we require AI code review in CI?",
+            "question": "Should we require AI code review in CI?",
+            "source": "demo",
+        }
+    )
+    cached_mock = {
+        "id": "cached-fallback",
+        "topic": "Should we require AI code review in CI?",
+        "status": "completed",
+        "participants": ["analyst", "critic"],
+        "proposals": {"analyst": "Mock answer"},
+        "final_answer": "Mock answer",
+    }
+
+    with (
+        patch(
+            "aragora.storage.debate_store.DebateResultStore.get_by_cache_key",
+            return_value=cached_mock,
+        ),
+        patch(
+            "aragora.server.handlers.playground._try_oracle_tentacles",
+            return_value=_live_result("fresh-live-result"),
+        ) as mock_tentacles,
+    ):
+        result = handler.handle_post("/api/v1/playground/debate", {}, request)
+
+    body, status = _parse_result(result)
+    assert status == 200
+    assert body["id"] == "fresh-live-result"
+    assert body["is_live"] is True
+    assert body.get("cached") is not True
+    mock_tentacles.assert_called_once()
+
+
+def test_demo_source_can_replay_cached_live_results(handler):
+    request = _make_http_handler(
+        {
+            "topic": "Should we require AI code review in CI?",
+            "question": "Should we require AI code review in CI?",
+            "source": "demo",
+        }
+    )
+    cached_live = _live_result("cached-live-result")
+
+    with (
+        patch(
+            "aragora.storage.debate_store.DebateResultStore.get_by_cache_key",
+            return_value=cached_live,
+        ),
+        patch("aragora.server.handlers.playground._try_oracle_tentacles") as mock_tentacles,
+    ):
+        result = handler.handle_post("/api/v1/playground/debate", {}, request)
+
+    body, status = _parse_result(result)
+    assert status == 200
+    assert body["id"] == "cached-live-result"
+    assert body["is_live"] is True
+    assert body["cached"] is True
+    mock_tentacles.assert_not_called()
+
+
+@patch("aragora.storage.debate_store.DebateResultStore.get_by_cache_key", return_value=None)
+def test_try_source_keeps_shareable_beta_fallbacks(
+    _mock_cache,
+    handler,
+):
+    request = _make_http_handler(
+        {
+            "topic": "Should we require AI code review in CI?",
+            "question": "Should we require AI code review in CI?",
+            "source": "try",
+        }
+    )
+
+    with (
+        patch("aragora.server.handlers.playground._try_oracle_tentacles", return_value=None),
+        patch.object(
+            handler,
+            "_run_live_debate",
+            return_value=error_response("Live playground unavailable", 503),
+        ),
+    ):
+        result = handler.handle_post("/api/v1/playground/debate", {}, request)
+
+    body, status = _parse_result(result)
+    assert status == 200
+    assert body["source"] == "try"
+    assert body["is_live"] is False
+    assert body["mock_fallback"] is True
+    assert body["share_token"] == body["id"]
+    assert body["share_url"] == f"/debate/{body['id']}"


### PR DESCRIPTION
## Summary
- keep `/demo` truthful by only replaying cached results with explicit live provenance
- return an explicit `live_demo_unavailable` response when `/demo` cannot prove a live result
- treat `/try` as the shareable beta surface and add focused regression coverage for the public proof behavior

## Validation
- `python3 -m ruff check aragora/server/handlers/playground.py tests/server/handlers/test_demo_live_proof_surface.py`
- `python3 -m pytest tests/server/handlers/test_demo_live_proof_surface.py -q`

## Notes
- I intentionally left `aragora/live/src/app/(standalone)/demo/page.tsx` unchanged on current `main`; the older UI rewrite in the preserved branch no longer rebases cleanly and was not included in this salvage PR.
- Local TypeScript project validation from this worktree still reports missing `jest` and `node` type-definition entries in the environment, so I did not claim a clean frontend typecheck here.
