### PR TITLE
feat(mission-control): show node provenance with downstream execution

### DIFF
--- a/aragora/live/src/components/mission-control/MissionControlCanvas.tsx
+++ b/aragora/live/src/components/mission-control/MissionControlCanvas.tsx
@@ -37,8 +37,11 @@ import ActionNode from '../pipeline-canvas/nodes/ActionNode';
 import OrchestrationNode from '../pipeline-canvas/nodes/OrchestrationNode';
 import {
   PIPELINE_STAGE_CONFIG,
+  STAGE_COLOR_CLASSES,
   type PipelineStageType,
 } from '../pipeline-canvas/types';
+import { ProvenanceTrail } from '../pipeline-canvas/ProvenanceTrail';
+import { StatusBadge } from '../pipeline-canvas/StatusBadge';
 import { StageZoneHeader } from './StageZoneHeader';
 import { useMissionControl, STAGE_OFFSET_X } from '../../hooks/useMissionControl';
 
@@ -176,6 +179,17 @@ function StageFilterSidebar({ enabledStages, onToggle, onFocus, nodeCounts }: St
 interface ProvenanceSidebarProps {
   nodeId: string;
   nodeLabel: string;
+  nodeStage: PipelineStageType;
+  provenance: Array<{
+    source_node_id: string;
+    source_stage: PipelineStageType;
+    target_node_id: string;
+    target_stage: PipelineStageType;
+    content_hash: string;
+    method: string;
+    timestamp: number;
+  }>;
+  nodeLookup: Record<string, { label: string; stage: PipelineStageType }>;
   provenanceChain: Array<{
     nodeId: string;
     nodeLabel: string;
@@ -183,10 +197,33 @@ interface ProvenanceSidebarProps {
     contentHash: string;
     method: string;
   }>;
+  downstreamExecution: Array<{
+    nodeId: string;
+    label: string;
+    stage: PipelineStageType;
+    status: 'pending' | 'in_progress' | 'succeeded' | 'failed' | 'partial';
+    rawStatus: string;
+    agent?: string;
+    elapsedMs?: number;
+    outputPreview?: string;
+    navigable: boolean;
+    isSelectedNode?: boolean;
+  }>;
+  onNavigate: (nodeId: string, stage: PipelineStageType) => void;
   onClose: () => void;
 }
 
-function ProvenanceSidebar({ nodeId, nodeLabel, provenanceChain, onClose }: ProvenanceSidebarProps) {
+function ProvenanceSidebar({
+  nodeId,
+  nodeLabel,
+  nodeStage,
+  provenance,
+  nodeLookup,
+  provenanceChain,
+  downstreamExecution,
+  onNavigate,
+  onClose,
+}: ProvenanceSidebarProps) {
   return (
     <div
       className="w-72 flex-shrink-0 bg-surface border-l border-border h-full overflow-y-auto p-4"
@@ -208,42 +245,109 @@ function ProvenanceSidebar({ nodeId, nodeLabel, provenanceChain, onClose }: Prov
         <p className="text-xs text-text-muted font-mono">{nodeId}</p>
       </div>
 
-      {provenanceChain.length > 0 ? (
-        <div className="space-y-2">
+      <div className="space-y-4">
+        <div className="p-3 bg-bg rounded border border-border">
           <h4 className="text-xs font-mono font-bold text-text-muted uppercase mb-2">
-            Derivation Chain
+            Upstream Provenance
           </h4>
-          {provenanceChain.map((entry, i) => {
-            const stageColor = STAGE_COLORS[entry.stage] || '#6b7280';
-            return (
-              <div key={i} className="p-2 bg-bg rounded border border-border" data-testid="mc-provenance-entry">
-                <div className="flex items-center gap-2 mb-1">
-                  <span
-                    className="w-2 h-2 rounded-full inline-block"
-                    style={{ backgroundColor: stageColor }}
-                  />
-                  <span className="text-xs font-mono uppercase" style={{ color: stageColor }}>
-                    {entry.stage}
-                  </span>
-                  {entry.method && (
-                    <span className="text-xs text-text-muted font-mono">
-                      ({entry.method})
+          <ProvenanceTrail
+            selectedNodeId={nodeId}
+            selectedStage={nodeStage}
+            selectedLabel={nodeLabel}
+            provenance={provenance}
+            nodeLookup={nodeLookup}
+            onNavigate={onNavigate}
+          />
+        </div>
+
+        {provenanceChain.length > 0 ? (
+          <div className="space-y-2">
+            <h4 className="text-xs font-mono font-bold text-text-muted uppercase mb-2">
+              Derivation Chain
+            </h4>
+            {provenanceChain.map((entry, i) => {
+              const stageColor = STAGE_COLORS[entry.stage] || '#6b7280';
+              return (
+                <div key={i} className="p-2 bg-bg rounded border border-border" data-testid="mc-provenance-entry">
+                  <div className="flex items-center gap-2 mb-1">
+                    <span
+                      className="w-2 h-2 rounded-full inline-block"
+                      style={{ backgroundColor: stageColor }}
+                    />
+                    <span className="text-xs font-mono uppercase" style={{ color: stageColor }}>
+                      {entry.stage}
                     </span>
+                    {entry.method && (
+                      <span className="text-xs text-text-muted font-mono">
+                        ({entry.method})
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text truncate mb-1">{entry.nodeLabel}</p>
+                  {entry.contentHash && (
+                    <p className="text-xs text-text-muted font-mono">
+                      #{entry.contentHash.slice(0, 12)}
+                    </p>
                   )}
                 </div>
-                <p className="text-xs text-text truncate mb-1">{entry.nodeLabel}</p>
-                {entry.contentHash && (
-                  <p className="text-xs text-text-muted font-mono">
-                    #{entry.contentHash.slice(0, 12)}
-                  </p>
-                )}
-              </div>
-            );
-          })}
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-text-muted">No provenance chain for this node.</p>
+        )}
+
+        <div className="space-y-2">
+          <h4 className="text-xs font-mono font-bold text-text-muted uppercase mb-2">
+            Downstream Execution
+          </h4>
+          {downstreamExecution.length > 0 ? (
+            downstreamExecution.map((entry) => {
+              const colors = STAGE_COLOR_CLASSES[entry.stage];
+              const stageLabel = PIPELINE_STAGE_CONFIG[entry.stage].label;
+              return (
+                <button
+                  key={`${entry.nodeId}-${entry.stage}`}
+                  type="button"
+                  onClick={() => entry.navigable && onNavigate(entry.nodeId, entry.stage)}
+                  disabled={!entry.navigable}
+                  className={`w-full text-left p-2 bg-bg rounded border border-border transition-colors ${
+                    entry.navigable
+                      ? 'hover:border-acid-green/50'
+                      : 'opacity-80 cursor-default'
+                  }`}
+                  data-testid="mc-downstream-execution-entry"
+                >
+                  <div className="flex items-center gap-2 mb-1.5 flex-wrap">
+                    <span className={`px-1 py-0.5 text-xs rounded font-mono ${colors.bg} ${colors.text}`}>
+                      {stageLabel}
+                    </span>
+                    <StatusBadge status={entry.status} size="sm" agent={entry.agent} />
+                    {entry.isSelectedNode && (
+                      <span className="px-1 py-0.5 text-[10px] rounded font-mono bg-acid-green/10 text-acid-green border border-acid-green/30">
+                        selected
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-text truncate mb-1">{entry.label}</p>
+                  <div className="flex items-center gap-2 text-[10px] text-text-muted font-mono flex-wrap">
+                    {entry.agent && <span>{entry.agent}</span>}
+                    {entry.elapsedMs != null && <span>{(entry.elapsedMs / 1000).toFixed(1)}s</span>}
+                    {entry.rawStatus && <span>{entry.rawStatus.replace('_', ' ')}</span>}
+                  </div>
+                  {entry.outputPreview && (
+                    <p className="mt-1 text-[10px] text-text-muted font-mono bg-surface/40 rounded px-1.5 py-1 line-clamp-2">
+                      {entry.outputPreview}
+                    </p>
+                  )}
+                </button>
+              );
+            })
+          ) : (
+            <p className="text-sm text-text-muted">No downstream execution state yet.</p>
+          )}
         </div>
-      ) : (
-        <p className="text-sm text-text-muted">No provenance chain for this node.</p>
-      )}
+      </div>
     </div>
   );
 }
@@ -260,9 +364,12 @@ function MissionControlCanvasInner() {
     stageNodeCounts,
     pipelineId,
     selectedNodeId,
-    selectedNodeData: _selectedNodeData,
+    selectedNodeData,
+    selectedNodeStage,
     onNodeSelect,
+    provenance,
     provenanceChain,
+    downstreamExecution,
     loading,
     error,
   } = useMissionControl();
@@ -335,16 +442,32 @@ function MissionControlCanvasInner() {
 
   // -- Compute visible stages -----------------------------------------------
   const semanticVisible = useMemo(() => getVisibleStages(zoomLevel), [zoomLevel]);
+  const lineageStages = useMemo(() => {
+    const stages = new Set<PipelineStageType>();
+    if (selectedNodeStage) {
+      stages.add(selectedNodeStage);
+    }
+    for (const crumb of provenanceChain) {
+      stages.add(crumb.stage);
+    }
+    for (const entry of downstreamExecution) {
+      stages.add(entry.stage);
+    }
+    return stages;
+  }, [downstreamExecution, provenanceChain, selectedNodeStage]);
 
   const visibleStages = useMemo(() => {
     const result = new Set<PipelineStageType>();
     for (const stage of ALL_STAGES) {
-      if (semanticVisible.has(stage) && stageFilterOverrides.has(stage)) {
+      if (
+        (semanticVisible.has(stage) && stageFilterOverrides.has(stage)) ||
+        (showProvenance && lineageStages.has(stage))
+      ) {
         result.add(stage);
       }
     }
     return result;
-  }, [semanticVisible, stageFilterOverrides]);
+  }, [lineageStages, semanticVisible, showProvenance, stageFilterOverrides]);
 
   // -- Filter nodes/edges to visible stages ---------------------------------
   const { displayNodes, displayEdges } = useMemo(() => {
@@ -366,6 +489,20 @@ function MissionControlCanvasInner() {
     return (node?.data as Record<string, unknown>)?.label as string || selectedNodeId;
   }, [selectedNodeId, allNodes]);
 
+  const nodeLookup = useMemo(() => {
+    const lookup: Record<string, { label: string; stage: PipelineStageType }> = {};
+    for (const node of allNodes) {
+      const data = node.data as Record<string, unknown>;
+      const stage = data.stage as PipelineStageType | undefined;
+      if (!stage) continue;
+      lookup[node.id] = {
+        label: (data.label as string) || node.id,
+        stage,
+      };
+    }
+    return lookup;
+  }, [allNodes]);
+
   // -- Node click -----------------------------------------------------------
   const onNodeClick = useCallback(
     (_: React.MouseEvent, node: Node) => {
@@ -379,6 +516,35 @@ function MissionControlCanvasInner() {
     onNodeSelect(null);
     setShowProvenance(false);
   }, [onNodeSelect]);
+
+  const handleSidebarNavigate = useCallback(
+    (nodeId: string, stage: PipelineStageType) => {
+      setStageFilterOverrides((prev) => {
+        const next = new Set(prev);
+        next.add(stage);
+        return next;
+      });
+      onNodeSelect(nodeId);
+      setShowProvenance(true);
+
+      const targetNode = allNodes.find((node) => node.id === nodeId);
+      setTimeout(() => {
+        if (targetNode) {
+          fitView({
+            padding: 0.3,
+            nodes: [{
+              id: targetNode.id,
+              position: targetNode.position,
+              measured: { width: 260, height: 140 },
+            }],
+          });
+          return;
+        }
+        focusStage(stage);
+      }, 50);
+    },
+    [allNodes, fitView, focusStage, onNodeSelect],
+  );
 
   // -- MiniMap color --------------------------------------------------------
   const miniMapNodeColor = useCallback((node: { type?: string }) => {
@@ -548,11 +714,16 @@ function MissionControlCanvasInner() {
       </div>
 
       {/* Right: Provenance Sidebar */}
-      {showProvenance && selectedNodeId && (
+      {showProvenance && selectedNodeId && selectedNodeData && selectedNodeStage && (
         <ProvenanceSidebar
           nodeId={selectedNodeId}
           nodeLabel={selectedNodeLabel}
+          nodeStage={selectedNodeStage}
+          provenance={provenance}
+          nodeLookup={nodeLookup}
           provenanceChain={provenanceChain}
+          downstreamExecution={downstreamExecution}
+          onNavigate={handleSidebarNavigate}
           onClose={() => {
             setShowProvenance(false);
             onNodeSelect(null);

--- a/aragora/live/src/hooks/useMissionControl.ts
+++ b/aragora/live/src/hooks/useMissionControl.ts
@@ -17,6 +17,8 @@ import type {
   PipelineResultResponse,
   ReactFlowData,
   ProvenanceBreadcrumb,
+  ProvenanceLink,
+  ExecutionStatus,
 } from '../components/pipeline-canvas/types';
 import {
   getNodeTypeForStage,
@@ -26,6 +28,7 @@ import {
   usePipelineWebSocket,
   type PipelineStageEvent,
   type PipelineNodeEvent,
+  type PipelineNodeStatusEvent,
 } from './usePipelineWebSocket';
 
 // ---------------------------------------------------------------------------
@@ -69,6 +72,23 @@ const DEFAULT_STATUS: Record<PipelineStageType, string> = {
   goals: 'pending',
   actions: 'pending',
   orchestration: 'pending',
+};
+
+const EXECUTION_STATUS_MAP: Record<string, ExecutionStatus> = {
+  pending: 'pending',
+  queued: 'pending',
+  running: 'in_progress',
+  in_progress: 'in_progress',
+  active: 'in_progress',
+  complete: 'succeeded',
+  completed: 'succeeded',
+  succeeded: 'succeeded',
+  success: 'succeeded',
+  failed: 'failed',
+  error: 'failed',
+  blocked: 'partial',
+  awaiting_human: 'partial',
+  partial: 'partial',
 };
 
 export const STAGE_OFFSET_X: Record<string, number> = {
@@ -125,6 +145,37 @@ function parseStageEdges(stage: PipelineStageType, data: ReactFlowData | Record<
   }));
 }
 
+function normalizeExecutionStatus(status?: string | null): ExecutionStatus {
+  if (!status) return 'pending';
+  return EXECUTION_STATUS_MAP[status] ?? 'pending';
+}
+
+function findNodeInStages(
+  stageNodes: Record<PipelineStageType, Node[]>,
+  nodeId: string,
+): { stage: PipelineStageType; node: Node } | null {
+  for (const stage of ALL_STAGES) {
+    const node = stageNodes[stage].find((candidate) => candidate.id === nodeId);
+    if (node) {
+      return { stage, node };
+    }
+  }
+  return null;
+}
+
+export interface MissionControlExecutionState {
+  nodeId: string;
+  label: string;
+  stage: PipelineStageType;
+  status: ExecutionStatus;
+  rawStatus: string;
+  agent?: string;
+  elapsedMs?: number;
+  outputPreview?: string;
+  navigable: boolean;
+  isSelectedNode?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Return type
 // ---------------------------------------------------------------------------
@@ -150,10 +201,13 @@ export interface UseMissionControlReturn {
   // Selection
   selectedNodeId: string | null;
   selectedNodeData: Record<string, unknown> | null;
+  selectedNodeStage: PipelineStageType | null;
   onNodeSelect: (nodeId: string | null) => void;
 
   // Provenance
+  provenance: ProvenanceLink[];
   provenanceChain: ProvenanceBreadcrumb[];
+  downstreamExecution: MissionControlExecutionState[];
 
   // WebSocket
   wsStatus: string;
@@ -183,19 +237,10 @@ export function useMissionControl(
   const [stageNodes, setStageNodes] = useState<Record<PipelineStageType, Node[]>>({ ...EMPTY_STAGE_NODES });
   const [stageEdges, setStageEdges] = useState<Record<PipelineStageType, Edge[]>>({ ...EMPTY_STAGE_EDGES });
   const [stageStatus, setStageStatus] = useState<Record<PipelineStageType, string>>({ ...DEFAULT_STATUS });
+  const [provenance, setProvenance] = useState<ProvenanceLink[]>([]);
 
   // Selection
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
-
-  // Provenance links from API
-  const provenanceLinksRef = useRef<Array<{
-    source_node_id: string;
-    target_node_id: string;
-    source_stage: string;
-    target_stage: string;
-    content_hash: string;
-    method: string;
-  }>>([]);
 
   const syncCacheToState = useCallback(() => {
     setStageNodes({ ...stageNodesRef.current });
@@ -215,9 +260,7 @@ export function useMissionControl(
         stageEdgesRef.current[stage] = parseStageEdges(stage, stageData);
       }
 
-      if (result.provenance) {
-        provenanceLinksRef.current = result.provenance as typeof provenanceLinksRef.current;
-      }
+      setProvenance((result.provenance ?? []) as ProvenanceLink[]);
 
       syncCacheToState();
     },
@@ -253,6 +296,9 @@ export function useMissionControl(
       setLoading(true);
       setError(null);
       try {
+        if (automationLevel === 'full') {
+          setIsExecuting(true);
+        }
         const res = await fetch(`${API_PREFIX}/from-ideas`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -263,6 +309,9 @@ export function useMissionControl(
         });
 
         if (!res.ok) {
+          if (automationLevel === 'full') {
+            setIsExecuting(false);
+          }
           setError(`Failed to start brain dump: ${res.status}`);
           return null;
         }
@@ -277,6 +326,9 @@ export function useMissionControl(
 
         return newId;
       } catch {
+        if (automationLevel === 'full') {
+          setIsExecuting(false);
+        }
         setError('Failed to start brain dump');
         return null;
       } finally {
@@ -292,6 +344,7 @@ export function useMissionControl(
       if (!pipelineId) return;
       setLoading(true);
       setError(null);
+      setIsExecuting(true);
       try {
         const res = await fetch(`${API_PREFIX}/advance`, {
           method: 'POST',
@@ -303,6 +356,7 @@ export function useMissionControl(
         });
 
         if (!res.ok) {
+          setIsExecuting(false);
           setError(`Failed to advance to ${targetStage}: ${res.status}`);
           return;
         }
@@ -312,6 +366,7 @@ export function useMissionControl(
           populateFromResult(data.result as PipelineResultResponse);
         }
       } catch {
+        setIsExecuting(false);
         setError(`Failed to advance to ${targetStage}`);
       } finally {
         setLoading(false);
@@ -325,14 +380,18 @@ export function useMissionControl(
     setSelectedNodeId(nodeId);
   }, []);
 
-  const selectedNodeData = useMemo(() => {
+  const selectedNode = useMemo(() => {
     if (!selectedNodeId) return null;
-    for (const stage of ALL_STAGES) {
-      const node = stageNodes[stage].find((n) => n.id === selectedNodeId);
-      if (node) return node.data as Record<string, unknown>;
-    }
-    return null;
+    const result = findNodeInStages(stageNodes, selectedNodeId);
+    if (!result) return null;
+    return {
+      stage: result.stage,
+      data: result.node.data as Record<string, unknown>,
+    };
   }, [selectedNodeId, stageNodes]);
+
+  const selectedNodeData = selectedNode?.data ?? null;
+  const selectedNodeStage = selectedNode?.stage ?? null;
 
   // -- Provenance chain ---------------------------------------------------
   const provenanceChain = useMemo((): ProvenanceBreadcrumb[] => {
@@ -344,7 +403,7 @@ export function useMissionControl(
 
     while (currentId && !visited.has(currentId)) {
       visited.add(currentId);
-      const link = provenanceLinksRef.current.find((l) => l.target_node_id === currentId);
+      const link = provenance.find((entry) => entry.target_node_id === currentId);
       if (!link) break;
 
       const sourceStage = link.source_stage as PipelineStageType;
@@ -362,7 +421,97 @@ export function useMissionControl(
     }
 
     return chain;
-  }, [selectedNodeId, stageNodes]);
+  }, [selectedNodeId, provenance, stageNodes]);
+
+  const downstreamExecution = useMemo((): MissionControlExecutionState[] => {
+    if (!selectedNodeId || !selectedNodeStage) return [];
+
+    const entries = new Map<string, MissionControlExecutionState>();
+    const addExecutionState = (
+      nodeId: string,
+      stage: PipelineStageType,
+      data: Record<string, unknown>,
+      options?: { isSelectedNode?: boolean; navigable?: boolean; label?: string },
+    ) => {
+      const rawStatus =
+        (data.executionStatus as string | undefined) ??
+        (data.status as string | undefined) ??
+        stageStatus[stage] ??
+        'pending';
+      entries.set(nodeId, {
+        nodeId,
+        label: options?.label ?? (data.label as string) ?? nodeId,
+        stage,
+        status: normalizeExecutionStatus(rawStatus),
+        rawStatus,
+        agent:
+          (data.executionAgent as string | undefined) ??
+          (data.assignedAgent as string | undefined) ??
+          (data.assignee as string | undefined) ??
+          (data.agent as string | undefined),
+        elapsedMs:
+          typeof data.elapsedMs === 'number'
+            ? data.elapsedMs
+            : typeof data.elapsed_ms === 'number'
+              ? (data.elapsed_ms as number)
+              : undefined,
+        outputPreview:
+          (data.outputPreview as string | undefined) ??
+          (data.output_preview as string | undefined),
+        navigable: options?.navigable ?? true,
+        isSelectedNode: options?.isSelectedNode ?? false,
+      });
+    };
+
+    if (selectedNodeData && (selectedNodeStage === 'actions' || selectedNodeStage === 'orchestration')) {
+      addExecutionState(selectedNodeId, selectedNodeStage, selectedNodeData, {
+        isSelectedNode: true,
+      });
+    }
+
+    const queue = [selectedNodeId];
+    const visited = new Set<string>(queue);
+    while (queue.length > 0) {
+      const currentId = queue.shift();
+      if (!currentId) continue;
+
+      for (const link of provenance) {
+        if (link.source_node_id !== currentId) continue;
+
+        const nextId = link.target_node_id;
+        if (!visited.has(nextId)) {
+          visited.add(nextId);
+          queue.push(nextId);
+        }
+
+        const nodeMatch = findNodeInStages(stageNodes, nextId);
+        if (!nodeMatch) continue;
+        addExecutionState(nextId, nodeMatch.stage, nodeMatch.node.data as Record<string, unknown>);
+      }
+    }
+
+    const selectedStageIndex = ALL_STAGES.indexOf(selectedNodeStage);
+    for (const stage of ALL_STAGES.slice(selectedStageIndex + 1)) {
+      const hasStageEntry = Array.from(entries.values()).some((entry) => entry.stage === stage);
+      if (hasStageEntry) continue;
+      entries.set(`stage:${stage}`, {
+        nodeId: `stage:${stage}`,
+        label: `${PIPELINE_STAGE_CONFIG[stage].label} stage`,
+        stage,
+        status: normalizeExecutionStatus(stageStatus[stage]),
+        rawStatus: stageStatus[stage] ?? 'pending',
+        navigable: false,
+      });
+    }
+
+    return Array.from(entries.values()).sort((left, right) => {
+      if (left.isSelectedNode && !right.isSelectedNode) return -1;
+      if (right.isSelectedNode && !left.isSelectedNode) return 1;
+      const stageDelta = ALL_STAGES.indexOf(left.stage) - ALL_STAGES.indexOf(right.stage);
+      if (stageDelta !== 0) return stageDelta;
+      return left.label.localeCompare(right.label);
+    });
+  }, [selectedNodeData, selectedNodeId, selectedNodeStage, provenance, stageNodes, stageStatus]);
 
   // -- Stage node counts --------------------------------------------------
   const stageNodeCounts = useMemo(() => {
@@ -409,10 +558,18 @@ export function useMissionControl(
     return { nodes: allNodes, edges: allEdges };
   }, [stageNodes, stageEdges]);
 
+  const handleStageStarted = useCallback((event: PipelineStageEvent) => {
+    const stage = event.stage as PipelineStageType;
+    if (!ALL_STAGES.includes(stage)) return;
+    setStageStatus((prev) => ({ ...prev, [stage]: 'running' }));
+    setIsExecuting(true);
+  }, []);
+
   // -- WebSocket integration ----------------------------------------------
   const handleStageCompleted = useCallback(
     (event: PipelineStageEvent) => {
       const stage = event.stage as PipelineStageType;
+      if (!ALL_STAGES.includes(stage)) return;
       setStageStatus((prev) => ({ ...prev, [stage]: 'complete' }));
 
       // Reload stage data
@@ -432,6 +589,37 @@ export function useMissionControl(
     [pipelineId, syncCacheToState],
   );
 
+  const handleNodeStatus = useCallback(
+    (event: PipelineNodeStatusEvent) => {
+      let updated = false;
+
+      for (const stage of ALL_STAGES) {
+        stageNodesRef.current[stage] = stageNodesRef.current[stage].map((node) => {
+          if (node.id !== event.node_id) {
+            return node;
+          }
+
+          updated = true;
+          return {
+            ...node,
+            data: {
+              ...(node.data as Record<string, unknown>),
+              executionStatus: normalizeExecutionStatus(event.status),
+              ...(event.agent ? { executionAgent: event.agent } : {}),
+              ...(event.elapsed_ms != null ? { elapsedMs: event.elapsed_ms } : {}),
+              ...(event.output_preview ? { outputPreview: event.output_preview } : {}),
+            },
+          };
+        });
+      }
+
+      if (updated) {
+        syncCacheToState();
+      }
+    },
+    [syncCacheToState],
+  );
+
   const {
     status: wsStatus,
     completedStages,
@@ -439,7 +627,9 @@ export function useMissionControl(
   } = usePipelineWebSocket({
     pipelineId: pipelineId ?? undefined,
     enabled: !!pipelineId,
+    onStageStarted: handleStageStarted,
     onStageCompleted: handleStageCompleted,
+    onNodeStatus: handleNodeStatus,
     onCompleted: () => setIsExecuting(false),
     onFailed: () => setIsExecuting(false),
   });
@@ -464,8 +654,11 @@ export function useMissionControl(
     advanceStage,
     selectedNodeId,
     selectedNodeData,
+    selectedNodeStage,
     onNodeSelect,
+    provenance,
     provenanceChain,
+    downstreamExecution,
     wsStatus: wsStatus as string,
     completedStages,
     streamedNodes,


### PR DESCRIPTION
## Summary
- surface upstream provenance directly in the Mission Control sidebar
- show downstream execution state for the selected node with stage/status context and navigation
- wire the Mission Control hook to derive lineage and downstream execution data for the canvas

## Why
This preserved one-commit swarm slice still replayed cleanly on current `main` and adds real operator-facing visibility to Mission Control without touching unrelated pipeline behavior.

## Validation
- `PATH="/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH" NODE_PATH="/Users/armand/Development/aragora/aragora/live/node_modules" npm test -- --runTestsByPath src/components/pipeline-canvas/__tests__/ProvenanceTrail.test.tsx src/components/pipeline-canvas/__tests__/UnifiedPipelineCanvas.test.tsx`
- `PATH="/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH" NODE_PATH="/Users/armand/Development/aragora/aragora/live/node_modules" tsc -p aragora/live/tsconfig.json --pretty false --noEmit`
  - still blocked by the pre-existing missing `jest` and `node` type definitions in this worktree, not by a slice-specific type error
