### PR TITLE
fix(playground): accept trailing-slash debate route

### DIFF
--- a/aragora/rbac/middleware.py
+++ b/aragora/rbac/middleware.py
@@ -464,7 +464,7 @@ DEFAULT_ROUTE_PERMISSIONS = [
         r"^/api/(v1/)?scheduler/webhooks/[^/]+$", "POST", "", allow_unauthenticated=True
     ),
     # Playground - public demo endpoints (rate-limited, mock agents only)
-    RoutePermission(r"^/api/(v1/)?playground/debate$", "POST", "", allow_unauthenticated=True),
+    RoutePermission(r"^/api/(v1/)?playground/debate/?$", "POST", "", allow_unauthenticated=True),
     RoutePermission(r"^/api/(v1/)?playground/status$", "GET", "", allow_unauthenticated=True),
     # Health endpoints (additional patterns)
     RoutePermission(

--- a/aragora/server/auth_checks.py
+++ b/aragora/server/auth_checks.py
@@ -306,6 +306,7 @@ class AuthChecksMixin:
             # "/api/v1/nomic/state",
             # Playground - only mock debate is free (no API credits used)
             "/api/v1/playground/debate",
+            "/api/v1/playground/debate/",
             # Live debate + TTS: NOT exempt — require auth + budget gate
             # (handled by _check_live_streaming_budget in the request pipeline)
             "/api/v1/playground/status",

--- a/aragora/server/auth_requirements.py
+++ b/aragora/server/auth_requirements.py
@@ -109,6 +109,12 @@ PUBLIC_ENDPOINTS = [
         description="Public playground debate",
     ),
     EndpointAuth(
+        "/api/v1/playground/debate/",
+        "post",
+        AuthLevel.PUBLIC,
+        description="Public playground debate",
+    ),
+    EndpointAuth(
         "/api/v1/playground/status",
         "get",
         AuthLevel.PUBLIC,

--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -1546,13 +1546,17 @@ class PlaygroundHandler(BaseHandler):
     ]
 
     _DEBATE_ID_PATTERN = re.compile(r"^/api/v1/playground/debate/([a-f0-9]{16,32})$")
+    _CREATE_PATHS = {
+        "/api/v1/playground/debate",
+        "/api/v1/playground/debate/",
+    }
 
     def __init__(self, ctx: dict | None = None):
         self.ctx = ctx or {}
 
     def can_handle(self, path: str) -> bool:
         if path in (
-            "/api/v1/playground/debate",
+            *self._CREATE_PATHS,
             "/api/v1/playground/debate/live",
             "/api/v1/playground/debate/live/cost-estimate",
             "/api/v1/playground/status",
@@ -1716,7 +1720,7 @@ class PlaygroundHandler(BaseHandler):
             return self._handle_cost_estimate(handler)
         if path == "/api/v1/playground/debate/live":
             return self._handle_live_debate(handler)
-        if path != "/api/v1/playground/debate":
+        if path not in self._CREATE_PATHS:
             return None
 
         # Parse body early so we can check cache before rate limiting

--- a/aragora/server/middleware/timeout.py
+++ b/aragora/server/middleware/timeout.py
@@ -92,6 +92,7 @@ class RequestTimeoutConfig:
             "/api/evidence/collect",
             "/api/broadcast",
             "/api/v1/playground/debate",  # Oracle LLM calls take 15-40s
+            "/api/v1/playground/debate/",  # Oracle LLM calls take 15-40s
         ]
 
         for pattern in slow_patterns:

--- a/tests/server/handlers/test_playground.py
+++ b/tests/server/handlers/test_playground.py
@@ -158,6 +158,9 @@ class TestCanHandle:
     def test_handles_debate_path(self, handler):
         assert handler.can_handle("/api/v1/playground/debate") is True
 
+    def test_handles_trailing_slash_debate_path(self, handler):
+        assert handler.can_handle("/api/v1/playground/debate/") is True
+
     def test_handles_status_path(self, handler):
         assert handler.can_handle("/api/v1/playground/status") is True
 
@@ -214,6 +217,15 @@ class TestDebateEndpoint:
         assert "participants" in data
         assert len(data["participants"]) == 3  # default agent count
         assert data["duration_seconds"] >= 0
+
+    def test_debate_with_trailing_slash_path(self, handler, mock_http_handler):
+        """Trailing-slash create path is accepted for same-origin dev proxies."""
+        h = mock_http_handler({})
+        result = handler.handle_post("/api/v1/playground/debate/", {}, h)
+        data, status = _parse_result(result)
+
+        assert status == 200
+        assert "id" in data
 
     def test_debate_with_custom_topic(self, handler, mock_http_handler):
         """Custom topic is passed through correctly."""


### PR DESCRIPTION
## Summary
- accept `/api/v1/playground/debate/` alongside the existing create route
- keep the trailing-slash path public and slow-path budgeted anywhere auth and timeout routing check the playground endpoint
- add focused regression coverage for the trailing-slash route

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/server/handlers/test_playground.py
- ruff check aragora/rbac/middleware.py aragora/server/auth_checks.py aragora/server/auth_requirements.py aragora/server/handlers/playground.py aragora/server/middleware/timeout.py tests/server/handlers/test_playground.py
