### PR TITLE
fix(triage): harden staged dry-run profile

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -14,7 +14,9 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+import os
 import sys
+import warnings
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -91,63 +93,130 @@ def cmd_triage(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+async def _initialize_triage_storage() -> None:
+    """Initialize event-loop-bound PostgreSQL infrastructure for CLI triage.
+
+    This mirrors server startup: create the shared pool inside the active event
+    loop so stores used by debate hooks do not fall back to SQLite purely
+    because triage is running from the CLI.
+    """
+    try:
+        from aragora.server.startup.database import init_postgres_pool
+
+        await init_postgres_pool()
+    except Exception as exc:  # noqa: BLE001 - best-effort CLI initialization
+        logger.debug("Triage storage initialization skipped: %s", exc)
+
+
+async def _shutdown_triage_storage() -> None:
+    """Best-effort shutdown for triage-owned database resources."""
+    try:
+        from aragora.server.startup.database import close_postgres_pool
+
+        await close_postgres_pool()
+    except Exception as exc:  # noqa: BLE001 - best-effort CLI shutdown
+        logger.debug("Triage shared-pool shutdown skipped: %s", exc)
+
+    try:
+        from aragora.storage.connection_factory import close_all_pools
+
+        await close_all_pools()
+    except Exception as exc:  # noqa: BLE001 - best-effort CLI shutdown
+        logger.debug("Triage connection-factory shutdown skipped: %s", exc)
+
+    # Give async transports a brief chance to finish their close callbacks
+    # before the triage event loop shuts down.
+    await asyncio.sleep(0.05)
+
+
 async def _run_triage(batch_size: int, auto_approve: bool, dry_run: bool = False) -> None:
     """Run the inbox triage pipeline."""
     try:
         from aragora.inbox.triage_runner import InboxTriageRunner
+        from aragora.inbox.triage_diagnostics import TriageRunDiagnostics
     except ImportError:
         print("Error: inbox triage module not available", file=sys.stderr)
         sys.exit(1)
 
-    gmail = _get_gmail_connector()
-    if gmail is None:
-        print(
-            "Error: Gmail not configured. Run 'aragora triage auth' first,\n"
-            "or set GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET environment variables.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    from aragora.inbox.trust_wedge import get_inbox_trust_wedge_service
-
-    wedge_service = get_inbox_trust_wedge_service()
-    runner = InboxTriageRunner(
-        gmail_connector=gmail,
-        wedge_service=wedge_service,
-    )
-
-    if dry_run:
-        print(
-            f"[DRY RUN] Fetching up to {batch_size} unread messages "
-            "(no actions will be executed)..."
-        )
-    else:
-        print(f"Fetching up to {batch_size} unread messages...")
-
-    decisions = await runner.run_triage(
+    profile = os.getenv("ARAGORA_TRIAGE_PROFILE", "baseline")
+    verbose = logging.getLogger().isEnabledFor(logging.DEBUG)
+    diagnostics = TriageRunDiagnostics(
+        profile=profile,
         batch_size=batch_size,
         auto_approve=auto_approve and not dry_run,
+        dry_run=dry_run,
+        verbose=verbose,
+        diagnostics_dir=os.getenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR"),
+    )
+    warnings.filterwarnings(
+        "ignore",
+        message=r"resource_tracker: There appear to be \d+ leaked semaphore objects to clean up at shutdown",
+        category=UserWarning,
+        module=r"multiprocessing\.resource_tracker",
     )
 
-    if not decisions:
-        print("No messages to triage.")
-        return
-
-    if dry_run:
-        print("\n[DRY RUN] Proposed triage decisions (no actions executed):")
-        _print_decisions(decisions)
-        return
-
-    if not auto_approve:
+    with diagnostics.activate(), diagnostics.capture_logging():
+        decisions = []
         try:
-            from aragora.inbox.cli_review import CLIReviewLoop
+            await _initialize_triage_storage()
 
-            loop = CLIReviewLoop(review_fn=wedge_service.review_receipt)
-            loop.review_batch(decisions)
-        except ImportError:
+            gmail = _get_gmail_connector()
+            if gmail is None:
+                print(
+                    "Error: Gmail not configured. Run 'aragora triage auth' first,\n"
+                    "or set GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET environment variables.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+            from aragora.inbox.trust_wedge import get_inbox_trust_wedge_service
+
+            wedge_service = get_inbox_trust_wedge_service()
+            runner = InboxTriageRunner(
+                gmail_connector=gmail,
+                wedge_service=wedge_service,
+                diagnostics=diagnostics,
+                profile=profile,
+            )
+
+            if dry_run:
+                print(
+                    f"[DRY RUN] Fetching up to {batch_size} unread messages "
+                    "(no actions will be executed)..."
+                )
+            else:
+                print(f"Fetching up to {batch_size} unread messages...")
+
+            decisions = await runner.run_triage(
+                batch_size=batch_size,
+                auto_approve=auto_approve and not dry_run,
+            )
+            meta = diagnostics.finalize(decisions)
+
+            if not decisions:
+                print("No messages to triage.")
+                _print_run_footer(decisions, meta, diagnostics)
+                return
+
+            if dry_run:
+                print("\n[DRY RUN] Proposed triage decisions (no actions executed):")
+                _print_decisions(decisions)
+                _print_run_footer(decisions, meta, diagnostics)
+                return
+
             _print_decisions(decisions)
-    else:
-        _print_decisions(decisions)
+            _print_run_footer(decisions, meta, diagnostics)
+
+            if not auto_approve:
+                try:
+                    from aragora.inbox.cli_review import CLIReviewLoop
+
+                    loop = CLIReviewLoop(review_fn=wedge_service.review_receipt)
+                    loop.review_batch(decisions)
+                except ImportError:
+                    return
+        finally:
+            await _shutdown_triage_storage()
 
 
 async def _run_gmail_auth() -> None:
@@ -285,12 +354,14 @@ def _get_gmail_connector():
 def _print_decisions(decisions: list) -> None:
     """Print triage decisions as a summary table."""
     print(f"\n{'─' * 60}")
-    print(f"{'Action':<10} {'Confidence':>10}  {'Subject'}")
+    print(f"{'Action':<10} {'Confidence':>10}  {'Status':<10} {'Subject'}")
     print(f"{'─' * 60}")
 
     for d in decisions:
         action = _action_value(getattr(d, "final_action", "?"))
         confidence = getattr(d, "confidence", 0.0)
+        blocked = bool(getattr(d, "blocked_by_policy", False))
+        status = "blocked" if blocked else str(getattr(d, "receipt_state", "created"))
         intent = getattr(d, "intent", None)
         subject = "(unknown)"
         if intent and hasattr(intent, "_subject"):
@@ -299,7 +370,7 @@ def _print_decisions(decisions: list) -> None:
             subject = getattr(intent, "message_id", "?")
 
         bar = "█" * int(confidence * 10)
-        print(f"{action:<10} {confidence:>8.1%} {bar:<10}  {subject[:40]}")
+        print(f"{action:<10} {confidence:>8.1%} {bar:<10}  {status:<10} {subject[:29]}")
 
     print(f"{'─' * 60}")
     print(f"Total: {len(decisions)} decisions")
@@ -314,6 +385,20 @@ def _print_decisions(decisions: list) -> None:
     )
     if approved or executed:
         print(f"  Approved: {approved}  Executed: {executed}")
+
+
+def _print_run_footer(decisions: list, meta: dict[str, object], diagnostics: object) -> None:
+    """Print a compact diagnostics-aware run footer."""
+    print(
+        "Run summary: "
+        f"processed={len(decisions)} "
+        f"fast={meta.get('fast_tier_count', 0)} "
+        f"escalated={meta.get('escalated_count', 0)} "
+        f"blocked={meta.get('blocked_count', 0)} "
+        f"suppressed={meta.get('suppressed_diagnostics_count', 0)}"
+    )
+    if getattr(diagnostics, "has_degraded_or_blocking", lambda: False)():
+        print(f"Diagnostics: {meta.get('artifact_dir')}")
 
 
 def _show_status() -> None:

--- a/aragora/debate/cache/embeddings_lru.py
+++ b/aragora/debate/cache/embeddings_lru.py
@@ -370,7 +370,11 @@ def get_embedding_cache(
             )
             logger.warning(
                 "Using global embedding cache. For debate context, "
-                "use get_scoped_embedding_cache(debate_id) to prevent contamination."
+                "use get_scoped_embedding_cache(debate_id) to prevent contamination.",
+                extra={
+                    "triage_diag_code": "global_embedding_cache",
+                    "triage_diag_severity": "diagnostic",
+                },
             )
 
         return _embedding_cache

--- a/aragora/debate/performance_monitor.py
+++ b/aragora/debate/performance_monitor.py
@@ -45,6 +45,37 @@ DEFAULT_SLOW_ROUND_THRESHOLD = 30.0
 MAX_SLOW_DEBATES_HISTORY = 100
 
 
+def _record_triage_perf_event(
+    *,
+    code: str,
+    summary: str,
+    details: str = "",
+    debate_id: str | None = None,
+) -> bool:
+    try:
+        from aragora.inbox.triage_diagnostics import DiagnosticSeverity, record_triage_diagnostic
+
+        return record_triage_diagnostic(
+            code=code,
+            severity=DiagnosticSeverity.DIAGNOSTIC,
+            logger_name=__name__,
+            summary=summary,
+            details=details,
+            debate_id=debate_id,
+        )
+    except ImportError:
+        return False
+
+
+def _should_mirror_triage_perf_logs() -> bool:
+    try:
+        from aragora.inbox.triage_diagnostics import triage_diagnostics_should_mirror_logs
+
+        return triage_diagnostics_should_mirror_logs()
+    except ImportError:
+        return False
+
+
 @dataclass
 class PhaseMetric:
     """Metric for a single phase within a round."""
@@ -307,15 +338,29 @@ class DebatePerformanceMonitor:
             if metric.duration_seconds > self.slow_round_threshold:
                 metric.is_slow = True
                 slowest = metric.slowest_phase
-                logger.warning(
-                    "slow_round_detected debate_id=%s round=%d "
-                    "duration=%.2fs threshold=%.2fs slowest_phase=%s",
+                summary = (
+                    "slow_round_detected debate_id=%s round=%d duration=%.2fs "
+                    "threshold=%.2fs slowest_phase=%s"
+                ) % (
                     debate_id,
                     round_num,
                     metric.duration_seconds,
                     self.slow_round_threshold,
                     f"{slowest[0]}={slowest[1]:.2f}s" if slowest else "unknown",
                 )
+                recorded = _record_triage_perf_event(
+                    code="slow_round",
+                    summary=summary,
+                    debate_id=debate_id,
+                )
+                if not recorded or _should_mirror_triage_perf_logs():
+                    logger.warning(
+                        summary,
+                        extra={
+                            "triage_diag_code": "slow_round",
+                            "triage_diag_severity": "diagnostic",
+                        },
+                    )
             else:
                 logger.debug(
                     "round_perf_complete debate_id=%s round=%d duration=%.2fs",
@@ -483,9 +528,10 @@ class DebatePerformanceMonitor:
         """Log debate completion with performance summary."""
         if metric.is_slow:
             slowest = metric.get_slowest_round()
-            logger.warning(
+            summary = (
                 "slow_debate_complete debate_id=%s duration=%.2fs rounds=%d "
-                "slow_rounds=%d avg_round=%.2fs slowest_round=%s outcome=%s",
+                "slow_rounds=%d avg_round=%.2fs slowest_round=%s outcome=%s"
+            ) % (
                 metric.debate_id,
                 metric.duration_seconds or 0,
                 len(metric.rounds),
@@ -494,6 +540,19 @@ class DebatePerformanceMonitor:
                 f"r{slowest[0]}={slowest[1]:.2f}s" if slowest else "none",
                 metric.outcome,
             )
+            recorded = _record_triage_perf_event(
+                code="slow_debate",
+                summary=summary,
+                debate_id=metric.debate_id,
+            )
+            if not recorded or _should_mirror_triage_perf_logs():
+                logger.warning(
+                    summary,
+                    extra={
+                        "triage_diag_code": "slow_debate",
+                        "triage_diag_severity": "diagnostic",
+                    },
+                )
         else:
             logger.info(
                 "debate_perf_complete debate_id=%s duration=%.2fs rounds=%d "

--- a/aragora/debate/phases/consensus_phase.py
+++ b/aragora/debate/phases/consensus_phase.py
@@ -1344,6 +1344,10 @@ class ConsensusPhase:
             vote_count,
             required,
             total_agents,
+            extra={
+                "triage_diag_code": "insufficient_participation",
+                "triage_diag_severity": "blocking",
+            },
         )
 
         if self._notify_spectator:

--- a/aragora/debate/phases/debate_rounds.py
+++ b/aragora/debate/phases/debate_rounds.py
@@ -59,9 +59,23 @@ REVISION_PHASE_BASE_TIMEOUT = _REVISION_PHASE_BASE_TIMEOUT
 
 if TYPE_CHECKING:
     from aragora.core import Agent, Critique, Message
-    from aragora.debate.context import DebateContext
+from aragora.debate.context import DebateContext
 
 logger = logging.getLogger(__name__)
+
+
+def _should_emit_slow_round_warning() -> bool:
+    try:
+        from aragora.inbox.triage_diagnostics import (
+            get_active_triage_diagnostics,
+            triage_diagnostics_should_mirror_logs,
+        )
+
+        if get_active_triage_diagnostics() is None:
+            return True
+        return triage_diagnostics_should_mirror_logs()
+    except ImportError:
+        return True
 
 
 class DebateRoundsPhase:
@@ -710,13 +724,18 @@ class DebateRoundsPhase:
         _round_duration = time.time() - _round_start_time
         _slow_threshold = perf_monitor.slow_round_threshold
         if _round_duration > _slow_threshold:
-            logger.warning(
-                "slow_round_detected debate_id=%s round=%s duration=%ss threshold=%ss",
-                ctx.debate_id,
-                round_num,
-                _round_duration,
-                _slow_threshold,
-            )
+            if _should_emit_slow_round_warning():
+                logger.warning(
+                    "slow_round_detected debate_id=%s round=%s duration=%ss threshold=%ss",
+                    ctx.debate_id,
+                    round_num,
+                    _round_duration,
+                    _slow_threshold,
+                    extra={
+                        "triage_diag_code": "slow_round",
+                        "triage_diag_severity": "diagnostic",
+                    },
+                )
             try:
                 from aragora.observability.metrics import (
                     record_slow_round,

--- a/aragora/debate/phases/vote_collector.py
+++ b/aragora/debate/phases/vote_collector.py
@@ -420,7 +420,14 @@ class VoteCollector:
                     if isinstance(vote_result, Exception):
                         logger.error("vote_error agent=%s error=%s", agent.name, vote_result)
                     else:
-                        logger.error("vote_error agent=%s error=vote returned None", agent.name)
+                        logger.error(
+                            "vote_error agent=%s error=vote returned None",
+                            agent.name,
+                            extra={
+                                "triage_diag_code": "vote_none",
+                                "triage_diag_severity": "degraded",
+                            },
+                        )
                 else:
                     votes.append(vote_result)
                     self._handle_vote_success(ctx, agent, vote_result)
@@ -540,7 +547,12 @@ class VoteCollector:
                         )
                     else:
                         logger.error(
-                            "vote_error_unanimous agent=%s error=vote returned None", agent.name
+                            "vote_error_unanimous agent=%s error=vote returned None",
+                            agent.name,
+                            extra={
+                                "triage_diag_code": "vote_none",
+                                "triage_diag_severity": "degraded",
+                            },
                         )
                     voting_errors += 1
                 else:

--- a/aragora/inbox/cli_review.py
+++ b/aragora/inbox/cli_review.py
@@ -146,6 +146,10 @@ class CLIReviewLoop:
             self._print(f"  Snippet : {snippet[:120]}")
         self._print(f"  Action  : {_action_value(decision.final_action)}")
         self._print(f"  Conf.   : {decision.confidence:.0%}")
+        if decision.blocked_by_policy:
+            self._print("  Status  : blocked pending human review")
+        else:
+            self._print(f"  Status  : {decision.receipt_state}")
         if decision.dissent_summary:
             self._print(f"  Dissent : {decision.dissent_summary}")
         self._print(f"  Receipt : {decision.receipt_id}")

--- a/aragora/inbox/triage_diagnostics.py
+++ b/aragora/inbox/triage_diagnostics.py
@@ -1,0 +1,450 @@
+"""Triage-scoped diagnostics capture for quiet CLI runs."""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import re
+import traceback
+import warnings
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from aragora.debate.runtime_blockers import classify_stderr_signals
+from aragora.utils.error_sanitizer import sanitize_error
+
+_ACTIVE_RUN: contextvars.ContextVar[TriageRunDiagnostics | None] = contextvars.ContextVar(
+    "triage_diagnostics_run",
+    default=None,
+)
+_CURRENT_MESSAGE_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "triage_diagnostics_message_id",
+    default=None,
+)
+_CURRENT_TIER: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "triage_diagnostics_tier",
+    default=None,
+)
+_CURRENT_DEBATE_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "triage_diagnostics_debate_id",
+    default=None,
+)
+
+_TARGET_LOGGER_PREFIXES = (
+    "aragora.debate.cache.embeddings_lru",
+    "aragora.debate.novelty",
+    "aragora.debate.performance_monitor",
+    "aragora.debate.phases.consensus_phase",
+    "aragora.debate.phases.debate_rounds",
+    "aragora.debate.phases.vote_collector",
+    "aragora.inbox.triage_runner",
+    "aragora.pulse.ingestor",
+    "aragora.server.research_phase",
+    "aragora.server.startup.database",
+    "aragora.storage.connection_factory",
+    "aragora.storage.pool_manager",
+)
+
+
+class DiagnosticSeverity(str, Enum):
+    BLOCKING = "blocking"
+    DEGRADED = "degraded"
+    DIAGNOSTIC = "diagnostic"
+
+
+@dataclass(frozen=True)
+class TriageDiagnosticEvent:
+    ts: str
+    run_id: str
+    message_id: str | None
+    debate_id: str | None
+    tier: str | None
+    severity: str
+    code: str
+    logger: str
+    summary: str
+    details: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ts": self.ts,
+            "run_id": self.run_id,
+            "message_id": self.message_id,
+            "debate_id": self.debate_id,
+            "tier": self.tier,
+            "severity": self.severity,
+            "code": self.code,
+            "logger": self.logger,
+            "summary": self.summary,
+            "details": self.details,
+        }
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso_now() -> str:
+    return _utcnow().isoformat()
+
+
+def _slug_timestamp() -> str:
+    return _utcnow().strftime("%Y%m%dT%H%M%SZ")
+
+
+def _coerce_severity(value: str | DiagnosticSeverity | None) -> DiagnosticSeverity:
+    if isinstance(value, DiagnosticSeverity):
+        return value
+    normalized = str(value or DiagnosticSeverity.DIAGNOSTIC.value).strip().lower()
+    try:
+        return DiagnosticSeverity(normalized)
+    except ValueError:
+        return DiagnosticSeverity.DIAGNOSTIC
+
+
+def _extract_debate_id(text: str) -> str | None:
+    match = re.search(r"\bdebate_id=([A-Za-z0-9._:-]+)\b", text)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _classify_py_warning(text: str) -> tuple[str, DiagnosticSeverity]:
+    classified = classify_stderr_signals(text)
+    blockers = classified.get("runtime_blockers", [])
+    warning_signals = classified.get("warning_signals", [])
+    if blockers:
+        return blockers[0], DiagnosticSeverity.BLOCKING
+    if warning_signals:
+        if "resource_warning" in warning_signals:
+            return "resource_warning", DiagnosticSeverity.DIAGNOSTIC
+        return warning_signals[0], DiagnosticSeverity.DIAGNOSTIC
+    return "captured_warning", DiagnosticSeverity.DIAGNOSTIC
+
+
+def _infer_log_event(record: logging.LogRecord) -> tuple[str, DiagnosticSeverity]:
+    code = getattr(record, "triage_diag_code", None)
+    severity = getattr(record, "triage_diag_severity", None)
+    if code:
+        return str(code), _coerce_severity(severity)
+
+    message = record.getMessage()
+    text = message.lower()
+
+    if record.name == "py.warnings":
+        return _classify_py_warning(message)
+    if "vote returned none" in text:
+        return "vote_none", DiagnosticSeverity.DEGRADED
+    if "insufficient_participation" in text:
+        return "insufficient_participation", DiagnosticSeverity.BLOCKING
+    if "global embedding cache" in text:
+        return "global_embedding_cache", DiagnosticSeverity.DIAGNOSTIC
+    if "falling back to openrouter" in text:
+        return "provider_fallback", DiagnosticSeverity.DEGRADED
+    if "slow_round_detected" in text:
+        return "slow_round", DiagnosticSeverity.DIAGNOSTIC
+    if "slow_debate_complete" in text:
+        return "slow_debate", DiagnosticSeverity.DIAGNOSTIC
+    if record.levelno >= logging.ERROR:
+        return "captured_error", DiagnosticSeverity.DEGRADED
+    return "captured_warning", DiagnosticSeverity.DIAGNOSTIC
+
+
+class _CaptureHandler(logging.Handler):
+    def __init__(self, run: TriageRunDiagnostics):
+        super().__init__(level=logging.WARNING)
+        self._run = run
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if not self._run.should_capture_record(record):
+            return
+        code, severity = _infer_log_event(record)
+        message = sanitize_error(record.getMessage())
+        details = ""
+        if record.exc_info:
+            details = sanitize_error(
+                "".join(traceback.format_exception(*record.exc_info)),
+                max_length=2000,
+            )
+        self._run.record_event(
+            code=code,
+            severity=severity,
+            logger_name=record.name,
+            summary=message,
+            details=details,
+            debate_id=_extract_debate_id(message),
+        )
+
+
+class _SuppressionFilter(logging.Filter):
+    def __init__(self, run: TriageRunDiagnostics):
+        super().__init__()
+        self._run = run
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if self._run.verbose:
+            return True
+        return not self._run.should_capture_record(record)
+
+
+class TriageRunDiagnostics:
+    """Collects structured diagnostics for a single triage CLI run."""
+
+    def __init__(
+        self,
+        *,
+        profile: str,
+        batch_size: int,
+        auto_approve: bool,
+        dry_run: bool,
+        verbose: bool,
+        diagnostics_dir: str | Path | None = None,
+    ) -> None:
+        self.profile = profile
+        self.batch_size = batch_size
+        self.auto_approve = auto_approve
+        self.dry_run = dry_run
+        self.verbose = verbose
+        self.run_id = f"triage-{_slug_timestamp()}-{uuid4().hex[:6]}"
+        base_dir = (
+            Path(diagnostics_dir)
+            if diagnostics_dir is not None
+            else Path.home() / ".aragora" / "triage-runs"
+        )
+        self.artifact_dir = base_dir / self.run_id
+        self.artifact_dir.mkdir(parents=True, exist_ok=True)
+        self.events_path = self.artifact_dir / "events.jsonl"
+        self.meta_path = self.artifact_dir / "meta.json"
+        self.started_at = _iso_now()
+        self.finished_at: str | None = None
+        self._events: list[TriageDiagnosticEvent] = []
+        self._once_keys: set[str] = set()
+        self._suppressed_count = 0
+        self._capture_handler: _CaptureHandler | None = None
+        self._filters: list[tuple[logging.Handler, logging.Filter]] = []
+
+    @property
+    def suppressed_count(self) -> int:
+        return self._suppressed_count
+
+    @contextmanager
+    def activate(self):
+        token = _ACTIVE_RUN.set(self)
+        try:
+            yield self
+        finally:
+            _ACTIVE_RUN.reset(token)
+
+    @contextmanager
+    def capture_logging(self):
+        root = logging.getLogger()
+        capture_handler = _CaptureHandler(self)
+        self._capture_handler = capture_handler
+        root.addHandler(capture_handler)
+        previous_warning_filters = list(warnings.filters)
+
+        if not self.verbose:
+            for handler in list(root.handlers):
+                if handler is capture_handler:
+                    continue
+                suppression_filter = _SuppressionFilter(self)
+                handler.addFilter(suppression_filter)
+                self._filters.append((handler, suppression_filter))
+
+        logging.captureWarnings(True)
+        warnings.simplefilter("always", ResourceWarning)
+        try:
+            yield self
+        finally:
+            logging.captureWarnings(False)
+            warnings.filters[:] = previous_warning_filters
+            for handler, filter_obj in self._filters:
+                handler.removeFilter(filter_obj)
+            self._filters.clear()
+            root.removeHandler(capture_handler)
+            capture_handler.close()
+            self._capture_handler = None
+
+    def should_capture_record(self, record: logging.LogRecord) -> bool:
+        code = getattr(record, "triage_diag_code", None)
+        if code:
+            return True
+        if record.name == "py.warnings":
+            return True
+        return any(record.name.startswith(prefix) for prefix in _TARGET_LOGGER_PREFIXES)
+
+    @contextmanager
+    def message_scope(self, message_id: str):
+        token = _CURRENT_MESSAGE_ID.set(message_id)
+        try:
+            yield self
+        finally:
+            _CURRENT_MESSAGE_ID.reset(token)
+
+    @contextmanager
+    def tier_scope(self, tier: str):
+        token = _CURRENT_TIER.set(tier)
+        try:
+            yield self
+        finally:
+            _CURRENT_TIER.reset(token)
+
+    @contextmanager
+    def debate_scope(self, debate_id: str):
+        token = _CURRENT_DEBATE_ID.set(debate_id)
+        try:
+            yield self
+        finally:
+            _CURRENT_DEBATE_ID.reset(token)
+
+    def record_event(
+        self,
+        *,
+        code: str,
+        severity: str | DiagnosticSeverity,
+        logger_name: str,
+        summary: str,
+        details: str = "",
+        message_id: str | None = None,
+        debate_id: str | None = None,
+        tier: str | None = None,
+        once_key: str | None = None,
+    ) -> None:
+        if once_key and once_key in self._once_keys:
+            return
+        if once_key:
+            self._once_keys.add(once_key)
+
+        event = TriageDiagnosticEvent(
+            ts=_iso_now(),
+            run_id=self.run_id,
+            message_id=message_id or _CURRENT_MESSAGE_ID.get(),
+            debate_id=debate_id or _CURRENT_DEBATE_ID.get(),
+            tier=tier or _CURRENT_TIER.get(),
+            severity=_coerce_severity(severity).value,
+            code=str(code),
+            logger=logger_name,
+            summary=sanitize_error(summary),
+            details=sanitize_error(details, max_length=2000) if details else "",
+        )
+        self._events.append(event)
+        if not self.verbose:
+            self._suppressed_count += 1
+        with self.events_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(event.to_dict(), sort_keys=True) + "\n")
+
+    def get_message_summary(self, message_id: str, *, tier: str | None = None) -> dict[str, int]:
+        summary = {
+            DiagnosticSeverity.BLOCKING.value: 0,
+            DiagnosticSeverity.DEGRADED.value: 0,
+            DiagnosticSeverity.DIAGNOSTIC.value: 0,
+            "total": 0,
+        }
+        for event in self._events:
+            if event.message_id != message_id:
+                continue
+            if tier is not None and event.tier != tier:
+                continue
+            summary[event.severity] += 1
+            summary["total"] += 1
+        return summary
+
+    def has_degraded_or_blocking(self) -> bool:
+        return any(
+            event.severity in {DiagnosticSeverity.BLOCKING.value, DiagnosticSeverity.DEGRADED.value}
+            for event in self._events
+        )
+
+    def finalize(self, decisions: list[Any]) -> dict[str, Any]:
+        self.finished_at = _iso_now()
+        severity_counts = {
+            DiagnosticSeverity.BLOCKING.value: 0,
+            DiagnosticSeverity.DEGRADED.value: 0,
+            DiagnosticSeverity.DIAGNOSTIC.value: 0,
+        }
+        for event in self._events:
+            severity_counts[event.severity] += 1
+
+        meta = {
+            "run_id": self.run_id,
+            "profile": self.profile,
+            "batch_size": self.batch_size,
+            "auto_approve": self.auto_approve,
+            "dry_run": self.dry_run,
+            "verbose": self.verbose,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+            "processed_count": len(decisions),
+            "fast_tier_count": sum(
+                1 for decision in decisions if getattr(decision, "execution_tier", "") == "fast"
+            ),
+            "escalated_count": sum(
+                1
+                for decision in decisions
+                if getattr(decision, "execution_tier", "") == "escalated"
+            ),
+            "blocked_count": sum(
+                1 for decision in decisions if getattr(decision, "blocked_by_policy", False)
+            ),
+            "suppressed_diagnostics_count": self._suppressed_count,
+            "severity_counts": severity_counts,
+            "artifact_dir": str(self.artifact_dir),
+            "events_path": str(self.events_path),
+        }
+        with self.meta_path.open("w", encoding="utf-8") as handle:
+            json.dump(meta, handle, indent=2, sort_keys=True)
+        return meta
+
+
+def get_active_triage_diagnostics() -> TriageRunDiagnostics | None:
+    return _ACTIVE_RUN.get()
+
+
+def triage_diagnostics_should_mirror_logs() -> bool:
+    active = get_active_triage_diagnostics()
+    return bool(active and active.verbose)
+
+
+def record_triage_diagnostic(
+    *,
+    code: str,
+    severity: str | DiagnosticSeverity,
+    logger_name: str,
+    summary: str,
+    details: str = "",
+    message_id: str | None = None,
+    debate_id: str | None = None,
+    tier: str | None = None,
+    once_key: str | None = None,
+) -> bool:
+    active = get_active_triage_diagnostics()
+    if active is None:
+        return False
+    active.record_event(
+        code=code,
+        severity=severity,
+        logger_name=logger_name,
+        summary=summary,
+        details=details,
+        message_id=message_id,
+        debate_id=debate_id,
+        tier=tier,
+        once_key=once_key,
+    )
+    return True
+
+
+__all__ = [
+    "DiagnosticSeverity",
+    "TriageDiagnosticEvent",
+    "TriageRunDiagnostics",
+    "get_active_triage_diagnostics",
+    "record_triage_diagnostic",
+    "triage_diagnostics_should_mirror_logs",
+]

--- a/aragora/inbox/triage_profile_benchmark.py
+++ b/aragora/inbox/triage_profile_benchmark.py
@@ -1,0 +1,375 @@
+"""Benchmark baseline vs staged inbox-triage profiles on a fixed fixture set."""
+
+from __future__ import annotations
+
+import json
+import statistics
+import time
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from aragora.inbox.auto_approval import AutoApprovalPolicy
+from aragora.inbox.triage_diagnostics import TriageRunDiagnostics
+from aragora.inbox.triage_runner import InboxTriageRunner
+from aragora.inbox.trust_wedge import ReceiptState, TriageDecision
+
+
+DEFAULT_MIN_AGREEMENT_RATE = 0.95
+DEFAULT_MIN_LATENCY_IMPROVEMENT_PCT = 40.0
+DEFAULT_MAX_BLOCKED_RATE_DELTA_PP = 5.0
+
+
+@dataclass
+class ProfileRunResult:
+    profile: str
+    fixture_path: str
+    message_count: int
+    total_duration_seconds: float
+    diagnostics_artifact_dir: str
+    meta: dict[str, Any]
+    decisions: list[dict[str, Any]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class FixtureGmailConnector:
+    """Minimal connector that serves a fixed list of messages."""
+
+    connector_id = "fixture-gmail"
+    user_id = "fixture-user"
+
+    def __init__(self, messages: list[dict[str, Any]]) -> None:
+        self._messages = [dict(message) for message in messages]
+        self._by_id = {str(message["id"]): dict(message) for message in self._messages}
+
+    async def list_messages(self, *, query: str, max_results: int):
+        del query
+        return [str(message["id"]) for message in self._messages[:max_results]], None
+
+    async def get_message(self, message_id: str) -> dict[str, Any]:
+        return dict(self._by_id[message_id])
+
+
+class BenchmarkWedgeService:
+    """Receipt stub for offline triage benchmarking."""
+
+    def __init__(self, policy: AutoApprovalPolicy | None = None) -> None:
+        self._policy = policy or AutoApprovalPolicy()
+
+    def create_receipt(
+        self,
+        intent: Any,
+        decision: TriageDecision,
+        *,
+        auto_approve: bool = False,
+    ) -> Any:
+        eligible = self._policy.can_auto_approve(decision)
+        state = ReceiptState.APPROVED if auto_approve and eligible else ReceiptState.CREATED
+        updated = replace(
+            decision,
+            receipt_id=f"fixture-{intent.message_id}",
+            auto_approval_eligible=eligible,
+            receipt_state=state.value,
+            intent=intent,
+        )
+        return SimpleNamespace(
+            intent=intent,
+            decision=updated,
+            receipt=SimpleNamespace(receipt_id=updated.receipt_id, state=state),
+            provider_route=updated.provider_route,
+        )
+
+    async def execute_receipt(self, receipt_id: str) -> None:
+        del receipt_id
+        return None
+
+
+def load_fixture_messages(path: str | Path) -> list[dict[str, Any]]:
+    fixture_path = Path(path)
+    payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list) or not payload:
+        raise ValueError(f"Expected non-empty message list in {fixture_path}")
+
+    messages: list[dict[str, Any]] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            raise ValueError(f"Fixture item {index} in {fixture_path} is not an object")
+        message_id = str(item.get("id", "")).strip()
+        if not message_id:
+            raise ValueError(f"Fixture item {index} in {fixture_path} is missing id")
+        subject = str(item.get("subject", "")).strip()
+        sender = str(item.get("from_address", item.get("sender", ""))).strip()
+        body_text = str(item.get("body_text", item.get("body", item.get("snippet", ""))))
+        messages.append(
+            {
+                "id": message_id,
+                "subject": subject or "(no subject)",
+                "from_address": sender or "(unknown)",
+                "snippet": str(item.get("snippet", body_text[:120])),
+                "body_text": body_text,
+            }
+        )
+    return messages
+
+
+def _summarize_decision(decision: TriageDecision, policy: AutoApprovalPolicy) -> dict[str, Any]:
+    message_id = ""
+    subject = "(unknown)"
+    if decision.intent is not None:
+        message_id = decision.intent.message_id
+        subject = getattr(decision.intent, "_subject", subject)
+    return {
+        "message_id": message_id,
+        "subject": subject,
+        "final_action": str(decision.final_action.value),
+        "confidence": float(decision.confidence),
+        "blocked_by_policy": bool(decision.blocked_by_policy),
+        "execution_tier": str(decision.execution_tier),
+        "escalation_reasons": list(decision.escalation_reasons),
+        "suppressed_diagnostics_count": int(decision.suppressed_diagnostics_count),
+        "latency_seconds": float(decision.latency_seconds or 0.0),
+        "auto_approval_candidate": bool(policy.can_auto_approve(decision)),
+    }
+
+
+def _median(values: list[float]) -> float | None:
+    if not values:
+        return None
+    return round(float(statistics.median(values)), 4)
+
+
+def compare_profile_runs(
+    baseline: ProfileRunResult,
+    staged: ProfileRunResult,
+    *,
+    min_agreement_rate: float = DEFAULT_MIN_AGREEMENT_RATE,
+    min_latency_improvement_pct: float = DEFAULT_MIN_LATENCY_IMPROVEMENT_PCT,
+    max_blocked_rate_delta_pp: float = DEFAULT_MAX_BLOCKED_RATE_DELTA_PP,
+) -> dict[str, Any]:
+    baseline_by_id = {item["message_id"]: item for item in baseline.decisions}
+    staged_by_id = {item["message_id"]: item for item in staged.decisions}
+    all_ids = sorted(set(baseline_by_id) | set(staged_by_id))
+
+    agreement_count = 0
+    disagreements: list[dict[str, Any]] = []
+    unsafe_auto_approval_ids: list[str] = []
+
+    for message_id in all_ids:
+        left = baseline_by_id.get(message_id)
+        right = staged_by_id.get(message_id)
+        agreed = bool(
+            left
+            and right
+            and left["final_action"] == right["final_action"]
+            and left["blocked_by_policy"] == right["blocked_by_policy"]
+        )
+        if agreed:
+            agreement_count += 1
+        else:
+            disagreements.append(
+                {
+                    "message_id": message_id,
+                    "baseline": left,
+                    "staged_v1": right,
+                }
+            )
+
+        if left and right and left["blocked_by_policy"] and right["auto_approval_candidate"]:
+            unsafe_auto_approval_ids.append(message_id)
+
+    baseline_blocked_rate = sum(
+        1 for item in baseline.decisions if item["blocked_by_policy"]
+    ) / max(len(baseline.decisions), 1)
+    staged_blocked_rate = sum(1 for item in staged.decisions if item["blocked_by_policy"]) / max(
+        len(staged.decisions), 1
+    )
+    blocked_rate_delta_pp = round((staged_blocked_rate - baseline_blocked_rate) * 100.0, 2)
+
+    non_escalated_ids = [
+        item["message_id"] for item in staged.decisions if item["execution_tier"] == "fast"
+    ]
+    baseline_fast_latencies = [
+        float(baseline_by_id[item_id]["latency_seconds"])
+        for item_id in non_escalated_ids
+        if item_id in baseline_by_id
+    ]
+    staged_fast_latencies = [
+        float(staged_by_id[item_id]["latency_seconds"])
+        for item_id in non_escalated_ids
+        if item_id in staged_by_id
+    ]
+    baseline_p50 = _median(baseline_fast_latencies)
+    staged_p50 = _median(staged_fast_latencies)
+    latency_improvement_pct = None
+    if baseline_p50 and staged_p50 is not None and baseline_p50 > 0:
+        latency_improvement_pct = round(((baseline_p50 - staged_p50) / baseline_p50) * 100.0, 2)
+
+    agreement_rate = round(agreement_count / max(len(all_ids), 1), 4)
+    acceptance = {
+        "latency_improvement": bool(
+            latency_improvement_pct is not None
+            and latency_improvement_pct >= min_latency_improvement_pct
+        ),
+        "decision_agreement": agreement_rate >= min_agreement_rate,
+        "unsafe_auto_approval": len(unsafe_auto_approval_ids) == 0,
+        "blocked_rate_delta": blocked_rate_delta_pp <= max_blocked_rate_delta_pp,
+    }
+
+    return {
+        "message_count": len(all_ids),
+        "agreement_rate": agreement_rate,
+        "agreement_count": agreement_count,
+        "disagreements": disagreements,
+        "unsafe_auto_approval_ids": unsafe_auto_approval_ids,
+        "baseline_blocked_rate": round(baseline_blocked_rate, 4),
+        "staged_blocked_rate": round(staged_blocked_rate, 4),
+        "blocked_rate_delta_pp": blocked_rate_delta_pp,
+        "non_escalated_message_ids": non_escalated_ids,
+        "baseline_non_escalated_p50_latency_seconds": baseline_p50,
+        "staged_non_escalated_p50_latency_seconds": staged_p50,
+        "latency_improvement_pct": latency_improvement_pct,
+        "thresholds": {
+            "min_agreement_rate": min_agreement_rate,
+            "min_latency_improvement_pct": min_latency_improvement_pct,
+            "max_blocked_rate_delta_pp": max_blocked_rate_delta_pp,
+        },
+        "acceptance": acceptance,
+        "passes_all_thresholds": all(acceptance.values()),
+    }
+
+
+async def run_triage_profile(
+    fixture_path: str | Path,
+    *,
+    profile: str,
+    diagnostics_root: str | Path | None = None,
+    verbose: bool = False,
+) -> ProfileRunResult:
+    messages = load_fixture_messages(fixture_path)
+    policy = AutoApprovalPolicy()
+    diagnostics_dir = Path(diagnostics_root) / profile if diagnostics_root is not None else None
+    diagnostics = TriageRunDiagnostics(
+        profile=profile,
+        batch_size=len(messages),
+        auto_approve=False,
+        dry_run=True,
+        verbose=verbose,
+        diagnostics_dir=diagnostics_dir,
+    )
+    runner = InboxTriageRunner(
+        gmail_connector=FixtureGmailConnector(messages),
+        wedge_service=BenchmarkWedgeService(policy=policy),
+        diagnostics=diagnostics,
+        profile=profile,
+    )
+
+    started = time.perf_counter()
+    with diagnostics.activate(), diagnostics.capture_logging():
+        decisions = await runner.run_triage(batch_size=len(messages), auto_approve=False)
+    elapsed = round(time.perf_counter() - started, 4)
+    meta = diagnostics.finalize(decisions)
+    summarized = [_summarize_decision(decision, policy) for decision in decisions]
+
+    return ProfileRunResult(
+        profile=profile,
+        fixture_path=str(Path(fixture_path)),
+        message_count=len(messages),
+        total_duration_seconds=elapsed,
+        diagnostics_artifact_dir=str(meta["artifact_dir"]),
+        meta=meta,
+        decisions=summarized,
+    )
+
+
+async def run_fixture_benchmark(
+    fixture_path: str | Path,
+    *,
+    diagnostics_root: str | Path | None = None,
+    verbose: bool = False,
+) -> dict[str, Any]:
+    baseline = await run_triage_profile(
+        fixture_path,
+        profile="baseline",
+        diagnostics_root=diagnostics_root,
+        verbose=verbose,
+    )
+    staged = await run_triage_profile(
+        fixture_path,
+        profile="staged_v1",
+        diagnostics_root=diagnostics_root,
+        verbose=verbose,
+    )
+    comparison = compare_profile_runs(baseline, staged)
+    return {
+        "fixture_path": str(Path(fixture_path)),
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "profiles": {
+            baseline.profile: baseline.to_dict(),
+            staged.profile: staged.to_dict(),
+        },
+        "comparison": comparison,
+    }
+
+
+def render_benchmark_report(report: dict[str, Any]) -> str:
+    comparison = report["comparison"]
+    baseline = report["profiles"]["baseline"]
+    staged = report["profiles"]["staged_v1"]
+    acceptance = comparison["acceptance"]
+    lines = [
+        "Triage Profile Benchmark",
+        f"Fixture: {report['fixture_path']}",
+        f"Messages: {comparison['message_count']}",
+        "",
+        "Profile runs:",
+        (
+            f"  baseline   duration={baseline['total_duration_seconds']:.2f}s "
+            f"blocked={baseline['meta']['blocked_count']} "
+            f"diag={baseline['meta']['suppressed_diagnostics_count']} "
+            f"artifact={baseline['diagnostics_artifact_dir']}"
+        ),
+        (
+            f"  staged_v1  duration={staged['total_duration_seconds']:.2f}s "
+            f"fast={staged['meta']['fast_tier_count']} "
+            f"escalated={staged['meta']['escalated_count']} "
+            f"blocked={staged['meta']['blocked_count']} "
+            f"diag={staged['meta']['suppressed_diagnostics_count']} "
+            f"artifact={staged['diagnostics_artifact_dir']}"
+        ),
+        "",
+        "Acceptance checks:",
+        f"  agreement_rate={comparison['agreement_rate']:.2%} pass={acceptance['decision_agreement']}",
+        (
+            "  latency_improvement_pct="
+            f"{comparison['latency_improvement_pct']} "
+            f"pass={acceptance['latency_improvement']}"
+        ),
+        (
+            f"  blocked_rate_delta_pp={comparison['blocked_rate_delta_pp']} "
+            f"pass={acceptance['blocked_rate_delta']}"
+        ),
+        (
+            f"  unsafe_auto_approval_ids={len(comparison['unsafe_auto_approval_ids'])} "
+            f"pass={acceptance['unsafe_auto_approval']}"
+        ),
+        f"Overall: {'PASS' if comparison['passes_all_thresholds'] else 'FAIL'}",
+    ]
+    return "\n".join(lines)
+
+
+__all__ = [
+    "BenchmarkWedgeService",
+    "DEFAULT_MAX_BLOCKED_RATE_DELTA_PP",
+    "DEFAULT_MIN_AGREEMENT_RATE",
+    "DEFAULT_MIN_LATENCY_IMPROVEMENT_PCT",
+    "FixtureGmailConnector",
+    "ProfileRunResult",
+    "compare_profile_runs",
+    "load_fixture_messages",
+    "render_benchmark_report",
+    "run_fixture_benchmark",
+    "run_triage_profile",
+]

--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -15,9 +15,13 @@ Usage::
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import os
 import re
+import time
 import uuid
+from contextlib import contextmanager, nullcontext, suppress
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,8 +35,22 @@ from aragora.inbox.trust_wedge import (
     compute_content_hash,
     get_inbox_trust_wedge_service,
 )
+from aragora.inbox.triage_diagnostics import (
+    DiagnosticSeverity,
+    TriageRunDiagnostics,
+    record_triage_diagnostic,
+)
 
 logger = logging.getLogger(__name__)
+
+_SUPPORTED_TRIAGE_PROFILES = {"baseline", "staged_v1"}
+_FAST_TIER_CONFIDENCE_THRESHOLD = 0.85
+_FAST_TIER_TIMEOUT_SECONDS = 12.0
+_HIGH_RISK_ACTIONS = {InboxWedgeAction.LABEL, InboxWedgeAction.STAR}
+_DEGRADED_DIAGNOSTIC_SEVERITIES = {
+    DiagnosticSeverity.BLOCKING.value,
+    DiagnosticSeverity.DEGRADED.value,
+}
 
 _ACTION_PATTERNS = {
     AllowedAction.ARCHIVE: re.compile(r"\barchiv(?:e|ed|ing)\b", re.IGNORECASE),
@@ -57,6 +75,8 @@ class _NormalizedDebateOutcome:
     dissent_summary: str
     rationale: str
     debate_id: str
+    status: str
+    parse_failed: bool
 
 
 def _result_field(debate_result: Any, field: str, default: Any = None) -> Any:
@@ -117,6 +137,74 @@ def _result_dissenting_views(debate_result: Any) -> list[str]:
     return [str(view).strip() for view in views if str(view).strip()]
 
 
+def _result_status(debate_result: Any) -> str:
+    candidates = [
+        _result_field(debate_result, "status", None),
+        _result_metadata(debate_result).get("status"),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        text = str(candidate).strip().lower()
+        if text:
+            return text
+    return ""
+
+
+def _normalize_triage_profile(profile: str | None) -> str:
+    normalized = str(profile or "baseline").strip().lower()
+    if normalized in _SUPPORTED_TRIAGE_PROFILES:
+        return normalized
+    return "baseline"
+
+
+def _result_triage_execution_metadata(debate_result: Any) -> dict[str, Any]:
+    metadata = _result_metadata(debate_result)
+    execution = metadata.get("triage_execution")
+    return dict(execution) if isinstance(execution, dict) else {}
+
+
+def _attach_triage_execution_metadata(
+    debate_result: Any,
+    *,
+    execution_tier: str,
+    escalation_reasons: list[str] | None = None,
+    profile: str | None = None,
+) -> Any:
+    execution = _result_triage_execution_metadata(debate_result)
+    execution["execution_tier"] = execution_tier
+    execution["escalation_reasons"] = list(escalation_reasons or [])
+    if profile:
+        execution["profile"] = profile
+
+    if isinstance(debate_result, dict):
+        metadata = debate_result.get("metadata")
+        if not isinstance(metadata, dict):
+            metadata = {}
+            debate_result["metadata"] = metadata
+        metadata["triage_execution"] = execution
+        return debate_result
+
+    metadata = dict(_result_metadata(debate_result))
+    metadata["triage_execution"] = execution
+    try:
+        setattr(debate_result, "metadata", metadata)
+    except (AttributeError, TypeError):
+        pass
+    return debate_result
+
+
+def _is_blocked_status(status: str) -> bool:
+    return status in {
+        "blocked",
+        "error",
+        "failed",
+        "insufficient_participation",
+        "runtime_error",
+        "timeout",
+    }
+
+
 def _parse_action_from_rationale(rationale: str) -> tuple[InboxWedgeAction, bool]:
     normalized = rationale.strip().lower()
     if not normalized:
@@ -141,18 +229,29 @@ def _normalize_debate_outcome(debate_result: Any) -> _NormalizedDebateOutcome:
     consensus_reached = _result_consensus_reached(debate_result, rationale)
     debate_id = _result_debate_id(debate_result)
     dissenting_views = _result_dissenting_views(debate_result)
+    status = _result_status(debate_result)
     final_action, parse_failed = _parse_action_from_rationale(rationale)
 
     reasons: list[str] = []
     if not consensus_reached:
         reasons.append("No consensus reached; manual review required.")
+    if status == "insufficient_participation":
+        reasons.append(
+            "Debate quorum failed; showing a blocked recommendation pending human review."
+        )
+    elif _is_blocked_status(status):
+        reasons.append(f"Debate ended in {status.replace('_', ' ')}; manual review required.")
     if parse_failed:
         if rationale.strip():
             reasons.append(
-                "Could not map the debate answer to a single inbox action; fell back to ignore."
+                "Could not map the debate answer to a single inbox action; showing a blocked recommendation."
             )
         else:
-            reasons.append("Debate returned no final answer; fell back to ignore.")
+            reasons.append(
+                "Debate returned no actionable final answer; showing a blocked recommendation."
+            )
+    if confidence <= 0.0 and not rationale.strip():
+        reasons.append("No confident recommendation was produced.")
     if dissenting_views:
         reasons.append(f"Dissent: {'; '.join(dissenting_views[:3])}")
 
@@ -163,10 +262,12 @@ def _normalize_debate_outcome(debate_result: Any) -> _NormalizedDebateOutcome:
         dissent_summary=" ".join(reasons).strip(),
         rationale=rationale,
         debate_id=debate_id,
+        status=status,
+        parse_failed=parse_failed,
     )
 
 
-def _create_triage_agents() -> list[Any]:
+def _create_triage_agents(*, max_agents: int | None = None) -> list[Any]:
     """Create agents for triage debates.
 
     Prefers cheap, fast models:
@@ -179,41 +280,102 @@ def _create_triage_agents() -> list[Any]:
     from aragora.agents.base import create_agent
 
     agents: list[Any] = []
-    if os.environ.get("ANTHROPIC_API_KEY"):
+    providers_used: set[str] = set()
+
+    def _append_agent(
+        provider: str,
+        *,
+        name: str,
+        role: str,
+        model: str | None = None,
+    ) -> None:
         try:
-            agents.append(
-                create_agent(
-                    "anthropic-api",
-                    name="triage-proposer",
-                    role="proposer",
-                    model="claude-haiku-4-5-20251001",
-                )
-            )
+            kwargs: dict[str, Any] = {
+                "name": name,
+                "role": role,
+            }
+            if model is not None:
+                kwargs["model"] = model
+            agents.append(create_agent(provider, **kwargs))
+            providers_used.add(provider)
         except (ImportError, RuntimeError, ValueError, OSError):
-            pass
+            logger.debug("Triage agent unavailable: provider=%s role=%s", provider, role)
+
+    if os.environ.get("OPENAI_API_KEY"):
+        _append_agent(
+            "openai-api",
+            name="triage-proposer",
+            role="proposer",
+            model="gpt-4.1-mini",
+        )
+    elif os.environ.get("ANTHROPIC_API_KEY"):
+        _append_agent(
+            "anthropic-api",
+            name="triage-proposer",
+            role="proposer",
+            model="claude-haiku-4-5-20251001",
+        )
 
     if os.environ.get("OPENROUTER_API_KEY"):
-        try:
-            agents.append(
-                create_agent(
-                    "openrouter",
-                    name="triage-critic",
-                    role="critic",
-                    model="deepseek/deepseek-chat",
-                )
-            )
-        except (ImportError, RuntimeError, ValueError, OSError):
-            pass
+        _append_agent(
+            "openrouter",
+            name="triage-critic",
+            role="critic",
+            model="deepseek/deepseek-chat",
+        )
+    elif os.environ.get("OPENAI_API_KEY"):
+        _append_agent(
+            "openai-api",
+            name="triage-critic",
+            role="critic",
+            model="gpt-4.1-mini",
+        )
+    elif os.environ.get("ANTHROPIC_API_KEY"):
+        _append_agent(
+            "anthropic-api",
+            name="triage-critic",
+            role="critic",
+            model="claude-haiku-4-5-20251001",
+        )
 
-    # Fallback: try OpenAI if still short
-    if len(agents) < 2 and os.environ.get("OPENAI_API_KEY"):
-        role = "critic" if agents else "proposer"
-        try:
-            agents.append(create_agent("openai-api", name=f"triage-{role}", role=role))
-        except (ImportError, RuntimeError, ValueError, OSError):
-            logger.debug("OpenAI triage fallback unavailable")
+    if os.environ.get("ANTHROPIC_API_KEY") and "anthropic-api" not in providers_used:
+        _append_agent(
+            "anthropic-api",
+            name="triage-reviewer",
+            role="synthesizer",
+            model="claude-haiku-4-5-20251001",
+        )
+    elif os.environ.get("OPENAI_API_KEY") and len(agents) < 2:
+        _append_agent(
+            "openai-api",
+            name="triage-reviewer",
+            role="synthesizer",
+            model="gpt-4.1-mini",
+        )
 
+    if max_agents is not None:
+        return agents[:max_agents]
     return agents
+
+
+def _attach_display_metadata(intent: ActionIntent, msg: dict[str, Any], body: str) -> None:
+    """Attach non-persisted email display metadata for CLI summaries."""
+    intent._subject = msg.get("subject", "(no subject)")  # type: ignore[attr-defined]
+    intent._sender = msg.get("from_address", msg.get("sender", "(unknown)"))  # type: ignore[attr-defined]
+    intent._snippet = msg.get("snippet", body[:120])  # type: ignore[attr-defined]
+
+
+@contextmanager
+def _set_env_if_missing(key: str, value: str):
+    """Temporarily set an environment variable only when unset."""
+    existed = key in os.environ
+    if not existed:
+        os.environ[key] = value
+    try:
+        yield
+    finally:
+        if not existed:
+            os.environ.pop(key, None)
 
 
 class InboxTriageRunner:
@@ -235,10 +397,14 @@ class InboxTriageRunner:
         gmail_connector: Any | None = None,
         auto_approval_policy: AutoApprovalPolicy | None = None,
         wedge_service: Any | None = None,
+        diagnostics: TriageRunDiagnostics | None = None,
+        profile: str | None = None,
     ) -> None:
         self._gmail = gmail_connector
         self._policy = auto_approval_policy or AutoApprovalPolicy()
         self._wedge_service = wedge_service or get_inbox_trust_wedge_service()
+        self._diagnostics = diagnostics
+        self._profile = _normalize_triage_profile(profile or os.getenv("ARAGORA_TRIAGE_PROFILE"))
         self._triaged: list[TriageDecision] = []
 
     @property
@@ -339,12 +505,41 @@ class InboxTriageRunner:
         auto_approve: bool = False,
     ) -> TriageDecision:
         """Run debate and build a TriageDecision for a single message."""
+        started = time.perf_counter()
         message_id = msg.get("id", str(uuid.uuid4()))
         body = msg.get("body_text", msg.get("body", msg.get("snippet", "")))
         content_hash = compute_content_hash(body)
+        scope = self._diagnostics.message_scope(message_id) if self._diagnostics else nullcontext()
 
-        debate_result = await self._run_debate(msg)
-        normalized = _normalize_debate_outcome(debate_result)
+        with scope:
+            debate_result = await self._run_debate(msg)
+            normalized = _normalize_debate_outcome(debate_result)
+            execution_metadata = _result_triage_execution_metadata(debate_result)
+            execution_tier = str(execution_metadata.get("execution_tier", "baseline"))
+            escalation_reasons = [
+                str(reason)
+                for reason in execution_metadata.get("escalation_reasons", [])
+                if str(reason).strip()
+            ]
+            diagnostics_summary = (
+                self._diagnostics.get_message_summary(message_id)
+                if self._diagnostics
+                else {"total": 0}
+            )
+            final_tier_summary = (
+                self._diagnostics.get_message_summary(message_id, tier=execution_tier)
+                if self._diagnostics
+                else {
+                    DiagnosticSeverity.BLOCKING.value: 0,
+                    DiagnosticSeverity.DEGRADED.value: 0,
+                    DiagnosticSeverity.DIAGNOSTIC.value: 0,
+                    "total": 0,
+                }
+            )
+            degraded_final_diagnostics = any(
+                final_tier_summary.get(severity, 0) > 0
+                for severity in _DEGRADED_DIAGNOSTIC_SEVERITIES
+            )
         provider = (
             getattr(self._gmail, "connector_id", "gmail") if self._gmail is not None else "gmail"
         )
@@ -361,10 +556,7 @@ class InboxTriageRunner:
             debate_id=normalized.debate_id,
             user_id=user_id,
         )
-        # Attach email metadata for CLI display (private attrs)
-        intent._subject = msg.get("subject", "(no subject)")  # type: ignore[attr-defined]
-        intent._sender = msg.get("from_address", msg.get("sender", "(unknown)"))  # type: ignore[attr-defined]
-        intent._snippet = msg.get("snippet", body[:120])  # type: ignore[attr-defined]
+        _attach_display_metadata(intent, msg, body)
 
         decision = TriageDecision(
             final_action=normalized.final_action,
@@ -373,7 +565,10 @@ class InboxTriageRunner:
             auto_approval_eligible=False,
             provider_route="direct",
             intent=intent,
-            blocked_by_policy=bool(normalized.dissent_summary),
+            blocked_by_policy=bool(normalized.dissent_summary) or degraded_final_diagnostics,
+            execution_tier=execution_tier,
+            escalation_reasons=escalation_reasons,
+            suppressed_diagnostics_count=int(diagnostics_summary.get("total", 0)),
         )
 
         should_auto_approve = auto_approve and self._policy.can_auto_approve(decision)
@@ -388,14 +583,156 @@ class InboxTriageRunner:
         decision.receipt_state = envelope.receipt.state.value
         decision.provider_route = envelope.provider_route
         decision.label_id = envelope.intent.label_id or decision.label_id
+        decision.execution_tier = execution_tier
+        decision.escalation_reasons = escalation_reasons
+        decision.suppressed_diagnostics_count = int(diagnostics_summary.get("total", 0))
+        decision.blocked_by_policy = bool(normalized.dissent_summary) or degraded_final_diagnostics
+        decision.latency_seconds = time.perf_counter() - started
+        _attach_display_metadata(decision.intent, msg, body)
 
         return decision
 
     async def _run_debate(self, msg: dict[str, Any]) -> Any:
+        message_id = str(msg.get("id", ""))
+        if self._profile == "staged_v1":
+            fast_task = asyncio.create_task(
+                self._run_debate_once(
+                    msg,
+                    tier="fast",
+                    rounds=1,
+                    max_agents=2,
+                )
+            )
+            try:
+                fast_result = await asyncio.wait_for(
+                    fast_task,
+                    timeout=_FAST_TIER_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                fast_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await fast_task
+                record_triage_diagnostic(
+                    code="fast_tier_timeout",
+                    severity=DiagnosticSeverity.BLOCKING,
+                    logger_name=__name__,
+                    summary="Fast-tier triage debate exceeded its time budget; returning blocked result.",
+                    details=f"timeout_seconds={_FAST_TIER_TIMEOUT_SECONDS}",
+                    message_id=message_id or None,
+                    tier="fast",
+                )
+                fast_result = {
+                    "final_answer": "",
+                    "confidence": 0.0,
+                    "debate_id": f"timeout-{uuid.uuid4().hex[:8]}",
+                    "status": "timeout",
+                }
+            fast_result = _attach_triage_execution_metadata(
+                fast_result,
+                execution_tier="fast",
+                escalation_reasons=[],
+                profile=self._profile,
+            )
+            fast_outcome = _normalize_debate_outcome(fast_result)
+            fast_summary = (
+                self._diagnostics.get_message_summary(message_id, tier="fast")
+                if self._diagnostics
+                else {
+                    DiagnosticSeverity.BLOCKING.value: 0,
+                    DiagnosticSeverity.DEGRADED.value: 0,
+                    DiagnosticSeverity.DIAGNOSTIC.value: 0,
+                    "total": 0,
+                }
+            )
+            truthful_stop_reasons: list[str] = []
+            if fast_outcome.status == "timeout":
+                truthful_stop_reasons.append("fast_timeout")
+            elif _is_blocked_status(fast_outcome.status):
+                truthful_stop_reasons.append("blocked_status")
+            if not fast_outcome.consensus_reached:
+                truthful_stop_reasons.append("no_consensus")
+            if fast_outcome.parse_failed:
+                truthful_stop_reasons.append("parse_failed")
+
+            if truthful_stop_reasons:
+                record_triage_diagnostic(
+                    code="fast_tier_truthful_stop",
+                    severity=DiagnosticSeverity.BLOCKING,
+                    logger_name=__name__,
+                    summary="Fast-tier triage result was non-decisive; returning blocked result.",
+                    details=", ".join(truthful_stop_reasons),
+                    message_id=message_id or None,
+                    tier="fast",
+                )
+                return _attach_triage_execution_metadata(
+                    fast_result,
+                    execution_tier="fast",
+                    escalation_reasons=truthful_stop_reasons,
+                    profile=self._profile,
+                )
+
+            escalation_reasons: list[str] = []
+            if fast_outcome.confidence < _FAST_TIER_CONFIDENCE_THRESHOLD:
+                escalation_reasons.append("low_confidence")
+            if fast_outcome.final_action in _HIGH_RISK_ACTIONS:
+                escalation_reasons.append("high_risk_action")
+            if any(
+                fast_summary.get(severity, 0) > 0 for severity in _DEGRADED_DIAGNOSTIC_SEVERITIES
+            ):
+                escalation_reasons.append("diagnostic_degraded")
+
+            if not escalation_reasons:
+                return fast_result
+
+            record_triage_diagnostic(
+                code="fast_tier_escalation",
+                severity=DiagnosticSeverity.DIAGNOSTIC,
+                logger_name=__name__,
+                summary="Escalating triage decision to full review tier.",
+                details=", ".join(escalation_reasons),
+                message_id=message_id or None,
+                tier="fast",
+            )
+
+            escalated_result = await self._run_debate_once(
+                msg,
+                tier="escalated",
+                rounds=2,
+                max_agents=None,
+            )
+            return _attach_triage_execution_metadata(
+                escalated_result,
+                execution_tier="escalated",
+                escalation_reasons=escalation_reasons,
+                profile=self._profile,
+            )
+
+        baseline_result = await self._run_debate_once(
+            msg,
+            tier="baseline",
+            rounds=2,
+            max_agents=None,
+        )
+        return _attach_triage_execution_metadata(
+            baseline_result,
+            execution_tier="baseline",
+            escalation_reasons=[],
+            profile=self._profile,
+        )
+
+    async def _run_debate_once(
+        self,
+        msg: dict[str, Any],
+        *,
+        tier: str,
+        rounds: int,
+        max_agents: int | None,
+    ) -> Any:
         """Run an adversarial debate on a message.
 
-        Attempts to use the Arena with API agents. Falls back to a stub
-        result if the debate engine or agents are unavailable.
+        Attempts to use the Arena with API agents. When debate infrastructure
+        is unavailable or quorum fails, returns a blocked result rather than a
+        silent IGNORE recommendation.
         """
         subject = msg.get("subject", "(no subject)")
         sender = msg.get("from_address", msg.get("sender", "(unknown)"))
@@ -409,42 +746,82 @@ class InboxTriageRunner:
             "Your final answer MUST begin with the action word "
             "(archive, star, label, or ignore) followed by your reasoning."
         )
+        tier_scope = self._diagnostics.tier_scope(tier) if self._diagnostics else nullcontext()
 
-        try:
-            from aragora.core import Environment
-            from aragora.debate.orchestrator import Arena
-            from aragora.debate.protocol import DebateProtocol
+        with tier_scope:
+            try:
+                from aragora.core import Environment
+                from aragora.debate.orchestrator import Arena
+                from aragora.debate.protocol import DebateProtocol
 
-            env = Environment(task=question)
-            protocol = DebateProtocol(rounds=2, consensus="majority")
-
-            agents = _create_triage_agents()
-
-            if len(agents) < 2:
-                logger.warning(
-                    "%d triage agents available (need 2); using stub debate", len(agents)
+                env = Environment(task=question)
+                protocol = DebateProtocol(
+                    rounds=rounds,
+                    consensus="majority",
+                    enable_research=False,
+                    enable_trickster=False,
+                    role_rotation=False,
+                    role_matching=False,
                 )
+
+                record_triage_diagnostic(
+                    code="research_disabled_for_profile",
+                    severity=DiagnosticSeverity.DIAGNOSTIC,
+                    logger_name=__name__,
+                    summary="Research is disabled for inbox triage execution.",
+                    details=f"profile={self._profile} tier={tier}",
+                    once_key=f"research_disabled:{self._profile}:{tier}",
+                    tier=tier,
+                )
+
+                if max_agents is None:
+                    agents = _create_triage_agents()
+                else:
+                    agents = _create_triage_agents(max_agents=max_agents)
+
+                if len(agents) < 2:
+                    logger.warning(
+                        "%d triage agents available (need 2); returning blocked triage result",
+                        len(agents),
+                    )
+                    return {
+                        "final_answer": "",
+                        "confidence": 0.0,
+                        "debate_id": f"no-agents-{uuid.uuid4().hex[:8]}",
+                        "status": "insufficient_participation",
+                    }
+                with _set_env_if_missing("ARAGORA_DISABLE_TRENDING", "true"):
+                    arena = Arena(
+                        env,
+                        agents=agents,
+                        protocol=protocol,
+                        enable_knowledge_retrieval=False,
+                        disable_post_debate_pipeline=True,
+                    )
+                    result = await arena.run()
+                    debate_scope = (
+                        self._diagnostics.debate_scope(_result_debate_id(result))
+                        if self._diagnostics
+                        else nullcontext()
+                    )
+                    with debate_scope:
+                        return result
+            except ImportError:
+                logger.debug("Debate engine not available; returning blocked triage result")
                 return {
-                    "final_answer": "ignore",
+                    "final_answer": "",
                     "confidence": 0.0,
-                    "debate_id": f"no-agents-{uuid.uuid4().hex[:8]}",
+                    "debate_id": f"stub-{uuid.uuid4().hex[:8]}",
+                    "status": "insufficient_participation",
                 }
-            arena = Arena(env, agents=agents, protocol=protocol)
-            return await arena.run()
-        except ImportError:
-            logger.debug("Debate engine not available; using stub result")
-            return {
-                "final_answer": "ignore",
-                "confidence": 0.5,
-                "debate_id": f"stub-{uuid.uuid4().hex[:8]}",
-            }
-        except (RuntimeError, OSError, ValueError, TypeError) as exc:
-            logger.warning("Debate failed, falling back to ignore: %s", exc)
-            return {
-                "final_answer": "ignore",
-                "confidence": 0.0,
-                "debate_id": f"err-{uuid.uuid4().hex[:8]}",
-            }
+            except (RuntimeError, OSError, ValueError, TypeError) as exc:
+                logger.warning("Debate failed, returning blocked triage result: %s", exc)
+                return {
+                    "final_answer": "",
+                    "confidence": 0.0,
+                    "debate_id": f"err-{uuid.uuid4().hex[:8]}",
+                    "status": "failed",
+                }
 
     async def _execute_action(self, decision: TriageDecision) -> None:
         """Execute an approved triage action via the Gmail connector.

--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -24,7 +24,7 @@ import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
@@ -250,6 +250,9 @@ class TriageDecision:
     blocked_by_policy: bool = False
     cost_usd: float | None = None
     latency_seconds: float | None = None
+    execution_tier: str = "baseline"
+    escalation_reasons: list[str] = field(default_factory=list)
+    suppressed_diagnostics_count: int = 0
 
     @classmethod
     def create(
@@ -267,6 +270,9 @@ class TriageDecision:
         blocked_by_policy: bool = False,
         cost_usd: float | None = None,
         latency_seconds: float | None = None,
+        execution_tier: str = "baseline",
+        escalation_reasons: list[str] | None = None,
+        suppressed_diagnostics_count: int = 0,
     ) -> TriageDecision:
         return cls(
             final_action=InboxWedgeAction.parse(final_action),
@@ -281,6 +287,9 @@ class TriageDecision:
             blocked_by_policy=blocked_by_policy,
             cost_usd=cost_usd,
             latency_seconds=latency_seconds,
+            execution_tier=execution_tier,
+            escalation_reasons=list(escalation_reasons or []),
+            suppressed_diagnostics_count=int(suppressed_diagnostics_count),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -298,6 +307,9 @@ class TriageDecision:
             "blocked_by_policy": self.blocked_by_policy,
             "cost_usd": self.cost_usd,
             "latency_seconds": self.latency_seconds,
+            "execution_tier": self.execution_tier,
+            "escalation_reasons": list(self.escalation_reasons),
+            "suppressed_diagnostics_count": self.suppressed_diagnostics_count,
         }
         if self.intent is not None:
             result["intent"] = self.intent.to_dict()

--- a/aragora/server/research_phase.py
+++ b/aragora/server/research_phase.py
@@ -201,6 +201,10 @@ class PreDebateResearcher:
             logger.warning(
                 "[research] Anthropic generation failed (%s), falling back to OpenRouter",
                 type(e).__name__,
+                extra={
+                    "triage_diag_code": "provider_fallback",
+                    "triage_diag_severity": "degraded",
+                },
             )
             return await asyncio.wait_for(
                 fallback_agent.generate(prompt),

--- a/aragora/storage/connection_factory.py
+++ b/aragora/storage/connection_factory.py
@@ -491,7 +491,8 @@ def create_persistent_store(
         asyncio.get_running_loop()
         in_async_context = True
     except RuntimeError as e:
-        logger.warning("connection_factory operation failed: %s", e)
+        if "no running event loop" not in str(e).lower():
+            logger.warning("connection_factory operation failed: %s", e)
 
     # Determine if SQLite is allowed (not in production unless explicitly allowed)
     allow_sqlite = not is_production_environment()

--- a/scripts/benchmark_triage_profiles.py
+++ b/scripts/benchmark_triage_profiles.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Benchmark inbox-triage baseline vs staged_v1 on a fixed fixture set."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from aragora.inbox.triage_profile_benchmark import render_benchmark_report, run_fixture_benchmark
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare baseline and staged_v1 inbox-triage profiles on a fixed message set.",
+    )
+    parser.add_argument(
+        "--fixtures",
+        type=Path,
+        required=True,
+        help="Path to a JSON array of fixture messages.",
+    )
+    parser.add_argument(
+        "--diagnostics-dir",
+        type=Path,
+        help="Optional root directory for per-profile diagnostics artifacts.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path to write the full JSON benchmark report.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Mirror captured diagnostics inline while benchmarking.",
+    )
+    parser.add_argument(
+        "--fail-on-thresholds",
+        action="store_true",
+        help="Exit 1 when the staged profile misses any acceptance threshold.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    report = asyncio.run(
+        run_fixture_benchmark(
+            args.fixtures,
+            diagnostics_root=args.diagnostics_dir,
+            verbose=args.verbose,
+        )
+    )
+
+    print(render_benchmark_report(report))
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+        print(f"\nReport written to {args.output}")
+
+    if args.fail_on_thresholds and not report["comparison"]["passes_all_thresholds"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from aragora.cli.commands import triage as triage_cmd
+from aragora.inbox.triage_diagnostics import DiagnosticSeverity, record_triage_diagnostic
 from aragora.inbox.trust_wedge import InboxWedgeAction, TriageDecision
 
 
@@ -29,13 +31,14 @@ def test_add_triage_parser_supports_auth_and_dry_run():
 
 
 @pytest.mark.asyncio
-async def test_run_triage_uses_receipt_review_loop():
+async def test_run_triage_uses_receipt_review_loop(tmp_path, monkeypatch):
     decision = TriageDecision.create(
         final_action="ignore",
         confidence=0.4,
         dissent_summary="",
         receipt_id="receipt-1",
     )
+    monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
     fake_runner = SimpleNamespace(run_triage=AsyncMock(return_value=[decision]))
     fake_service = SimpleNamespace(review_receipt=object())
     captured: dict[str, object] = {}
@@ -70,13 +73,14 @@ async def test_run_triage_uses_receipt_review_loop():
 
 
 @pytest.mark.asyncio
-async def test_run_triage_dry_run_disables_action_execution(capsys):
+async def test_run_triage_dry_run_disables_action_execution(capsys, tmp_path, monkeypatch):
     decision = TriageDecision.create(
         final_action="archive",
         confidence=0.92,
         dissent_summary="",
         receipt_id="receipt-2",
     )
+    monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
     fake_runner = SimpleNamespace(run_triage=AsyncMock(return_value=[decision]))
     fake_service = SimpleNamespace(review_receipt=object())
 
@@ -98,6 +102,50 @@ async def test_run_triage_dry_run_disables_action_execution(capsys):
     assert "[DRY RUN] Fetching up to 2 unread messages" in out
     assert "[DRY RUN] Proposed triage decisions" in out
     assert "archive" in out
+    assert "Run summary:" in out
+
+
+@pytest.mark.asyncio
+async def test_run_triage_footer_shows_diagnostics_path(capsys, tmp_path, monkeypatch):
+    decision = TriageDecision.create(
+        final_action="archive",
+        confidence=0.92,
+        dissent_summary="",
+        receipt_id="receipt-3",
+    )
+    monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
+
+    async def _run_triage(*, batch_size, auto_approve):
+        record_triage_diagnostic(
+            code="provider_fallback",
+            severity=DiagnosticSeverity.DEGRADED,
+            logger_name="aragora.server.research_phase",
+            summary="Fallback to OpenRouter",
+            tier="baseline",
+        )
+        return [decision]
+
+    fake_runner = SimpleNamespace(run_triage=AsyncMock(side_effect=_run_triage))
+    fake_service = SimpleNamespace(review_receipt=object())
+
+    with (
+        patch.object(triage_cmd, "_get_gmail_connector", return_value=object()),
+        patch("aragora.inbox.triage_runner.InboxTriageRunner", return_value=fake_runner),
+        patch(
+            "aragora.inbox.trust_wedge.get_inbox_trust_wedge_service",
+            return_value=fake_service,
+        ),
+    ):
+        await triage_cmd._run_triage(batch_size=1, auto_approve=True, dry_run=True)
+
+    out = capsys.readouterr().out
+    assert "Run summary:" in out
+    assert "Diagnostics:" in out
+    diag_root = tmp_path / "triage-runs"
+    meta_files = list(diag_root.glob("*/meta.json"))
+    assert len(meta_files) == 1
+    meta = json.loads(meta_files[0].read_text())
+    assert meta["severity_counts"]["degraded"] == 1
 
 
 def test_print_decisions_formats_enum_values(capsys):
@@ -114,6 +162,35 @@ def test_print_decisions_formats_enum_values(capsys):
     out = capsys.readouterr().out
     assert "ignore" in out
     assert "InboxWedgeAction" not in out
+    assert "created" in out
+
+
+def test_print_decisions_shows_blocked_status_for_truthful_stop(capsys):
+    decision = TriageDecision.create(
+        final_action=InboxWedgeAction.IGNORE,
+        confidence=0.0,
+        dissent_summary="Debate quorum failed.",
+        receipt_id="receipt-blocked",
+        blocked_by_policy=True,
+    )
+    decision.intent = SimpleNamespace(_subject="Blocked subject")
+
+    triage_cmd._print_decisions([decision])
+
+    out = capsys.readouterr().out
+    assert "blocked" in out
+    assert "Blocked subject" in out
+
+
+@pytest.mark.asyncio
+async def test_initialize_triage_storage_bootstraps_shared_pool():
+    with patch(
+        "aragora.server.startup.database.init_postgres_pool",
+        AsyncMock(return_value={"enabled": True}),
+    ) as mocked:
+        await triage_cmd._initialize_triage_storage()
+
+    mocked.assert_awaited_once()
 
 
 def test_get_gmail_connector_loads_refresh_token_from_home_file(tmp_path, monkeypatch):

--- a/tests/fixtures/inbox/triage_profile_eval_sample.json
+++ b/tests/fixtures/inbox/triage_profile_eval_sample.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "msg-newsletter",
+    "subject": "Weekly product digest",
+    "from_address": "news@example.com",
+    "snippet": "This week in AI, product launches, and new features.",
+    "body_text": "Welcome to the weekly digest. This edition covers launches, pricing updates, and unsubscribe options."
+  },
+  {
+    "id": "msg-founder-intro",
+    "subject": "Intro from a design partner candidate",
+    "from_address": "founder@startup.io",
+    "snippet": "We might want to try Aragora on our shared inbox.",
+    "body_text": "Hi, we run a shared support inbox and want to test Aragora on real customer escalation mail. Are you open to a quick call next week?"
+  },
+  {
+    "id": "msg-invoice",
+    "subject": "Invoice 2026-031 for March services",
+    "from_address": "billing@vendor.io",
+    "snippet": "Invoice attached. Payment due April 1.",
+    "body_text": "Please see attached invoice 2026-031 for your March retainer. Payment is due April 1. Reply if you need a revised PO."
+  },
+  {
+    "id": "msg-legal",
+    "subject": "Urgent: review exclusivity language",
+    "from_address": "counsel@lawfirm.com",
+    "snippet": "Need founder review on contract wording.",
+    "body_text": "We need your review today on the exclusivity language in the proposed partner agreement. The current wording creates a broader restriction than we discussed."
+  }
+]

--- a/tests/inbox/test_triage_diagnostics.py
+++ b/tests/inbox/test_triage_diagnostics.py
@@ -1,0 +1,140 @@
+"""Tests for triage-scoped diagnostics capture."""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import warnings
+
+from aragora.inbox.triage_diagnostics import TriageRunDiagnostics
+
+
+def _root_logger_with_stream():
+    root = logging.getLogger()
+    stream = io.StringIO()
+    handler = logging.StreamHandler(stream)
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+    previous_level = root.level
+    root.setLevel(logging.WARNING)
+    return root, handler, stream, previous_level
+
+
+def test_capture_logging_suppresses_targeted_warning_and_records_event(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="baseline",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    root, handler, stream, previous_level = _root_logger_with_stream()
+    try:
+        with (
+            diagnostics.activate(),
+            diagnostics.capture_logging(),
+            diagnostics.message_scope("msg-1"),
+        ):
+            logging.getLogger("aragora.debate.phases.vote_collector").error(
+                "vote_error agent=triage-proposer error=vote returned None",
+                extra={
+                    "triage_diag_code": "vote_none",
+                    "triage_diag_severity": "degraded",
+                },
+            )
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+    assert stream.getvalue() == ""
+    events = [json.loads(line) for line in diagnostics.events_path.read_text().splitlines() if line]
+    assert len(events) == 1
+    assert events[0]["code"] == "vote_none"
+    assert events[0]["severity"] == "degraded"
+    assert events[0]["message_id"] == "msg-1"
+
+
+def test_capture_logging_mirrors_targeted_warning_in_verbose_mode(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="baseline",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=True,
+        diagnostics_dir=tmp_path,
+    )
+    root, handler, stream, previous_level = _root_logger_with_stream()
+    try:
+        with diagnostics.activate(), diagnostics.capture_logging():
+            logging.getLogger("aragora.server.research_phase").warning(
+                "[research] Anthropic generation failed (BadRequestError), falling back to OpenRouter",
+                extra={
+                    "triage_diag_code": "provider_fallback",
+                    "triage_diag_severity": "degraded",
+                },
+            )
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+    assert "falling back to OpenRouter" in stream.getvalue()
+    events = [json.loads(line) for line in diagnostics.events_path.read_text().splitlines() if line]
+    assert events[0]["code"] == "provider_fallback"
+
+
+def test_capture_logging_records_resource_warning_artifact(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="baseline",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    root, handler, stream, previous_level = _root_logger_with_stream()
+    try:
+        with (
+            diagnostics.activate(),
+            diagnostics.capture_logging(),
+            diagnostics.message_scope("msg-2"),
+        ):
+            warnings.warn("unclosed transport while testing", ResourceWarning)
+    finally:
+        root.removeHandler(handler)
+        root.setLevel(previous_level)
+
+    assert stream.getvalue() == ""
+    events = [json.loads(line) for line in diagnostics.events_path.read_text().splitlines() if line]
+    assert events[0]["code"] == "resource_warning"
+    assert events[0]["message_id"] == "msg-2"
+
+
+def test_finalize_writes_meta_and_event_artifacts(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=2,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    with diagnostics.activate(), diagnostics.message_scope("msg-3"):
+        diagnostics.record_event(
+            code="slow_round",
+            severity="diagnostic",
+            logger_name="aragora.debate.performance_monitor",
+            summary="slow_round_detected debate_id=debate-3 round=1",
+            details="threshold=30.0",
+            tier="fast",
+        )
+
+    meta = diagnostics.finalize([])
+    assert diagnostics.meta_path.exists()
+    assert diagnostics.events_path.exists()
+    written_meta = json.loads(diagnostics.meta_path.read_text())
+    assert written_meta["profile"] == "staged_v1"
+    assert written_meta["artifact_dir"] == str(diagnostics.artifact_dir)
+    assert meta["severity_counts"]["diagnostic"] == 1

--- a/tests/inbox/test_triage_profile_benchmark.py
+++ b/tests/inbox/test_triage_profile_benchmark.py
@@ -1,0 +1,172 @@
+"""Tests for triage profile benchmark comparison logic."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from aragora.inbox.triage_profile_benchmark import (
+    ProfileRunResult,
+    compare_profile_runs,
+    load_fixture_messages,
+)
+
+
+def _make_run(
+    *,
+    profile: str,
+    decisions: list[dict[str, object]],
+) -> ProfileRunResult:
+    return ProfileRunResult(
+        profile=profile,
+        fixture_path="fixtures.json",
+        message_count=len(decisions),
+        total_duration_seconds=1.0,
+        diagnostics_artifact_dir=f"/tmp/{profile}",
+        meta={
+            "blocked_count": sum(1 for item in decisions if item["blocked_by_policy"]),
+            "suppressed_diagnostics_count": sum(
+                int(item.get("suppressed_diagnostics_count", 0)) for item in decisions
+            ),
+            "fast_tier_count": sum(1 for item in decisions if item["execution_tier"] == "fast"),
+            "escalated_count": sum(
+                1 for item in decisions if item["execution_tier"] == "escalated"
+            ),
+            "artifact_dir": f"/tmp/{profile}",
+        },
+        decisions=decisions,
+    )
+
+
+def test_load_fixture_messages_reads_sample_fixture() -> None:
+    fixture = (
+        Path(__file__).resolve().parent.parent
+        / "fixtures"
+        / "inbox"
+        / "triage_profile_eval_sample.json"
+    )
+    messages = load_fixture_messages(fixture)
+
+    assert len(messages) == 4
+    assert messages[0]["id"] == "msg-newsletter"
+    assert messages[1]["from_address"] == "founder@startup.io"
+
+
+def test_compare_profile_runs_accepts_clean_staged_result() -> None:
+    baseline = _make_run(
+        profile="baseline",
+        decisions=[
+            {
+                "message_id": "m1",
+                "subject": "One",
+                "final_action": "archive",
+                "blocked_by_policy": False,
+                "execution_tier": "baseline",
+                "latency_seconds": 10.0,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+            {
+                "message_id": "m2",
+                "subject": "Two",
+                "final_action": "ignore",
+                "blocked_by_policy": False,
+                "execution_tier": "baseline",
+                "latency_seconds": 8.0,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+        ],
+    )
+    staged = _make_run(
+        profile="staged_v1",
+        decisions=[
+            {
+                "message_id": "m1",
+                "subject": "One",
+                "final_action": "archive",
+                "blocked_by_policy": False,
+                "execution_tier": "fast",
+                "latency_seconds": 4.0,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+            {
+                "message_id": "m2",
+                "subject": "Two",
+                "final_action": "ignore",
+                "blocked_by_policy": False,
+                "execution_tier": "fast",
+                "latency_seconds": 4.0,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+        ],
+    )
+
+    comparison = compare_profile_runs(baseline, staged)
+
+    assert comparison["agreement_rate"] == 1.0
+    assert comparison["latency_improvement_pct"] == 55.56
+    assert comparison["blocked_rate_delta_pp"] == 0.0
+    assert comparison["unsafe_auto_approval_ids"] == []
+    assert comparison["passes_all_thresholds"] is True
+
+
+def test_compare_profile_runs_flags_unsafe_and_regressed_staged_result() -> None:
+    baseline = _make_run(
+        profile="baseline",
+        decisions=[
+            {
+                "message_id": "m1",
+                "subject": "One",
+                "final_action": "archive",
+                "blocked_by_policy": True,
+                "execution_tier": "baseline",
+                "latency_seconds": 10.0,
+                "auto_approval_candidate": False,
+                "suppressed_diagnostics_count": 0,
+            },
+            {
+                "message_id": "m2",
+                "subject": "Two",
+                "final_action": "ignore",
+                "blocked_by_policy": False,
+                "execution_tier": "baseline",
+                "latency_seconds": 7.0,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+        ],
+    )
+    staged = _make_run(
+        profile="staged_v1",
+        decisions=[
+            {
+                "message_id": "m1",
+                "subject": "One",
+                "final_action": "archive",
+                "blocked_by_policy": False,
+                "execution_tier": "fast",
+                "latency_seconds": 9.5,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+            {
+                "message_id": "m2",
+                "subject": "Two",
+                "final_action": "star",
+                "blocked_by_policy": False,
+                "execution_tier": "fast",
+                "latency_seconds": 6.5,
+                "auto_approval_candidate": True,
+                "suppressed_diagnostics_count": 0,
+            },
+        ],
+    )
+
+    comparison = compare_profile_runs(baseline, staged)
+
+    assert comparison["agreement_count"] == 0
+    assert comparison["unsafe_auto_approval_ids"] == ["m1"]
+    assert comparison["blocked_rate_delta_pp"] == -50.0
+    assert comparison["passes_all_thresholds"] is False

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from aragora.core import DebateResult
+from aragora.inbox.triage_diagnostics import DiagnosticSeverity, TriageRunDiagnostics
 from aragora.inbox.triage_runner import InboxTriageRunner, _create_triage_agents
 from aragora.inbox.trust_wedge import (
     InboxWedgeAction,
@@ -254,7 +257,7 @@ async def test_unparseable_final_answer_falls_back_to_ignore_and_blocks_auto_app
     assert decision.receipt_state == ReceiptState.CREATED.value
     assert decision.final_action == InboxWedgeAction.IGNORE
     assert decision.blocked_by_policy is True
-    assert "fell back to ignore" in decision.dissent_summary
+    assert "showing a blocked recommendation" in decision.dissent_summary
     wedge_service.execute_receipt.assert_not_awaited()
 
 
@@ -425,9 +428,10 @@ async def test_run_debate_uses_fast_agent_subset_and_explicit_action_prompt(monk
     captured_tasks: list[str] = []
 
     class _Arena:
-        def __init__(self, env, agents, protocol):
+        def __init__(self, env, agents, protocol, **kwargs):
             captured_tasks.append(env.task)
             created_agents.extend(agents)
+            self.kwargs = kwargs
 
         async def run(self):
             return {"final_answer": "archive", "confidence": 0.9}
@@ -468,7 +472,57 @@ async def test_run_debate_uses_fast_agent_subset_and_explicit_action_prompt(monk
 
 
 @pytest.mark.asyncio
-async def test_run_debate_falls_back_to_stub_when_fewer_than_two_agents(monkeypatch):
+async def test_run_debate_disables_trending_and_post_debate_pipeline(monkeypatch):
+    captured_kwargs: dict[str, object] = {}
+    captured_protocol: dict[str, object] = {}
+
+    class _Arena:
+        def __init__(self, env, agents, protocol, **kwargs):
+            captured_kwargs.update(kwargs)
+            captured_protocol.update(protocol.__dict__)
+
+        async def run(self):
+            assert os.environ.get("ARAGORA_DISABLE_TRENDING") == "true"
+            return {"final_answer": "archive", "confidence": 0.9}
+
+    def _environment(*, task):
+        return SimpleNamespace(task=task)
+
+    import os
+    import aragora.core as core_mod
+    import aragora.debate.orchestrator as orch_mod
+    import aragora.debate.protocol as proto_mod
+
+    monkeypatch.delenv("ARAGORA_DISABLE_TRENDING", raising=False)
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner._create_triage_agents",
+        lambda: [
+            SimpleNamespace(name="triage-proposer", role="proposer", model_type="openai-api"),
+            SimpleNamespace(name="triage-critic", role="critic", model_type="openrouter"),
+        ],
+    )
+    monkeypatch.setattr(core_mod, "Environment", _environment)
+    monkeypatch.setattr(proto_mod, "DebateProtocol", lambda **kwargs: SimpleNamespace(**kwargs))
+    monkeypatch.setattr(orch_mod, "Arena", _Arena)
+
+    runner = InboxTriageRunner(gmail_connector=None)
+    await runner._run_debate(
+        {
+            "id": "msg-runtime-flags",
+            "subject": "Runtime flags",
+            "from_address": "sender@example.com",
+            "body_text": "Body",
+        }
+    )
+
+    assert captured_kwargs["disable_post_debate_pipeline"] is True
+    assert captured_kwargs["enable_knowledge_retrieval"] is False
+    assert captured_protocol["enable_research"] is False
+    assert "ARAGORA_DISABLE_TRENDING" not in os.environ
+
+
+@pytest.mark.asyncio
+async def test_run_debate_returns_blocked_result_when_fewer_than_two_agents(monkeypatch):
     import aragora.core as core_mod
     import aragora.debate.orchestrator as orch_mod
     import aragora.debate.protocol as proto_mod
@@ -493,8 +547,9 @@ async def test_run_debate_falls_back_to_stub_when_fewer_than_two_agents(monkeypa
         }
     )
 
-    assert result["final_answer"] == "ignore"
+    assert result["final_answer"] == ""
     assert result["confidence"] == 0.0
+    assert result["status"] == "insufficient_participation"
 
 
 def test_create_triage_agents_prefers_fast_pair(monkeypatch):
@@ -517,10 +572,11 @@ def test_create_triage_agents_prefers_fast_pair(monkeypatch):
 
     agents = _create_triage_agents()
 
-    assert len(agents) == 2
+    assert len(agents) == 3
     assert calls == [
-        ("anthropic-api", "proposer", "claude-haiku-4-5-20251001"),
+        ("openai-api", "proposer", "gpt-4.1-mini"),
         ("openrouter", "critic", "deepseek/deepseek-chat"),
+        ("anthropic-api", "synthesizer", "claude-haiku-4-5-20251001"),
     ]
 
 
@@ -544,8 +600,368 @@ def test_create_triage_agents_falls_back_to_openai_when_needed(monkeypatch):
 
     agents = _create_triage_agents()
 
-    assert len(agents) == 2
+    assert len(agents) == 3
     assert calls == [
-        ("anthropic-api", "proposer", "claude-haiku-4-5-20251001"),
-        ("openai-api", "critic", None),
+        ("openai-api", "proposer", "gpt-4.1-mini"),
+        ("openai-api", "critic", "gpt-4.1-mini"),
+        ("anthropic-api", "synthesizer", "claude-haiku-4-5-20251001"),
     ]
+
+
+@pytest.mark.asyncio
+async def test_triage_message_reattaches_subject_after_receipt_creation():
+    gmail = _DummyGmail()
+    wedge_service = SimpleNamespace()
+    wedge_service.execute_receipt = AsyncMock()
+
+    def _create_envelope(intent, decision, auto_approve=False):
+        copied_intent = type(intent)(**intent.to_dict())
+        updated = TriageDecision.create(
+            final_action=decision.final_action,
+            confidence=decision.confidence,
+            dissent_summary=decision.dissent_summary,
+            receipt_id="receipt-copy",
+            auto_approval_eligible=auto_approve,
+            receipt_state=ReceiptState.CREATED.value,
+            intent=copied_intent,
+            provider_route=decision.provider_route,
+            label_id=decision.label_id,
+            blocked_by_policy=decision.blocked_by_policy,
+        )
+        return SimpleNamespace(
+            intent=copied_intent,
+            decision=updated,
+            receipt=SimpleNamespace(receipt_id="receipt-copy", state=ReceiptState.CREATED),
+            provider_route=decision.provider_route,
+        )
+
+    wedge_service.create_receipt = MagicMock(side_effect=_create_envelope)
+
+    runner = InboxTriageRunner(gmail_connector=gmail, wedge_service=wedge_service)
+    runner._run_debate = AsyncMock(
+        return_value={
+            "final_answer": "archive",
+            "confidence": 0.9,
+            "debate_id": "debate-copy",
+        }
+    )
+
+    decisions = await runner.run_triage(batch_size=1, auto_approve=False)
+
+    intent = decisions[0].intent
+    assert intent is not None
+    assert intent._subject == "Test subject"  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stub_debate_result_is_blocked_instead_of_silent_ignore(monkeypatch):
+    import aragora.core as core_mod
+    import aragora.debate.orchestrator as orch_mod
+    import aragora.debate.protocol as proto_mod
+
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner._create_triage_agents",
+        lambda: [SimpleNamespace(name="triage-proposer", role="proposer", model_type="openai-api")],
+    )
+    monkeypatch.setattr(core_mod, "Environment", lambda **kwargs: SimpleNamespace(**kwargs))
+    monkeypatch.setattr(proto_mod, "DebateProtocol", lambda **kwargs: SimpleNamespace(**kwargs))
+    monkeypatch.setattr(orch_mod, "Arena", MagicMock())
+
+    runner = InboxTriageRunner(gmail_connector=None)
+    result = await runner._run_debate(
+        {
+            "id": "msg-stub",
+            "subject": "Stub subject",
+            "from_address": "sender@example.com",
+            "body_text": "Stub body",
+        }
+    )
+
+    assert result["final_answer"] == ""
+    assert result["confidence"] == 0.0
+    assert result["status"] == "insufficient_participation"
+
+
+@pytest.mark.asyncio
+async def test_staged_profile_uses_fast_tier_without_escalation(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    runner = InboxTriageRunner(gmail_connector=None, diagnostics=diagnostics, profile="staged_v1")
+    runner._run_debate_once = AsyncMock(
+        return_value={
+            "final_answer": "archive",
+            "confidence": 0.96,
+            "consensus_reached": True,
+            "debate_id": "debate-fast",
+        }
+    )
+
+    with diagnostics.activate():
+        result = await runner._run_debate(
+            {
+                "id": "msg-fast",
+                "subject": "Fast path",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    execution = result["metadata"]["triage_execution"]
+    assert execution["execution_tier"] == "fast"
+    assert execution["escalation_reasons"] == []
+    runner._run_debate_once.assert_awaited_once_with(
+        {
+            "id": "msg-fast",
+            "subject": "Fast path",
+            "from_address": "sender@example.com",
+            "body_text": "Body",
+        },
+        tier="fast",
+        rounds=1,
+        max_agents=2,
+    )
+
+
+@pytest.mark.asyncio
+async def test_staged_profile_escalates_high_risk_actions(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    runner = InboxTriageRunner(gmail_connector=None, diagnostics=diagnostics, profile="staged_v1")
+    runner._run_debate_once = AsyncMock(
+        side_effect=[
+            {
+                "final_answer": "star",
+                "confidence": 0.97,
+                "consensus_reached": True,
+                "debate_id": "debate-fast",
+            },
+            {
+                "final_answer": "archive",
+                "confidence": 0.91,
+                "consensus_reached": True,
+                "debate_id": "debate-escalated",
+            },
+        ]
+    )
+
+    with diagnostics.activate(), diagnostics.message_scope("msg-escalated"):
+        result = await runner._run_debate(
+            {
+                "id": "msg-escalated",
+                "subject": "Escalate",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    execution = result["metadata"]["triage_execution"]
+    assert execution["execution_tier"] == "escalated"
+    assert "high_risk_action" in execution["escalation_reasons"]
+    assert runner._run_debate_once.await_count == 2
+    event_codes = [
+        json.loads(line)["code"]
+        for line in diagnostics.events_path.read_text().splitlines()
+        if line.strip()
+    ]
+    assert "fast_tier_escalation" in event_codes
+
+
+@pytest.mark.asyncio
+async def test_staged_profile_truthfully_stops_on_no_consensus(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    runner = InboxTriageRunner(gmail_connector=None, diagnostics=diagnostics, profile="staged_v1")
+    runner._run_debate_once = AsyncMock(
+        return_value={
+            "final_answer": "archive",
+            "confidence": 0.84,
+            "consensus_reached": False,
+            "debate_id": "debate-no-consensus-fast",
+        }
+    )
+
+    with diagnostics.activate(), diagnostics.message_scope("msg-no-consensus"):
+        result = await runner._run_debate(
+            {
+                "id": "msg-no-consensus",
+                "subject": "No consensus",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    execution = result["metadata"]["triage_execution"]
+    assert execution["execution_tier"] == "fast"
+    assert execution["escalation_reasons"] == ["no_consensus"]
+    runner._run_debate_once.assert_awaited_once()
+    event_codes = [
+        json.loads(line)["code"]
+        for line in diagnostics.events_path.read_text().splitlines()
+        if line.strip()
+    ]
+    assert "fast_tier_truthful_stop" in event_codes
+
+
+@pytest.mark.asyncio
+async def test_staged_profile_truthfully_stops_on_parse_failed_fast_result(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    runner = InboxTriageRunner(gmail_connector=None, diagnostics=diagnostics, profile="staged_v1")
+    runner._run_debate_once = AsyncMock(
+        return_value={
+            "final_answer": "archive or ignore depending on urgency",
+            "confidence": 0.94,
+            "consensus_reached": True,
+            "debate_id": "debate-parse-fast",
+        }
+    )
+
+    with diagnostics.activate(), diagnostics.message_scope("msg-parse-fast"):
+        result = await runner._run_debate(
+            {
+                "id": "msg-parse-fast",
+                "subject": "Parse failed",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    execution = result["metadata"]["triage_execution"]
+    assert execution["execution_tier"] == "fast"
+    assert execution["escalation_reasons"] == ["parse_failed"]
+    runner._run_debate_once.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_staged_profile_returns_blocked_timeout_without_escalation(tmp_path, monkeypatch):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    runner = InboxTriageRunner(gmail_connector=None, diagnostics=diagnostics, profile="staged_v1")
+
+    async def _slow_debate(*args, **kwargs):
+        await asyncio.sleep(0.05)
+        return {
+            "final_answer": "archive",
+            "confidence": 0.95,
+            "consensus_reached": True,
+            "debate_id": "debate-slow-fast",
+        }
+
+    monkeypatch.setattr("aragora.inbox.triage_runner._FAST_TIER_TIMEOUT_SECONDS", 0.01)
+    runner._run_debate_once = AsyncMock(side_effect=_slow_debate)
+
+    with diagnostics.activate(), diagnostics.message_scope("msg-timeout-fast"):
+        result = await runner._run_debate(
+            {
+                "id": "msg-timeout-fast",
+                "subject": "Timeout",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    execution = result["metadata"]["triage_execution"]
+    assert execution["execution_tier"] == "fast"
+    assert execution["escalation_reasons"] == ["fast_timeout", "no_consensus", "parse_failed"]
+    assert result["status"] == "timeout"
+    runner._run_debate_once.assert_awaited_once()
+    event_codes = [
+        json.loads(line)["code"]
+        for line in diagnostics.events_path.read_text().splitlines()
+        if line.strip()
+    ]
+    assert "fast_tier_timeout" in event_codes
+    assert "fast_tier_truthful_stop" in event_codes
+
+
+@pytest.mark.asyncio
+async def test_triage_message_carries_execution_and_diagnostics_metadata(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    wedge_service = SimpleNamespace()
+    wedge_service.execute_receipt = AsyncMock()
+    wedge_service.create_receipt = MagicMock(
+        side_effect=lambda intent, decision, auto_approve=False: _make_envelope(
+            decision,
+            receipt_id="receipt-meta",
+            state=ReceiptState.CREATED,
+        )
+    )
+    runner = InboxTriageRunner(
+        gmail_connector=None,
+        wedge_service=wedge_service,
+        diagnostics=diagnostics,
+        profile="staged_v1",
+    )
+    runner._run_debate = AsyncMock(
+        return_value={
+            "final_answer": "archive",
+            "confidence": 0.91,
+            "consensus_reached": True,
+            "debate_id": "debate-meta",
+            "metadata": {
+                "triage_execution": {
+                    "execution_tier": "escalated",
+                    "escalation_reasons": ["low_confidence"],
+                }
+            },
+        }
+    )
+
+    with diagnostics.activate(), diagnostics.message_scope("msg-meta"):
+        diagnostics.record_event(
+            code="provider_fallback",
+            severity=DiagnosticSeverity.DEGRADED,
+            logger_name="aragora.server.research_phase",
+            summary="Fallback to OpenRouter",
+            tier="escalated",
+        )
+        decision = await runner._triage_message(
+            {
+                "id": "msg-meta",
+                "subject": "Metadata",
+                "from_address": "sender@example.com",
+                "body_text": "Body",
+            }
+        )
+
+    assert decision.execution_tier == "escalated"
+    assert decision.escalation_reasons == ["low_confidence"]
+    assert decision.suppressed_diagnostics_count == 1
+    assert decision.blocked_by_policy is True

--- a/tests/scripts/test_benchmark_triage_profiles.py
+++ b/tests/scripts/test_benchmark_triage_profiles.py
@@ -1,0 +1,132 @@
+"""Tests for scripts/benchmark_triage_profiles.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import benchmark_triage_profiles  # noqa: E402
+
+
+def test_main_writes_report_and_returns_success(monkeypatch, tmp_path, capsys) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {
+                "total_duration_seconds": 12.0,
+                "diagnostics_artifact_dir": "/tmp/baseline",
+                "meta": {
+                    "blocked_count": 1,
+                    "suppressed_diagnostics_count": 3,
+                    "fast_tier_count": 0,
+                    "escalated_count": 0,
+                },
+            },
+            "staged_v1": {
+                "total_duration_seconds": 7.0,
+                "diagnostics_artifact_dir": "/tmp/staged",
+                "meta": {
+                    "blocked_count": 1,
+                    "suppressed_diagnostics_count": 2,
+                    "fast_tier_count": 3,
+                    "escalated_count": 1,
+                },
+            },
+        },
+        "comparison": {
+            "message_count": 4,
+            "agreement_rate": 1.0,
+            "latency_improvement_pct": 42.0,
+            "blocked_rate_delta_pp": 0.0,
+            "unsafe_auto_approval_ids": [],
+            "acceptance": {
+                "decision_agreement": True,
+                "latency_improvement": True,
+                "blocked_rate_delta": True,
+                "unsafe_auto_approval": True,
+            },
+            "passes_all_thresholds": True,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    output_path = tmp_path / "report.json"
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--output", str(output_path)]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output_path.read_text(encoding="utf-8")) == report
+    out = capsys.readouterr().out
+    assert "Triage Profile Benchmark" in out
+    assert "Report written to" in out
+
+
+def test_main_fails_when_thresholds_missed(monkeypatch, tmp_path) -> None:
+    report = {
+        "fixture_path": "/tmp/fixtures.json",
+        "generated_at": "2026-03-25T00:00:00Z",
+        "profiles": {
+            "baseline": {
+                "total_duration_seconds": 12.0,
+                "diagnostics_artifact_dir": "/tmp/baseline",
+                "meta": {
+                    "blocked_count": 1,
+                    "suppressed_diagnostics_count": 3,
+                    "fast_tier_count": 0,
+                    "escalated_count": 0,
+                },
+            },
+            "staged_v1": {
+                "total_duration_seconds": 11.0,
+                "diagnostics_artifact_dir": "/tmp/staged",
+                "meta": {
+                    "blocked_count": 2,
+                    "suppressed_diagnostics_count": 4,
+                    "fast_tier_count": 1,
+                    "escalated_count": 3,
+                },
+            },
+        },
+        "comparison": {
+            "message_count": 4,
+            "agreement_rate": 0.75,
+            "latency_improvement_pct": 5.0,
+            "blocked_rate_delta_pp": 25.0,
+            "unsafe_auto_approval_ids": ["m1"],
+            "acceptance": {
+                "decision_agreement": False,
+                "latency_improvement": False,
+                "blocked_rate_delta": False,
+                "unsafe_auto_approval": False,
+            },
+            "passes_all_thresholds": False,
+        },
+    }
+
+    async def _fake_run(*args, **kwargs):
+        del args, kwargs
+        return report
+
+    fixture_path = tmp_path / "fixtures.json"
+    fixture_path.write_text("[]", encoding="utf-8")
+    monkeypatch.setattr(benchmark_triage_profiles, "run_fixture_benchmark", _fake_run)
+
+    exit_code = benchmark_triage_profiles.main(
+        ["--fixtures", str(fixture_path), "--fail-on-thresholds"]
+    )
+
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- add triage-scoped diagnostics capture so dry-run output stays quiet while artifacts preserve degraded/blocking signals
- harden the staged fast path with bounded timeouts and fixture benchmarking support
- add focused inbox/CLI benchmark and diagnostics regression coverage

## Validation
- python3 -m pytest tests/inbox/test_triage_runner.py tests/inbox/test_triage_diagnostics.py tests/cli/test_triage_command.py -q
- ruff check aragora/cli/commands/triage.py aragora/debate/cache/embeddings_lru.py aragora/debate/performance_monitor.py aragora/debate/phases/consensus_phase.py aragora/debate/phases/debate_rounds.py aragora/debate/phases/vote_collector.py aragora/inbox/cli_review.py aragora/inbox/triage_runner.py aragora/inbox/trust_wedge.py aragora/server/research_phase.py aragora/storage/connection_factory.py tests/cli/test_triage_command.py tests/inbox/test_triage_runner.py tests/inbox/test_triage_diagnostics.py tests/inbox/test_triage_profile_benchmark.py tests/scripts/test_benchmark_triage_profiles.py