### PR TITLE
fix(receipts): restore delivery history bridge

### DIFF
--- a/aragora/server/handlers/receipts.py
+++ b/aragora/server/handlers/receipts.py
@@ -22,6 +22,7 @@ Endpoints:
     GET  /api/v2/receipts/stats                        - Receipt statistics
     POST /api/v2/receipts/:receipt_id/share            - Create shareable link
     GET  /api/v2/receipts/share/:token                 - Access receipt via share token
+    GET  /api/v1/receipts/deliveries                   - Legacy/frontend delivery history bridge
 
 These endpoints support the "defensible decisions" pillar with:
 - Cryptographic signature verification
@@ -51,6 +52,9 @@ from aragora.server.handlers.base import (
     safe_error_message,
 )
 from aragora.server.handlers.utils.lazy_stores import LazyStoreFactory
+from aragora.server.handlers.utils.receipt_delivery_history import (
+    get_receipt_delivery_history_store,
+)
 from aragora.server.handlers.utils.rate_limit import rate_limit
 from aragora.server.handlers.openapi_decorator import api_endpoint
 from aragora.rbac.decorators import require_permission
@@ -240,6 +244,7 @@ class ReceiptsHandler(BaseHandler):
         "/api/v2/receipts/*",
         "/api/v2/receipts/search",
         "/api/v2/receipts/stats",
+        "/api/v1/receipts/deliveries",
         "/api/v1/receipts/*/deliver",
     ]
 
@@ -277,6 +282,8 @@ class ReceiptsHandler(BaseHandler):
         """Check if this handler can process the request."""
         if path.startswith("/api/v2/receipts"):
             return method in ("GET", "POST")
+        if path == "/api/v1/receipts/deliveries":
+            return method == "GET"
         # v1 delivery bridge for frontend DeliveryModal
         if path.startswith("/api/v1/receipts/") and path.endswith("/deliver"):
             return method == "POST"
@@ -367,6 +374,10 @@ class ReceiptsHandler(BaseHandler):
             if path.startswith("/api/v2/receipts/share/") and method == "GET":
                 token = path.split("/api/v2/receipts/share/")[1].rstrip("/")
                 return await self._get_shared_receipt(token, query_params, headers)
+
+            # v1 delivery history bridge: GET /api/v1/receipts/deliveries
+            if path == "/api/v1/receipts/deliveries" and method == "GET":
+                return await self._list_delivery_history(query_params)
 
             # v1 delivery bridge: POST /api/v1/receipts/{id}/deliver
             # Maps frontend DeliveryModal calls to v2 send-to-channel logic
@@ -977,6 +988,89 @@ class ReceiptsHandler(BaseHandler):
             }
         )
 
