### PR TITLE
fix(frontend): avoid local health redirect churn

### DIFF
--- a/aragora/live/__tests__/BackendSelector.test.tsx
+++ b/aragora/live/__tests__/BackendSelector.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { BackendSelector, BACKENDS, useBackend } from '../src/components/BackendSelector';
+import { BackendSelector, BACKENDS, buildHealthCheckUrl, useBackend } from '../src/components/BackendSelector';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -62,6 +62,15 @@ describe('BackendSelector', () => {
     it('has development backend configured', () => {
       expect(BACKENDS.development).toBeDefined();
       expect(BACKENDS.development.fallbackApi).toBe('');
+    });
+
+    it('builds a same-origin health URL with trailing slash for local rewrites', () => {
+      expect(buildHealthCheckUrl('')).toBe('/api/health/');
+    });
+
+    it('builds an absolute health URL without adding a trailing slash route', () => {
+      expect(buildHealthCheckUrl('http://127.0.0.1:8086')).toBe('http://127.0.0.1:8086/api/health');
+      expect(buildHealthCheckUrl('http://127.0.0.1:8086/')).toBe('http://127.0.0.1:8086/api/health');
     });
   });
 

--- a/aragora/live/src/app/(app)/AppLayoutClient.tsx
+++ b/aragora/live/src/app/(app)/AppLayoutClient.tsx
@@ -5,7 +5,7 @@ import { usePathname } from 'next/navigation';
 import { AppShell } from '@/components/layout';
 import { TopBar } from '@/components/layout/TopBar';
 import { useAuth } from '@/context/AuthContext';
-import { useBackend } from '@/components/BackendSelector';
+import { buildHealthCheckUrl, useBackend } from '@/components/BackendSelector';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 const NO_SHELL_PREFIXES = ['/auth'];
@@ -26,7 +26,7 @@ export default function AppLayoutClient({ children }: { children: React.ReactNod
   useEffect(() => {
     if (isAuthenticated) return;
     const controller = new AbortController();
-    fetch(`${backendConfig.api}/api/health`, { signal: controller.signal })
+    fetch(buildHealthCheckUrl(backendConfig.api), { signal: controller.signal })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data?.demo_mode || data?.mode === 'demo' || data?.offline) {

--- a/aragora/live/src/app/(app)/admin/page.tsx
+++ b/aragora/live/src/app/(app)/admin/page.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { UsageChart, DataPoint } from '@/components/admin/UsageChart';
-import { useBackend } from '@/components/BackendSelector';
+import { buildHealthCheckUrl, useBackend } from '@/components/BackendSelector';
 import { useAuth } from '@/context/AuthContext';
 import { useAragoraClient } from '@/hooks/useAragoraClient';
 
@@ -106,7 +106,7 @@ export default function AdminOverviewPage() {
       setError(null);
 
       // Fetch health status
-      const healthRes = await fetch(`${backendConfig.api}/api/health`);
+      const healthRes = await fetch(buildHealthCheckUrl(backendConfig.api));
       if (healthRes.ok) {
         const healthData = await healthRes.json();
         setHealth(healthData);

--- a/aragora/live/src/app/(app)/page.tsx
+++ b/aragora/live/src/app/(app)/page.tsx
@@ -17,7 +17,7 @@ import { DebateExportModal } from '@/components/DebateExportModal';
 import { VerdictCard } from '@/components/VerdictCard';
 import { DocumentUpload } from '@/components/DocumentUpload';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
-import { useBackend, BACKENDS } from '@/components/BackendSelector';
+import { useBackend, BACKENDS, buildHealthCheckUrl } from '@/components/BackendSelector';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { CollapsibleSection } from '@/components/CollapsibleSection';
 import { FeaturesProvider } from '@/context/FeaturesContext';
@@ -167,7 +167,7 @@ export default function Home() {
   useEffect(() => {
     if (isAuthenticated) return;
     const controller = new AbortController();
-    fetch(`${backendConfig.api}/api/health`, { signal: controller.signal })
+    fetch(buildHealthCheckUrl(backendConfig.api), { signal: controller.signal })
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (data?.demo_mode || data?.mode === 'demo' || data?.offline) {

--- a/aragora/live/src/components/BackendSelector.tsx
+++ b/aragora/live/src/components/BackendSelector.tsx
@@ -37,6 +37,16 @@ export const BACKENDS: Record<BackendType, BackendConfig> = {
 
 const STORAGE_KEY = 'aragora-backend';
 
+export function buildHealthCheckUrl(apiBase: string): string {
+  const normalizedBase = apiBase.trim().replace(/\/$/, '');
+  if (!normalizedBase) {
+    // In local same-origin dev, Next rewrites `/api/*` and `trailingSlash: true`
+    // turns `/api/health` into a redirect chain. Use the stable path directly.
+    return '/api/health/';
+  }
+  return `${normalizedBase}/api/health`;
+}
+
 function isLocalHost(hostname: string | undefined): boolean {
   if (!hostname) return false;
   return (
@@ -114,7 +124,7 @@ export function BackendSelector({ onChange, compact = false }: BackendSelectorPr
   useEffect(() => {
     const checkEndpoint = async (url: string): Promise<boolean> => {
       try {
-        const res = await fetch(`${url}/api/health`, {
+        const res = await fetch(buildHealthCheckUrl(url), {
           method: 'GET',
           signal: AbortSignal.timeout(3000),
         });


### PR DESCRIPTION
## Summary
- add a shared health-check URL helper for backend-selected frontend surfaces
- use `/api/health/` only for same-origin local dev, while keeping absolute backends on `/api/health`
- remove onboarding/app-shell local `308` + aborted health-request churn

## Verification
- `cd aragora/live && npx jest --ci --runTestsByPath '__tests__/BackendSelector.test.tsx' '__tests__/DashboardPage.test.tsx'`
- `cd aragora/live && npx eslint 'src/components/BackendSelector.tsx' 'src/app/(app)/AppLayoutClient.tsx' 'src/app/(app)/page.tsx' 'src/app/(app)/admin/page.tsx' '__tests__/BackendSelector.test.tsx'`
- browser proof on local merged stack:
  - `GET /api/health/ => 200`
  - no `308 /api/health` redirect churn on `/onboarding/`
