### PR TITLE
fix(receipts): restore public import contract

### DIFF
--- a/aragora/receipts/__init__.py
+++ b/aragora/receipts/__init__.py
@@ -1,10 +1,21 @@
-"""Operational receipt helpers."""
+"""Receipt import surface.
+
+This package now coexists with the historical ``aragora.receipts`` module import
+path used for decision-receipt classes. Re-export those classes here so imports
+like ``from aragora.receipts import DecisionReceipt`` keep working while the
+package also exposes operational receipt helpers.
+"""
+
+from aragora.export.decision_receipt import DecisionReceipt as LegacyDecisionReceipt
+from aragora.gauntlet.receipt import DecisionReceipt
 
 from .lane import LaneCompletionReceipt, emit_lane_receipt, validate_receipt
 from .provenance import emit_operational_receipt
 
 __all__ = [
+    "DecisionReceipt",
     "LaneCompletionReceipt",
+    "LegacyDecisionReceipt",
     "emit_lane_receipt",
     "emit_operational_receipt",
     "validate_receipt",


### PR DESCRIPTION
## Summary
- re-export the canonical `DecisionReceipt` classes from `aragora.receipts`
- preserve the operational receipt helpers already exposed by the package

## Validation
- `python3 - <<'PY' ... from aragora.receipts import DecisionReceipt, LegacyDecisionReceipt ... PY`
- `ruff check aragora/receipts/__init__.py`