+    @require_permission("receipts:read")
+    async def _list_delivery_history(self, query_params: dict[str, str]) -> HandlerResult:
+        """Return receipt delivery history in the legacy/frontend response shape."""
+        limit = safe_query_int(query_params, "limit", default=50, max_val=100)
+        offset = safe_query_int(query_params, "offset", default=0, min_val=0, max_val=1000000)
+        receipt_id = (
+            query_params.get("receipt_id") or query_params.get("receiptId") or ""
+        ).strip() or None
+        channel_type = (
+            query_params.get("channel_type") or query_params.get("channel") or ""
+        ).strip() or None
+        status = (query_params.get("status") or "").strip() or None
+
+        history = list(get_receipt_delivery_history_store())
+        filtered = [
+            item
+            for item in history
+            if (not receipt_id or item.get("receiptId") == receipt_id)
+            and (not channel_type or item.get("channel") == channel_type)
+            and (not status or item.get("status") == status)
+        ]
+        filtered.sort(
+            key=lambda item: str(item.get("deliveredAt") or item.get("delivered_at") or ""),
+            reverse=True,
+        )
+        paginated = filtered[offset : offset + limit]
+
+        return json_response(
+            {
+                "deliveries": paginated,
+                "total": len(filtered),
+                "limit": limit,
+                "offset": offset,
+            }
+        )
+
+    def _record_delivery_history(
+        self,
+        *,
+        receipt_id: str,
+        channel_type: str,
+        channel_id: str,
+        workspace_id: str | None,
+        status: str,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+    ) -> None:
+        """Record a lightweight delivery event for frontend history views."""
+        delivery_result = result or {}
+        delivered_at = datetime.now(timezone.utc).isoformat()
+        destination_name = (
+            delivery_result.get("channel_name")
+            or delivery_result.get("channel")
+            or delivery_result.get("email_sent_to")
+            or channel_id
+        )
+        message_id = delivery_result.get("message_id") or delivery_result.get("message_ts")
+        get_receipt_delivery_history_store().append(
+            {
+                "id": f"delivery-{int(datetime.now(timezone.utc).timestamp() * 1000)}-{secrets.token_hex(4)}",
+                "receiptId": receipt_id,
+                "receipt_id": receipt_id,
+                "channel": channel_type,
+                "channel_type": channel_type,
+                "destination": channel_id,
+                "channel_id": channel_id,
+                "destinationName": destination_name,
+                "destination_name": destination_name,
+                "deliveredAt": delivered_at,
+                "delivered_at": delivered_at,
+                "status": status,
+                "workspaceId": workspace_id,
+                "workspace_id": workspace_id,
+                "messageId": message_id,
+                "message_id": message_id,
+                "errorMessage": error,
+                "error_message": error,
+            }
+        )
+        history = get_receipt_delivery_history_store()
+        if len(history) > 1000:
+            del history[:-1000]
+
     @require_permission("receipts:send")
     async def _send_to_channel(self, receipt_id: str, body: dict[str, Any]) -> HandlerResult:
         """
@@ -1030,6 +1124,14 @@ class ReceiptsHandler(BaseHandler):
                     400,
                 )
 
+            self._record_delivery_history(
+                receipt_id=receipt_id,
+                channel_type=channel_type,
+                channel_id=channel_id,
+                workspace_id=workspace_id,
+                status="success",
+                result=result,
+            )
             return json_response(
                 {
                     "sent": True,
@@ -1041,9 +1143,25 @@ class ReceiptsHandler(BaseHandler):
             )
 
         except ImportError as e:
+            self._record_delivery_history(
+                receipt_id=receipt_id,
+                channel_type=channel_type,
+                channel_id=channel_id,
+                workspace_id=workspace_id,
+                status="failed",
+                error=safe_error_message(e, f"channel {channel_type}"),
+            )
             logger.exception("Missing dependency for channel %s: %s", channel_type, e)
             return error_response(safe_error_message(e, f"channel {channel_type}"), 501)
         except (ConnectionError, TimeoutError, OSError, ValueError) as e:
+            self._record_delivery_history(
+                receipt_id=receipt_id,
+                channel_type=channel_type,
+                channel_id=channel_id,
+                workspace_id=workspace_id,
+                status="failed",
+                error=safe_error_message(e, "receipt send"),
+            )
             logger.exception("Failed to send receipt to channel: %s", e)
             return error_response(safe_error_message(e, "receipt send"), 500)
 

--- a/aragora/server/handlers/sme/receipt_delivery.py
+++ b/aragora/server/handlers/sme/receipt_delivery.py
@@ -24,6 +24,7 @@ from ..base import (
 )
 from ..utils.responses import HandlerResult
 from ..utils.url_security import validate_webhook_url
+from ..utils.receipt_delivery_history import get_receipt_delivery_history_store
 from ..secure import SecureHandler
 from aragora.rbac.decorators import require_permission
 from ..utils.rate_limit import RateLimiter, get_client_ip
@@ -110,11 +111,7 @@ class ReceiptDeliveryHandler(SecureHandler):
 
     def _get_delivery_history_store(self):
         """Get delivery history store instance."""
-        # Use a simple in-memory store for delivery history
-        # In production, this would be backed by a database
-        if not hasattr(self, "_delivery_history"):
-            self._delivery_history: list[dict[str, Any]] = []
-        return self._delivery_history
+        return get_receipt_delivery_history_store()
 
     def _get_user_and_org(self, handler, user):
         """Get user and organization from context."""

--- a/aragora/server/handlers/utils/receipt_delivery_history.py
+++ b/aragora/server/handlers/utils/receipt_delivery_history.py
@@ -1,0 +1,18 @@
+"""
+Shared in-memory receipt delivery history for lightweight server bridges.
+
+This keeps receipt send history available to both the legacy SME delivery
+handler and the receipts handler without introducing a heavier persistence
+dependency for the demo/live dashboard path.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+_receipt_delivery_history: list[dict[str, Any]] = []
+
+
+def get_receipt_delivery_history_store() -> list[dict[str, Any]]:
+    """Return the shared mutable in-memory delivery history store."""
+    return _receipt_delivery_history

--- a/tests/server/handlers/test_receipts_handler.py
+++ b/tests/server/handlers/test_receipts_handler.py
@@ -25,6 +25,9 @@ from aragora.server.handlers.receipts import (
     ReceiptsHandler,
     create_receipts_handler,
 )
+from aragora.server.handlers.utils.receipt_delivery_history import (
+    get_receipt_delivery_history_store,
+)
 import builtins
 
 
@@ -304,6 +307,15 @@ def receipts_handler(mock_server_context, mock_receipt_store):
     return handler
 
 
+@pytest.fixture(autouse=True)
+def clear_receipt_delivery_history():
+    """Keep the shared in-memory delivery history isolated per test."""
+    history = get_receipt_delivery_history_store()
+    history.clear()
+    yield
+    history.clear()
+
+
 def parse_handler_response(result) -> dict[str, Any]:
     """Parse handler result body as JSON."""
     if hasattr(result, "body"):
