### PR TITLE
fix(auth): keep oauth provider catalog off auth rate limits

### DIFF
--- a/aragora/server/handlers/_oauth/base.py
+++ b/aragora/server/handlers/_oauth/base.py
@@ -176,6 +176,10 @@ class OAuthHandler(
         _cs = impl.create_span
         _asa = impl.add_span_attributes
 
+        # Normalize path once so routing and limiter exemptions stay aligned
+        # across /api/v1 and /api aliases.
+        normalized = path.replace("/api/v1/", "/api/")
+
         with _cs(f"oauth.{provider}", {"oauth.provider": provider, "oauth.path": path}) as span:
             # Get client IP for rate limiting
             client_ip = get_client_ip(handler)
@@ -184,12 +188,13 @@ class OAuthHandler(
             # - "token": Token exchange endpoints (POST /callback API, link/unlink)
             # - "callback": OAuth callback handlers (GET /callback from providers)
             # - "auth_start": Auth redirect endpoints (GET /google, /github, etc.)
-            is_callback = "/callback" in path
+            is_callback = "/callback" in normalized
             is_token_endpoint = (
-                path.endswith("/link")
-                or path.endswith("/unlink")
+                normalized.endswith("/link")
+                or normalized.endswith("/unlink")
                 or (is_callback and method == "POST")
             )
+            is_provider_catalog = normalized == "/api/auth/oauth/providers"
 
             if is_token_endpoint:
                 endpoint_type = "token"
@@ -198,9 +203,12 @@ class OAuthHandler(
             else:
                 endpoint_type = "auth_start"
 
-            # Rate limit check using the wrapper in _impl (backward compatible)
-            # The wrapper uses the new OAuthRateLimiter with exponential backoff
-            if not impl._oauth_limiter.is_allowed(client_ip, endpoint_type):
+            # The provider catalog powers the public login/signup UI and is already
+            # auth-exempt higher up in the stack. Treating it as an auth attempt
+            # makes the page hide social login options after a few refreshes.
+            if not is_provider_catalog and not impl._oauth_limiter.is_allowed(
+                client_ip, endpoint_type
+            ):
                 logger.warning(
                     "OAuth rate limit exceeded: ip=%s, endpoint=%s, provider=%s",
                     client_ip,
@@ -218,9 +226,6 @@ class OAuthHandler(
 
             # Add method to span
             _asa(span, {"oauth.method": method})
-
-            # Normalize path - support both /api/v1/ and /api/ prefixes
-            normalized = path.replace("/api/v1/", "/api/")
 
             # Determine if this is a callback (more important to trace)
             is_callback = "/callback" in normalized

--- a/tests/server/handlers/_oauth/test_base.py
+++ b/tests/server/handlers/_oauth/test_base.py
@@ -257,6 +257,33 @@ class TestOAuthRateLimiting:
     @patch("aragora.server.handlers._oauth_impl._oauth_limiter")
     @patch("aragora.server.handlers._oauth_impl.create_span")
     @patch("aragora.server.handlers._oauth_impl.add_span_attributes")
+    def test_provider_catalog_bypasses_rate_limit(
+        self, mock_add_span, mock_create_span, mock_limiter, oauth_handler, mock_request_handler
+    ):
+        """Provider catalog should stay available even when auth starts are rate-limited."""
+        mock_span = MagicMock()
+        mock_create_span.return_value.__enter__ = MagicMock(return_value=mock_span)
+        mock_create_span.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_limiter.is_allowed.return_value = False
+
+        with patch.object(oauth_handler, "_handle_list_providers") as mock_method:
+            mock_method.return_value = MagicMock(status_code=200, body=b"{}")
+            result = oauth_handler.handle(
+                "/api/v1/auth/oauth/providers",
+                {},
+                mock_request_handler,
+                "GET",
+            )
+
+        assert result is not None
+        assert result.status_code == 200
+        mock_method.assert_called_once()
+        mock_limiter.is_allowed.assert_not_called()
+
+    @patch("aragora.server.handlers._oauth_impl._oauth_limiter")
+    @patch("aragora.server.handlers._oauth_impl.create_span")
+    @patch("aragora.server.handlers._oauth_impl.add_span_attributes")
     @patch("aragora.server.handlers._oauth_impl._get_google_client_id")
     def test_rate_limit_allowed_proceeds(
         self,


### PR DESCRIPTION
## Summary
- keep `/api/auth/oauth/providers` off the OAuth auth-start rate limiter
- add a regression proving the provider catalog remains available even when auth starts are rate-limited
- preserve the existing limiter behavior for actual auth starts and callbacks

## Root cause
`AuthChecksMixin` already treats `/api/auth/oauth/providers` as auth-exempt so the public login page can render available social providers. `OAuthHandler.handle()` still classified the same endpoint as `auth_start`, so a few refreshes would trip the OAuth limiter and the login page would hide every social login button.

## Verification
- `python3 -m ruff check aragora/server/handlers/_oauth/base.py tests/server/handlers/_oauth/test_base.py`
- `python3 -m pytest tests/server/handlers/_oauth/test_base.py -q -k 'provider_catalog_bypasses_rate_limit or rate_limit_exceeded_returns_429 or rate_limit_allowed_proceeds'`
- live proof: 7 consecutive `GET http://127.0.0.1:8080/api/auth/oauth/providers` calls returned `200` with `google`, `github`, and `microsoft`
- browser proof: `/auth/login/` rendered all three social buttons and console showed provider fetches returning `200` with `3` providers
