### PR TITLE
fix(spectate): serve buffered SSE snapshots

### DIFF
--- a/aragora/server/handlers/spectate_ws.py
+++ b/aragora/server/handlers/spectate_ws.py
@@ -3,7 +3,7 @@
 Endpoints:
 - GET /api/v1/spectate/recent  - Get recent buffered spectate events
 - GET /api/v1/spectate/status  - Get bridge status (active, subscribers, buffer size)
-- GET /api/v1/spectate/stream  - SSE endpoint (returns snapshot of recent events)
+- GET /api/v1/spectate/stream  - Finite SSE snapshot or JSON preview of recent events
 """
 
 from __future__ import annotations
@@ -12,6 +12,7 @@ __all__ = [
     "SpectateStreamHandler",
 ]
 
+import json
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -142,6 +143,12 @@ def _redact_live_debate_details(summary: dict[str, Any]) -> dict[str, Any]:
     return redacted
 
 
+def _sse_frame(event_type: str, data: Any) -> str:
+    """Format a single SSE frame."""
+    payload = json.dumps(data, default=str, separators=(",", ":"))
+    return f"event: {event_type}\ndata: {payload}\n\n"
+
+
 class SpectateStreamHandler(BaseHandler):
     """Handler for spectate stream endpoints.
 
@@ -157,9 +164,16 @@ class SpectateStreamHandler(BaseHandler):
 
     STREAM_MODE = "snapshot"
     STREAM_READINESS = "partial"
-    STREAM_MESSAGE = (
-        "Public spectate streaming is currently snapshot-only on this endpoint; "
-        "live SSE delivery has not shipped yet."
+    STREAM_JSON_TRANSPORT = "json_preview"
+    STREAM_SSE_TRANSPORT = "sse_snapshot"
+    STREAM_JSON_MESSAGE = (
+        "Buffered spectate events are available as a JSON preview on this endpoint. "
+        "Request Accept: text/event-stream or ?format=sse for a finite SSE snapshot; "
+        "full live SSE delivery has not shipped yet."
+    )
+    STREAM_SSE_MESSAGE = (
+        "Buffered spectate events are being delivered as a finite SSE snapshot on this "
+        "endpoint; full live SSE delivery has not shipped yet."
     )
 
     @handle_errors("spectate")
@@ -173,35 +187,61 @@ class SpectateStreamHandler(BaseHandler):
         if path.endswith("/status"):
             return self._handle_status(handler)
         if path.endswith("/stream"):
-            return self._handle_stream(query_params)
+            return self._handle_stream(query_params, handler)
 
         return None
 
     def _handle_recent(self, query_params: dict[str, Any]) -> HandlerResult:
         """GET /api/v1/spectate/recent -- get recent events from the buffer."""
-        return json_response(self._build_recent_payload(query_params))
+        events = self._get_recent_events(query_params)
+        return json_response(self._recent_payload(events))
 
-    def _handle_stream(self, query_params: dict[str, Any]) -> HandlerResult:
-        """GET /api/v1/spectate/stream -- snapshot preview, not live SSE."""
-        payload = self._build_recent_payload(query_params)
+    def _handle_stream(self, query_params: dict[str, Any], handler: Any) -> HandlerResult:
+        """GET /api/v1/spectate/stream -- finite SSE snapshot or JSON preview."""
+        events = self._get_recent_events(query_params)
+        if self._wants_sse(query_params, handler):
+            metadata = self._stream_metadata(
+                query_params,
+                count=len(events),
+                transport=self.STREAM_SSE_TRANSPORT,
+                message=self.STREAM_SSE_MESSAGE,
+            )
+            return HandlerResult(
+                status_code=200,
+                content_type="text/event-stream",
+                body=self._build_sse_snapshot_body(events, metadata),
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "Vary": "Accept",
+                    "X-Accel-Buffering": "no",
+                    "X-Aragora-Endpoint-State": self.STREAM_READINESS,
+                    "X-Aragora-Stream-Mode": self.STREAM_MODE,
+                    "X-Aragora-Stream-Transport": self.STREAM_SSE_TRANSPORT,
+                },
+            )
+
+        payload = self._recent_payload(events)
         payload.update(
-            {
-                "mode": self.STREAM_MODE,
-                "readiness": self.STREAM_READINESS,
-                "streaming_ready": False,
-                "message": self.STREAM_MESSAGE,
-            }
+            self._stream_metadata(
+                query_params,
+                count=len(events),
+                transport=self.STREAM_JSON_TRANSPORT,
+                message=self.STREAM_JSON_MESSAGE,
+            )
         )
         return json_response(
             payload,
             headers={
+                "Vary": "Accept",
                 "X-Aragora-Endpoint-State": self.STREAM_READINESS,
                 "X-Aragora-Stream-Mode": self.STREAM_MODE,
+                "X-Aragora-Stream-Transport": self.STREAM_JSON_TRANSPORT,
             },
         )
 
