### PR TITLE
fix(live): normalize persisted pipeline live state

### DIFF
--- a/aragora/live/src/components/pipeline-canvas/ProvenanceNodeDetailPanel.tsx
+++ b/aragora/live/src/components/pipeline-canvas/ProvenanceNodeDetailPanel.tsx
@@ -12,6 +12,7 @@ import {
   PIPELINE_STAGE_CONFIG,
   PIPELINE_NODE_TYPE_CONFIGS,
   STAGE_COLOR_CLASSES,
+  getMirroredNodeField,
   type PipelineStageType,
   type ProvenanceLink,
   type StageTransition,
@@ -58,16 +59,17 @@ function getNodeTypeInfo(
   stage: PipelineStageType,
   nodeData: Record<string, unknown>,
 ): { label: string; icon: string } | null {
-  const subtypeKey =
+  const subtype = (
     stage === 'ideas'
-      ? 'ideaType'
-      : stage === 'goals'
-        ? 'goalType'
-        : stage === 'actions'
-          ? 'stepType'
-          : 'orchType';
-
-  const subtype = nodeData[subtypeKey] as string | undefined;
+      ? getMirroredNodeField<string>(nodeData, 'ideaType', 'idea_type')
+      : stage === 'principles'
+        ? getMirroredNodeField<string>(nodeData, 'principleType', 'principle_type')
+        : stage === 'goals'
+          ? getMirroredNodeField<string>(nodeData, 'goalType', 'goal_type')
+          : stage === 'actions'
+            ? getMirroredNodeField<string>(nodeData, 'stepType', 'step_type')
+            : getMirroredNodeField<string>(nodeData, 'orchType', 'orch_type')
+  );
   if (!subtype) return null;
 
   const config = PIPELINE_NODE_TYPE_CONFIGS[stage]?.[subtype];
@@ -257,12 +259,13 @@ export const ProvenanceNodeDetailPanel = memo(function ProvenanceNodeDetailPanel
   );
 
   // Content hash from node data
-  const contentHash = (nodeData?.contentHash as string) ?? '';
+  const contentHash =
+    (nodeData && getMirroredNodeField<string>(nodeData, 'contentHash', 'content_hash')) ?? '';
 
   // Node description/content
   const description =
     (nodeData?.description as string) ??
-    (nodeData?.fullContent as string) ??
+    (nodeData && getMirroredNodeField<string>(nodeData, 'fullContent', 'full_content')) ??
     '';
 
   // Status from node data
@@ -274,7 +277,7 @@ export const ProvenanceNodeDetailPanel = memo(function ProvenanceNodeDetailPanel
 
   // Assigned agent/assignee
   const agent =
-    (nodeData?.assignedAgent as string) ??
+    (nodeData && getMirroredNodeField<string>(nodeData, 'assignedAgent', 'assigned_agent')) ??
     (nodeData?.assignee as string) ??
     (nodeData?.agent as string) ??
     '';

--- a/aragora/live/src/components/pipeline-canvas/__tests__/nodes.test.tsx
+++ b/aragora/live/src/components/pipeline-canvas/__tests__/nodes.test.tsx
@@ -160,4 +160,26 @@ describe('OrchestrationNode', () => {
     const root = container.firstChild as HTMLElement;
     expect(root.className).toContain('border-dashed');
   });
+
+  it('renders live state from persisted snake_case fields', () => {
+    render(
+      <OrchestrationNode
+        data={{
+          ...data,
+          execution_status: 'in_progress',
+          execution_agent: 'codex',
+          execution_duration: '4.2s',
+          elapsed_ms: 4200,
+          output_preview: 'repair patch ready',
+          locked_by: 'review-lane',
+        }}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('in progress')).toBeInTheDocument();
+    expect(screen.getByText('via codex')).toBeInTheDocument();
+    expect(screen.getByText('repair patch ready')).toBeInTheDocument();
+    expect(screen.getByText('Locked by review-lane')).toBeInTheDocument();
+  });
 });

--- a/aragora/live/src/components/pipeline-canvas/editors/PipelinePropertyEditor.tsx
+++ b/aragora/live/src/components/pipeline-canvas/editors/PipelinePropertyEditor.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useState } from 'react';
 import {
   PIPELINE_STAGE_CONFIG,
   STAGE_COLOR_CLASSES,
+  getMirroredNodeField,
   type PipelineStageType,
   type IdeaType,
   type GoalType,
@@ -333,11 +334,20 @@ function OrchestrationEditor({
   if (readOnly) {
     return (
       <>
-        <ReadOnlyField label="Orchestration Type" value={String(node.orchType ?? '')} />
+        <ReadOnlyField
+          label="Orchestration Type"
+          value={String(getMirroredNodeField(node, 'orchType', 'orch_type') ?? '')}
+        />
         <ReadOnlyField label="Status" value={String(node.status ?? 'pending').replace('_', ' ')} />
         <ReadOnlyField label="Description" value={String(node.description ?? '')} />
-        <ReadOnlyField label="Assigned Agent" value={String(node.assignedAgent ?? '')} />
-        <ReadOnlyField label="Agent Type" value={String(node.agentType ?? '')} />
+        <ReadOnlyField
+          label="Assigned Agent"
+          value={String(getMirroredNodeField(node, 'assignedAgent', 'assigned_agent') ?? '')}
+        />
+        <ReadOnlyField
+          label="Agent Type"
+          value={String(getMirroredNodeField(node, 'agentType', 'agent_type') ?? '')}
+        />
         <ReadOnlyField label="Capabilities" value={capsStr} />
       </>
     );
@@ -347,7 +357,7 @@ function OrchestrationEditor({
     <>
       <SelectField
         label="Orchestration Type"
-        value={String(node.orchType ?? 'agent_task')}
+        value={String(getMirroredNodeField(node, 'orchType', 'orch_type') ?? 'agent_task')}
         options={ORCH_TYPE_OPTIONS}
         onChange={(v) => onUpdate({ orchType: v })}
       />
@@ -366,13 +376,13 @@ function OrchestrationEditor({
       />
       <InputField
         label="Assigned Agent"
-        value={String(node.assignedAgent ?? '')}
+        value={String(getMirroredNodeField(node, 'assignedAgent', 'assigned_agent') ?? '')}
         onChange={(v) => onUpdate({ assignedAgent: v })}
         placeholder="e.g., claude, gpt-4"
       />
       <InputField
         label="Agent Type"
-        value={String(node.agentType ?? '')}
+        value={String(getMirroredNodeField(node, 'agentType', 'agent_type') ?? '')}
         onChange={(v) => onUpdate({ agentType: v })}
         placeholder="e.g., reviewer, coder"
       />

--- a/aragora/live/src/components/pipeline-canvas/nodes/ActionNode.tsx
+++ b/aragora/live/src/components/pipeline-canvas/nodes/ActionNode.tsx
@@ -5,6 +5,7 @@ import { Handle, Position } from '@xyflow/react';
 import {
   PIPELINE_NODE_TYPE_CONFIGS,
   ACTION_STATUS_COLORS,
+  getMirroredNodeField,
   type ActionType,
   type ActionStatus,
 } from '../types';
@@ -15,14 +16,14 @@ interface ActionNodeProps {
 }
 
 export const ActionNode = memo(function ActionNode({ data, selected }: ActionNodeProps) {
-  const stepType = (data.stepType || data.step_type || 'task') as ActionType;
+  const stepType = getMirroredNodeField<ActionType>(data, 'stepType', 'step_type') ?? 'task';
   const label = data.label as string;
   const description = data.description as string | undefined;
   const optional = data.optional as boolean | undefined;
-  const timeout = (data.timeoutSeconds || data.timeout) as number | undefined;
-  const status = (data.status || 'pending') as ActionStatus;
+  const timeout = getMirroredNodeField<number>(data, 'timeoutSeconds', 'timeout');
+  const status = getMirroredNodeField<ActionStatus>(data, 'status') ?? 'pending';
   const assignee = data.assignee as string | undefined;
-  const lockedBy = data.lockedBy as string | undefined;
+  const lockedBy = getMirroredNodeField<string>(data, 'lockedBy', 'locked_by');
 
   const config = PIPELINE_NODE_TYPE_CONFIGS.actions[stepType] || PIPELINE_NODE_TYPE_CONFIGS.actions.task;
   const statusClass = ACTION_STATUS_COLORS[status] || ACTION_STATUS_COLORS.pending;

--- a/aragora/live/src/components/pipeline-canvas/nodes/OrchestrationNode.tsx
+++ b/aragora/live/src/components/pipeline-canvas/nodes/OrchestrationNode.tsx
@@ -6,6 +6,7 @@ import {
   PIPELINE_NODE_TYPE_CONFIGS,
   ORCH_STATUS_COLORS,
   EXECUTION_STATUS_COLORS,
+  getMirroredNodeField,
   type OrchType,
   type OrchStatus,
   type ExecutionStatus,
@@ -21,22 +22,46 @@ export const OrchestrationNode = memo(function OrchestrationNode({
   data,
   selected,
 }: OrchestrationNodeProps) {
-  const orchType = (data.orchType || data.orch_type || 'agent_task') as OrchType;
+  const orchType = getMirroredNodeField<OrchType>(data, 'orchType', 'orch_type') ?? 'agent_task';
   const label = data.label as string;
   const description = data.description as string | undefined;
-  const assignedAgent = (data.assignedAgent || data.assigned_agent) as string | undefined;
-  const agentType = (data.agentType || data.agent_type) as string | undefined;
+  const assignedAgent = getMirroredNodeField<string>(data, 'assignedAgent', 'assigned_agent');
+  const agentType = getMirroredNodeField<string>(data, 'agentType', 'agent_type');
   const capabilities = data.capabilities as string[] | undefined;
-  const status = (data.status || 'pending') as OrchStatus;
-  const lockedBy = data.lockedBy as string | undefined;
-  const executionStatus = data.executionStatus as ExecutionStatus | undefined;
-  const executionDuration = data.executionDuration as string | undefined;
-  const executionAgent = data.executionAgent as string | undefined;
-  const eloScore = (data.eloScore || data.elo_score) as number | undefined;
-  const selectionRationale = (data.selectionRationale || data.selection_rationale) as string | undefined;
-  const alternativeAgents = (data.alternativeAgents || data.alternative_agents) as AlternativeAgent[] | undefined;
-  const elapsedMs = (data.elapsedMs || data.elapsed_ms) as number | undefined;
-  const outputPreview = (data.outputPreview || data.output_preview) as string | undefined;
+  const status = getMirroredNodeField<OrchStatus>(data, 'status') ?? 'pending';
+  const lockedBy = getMirroredNodeField<string>(data, 'lockedBy', 'locked_by');
+  const executionStatus = getMirroredNodeField<ExecutionStatus>(
+    data,
+    'executionStatus',
+    'execution_status',
+  );
+  const executionDuration = getMirroredNodeField<string>(
+    data,
+    'executionDuration',
+    'execution_duration',
+  );
+  const executionAgent = getMirroredNodeField<string>(
+    data,
+    'executionAgent',
+    'execution_agent',
+  );
+  const eloScore = getMirroredNodeField<number>(data, 'eloScore', 'elo_score');
+  const selectionRationale = getMirroredNodeField<string>(
+    data,
+    'selectionRationale',
+    'selection_rationale',
+  );
+  const alternativeAgents = getMirroredNodeField<AlternativeAgent[]>(
+    data,
+    'alternativeAgents',
+    'alternative_agents',
+  );
+  const elapsedMs = getMirroredNodeField<number>(data, 'elapsedMs', 'elapsed_ms');
+  const outputPreview = getMirroredNodeField<string>(
+    data,
+    'outputPreview',
+    'output_preview',
+  );
 
   const isAgent = orchType === 'agent_task' || orchType === 'debate';
   const isHumanGate = orchType === 'human_gate';

--- a/aragora/live/src/components/pipeline-canvas/types.ts
+++ b/aragora/live/src/components/pipeline-canvas/types.ts
@@ -48,6 +48,24 @@ export const ORCH_STATUS_COLORS: Record<OrchStatus, string> = {
   awaiting_human: 'bg-amber-500/30 text-amber-200',
 };
 
+/**
+ * Persisted pipeline payloads arrive from Python handlers in snake_case, while
+ * local editor and websocket mutations use camelCase. Keep both key spellings
+ * aligned here so reloaded live state matches in-session live state.
+ */
+export function getMirroredNodeField<T>(
+  node: Record<string, unknown>,
+  ...keys: string[]
+): T | undefined {
+  for (const key of keys) {
+    const value = node[key];
+    if (value !== undefined && value !== null) {
+      return value as T;
+    }
+  }
+  return undefined;
+}
+
 // =============================================================================
 // Node Data Interfaces
 // =============================================================================


### PR DESCRIPTION
## Summary
- make pipeline canvas components read persisted snake_case node fields alongside camelCase fields
- cover orchestration node live-state rendering when persisted pipeline data uses server-style field names
- keep the change isolated to pipeline-canvas display and editor surfaces

## Validation
- `PATH="/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH" NODE_PATH="/Users/armand/Development/aragora/aragora/live/node_modules" npm test -- --runTestsByPath src/components/pipeline-canvas/__tests__/nodes.test.tsx`
- `PATH="/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH" NODE_PATH="/Users/armand/Development/aragora/aragora/live/node_modules" tsc -p /Users/armand/Development/aragora/aragora/live/tsconfig.json --pretty false --noEmit`
  - fails on current `main` too with `aragora/live/.next/types/validator.ts` referencing missing `(standalone)/onboarding/page.js`
