### PR TITLE
fix(cli): clean quickstart summaries and demote expected KM fallback

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -575,6 +575,28 @@ def _extract_thinking_traces(result: Any) -> dict[str, str] | None:
     return None
 
 
+def _clean_summary(text: str) -> str:
+    """Strip LLM chain-of-thought preamble from the summary for clean CLI output."""
+    import re
+
+    # Strip common LLM preamble patterns (both at start and after markdown headers)
+    preamble_patterns = [
+        r"Okay,\s+I\s+will\s+.*?\n+",
+        r"Here'?s?\s+(?:the|my)\s+(?:revised\s+)?.*?\n+",
+        r"Let\s+me\s+.*?\n+",
+        r"Sure[,!.].*?\n+",
+        r"I'?ll\s+.*?\n+",
+    ]
+    cleaned = text.strip()
+    for pattern in preamble_patterns:
+        cleaned = re.sub(pattern, "", cleaned, flags=re.IGNORECASE | re.MULTILINE)
+
+    # Collapse multiple blank lines
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+
+    return cleaned.strip() or text.strip()
+
+
 def _summarize_dissenting_views(
     dissenting_views: list[str], participants: list[str]
 ) -> list[dict[str, str]]:
@@ -931,9 +953,8 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
         print(f"  Artifact:   {str(result['artifact_hash'])[:16]}...")
 
     if result.get("summary"):
-        summary_text = result["summary"]
+        summary_text = _clean_summary(result["summary"])
         if len(summary_text) > 800:
-            # Truncate at sentence boundary to avoid mid-sentence clipping
             cutoff = summary_text[:800].rfind(".")
             if cutoff > 200:
                 summary_text = summary_text[: cutoff + 1] + "\n  [... truncated]"

--- a/aragora/knowledge/mound/api/query.py
+++ b/aragora/knowledge/mound/api/query.py
@@ -528,7 +528,7 @@ class QueryOperationsMixin(_QueryMixinBase):
                         items.append(node)
                 return items
             except (RuntimeError, ValueError, OSError, aiohttp.ClientError) as e:
-                logger.warning("Semantic store search failed: %s, falling back", e)
+                logger.debug("Semantic store search failed (falling back to keyword): %s", e)
 
         if not allow_fallback:
             return []


### PR DESCRIPTION
## Summary
- strip the LLM-style preamble from quickstart summary output before surfacing it to the user
- demote the expected KM semantic-dimension mismatch fallback from warning to debug noise
- keep the change tightly scoped to quickstart presentation and KM search logging

## Validation
- `python3 -m ruff check aragora/cli/commands/quickstart.py aragora/knowledge/mound/api/query.py tests/cli/test_quickstart.py tests/server/handlers/knowledge_base/test_search.py`
- `python3 -m pytest tests/cli/test_quickstart.py -q`
- `python3 -m pytest tests/server/handlers/knowledge_base/test_search.py -q`
  - passes with the same pre-existing async runtime warnings already present in the KM search suite
