### PR TITLE
fix(test): restore UTC constant in swarm reporter suite

### DIFF
--- a/tests/swarm/test_reporter.py
+++ b/tests/swarm/test_reporter.py
@@ -11,6 +11,8 @@ import pytest
 from aragora.swarm.reporter import SwarmReport, SwarmReporter, build_integrator_view
 from aragora.swarm.spec import SwarmSpec
 
+UTC = timezone.utc
+
 
 @dataclass
 class MockAssignment:


### PR DESCRIPTION
## Summary
- restore the missing `UTC` alias in `tests/swarm/test_reporter.py`
- re-green the reporter suite on current `main`

## Why
While checking the preserved integrator-reporter branch family, current `main` still failed `tests/swarm/test_reporter.py` with `NameError: name 'UTC' is not defined`. The preserved top commit itself was already absorbed, so this lane became the narrow real fix.

## Validation
- `python3 -m ruff check tests/swarm/test_reporter.py`
- `python3 -m pytest tests/swarm/test_reporter.py -q`