-    def _build_recent_payload(self, query_params: dict[str, Any]) -> dict[str, Any]:
-        """Build the recent-events payload shared by snapshot endpoints."""
+    def _get_recent_events(self, query_params: dict[str, Any]) -> list[Any]:
+        """Return filtered recent spectate events from the bridge buffer."""
         try:
             from aragora.spectate.ws_bridge import get_spectate_bridge
 
@@ -215,7 +255,6 @@ class SpectateStreamHandler(BaseHandler):
 
             events = bridge.get_recent_events(count)
 
-            # Optional filtering by debate_id or pipeline_id
             debate_id = query_params.get("debate_id") if query_params else None
             pipeline_id = query_params.get("pipeline_id") if query_params else None
 
@@ -224,12 +263,56 @@ class SpectateStreamHandler(BaseHandler):
             if pipeline_id:
                 events = [e for e in events if e.pipeline_id == pipeline_id]
 
-            return {
-                "events": [e.to_dict() for e in events],
-                "count": len(events),
-            }
+            return events
         except ImportError:
-            return {"events": [], "count": 0}
+            return []
+
+    def _recent_payload(self, events: list[Any]) -> dict[str, Any]:
+        """Build the recent-events payload shared by snapshot endpoints."""
+        return {
+            "events": [e.to_dict() for e in events],
+            "count": len(events),
+        }
+
+    def _stream_metadata(
+        self,
+        query_params: dict[str, Any],
+        *,
+        count: int,
+        transport: str,
+        message: str,
+    ) -> dict[str, Any]:
+        """Build stream metadata shared across JSON and SSE snapshot responses."""
+        metadata: dict[str, Any] = {
+            "mode": self.STREAM_MODE,
+            "transport": transport,
+            "readiness": self.STREAM_READINESS,
+            "streaming_ready": False,
+            "message": message,
+            "count": count,
+        }
+        if query_params.get("debate_id"):
+            metadata["debate_id"] = query_params["debate_id"]
+        if query_params.get("pipeline_id"):
+            metadata["pipeline_id"] = query_params["pipeline_id"]
+        return metadata
+
+    def _build_sse_snapshot_body(self, events: list[Any], metadata: dict[str, Any]) -> bytes:
+        """Serialize buffered spectate events into a finite SSE snapshot body."""
+        frames = [_sse_frame("connected", metadata)]
+        for event in events:
+            event_type = getattr(event, "event_type", None) or "event"
+            frames.append(_sse_frame(event_type, event.to_dict()))
+        frames.append(_sse_frame("snapshot_complete", metadata))
+        return "".join(frames).encode("utf-8")
+
+    def _wants_sse(self, query_params: dict[str, Any], handler: Any) -> bool:
+        """Return True when the caller requested an SSE response."""
+        if (query_params.get("format") or "").lower() == "sse":
+            return True
+        headers = getattr(handler, "headers", {}) or {}
+        accept = headers.get("Accept") or headers.get("accept") or ""
+        return "text/event-stream" in accept
 
     def _handle_status(self, handler: Any) -> HandlerResult:
         """GET /api/v1/spectate/status -- bridge status."""

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -64,7 +64,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Partial | Debate spectating exists, but `/api/v1/spectate/stream` is currently served as an SSE snapshot/stub rather than full live streaming | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
+| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` now serves a finite buffered SSE snapshot with JSON preview fallback, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
 
 ### Configuration
 

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -72,7 +72,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - OpenAPI and SDK parity claims are still inflated by spec-only endpoints defined in `aragora/server/openapi/endpoints/sdk_missing.py`.
 - `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
 - `aragora/server/handlers/goal_canvas.py` still returns placeholder data for advancing a canvas into the actions stage.
-- `aragora/server/handlers/spectate_ws.py` still serves `/api/v1/spectate/stream` as an SSE snapshot stub rather than full real-time streaming.
+- `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
 - `aragora/server/handlers/sme/slack_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
 - `aragora/server/handlers/sme/teams_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
 - `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -62,7 +62,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Partial | Debate spectating exists, but `/api/v1/spectate/stream` is currently served as an SSE snapshot/stub rather than full live streaming | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
+| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` now serves a finite buffered SSE snapshot with JSON preview fallback, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
 
 ### Configuration
 

--- a/tests/handlers/test_spectate_ws.py
+++ b/tests/handlers/test_spectate_ws.py
@@ -6,6 +6,7 @@ SpectateWebSocketBridge over the /api/v1/spectate/* endpoints.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -48,6 +49,24 @@ def mock_handler():
     return h
 
 
+def _parse_sse_frames(body: bytes) -> list[tuple[str, object]]:
+    """Parse a finite SSE snapshot body into (event_type, payload) pairs."""
+    frames: list[tuple[str, object]] = []
+    for chunk in body.decode("utf-8").strip().split("\n\n"):
+        lines = chunk.splitlines()
+        if not lines or lines[0].startswith(":"):
+            continue
+        event_type = "event"
+        payload: object = None
+        for line in lines:
+            if line.startswith("event: "):
+                event_type = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                payload = json.loads(line.removeprefix("data: "))
+        frames.append((event_type, payload))
+    return frames
+
+
 # ---------------------------------------------------------------------------
 # Route matching tests
 # ---------------------------------------------------------------------------
@@ -83,17 +102,64 @@ class TestRouteMatching:
         assert "buffer_size" in body
 
     def test_handle_stream_path(self, handler: SpectateStreamHandler, mock_handler: MagicMock):
-        """Stream endpoint is truthfully marked as a snapshot preview."""
+        """Stream endpoint defaults to a JSON preview for non-SSE callers."""
         result = handler.handle("/api/v1/spectate/stream", {}, mock_handler)
         assert result is not None
         body = result[0]
         assert "events" in body
         assert body["mode"] == "snapshot"
+        assert body["transport"] == "json_preview"
         assert body["readiness"] == "partial"
         assert body["streaming_ready"] is False
-        assert "snapshot-only" in body["message"]
+        assert "JSON preview" in body["message"]
         assert result[2]["X-Aragora-Endpoint-State"] == "partial"
         assert result[2]["X-Aragora-Stream-Mode"] == "snapshot"
+        assert result[2]["X-Aragora-Stream-Transport"] == "json_preview"
+
+    def test_handle_stream_path_returns_sse_snapshot_when_requested(
+        self, handler: SpectateStreamHandler, mock_handler: MagicMock
+    ):
+        from aragora.spectate.ws_bridge import get_spectate_bridge
+
+        bridge = get_spectate_bridge()
+        bridge._event_buffer.append(
+            SpectateEvent(
+                event_type="proposal",
+                timestamp="2026-02-18T10:00:00+00:00",
+                debate_id="d-111",
+                agent_name="claude",
+                data={"details": "Bounded fix"},
+            )
+        )
+        mock_handler.headers = {"Accept": "text/event-stream"}
+
+        result = handler.handle("/api/v1/spectate/stream", {"debate_id": "d-111"}, mock_handler)
+
+        assert result is not None
+        assert result.content_type == "text/event-stream"
+        assert result.headers["X-Aragora-Stream-Transport"] == "sse_snapshot"
+        frames = _parse_sse_frames(result.body)
+        assert [frame[0] for frame in frames] == ["connected", "proposal", "snapshot_complete"]
+        connected = frames[0][1]
+        proposal = frames[1][1]
+        complete = frames[2][1]
+        assert isinstance(connected, dict)
+        assert connected["transport"] == "sse_snapshot"
+        assert connected["debate_id"] == "d-111"
+        assert isinstance(proposal, dict)
+        assert proposal["event_type"] == "proposal"
+        assert proposal["agent_name"] == "claude"
+        assert isinstance(complete, dict)
+        assert complete["count"] == 1
+
+    def test_handle_stream_path_honors_format_sse_query(
+        self, handler: SpectateStreamHandler, mock_handler: MagicMock
+    ):
+        result = handler.handle("/api/v1/spectate/stream", {"format": "sse"}, mock_handler)
+        assert result is not None
+        assert result.content_type == "text/event-stream"
+        frames = _parse_sse_frames(result.body)
+        assert [frame[0] for frame in frames] == ["connected", "snapshot_complete"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `/api/v1/spectate/stream` return a finite SSE snapshot when callers request `text/event-stream` or `?format=sse`
- keep the JSON preview fallback for non-SSE callers and annotate the transport explicitly
- update Spectate truth docs to reflect finite buffered SSE snapshots rather than a JSON stub

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/test_spectate_ws.py`
- `ruff check aragora/server/handlers/spectate_ws.py tests/handlers/test_spectate_ws.py`
- `python3 -m compileall aragora/server/handlers/spectate_ws.py`