### PR TITLE
fix(marketplace): route /templates/search alias to search handler

### DIFF
--- a/aragora/server/handlers/features/marketplace/handler.py
+++ b/aragora/server/handlers/features/marketplace/handler.py
@@ -151,7 +151,14 @@ class MarketplaceHandler:
                 return await self._handle_list_categories(request, tenant_id)
 
             # Search templates
-            elif path == "/api/v1/marketplace/search" and method == "GET":
+            elif (
+                path
+                in (
+                    "/api/v1/marketplace/search",
+                    "/api/v1/marketplace/templates/search",
+                )
+                and method == "GET"
+            ):
                 return await self._handle_search(request, tenant_id)
 
             # Popular templates

--- a/tests/handlers/features/marketplace/test_handler.py
+++ b/tests/handlers/features/marketplace/test_handler.py
@@ -347,6 +347,9 @@ class TestCanHandle:
     def test_handles_search(self, handler):
         assert handler.can_handle("/api/v1/marketplace/search") is True
 
+    def test_handles_templates_search_alias(self, handler):
+        assert handler.can_handle("/api/v1/marketplace/templates/search") is True
+
     def test_handles_deployments(self, handler):
         assert handler.can_handle("/api/v1/marketplace/deployments") is True
 
@@ -618,6 +621,17 @@ class TestSearch:
             handler, "/api/v1/marketplace/search", templates=templates, request=req
         )
         assert _status(result) == 200
+
+    @pytest.mark.asyncio
+    async def test_templates_search_alias_returns_search_results(self, handler, templates):
+        req = _req(query={"q": "contract"})
+        result = await _call(
+            handler, "/api/v1/marketplace/templates/search", templates=templates, request=req
+        )
+        body = _body(result)
+        assert _status(result) == 200
+        assert body["total"] == 1
+        assert body["results"][0]["id"] == "tpl-legal-1"
 
     @pytest.mark.asyncio
     async def test_search_filters_by_query(self, handler, templates):


### PR DESCRIPTION
## Summary
`/api/v1/marketplace/templates/search` was advertised in `can_handle()` and the stability manifest but returned 404 because it fell through to template-detail dispatch. Fixed by checking for the search suffix before template-ID extraction.

## From
Codex engineering autopilot (run 2)

## Test plan
- [x] Direct repro: 404 before fix → 200 after fix
- [x] 2 new regression tests pass
- [x] Ruff clean