### PR TITLE
fix(frontend): keep compact banner out of nested links

### DIFF
--- a/aragora/live/src/app/(app)/audit/new/page.tsx
+++ b/aragora/live/src/app/(app)/audit/new/page.tsx
@@ -127,7 +127,9 @@ function NewAuditContent() {
       <header className="border-b border-border bg-surface/50 backdrop-blur-sm sticky top-0 z-40">
         <div className="container mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <AsciiBannerCompact />
+            <Link href="/" className="hover:text-accent">
+              <AsciiBannerCompact />
+            </Link>
             <span className="text-muted font-mono text-sm">{'//'} NEW AUDIT</span>
           </div>
           <div className="flex items-center gap-3">

--- a/aragora/live/src/app/(app)/audit/templates/page.tsx
+++ b/aragora/live/src/app/(app)/audit/templates/page.tsx
@@ -97,7 +97,9 @@ export default function AuditTemplatesPage() {
       <header className="border-b border-border bg-surface/50 backdrop-blur-sm sticky top-0 z-40">
         <div className="container mx-auto px-4 py-3 flex items-center justify-between">
           <div className="flex items-center gap-4">
-            <AsciiBannerCompact />
+            <Link href="/" className="hover:text-accent">
+              <AsciiBannerCompact />
+            </Link>
             <span className="text-muted font-mono text-sm">{'//'} AUDIT TEMPLATES</span>
           </div>
           <div className="flex items-center gap-3">

--- a/aragora/live/src/app/(app)/components/DashboardHeader.tsx
+++ b/aragora/live/src/app/(app)/components/DashboardHeader.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { AsciiBannerCompact } from '@/components/AsciiBanner';
 import { StatusPill } from '@/components/StatusBar';
 import { BackendSelector } from '@/components/BackendSelector';
@@ -64,7 +65,9 @@ export function DashboardHeader({
       <div className="max-w-screen-2xl mx-auto px-3 sm:px-4 lg:px-6 py-2 sm:py-3">
         <div className="flex items-center justify-between gap-2">
           {/* ASCII Logo */}
-          <AsciiBannerCompact connected={connected} showAsciiArt={showHeaderAscii} />
+          <Link href="/" className="hover:opacity-80 transition-opacity">
+            <AsciiBannerCompact connected={connected} showAsciiArt={showHeaderAscii} />
+          </Link>
 
           {/* Controls */}
           <div className="flex items-center gap-1 sm:gap-2 lg:gap-3">

--- a/aragora/live/src/app/(app)/portal/page.tsx
+++ b/aragora/live/src/app/(app)/portal/page.tsx
@@ -51,7 +51,9 @@ export default function PortalPage() {
       <section className="relative z-10 py-16 px-4 border-b border-acid-green/20">
         <div className="container mx-auto max-w-6xl text-center">
           <div className="mb-6">
-            <AsciiBannerCompact connected={true} />
+            <Link href="/" className="inline-flex hover:opacity-80 transition-opacity">
+              <AsciiBannerCompact connected={true} />
+            </Link>
           </div>
           <h1 className="text-4xl md:text-5xl font-mono font-bold text-acid-green mb-4">
             Multi Agent Decision Making

--- a/aragora/live/src/components/AsciiBanner.tsx
+++ b/aragora/live/src/components/AsciiBanner.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react';
 import { Logo } from './Logo';
-import { useSidebar } from '@/context/SidebarContext';
 
 interface AsciiBannerProps {
   subtitle?: string;
@@ -114,13 +113,10 @@ export function AsciiBannerCompact({
   showLogo?: boolean;
   onLogoClick?: () => void;
 }) {
-  const { toggle } = useSidebar();
-  const handleLogoClick = onLogoClick ?? toggle;
-
   return (
     <div className="flex items-center gap-3">
       {showLogo && (
-        <Logo size="sm" onClick={handleLogoClick} />
+        <Logo size="sm" onClick={onLogoClick} />
       )}
       {showAsciiArt && (
         <pre className="font-mono text-[8px] leading-none text-acid-green glow-text-subtle hidden sm:block">
@@ -131,9 +127,9 @@ export function AsciiBannerCompact({
 /_/   \\_\\_| \\_\\`}
         </pre>
       )}
-      <a href="https://aragora.ai" className="text-acid-green font-mono font-bold hover:text-acid-cyan transition-colors">
+      <span className="text-acid-green font-mono font-bold">
         [ARAGORA]
-      </a>
+      </span>
       {showStatus && (
         <span
           className={`w-2 h-2 rounded-full ${

--- a/aragora/live/src/components/Logo.tsx
+++ b/aragora/live/src/components/Logo.tsx
@@ -19,6 +19,20 @@ export function Logo({ size = 'md', pixelSize, onClick, className = '' }: LogoPr
   // Pick the closest asset and scale with pixelated rendering when needed.
   const assetSize = dimension <= 16 ? 16 : dimension <= 32 ? 32 : 64;
   const src = `/logo-mark-${assetSize}.png`;
+  const image = (
+    <img
+      src={src}
+      alt="Aragora"
+      width={assetSize}
+      height={assetSize}
+      style={{ width: dimension, height: dimension, imageRendering: 'pixelated' }}
+      className="block transition-all group-hover:drop-shadow-[0_0_10px_rgba(57,255,20,0.7)] group-hover:brightness-110"
+    />
+  );
+
+  if (!onClick) {
+    return <div className={`group flex-shrink-0 ${className}`}>{image}</div>;
+  }
 
   return (
     <button
@@ -27,14 +41,7 @@ export function Logo({ size = 'md', pixelSize, onClick, className = '' }: LogoPr
       aria-label="Aragora menu"
       type="button"
     >
-      <img
-        src={src}
-        alt="Aragora"
-        width={assetSize}
-        height={assetSize}
-        style={{ width: dimension, height: dimension, imageRendering: 'pixelated' }}
-        className="block transition-all group-hover:drop-shadow-[0_0_10px_rgba(57,255,20,0.7)] group-hover:brightness-110"
-      />
+      {image}
     </button>
   );
 }

--- a/aragora/live/src/components/__tests__/AsciiBanner.test.tsx
+++ b/aragora/live/src/components/__tests__/AsciiBanner.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AsciiBannerCompact } from '@/components/AsciiBanner';
+
+describe('AsciiBannerCompact', () => {
+  it('does not render nested anchors or buttons when wrapped in a link', () => {
+    const { container } = render(
+      <a href="/">
+        <AsciiBannerCompact connected />
+      </a>,
+    );
+
+    expect(container.querySelectorAll('a')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: /aragora menu/i })).not.toBeInTheDocument();
+    expect(screen.getByText('[ARAGORA]')).toBeInTheDocument();
+  });
+
+  it('renders an interactive logo only when onLogoClick is provided', async () => {
+    const user = userEvent.setup();
+    const onLogoClick = jest.fn();
+
+    render(<AsciiBannerCompact onLogoClick={onLogoClick} />);
+
+    await user.click(screen.getByRole('button', { name: /aragora menu/i }));
+    expect(onLogoClick).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- remove nested interactive markup from `AsciiBannerCompact`
- keep the few bare brand headers navigable with explicit home links
- add a regression test for wrapping the compact banner in a link

## Root cause
`AsciiBannerCompact` rendered its own anchor and interactive logo by default. Many app headers wrapped the component in `Link`, which produced invalid nested interactive markup in the standalone debate route and triggered a hydration error in the browser.

## Verification
- `cd aragora/live && npx jest --ci --runTestsByPath 'src/components/__tests__/AsciiBanner.test.tsx' 'src/components/__tests__/DebateViewer.test.tsx' 'src/app/(standalone)/debate/__tests__/page.test.tsx'`
- `cd aragora/live && npx eslint 'src/components/Logo.tsx' 'src/components/AsciiBanner.tsx' 'src/components/__tests__/AsciiBanner.test.tsx' 'src/app/(app)/components/DashboardHeader.tsx' 'src/app/(app)/portal/page.tsx' 'src/app/(app)/audit/new/page.tsx' 'src/app/(app)/audit/templates/page.tsx'`
- Browser repro via Playwright wrapper:
  - landing hero `Try a Demo Debate`
  - navigated to `/debate/938628f4d80a4518/`
  - console no longer shows the nested `<a>` hydration error
  - remaining warning is only Next's smooth-scroll note
