### PR TITLE
fix(fastapi): await analytics dashboard calls in async routes

### DIFF
--- a/aragora/server/fastapi/routes/analytics.py
+++ b/aragora/server/fastapi/routes/analytics.py
@@ -49,6 +49,7 @@ Migration Notes:
 
 from __future__ import annotations
 
+import inspect
 import logging
 from enum import Enum
 from typing import Any
@@ -329,15 +330,11 @@ def _get_analytics_response(path: str) -> dict[str, Any]:
         return {}
 
 
-def _run_async_helper(coro: Any) -> Any:
-    """Run an async coroutine from a sync context."""
-    try:
-        from aragora.server.http_utils import run_async
-
-        return run_async(coro)
-    except (ImportError, RuntimeError) as e:
-        logger.debug("run_async helper not available: %s", e)
-        raise HTTPException(status_code=503, detail="Async runtime not available") from e
+async def _await_if_needed(result: Any) -> Any:
+    """Await async dashboard results while tolerating sync test doubles."""
+    if inspect.isawaitable(result):
+        return await result
+    return result
 
 
 # =============================================================================
@@ -368,7 +365,7 @@ async def get_summary(
 
         dashboard = get_analytics_dashboard()
         tr = TimeRange(time_range.value)
-        summary = _run_async_helper(dashboard.get_summary(workspace_id, tr))
+        summary = await _await_if_needed(dashboard.get_summary(workspace_id, tr))
         return AnalyticsSummaryResponse(data=summary.to_dict())
 
     except ValueError as e:
@@ -399,8 +396,6 @@ async def get_finding_trends(
     workspace and time range.
     """
     try:
-        import asyncio
-
         from aragora.analytics import (
             Granularity,
             TimeRange,
@@ -411,7 +406,7 @@ async def get_finding_trends(
         tr = TimeRange(time_range.value)
         gran = Granularity(granularity.value)
 
-        trends = asyncio.run(dashboard.get_finding_trends(workspace_id, tr, gran))
+        trends = await _await_if_needed(dashboard.get_finding_trends(workspace_id, tr, gran))
 
         return FindingTrendsResponse(
             workspace_id=workspace_id,
@@ -448,7 +443,7 @@ async def get_remediation_metrics(
 
         dashboard = get_analytics_dashboard()
         tr = TimeRange(time_range.value)
-        metrics = _run_async_helper(dashboard.get_remediation_metrics(workspace_id, tr))
+        metrics = await _await_if_needed(dashboard.get_remediation_metrics(workspace_id, tr))
 
         return RemediationResponse(
             workspace_id=workspace_id,
@@ -484,7 +479,7 @@ async def get_agent_metrics(
 
         dashboard = get_analytics_dashboard()
         tr = TimeRange(time_range.value)
-        metrics = _run_async_helper(dashboard.get_agent_metrics(workspace_id, tr))
+        metrics = await _await_if_needed(dashboard.get_agent_metrics(workspace_id, tr))
 
         return AgentMetricsResponse(
             workspace_id=workspace_id,
@@ -520,7 +515,7 @@ async def get_risk_heatmap(
 
         dashboard = get_analytics_dashboard()
         tr = TimeRange(time_range.value)
-        cells = _run_async_helper(dashboard.get_risk_heatmap(workspace_id, tr))
+        cells = await _await_if_needed(dashboard.get_risk_heatmap(workspace_id, tr))
 
         return HeatmapResponse(
             workspace_id=workspace_id,
@@ -563,7 +558,7 @@ async def get_cost_metrics(
 
         dashboard = get_analytics_dashboard()
         tr = TimeRange(time_range.value)
-        metrics = _run_async_helper(dashboard.get_cost_metrics(workspace_id, tr))
+        metrics = await _await_if_needed(dashboard.get_cost_metrics(workspace_id, tr))
 
         return CostMetricsResponse(
             workspace_id=workspace_id,
@@ -662,7 +657,9 @@ async def get_compliance_scorecard(
         from aragora.analytics import get_analytics_dashboard
 
         dashboard = get_analytics_dashboard()
-        scores = _run_async_helper(dashboard.get_compliance_scorecard(workspace_id, framework_list))
+        scores = await _await_if_needed(
+            dashboard.get_compliance_scorecard(workspace_id, framework_list)
+        )
 
         return ComplianceScorecardResponse(
             workspace_id=workspace_id,

--- a/tests/server/fastapi/test_analytics_routes.py
+++ b/tests/server/fastapi/test_analytics_routes.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aragora.server.fastapi.routes import analytics as analytics_routes
+
+
+def _auth() -> SimpleNamespace:
+    return SimpleNamespace(user_id="user-1", email="user@example.com")
+
+
+def _analytics_module(dashboard: MagicMock) -> SimpleNamespace:
+    return SimpleNamespace(
+        get_analytics_dashboard=lambda: dashboard,
+        TimeRange=lambda value: f"time:{value}",
+        Granularity=lambda value: f"gran:{value}",
+    )
+
+
+def test_get_summary_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_summary = AsyncMock(return_value=SimpleNamespace(to_dict=lambda: {"debates": 12}))
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_summary(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                auth=_auth(),
+            )
+        )
+
+    assert response.data["debates"] == 12
+    dashboard.get_summary.assert_awaited_once_with("ws-1", "time:30d")
+
+
+def test_get_finding_trends_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_finding_trends = AsyncMock(
+        return_value=[SimpleNamespace(to_dict=lambda: {"bucket": "2026-03-24", "count": 3})]
+    )
+
+    with patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}):
+        response = asyncio.run(
+            analytics_routes.get_finding_trends(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                granularity=analytics_routes.GranularityEnum.day,
+                auth=_auth(),
+            )
+        )
+
+    assert response.trends[0]["count"] == 3
+    dashboard.get_finding_trends.assert_awaited_once_with("ws-1", "time:30d", "gran:day")
+
+
+def test_get_remediation_metrics_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_remediation_metrics = AsyncMock(
+        return_value=SimpleNamespace(to_dict=lambda: {"total_findings": 4})
+    )
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_remediation_metrics(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                auth=_auth(),
+            )
+        )
+
+    assert response.total_findings == 4
+    dashboard.get_remediation_metrics.assert_awaited_once_with("ws-1", "time:30d")
+
+
+def test_get_agent_metrics_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_agent_metrics = AsyncMock(
+        return_value=[SimpleNamespace(to_dict=lambda: {"agent": "gemini", "debates": 7})]
+    )
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_agent_metrics(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                auth=_auth(),
+            )
+        )
+
+    assert response.agents[0]["agent"] == "gemini"
+    dashboard.get_agent_metrics.assert_awaited_once_with("ws-1", "time:30d")
+
+
+def test_get_risk_heatmap_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_risk_heatmap = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                to_dict=lambda: {"category": "security", "severity": "high", "value": 2}
+            )
+        ]
+    )
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_risk_heatmap(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                auth=_auth(),
+            )
+        )
+
+    assert response.cells[0]["category"] == "security"
+    dashboard.get_risk_heatmap.assert_awaited_once_with("ws-1", "time:30d")
+
+
+def test_get_cost_metrics_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_cost_metrics = AsyncMock(
+        return_value=SimpleNamespace(to_dict=lambda: {"total_cost_usd": "1.23"})
+    )
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_cost_metrics(
+                workspace_id="ws-1",
+                time_range=analytics_routes.TimeRangeEnum.d30,
+                auth=_auth(),
+            )
+        )
+
+    assert response.total_cost_usd == "1.23"
+    dashboard.get_cost_metrics.assert_awaited_once_with("ws-1", "time:30d")
+
+
+def test_get_compliance_scorecard_awaits_dashboard_call() -> None:
+    dashboard = MagicMock()
+    dashboard.get_compliance_scorecard = AsyncMock(
+        return_value=[SimpleNamespace(to_dict=lambda: {"framework": "SOC2", "score": 0.9})]
+    )
+
+    with (
+        patch.dict(sys.modules, {"aragora.analytics": _analytics_module(dashboard)}),
+        patch(
+            "aragora.server.http_utils.run_async",
+            side_effect=AssertionError("sync bridge should not be used"),
+        ),
+    ):
+        response = asyncio.run(
+            analytics_routes.get_compliance_scorecard(
+                workspace_id="ws-1",
+                frameworks="SOC2,GDPR",
+                auth=_auth(),
+            )
+        )
+
+    assert response.scores[0]["framework"] == "SOC2"
+    dashboard.get_compliance_scorecard.assert_awaited_once_with("ws-1", ["SOC2", "GDPR"])


### PR DESCRIPTION
## Summary
- await analytics dashboard calls directly inside async FastAPI routes
- remove the `asyncio.run(...)` path from finding trends and replace the sync helper with async-aware awaiting
- add focused FastAPI route tests covering summary, trends, remediation, agents, heatmap, cost, and compliance endpoints

## Testing
- python3 -m ruff check aragora/server/fastapi/routes/analytics.py tests/server/fastapi/test_analytics_routes.py
- python3 -m pytest tests/server/fastapi/test_factory.py tests/server/fastapi/test_auth_routes.py tests/server/fastapi/test_admin_routes.py tests/server/fastapi/test_analytics_routes.py -q
