### PR TITLE
fix(swarm): sync expired leases into supervisor runs

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -931,6 +931,10 @@ class DevCoordinationStore:
                     "worktree_path": lease.worktree_path,
                 },
             )
+            self._sync_supervisor_run_from_lease(
+                lease.metadata,
+                update={"status": "needs_human", "failure_reason": "expired_lease_reaped"},
+            )
         return expired
 
     def reap_stale_leases(

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -2374,6 +2374,68 @@ def test_refresh_run_reaps_expired_leases(repo: Path, store: DevCoordinationStor
     assert expired.lease_id not in active_lease_ids
 
 
+def test_refresh_run_marks_expired_leased_work_order(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    """TTL expiry must reconcile the supervisor lane, not just release the lease."""
+    lifecycle = MagicMock()
+    session_path = repo / "wt-expired"
+    session_path.mkdir()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="expired-worker",
+        agent="codex",
+        branch="codex/expired-worker",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="expired-lane",
+                title="Expired work",
+                description="Do expired work.",
+                file_scope=["other/file.py"],
+            )
+        ],
+    )
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+    run = supervisor.start_run(spec=SwarmSpec(raw_goal="Goal", refined_goal="Goal"))
+    lease_id = str(run.work_orders[0]["lease_id"])
+    assert lease_id
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE leases SET expires_at = ? WHERE lease_id = ?",
+            ("2020-01-01T00:00:00+00:00", lease_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    refreshed = supervisor.refresh_run(run.run_id)
+
+    assert refreshed.status == "needs_human"
+    work_order = refreshed.work_orders[0]
+    assert work_order["status"] == "needs_human"
+    assert work_order["failure_reason"] == "expired_lease_reaped"
+    assert lease_id not in {lease.lease_id for lease in store.list_active_leases()}
+
+
 def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordinationStore) -> None:
     """refresh_run should not leave dead leased work orders active forever."""
     lifecycle = MagicMock()


### PR DESCRIPTION
## Summary
- reconcile expired lease reaping back into the supervisor run state
- mark the affected work order as `needs_human` with `expired_lease_reaped`
- add focused supervisor coverage so TTL expiry updates the lane instead of only releasing the lease

## Validation
- `python3 -m ruff check aragora/nomic/dev_coordination.py tests/swarm/test_supervisor.py`
- `python3 -m pytest tests/swarm/test_supervisor.py -q`
