### PR TITLE
fix(spectate): mark stream endpoint as partial snapshot

### DIFF
--- a/aragora/live/src/components/ApiExplorerPanel.tsx
+++ b/aragora/live/src/components/ApiExplorerPanel.tsx
@@ -2,11 +2,14 @@
 
 import { useState, useMemo } from 'react';
 import { CollapsibleSection } from '@/components/CollapsibleSection';
+import { ExperimentalBadge } from '@/components/shared/ExperimentalBadge';
+import { type FeatureStatus } from '@/lib/featureFlags';
 import {
   useApiExplorer,
   type HttpMethod,
   type OpenApiSchema,
   type OpenApiResponse,
+  type OpenApiStability,
 } from '@/hooks/useApiExplorer';
 
 // ---------------------------------------------------------------------------
@@ -36,6 +39,22 @@ function getStatusColor(status: number): string {
 }
 
 const METHOD_LIST: HttpMethod[] = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
+
+function getBadgeStatus(
+  stability: OpenApiStability | undefined,
+  deprecated: boolean | undefined,
+): FeatureStatus | null {
+  if (deprecated || stability === 'deprecated') {
+    return 'deprecated';
+  }
+  if (stability === 'beta') {
+    return 'beta';
+  }
+  if (stability === 'experimental' || stability === 'internal') {
+    return 'alpha';
+  }
+  return null;
+}
 
 // ---------------------------------------------------------------------------
 // SchemaViewer -- renders OpenAPI schema as a readable tree
@@ -282,6 +301,7 @@ export function ApiExplorerPanel() {
   }
 
   const ep = explorer.selectedEndpoint;