@@ -341,6 +353,10 @@ class TestReceiptsHandlerRouting:
     def test_can_handle_stats(self, receipts_handler):
         """Test can_handle for stats endpoint."""
         assert receipts_handler.can_handle("/api/v2/receipts/stats", "GET") is True
+
+    def test_can_handle_v1_deliveries(self, receipts_handler):
+        """Test can_handle for legacy/frontend delivery history bridge."""
+        assert receipts_handler.can_handle("/api/v1/receipts/deliveries", "GET") is True
 
     def test_cannot_handle_other_paths(self, receipts_handler):
         """Test can_handle returns False for other paths."""
@@ -1747,6 +1763,101 @@ class TestReceiptsHandlerSendToChannel:
             )
 
         assert result.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_v1_delivery_bridge_records_history(self, receipts_handler, mock_receipt_store):
+        """Legacy deliver bridge should populate the frontend delivery history route."""
+        mock_receipt_store.save({"receipt_id": "r1", "gauntlet_id": "g1"})
+
+        mock_format = MagicMock(return_value={"blocks": []})
+        mock_receipt = MagicMock()
+        mock_receipt_class = MagicMock(from_dict=MagicMock(return_value=mock_receipt))
+
+        with (
+            patch.multiple(
+                "aragora.channels.formatter",
+                create=True,
+                format_receipt_for_channel=mock_format,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"aragora.export.decision_receipt": MagicMock(DecisionReceipt=mock_receipt_class)},
+            ),
+            patch.object(
+                receipts_handler,
+                "_send_to_slack",
+                AsyncMock(return_value={"message_ts": "123.456", "channel": "C123"}),
+            ),
+        ):
+            result = await receipts_handler.handle(
+                "POST",
+                "/api/v1/receipts/r1/deliver",
+                body={"channel": "slack", "destination": "C123"},
+            )
+
+        assert result.status_code == 200
+
+        history_result = await receipts_handler.handle(
+            "GET",
+            "/api/v1/receipts/deliveries",
+            query_params={"receipt_id": "r1"},
+        )
+
+        assert history_result.status_code == 200
+        data = parse_handler_response(history_result)
+        assert data["total"] == 1
+        assert data["deliveries"][0]["receiptId"] == "r1"
+        assert data["deliveries"][0]["channel"] == "slack"
+        assert data["deliveries"][0]["destination"] == "C123"
+        assert data["deliveries"][0]["status"] == "success"
+
+    @pytest.mark.asyncio
+    async def test_failed_send_records_failed_delivery_history(
+        self, receipts_handler, mock_receipt_store
+    ):
+        """Failed sends should still be visible in delivery history for debugging."""
+        mock_receipt_store.save({"receipt_id": "r1", "gauntlet_id": "g1"})
+
+        mock_format = MagicMock(return_value={"blocks": []})
+        mock_receipt = MagicMock()
+        mock_receipt_class = MagicMock(from_dict=MagicMock(return_value=mock_receipt))
+
+        with (
+            patch.multiple(
+                "aragora.channels.formatter",
+                create=True,
+                format_receipt_for_channel=mock_format,
+            ),
+            patch.dict(
+                "sys.modules",
+                {"aragora.export.decision_receipt": MagicMock(DecisionReceipt=mock_receipt_class)},
+            ),
+            patch.object(
+                receipts_handler,
+                "_send_to_slack",
+                AsyncMock(side_effect=ConnectionError("slack offline")),
+            ),
+        ):
+            result = await receipts_handler.handle(
+                "POST",
+                "/api/v2/receipts/r1/send-to-channel",
+                body={"channel_type": "slack", "channel_id": "C123", "workspace_id": "T123"},
+            )
+
+        assert result.status_code == 500
+
+        history_result = await receipts_handler.handle(
+            "GET",
+            "/api/v1/receipts/deliveries",
+            query_params={"receipt_id": "r1", "status": "failed"},
+        )
+
+        assert history_result.status_code == 200
+        data = parse_handler_response(history_result)
+        assert data["total"] == 1
+        assert data["deliveries"][0]["status"] == "failed"
+        assert data["deliveries"][0]["channel"] == "slack"
+        assert data["deliveries"][0]["errorMessage"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- add the legacy/frontend `/api/v1/receipts/deliveries` bridge to the receipts handler
- share lightweight in-memory delivery history between the legacy SME delivery handler and the receipts handler
- add regression coverage for successful and failed delivery history visibility

## Validation
- python3 -m pytest tests/server/handlers/test_receipts_handler.py -q
- ruff check aragora/server/handlers/receipts.py aragora/server/handlers/sme/receipt_delivery.py aragora/server/handlers/utils/receipt_delivery_history.py tests/server/handlers/test_receipts_handler.py