### PR TITLE
fix(frontend): restore mission control live wiring

### DIFF
--- a/aragora/live/src/app/(app)/mission-control/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(app)/mission-control/__tests__/page.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import MissionControlPage from '../page';
+
+const mockPush = jest.fn();
+const mockShowToast = jest.fn();
+const mockUseSWRFetch = jest.fn();
+const mockUseSystemHealth = jest.fn();
+const mockUseCircuitBreakers = jest.fn();
+const mockUseAgentPoolHealth = jest.fn();
+const mockUseBudgetStatus = jest.fn();
+const mockUseAuth = jest.fn();
+const mockFetch = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/components/BackendSelector', () => ({
+  useBackend: () => ({ config: { api: 'http://backend.test' } }),
+}));
+
+jest.mock('@/context/ToastContext', () => ({
+  useToastContext: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+jest.mock('@/hooks/useSystemHealth', () => ({
+  useSystemHealth: () => mockUseSystemHealth(),
+  useCircuitBreakers: () => mockUseCircuitBreakers(),
+  useAgentPoolHealth: () => mockUseAgentPoolHealth(),
+  useBudgetStatus: () => mockUseBudgetStatus(),
+}));
+
+jest.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (...args: unknown[]) => mockUseSWRFetch(...args),
+}));
+
+jest.mock('@/components/MatrixRain', () => ({
+  Scanlines: () => <div data-testid="scanlines" />,
+  CRTVignette: () => <div data-testid="crt-vignette" />,
+}));
+
+describe('MissionControlPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = mockFetch as typeof global.fetch;
+
+    mockUseAuth.mockReturnValue({
+      tokens: { access_token: 'token-123' },
+    });
+
+    mockUseSystemHealth.mockReturnValue({
+      health: {
+        overall_status: 'healthy',
+        subsystems: {},
+        last_check: '2026-03-25T00:00:00Z',
+        collection_time_ms: 18,
+      },
+    });
+    mockUseCircuitBreakers.mockReturnValue({
+      breakers: [],
+    });
+    mockUseAgentPoolHealth.mockReturnValue({
+      agents: [],
+      total: 4,
+      active: 3,
+    });
+    mockUseBudgetStatus.mockReturnValue({
+      budget: {
+        utilization: 0.42,
+        forecast: { eom: 321, trend: 'stable' },
+      },
+    });
+
+    mockUseSWRFetch.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/debates?status=running&limit=10') {
+        return {
+          data: { data: { debates: [{ id: 'deb-1', task: 'Test debate', status: 'running', agents: 3, round: 1, total_rounds: 3, created_at: '2026-03-25T00:00:00Z' }] } },
+          error: null,
+          isLoading: false,
+        };
+      }
+      if (endpoint === '/api/control-plane/queue/metrics') {
+        return {
+          data: { pending: 2, running: 1, completed_today: 5, failed_today: 1 },
+          error: null,
+          isLoading: false,
+        };
+      }
+      if (endpoint === '/api/history/events?limit=10') {
+        return {
+          data: {
+            events: [
+              {
+                id: 'evt-1',
+                event_type: 'debate_completed',
+                agent: 'codex',
+                timestamp: '2026-03-25T00:00:00Z',
+                event_data: { message: 'Debate completed successfully' },
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+      return { data: null, error: null, isLoading: false };
+    });
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+  });
+
+  it('reads queue metrics and history events from current endpoints', () => {
+    render(<MissionControlPage />);
+
+    expect(mockUseSWRFetch).toHaveBeenCalledWith(
+      '/api/control-plane/queue/metrics',
+      expect.objectContaining({ refreshInterval: 10000 }),
+    );
+    expect(mockUseSWRFetch).toHaveBeenCalledWith(
+      '/api/history/events?limit=10',
+      expect.objectContaining({ refreshInterval: 15000 }),
+    );
+    expect(screen.getByText('Debate completed successfully')).toBeInTheDocument();
+    expect(screen.getByText('codex')).toBeInTheDocument();
+  });
+
+  it('routes setup-heavy quick actions to the correct workflow pages', async () => {
+    const user = userEvent.setup();
+    render(<MissionControlPage />);
+
+    await user.click(screen.getByRole('button', { name: /\[START DEBATE\]/i }));
+    await user.click(screen.getByRole('button', { name: /\[RUN GAUNTLET\]/i }));
+    await user.click(screen.getByRole('button', { name: /\[SELF-IMPROVE SCAN\]/i }));
+
+    expect(mockPush).toHaveBeenNthCalledWith(1, '/arena');
+    expect(mockPush).toHaveBeenNthCalledWith(2, '/gauntlet');
+    expect(mockPush).toHaveBeenNthCalledWith(3, '/self-improve');
+  });
+
+  it('resets breakers through the admin nomic endpoint with auth', async () => {
+    const user = userEvent.setup();
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<MissionControlPage />);
+
+    await user.click(screen.getByRole('button', { name: /\[RESET BREAKERS\]/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://backend.test/api/v1/admin/nomic/circuit-breakers/reset',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer token-123',
+            'Content-Type': 'application/json',
+          }),
+        }),
+      );
+    });
+    expect(mockShowToast).toHaveBeenCalledWith('Circuit breaker reset initiated successfully', 'success');
+  });
+});

