### PR TITLE
fix(receipts): use canonical v2 summaries in dashboard

### DIFF
--- a/aragora/live/src/components/RecentReceipts.tsx
+++ b/aragora/live/src/components/RecentReceipts.tsx
@@ -6,16 +6,13 @@ import { apiFetch } from '@/lib/api';
 import { DebateThisButton } from './DebateThisButton';
 
 interface ReceiptSummary {
-  id: string;
-  receipt_id?: string;
-  run_id?: string;
-  verdict: 'PASS' | 'FAIL' | 'WARN' | 'CONDITIONAL';
-  created_at: string;
-  artifact_hash: string;
-  findings_count: number;
+  receipt_id: string;
+  gauntlet_id?: string;
+  timestamp?: string;
   input_summary?: string;
+  verdict: string;
+  findings_count: number;
   confidence?: number;
-  metadata?: Record<string, unknown>;
 }
 
 interface RecentReceiptsProps {
@@ -29,6 +26,23 @@ const VERDICT_STYLES: Record<string, string> = {
   CONDITIONAL: 'text-[var(--acid-yellow)] border-[var(--acid-yellow)]/30 bg-[var(--acid-yellow)]/10',
 };
 
+function normalizeVerdict(verdict: string): 'PASS' | 'FAIL' | 'WARN' | 'CONDITIONAL' {
+  switch (verdict.toUpperCase()) {
+    case 'PASS':
+    case 'APPROVED':
+      return 'PASS';
+    case 'FAIL':
+    case 'REJECTED':
+      return 'FAIL';
+    case 'CONDITIONAL':
+    case 'WARNING':
+    case 'WARN':
+      return 'CONDITIONAL';
+    default:
+      return 'WARN';
+  }
+}
+
 export function RecentReceipts({ limit = 5 }: RecentReceiptsProps) {
   const [receipts, setReceipts] = useState<ReceiptSummary[]>([]);
   const [loading, setLoading] = useState(true);
@@ -37,7 +51,7 @@ export function RecentReceipts({ limit = 5 }: RecentReceiptsProps) {
   const fetchReceipts = useCallback(async () => {
     try {
       const data = await apiFetch<{ receipts: ReceiptSummary[] }>(
-        `/api/gauntlet/receipts?limit=${limit}`
+        `/api/v2/receipts?limit=${limit}`
       );
       setReceipts(data.receipts || []);
     } catch (err) {
@@ -90,17 +104,17 @@ export function RecentReceipts({ limit = 5 }: RecentReceiptsProps) {
       <div className="space-y-2">
         {receipts.map((receipt) => (
           <Link
-            key={receipt.id}
-            href={`/receipts?id=${receipt.id}`}
+            key={receipt.receipt_id}
+            href={`/receipts?id=${receipt.receipt_id}`}
             className="block border border-[var(--border)] p-3 hover:border-[var(--acid-green)]/40 transition-colors"
           >
             <div className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2 min-w-0">
-                <span className={`px-1.5 py-0.5 text-[10px] font-mono font-bold border ${VERDICT_STYLES[receipt.verdict] || VERDICT_STYLES.WARN}`}>
-                  {receipt.verdict}
+                <span className={`px-1.5 py-0.5 text-[10px] font-mono font-bold border ${VERDICT_STYLES[normalizeVerdict(receipt.verdict)] || VERDICT_STYLES.WARN}`}>
+                  {normalizeVerdict(receipt.verdict)}
                 </span>
                 <span className="text-xs font-mono text-[var(--text)] truncate">
-                  {receipt.input_summary || `Receipt ${(receipt.receipt_id || receipt.id).slice(0, 8)}`}
+                  {receipt.input_summary || `Receipt ${receipt.receipt_id.slice(0, 8)}`}
                 </span>
               </div>
               <div className="flex items-center gap-3 shrink-0">
@@ -110,10 +124,10 @@ export function RecentReceipts({ limit = 5 }: RecentReceiptsProps) {
                   </span>
                 )}
                 <span className="text-[10px] font-mono text-[var(--text-muted)]">
-                  {new Date(receipt.created_at).toLocaleDateString()}
+                  {receipt.timestamp ? new Date(receipt.timestamp).toLocaleDateString() : 'Unknown'}
                 </span>
                 <DebateThisButton
-                  question={receipt.input_summary || `Re-examine receipt ${(receipt.receipt_id || receipt.id).slice(0, 8)}`}
+                  question={receipt.input_summary || `Re-examine receipt ${receipt.receipt_id.slice(0, 8)}`}
                   source="receipt"
                   variant="icon"
                 />

--- a/aragora/live/src/components/__tests__/RecentReceipts.test.tsx
+++ b/aragora/live/src/components/__tests__/RecentReceipts.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { RecentReceipts } from '../RecentReceipts';
+import { apiFetch } from '@/lib/api';
+
+jest.mock('next/link', () => {
+  return function MockLink({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) {
+    return <a href={href} className={className}>{children}</a>;
+  };
+});
+
+jest.mock('@/lib/api', () => ({
+  apiFetch: jest.fn(),
+}));
+
+jest.mock('../DebateThisButton', () => ({
+  DebateThisButton: ({ question }: { question: string }) => <button>{question}</button>,
+}));
+
+const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+
+describe('RecentReceipts', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads recent receipts from the canonical v2 endpoint', async () => {
+    mockApiFetch.mockResolvedValue({
+      receipts: [
+        {
+          receipt_id: 'rcpt_12345678',
+          gauntlet_id: 'gauntlet-123',
+          timestamp: '2026-03-25T12:00:00Z',
+          input_summary: 'Assess production founder loop readiness',
+          verdict: 'APPROVED',
+          findings_count: 2,
+          confidence: 0.94,
+        },
+      ],
+    } as never);
+
+    render(<RecentReceipts limit={3} />);
+
+    await waitFor(() => {
+      expect(mockApiFetch).toHaveBeenCalledWith('/api/v2/receipts?limit=3');
+    });
+
+    expect(await screen.findByText('DECISION RECEIPTS')).toBeInTheDocument();
+    expect(screen.getByText('PASS')).toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /Assess production founder loop readiness/i });
+    expect(link).toHaveAttribute('href', '/receipts?id=rcpt_12345678');
+    expect(screen.getByText('2 findings')).toBeInTheDocument();
+  });
+
+  it('falls back to a receipt id label when input_summary is absent', async () => {
+    mockApiFetch.mockResolvedValue({
+      receipts: [
+        {
+          receipt_id: 'rcpt_fallback99',
+          verdict: 'REJECTED',
+          findings_count: 0,
+          confidence: 0.41,
+          timestamp: '2026-03-25T12:00:00Z',
+        },
+      ],
+    } as never);
+
+    render(<RecentReceipts />);
+
+    expect(await screen.findByText('FAIL')).toBeInTheDocument();
+    expect(screen.getByText('Receipt rcpt_fal')).toBeInTheDocument();
+  });
+});

--- a/aragora/server/fastapi/routes/receipts.py
+++ b/aragora/server/fastapi/routes/receipts.py
@@ -49,6 +49,7 @@ class ReceiptSummary(BaseModel):
     receipt_id: str
     gauntlet_id: str
     timestamp: str | None = None
+    input_summary: str = ""
     verdict: str = ""
     confidence: float = 0.0
     risk_level: str = "MEDIUM"
@@ -235,6 +236,7 @@ def _to_receipt_summary(r: Any) -> ReceiptSummary:
             receipt_id=data.get("receipt_id", ""),
             gauntlet_id=data.get("gauntlet_id", ""),
             timestamp=data.get("timestamp"),
+            input_summary=data.get("input_summary", ""),
             verdict=data.get("verdict", ""),
             confidence=data.get("confidence", 0.0),
             risk_level=data.get("risk_level", "MEDIUM"),
@@ -247,6 +249,7 @@ def _to_receipt_summary(r: Any) -> ReceiptSummary:
         receipt_id=getattr(r, "receipt_id", ""),
         gauntlet_id=getattr(r, "gauntlet_id", ""),
         timestamp=str(getattr(r, "timestamp", "")) if hasattr(r, "timestamp") else None,
+        input_summary=getattr(r, "input_summary", ""),
         verdict=getattr(r, "verdict", ""),
         confidence=getattr(r, "confidence", 0.0),
         risk_level=getattr(r, "risk_level", "MEDIUM"),

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -151,6 +151,7 @@ class TestListReceipts:
         data = response.json()
         assert len(data["receipts"]) == 1
         assert data["receipts"][0]["receipt_id"] == "rcpt_test123"
+        assert data["receipts"][0]["input_summary"] == "Test input content"
         assert data["receipts"][0]["verdict"] == "APPROVED"
         assert data["total"] == 1
 
@@ -179,6 +180,7 @@ class TestListReceipts:
         data = response.json()
         assert data["total"] == 1
         assert data["receipts"][0]["receipt_id"] == "rcpt_test123"
+        assert data["receipts"][0]["input_summary"] == "Test input content"
         assert data["receipts"][0]["findings_count"] == 1
 
     def test_list_receipts_validation_limit_bounds(self, client):


### PR DESCRIPTION
## Summary
- switch `RecentReceipts` to the canonical `/api/v2/receipts` summary endpoint
- expose `input_summary` in the v2 receipt summary payload so the dashboard keeps useful receipt labels
- normalize canonical verdict strings like `APPROVED` and `REJECTED` in the dashboard widget
- add focused FastAPI and frontend coverage for the converged receipt summary path

## Testing
- python3 -m pytest tests/server/fastapi/test_receipts_routes.py -q
- cd aragora/live && npx jest --ci --runTestsByPath 'src/components/__tests__/RecentReceipts.test.tsx'
- cd aragora/live && npx eslint 'src/components/RecentReceipts.tsx' 'src/components/__tests__/RecentReceipts.test.tsx'
