### PR TITLE
fix(receipts): support legacy unified-server v2 routes

### DIFF
--- a/aragora/server/handlers/receipts.py
+++ b/aragora/server/handlers/receipts.py
@@ -37,6 +37,7 @@ import logging
 import secrets
 import zipfile
 from datetime import datetime, timezone
+from inspect import signature
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -190,6 +191,42 @@ def _render_shared_receipt_html(receipt: Any, token: str) -> str:
 </html>"""
 
 
+def _extract_decision_receipt_payload(receipt: Any) -> dict[str, Any]:
+    """Extract only the constructor-supported DecisionReceipt payload."""
+    if isinstance(receipt, dict):
+        nested = receipt.get("data")
+        if isinstance(nested, dict):
+            payload = dict(nested)
+        else:
+            payload = dict(receipt)
+        plain = receipt
+    else:
+        nested = getattr(receipt, "data", None)
+        if isinstance(nested, dict):
+            payload = dict(nested)
+        elif hasattr(receipt, "to_dict"):
+            plain_value = receipt.to_dict()
+            payload = dict(plain_value) if isinstance(plain_value, dict) else {}
+        else:
+            payload = {}
+        plain = receipt.to_dict() if hasattr(receipt, "to_dict") else {}
+
+    if isinstance(plain, dict):
+        for key in ("receipt_id", "gauntlet_id", "timestamp", "checksum"):
+            payload.setdefault(key, plain.get(key))
+
+    if not payload:
+        return {}
+
+    try:
+        from aragora.export.decision_receipt import DecisionReceipt
+
+        allowed_fields = signature(DecisionReceipt).parameters
+        return {key: value for key, value in payload.items() if key in allowed_fields}
+    except (ImportError, ValueError, TypeError):
+        return payload
+
+
 class ReceiptsHandler(BaseHandler):
     """
     HTTP handler for decision receipt operations.
@@ -246,17 +283,52 @@ class ReceiptsHandler(BaseHandler):
         return False
 
     @rate_limit(requests_per_minute=60)
-    async def handle(  # type: ignore[override]
-        self,
-        method: str,
-        path: str,
-        body: dict[str, Any] | None = None,
-        query_params: dict[str, str] | None = None,
-        headers: dict[str, str] | None = None,
-    ) -> HandlerResult:
-        """Route request to appropriate handler method."""
-        query_params = query_params or {}
-        body = body or {}
+    async def handle(self, *args: Any, **kwargs: Any) -> HandlerResult | None:  # type: ignore[override]
+        """Route request to appropriate handler method.
+
+        Supports both (path, query_params, handler) and (method, path, ...) call signatures.
+        """
+        method = kwargs.pop("method", None)
+        path = kwargs.pop("path", None)
+        body = kwargs.pop("body", None)
+        query_params = kwargs.pop("query_params", None)
+        headers = kwargs.pop("headers", None)
+        handler = kwargs.pop("handler", None)
+
+        if args:
+            first = args[0]
+            http_methods = {"GET", "POST", "PUT", "PATCH", "DELETE"}
+            if isinstance(first, str) and first.upper() in http_methods:
+                method = first.upper()
+                path = args[1] if len(args) > 1 else path
+                if body is None and len(args) > 2 and isinstance(args[2], dict):
+                    body = args[2]
+                if query_params is None and len(args) > 3 and isinstance(args[3], dict):
+                    query_params = args[3]
+                if headers is None and len(args) > 4 and isinstance(args[4], dict):
+                    headers = args[4]
+                if handler is None and len(args) > 5:
+                    handler = args[5]
+            else:
+                path = first
+                if query_params is None and len(args) > 1 and isinstance(args[1], dict):
+                    query_params = args[1]
+                if handler is None and len(args) > 2:
+                    handler = args[2]
+
+        if method is None:
+            method = getattr(handler, "command", "GET") if handler else "GET"
+        if path is None or not isinstance(path, str):
+            return error_response("Invalid receipt path", 400)
+        if query_params is None:
+            query_params = {}
+        if body is None:
+            if handler and method in {"POST", "PUT", "PATCH"}:
+                body = self.read_json_body(handler) or {}
+            else:
+                body = {}
+        if headers is None:
+            headers = dict(handler.headers) if handler and hasattr(handler, "headers") else {}
 
         try:
             # Stats endpoint
@@ -631,7 +703,7 @@ class ReceiptsHandler(BaseHandler):
             from aragora.export.decision_receipt import DecisionReceipt
 
             # Reconstruct DecisionReceipt from stored data
-            decision_receipt = DecisionReceipt.from_dict(receipt.data)
+            decision_receipt = DecisionReceipt.from_dict(_extract_decision_receipt_payload(receipt))
 
             if export_format == "json":
                 content = decision_receipt.to_json(indent=2)
@@ -937,7 +1009,7 @@ class ReceiptsHandler(BaseHandler):
             from aragora.export.decision_receipt import DecisionReceipt
 
             # Reconstruct DecisionReceipt from stored data
-            decision_receipt = DecisionReceipt.from_dict(receipt.data)
+            decision_receipt = DecisionReceipt.from_dict(_extract_decision_receipt_payload(receipt))
 
             # Format the receipt for the channel
             formatted = format_receipt_for_channel(decision_receipt, channel_type, options)
