### PR TITLE
fix(receipts): allow manual delivery destinations

### DIFF
--- a/aragora/live/src/components/receipts/ChannelSelector.tsx
+++ b/aragora/live/src/components/receipts/ChannelSelector.tsx
@@ -32,6 +32,36 @@ export interface ChannelSelectorProps {
   loading?: boolean;
 }
 
+const MANUAL_DESTINATION_CONFIG: Record<
+  ChannelType,
+  { label: string; placeholder: string; type: 'text' | 'email'; helper: string }
+> = {
+  slack: {
+    label: 'Slack Channel',
+    placeholder: '#security-alerts or C01234567',
+    type: 'text',
+    helper: 'Enter a Slack channel name or channel ID.',
+  },
+  teams: {
+    label: 'Teams Channel',
+    placeholder: 'Channel ID or channel name',
+    type: 'text',
+    helper: 'Enter the Teams channel identifier or display name.',
+  },
+  discord: {
+    label: 'Discord Channel',
+    placeholder: '123456789012345678',
+    type: 'text',
+    helper: 'Enter the Discord channel ID.',
+  },
+  email: {
+    label: 'Recipient Email',
+    placeholder: 'recipient@example.com',
+    type: 'email',
+    helper: 'Enter the email address that should receive the receipt.',
+  },
+};
+
 /**
  * Channel selector for receipt delivery.
  */
