### PR TITLE
fix(sme): use live connectors for channel listing

### DIFF
--- a/aragora/server/handlers/sme/slack_workspace.py
+++ b/aragora/server/handlers/sme/slack_workspace.py
@@ -35,6 +35,7 @@ from ..utils.responses import HandlerResult
 from ..secure import SecureHandler
 from aragora.billing.tier_gating import require_tier
 from aragora.rbac.decorators import require_permission
+from aragora.utils.async_utils import run_async
 from ..utils.rate_limit import RateLimiter, get_client_ip
 
 logger = logging.getLogger(__name__)
@@ -579,6 +580,7 @@ class SlackWorkspaceHandler(SecureHandler):
 
         Query Parameters:
             types: Channel types to include (public_channel, private_channel)
+            limit: Maximum number of channels to return (default: 100)
 
         Returns:
             JSON response with channel list:
@@ -607,28 +609,36 @@ class SlackWorkspaceHandler(SecureHandler):
         if workspace.tenant_id != org.id:
             return error_response("Workspace not found", 404)
 
-        _types = get_string_param(handler, "types", "public_channel")  # noqa: F841
+        channel_types = get_string_param(handler, "types", "public_channel")
+        limit = int(get_string_param(handler, "limit", "100"))
 
-        # Try to fetch channels from Slack API
         channels: list[dict[str, Any]] = []
 
         try:
             from aragora.connectors.chat.slack import SlackConnector
 
-            _connector = SlackConnector(token=workspace.access_token)  # noqa: F841
-            # Note: In production, this would make actual API calls
-            # For now, return placeholder indicating API integration needed
+            connector = SlackConnector(
+                bot_token=workspace.access_token,
+                workspace_id=workspace.workspace_id,
+            )
+            connector_channels = run_async(
+                connector.list_channels(
+                    types=channel_types or "public_channel",
+                    limit=limit,
+                )
+            )
             channels = [
                 {
-                    "id": "placeholder",
-                    "name": "Channel listing requires Slack Web API integration",
-                    "is_private": False,
-                    "num_members": 0,
+                    "id": channel.id,
+                    "name": channel.name,
+                    "is_private": channel.is_private,
+                    "num_members": channel.metadata.get("num_members", 0),
                 }
+                for channel in connector_channels
             ]
         except ImportError:
             logger.warning("Slack connector not available")