@@ -1137,7 +1209,7 @@ class ReceiptsHandler(BaseHandler):
             from aragora.channels.formatter import format_receipt_for_channel
             from aragora.export.decision_receipt import DecisionReceipt
 
-            decision_receipt = DecisionReceipt.from_dict(receipt.data)
+            decision_receipt = DecisionReceipt.from_dict(_extract_decision_receipt_payload(receipt))
             formatted = format_receipt_for_channel(decision_receipt, channel_type, options)
 
             return json_response(
@@ -1488,7 +1560,9 @@ class ReceiptsHandler(BaseHandler):
                 try:
                     from aragora.export.decision_receipt import DecisionReceipt
 
-                    decision_receipt = DecisionReceipt.from_dict(receipt.data)
+                    decision_receipt = DecisionReceipt.from_dict(
+                        _extract_decision_receipt_payload(receipt)
+                    )
 
                     # Determine file extension
                     if export_format == "json":

--- a/tests/server/handlers/test_receipts_handler.py
+++ b/tests/server/handlers/test_receipts_handler.py
@@ -371,6 +371,20 @@ class TestReceiptsHandlerList:
         assert data["pagination"]["total"] == 0
 
     @pytest.mark.asyncio
+    async def test_list_supports_legacy_handler_signature(self, receipts_handler):
+        """Unified server should be able to call the generic legacy handler signature."""
+        http_handler = MagicMock()
+        http_handler.command = "GET"
+        http_handler.headers = {}
+
+        result = await receipts_handler.handle("/api/v2/receipts", {}, http_handler)
+
+        assert result.status_code == 200
+        data = parse_handler_response(result)
+        assert data["receipts"] == []
+        assert data["pagination"]["total"] == 0
+
+    @pytest.mark.asyncio
     async def test_list_with_receipts(self, receipts_handler, mock_receipt_store):
         """Test list returns receipts."""
         mock_receipt_store.save({"receipt_id": "r1", "gauntlet_id": "g1", "verdict": "APPROVED"})
@@ -514,6 +528,37 @@ class TestReceiptsHandlerExport:
 
         assert result.status_code == 200
         assert result.content_type.startswith("application/json")
+
+    @pytest.mark.asyncio
+    async def test_export_json_filters_extended_payload(self, receipts_handler, mock_receipt_store):
+        """Export should strip newer stored-only fields before reconstruction."""
+        mock_receipt_store.save(
+            {
+                "receipt_id": "receipt-001",
+                "gauntlet_id": "gauntlet-001",
+                "timestamp": "2026-03-25T15:00:00Z",
+                "input_summary": "Should we ship the receipt fix?",
+                "verdict": "APPROVED",
+                "confidence": 0.85,
+                "risk_level": "LOW",
+                "risk_score": 0.1,
+                "findings": [],
+                "dissenting_views": [],
+                "verified_claims": [],
+                "input_hash": "sha256:deadbeef",
+            }
+        )
+
+        result = await receipts_handler.handle(
+            "GET",
+            "/api/v2/receipts/receipt-001/export",
+            query_params={"format": "json"},
+        )
+
+        assert result.status_code == 200
+        data = parse_handler_response(result)
+        assert data["receipt_id"] == "receipt-001"
+        assert data["input_summary"] == "Should we ship the receipt fix?"
 
     @pytest.mark.asyncio
     async def test_export_html(self, receipts_handler, mock_receipt_store):


### PR DESCRIPTION
## Summary
- support the legacy unified-server `(path, query_params, handler)` invocation shape in `ReceiptsHandler.handle()`
- normalize stored receipt payloads before `DecisionReceipt` reconstruction so newer fields like `input_hash` do not break legacy export/formatting paths
- add focused regression coverage for legacy list routing and extended-payload export

## Root cause
The demo proof exposed that the unified server still invokes generic handlers as `(path, query_params, handler)`, but `ReceiptsHandler` only accepted the newer `(method, path, ...)` signature. That made `/api/v2/receipts` crash with `'dict' object has no attribute 'startswith'` because the query dict was landing in the `path` slot.

The same proof also showed legacy JSON export still reconstructed `DecisionReceipt` directly from `receipt.data`, which broke on newer stored payload fields such as `input_hash`.

## Verification
- `python3 -m ruff check aragora/server/handlers/receipts.py tests/server/handlers/test_receipts_handler.py`
- `python3 -m pytest tests/server/handlers/test_receipts_handler.py -q`
- live demo proof from a fresh `origin/main` worktree:
  - `python3 -m aragora.cli.main quickstart --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" --no-browser`
  - `NO_BROWSER=1 ./scripts/demo.sh`
  - `curl -sf 'http://localhost:8080/api/v2/receipts?limit=3'`
  - `curl -sf 'http://localhost:8080/api/v2/receipts/8f2e1595-38ec-4295-9190-39ceaee4ec77'`
  - `curl -sf 'http://localhost:8080/api/v2/receipts/8f2e1595-38ec-4295-9190-39ceaee4ec77/export?format=json'`