@@ -53,10 +83,21 @@ export function ChannelSelector({
   const handleChannelClick = (channel: ChannelOption) => {
     if (!channel.configured) return;
     onChannelSelect(channel.type);
-    if (channel.destinations && channel.destinations.length > 0) {
-      setShowDestinations(true);
-    }
+    setShowDestinations(Boolean(channel.destinations && channel.destinations.length > 0));
   };
+
+  const manualDestinationConfig = selectedChannel
+    ? MANUAL_DESTINATION_CONFIG[selectedChannel]
+    : null;
+  const hasDestinations = Boolean(
+    selectedChannelData?.destinations && selectedChannelData.destinations.length > 0
+  );
+  const showManualDestinationInput = Boolean(
+    selectedChannelData &&
+      selectedChannel === selectedChannelData.type &&
+      selectedChannelData.configured &&
+      !hasDestinations
+  );
 
   if (loading) {
     return (
@@ -136,19 +177,25 @@ export function ChannelSelector({
         </div>
       )}
 
-      {/* Email Input (for email channel) */}
-      {selectedChannel === 'email' && (
+      {/* Manual Destination Input */}
+      {showManualDestinationInput && manualDestinationConfig && (
         <div className="p-4 bg-surface rounded-lg border border-border">
-          <label className="block text-sm font-mono font-medium mb-2">
-            Recipient Email
+          <label
+            htmlFor="manual-destination-input"
+            className="block text-sm font-mono font-medium mb-2"
+          >
+            {manualDestinationConfig.label}
           </label>
           <input
-            type="email"
-            placeholder="recipient@example.com"
+            id="manual-destination-input"
+            type={manualDestinationConfig.type}
+            value={selectedDestination ?? ''}
+            placeholder={manualDestinationConfig.placeholder}
             onChange={(e) => onDestinationSelect(e.target.value)}
             className="w-full px-3 py-2 text-sm bg-bg border border-border rounded
                        focus:border-acid-green focus:outline-none font-mono"
           />
+          <p className="mt-2 text-xs text-text-muted">{manualDestinationConfig.helper}</p>
         </div>
       )}
     </div>

--- a/aragora/live/src/components/receipts/DeliveryModal.tsx
+++ b/aragora/live/src/components/receipts/DeliveryModal.tsx
@@ -40,11 +40,7 @@ const DEFAULT_CHANNELS: ChannelOption[] = [
     icon: '?',
     description: 'Send to Slack channel',
     configured: true,
-    destinations: [
-      { id: 'C01234567', name: 'security-alerts', type: 'channel' },
-      { id: 'C01234568', name: 'compliance', type: 'channel' },
-      { id: 'C01234569', name: 'general', type: 'channel' },
-    ],
+    destinations: [],
   },
   {
     type: 'teams',
@@ -52,10 +48,7 @@ const DEFAULT_CHANNELS: ChannelOption[] = [
     icon: '?',
     description: 'Send to Teams channel',
     configured: true,
-    destinations: [
-      { id: 'T01234567', name: 'Security Team', type: 'channel' },
-      { id: 'T01234568', name: 'Compliance', type: 'channel' },
-    ],
+    destinations: [],
   },
   {
     type: 'discord',
@@ -74,6 +67,23 @@ const DEFAULT_CHANNELS: ChannelOption[] = [
     destinations: [],
   },
 ];
+
+function mergeChannelHealth(
+  defaults: ChannelOption[],
+  channels: Record<string, { status?: string }> | undefined
+): ChannelOption[] {
+  if (!channels) {
+    return defaults;
+  }
+
+  return defaults.map((channel) => {
+    const status = channels[channel.type]?.status;
+    return {
+      ...channel,
+      configured: status ? status !== 'unconfigured' : channel.configured,
+    };
+  });
+}
 
 /**
  * Modal for delivering receipts to communication channels.
@@ -102,7 +112,7 @@ export function DeliveryModal({
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
-  // Fetch available channels on mount
+  // Fetch available channel health whenever the modal opens.
   useEffect(() => {
     const fetchChannels = async () => {
       setChannelsLoading(true);
@@ -111,12 +121,10 @@ export function DeliveryModal({
         if (tokens?.access_token) {
           headers['Authorization'] = `Bearer ${tokens.access_token}`;
         }
-        const response = await fetch(`${apiUrl}/api/channels`, { headers });
+        const response = await fetch(`${apiUrl}/api/v1/channels/health`, { headers });
         if (response.ok) {
           const data = await response.json();
-          if (data.channels) {
-            setChannels(data.channels);
-          }
+          setChannels(mergeChannelHealth(DEFAULT_CHANNELS, data.channels));
         }
       } catch {
         // Use defaults on error
@@ -136,7 +144,9 @@ export function DeliveryModal({
   }, [isOpen, apiUrl, tokens?.access_token]);
 
   const handleDeliver = useCallback(async () => {
-    if (!selectedChannel || !selectedDestination) {
+    const destination = selectedDestination?.trim();
+
+    if (!selectedChannel || !destination) {
       setError('Please select a channel and destination');
       return;
     }
@@ -154,7 +164,7 @@ export function DeliveryModal({
         headers,
         body: JSON.stringify({
           channel_type: selectedChannel,
-          destination: selectedDestination,
+          destination,
           options,
         }),
       });
@@ -165,7 +175,7 @@ export function DeliveryModal({
       }
 
       setSuccess(true);
-      onDeliverySuccess?.(selectedChannel, selectedDestination);
+      onDeliverySuccess?.(selectedChannel, destination);
 
       // Close after brief success message
       setTimeout(() => {
@@ -240,7 +250,10 @@ export function DeliveryModal({
                   channels={channels}
                   selectedChannel={selectedChannel}
                   selectedDestination={selectedDestination}
-                  onChannelSelect={setSelectedChannel}
+                  onChannelSelect={(channel) => {
+                    setSelectedChannel(channel);
+                    setSelectedDestination(null);
+                  }}
                   onDestinationSelect={setSelectedDestination}
                   loading={channelsLoading}
                 />
@@ -330,7 +343,7 @@ export function DeliveryModal({
             </button>
             <button
               onClick={handleDeliver}
-              disabled={loading || !selectedChannel || !selectedDestination}
+              disabled={loading || !selectedChannel || !selectedDestination?.trim()}
               className="px-4 py-2 text-sm font-mono bg-acid-green text-bg rounded
                          hover:bg-acid-green/80 transition-colors
                          disabled:opacity-50 disabled:cursor-not-allowed"

--- a/aragora/live/src/components/receipts/__tests__/DeliveryModal.test.tsx
+++ b/aragora/live/src/components/receipts/__tests__/DeliveryModal.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DeliveryModal } from '../DeliveryModal';
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({
+    tokens: { access_token: 'test-token' },
+  }),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function jsonResponse(data: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => data,
+  } as Response;
+}
+
+describe('DeliveryModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('allows manual Slack delivery when channel discovery data is unavailable', async () => {
+    mockFetch.mockImplementation((input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url === 'http://localhost:8080/api/v1/channels/health') {
+        return Promise.resolve(jsonResponse({}, false, 404));
+      }
+
+      if (url === 'http://localhost:8080/api/v1/receipts/receipt-123/deliver') {
+        return Promise.resolve(jsonResponse({ success: true }));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+
+    const user = userEvent.setup();
+
+    render(
+      <DeliveryModal
+        isOpen
+        onClose={jest.fn()}
+        receiptId="receipt-123"
+        receiptSummary="Critical deployment receipt"
+        apiUrl="http://localhost:8080"
+      />
+    );
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls[0]?.[0]).toBe('http://localhost:8080/api/v1/channels/health');
+    });
+
+    const slackButton = await screen.findByRole('button', { name: /slack/i });
+    await user.click(slackButton);
+
+    const destinationInput = await screen.findByLabelText(/slack channel/i);
+    await user.type(destinationInput, 'C12345678');
+    await user.click(screen.getByRole('button', { name: /deliver receipt/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8080/api/v1/receipts/receipt-123/deliver',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('"destination":"C12345678"'),
+        })
+      );
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:8080/api/v1/receipts/receipt-123/deliver',
+      expect.objectContaining({
+        body: expect.stringContaining('"channel_type":"slack"'),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- allow manual destination entry for configured receipt-delivery channels when discovery data is unavailable
- use channel health to mark configured vs unconfigured destinations in the delivery modal
- add focused Jest coverage for manual Slack delivery fallback

## Validation
- cd aragora/live && node_modules/.bin/jest --runInBand --runTestsByPath "/Users/armand/Development/aragora/aragora/live/src/components/receipts/__tests__/DeliveryModal.test.tsx"
- cd aragora/live && node_modules/.bin/jest --runInBand --runTestsByPath "/Users/armand/Development/aragora/aragora/live/src/components/__tests__/BackendSelector.test.tsx" "/Users/armand/Development/aragora/aragora/live/__tests__/DashboardPage.test.tsx"