+  const selectedBadgeStatus = ep ? getBadgeStatus(ep.stability, ep.deprecated) : null;
 
   return (
     <div className="space-y-4">
@@ -384,6 +404,7 @@ export function ApiExplorerPanel() {
                   {group.endpoints.map(endpoint => {
                     const isSelected =
                       ep?.path === endpoint.path && ep?.method === endpoint.method;
+                    const badgeStatus = getBadgeStatus(endpoint.stability, endpoint.deprecated);
                     return (
                       <button
                         key={`${endpoint.method}-${endpoint.path}`}
@@ -405,6 +426,7 @@ export function ApiExplorerPanel() {
                           <span className="text-xs font-mono text-text truncate">
                             {endpoint.path}
                           </span>
+                          {badgeStatus && <ExperimentalBadge status={badgeStatus} size="sm" />}
                           {endpoint.deprecated && (
                             <span className="text-[9px] font-mono text-yellow-400 border border-yellow-400/30 px-1">
                               DEP
@@ -446,6 +468,9 @@ export function ApiExplorerPanel() {
                   <code className="text-base font-mono text-acid-cyan break-all">
                     {ep.path}
                   </code>
+                  {selectedBadgeStatus && (
+                    <ExperimentalBadge status={selectedBadgeStatus} size="sm" />
+                  )}
                   {ep.deprecated && (
                     <span className="text-xs font-mono text-yellow-400 border border-yellow-400/30 px-1.5 py-0.5">
                       DEPRECATED

--- a/aragora/live/src/hooks/useApiExplorer.ts
+++ b/aragora/live/src/hooks/useApiExplorer.ts
@@ -49,6 +49,8 @@ export interface OpenApiResponse {
   }>;
 }
 
+export type OpenApiStability = 'stable' | 'beta' | 'experimental' | 'internal' | 'deprecated';
+
 export interface OpenApiOperation {
   operationId?: string;
   summary?: string;
@@ -59,6 +61,7 @@ export interface OpenApiOperation {
   responses?: Record<string, OpenApiResponse>;
   security?: Array<Record<string, string[]>>;
   deprecated?: boolean;
+  'x-aragora-stability'?: OpenApiStability;
 }
 
 export interface OpenApiSpec {
@@ -90,6 +93,7 @@ export interface ParsedEndpoint {
   summary: string;
   description?: string;
   deprecated?: boolean;
+  stability?: OpenApiStability;
   requiresAuth: boolean;
   pathParams: OpenApiParameter[];
   queryParams: OpenApiParameter[];
@@ -164,6 +168,7 @@ function parseEndpoints(spec: OpenApiSpec): ParsedEndpoint[] {
       if (!HTTP_METHODS.includes(upperMethod)) continue;
 
       const op = operation as OpenApiOperation;
+      const stability = op['x-aragora-stability'];
       const tag = op.tags?.[0] || 'Untagged';
       const params = op.parameters || [];
 
@@ -174,7 +179,8 @@ function parseEndpoints(spec: OpenApiSpec): ParsedEndpoint[] {
         tag,
         summary: op.summary || `${upperMethod} ${path}`,
         description: op.description,
-        deprecated: op.deprecated,
+        deprecated: op.deprecated || stability === 'deprecated',
+        stability,
         requiresAuth: !!(op.security && op.security.length > 0),
         pathParams: params.filter(p => p.in === 'path'),
         queryParams: params.filter(p => p.in === 'query'),

--- a/aragora/server/handlers/spectate_ws.py
+++ b/aragora/server/handlers/spectate_ws.py
@@ -155,6 +155,13 @@ class SpectateStreamHandler(BaseHandler):
         "/api/v1/spectate/stream",
     ]
 
+    STREAM_MODE = "snapshot"
+    STREAM_READINESS = "partial"
+    STREAM_MESSAGE = (
+        "Public spectate streaming is currently snapshot-only on this endpoint; "
+        "live SSE delivery has not shipped yet."
+    )
+
     @handle_errors("spectate")
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
         """Route GET requests to the appropriate sub-handler."""
@@ -166,13 +173,35 @@ class SpectateStreamHandler(BaseHandler):
         if path.endswith("/status"):
             return self._handle_status(handler)
         if path.endswith("/stream"):
-            # SSE stub - returns snapshot for now
-            return self._handle_recent(query_params)
+            return self._handle_stream(query_params)
 
         return None
 
     def _handle_recent(self, query_params: dict[str, Any]) -> HandlerResult:
         """GET /api/v1/spectate/recent -- get recent events from the buffer."""
+        return json_response(self._build_recent_payload(query_params))
+
+    def _handle_stream(self, query_params: dict[str, Any]) -> HandlerResult:
+        """GET /api/v1/spectate/stream -- snapshot preview, not live SSE."""
+        payload = self._build_recent_payload(query_params)
+        payload.update(
+            {
+                "mode": self.STREAM_MODE,
+                "readiness": self.STREAM_READINESS,
+                "streaming_ready": False,
+                "message": self.STREAM_MESSAGE,
+            }
+        )
+        return json_response(
+            payload,
+            headers={
+                "X-Aragora-Endpoint-State": self.STREAM_READINESS,
+                "X-Aragora-Stream-Mode": self.STREAM_MODE,
+            },
+        )
+
+    def _build_recent_payload(self, query_params: dict[str, Any]) -> dict[str, Any]:
+        """Build the recent-events payload shared by snapshot endpoints."""
         try:
             from aragora.spectate.ws_bridge import get_spectate_bridge
 
@@ -195,14 +224,12 @@ class SpectateStreamHandler(BaseHandler):
             if pipeline_id:
                 events = [e for e in events if e.pipeline_id == pipeline_id]
 
-            return json_response(
-                {
-                    "events": [e.to_dict() for e in events],
-                    "count": len(events),
-                }
-            )
+            return {
+                "events": [e.to_dict() for e in events],
+                "count": len(events),
+            }
         except ImportError:
-            return json_response({"events": [], "count": 0})
+            return {"events": [], "count": 0}
 
     def _handle_status(self, handler: Any) -> HandlerResult:
         """GET /api/v1/spectate/status -- bridge status."""

--- a/aragora/server/openapi/stability_manifest.json
+++ b/aragora/server/openapi/stability_manifest.json
@@ -905,7 +905,6 @@
     "GET /api/v1/sme/slack/workspaces/{param}",
     "GET /api/v1/spectate/recent",
     "GET /api/v1/spectate/status",
-    "GET /api/v1/spectate/stream",
     "GET /api/v1/status",
     "GET /api/v1/status/components",
     "GET /api/v1/status/history",
@@ -1432,5 +1431,8 @@
     "PUT /api/v1/workspaces/{param}/members/{param}/role",
     "PUT /scim/v2/Groups/{param}",
     "PUT /scim/v2/Users/{param}"
+  ],
+  "beta": [
+    "GET /api/v1/spectate/stream"
   ]
 }

--- a/tests/handlers/test_spectate_ws.py
+++ b/tests/handlers/test_spectate_ws.py
@@ -83,11 +83,17 @@ class TestRouteMatching:
         assert "buffer_size" in body
 
     def test_handle_stream_path(self, handler: SpectateStreamHandler, mock_handler: MagicMock):
-        """Stream endpoint returns recent events as a snapshot."""
+        """Stream endpoint is truthfully marked as a snapshot preview."""
         result = handler.handle("/api/v1/spectate/stream", {}, mock_handler)
         assert result is not None
         body = result[0]
         assert "events" in body
+        assert body["mode"] == "snapshot"
+        assert body["readiness"] == "partial"
+        assert body["streaming_ready"] is False
+        assert "snapshot-only" in body["message"]
+        assert result[2]["X-Aragora-Endpoint-State"] == "partial"
+        assert result[2]["X-Aragora-Stream-Mode"] == "snapshot"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `GET /api/v1/spectate/stream` truthfully report that it is currently snapshot-only
- add readiness/mode metadata and response headers so the UI can label the endpoint honestly
- mark the endpoint as beta in the stability manifest and surface the badge in the API explorer

## Validation
- `python3 -m ruff check aragora/server/handlers/spectate_ws.py tests/handlers/test_spectate_ws.py`
- `python3 -m pytest tests/handlers/test_spectate_ws.py -q`
- `tsc -p aragora/live/tsconfig.json --noEmit` still fails locally in this worktree because the installed type definitions for `jest` and `node` are missing; I did not treat that as branch-specific because the error occurs before checking this slice's symbols