-        except (RuntimeError, ValueError, OSError) as e:
+        except (RuntimeError, ValueError, OSError, TimeoutError) as e:
             logger.warning("Failed to list Slack channels: %s", e)
 
         return json_response(

--- a/aragora/server/handlers/sme/teams_workspace.py
+++ b/aragora/server/handlers/sme/teams_workspace.py
@@ -34,6 +34,7 @@ from ..utils.responses import HandlerResult
 from ..secure import SecureHandler
 from aragora.billing.tier_gating import require_tier
 from aragora.rbac.decorators import require_permission
+from aragora.utils.async_utils import run_async
 from ..utils.rate_limit import RateLimiter, get_client_ip
 
 logger = logging.getLogger(__name__)
@@ -536,7 +537,8 @@ class TeamsWorkspaceHandler(SecureHandler):
             tenant_id: Azure AD tenant ID
 
         Query Parameters:
-            team_id: Optional team ID to filter channels
+            team_id: Team ID to list channels for (required)
+            include_private: Whether to include private channels (default: false)
 
         Returns:
             JSON response with channel list:
@@ -567,32 +569,42 @@ class TeamsWorkspaceHandler(SecureHandler):
             return error_response("Workspace not found", 404)
 
         team_id = get_string_param(handler, "team_id", None)
+        if not team_id:
+            return error_response("team_id is required to list Teams channels", 400)
 
-        # Try to fetch channels from Teams API
+        include_private = (
+            get_string_param(handler, "include_private", "false") or "false"
+        ).lower() in {"1", "true", "yes", "on"}
+
         channels: list[dict[str, Any]] = []
 
         try:
-            from aragora.connectors.enterprise.collaboration.teams import (
-                TeamsEnterpriseConnector,
-            )
+            from aragora.connectors.chat.teams import TeamsConnector
 
-            _connector = TeamsEnterpriseConnector(  # noqa: F841
+            connector = TeamsConnector(
+                app_id=workspace.bot_id,
+                app_password=workspace.access_token,
                 tenant_id=workspace.tenant_id,
             )
-            # Note: In production, this would make actual API calls
-            # For now, return placeholder indicating API integration needed
+            connector_channels = run_async(
+                connector.list_channels(
+                    team_id=team_id,
+                    include_private=include_private,
+                )
+            )
             channels = [
                 {
-                    "id": "placeholder",
-                    "team_id": team_id or "default",
-                    "display_name": "Channel listing requires Graph API integration",
-                    "description": "Configure Microsoft Graph API credentials to list channels",
-                    "web_url": "",
+                    "id": channel.id,
+                    "team_id": channel.team_id or team_id,
+                    "display_name": channel.name,
+                    "description": channel.metadata.get("description", ""),
+                    "web_url": channel.metadata.get("web_url", ""),
                 }
+                for channel in connector_channels
             ]
         except ImportError:
             logger.warning("Teams connector not available")
-        except (RuntimeError, ValueError, OSError) as e:
+        except (RuntimeError, ValueError, OSError, TimeoutError) as e:
             logger.warning("Failed to list Teams channels: %s", e)
 
         return json_response(

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -351,9 +351,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Partial | Core Teams support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -73,8 +73,8 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
 - `aragora/server/handlers/goal_canvas.py` still returns placeholder data for advancing a canvas into the actions stage.
 - `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
-- `aragora/server/handlers/sme/slack_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
-- `aragora/server/handlers/sme/teams_workspace.py` has placeholder channel listing plus placeholder SME OAuth start/callback endpoints.
+- `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, but the SME OAuth start/callback endpoints are still placeholder-backed.
+- `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, but the SME OAuth start/callback endpoints are still placeholder-backed.
 - `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.
 - `aragora/server/handlers/gauntlet/receipts.py` and the compliance UI still have placeholder or optional anchor-verification paths.
 - `aragora/server/handlers/security_debate.py` exposes an async-status endpoint that is explicitly a placeholder because debates are synchronous and not persisted.
@@ -91,7 +91,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 
 ### Documentation Positioning Needed
 
-- Slack and Teams integration docs should distinguish between shipped general integrations and still-placeholder SME workspace onboarding/channel enumeration surfaces.
+- Slack and Teams integration docs should distinguish between shipped general integrations and still-partial SME workspace onboarding/OAuth helper surfaces.
 - `docs/status/FEATURE_DISCOVERY.md` still contains some optimistic `Stable` labels for backend-conditional or placeholder-backed surfaces and should continue to be tightened.
 - RLM and unified memory inventory entries need to reference current file paths (`aragora/server/handlers/rlm.py`, `aragora/memory/gateway.py`, related modules) rather than stale package layouts.
 - Knowledge Mound adapter counts need a dedicated normalization sweep: many current docs still say `45`, while the current factory registry exposes `42` adapter specs.

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -349,9 +349,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Partial | Core Teams support exists; SME workspace channel listing and SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |

--- a/tests/handlers/sme/test_slack_workspace.py
+++ b/tests/handlers/sme/test_slack_workspace.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.connectors.chat.models import ChatChannel
 from aragora.server.handlers.sme.slack_workspace import SlackWorkspaceHandler
 
 
@@ -335,13 +336,57 @@ class TestListChannels:
         workspace = MockSlackWorkspace()
         mock_workspace_store.get.return_value = workspace
 
-        request = MockRequest(command="GET")
-        result = handler._list_channels(request, {}, "T12345678", user=MockUser())
+        request = MockRequest(
+            command="GET",
+            query_params={"types": "public_channel,private_channel"},
+        )
+        connector_channels = [
+            ChatChannel(
+                id="C12345678",
+                platform="slack",
+                name="general",
+                metadata={"num_members": 42},
+            ),
+            ChatChannel(
+                id="C99999999",
+                platform="slack",
+                name="private-room",
+                is_private=True,
+                metadata={"num_members": 3},
+            ),
+        ]
+
+        with patch("aragora.connectors.chat.slack.SlackConnector") as mock_connector_cls:
+            mock_connector = MagicMock()
+            mock_connector.list_channels = AsyncMock(return_value=connector_channels)
+            mock_connector_cls.return_value = mock_connector
+            result = handler._list_channels(request, {}, "T12345678", user=MockUser())
 
         assert result.status_code == 200
         body = json.loads(result.body)
-        assert "channels" in body
+        assert body["channels"] == [
+            {
+                "id": "C12345678",
+                "name": "general",
+                "is_private": False,
+                "num_members": 42,
+            },
+            {
+                "id": "C99999999",
+                "name": "private-room",
+                "is_private": True,
+                "num_members": 3,
+            },
+        ]
         assert body["workspace_id"] == "T12345678"
+        mock_connector_cls.assert_called_once_with(
+            bot_token=workspace.access_token,
+            workspace_id=workspace.workspace_id,
+        )
+        mock_connector.list_channels.assert_awaited_once_with(
+            types="public_channel,private_channel",
+            limit=100,
+        )
 
 
 class TestSubscribeChannel:

--- a/tests/handlers/sme/test_teams_workspace.py
+++ b/tests/handlers/sme/test_teams_workspace.py
@@ -7,10 +7,11 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from io import BytesIO
 from typing import Any, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.connectors.chat.models import ChatChannel
 from aragora.server.handlers.sme.teams_workspace import TeamsWorkspaceHandler
 
 
@@ -378,18 +379,67 @@ class TestListChannels:
 
         assert result.status_code == 404
 
-    def test_list_channels_success(self, handler, mock_workspace_store):
-        """Test listing channels successfully."""
+    def test_list_channels_requires_team_id(self, handler, mock_workspace_store):
+        """Test listing channels requires a team_id query parameter."""
         workspace = MockTeamsWorkspace()
         mock_workspace_store.get.return_value = workspace
 
         request = MockRequest(command="GET")
         result = handler._list_channels(request, {}, "tenant-123", user=MockUser())
 
+        assert result.status_code == 400
+        body = json.loads(result.body)
+        assert body["error"] == "team_id is required to list Teams channels"
+
+    def test_list_channels_success(self, handler, mock_workspace_store):
+        """Test listing channels successfully."""
+        workspace = MockTeamsWorkspace()
+        mock_workspace_store.get.return_value = workspace
+
+        request = MockRequest(
+            command="GET",
+            query_params={"team_id": "team-123", "include_private": "true"},
+        )
+        connector_channels = [
+            ChatChannel(
+                id="channel-123",
+                platform="teams",
+                name="General",
+                team_id="team-123",
+                metadata={
+                    "description": "Main discussion channel",
+                    "web_url": "https://teams.example/channel-123",
+                },
+            )
+        ]
+
+        with patch("aragora.connectors.chat.teams.TeamsConnector") as mock_connector_cls:
+            mock_connector = MagicMock()
+            mock_connector.list_channels = AsyncMock(return_value=connector_channels)
+            mock_connector_cls.return_value = mock_connector
+            result = handler._list_channels(request, {}, "tenant-123", user=MockUser())
+
         assert result.status_code == 200
         body = json.loads(result.body)
-        assert "channels" in body
+        assert body["channels"] == [
+            {
+                "id": "channel-123",
+                "team_id": "team-123",
+                "display_name": "General",
+                "description": "Main discussion channel",
+                "web_url": "https://teams.example/channel-123",
+            }
+        ]
         assert body["tenant_id"] == "tenant-123"
+        mock_connector_cls.assert_called_once_with(
+            app_id=workspace.bot_id,
+            app_password=workspace.access_token,
+            tenant_id=workspace.tenant_id,
+        )
+        mock_connector.list_channels.assert_awaited_once_with(
+            team_id="team-123",
+            include_private=True,
+        )
 
 
 class TestSubscribeChannel:


### PR DESCRIPTION
## Summary
- replace placeholder Slack SME channel listing with the live Slack connector
- replace placeholder Teams SME channel listing with the live Teams connector when `team_id` is supplied
- tighten SME handler tests and update discovery docs to reflect the remaining OAuth helper gap

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/sme/test_slack_workspace.py tests/handlers/sme/test_teams_workspace.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/server/handlers/sme/test_slack_workspace.py tests/server/handlers/sme/test_teams_workspace.py
- ruff check aragora/server/handlers/sme/slack_workspace.py aragora/server/handlers/sme/teams_workspace.py tests/handlers/sme/test_slack_workspace.py tests/handlers/sme/test_teams_workspace.py
- python3 -m compileall aragora/server/handlers/sme/slack_workspace.py aragora/server/handlers/sme/teams_workspace.py
