### PR TITLE
fix(frontend): recover public standalone debate permalinks

### DIFF
--- a/aragora/live/src/app/(standalone)/debate/[[...id]]/DebateViewerWrapper.tsx
+++ b/aragora/live/src/app/(standalone)/debate/[[...id]]/DebateViewerWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { DebateViewer } from '@/components/debate-viewer';
 import { CruxPanel } from '@/components/CruxPanel';
@@ -26,7 +26,7 @@ import { ThemeToggle } from '@/components/ThemeToggle';
 import { useBackend } from '@/components/BackendSelector';
 import { useDebateWebSocketStore } from '@/hooks/useDebateWebSocketStore';
 import { DEFAULT_AGENTS } from '@/config';
-import type { SavedDebate } from './fetchDebate';
+import { fetchDebateClient, type SavedDebate } from './fetchDebate';
 
 // ---------------------------------------------------------------------------
 // Agent color palette — rotates through neon accents per agent
@@ -330,6 +330,10 @@ export function DebateViewerWrapper({
   const pathname = usePathname();
   const [showAnalysis, setShowAnalysis] = useState(false);
   const [showDeepAnalysis, setShowDeepAnalysis] = useState(false);
+  const [resolvedSavedDebate, setResolvedSavedDebate] = useState<SavedDebate | null>(
+    savedDebate ?? null,
+  );
+  const [isResolvingSavedDebate, setIsResolvingSavedDebate] = useState(false);
   const { config } = useBackend();
 
   // Extract debate ID from pathname: /debate/abc123 -> abc123
@@ -362,6 +366,36 @@ export function DebateViewerWrapper({
   // Live debates start with 'adhoc_' - hide analysis during streaming for better UX
   const isLiveDebate = debateId?.startsWith('adhoc_') ?? false;
 
+  useEffect(() => {
+    if (savedDebate) {
+      setResolvedSavedDebate(savedDebate);
+      return;
+    }
+
+    if (!debateId || isLiveDebate) {
+      setResolvedSavedDebate(null);
+      setIsResolvingSavedDebate(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsResolvingSavedDebate(true);
+
+    const resolveSavedDebate = async () => {
+      const debate = await fetchDebateClient(debateId);
+      if (!cancelled) {
+        setResolvedSavedDebate(debate);
+        setIsResolvingSavedDebate(false);
+      }
+    };
+
+    void resolveSavedDebate();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [debateId, isLiveDebate, savedDebate]);
+
   // Get WebSocket actions for voice input integration
   // Note: This creates a separate connection for voice suggestions
   // DebateViewer has its own connection for main debate events
@@ -373,8 +407,8 @@ export function DebateViewerWrapper({
   });
 
   // ---- Saved (read-only) debate from server-side fetch ----
-  if (savedDebate) {
-    return <SavedDebateView debate={savedDebate} />;
+  if (resolvedSavedDebate) {
+    return <SavedDebateView debate={resolvedSavedDebate} />;
   }
 
   // No ID provided - show CTA to start a debate
@@ -410,6 +444,30 @@ export function DebateViewerWrapper({
               >
                 BACK TO ARAGORA
               </Link>
+            </div>
+          </div>
+        </main>
+      </>
+    );
+  }
+
+  if (isResolvingSavedDebate && !isLiveDebate) {
+    return (
+      <>
+        <Scanlines opacity={0.02} />
+        <CRTVignette />
+        <main className="min-h-screen bg-bg text-text relative z-10">
+          <header className="border-b border-acid-green/30 bg-surface/80 backdrop-blur-sm sticky top-0 z-50">
+            <div className="container mx-auto px-4 py-3 flex items-center justify-between">
+              <Link href="/landing/">
+                <AsciiBannerCompact connected={true} />
+              </Link>
+              <ThemeToggle />
+            </div>
+          </header>
+          <div className="container mx-auto px-4 py-20 text-center max-w-lg">
+            <div className="text-acid-green font-mono animate-pulse">
+              {'>'} LOADING DEBATE...
             </div>
           </div>
         </main>

--- a/aragora/live/src/app/(standalone)/debate/[[...id]]/fetchDebate.ts
+++ b/aragora/live/src/app/(standalone)/debate/[[...id]]/fetchDebate.ts
@@ -18,6 +18,29 @@ export interface SavedDebate {
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
+async function fetchDebateFromCandidateUrls(
+  debateId: string,
+  init: RequestInit,
+): Promise<SavedDebate | null> {
+  const urls = [
+    `${API_BASE}/api/v1/debates/public/${debateId}`,
+    `${API_BASE}/api/v1/playground/debate/${debateId}`,
+  ];
+
+  for (const url of urls) {
+    try {
+      const res = await fetch(url, init);
+      if (!res.ok) continue;
+      const data = await res.json();
+      return (data?.data ?? data) as SavedDebate;
+    } catch {
+      // Try the next candidate URL
+    }
+  }
+
+  return null;
+}
+
 /**
  * Fetch a saved debate from the backend API (server-side).
  *
@@ -28,30 +51,17 @@ const API_BASE =
 export async function fetchDebate(
   debateId: string,
 ): Promise<SavedDebate | null> {
-  // Try public viewer endpoint first (preferred for shared debates)
-  try {
-    const res = await fetch(
-      `${API_BASE}/api/v1/debates/public/${debateId}`,
-      { next: { revalidate: 300 } },
-    );
-    if (res.ok) {
-      const data = await res.json();
-      return (data?.data ?? data) as SavedDebate;
-    }
-  } catch {
-    // Fall through to playground endpoint
-  }
+  return fetchDebateFromCandidateUrls(debateId, { next: { revalidate: 300 } });
+}
 
-  // Fallback to playground endpoint
-  try {
-    const res = await fetch(
-      `${API_BASE}/api/v1/playground/debate/${debateId}`,
-      { next: { revalidate: 300 } },
-    );
-    if (!res.ok) return null;
-    const data = await res.json();
-    return (data?.data ?? data) as SavedDebate;
-  } catch {
-    return null;
-  }
+/**
+ * Fetch a saved debate from the browser runtime.
+ *
+ * Used by the standalone viewer as a fail-soft recovery path when the initial
+ * server-side preload misses but the permalink still resolves publicly.
+ */
+export async function fetchDebateClient(
+  debateId: string,
+): Promise<SavedDebate | null> {
+  return fetchDebateFromCandidateUrls(debateId, { cache: 'no-store' });
 }

--- a/aragora/live/src/app/(standalone)/debate/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(standalone)/debate/__tests__/page.test.tsx
@@ -1,5 +1,6 @@
 import { renderWithProviders, screen, waitFor } from '@/test-utils';
 import { DebateViewerWrapper } from '../[[...id]]/DebateViewerWrapper';
+import { fetchDebateClient } from '../[[...id]]/fetchDebate';
 
 // Mock next/link
 jest.mock('next/link', () => {
@@ -48,6 +49,10 @@ jest.mock('@/components/debate-viewer', () => ({
       Debate Viewer
     </div>
   ),
+}));
+
+jest.mock('../[[...id]]/fetchDebate', () => ({
+  fetchDebateClient: jest.fn(),
 }));
 
 // Mock analysis panel components
@@ -124,6 +129,7 @@ jest.mock('@/hooks/useDebateWebSocketStore', () => ({
 // Mock fetch globally
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
+const mockFetchDebateClient = fetchDebateClient as jest.MockedFunction<typeof fetchDebateClient>;
 
 // Helper to set the mocked pathname for usePathname()
 function setMockPathname(pathname: string) {
@@ -134,6 +140,7 @@ describe('DebateViewerPage (via DebateViewerWrapper)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setMockPathname('/debate');
+    mockFetchDebateClient.mockResolvedValue(null);
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({}),
@@ -199,6 +206,7 @@ describe('DebateViewerWrapper', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     setMockPathname('/debate');
+    mockFetchDebateClient.mockResolvedValue(null);
     mockFetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({}),
@@ -308,6 +316,37 @@ describe('DebateViewerWrapper', () => {
         const viewer = screen.getByTestId('debate-viewer');
         expect(viewer).toHaveAttribute('data-ws-url', 'ws://localhost:8080/ws');
       });
+    });
+
+    it('recovers a public permalink client-side before falling back to archived loader', async () => {
+      setMockPathname('/debate/abcdef1234567890');
+      mockFetchDebateClient.mockResolvedValue({
+        id: 'abcdef1234567890',
+        topic: 'Should we publish the public demo permalink?',
+        status: 'completed',
+        consensus_reached: true,
+        confidence: 0.91,
+        verdict: 'Yes',
+        duration_seconds: 8.2,
+        participants: ['analyst', 'critic'],
+        proposals: {
+          analyst: 'Make the permalink public.',
+          critic: 'Validate the permalink path first.',
+        },
+        critiques: [],
+        votes: [],
+        final_answer: 'Publish the permalink after validating the viewer path.',
+        receipt_hash: 'sha256:test',
+      });
+
+      renderWithProviders(<DebateViewerWrapper />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Should we publish the public demo permalink?'),
+        ).toBeInTheDocument();
+      });
+      expect(screen.queryByTestId('debate-viewer')).not.toBeInTheDocument();
     });
 
     it('shows analysis toggle button for archived debates', async () => {


### PR DESCRIPTION
## Summary
- recover standalone debate permalinks client-side when the initial server preload misses
- share the public/playground debate fetch path between server and browser runtimes
- cover the public permalink recovery path in the standalone page tests

## Verification
- cd /tmp/aragora-standalone-debate-iFJFzH/aragora/live && npx jest --ci --runTestsByPath 'src/app/(standalone)/debate/__tests__/page.test.tsx' 'src/components/__tests__/DebateViewer.test.tsx'\n- cd /tmp/aragora-standalone-debate-iFJFzH/aragora/live && npx eslint 'src/app/(standalone)/debate/[[...id]]/fetchDebate.ts' 'src/app/(standalone)/debate/[[...id]]/DebateViewerWrapper.tsx' 'src/app/(standalone)/debate/__tests__/page.test.tsx'\n- browser proof on the patched Next dev server: open /debate/edc02c3e5d844a49 and confirm the saved debate renders instead of Debated not found\n\n## Follow-up\n- local landing demo flow is still blocked by a separate CORS/base-URL issue hitting https://api.aragora.ai from localhost; that is intentionally left out of this PR