### PR TITLE
fix(fastapi): await knowledge-base engine calls in async routes

### DIFF
--- a/aragora/server/fastapi/routes/knowledge_base.py
+++ b/aragora/server/fastapi/routes/knowledge_base.py
@@ -37,6 +37,7 @@ Migration Notes:
 
 from __future__ import annotations
 
+import inspect
 import logging
 import time
 from typing import Any
@@ -435,6 +436,13 @@ def _relation_to_model(relation: Any) -> FactRelation:
     )
 
 
+async def _await_if_needed(result: Any) -> Any:
+    """Await async engine results while tolerating sync test doubles."""
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
 # =============================================================================
 # Fact CRUD Endpoints
 # =============================================================================
@@ -651,9 +659,7 @@ async def verify_fact(
             )
 
         try:
-            from aragora.server.http_utils import run_async as _run_async
-
-            verified = _run_async(engine.verify_fact(fact_id))
+            verified = await _await_if_needed(engine.verify_fact(fact_id))
         except (KeyError, ValueError, OSError, TypeError, RuntimeError) as e:
             logger.error("Verification failed: %s", e)
             raise HTTPException(status_code=500, detail="Verification failed")
@@ -858,9 +864,7 @@ async def query_knowledge_base(
         )
 
         try:
-            from aragora.server.http_utils import run_async as _run_async
-
-            result = _run_async(engine.query(body.question, body.workspace_id, options))
+            result = await _await_if_needed(engine.query(body.question, body.workspace_id, options))
         except (KeyError, ValueError, OSError, TypeError, RuntimeError) as e:
             logger.error("Query execution failed: %s", e)
             raise HTTPException(status_code=500, detail="Query execution failed")
@@ -907,9 +911,7 @@ async def search_knowledge_base(
             )
 
         try:
-            from aragora.server.http_utils import run_async as _run_async
-
-            results = _run_async(engine.search(q, workspace_id, limit))
+            results = await _await_if_needed(engine.search(q, workspace_id, limit))
         except (KeyError, ValueError, OSError, TypeError, RuntimeError) as e:
             logger.error("Search failed: %s", e)
             raise HTTPException(status_code=500, detail="Search operation failed")

--- a/tests/server/fastapi/test_knowledge_base_routes.py
+++ b/tests/server/fastapi/test_knowledge_base_routes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aragora.server.fastapi.routes import knowledge_base
+
+
+def _auth() -> SimpleNamespace:
+    return SimpleNamespace(user_id="user-1", email="user@example.com")
+
+
+def test_verify_fact_awaits_engine_in_async_route() -> None:
+    class FakeDatasetQueryEngine:
+        pass
+
+    engine = FakeDatasetQueryEngine()
+    engine.verify_fact = AsyncMock(
+        return_value=SimpleNamespace(
+            to_dict=lambda: {
+                "fact_id": "fact-1",
+                "verified": True,
+                "status": "completed",
+                "message": "verified",
+            }
+        )
+    )
+    store = MagicMock()
+    store.get_fact.return_value = SimpleNamespace(metadata={})
+
+    with patch.object(knowledge_base, "DatasetQueryEngine", FakeDatasetQueryEngine):
+        response = asyncio.run(
+            knowledge_base.verify_fact(
+                fact_id="fact-1",
+                auth=_auth(),
+                store=store,
+                engine=engine,
+            )
+        )
+
+    assert response.fact_id == "fact-1"
+    assert response.verified is True
+    engine.verify_fact.assert_awaited_once_with("fact-1")
+
+
+def test_query_knowledge_base_awaits_engine_query() -> None:
+    engine = MagicMock()
+    engine.query = AsyncMock(
+        return_value=SimpleNamespace(
+            to_dict=lambda: {
+                "answer": "Use the knowledge base directly.",
+                "confidence": 0.81,
+                "citations": [{"fact_id": "fact-1"}],
+                "sources": [{"workspace_id": "default"}],
+            }
+        )
+    )
+
+    with patch(
+        "aragora.server.http_utils.run_async",
+        side_effect=AssertionError("sync bridge should not be used"),
+    ):
+        response = asyncio.run(
+            knowledge_base.query_knowledge_base(
+                body=knowledge_base.QueryRequest(
+                    question="What should we use?",
+                    workspace_id="default",
+                    options={},
+                ),
+                auth=_auth(),
+                engine=engine,
+            )
+        )
+
+    assert response.answer == "Use the knowledge base directly."
+    assert response.confidence == 0.81
+    engine.query.assert_awaited_once()
+
+
+def test_search_knowledge_base_awaits_engine_search() -> None:
+    result = SimpleNamespace(
+        to_dict=lambda: {
+            "chunk_id": "chunk-1",
+            "content": "Found result",
+            "score": 0.9,
+        }
+    )
+    engine = MagicMock()
+    engine.search = AsyncMock(return_value=[result])
+
+    with patch(
+        "aragora.server.http_utils.run_async",
+        side_effect=AssertionError("sync bridge should not be used"),
+    ):
+        response = asyncio.run(
+            knowledge_base.search_knowledge_base(
+                q="result",
+                workspace_id="default",
+                limit=5,
+                auth=_auth(),
+                engine=engine,
+            )
+        )
+
+    assert response.count == 1
+    assert response.results[0]["chunk_id"] == "chunk-1"
+    engine.search.assert_awaited_once_with("result", "default", 5)


### PR DESCRIPTION
## Summary
- await knowledge-base engine calls directly inside async FastAPI routes
- keep route behavior compatible with sync test doubles via a small await-if-needed helper
- add focused FastAPI route tests that fail if the sync bridge is used from the event loop

## Testing
- python3 -m ruff check aragora/server/fastapi/routes/knowledge_base.py tests/server/fastapi/test_knowledge_base_routes.py
- python3 -m pytest tests/server/fastapi/test_factory.py tests/server/fastapi/test_auth_routes.py tests/server/fastapi/test_admin_routes.py tests/server/fastapi/test_knowledge_base_routes.py -q
