### PR TITLE
feat(debate): add large-roster provider diversity observability

### DIFF
--- a/aragora/debate/provider_diversity.py
+++ b/aragora/debate/provider_diversity.py
@@ -7,9 +7,14 @@ as a post-selection filter.
 
 from __future__ import annotations
 
+import json
 import re
+import time
 from collections import defaultdict
 from dataclasses import dataclass, field
+
+DEFAULT_RECEIPT_AGENT_SAMPLE_LIMIT = 3
+DEFAULT_RECEIPT_SWAP_LIMIT = 5
 
 
 # Model name → provider mapping patterns
@@ -27,6 +32,37 @@ PROVIDER_PATTERNS: dict[str, list[re.Pattern[str]]] = {
 
 
 @dataclass
+class DiversityBenchmark:
+    """Compact benchmark summary for provider-diversity enforcement."""
+
+    path: str
+    roster_size: int
+    alternative_pool_size: int
+    iterations: int
+    average_runtime_ms: float
+    max_runtime_ms: float
+    provider_shortfall: int
+    swap_budget: int
+    swaps_made: int
+    receipt_payload_bytes: int
+
+    def to_dict(self) -> dict[str, int | float | str]:
+        """Serialize benchmark data for receipts and diagnostics."""
+        return {
+            "path": self.path,
+            "roster_size": self.roster_size,
+            "alternative_pool_size": self.alternative_pool_size,
+            "iterations": self.iterations,
+            "average_runtime_ms": round(self.average_runtime_ms, 4),
+            "max_runtime_ms": round(self.max_runtime_ms, 4),
+            "provider_shortfall": self.provider_shortfall,
+            "swap_budget": self.swap_budget,
+            "swaps_made": self.swaps_made,
+            "receipt_payload_bytes": self.receipt_payload_bytes,
+        }
+
+
+@dataclass
 class DiversityReport:
     """Report on provider diversity in a debate team."""
 
@@ -35,6 +71,105 @@ class DiversityReport:
     meets_minimum: bool
     swaps_made: list[tuple[str, str]]  # (removed, added)
     min_providers: int = 2
+    roster_size: int = 0
+    alternative_pool_size: int = 0
+    provider_shortfall: int = 0
+    swap_budget: int = 0
+    runtime_ms: float = 0.0
+    receipt_payload_bytes: int = 0
+    benchmark: DiversityBenchmark | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Serialize the full diversity report."""
+        result: dict[str, object] = {
+            "providers": {
+                provider: list(agent_names) for provider, agent_names in self.providers.items()
+            },
+            "provider_count": self.provider_count,
+            "meets_minimum": self.meets_minimum,
+            "swaps_made": [
+                {"removed": removed, "added": added} for removed, added in self.swaps_made
+            ],
+            "min_providers": self.min_providers,
+            "roster_size": self.roster_size,
+            "alternative_pool_size": self.alternative_pool_size,
+            "provider_shortfall": self.provider_shortfall,
+            "swap_budget": self.swap_budget,
+            "runtime_ms": round(self.runtime_ms, 4),
+            "receipt_payload_bytes": self.receipt_payload_bytes,
+        }
+        if self.benchmark is not None:
+            result["benchmark"] = self.benchmark.to_dict()
+        return result
+
+    def to_receipt_payload(
+        self,
+        *,
+        max_agents_per_provider: int = DEFAULT_RECEIPT_AGENT_SAMPLE_LIMIT,
+        max_swaps: int = DEFAULT_RECEIPT_SWAP_LIMIT,
+    ) -> dict[str, object]:
+        """Serialize a bounded receipt payload for large rosters."""
+        provider_samples: dict[str, dict[str, object]] = {}
+        sample_limit = max(max_agents_per_provider, 0)
+        for provider in sorted(self.providers):
+            agent_names = list(self.providers[provider])
+            sampled_agents = agent_names[:sample_limit]
+            provider_samples[provider] = {
+                "count": len(agent_names),
+                "sample_agents": sampled_agents,
+                "truncated_agents": max(0, len(agent_names) - len(sampled_agents)),
+            }
+
+        swap_limit = max(max_swaps, 0)
+        sampled_swaps = self.swaps_made[:swap_limit]
+        payload: dict[str, object] = {
+            "provider_count": self.provider_count,
+            "meets_minimum": self.meets_minimum,
+            "min_providers": self.min_providers,
+            "roster_size": self.roster_size,
+            "alternative_pool_size": self.alternative_pool_size,
+            "provider_shortfall": self.provider_shortfall,
+            "swap_budget": self.swap_budget,
+            "swaps_made": [
+                {"removed": removed, "added": added} for removed, added in sampled_swaps
+            ],
+            "swaps_truncated": max(0, len(self.swaps_made) - len(sampled_swaps)),
+            "runtime_ms": round(self.runtime_ms, 4),
+            "providers": provider_samples,
+        }
+        if self.benchmark is not None:
+            payload["benchmark"] = self.benchmark.to_dict()
+        return payload
+
+    def to_runtime_summary(self) -> dict[str, object]:
+        """Serialize the bounded runtime summary for observability receipts."""
+        summary: dict[str, object] = {
+            "path": "provider_diversity_filter",
+            "roster_size": self.roster_size,
+            "provider_count": self.provider_count,
+            "min_providers": self.min_providers,
+            "provider_shortfall": self.provider_shortfall,
+            "swap_budget": self.swap_budget,
+            "swaps_made": len(self.swaps_made),
+            "runtime_ms": round(self.runtime_ms, 4),
+            "receipt_payload_bytes": self.receipt_payload_bytes,
+        }
+        if self.benchmark is not None:
+            summary["benchmark"] = self.benchmark.to_dict()
+        return summary
+
+    def estimate_receipt_payload_bytes(
+        self,
+        *,
+        max_agents_per_provider: int = DEFAULT_RECEIPT_AGENT_SAMPLE_LIMIT,
+        max_swaps: int = DEFAULT_RECEIPT_SWAP_LIMIT,
+    ) -> int:
+        """Estimate serialized receipt payload size in bytes."""
+        payload = self.to_receipt_payload(
+            max_agents_per_provider=max_agents_per_provider,
+            max_swaps=max_swaps,
+        )
+        return len(json.dumps(payload, sort_keys=True).encode("utf-8"))
 
 
 @dataclass
@@ -74,22 +209,31 @@ class ProviderDiversityFilter:
 
     def check(self, agents: list[AgentInfo]) -> DiversityReport:
         """Check provider diversity without modifying the team."""
+        started_at = time.perf_counter()
         providers: dict[str, list[str]] = defaultdict(list)
         for agent in agents:
             providers[agent.provider].append(agent.name)
 
-        return DiversityReport(
+        runtime_ms = (time.perf_counter() - started_at) * 1000
+        report = DiversityReport(
             providers=dict(providers),
             provider_count=len(providers),
             meets_minimum=len(providers) >= self.min_providers,
             swaps_made=[],
             min_providers=self.min_providers,
+            roster_size=len(agents),
+            provider_shortfall=max(0, self.min_providers - len(providers)),
+            swap_budget=max(0, self.min_providers - len(providers)),
+            runtime_ms=runtime_ms,
         )
+        report.receipt_payload_bytes = report.estimate_receipt_payload_bytes()
+        return report
 
     def enforce(
         self,
         agents: list[AgentInfo],
         alternatives: list[AgentInfo] | None = None,
+        benchmark_iterations: int = 0,
     ) -> tuple[list[AgentInfo], DiversityReport]:
         """Enforce provider diversity, swapping agents if needed.
 
@@ -99,15 +243,31 @@ class ProviderDiversityFilter:
         Returns:
             Tuple of (possibly modified agent list, diversity report).
         """
-        alt_pool = alternatives or self.available_alternatives
+        started_at = time.perf_counter()
+        alt_pool = list(self.available_alternatives if alternatives is None else alternatives)
         providers: dict[str, list[AgentInfo]] = defaultdict(list)
         for agent in agents:
             providers[agent.provider].append(agent)
 
         swaps: list[tuple[str, str]] = []
+        provider_shortfall = max(0, self.min_providers - len(providers))
 
         if len(providers) >= self.min_providers:
-            return agents, self._make_report(agents, swaps)
+            report = self._make_report(
+                agents,
+                swaps,
+                alternative_pool_size=len(alt_pool),
+                swap_budget=provider_shortfall,
+                runtime_ms=(time.perf_counter() - started_at) * 1000,
+            )
+            if benchmark_iterations > 0:
+                report.benchmark = self.benchmark(
+                    agents,
+                    alternatives=alt_pool,
+                    iterations=benchmark_iterations,
+                )
+                report.receipt_payload_bytes = report.estimate_receipt_payload_bytes()
+            return agents, report
 
         # Find providers not in current team
         current_providers = set(providers.keys())
@@ -163,20 +323,81 @@ class ProviderDiversityFilter:
                 del alt_by_provider[best_provider]
             current_providers.add(best_provider)
 
-        return result, self._make_report(result, swaps)
+        report = self._make_report(
+            result,
+            swaps,
+            alternative_pool_size=len(alt_pool),
+            swap_budget=provider_shortfall,
+            runtime_ms=(time.perf_counter() - started_at) * 1000,
+        )
+        if benchmark_iterations > 0:
+            report.benchmark = self.benchmark(
+                agents,
+                alternatives=alt_pool,
+                iterations=benchmark_iterations,
+            )
+            report.receipt_payload_bytes = report.estimate_receipt_payload_bytes()
+        return result, report
+
+    def benchmark(
+        self,
+        agents: list[AgentInfo],
+        alternatives: list[AgentInfo] | None = None,
+        *,
+        iterations: int = 5,
+    ) -> DiversityBenchmark:
+        """Benchmark provider-diversity enforcement for a roster."""
+        if iterations < 1:
+            raise ValueError("iterations must be >= 1")
+
+        alt_pool = list(self.available_alternatives if alternatives is None else alternatives)
+        runtimes: list[float] = []
+        final_report: DiversityReport | None = None
+
+        for _ in range(iterations):
+            _, final_report = self.enforce(list(agents), alternatives=list(alt_pool))
+            runtimes.append(final_report.runtime_ms)
+
+        if final_report is None:
+            raise RuntimeError("provider diversity benchmark did not produce a report")
+        return DiversityBenchmark(
+            path="provider_diversity_filter",
+            roster_size=len(agents),
+            alternative_pool_size=len(alt_pool),
+            iterations=iterations,
+            average_runtime_ms=sum(runtimes) / len(runtimes),
+            max_runtime_ms=max(runtimes),
+            provider_shortfall=final_report.provider_shortfall,
+            swap_budget=final_report.swap_budget,
+            swaps_made=len(final_report.swaps_made),
+            receipt_payload_bytes=final_report.receipt_payload_bytes,
+        )
 
     def _make_report(
-        self, agents: list[AgentInfo], swaps: list[tuple[str, str]]
+        self,
+        agents: list[AgentInfo],
+        swaps: list[tuple[str, str]],
+        *,
+        alternative_pool_size: int = 0,
+        swap_budget: int = 0,
+        runtime_ms: float = 0.0,
     ) -> DiversityReport:
         """Build diversity report from final agent list."""
         providers: dict[str, list[str]] = defaultdict(list)
         for agent in agents:
             providers[agent.provider].append(agent.name)
 
-        return DiversityReport(
+        report = DiversityReport(
             providers=dict(providers),
             provider_count=len(providers),
             meets_minimum=len(providers) >= self.min_providers,
             swaps_made=swaps,
             min_providers=self.min_providers,
+            roster_size=len(agents),
+            alternative_pool_size=alternative_pool_size,
+            provider_shortfall=max(0, self.min_providers - len(providers)),
+            swap_budget=swap_budget,
+            runtime_ms=runtime_ms,
         )
+        report.receipt_payload_bytes = report.estimate_receipt_payload_bytes()
+        return report

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -1025,6 +1025,19 @@ class DecisionReceipt:
         elif not input_hash:
             input_hash = ""
 
+        metadata = getattr(result, "metadata", {}) or {}
+        config_used: dict[str, Any] = {
+            "rounds": result.rounds_used,
+            "participants": participants,
+            "duration_seconds": result.duration_seconds,
+        }
+        provider_diversity = metadata.get("provider_diversity_report")
+        if isinstance(provider_diversity, dict):
+            config_used["provider_diversity"] = provider_diversity
+        large_roster_runtime = metadata.get("large_roster_runtime")
+        if isinstance(large_roster_runtime, dict):
+            config_used["large_roster_runtime"] = large_roster_runtime
+
         # Determine verdict from consensus
         if result.consensus_reached and result.confidence >= 0.7:
             verdict = "PASS"
@@ -1083,11 +1096,7 @@ class DecisionReceipt:
             agent_responses=agent_responses,
             cost_summary=cost_summary,
             settlement_metadata=settlement_metadata,
-            config_used={
-                "rounds": result.rounds_used,
-                "participants": participants,
-                "duration_seconds": result.duration_seconds,
-            },
+            config_used=config_used,
         )
 
     @classmethod

--- a/aragora/pipeline/unified_orchestrator.py
+++ b/aragora/pipeline/unified_orchestrator.py
@@ -251,6 +251,7 @@ class UnifiedOrchestrator:
             self._annotate_provider_metadata(
                 result.debate_result,
                 provider_hints=provider_hints,
+                diversity_report=result.diversity_report,
             )
             result.stages_completed.append("debate")
 
@@ -524,6 +525,7 @@ class UnifiedOrchestrator:
         debate_result: Any,
         *,
         provider_hints: list[str] | None = None,
+        diversity_report: Any | None = None,
     ) -> None:
         """Persist routed provider choices into debate metadata when available.
 
@@ -544,9 +546,26 @@ class UnifiedOrchestrator:
                 return
         provider_names = [str(item) for item in provider_hints if str(item)]
         if not provider_names:
+            provider_names = []
+        if provider_names:
+            metadata.setdefault("provider_hints", list(provider_names))
+            metadata.setdefault("provider_names", list(provider_names))
+
+        if diversity_report is None:
             return
-        metadata.setdefault("provider_hints", list(provider_names))
-        metadata.setdefault("provider_names", list(provider_names))
+
+        if hasattr(diversity_report, "to_receipt_payload"):
+            receipt_payload = diversity_report.to_receipt_payload()
+            if isinstance(receipt_payload, dict):
+                metadata.setdefault("provider_diversity_report", receipt_payload)
+
+        if getattr(diversity_report, "roster_size", 0) < 10:
+            return
+
+        if hasattr(diversity_report, "to_runtime_summary"):
+            runtime_summary = diversity_report.to_runtime_summary()
+            if isinstance(runtime_summary, dict):
+                metadata.setdefault("large_roster_runtime", runtime_summary)
 
     def _update_phase_elo(self, debate_result: Any, domain: str) -> None:
         """Update phase ELO ratings from debate results."""

--- a/tests/debate/test_provider_diversity.py
+++ b/tests/debate/test_provider_diversity.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import pytest
+from aragora.core_types import DebateResult
 from aragora.debate.provider_diversity import (
     AgentInfo,
     DiversityReport,
     ProviderDiversityFilter,
     detect_provider,
 )
+from aragora.gauntlet.receipt_models import DecisionReceipt
+from aragora.pipeline.unified_orchestrator import UnifiedOrchestrator
 
 
 class TestDetectProvider:
@@ -118,3 +121,103 @@ class TestDiversityEnforce:
     def test_explicit_provider(self):
         a = AgentInfo(name="x", model="custom", provider="custom_co")
         assert a.provider == "custom_co"
+
+
+class TestLargeRosterObservability:
+    def test_large_roster_receipt_payload_is_bounded(self):
+        f = ProviderDiversityFilter(min_providers=3)
+        agents = [
+            AgentInfo(name=f"claude{i}", model="claude-3-opus", score=1.0 - (i * 0.01))
+            for i in range(10)
+        ] + [
+            AgentInfo(name="gpt-primary", model="gpt-4o", score=0.85),
+            AgentInfo(name="gpt-secondary", model="gpt-4o-mini", score=0.75),
+        ]
+        alternatives = [
+            AgentInfo(name="gemini-primary", model="gemini-3.1-pro", score=0.82),
+            AgentInfo(name="mistral-primary", model="mistral-large", score=0.81),
+        ]
+
+        result, report = f.enforce(agents, alternatives=alternatives)
+
+        assert len(result) == 12
+        assert report.roster_size == 12
+        assert report.alternative_pool_size == 2
+        assert report.runtime_ms >= 0.0
+        assert report.receipt_payload_bytes > 0
+
+        payload = report.to_receipt_payload(max_agents_per_provider=2, max_swaps=1)
+
+        assert payload["roster_size"] == 12
+        assert payload["provider_count"] == 3
+        assert payload["runtime_ms"] == round(report.runtime_ms, 4)
+        assert payload["providers"]["anthropic"]["count"] == 9
+        assert payload["providers"]["anthropic"]["sample_agents"] == ["claude0", "claude1"]
+        assert payload["providers"]["anthropic"]["truncated_agents"] == 7
+        assert len(payload["swaps_made"]) == 1
+        assert payload["swaps_truncated"] == 0
+
+    def test_large_roster_benchmark_records_runtime_envelope(self):
+        f = ProviderDiversityFilter(min_providers=3)
+        agents = [
+            AgentInfo(name=f"claude{i}", model="claude-3-opus", score=1.0 - (i * 0.01))
+            for i in range(11)
+        ] + [AgentInfo(name="gpt-primary", model="gpt-4o", score=0.8)]
+        alternatives = [
+            AgentInfo(name="gemini-primary", model="gemini-3.1-pro", score=0.79),
+            AgentInfo(name="mistral-primary", model="mistral-large", score=0.78),
+        ]
+
+        benchmark = f.benchmark(agents, alternatives=alternatives, iterations=4)
+
+        assert benchmark.path == "provider_diversity_filter"
+        assert benchmark.roster_size == 12
+        assert benchmark.iterations == 4
+        assert benchmark.average_runtime_ms >= 0.0
+        assert benchmark.max_runtime_ms >= benchmark.average_runtime_ms
+        assert benchmark.swap_budget == 1
+        assert benchmark.swaps_made == 1
+        assert benchmark.receipt_payload_bytes > 0
+
+    def test_unified_orchestrator_and_receipt_preserve_large_roster_metadata(self):
+        f = ProviderDiversityFilter(min_providers=3)
+        agents = [
+            AgentInfo(name=f"claude{i}", model="claude-3-opus", score=1.0 - (i * 0.01))
+            for i in range(10)
+        ] + [
+            AgentInfo(name="gpt-primary", model="gpt-4o", score=0.85),
+            AgentInfo(name="gpt-secondary", model="gpt-4o-mini", score=0.75),
+        ]
+        alternatives = [
+            AgentInfo(name="gemini-primary", model="gemini-3.1-pro", score=0.82),
+            AgentInfo(name="mistral-primary", model="mistral-large", score=0.81),
+        ]
+
+        _, report = f.enforce(agents, alternatives=alternatives)
+        report.benchmark = f.benchmark(agents, alternatives=alternatives, iterations=2)
+        report.receipt_payload_bytes = report.estimate_receipt_payload_bytes()
+
+        result = DebateResult(
+            debate_id="debate-large-roster",
+            task="Plan a 12-agent heterogeneous debate",
+            final_answer="Use a bounded large-roster path",
+            confidence=0.82,
+            consensus_reached=True,
+            rounds_used=2,
+            participants=[agent.name for agent in agents],
+            metadata={},
+        )
+
+        UnifiedOrchestrator._annotate_provider_metadata(
+            result,
+            provider_hints=["claude-sonnet-4", "gpt-4o", "gemini-3.1-pro"],
+            diversity_report=report,
+        )
+
+        receipt = DecisionReceipt.from_debate_result(result)
+
+        assert result.metadata["provider_diversity_report"]["roster_size"] == 12
+        assert result.metadata["large_roster_runtime"]["path"] == "provider_diversity_filter"
+        assert receipt.config_used["provider_diversity"]["provider_count"] == 3
+        assert receipt.config_used["large_roster_runtime"]["roster_size"] == 12
+        assert receipt.config_used["large_roster_runtime"]["benchmark"]["iterations"] == 2


### PR DESCRIPTION
## Summary
- add bounded receipt/runtime summaries for provider-diversity enforcement on large rosters
- record swap budget, provider shortfall, runtime, and payload sizing in the diversity report
- add focused provider-diversity coverage for the new observability surface

## Validation
- `python3 -m ruff check aragora/debate/provider_diversity.py aragora/gauntlet/receipt_models.py aragora/pipeline/unified_orchestrator.py tests/debate/test_provider_diversity.py`
- `python3 -m pytest tests/debate/test_provider_diversity.py -q`
