### PR TITLE
fix(knowledge): skip mismatched semantic embedding dimensions

### DIFF
--- a/aragora/knowledge/mound/semantic_store.py
+++ b/aragora/knowledge/mound/semantic_store.py
@@ -493,8 +493,9 @@ class SemanticStore(SQLiteStore):
                    domain, importance, tenant_id, metadata
             FROM semantic_index
             WHERE tenant_id = ?
+              AND embedding_dim = ?
         """
-        params: list = [tenant_id]
+        params: list = [tenant_id, len(query_embedding)]
 
         if domain_filter:
             sql += " AND (domain = ? OR domain LIKE ?)"

--- a/tests/knowledge/mound/test_semantic_store.py
+++ b/tests/knowledge/mound/test_semantic_store.py
@@ -515,6 +515,45 @@ class TestSearchOperations:
 
         assert all(r.tenant_id == "tenant_a" for r in results)
 
+    @pytest.mark.asyncio
+    async def test_search_skips_rows_with_mismatched_embedding_dimension(self, temp_db_path):
+        """Search should ignore old rows indexed with a different embedding dimension."""
+
+        small_provider = MockEmbeddingProvider(dimension=256)
+        large_provider = MockEmbeddingProvider(dimension=1536)
+
+        legacy_store = SemanticStore(
+            db_path=temp_db_path,
+            embedding_provider=small_provider,
+            default_tenant_id="test_tenant",
+        )
+        current_store = SemanticStore(
+            db_path=temp_db_path,
+            embedding_provider=large_provider,
+            default_tenant_id="test_tenant",
+        )
+
+        await legacy_store.index_item(
+            source_type=KnowledgeSource.FACT,
+            source_id="legacy_fact",
+            content="Legacy fallback embedding content",
+        )
+        await current_store.index_item(
+            source_type=KnowledgeSource.FACT,
+            source_id="current_fact",
+            content="Current live embedding content",
+        )
+
+        results = await current_store.search_similar(
+            query="Current live embedding content",
+            limit=10,
+            min_similarity=-1.0,
+        )
+
+        assert results
+        assert all(r.source_id != "legacy_fact" for r in results)
+        assert any(r.source_id == "current_fact" for r in results)
+
 
 # ============================================================================
 # Batch Operations Tests


### PR DESCRIPTION
## Summary
- filter semantic-store search candidates by stored `embedding_dim`
- avoid comparing legacy 256-dim fallback vectors against live 1536-dim query embeddings
- add regression coverage for mixed-dimension semantic indexes

## Verification
- `python3 -m ruff check aragora/knowledge/mound/semantic_store.py tests/knowledge/mound/test_semantic_store.py tests/cli/test_quickstart.py`
- `python3 -m pytest tests/knowledge/mound/test_semantic_store.py tests/cli/test_quickstart.py -q`
- `python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser`