--- a/aragora/live/src/app/(app)/mission-control/page.tsx
+++ b/aragora/live/src/app/(app)/mission-control/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useState, useCallback, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { useBackend } from '@/components/BackendSelector';
 import { useToastContext } from '@/context/ToastContext';
+import { useAuth } from '@/context/AuthContext';
 import {
   useSystemHealth,
   useCircuitBreakers,
@@ -43,6 +45,14 @@ interface QueueStats {
   running: number;
   completed_today: number;
   failed_today: number;
+}
+
+interface HistoryEvent {
+  id: string;
+  event_type: string;
+  agent: string | null;
+  timestamp: string;
+  event_data?: Record<string, unknown>;
 }
 
 // ============================================================================
@@ -87,6 +97,56 @@ function timeAgo(timestamp: string): string {
 
 function formatPercent(value: number): string {
   return `${Math.round(value * 100)}%`;
+}
+
+function getOptionalString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function humanizeEventType(eventType: string): string {
+  return eventType
+    .split('_')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function inferEventSeverity(eventType: string, eventData: Record<string, unknown>): SystemEvent['severity'] {
+  const explicitSeverity = getOptionalString(eventData.severity);
+  if (explicitSeverity === 'critical' || explicitSeverity === 'error' || explicitSeverity === 'warning' || explicitSeverity === 'info') {
+    return explicitSeverity;
+  }
+
+  const normalized = eventType.toLowerCase();
+  if (normalized.includes('critical')) return 'critical';
+  if (normalized.includes('error') || normalized.includes('fail') || normalized.includes('abort')) return 'error';
+  if (normalized.includes('warning') || normalized.includes('retry') || normalized.includes('degraded')) return 'warning';
+  return 'info';
+}
+
+function mapHistoryEvent(event: HistoryEvent): SystemEvent {
+  const eventData = event.event_data ?? {};
+  const source =
+    event.agent ||
+    getOptionalString(eventData.source) ||
+    getOptionalString(eventData.agent) ||
+    humanizeEventType(event.event_type);
+  const message =
+    getOptionalString(eventData.message) ||
+    getOptionalString(eventData.summary) ||
+    getOptionalString(eventData.title) ||
+    getOptionalString(eventData.task) ||
+    humanizeEventType(event.event_type);
+
+  return {
+    id: event.id,
+    type: event.event_type,
+    source,
+    message,
+    severity: inferEventSeverity(event.event_type, eventData),
+    timestamp: event.timestamp,
+    metadata: eventData,
+  };
 }
 
 // ============================================================================
@@ -332,8 +392,10 @@ function DebateQueuePanel({
 // ============================================================================
 
 export default function MissionControlPage() {
+  const router = useRouter();
   const { config: backendConfig } = useBackend();
   const { showToast } = useToastContext();
+  const { tokens } = useAuth();
 
   // ---- Data hooks ----
   const { health } = useSystemHealth();
@@ -352,19 +414,19 @@ export default function MissionControlPage() {
   );
 
   // Queue stats
-  const { data: queueData } = useSWRFetch<{ data: QueueStats }>(
-    '/api/scheduler/stats',
+  const { data: queueData } = useSWRFetch<QueueStats>(
+    '/api/control-plane/queue/metrics',
     { refreshInterval: 10000 },
   );
-  const queueStats = (queueData?.data ?? null) as QueueStats | null;
+  const queueStats = queueData ?? null;
 
   // Recent events
-  const { data: eventsData } = useSWRFetch<{ data: { events: SystemEvent[] } }>(
-    '/api/events/recent?limit=10',
+  const { data: eventsData } = useSWRFetch<{ events: HistoryEvent[] }>(
+    '/api/history/events?limit=10',
     { refreshInterval: 15000 },
   );
   const recentEvents = useMemo(
-    () => (eventsData?.data?.events ?? []) as SystemEvent[],
+    () => (eventsData?.events ?? []).map(mapHistoryEvent) as SystemEvent[],
     [eventsData],
   );
 
@@ -372,17 +434,40 @@ export default function MissionControlPage() {
   const [actionLoading, setActionLoading] = useState<string | null>(null);
 
   const executeAction = useCallback(
-    async (action: string, endpoint: string, method = 'POST') => {
+    async (
+      action: string,
+      endpoint: string,
+      method = 'POST',
+      body?: Record<string, unknown>,
+    ) => {
       setActionLoading(action);
       try {
+        const headers: HeadersInit = { 'Content-Type': 'application/json' };
+        if (tokens?.access_token) {
+          headers.Authorization = `Bearer ${tokens.access_token}`;
+        }
         const res = await fetch(`${backendConfig.api}${endpoint}`, {
           method,
-          headers: { 'Content-Type': 'application/json' },
+          headers,
+          ...(body ? { body: JSON.stringify(body) } : {}),
         });
         if (res.ok) {
           showToast(`${action} initiated successfully`, 'success');
         } else {
-          showToast(`Failed to initiate ${action}`, 'error');
+          const errorText =
+            await res
+              .json()
+              .then((data: unknown) => {
+                if (data && typeof data === 'object') {
+                  const message =
+                    getOptionalString((data as Record<string, unknown>).error) ||
+                    getOptionalString((data as Record<string, unknown>).message);
+                  if (message) return message;
+                }
+                return null;
+              })
+              .catch(() => null);
+          showToast(errorText || `Failed to initiate ${action}`, 'error');
         }
       } catch (err) {
         logger.error(`Quick action ${action} failed:`, err);
@@ -391,8 +476,19 @@ export default function MissionControlPage() {
         setActionLoading(null);
       }
     },
-    [backendConfig.api, showToast],
+    [backendConfig.api, showToast, tokens?.access_token],
   );
+
+  const navigateTo = useCallback((href: string) => {
+    router.push(href);
+  }, [router]);
+
+  const handleResetBreakers = useCallback(async () => {
+    if (typeof window !== 'undefined' && !window.confirm('Reset all Nomic circuit breakers?')) {
+      return;
+    }
+    await executeAction('Circuit breaker reset', '/api/v1/admin/nomic/circuit-breakers/reset', 'POST');
+  }, [executeAction]);
 
   // ---- Derived state ----
   const overallStatus = health?.overall_status ?? 'healthy';
@@ -499,28 +595,28 @@ export default function MissionControlPage() {
                   <QuickActionButton
                     label="[START DEBATE]"
                     icon="$"
-                    onClick={() => executeAction('Debate', '/api/debates', 'POST')}
+                    onClick={() => navigateTo('/arena')}
                     loading={actionLoading === 'Debate'}
                     variant="primary"
                   />
                   <QuickActionButton
                     label="[RUN GAUNTLET]"
                     icon="#"
-                    onClick={() => executeAction('Gauntlet', '/api/gauntlet/run', 'POST')}
+                    onClick={() => navigateTo('/gauntlet')}
                     loading={actionLoading === 'Gauntlet'}
                     variant="secondary"
                   />
                   <QuickActionButton
                     label="[SELF-IMPROVE SCAN]"
                     icon="@"
-                    onClick={() => executeAction('Self-improvement', '/api/nomic/scan', 'POST')}
+                    onClick={() => navigateTo('/self-improve')}
                     loading={actionLoading === 'Self-improvement'}
                     variant="secondary"
                   />
                   <QuickActionButton
                     label="[RESET BREAKERS]"
                     icon="!"
-                    onClick={() => executeAction('Circuit breaker reset', '/api/admin/circuit-breakers/reset', 'POST')}
+                    onClick={handleResetBreakers}
                     loading={actionLoading === 'Circuit breaker reset'}
                     variant="danger"
                   />


### PR DESCRIPTION
## Summary
- reconnect mission control queue metrics and history events to current API endpoints
- route quick actions to the current workflow pages and wire breaker reset through the admin nomic endpoint
- add focused Jest coverage for the live mission-control wiring

## Validation
- cd aragora/live && node_modules/.bin/jest --runInBand --runTestsByPath "/Users/armand/Development/aragora/aragora/live/src/app/(app)/mission-control/__tests__/page.test.tsx"