### PR TITLE
feat(dev): guard ad-hoc worktree cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,8 @@ When many agents are committing concurrently, use disposable worktrees with freq
 
 - Start sessions with `./scripts/codex_session.sh` (or `make codex-session`).
   This writes an active-session lock so background maintenance skips in-use worktrees.
+- Do not delete side worktrees with raw `git worktree remove` plus `rm -rf`.
+  Inspect/remove them with `python3 scripts/safe_worktree_cleanup.py` so active-session locks and open PR branches block accidental deletion.
 - Auto-heal unexpected worktree/branch drift with:
   `python3 scripts/codex_worktree_autopilot.py ensure --agent codex --base main --reconcile --print-path`
 - Prefer one-shot upkeep during rapid churn:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Aragora Makefile
 # Common development tasks for the Aragora multi-agent debate platform
 
-.PHONY: help install dev test test-e2e lint format typecheck check check-all ci ci-required guard guard-strict clean clean-all clean-runtime clean-runtime-dry docs serve docker demo demo-docker demo-stop quickstart quickstart-live worktree-ensure worktree-reconcile worktree-cleanup worktree-maintain worktree-maintainer-install worktree-maintainer-uninstall worktree-maintainer-status codex-session branch-start pr-open
+.PHONY: help install dev test test-e2e lint format typecheck check check-all ci ci-required guard guard-strict clean clean-all clean-runtime clean-runtime-dry docs serve docker demo demo-docker demo-stop quickstart quickstart-live worktree-ensure worktree-reconcile worktree-cleanup worktree-maintain worktree-maintainer-install worktree-maintainer-uninstall worktree-maintainer-status worktree-inspect worktree-safe-remove codex-session branch-start pr-open
 
 # Default target
 help:
@@ -58,6 +58,10 @@ help:
 	@echo "  make worktree-maintainer-install Install launchd auto-maintainer (macOS)"
 	@echo "  make worktree-maintainer-uninstall Uninstall launchd auto-maintainer"
 	@echo "  make worktree-maintainer-status Show launchd auto-maintainer status"
+	@echo "  make worktree-inspect WT_PATH=/abs/path"
+	@echo "                    Inspect a side worktree for active-session/open-PR blockers"
+	@echo "  make worktree-safe-remove WT_PATH=/abs/path [DELETE_BRANCH=1] [PURGE_PATH=1]"
+	@echo "                    Safely remove a side worktree after guard checks"
 	@echo ""
 	@echo "Documentation:"
 	@echo "  make docs         Generate documentation"
@@ -211,6 +215,23 @@ worktree-maintainer-uninstall:
 
 worktree-maintainer-status:
 	./scripts/status_worktree_maintainer_launchd.sh
+
+worktree-inspect:
+	@if [ -z "$(WT_PATH)" ]; then \
+		echo "Usage: make worktree-inspect WT_PATH=/abs/path"; \
+		exit 1; \
+	fi
+	python3 scripts/safe_worktree_cleanup.py inspect "$(WT_PATH)"
+
+worktree-safe-remove:
+	@if [ -z "$(WT_PATH)" ]; then \
+		echo "Usage: make worktree-safe-remove WT_PATH=/abs/path [DELETE_BRANCH=1] [PURGE_PATH=1]"; \
+		exit 1; \
+	fi
+	@cmd="python3 scripts/safe_worktree_cleanup.py remove \"$(WT_PATH)\""; \
+	if [ -n "$(DELETE_BRANCH)" ]; then cmd="$$cmd --delete-branch"; fi; \
+	if [ -n "$(PURGE_PATH)" ]; then cmd="$$cmd --purge-path"; fi; \
+	eval "$$cmd"
 
 branch-start:
 	@if [ -z "$(TYPE)" ] || [ -z "$(SLUG)" ]; then \

