### PR TITLE
fix(fastapi): make postgres startup and auth async-safe

### DIFF
--- a/aragora/server/fastapi/factory.py
+++ b/aragora/server/fastapi/factory.py
@@ -225,6 +225,15 @@ async def lifespan(app: FastAPI):
     """
     logger.info("FastAPI server starting up...")
 
+    # Initialize shared PostgreSQL pool on the running event loop before
+    # any stores attempt backend selection.
+    try:
+        from aragora.server.startup.database import init_postgres_pool
+
+        await init_postgres_pool()
+    except (ImportError, OSError, RuntimeError, ValueError) as e:
+        logger.debug("PostgreSQL pool startup unavailable: %s", e)
+
     # Initialize server context
     nomic_dir = Path(os.environ.get("ARAGORA_NOMIC_DIR", "."))
     ctx = _build_server_context(nomic_dir)
@@ -258,6 +267,13 @@ async def lifespan(app: FastAPI):
             storage.close()
         except (OSError, RuntimeError) as e:
             logger.debug("Error closing storage during shutdown: %s", e)
+
+    try:
+        from aragora.server.startup.database import close_postgres_pool
+
+        await close_postgres_pool()
+    except (ImportError, OSError, RuntimeError, ValueError) as e:
+        logger.debug("PostgreSQL pool shutdown unavailable: %s", e)
 
 
 def create_app(

--- a/aragora/server/fastapi/routes/auth.py
+++ b/aragora/server/fastapi/routes/auth.py
@@ -17,6 +17,7 @@ Migration Notes:
 
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any
 
@@ -128,6 +129,26 @@ AUTH_NO_CACHE_HEADERS = {
 }
 
 
+async def _call_store_method(
+    user_store: Any,
+    async_name: str,
+    sync_name: str,
+    *args: Any,
+) -> Any:
+    """Prefer async user-store methods inside FastAPI request handlers."""
+    async_method = getattr(user_store, async_name, None)
+    if callable(async_method):
+        result = async_method(*args)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    sync_method = getattr(user_store, sync_name, None)
+    if callable(sync_method):
+        return sync_method(*args)
+    return None
+
+
 @router.post("/login", response_model=LoginResponse)
 async def login(
     body: LoginRequest,
@@ -173,7 +194,12 @@ async def login(
         lockout_tracker = None
 
     # Find user
-    user = user_store.get_user_by_email(email)
+    user = await _call_store_method(
+        user_store,
+        "get_user_by_email_async",
+        "get_user_by_email",
+        email,
+    )
     if not user:
         if lockout_tracker:
             lockout_tracker.record_failure(email=email, ip=client_ip)
@@ -223,7 +249,12 @@ async def login(
     org_membership: list[dict[str, Any]] = []
     if user.org_id:
         try:
-            org = user_store.get_organization_by_id(user.org_id)
+            org = await _call_store_method(
+                user_store,
+                "get_organization_by_id_async",
+                "get_organization_by_id",
+                user.org_id,
+            )
             if org:
                 org_data = org.to_dict()
                 joined_at = getattr(user, "created_at", None)
@@ -397,8 +428,12 @@ async def refresh_token(
         raise HTTPException(status_code=401, detail="Invalid or expired refresh token")
 
     # Get user to ensure they still exist and are active
-    get_user_by_id = getattr(user_store, "get_user_by_id", None)
-    user = get_user_by_id(payload.user_id) if callable(get_user_by_id) else None
+    user = await _call_store_method(
+        user_store,
+        "get_user_by_id_async",
+        "get_user_by_id",
+        payload.user_id,
+    )
 
     if not user:
         raise HTTPException(status_code=401, detail="User not found")

--- a/tests/server/fastapi/test_auth_routes.py
+++ b/tests/server/fastapi/test_auth_routes.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aragora.server.fastapi.routes import auth as auth_routes
+
+
+class _TokenPair:
+    def __init__(self) -> None:
+        self._payload = {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "token_type": "bearer",
+            "expires_in": 3600,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return dict(self._payload)
+
+
+def _build_app(store: object) -> FastAPI:
+    app = FastAPI()
+    app.include_router(auth_routes.router)
+    app.dependency_overrides[auth_routes.get_user_store] = lambda: store
+    return app
+
+
+def test_login_prefers_async_user_store_methods() -> None:
+    store = MagicMock()
+    user = MagicMock()
+    user.id = "user-1"
+    user.email = "user@example.com"
+    user.org_id = "org-1"
+    user.role = "member"
+    user.is_active = True
+    user.mfa_enabled = False
+    user.mfa_secret = None
+    user.created_at = None
+    user.verify_password.return_value = True
+    user.to_dict.return_value = {"id": "user-1", "email": "user@example.com"}
+
+    org = MagicMock()
+    org.id = "org-1"
+    org.to_dict.return_value = {"id": "org-1", "name": "Acme"}
+
+    store.get_user_by_email.side_effect = AssertionError("sync email lookup should not be used")
+    store.get_user_by_email_async = AsyncMock(return_value=user)
+    store.get_organization_by_id.side_effect = AssertionError("sync org lookup should not be used")
+    store.get_organization_by_id_async = AsyncMock(return_value=org)
+
+    lockout_tracker = MagicMock()
+    lockout_tracker.is_locked.return_value = False
+
+    with (
+        patch("aragora.auth.lockout.get_lockout_tracker", return_value=lockout_tracker),
+        patch("aragora.billing.jwt_auth.create_token_pair", return_value=_TokenPair()),
+        patch("aragora.billing.jwt_auth.create_mfa_pending_token", return_value="pending"),
+        TestClient(_build_app(store)) as client,
+    ):
+        response = client.post(
+            "/api/v2/auth/login",
+            json={"email": "User@Example.com", "password": "secret"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["user"]["email"] == "user@example.com"
+    store.get_user_by_email_async.assert_awaited_once_with("user@example.com")
+    store.get_organization_by_id_async.assert_awaited_once_with("org-1")
+
+
+def test_refresh_prefers_async_user_store_methods() -> None:
+    store = MagicMock()
+    user = MagicMock()
+    user.id = "user-1"
+    user.email = "user@example.com"
+    user.org_id = "org-1"
+    user.role = "member"
+    user.is_active = True
+
+    store.get_user_by_id.side_effect = AssertionError("sync user lookup should not be used")
+    store.get_user_by_id_async = AsyncMock(return_value=user)
+
+    blacklist = MagicMock()
+
+    with (
+        patch(
+            "aragora.billing.jwt_auth.validate_refresh_token",
+            return_value=SimpleNamespace(user_id="user-1"),
+        ),
+        patch("aragora.billing.jwt_auth.create_token_pair", return_value=_TokenPair()),
+        patch("aragora.billing.jwt_auth.get_token_blacklist", return_value=blacklist),
+        patch("aragora.billing.jwt_auth.revoke_token_persistent"),
+        TestClient(_build_app(store)) as client,
+    ):
+        response = client.post("/api/v2/auth/refresh", json={"refresh_token": "refresh-1"})
+
+    assert response.status_code == 200
+    assert response.json()["tokens"]["access_token"] == "access-token"
+    store.get_user_by_id_async.assert_awaited_once_with("user-1")
+    blacklist.revoke_token.assert_called_once_with("refresh-1")

--- a/tests/server/fastapi/test_factory.py
+++ b/tests/server/fastapi/test_factory.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -19,6 +19,12 @@ def _patched_startup_dependencies():
         mocked["storage"] = stack.enter_context(patch("aragora.server.storage.DebateStorage"))
         mocked["get_user_store"] = stack.enter_context(
             patch("aragora.storage.user_store.get_user_store", return_value=MagicMock())
+        )
+        mocked["init_postgres_pool"] = stack.enter_context(
+            patch("aragora.server.startup.database.init_postgres_pool", new_callable=AsyncMock)
+        )
+        mocked["close_postgres_pool"] = stack.enter_context(
+            patch("aragora.server.startup.database.close_postgres_pool", new_callable=AsyncMock)
         )
         stack.enter_context(patch("aragora.ranking.elo.EloSystem", return_value=MagicMock()))
         stack.enter_context(
@@ -65,6 +71,8 @@ def test_create_app_lifespan_starts_with_fastapi_context(tmp_path: Path, monkeyp
 
     assert response.status_code == 200
     mocked["storage"].assert_called_once_with(str(tmp_path / "debates.db"))
+    mocked["init_postgres_pool"].assert_awaited_once()
+    mocked["close_postgres_pool"].assert_awaited_once()
 
 
 def test_build_server_context_defers_postgres_user_store_in_async_context(tmp_path: Path):


### PR DESCRIPTION
## Summary
- initialize the shared PostgreSQL pool during FastAPI lifespan before store selection
- defer eager Postgres user-store construction until the pool exists
- keep `/api/v2/auth/login` and `/api/v2/auth/refresh` on async user-store methods when available
- add focused FastAPI startup and auth route regression coverage

## Root cause
FastAPI startup was selecting user-store backends inside the running event loop before a shared pool existed, which triggered the async PostgreSQL fallback warning. Once the shared pool existed, the auth routes still called sync Postgres user-store wrappers from async endpoints, which crashed with `RuntimeError: This event loop is already running`.

## Verification
- `python3 -m ruff check aragora/server/fastapi/factory.py aragora/server/fastapi/routes/auth.py tests/server/fastapi/test_factory.py tests/server/fastapi/test_auth_routes.py`
- `python3 -m pytest tests/server/fastapi/test_factory.py tests/server/fastapi/test_auth_routes.py tests/server/fastapi/test_routes.py -q`
- `TestClient(create_app())` probe: `/healthz` -> `200`, `/api/v2/auth/login` -> `401`, no async PostgreSQL warning, no event-loop runtime error
