### PR TITLE
fix(fastapi): use real debate storage in app lifespan

### DIFF
--- a/aragora/server/fastapi/factory.py
+++ b/aragora/server/fastapi/factory.py
@@ -98,16 +98,17 @@ def _build_server_context(nomic_dir: Path | None = None) -> dict[str, Any]:
 
     This provides the same context as the legacy server for handler compatibility.
     """
-    from aragora.storage.debate_storage import DebateStorage
+    from aragora.server.storage import DebateStorage
 
     ctx: dict[str, Any] = {}
 
     # Initialize storage
     try:
-        storage = DebateStorage(nomic_dir=nomic_dir)
+        db_path = str(nomic_dir / "debates.db") if nomic_dir else "aragora_debates.db"
+        storage = DebateStorage(db_path)
         ctx["storage"] = storage
         logger.info("Initialized DebateStorage")
-    except (OSError, RuntimeError) as e:
+    except (OSError, RuntimeError, ValueError) as e:
         logger.warning("Failed to initialize DebateStorage: %s", e)
         ctx["storage"] = None
 
@@ -220,9 +221,10 @@ async def lifespan(app: FastAPI):
             if not task.done():
                 task.cancel()
 
-    if ctx.get("storage"):
+    storage = ctx.get("storage")
+    if storage and hasattr(storage, "close"):
         try:
-            ctx["storage"].close()
+            storage.close()
         except (OSError, RuntimeError) as e:
             logger.debug("Error closing storage during shutdown: %s", e)
 

--- a/tests/server/fastapi/test_factory.py
+++ b/tests/server/fastapi/test_factory.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from aragora.server.fastapi import create_app
+from aragora.server.fastapi import factory
+
+
+@contextmanager
+def _patched_startup_dependencies():
+    with ExitStack() as stack:
+        mocked = {}
+        mocked["storage"] = stack.enter_context(patch("aragora.server.storage.DebateStorage"))
+        stack.enter_context(patch("aragora.ranking.elo.EloSystem", return_value=MagicMock()))
+        stack.enter_context(
+            patch("aragora.storage.user_store.get_user_store", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("aragora.memory.continuum.get_continuum_memory", return_value=MagicMock())
+        )
+        mock_cross_config = stack.enter_context(
+            patch("aragora.memory.cross_debate_rlm.CrossDebateConfig")
+        )
+        mock_cross_config.return_value = MagicMock()
+        stack.enter_context(
+            patch("aragora.memory.cross_debate_rlm.CrossDebateMemory", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("aragora.knowledge.mound.get_knowledge_mound", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("aragora.rbac.checker.get_permission_checker", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("aragora.debate.decision_service.get_decision_service", return_value=MagicMock())
+        )
+        stack.enter_context(
+            patch("aragora.server.middleware.deprecation_enforcer.register_default_deprecations")
+        )
+        yield mocked
+
+
+def test_build_server_context_initializes_debate_storage_in_nomic_dir(tmp_path: Path):
+    with _patched_startup_dependencies() as mocked:
+        ctx = factory._build_server_context(tmp_path)
+
+    mocked["storage"].assert_called_once_with(str(tmp_path / "debates.db"))
+    assert ctx["storage"] is mocked["storage"].return_value
+
+
+def test_create_app_lifespan_starts_with_fastapi_context(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("ARAGORA_NOMIC_DIR", str(tmp_path))
+
+    with _patched_startup_dependencies() as mocked:
+        mocked["storage"].return_value = object()
+        app = create_app()
+        with TestClient(app) as client:
+            response = client.get("/healthz")
+
+    assert response.status_code == 200
+    mocked["storage"].assert_called_once_with(str(tmp_path / "debates.db"))


### PR DESCRIPTION
## Summary
- fix FastAPI lifespan to initialize debate storage from the real server storage module
- build the debate storage DB path from the configured nomic dir
- avoid shutdown crashes when storage does not implement close()
- add focused FastAPI factory startup coverage

## Verification
- python3 -m ruff check aragora/server/fastapi/factory.py tests/server/fastapi/test_factory.py
- python3 -m pytest tests/server/fastapi/test_factory.py -q
- python3 -m pytest tests/server/fastapi/test_routes.py tests/server/fastapi/test_factory.py -q
- python3 - <<'PY'
from fastapi.testclient import TestClient
from aragora.server.fastapi.factory import create_app
app = create_app()
with TestClient(app) as client:
    r = client.get("/healthz")
    print("HEALTH", r.status_code, r.json().get("status"))
PY