### PR TITLE
fix(frontend): validate standalone debate fetch payloads

### DIFF
--- a/aragora/live/src/app/(standalone)/debate/[[...id]]/fetchDebate.ts
+++ b/aragora/live/src/app/(standalone)/debate/[[...id]]/fetchDebate.ts
@@ -18,13 +18,42 @@ export interface SavedDebate {
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
 
+function parseSavedDebate(payload: unknown): SavedDebate | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const debate = payload as Partial<SavedDebate>;
+  if (
+    typeof debate.id !== 'string'
+    || typeof debate.topic !== 'string'
+    || typeof debate.status !== 'string'
+    || typeof debate.consensus_reached !== 'boolean'
+    || typeof debate.confidence !== 'number'
+    || typeof debate.verdict !== 'string'
+    || typeof debate.duration_seconds !== 'number'
+    || !Array.isArray(debate.participants)
+    || typeof debate.proposals !== 'object'
+    || debate.proposals === null
+    || !Array.isArray(debate.critiques)
+    || !Array.isArray(debate.votes)
+    || typeof debate.final_answer !== 'string'
+    || typeof debate.receipt_hash !== 'string'
+  ) {
+    return null;
+  }
+
+  return debate as SavedDebate;
+}
+
 async function fetchDebateFromCandidateUrls(
   debateId: string,
   init: RequestInit,
 ): Promise<SavedDebate | null> {
+  const encodedDebateId = encodeURIComponent(debateId);
   const urls = [
-    `${API_BASE}/api/v1/debates/public/${debateId}`,
-    `${API_BASE}/api/v1/playground/debate/${debateId}`,
+    `${API_BASE}/api/v1/debates/public/${encodedDebateId}`,
+    `${API_BASE}/api/v1/playground/debate/${encodedDebateId}`,
   ];
 
   for (const url of urls) {
@@ -32,7 +61,10 @@ async function fetchDebateFromCandidateUrls(
       const res = await fetch(url, init);
       if (!res.ok) continue;
       const data = await res.json();
-      return (data?.data ?? data) as SavedDebate;
+      const debate = parseSavedDebate(data?.data ?? data);
+      if (debate) {
+        return debate;
+      }
     } catch {
       // Try the next candidate URL
     }

--- a/aragora/live/src/app/(standalone)/debate/__tests__/fetchDebate.test.ts
+++ b/aragora/live/src/app/(standalone)/debate/__tests__/fetchDebate.test.ts
@@ -1,0 +1,51 @@
+import { fetchDebateClient } from '../[[...id]]/fetchDebate';
+
+describe('fetchDebateClient', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('falls back to the next candidate when the public endpoint returns malformed JSON', async () => {
+    const fetchMock = global.fetch as jest.MockedFunction<typeof fetch>;
+
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: { unexpected: 'shape' } }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          id: 'fallback-debate',
+          topic: 'Recovered via playground fallback',
+          status: 'completed',
+          consensus_reached: true,
+          confidence: 0.88,
+          verdict: 'Approve',
+          duration_seconds: 4.2,
+          participants: ['analyst', 'critic'],
+          proposals: { analyst: 'Use fallback.', critic: 'Validate the payload first.' },
+          critiques: [],
+          votes: [],
+          final_answer: 'Recovered debate payload.',
+          receipt_hash: 'sha256:test',
+        }),
+      } as Response);
+
+    const result = await fetchDebateClient('fallback-debate');
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('fallback-debate');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- validate standalone debate fetch payloads before accepting a response
- fall back to the playground endpoint when the public endpoint returns malformed JSON
- add focused Jest coverage for the malformed-public-payload fallback

## Validation
- cd aragora/live && node_modules/.bin/jest --runInBand --runTestsByPath "/Users/armand/Development/aragora/aragora/live/src/app/(standalone)/debate/__tests__/fetchDebate.test.ts"