### PR TITLE
fix(frontend): rewire system intelligence overview data

### DIFF
--- a/aragora/live/src/app/(app)/system-intelligence/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(app)/system-intelligence/__tests__/page.test.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import SystemIntelligencePage from '../page';
+
+const mockUseSWRFetch = jest.fn();
+const mockAddGoal = jest.fn();
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock('@/components/MatrixRain', () => ({
+  Scanlines: () => null,
+  CRTVignette: () => null,
+}));
+
+jest.mock('@/components/AsciiBanner', () => ({
+  AsciiBannerCompact: () => <div data-testid="ascii-banner" />,
+}));
+
+jest.mock('@/components/ThemeToggle', () => ({
+  ThemeToggle: () => <div data-testid="theme-toggle" />,
+}));
+
+jest.mock('@/components/BackendSelector', () => ({
+  BackendSelector: () => <div data-testid="backend-selector" />,
+}));
+
+jest.mock('@/components/PanelErrorBoundary', () => ({
+  PanelErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/hooks/useSystemIntelligence', () => ({
+  useSystemIntelligence: () => ({
+    overview: {
+      totalCycles: 12,
+      successRate: 0.75,
+      activeAgents: 4,
+      knowledgeItems: 128,
+      topAgents: [{ id: 'claude', elo: 1700, wins: 12 }],
+      recentImprovements: [],
+    },
+    isLoading: false,
+  }),
+  useAgentPerformance: () => ({
+    agents: [
+      {
+        id: 'claude',
+        name: 'claude',
+        elo: 1700,
+        eloHistory: [
+          { date: '2026-03-24T00:00:00Z', elo: 1680 },
+          { date: '2026-03-25T00:00:00Z', elo: 1700 },
+        ],
+        calibration: 0.83,
+        winRate: 0.67,
+        domains: ['security', 'architecture'],
+      },
+    ],
+    isLoading: false,
+  }),
+  useInstitutionalMemory: () => ({
+    memory: {
+      totalInjections: 18,
+      retrievalCount: 9,
+      topPatterns: [{ pattern: 'Use receipts', frequency: 5, confidence: 0.9 }],
+      confidenceChanges: [{ topic: 'receipts', before: 0.7, after: 0.9 }],
+    },
+    isLoading: false,
+  }),
+  useImprovementQueue: () => ({
+    items: [
+      {
+        id: 'imp-1',
+        goal: 'Reduce latency',
+        priority: 90,
+        source: 'debate',
+        status: 'pending',
+        createdAt: '2026-03-25T00:00:00Z',
+      },
+    ],
+    isLoading: false,
+    addGoal: mockAddGoal,
+  }),
+}));
+
+jest.mock('@/hooks/useSystemHealth', () => ({
+  useSystemHealth: () => ({
+    health: {
+      overall_status: 'healthy',
+      subsystems: {},
+      circuit_breakers: { available: true, breakers: [], total: 0 },
+      slos: { available: true, overall_healthy: true },
+      agents: { available: true, agents: [], total: 2, active: 1 },
+      budget: { available: true, utilization: 0.42, forecast: { eom: 1000, trend: 'stable' } },
+      last_check: '2026-03-25T00:00:00Z',
+      collection_time_ms: 18,
+    },
+    isLoading: false,
+  }),
+  useAgentPoolHealth: () => ({
+    agents: [{ agent_id: 'claude', type: 'anthropic-api', status: 'active' }],
+    total: 2,
+    active: 1,
+    available: true,
+  }),
+}));
+
+jest.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: (...args: unknown[]) => mockUseSWRFetch(...args),
+}));
+
+describe('SystemIntelligencePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseSWRFetch.mockImplementation((endpoint: string) => {
+      if (endpoint === '/api/v1/autonomous/monitoring/anomalies?hours=24') {
+        return {
+          data: {
+            anomalies: [
+              {
+                id: 'an-1',
+                severity: 'critical',
+                metric_name: 'latency',
+                description: 'Latency spike detected',
+                timestamp: '2026-03-25T00:00:00Z',
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint === '/api/history/events?limit=30') {
+        return {
+          data: {
+            events: [
+              {
+                id: 'evt-1',
+                event_type: 'debate_completed',
+                agent: 'codex',
+                timestamp: '2026-03-25T00:00:00Z',
+                event_data: { message: 'Debate completed successfully' },
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint === '/api/v1/knowledge/mound/dashboard/health') {
+        return {
+          data: {
+            success: true,
+            data: {
+              status: 'healthy',
+              checks: { adapters: true },
+              timestamp: '2026-03-25T00:00:00Z',
+            },
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint === '/api/v1/knowledge/mound/dashboard/adapters') {
+        return {
+          data: {
+            success: true,
+            data: {
+              total: 4,
+              enabled: 3,
+              last_sync: '2026-03-25T00:00:00Z',
+              adapters: [
+                { name: 'continuum', enabled: true },
+                { name: 'consensus', enabled: true },
+                { name: 'receipt', enabled: true },
+                { name: 'ranking', enabled: false },
+              ],
+            },
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint === '/api/v1/nomic/state') {
+        return {
+          data: {
+            state: 'running',
+            cycle: 12,
+            phase: 'verify',
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint === '/api/control-plane/queue/metrics') {
+        return {
+          data: {
+            pending: 2,
+            running: 1,
+            completed_today: 5,
+            avg_execution_time_ms: 4500,
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      return { data: null, error: null, isLoading: false };
+    });
+  });
+
+  it('uses live backend routes for overview data and renders normalized results', () => {
+    render(<SystemIntelligencePage />);
+
+    const endpoints = mockUseSWRFetch.mock.calls.map(([endpoint]) => endpoint);
+
+    expect(endpoints).toEqual(
+      expect.arrayContaining([
+        '/api/v1/autonomous/monitoring/anomalies?hours=24',
+        '/api/history/events?limit=30',
+        '/api/v1/knowledge/mound/dashboard/health',
+        '/api/v1/knowledge/mound/dashboard/adapters',
+        '/api/v1/nomic/state',
+        '/api/control-plane/queue/metrics',
+      ])
+    );
+
+    expect(endpoints).not.toContain('/api/v1/system-intelligence/anomalies');
+    expect(endpoints).not.toContain('/api/v1/system-intelligence/events?limit=30');
+    expect(endpoints).not.toContain('/api/v1/system-intelligence/km-sync');
+    expect(endpoints).not.toContain('/api/v1/system-intelligence/nomic-status');
+    expect(endpoints).not.toContain('/api/v1/system-intelligence/debate-queue');
+
+    expect(screen.getByText('Latency spike detected')).toBeInTheDocument();
+    expect(screen.getByText('Debate completed successfully')).toBeInTheDocument();
+    expect(screen.getByText('Verification')).toBeInTheDocument();
+    expect(screen.getByText('3/4')).toBeInTheDocument();
+    expect(screen.getByText('4.5s')).toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/app/(app)/system-intelligence/page.tsx
+++ b/aragora/live/src/app/(app)/system-intelligence/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { AsciiBannerCompact } from '@/components/AsciiBanner';
 import { ThemeToggle } from '@/components/ThemeToggle';
-import { BackendSelector, useBackend } from '@/components/BackendSelector';
+import { BackendSelector } from '@/components/BackendSelector';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import {
   useSystemIntelligence,
@@ -64,6 +64,83 @@ interface DebateQueueInfo {
   avg_duration_ms: number;
 }
 
+interface MonitoringAnomalyRecord {
+  id?: string;
+  severity?: string;
+  description?: string;
+  message?: string;
+  metric_name?: string;
+  source?: string;
+  timestamp?: string;
+  resolved?: boolean;
+}
+
+interface MonitoringAnomalyResponse {
+  anomalies?: MonitoringAnomalyRecord[];
+}
+
+interface HistoryEventRecord {
+  id?: string;
+  event_type?: string;
+  type?: string;
+  message?: string;
+  source?: string;
+  agent?: string;
+  timestamp?: string;
+  event_data?: {
+    message?: string;
+    summary?: string;
+  } | null;
+}
+
+interface HistoryEventsResponse {
+  events?: HistoryEventRecord[];
+}
+
+interface SuccessEnvelope<T> {
+  success?: boolean;
+  data?: T;
+}
+
+interface KMHealthPayload {
+  status?: string;
+  checks?: Record<string, boolean>;
+  timestamp?: string | null;
+}
+
+interface KMAdaptersPayload {
+  total?: number;
+  enabled?: number;
+  last_sync?: string | null;
+  adapters?: Array<{
+    name?: string;
+    enabled?: boolean;
+  }>;
+}
+
+interface NomicStatePayload {
+  state?: string;
+  status?: string;
+  active?: boolean;
+  running?: boolean;
+  cycle?: number;
+  current_cycle?: number;
+  phase?: string;
+  current_phase?: string;
+  success_rate?: number;
+  total_cycles?: number;
+  last_completed_at?: string | null;
+  last_update?: string | null;
+  updated_at?: string | null;
+}
+
+interface QueueMetricsPayload {
+  pending?: number;
+  running?: number;
+  completed_today?: number;
+  avg_execution_time_ms?: number;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -113,6 +190,91 @@ function getPhaseLabel(phase: string) {
   }
 }
 
+function normalizeAnomalies(data?: MonitoringAnomalyResponse | null): AnomalyAlert[] {
+  return (data?.anomalies ?? []).map((anomaly, index) => ({
+    id: anomaly.id ?? `anomaly-${index}`,
+    severity:
+      anomaly.severity === 'critical' || anomaly.severity === 'warning' || anomaly.severity === 'info'
+        ? anomaly.severity
+        : 'warning',
+    message: anomaly.description ?? anomaly.message ?? 'Anomaly detected',
+    source: anomaly.metric_name ?? anomaly.source ?? 'autonomous-monitoring',
+    timestamp: anomaly.timestamp ?? '',
+    resolved: anomaly.resolved ?? false,
+  }));
+}
+
+function normalizeSystemEvents(data?: HistoryEventsResponse | null): SystemEvent[] {
+  return (data?.events ?? []).map((event, index) => ({
+    id: event.id ?? `event-${index}`,
+    type: event.event_type ?? event.type ?? 'system_event',
+    message: event.message ?? event.event_data?.message ?? event.event_data?.summary ?? 'System event',
+    timestamp: event.timestamp ?? '',
+    source: event.agent ?? event.source ?? 'system',
+  }));
+}
+
+function normalizeKMSyncStatus(
+  healthEnvelope?: SuccessEnvelope<KMHealthPayload> | null,
+  adaptersEnvelope?: SuccessEnvelope<KMAdaptersPayload> | null
+): KMSyncStatus | null {
+  const health = healthEnvelope?.data;
+  const adapters = adaptersEnvelope?.data;
+
+  if (!health && !adapters) return null;
+
+  const adaptersTotal = adapters?.total ?? adapters?.adapters?.length ?? 0;
+  const derivedEnabledAdapters = adapters?.adapters?.filter((adapter) => adapter.enabled).length ?? 0;
+  const adaptersActive =
+    adapters?.enabled ?? derivedEnabledAdapters;
+  const syncHealthy =
+    typeof health?.checks?.adapters === 'boolean'
+      ? health.checks.adapters
+      : (health?.status ?? 'healthy') === 'healthy';
+
+  return {
+    last_sync: adapters?.last_sync ?? health?.timestamp ?? null,
+    pending_items: 0,
+    adapters_active: adaptersActive,
+    adapters_total: adaptersTotal,
+    sync_healthy: syncHealthy,
+  };
+}
+
+function normalizeNomicCycleStatus(
+  state: NomicStatePayload | null | undefined,
+  overview: SystemOverview | null
+): NomicCycleStatus | null {
+  if (!state && !overview) return null;
+
+  const stateLabel = (state?.state ?? state?.status ?? '').toLowerCase();
+  const active =
+    state?.active ??
+    state?.running ??
+    !['not_running', 'idle', 'stopped', 'complete', 'completed'].includes(stateLabel);
+  const currentCycle = state?.current_cycle ?? state?.cycle ?? overview?.totalCycles ?? 0;
+
+  return {
+    active,
+    current_cycle: currentCycle,
+    current_phase: state?.current_phase ?? state?.phase ?? (active ? 'debate' : 'complete'),
+    last_completed_at: state?.last_completed_at ?? state?.last_update ?? state?.updated_at ?? null,
+    success_rate: state?.success_rate ?? overview?.successRate ?? 0,
+    total_cycles: state?.total_cycles ?? overview?.totalCycles ?? currentCycle,
+  };
+}
+
+function normalizeDebateQueueInfo(data?: QueueMetricsPayload | null): DebateQueueInfo | null {
+  if (!data) return null;
+
+  return {
+    active_debates: data.running ?? 0,
+    queued_debates: data.pending ?? 0,
+    completed_today: data.completed_today ?? 0,
+    avg_duration_ms: data.avg_execution_time_ms ?? 0,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
@@ -120,7 +282,6 @@ function getPhaseLabel(phase: string) {
 type Section = 'overview' | 'agents' | 'knowledge' | 'queue';
 
 export default function SystemIntelligencePage() {
-  const { config: _config } = useBackend();
   const [activeSection, setActiveSection] = useState<Section>('overview');
 
   // --- Core hooks ---
@@ -134,36 +295,40 @@ export default function SystemIntelligencePage() {
   const { agents: poolAgents, total: poolTotal, active: poolActive, available: poolAvailable } = useAgentPoolHealth();
 
   // --- Additional data from backend ---
-  const { data: anomalyData } = useSWRFetch<{ data: { alerts: AnomalyAlert[] } }>(
-    '/api/v1/system-intelligence/anomalies',
+  const { data: anomalyData } = useSWRFetch<MonitoringAnomalyResponse>(
+    '/api/v1/autonomous/monitoring/anomalies?hours=24',
     { refreshInterval: 15000 }
   );
-  const anomalies = anomalyData?.data?.alerts ?? [];
+  const anomalies = normalizeAnomalies(anomalyData);
   const unresolvedAnomalies = anomalies.filter(a => !a.resolved);
 
-  const { data: eventsData } = useSWRFetch<{ data: { events: SystemEvent[] } }>(
-    '/api/v1/system-intelligence/events?limit=30',
+  const { data: eventsData } = useSWRFetch<HistoryEventsResponse>(
+    '/api/history/events?limit=30',
     { refreshInterval: 10000 }
   );
-  const systemEvents = eventsData?.data?.events ?? [];
+  const systemEvents = normalizeSystemEvents(eventsData);
 
-  const { data: kmSyncData } = useSWRFetch<{ data: KMSyncStatus }>(
-    '/api/v1/system-intelligence/km-sync',
+  const { data: kmHealthData } = useSWRFetch<SuccessEnvelope<KMHealthPayload>>(
+    '/api/v1/knowledge/mound/dashboard/health',
     { refreshInterval: 30000 }
   );
-  const kmSync = kmSyncData?.data ?? null;
+  const { data: kmAdaptersData } = useSWRFetch<SuccessEnvelope<KMAdaptersPayload>>(
+    '/api/v1/knowledge/mound/dashboard/adapters',
+    { refreshInterval: 30000 }
+  );
+  const kmSync = normalizeKMSyncStatus(kmHealthData, kmAdaptersData);
 
-  const { data: nomicData } = useSWRFetch<{ data: NomicCycleStatus }>(
-    '/api/v1/system-intelligence/nomic-status',
+  const { data: nomicData } = useSWRFetch<NomicStatePayload>(
+    '/api/v1/nomic/state',
     { refreshInterval: 15000 }
   );
-  const nomicStatus = nomicData?.data ?? null;
+  const nomicStatus = normalizeNomicCycleStatus(nomicData, overview);
 
-  const { data: debateQueueData } = useSWRFetch<{ data: DebateQueueInfo }>(
-    '/api/v1/system-intelligence/debate-queue',
+  const { data: debateQueueData } = useSWRFetch<QueueMetricsPayload>(
+    '/api/control-plane/queue/metrics',
     { refreshInterval: 10000 }
   );
-  const debateQueue = debateQueueData?.data ?? null;
+  const debateQueue = normalizeDebateQueueInfo(debateQueueData);
 
   // --- New goal form ---
   const [newGoal, setNewGoal] = useState('');


### PR DESCRIPTION
## Summary
- rewire the system intelligence overview page to live backend endpoints
- normalize the newer anomaly, history, KM, nomic, and queue payloads on the frontend
- add focused frontend coverage under the repo-standard __tests__ layout

## Validation
- cd aragora/live && npm test -- --runTestsByPath "src/app/(app)/system-intelligence/__tests__/page.test.tsx"
- cd aragora/live && npx eslint "src/app/(app)/system-intelligence/page.tsx" "src/app/(app)/system-intelligence/__tests__/page.test.tsx" --max-warnings 0
