### PR TITLE
fix(fastapi): keep admin user-store calls async-safe

### DIFF
--- a/aragora/server/fastapi/routes/admin.py
+++ b/aragora/server/fastapi/routes/admin.py
@@ -38,8 +38,10 @@ Migration Notes:
 
 from __future__ import annotations
 
+import inspect
 import logging
 import re
+import secrets
 from datetime import datetime, timezone
 from typing import Any
 
@@ -343,7 +345,7 @@ def _get_user_store(request: Request) -> Any:
 
     # Try module-level singleton
     try:
-        from aragora.auth.store import get_user_store
+        from aragora.storage.user_store import get_user_store
 
         return get_user_store()
     except (ImportError, RuntimeError, AttributeError) as e:
@@ -464,6 +466,31 @@ def _sanitize_user_dict(user_dict: dict[str, Any]) -> dict[str, Any]:
         return {k: v for k, v in user_dict.items() if k not in sensitive_keys}
 
 
+async def _call_user_store_method(
+    user_store: Any,
+    async_name: str,
+    sync_name: str,
+    *args: Any,
+    required: bool = False,
+    **kwargs: Any,
+) -> Any:
+    """Prefer async user-store methods inside FastAPI request handlers."""
+    async_method = getattr(user_store, async_name, None)
+    if callable(async_method):
+        result = async_method(*args, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+    sync_method = getattr(user_store, sync_name, None)
+    if callable(sync_method):
+        return sync_method(*args, **kwargs)
+
+    if required:
+        raise AttributeError(f"User store does not implement {async_name} or {sync_name}")
+    return None
+
+
 # =============================================================================
 # Endpoints — System Health & Metrics
 # =============================================================================
@@ -482,7 +509,12 @@ async def get_admin_stats(
     Requires `admin:stats:read` permission.
     """
     try:
-        stats = user_store.get_admin_stats()
+        stats = await _call_user_store_method(
+            user_store,
+            "get_admin_stats_async",
+            "get_admin_stats",
+            required=True,
+        )
         return SystemStatsResponse(stats=stats)
     except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
         logger.exception("Error getting admin stats: %s", e)
@@ -508,7 +540,12 @@ async def get_system_metrics(
 
         # User stats
         try:
-            metrics["users"] = user_store.get_admin_stats()
+            metrics["users"] = await _call_user_store_method(
+                user_store,
+                "get_admin_stats_async",
+                "get_admin_stats",
+                required=True,
+            )
         except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
             logger.warning("Failed to get user stats: %s", e)
             metrics["users"] = {"error": "unavailable"}
@@ -574,7 +611,12 @@ async def get_revenue_stats(
     permission.
     """
     try:
-        stats = user_store.get_admin_stats()
+        stats = await _call_user_store_method(
+            user_store,
+            "get_admin_stats_async",
+            "get_admin_stats",
+            required=True,
+        )
         tier_distribution = stats.get("tier_distribution", {})
 
         # Calculate MRR from tier pricing
@@ -636,10 +678,14 @@ async def list_organizations(
     Supports optional tier filtering. Requires `admin:organizations:read` permission.
     """
     try:
-        organizations, total = user_store.list_all_organizations(
+        organizations, total = await _call_user_store_method(
+            user_store,
+            "list_all_organizations_async",
+            "list_all_organizations",
             limit=limit,
             offset=offset,
             tier_filter=tier,
+            required=True,
         )
 
         return OrganizationListResponse(
@@ -679,12 +725,16 @@ async def list_users(
     response. Requires `admin:users:read` permission.
     """
     try:
-        users, total = user_store.list_all_users(
+        users, total = await _call_user_store_method(
+            user_store,
+            "list_all_users_async",
+            "list_all_users",
             limit=limit,
             offset=offset,
             org_id_filter=org_id,
             role_filter=role,
             active_only=active_only,
+            required=True,
         )
 
         user_dicts = [_sanitize_user_dict(user.to_dict()) for user in users]
@@ -718,23 +768,35 @@ async def create_user(
     """
     try:
         # Check for existing user
-        existing = None
-        if hasattr(user_store, "get_user_by_email"):
-            existing = user_store.get_user_by_email(body.email)
+        existing = await _call_user_store_method(
+            user_store,
+            "get_user_by_email_async",
+            "get_user_by_email",
+            body.email,
+        )
         if existing:
             raise HTTPException(status_code=409, detail="A user with this email already exists")
 
+        from aragora.billing.models import hash_password
+
+        password_hash, password_salt = hash_password(body.password or secrets.token_urlsafe(32))
         user_data: dict[str, Any] = {
             "email": body.email,
             "name": body.name,
             "role": body.role,
+            "password_hash": password_hash,
+            "password_salt": password_salt,
         }
         if body.org_id:
             user_data["org_id"] = body.org_id
-        if body.password:
-            user_data["password"] = body.password
 
-        user = user_store.create_user(**user_data)
+        user = await _call_user_store_method(
+            user_store,
+            "create_user_async",
+            "create_user",
+            required=True,
+            **user_data,
+        )
         user_id = getattr(user, "id", str(user)) if user else ""
 
         logger.info("Admin %s created user %s (%s)", auth.user_id, user_id, body.email)
@@ -782,11 +844,23 @@ async def deactivate_user(
         if user_id == auth.user_id:
             raise HTTPException(status_code=400, detail="Cannot deactivate yourself")
 
-        target_user = user_store.get_user_by_id(user_id)
+        target_user = await _call_user_store_method(
+            user_store,
+            "get_user_by_id_async",
+            "get_user_by_id",
+            user_id,
+        )
         if not target_user:
             raise NotFoundError(f"User {user_id} not found")
 
-        user_store.update_user(user_id, is_active=False)
+        await _call_user_store_method(
+            user_store,
+            "update_user_async",
+            "update_user",
+            user_id,
+            is_active=False,
+            required=True,
+        )
 
         logger.info("Admin %s deactivated user %s", auth.user_id, user_id)
 
@@ -833,11 +907,23 @@ async def activate_user(
     _validate_user_id(user_id)
 
     try:
-        target_user = user_store.get_user_by_id(user_id)
+        target_user = await _call_user_store_method(
+            user_store,
+            "get_user_by_id_async",
+            "get_user_by_id",
+            user_id,
+        )
         if not target_user:
             raise NotFoundError(f"User {user_id} not found")
 
-        user_store.update_user(user_id, is_active=True)
+        await _call_user_store_method(
+            user_store,
+            "update_user_async",
+            "update_user",
+            user_id,
+            is_active=True,
+            required=True,
+        )
 
         logger.info("Admin %s activated user %s", auth.user_id, user_id)
 
@@ -885,7 +971,12 @@ async def unlock_user(
     _validate_user_id(user_id)
 
     try:
-        target_user = user_store.get_user_by_id(user_id)
+        target_user = await _call_user_store_method(
+            user_store,
+            "get_user_by_id_async",
+            "get_user_by_id",
+            user_id,
+        )
         if not target_user:
             raise NotFoundError(f"User {user_id} not found")
 
@@ -903,8 +994,14 @@ async def unlock_user(
             logger.warning("Lockout tracker not available: %s", e)
 
         # Clear database lockout state
-        if hasattr(user_store, "reset_failed_login_attempts"):
-            db_cleared = user_store.reset_failed_login_attempts(email)
+        db_cleared = bool(
+            await _call_user_store_method(
+                user_store,
+                "reset_failed_login_attempts_async",
+                "reset_failed_login_attempts",
+                email,
+            )
+        )
 
         logger.info(
             "Admin %s unlocked user %s (tracker=%s, db=%s)",
@@ -960,7 +1057,12 @@ async def impersonate_user(
     _validate_user_id(user_id)
 
     try:
-        target_user = user_store.get_user_by_id(user_id)
+        target_user = await _call_user_store_method(
+            user_store,
+            "get_user_by_id_async",
+            "get_user_by_id",
+            user_id,
+        )
         if not target_user:
             raise NotFoundError(f"User {user_id} not found")
 

--- a/tests/server/fastapi/test_admin_routes.py
+++ b/tests/server/fastapi/test_admin_routes.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aragora.server.fastapi.routes import admin as admin_routes
+
+
+def _request() -> MagicMock:
+    request = MagicMock()
+    request.app.state.context = {}
+    return request
+
+
+def _auth(user_id: str = "admin-1") -> SimpleNamespace:
+    return SimpleNamespace(user_id=user_id)
+
+
+def test_list_users_prefers_async_store_methods() -> None:
+    user = MagicMock()
+    user.to_dict.return_value = {
+        "id": "user-1",
+        "email": "user@example.com",
+        "name": "User One",
+        "role": "member",
+        "org_id": "org-1",
+        "is_active": True,
+    }
+
+    store = MagicMock()
+    store.list_all_users.side_effect = AssertionError("sync list_all_users should not be used")
+    store.list_all_users_async = AsyncMock(return_value=([user], 1))
+
+    response = asyncio.run(
+        admin_routes.list_users(
+            request=_request(),
+            limit=50,
+            offset=0,
+            org_id=None,
+            role=None,
+            active_only=False,
+            auth=_auth(),
+            user_store=store,
+        )
+    )
+
+    assert response.total == 1
+    assert response.users[0]["email"] == "user@example.com"
+    store.list_all_users_async.assert_awaited_once_with(
+        limit=50,
+        offset=0,
+        org_id_filter=None,
+        role_filter=None,
+        active_only=False,
+    )
+
+
+def test_create_user_hashes_password_and_prefers_async_store_methods() -> None:
+    store = MagicMock()
+    store.get_user_by_email.side_effect = AssertionError(
+        "sync get_user_by_email should not be used"
+    )
+    store.get_user_by_email_async = AsyncMock(return_value=None)
+    store.create_user.side_effect = AssertionError("sync create_user should not be used")
+    store.create_user_async = AsyncMock(return_value=SimpleNamespace(id="user-1"))
+
+    with (
+        patch("aragora.billing.models.hash_password", return_value=("hashed-password", "salt-1")),
+        patch("aragora.audit.unified.audit_admin"),
+    ):
+        response = asyncio.run(
+            admin_routes.create_user(
+                body=admin_routes.CreateUserRequest(
+                    email="user@example.com",
+                    name="User One",
+                    role="member",
+                    password="super-secret-1",
+                ),
+                request=_request(),
+                auth=_auth(),
+                user_store=store,
+            )
+        )
+
+    assert response.success is True
+    assert response.user_id == "user-1"
+    store.get_user_by_email_async.assert_awaited_once_with("user@example.com")
+    store.create_user_async.assert_awaited_once_with(
+        email="user@example.com",
+        name="User One",
+        role="member",
+        password_hash="hashed-password",
+        password_salt="salt-1",
+    )
+
+
+def test_deactivate_user_prefers_async_store_methods() -> None:
+    target_user = SimpleNamespace(email="user@example.com")
+    store = MagicMock()
+    store.get_user_by_id.side_effect = AssertionError("sync get_user_by_id should not be used")
+    store.get_user_by_id_async = AsyncMock(return_value=target_user)
+    store.update_user.side_effect = AssertionError("sync update_user should not be used")
+    store.update_user_async = AsyncMock(return_value=True)
+
+    with patch("aragora.audit.unified.audit_admin"):
+        response = asyncio.run(
+            admin_routes.deactivate_user(
+                user_id="user-1",
+                request=_request(),
+                auth=_auth(),
+                user_store=store,
+            )
+        )
+
+    assert response.success is True
+    store.get_user_by_id_async.assert_awaited_once_with("user-1")
+    store.update_user_async.assert_awaited_once_with("user-1", is_active=False)
+
+
+def test_get_revenue_stats_prefers_async_store_methods() -> None:
+    store = MagicMock()
+    store.get_admin_stats.side_effect = AssertionError("sync get_admin_stats should not be used")
+    store.get_admin_stats_async = AsyncMock(
+        return_value={
+            "tier_distribution": {"free": 2, "professional": 1},
+            "total_organizations": 3,
+        }
+    )
+
+    response = asyncio.run(
+        admin_routes.get_revenue_stats(
+            request=_request(),
+            auth=_auth(),
+            user_store=store,
+        )
+    )
+
+    assert response.revenue["total_organizations"] == 3
+    store.get_admin_stats_async.assert_awaited_once_with()
+
+
+def test_get_user_store_falls_back_to_storage_singleton() -> None:
+    store = object()
+    request = _request()
+    request.app.state.context = {}
+
+    with patch("aragora.storage.user_store.get_user_store", return_value=store):
+        result = admin_routes._get_user_store(request)
+
+    assert result is store


### PR DESCRIPTION
Summary
- keep FastAPI admin routes on async user-store methods when available
- hash admin-created passwords into password_hash and password_salt before store writes
- fix the admin route fallback store import to use aragora.storage.user_store
- add focused regression tests for admin stats, list, create, and deactivate flows

Root cause
FastAPI admin endpoints were still calling sync user-store wrappers from async request handlers. On Postgres-backed stores that means run_async(...) inside a running event loop. The create-user route had a second contract mismatch: it passed a raw password argument to concrete stores that only accept password_hash and password_salt.

Verification
- python3 -m ruff check aragora/server/fastapi/routes/admin.py tests/server/fastapi/test_admin_routes.py
- python3 -m pytest tests/server/fastapi/test_admin_routes.py -q
