### PR TITLE
fix(debate): preserve KM outcome metadata on writeback

### DIFF
--- a/aragora/debate/km_outcome_bridge.py
+++ b/aragora/debate/km_outcome_bridge.py
@@ -515,14 +515,27 @@ class KMOutcomeBridge:
 
         try:
             km: Any = self._knowledge_mound  # Cast to Any for duck-typed access
+            rich_update = getattr(type(km), "update", None)
             # Try different update patterns
-            if hasattr(km, "update_confidence"):
-                return await km.update_confidence(item_id, new_confidence, validation_metadata)
-            elif hasattr(km, "update"):
-                # update(node_id, updates: dict) - pass updates as a dict
+            if validation_metadata and rich_update is not None:
+                existing_item = await self._get_km_item(item_id)
+                existing_metadata = self._item_get(existing_item, "metadata", {})
+                if not isinstance(existing_metadata, dict):
+                    existing_metadata = {}
+
                 result = await km.update(
-                    item_id, {"confidence": new_confidence, "metadata": validation_metadata}
+                    item_id,
+                    {
+                        "confidence": new_confidence,
+                        "metadata": {**existing_metadata, **validation_metadata},
+                    },
                 )
+                return result is not None
+            elif hasattr(km, "update_confidence"):
+                return await km.update_confidence(item_id, new_confidence)
+            elif rich_update is not None:
+                # update(node_id, updates: dict) - pass updates as a dict
+                result = await km.update(item_id, {"confidence": new_confidence})
                 return result is not None
             else:
                 # Log success for testing even without real KM

--- a/tests/debate/test_km_outcome_bridge.py
+++ b/tests/debate/test_km_outcome_bridge.py
@@ -435,6 +435,84 @@ class TestKMOutcomeBridgePropagation:
         assert result.validations[0].original_confidence == 0.6
 
 
+class TestKMOutcomeBridgeUpdates:
+    """Tests for KM confidence writeback behavior."""
+
+    @pytest.mark.asyncio
+    async def test_update_km_confidence_prefers_update_for_metadata(self):
+        """Bridge should use KM.update when validation metadata needs to be preserved."""
+
+        class MockMound:
+            def __init__(self) -> None:
+                self.update_mock = AsyncMock(
+                    return_value={
+                        "id": "km_123",
+                        "confidence": 0.9,
+                        "metadata": {
+                            "workspace_id": "default",
+                            "existing": "keep",
+                            "debate_id": "debate_1",
+                        },
+                    }
+                )
+                self.update_confidence = AsyncMock(return_value=True)
+
+            async def get(self, _item_id: str) -> dict[str, object]:
+                return {
+                    "id": "km_123",
+                    "confidence": 0.7,
+                    "metadata": {"workspace_id": "default", "existing": "keep"},
+                }
+
+            async def update(self, item_id: str, updates: dict[str, object]) -> dict[str, object]:
+                return await self.update_mock(item_id, updates)
+
+        mock_mound = MockMound()
+        bridge = KMOutcomeBridge(knowledge_mound=mock_mound)
+        ok = await bridge._update_km_confidence(
+            item_id="km_123",
+            new_confidence=0.9,
+            validation_metadata={"debate_id": "debate_1"},
+        )
+
+        assert ok is True
+        mock_mound.update_mock.assert_awaited_once_with(
+            "km_123",
+            {
+                "confidence": 0.9,
+                "metadata": {
+                    "workspace_id": "default",
+                    "existing": "keep",
+                    "debate_id": "debate_1",
+                },
+            },
+        )
+        mock_mound.update_confidence.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_km_confidence_falls_back_to_two_arg_api(self):
+        """Bridge should call the legacy two-argument update_confidence API correctly."""
+
+        class MockMound:
+            def __init__(self) -> None:
+                self.update_confidence = AsyncMock(return_value=True)
+
+            async def get(self, item_id: str) -> dict[str, object]:
+                return {"id": item_id, "confidence": 0.7}
+
+        mock_mound = MockMound()
+        bridge = KMOutcomeBridge(knowledge_mound=mock_mound)
+
+        ok = await bridge._update_km_confidence(
+            item_id="km_123",
+            new_confidence=0.8,
+            validation_metadata={"debate_id": "debate_1"},
+        )
+
+        assert ok is True
+        mock_mound.update_confidence.assert_awaited_once_with("km_123", 0.8)
+
+
 class TestKMOutcomeBridgeStats:
     """Tests for statistics."""
 


### PR DESCRIPTION
## Summary
- preserve existing Knowledge Mound metadata when confidence writeback uses the richer `update` API
- fall back correctly to legacy two-argument `update_confidence` implementations
- add focused regression coverage for both writeback paths

## Validation
- `python3 -m ruff check aragora/debate/km_outcome_bridge.py tests/debate/test_km_outcome_bridge.py`
- `python3 -m pytest tests/debate/test_km_outcome_bridge.py -q`