--- a/scripts/safe_worktree_cleanup.py
+++ b/scripts/safe_worktree_cleanup.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Guarded worktree inspection and cleanup for ad-hoc side branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import codex_worktree_autopilot as autopilot
+
+
+@dataclass
+class WorktreeInspection:
+    path: str
+    exists: bool
+    tracked_worktree: bool
+    branch: str | None
+    active_session: bool
+    lock_files: list[str]
+    open_prs: list[dict[str, Any]]
+    pr_lookup_failed: bool
+    blockers: list[str]
+
+
+def _active_lock_files(path: Path) -> list[str]:
+    return [
+        name
+        for name in (".claude-session-active", ".codex_session_active", ".nomic-session-active")
+        if (path / name).exists()
+    ]
+
+
+def _get_worktree_entry(repo_root: Path, path: Path) -> autopilot.WorktreeEntry | None:
+    target = path.resolve()
+    for entry in autopilot._get_worktree_entries(repo_root):
+        if entry.path.resolve() == target:
+            return entry
+    return None
+
+
+def _branch_for_path(path: Path, entry: autopilot.WorktreeEntry | None) -> str | None:
+    if entry and entry.branch:
+        return entry.branch
+    if not path.exists():
+        return None
+    if not (path / ".git").exists():
+        return None
+    proc = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return None
+    branch = proc.stdout.strip()
+    return None if not branch or branch == "HEAD" else branch
+
+
+def _lookup_open_prs(repo_root: Path, branch: str | None) -> tuple[list[dict[str, Any]], bool]:
+    if not branch:
+        return [], False
+    try:
+        proc = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--state",
+                "open",
+                "--head",
+                branch,
+                "--json",
+                "number,title,url",
+            ],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except OSError:
+        return [], True
+    if proc.returncode != 0:
+        return [], True
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return [], True
+    if not isinstance(payload, list):
+        return [], True
+    return payload, False
+
+
+def inspect_worktree(
+    repo_root: Path, path: Path, *, branch_override: str | None = None
+) -> WorktreeInspection:
+    path = path.resolve()
+    exists = path.exists()
+    entry = _get_worktree_entry(repo_root, path)
+    tracked_worktree = entry is not None
+    branch = branch_override or _branch_for_path(path, entry)
+    active_session = exists and autopilot._has_active_session(path)
+    lock_files = _active_lock_files(path) if exists else []
+    open_prs, pr_lookup_failed = _lookup_open_prs(repo_root, branch)
+
+    blockers: list[str] = []
+    if not exists:
+        blockers.append("missing_path")
+    if active_session:
+        blockers.append("active_session")
+    if open_prs:
+        blockers.append("open_pr")
+    if branch and pr_lookup_failed:
+        blockers.append("pr_lookup_failed")
+
+    return WorktreeInspection(
+        path=str(path),
+        exists=exists,
+        tracked_worktree=tracked_worktree,
+        branch=branch,
+        active_session=active_session,
+        lock_files=lock_files,
+        open_prs=open_prs,
+        pr_lookup_failed=pr_lookup_failed,
+        blockers=blockers,
+    )
+
+
+def _print_inspection(inspection: WorktreeInspection, *, as_json: bool) -> None:
+    payload = asdict(inspection)
+    payload["removable"] = not inspection.blockers
+    if as_json:
+        print(json.dumps(payload, indent=2))
+        return
+
+    print(f"path: {inspection.path}")
+    print(f"exists: {inspection.exists}")
+    print(f"tracked_worktree: {inspection.tracked_worktree}")
+    print(f"branch: {inspection.branch or '-'}")
+    print(f"active_session: {inspection.active_session}")
+    if inspection.lock_files:
+        print(f"lock_files: {', '.join(inspection.lock_files)}")
+    print(f"open_prs: {len(inspection.open_prs)}")
+    if inspection.open_prs:
+        for pr in inspection.open_prs:
+            print(f"  - #{pr.get('number')} {pr.get('title')} :: {pr.get('url')}")
+    print(f"removable: {not inspection.blockers}")
+    if inspection.blockers:
+        print("blockers:")
+        for blocker in inspection.blockers:
+            print(f"  - {blocker}")
+
+
+def _delete_branch(repo_root: Path, branch: str) -> bool:
+    if not autopilot._branch_exists(repo_root, branch):
+        return True
+    proc = autopilot._run_git(repo_root, "branch", "-D", branch)
+    return proc.returncode == 0
+
+
+def remove_worktree(
+    repo_root: Path,
+    inspection: WorktreeInspection,
+    *,
+    delete_branch: bool,
+    purge_path: bool,
+    force: bool,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "path": inspection.path,
+        "branch": inspection.branch,
+        "removed": False,
+        "branch_deleted": False,
+        "path_purged": False,
+        "blockers": list(inspection.blockers),
+    }
+    path = Path(inspection.path)
+    if inspection.blockers and not force:
+        result["status"] = "blocked"
+        return result
+
+    if inspection.tracked_worktree:
+        proc = autopilot._run_git(repo_root, "worktree", "remove", "--force", inspection.path)
+        if proc.returncode != 0:
+            result["status"] = "remove_failed"
+            result["stderr"] = proc.stderr.strip()
+            if not purge_path:
+                return result
+        else:
+            result["removed"] = True
+            result["status"] = "removed"
+    else:
+        result["status"] = "untracked_path"
+        if not purge_path:
+            return result
+
+    if path.exists() and purge_path:
+        shutil.rmtree(path, ignore_errors=True)
+        result["path_purged"] = not path.exists()
+        if result["path_purged"]:
+            result["removed"] = True
+
+    if delete_branch and inspection.branch:
+        result["branch_deleted"] = _delete_branch(repo_root, inspection.branch)
+
+    if result.get("status") in {"removed", "untracked_path"} and not result["removed"]:
+        result["status"] = "partial"
+    elif result.get("status") == "untracked_path" and result["removed"]:
+        result["status"] = "purged"
+    elif result.get("status") == "remove_failed" and result["path_purged"]:
+        result["status"] = "purged_after_failed_remove"
+
+    return result
+
+
+def _repo_root_from_arg(repo: str) -> Path:
+    return autopilot._repo_root_from(Path(repo))
+
+
+def cmd_inspect(args: argparse.Namespace) -> int:
+    repo_root = _repo_root_from_arg(args.repo)
+    inspection = inspect_worktree(repo_root, Path(args.path), branch_override=args.branch)
+    _print_inspection(inspection, as_json=args.json)
+    return 0 if not inspection.blockers else 1
+
+
+def cmd_remove(args: argparse.Namespace) -> int:
+    repo_root = _repo_root_from_arg(args.repo)
+    inspection = inspect_worktree(repo_root, Path(args.path), branch_override=args.branch)
+    result = remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=args.delete_branch,
+        purge_path=args.purge_path,
+        force=args.force,
+    )
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result, indent=2))
+    status = str(result.get("status", ""))
+    if status in {"blocked", "remove_failed", "untracked_path", "partial"}:
+        return 1
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inspect and safely remove ad-hoc worktrees.")
+    parser.add_argument("--repo", default=".", help="Path inside the target repository")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    inspect_parser = subparsers.add_parser(
+        "inspect", help="Inspect a worktree for active-session / open-PR blockers"
+    )
+    inspect_parser.add_argument("path", help="Worktree path to inspect")
+    inspect_parser.add_argument(
+        "--branch", help="Override the branch name for orphaned or partially deleted paths"
+    )
+    inspect_parser.add_argument("--json", action="store_true")
+    inspect_parser.set_defaults(func=cmd_inspect)
+
+    remove_parser = subparsers.add_parser(
+        "remove", help="Safely remove a worktree if no blockers exist"
+    )
+    remove_parser.add_argument("path", help="Worktree path to remove")
+    remove_parser.add_argument(
+        "--branch", help="Override the branch name for orphaned or partially deleted paths"
+    )
+    remove_parser.add_argument(
+        "--delete-branch",
+        action="store_true",
+        help="Delete the local branch after removing the worktree",
+    )
+    remove_parser.add_argument(
+        "--purge-path",
+        action="store_true",
+        help="Delete a residual path if git worktree removal leaves files behind",
+    )
+    remove_parser.add_argument(
+        "--force", action="store_true", help="Bypass active-session/open-PR blockers"
+    )
+    remove_parser.add_argument("--json", action="store_true")
+    remove_parser.set_defaults(func=cmd_remove)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_safe_worktree_cleanup.py
+++ b/tests/scripts/test_safe_worktree_cleanup.py
@@ -1,0 +1,231 @@
+"""Unit tests for scripts/safe_worktree_cleanup.py."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+
+
+@pytest.fixture(autouse=True)
+def _setup_path():
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    yield
+    sys.path.remove(str(SCRIPTS_DIR))
+
+
+def test_inspect_reports_open_pr_blocker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(
+        mod.autopilot,
+        "_get_worktree_entries",
+        lambda _repo: [mod.autopilot.WorktreeEntry(path=worktree, branch="codex/test")],
+    )
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_lookup_open_prs",
+        lambda _repo, _branch: (
+            [{"number": 1361, "title": "Open PR", "url": "https://example.com/pr/1361"}],
+            False,
+        ),
+    )
+
+    inspection = mod.inspect_worktree(repo_root, worktree)
+
+    assert inspection.tracked_worktree is True
+    assert inspection.branch == "codex/test"
+    assert inspection.blockers == ["open_pr"]
+
+
+def test_remove_refuses_blocked_worktree_without_force(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        open_prs=[{"number": 1361, "title": "Open PR", "url": "https://example.com/pr/1361"}],
+        pr_lookup_failed=False,
+        blockers=["open_pr"],
+    )
+    monkeypatch.setattr(
+        mod,
+        "inspect_worktree",
+        lambda _repo, _path, branch_override=None: inspection,
+    )
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+
+    args = argparse.Namespace(
+        repo=".",
+        path=str(worktree),
+        branch=None,
+        delete_branch=False,
+        purge_path=False,
+        force=False,
+        json=True,
+    )
+
+    rc = mod.cmd_remove(args)
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert payload["status"] == "blocked"
+    assert payload["blockers"] == ["open_pr"]
+
+
+def test_inspect_accepts_branch_override_for_orphaned_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    orphan_path = tmp_path / "manual-orphan"
+    orphan_path.mkdir()
+
+    monkeypatch.setattr(mod.autopilot, "_get_worktree_entries", lambda _repo: [])
+    monkeypatch.setattr(mod.autopilot, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_lookup_open_prs",
+        lambda _repo, branch: (
+            [{"number": 2000, "title": branch, "url": "https://example.com/pr/2000"}],
+            False,
+        ),
+    )
+
+    inspection = mod.inspect_worktree(
+        repo_root,
+        orphan_path,
+        branch_override="codex/orphaned-branch",
+    )
+
+    assert inspection.tracked_worktree is False
+    assert inspection.branch == "codex/orphaned-branch"
+    assert inspection.blockers == ["open_pr"]
+
+
+def test_branch_detection_requires_local_git_metadata(tmp_path: Path) -> None:
+    import safe_worktree_cleanup as mod
+
+    orphan_path = tmp_path / "orphan"
+    orphan_path.mkdir()
+
+    assert mod._branch_for_path(orphan_path, None) is None
+
+
+def test_remove_purges_residual_path_after_failed_git_remove(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    residual = worktree / "aragora" / "live" / ".next"
+    residual.mkdir(parents=True)
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=True,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+
+    monkeypatch.setattr(
+        mod.autopilot,
+        "_run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "worktree", "remove"],
+            returncode=255,
+            stdout="",
+            stderr="Directory not empty",
+        ),
+    )
+    monkeypatch.setattr(mod.autopilot, "_branch_exists", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(mod.autopilot, "_repo_root_from", lambda _path: repo_root)
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=False,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["status"] == "purged_after_failed_remove"
+    assert result["path_purged"] is True
+    assert worktree.exists() is False
+
+
+def test_remove_deletes_branch_when_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import safe_worktree_cleanup as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+
+    inspection = mod.WorktreeInspection(
+        path=str(worktree),
+        exists=True,
+        tracked_worktree=False,
+        branch="codex/test",
+        active_session=False,
+        lock_files=[],
+        open_prs=[],
+        pr_lookup_failed=False,
+        blockers=[],
+    )
+    monkeypatch.setattr(mod.autopilot, "_branch_exists", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        mod.autopilot,
+        "_run_git",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["git", "branch", "-D", "codex/test"],
+            returncode=0,
+            stdout="Deleted branch codex/test\n",
+            stderr="",
+        ),
+    )
+
+    result = mod.remove_worktree(
+        repo_root,
+        inspection,
+        delete_branch=True,
+        purge_path=True,
+        force=False,
+    )
+
+    assert result["branch_deleted"] is True
+    assert result["status"] == "purged"


### PR DESCRIPTION
## Summary
- add a guarded helper for inspecting and removing ad-hoc worktrees
- block default removal when a worktree has an active session or the branch still has an open PR
- add make targets and AGENTS guidance so side-worktree cleanup stops relying on raw `git worktree remove` plus `rm -rf`

## Verification
- `python3 -m ruff check scripts/safe_worktree_cleanup.py tests/scripts/test_safe_worktree_cleanup.py`
- `python3 -m pytest tests/scripts/test_safe_worktree_cleanup.py -q`
- `make worktree-inspect WT_PATH=/Users/armand/Development/aragora/.worktrees/manual-pmf-browser-20260325-161854`
