### PR TITLE
fix(sme): delegate OAuth helpers to canonical flows

### DIFF
--- a/aragora/server/handlers/sme/slack_workspace.py
+++ b/aragora/server/handlers/sme/slack_workspace.py
@@ -23,6 +23,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlencode
 
 from ..base import (
     error_response,
@@ -117,37 +118,35 @@ class SlackWorkspaceHandler(SecureHandler):
         # Determine HTTP method from handler if not provided
         if hasattr(handler, "command"):
             method = handler.command
+        if user is None and hasattr(handler, "user"):
+            user = handler.user
 
         # Handle static routes
         if path == "/api/v1/sme/slack/workspaces":
             if method == "GET":
-                return self._list_workspaces(handler, query_params)
+                return self._list_workspaces(handler, query_params, user=user)
             if method == "POST":
-                return self._create_workspace(handler, query_params)
+                return self._create_workspace(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/slack/oauth/start":
             if method == "GET":
-                return self._handle_oauth_start(handler, query_params)
+                return self._handle_oauth_start(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/slack/oauth/callback":
             if method == "GET":
-                code = query_params.get("code")
-                state = query_params.get("state")
-                if not code:
-                    return error_response("Missing OAuth code", 400)
-                return self._handle_oauth_callback(code, state, handler)
+                return self._handle_oauth_callback(query_params, handler)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/slack/subscribe":
             if method == "POST":
-                return self._subscribe_channel(handler, query_params)
+                return self._subscribe_channel(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/slack/subscriptions":
             if method == "GET":
-                return self._list_subscriptions(handler, query_params)
+                return self._list_subscriptions(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         # Handle parameterized routes
@@ -155,26 +154,26 @@ class SlackWorkspaceHandler(SecureHandler):
         if route_name:
             if route_name == "workspace_detail":
                 if method == "GET":
-                    return self._get_workspace(handler, query_params, param_id)
+                    return self._get_workspace(handler, query_params, param_id, user=user)
                 elif method == "PATCH":
-                    return self._update_workspace(handler, query_params, param_id)
+                    return self._update_workspace(handler, query_params, param_id, user=user)
                 elif method == "DELETE":
-                    return self._disconnect_workspace(handler, query_params, param_id)
+                    return self._disconnect_workspace(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name == "workspace_test":
                 if method == "POST":
-                    return self._test_connection(handler, query_params, param_id)
+                    return self._test_connection(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name in ("workspace_channels", "channels"):
                 if method == "GET":
-                    return self._list_channels(handler, query_params, param_id)
+                    return self._list_channels(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name == "subscription_detail":
                 if method == "DELETE":
-                    return self._delete_subscription(handler, query_params, param_id)
+                    return self._delete_subscription(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
         return error_response("Not found", 404)
@@ -867,13 +866,25 @@ class SlackWorkspaceHandler(SecureHandler):
         query_params: dict,
         user: Any = None,
     ) -> HandlerResult:
-        """Start Slack OAuth flow (placeholder for SME flow)."""
-        # In production this should redirect to Slack OAuth.
-        return json_response(
-            {
-                "status": "oauth_start",
-                "message": "Slack OAuth flow not configured for SME endpoint",
-            }
+        """Start Slack OAuth flow by delegating to the canonical install route."""
+        db_user, org, error = self._get_user_and_org(handler, user)
+        if error:
+            return error
+
+        redirect_params: dict[str, Any] = {"tenant_id": org.id}
+        host = query_params.get("host")
+        if host:
+            redirect_params["host"] = host
+
+        location = f"/api/integrations/slack/install?{urlencode(redirect_params, doseq=True)}"
+        return HandlerResult(
+            status_code=302,
+            content_type="text/html",
+            body=b"",
+            headers={
+                "Location": location,
+                "Cache-Control": "no-store",
+            },
         )
 
     @api_endpoint(
@@ -883,18 +894,30 @@ class SlackWorkspaceHandler(SecureHandler):
         tags=["SME", "Slack", "OAuth"],
     )
     @handle_errors("Slack OAuth callback")
-    @require_permission("sme:workspaces:write")
     def _handle_oauth_callback(
         self,
-        code: str,
-        state: str | None,
+        query_params: dict[str, Any],
         handler: Any,
         user: Any = None,
     ) -> HandlerResult:
-        """Handle Slack OAuth callback (placeholder)."""
-        if not code:
+        """Delegate Slack OAuth callback handling to the canonical integration route."""
+        if not query_params.get("code") and not query_params.get("error"):
             return error_response("Missing OAuth code", 400)
-        return json_response({"status": "oauth_callback", "code": code, "state": state})
+
+        encoded = urlencode(query_params, doseq=True)
+        location = "/api/integrations/slack/callback"
+        if encoded:
+            location = f"{location}?{encoded}"
+
+        return HandlerResult(
+            status_code=302,
+            content_type="text/html",
+            body=b"",
+            headers={
+                "Location": location,
+                "Cache-Control": "no-store",
+            },
+        )
 
 
 __all__ = ["SlackWorkspaceHandler"]

--- a/aragora/server/handlers/sme/teams_workspace.py
+++ b/aragora/server/handlers/sme/teams_workspace.py
@@ -23,6 +23,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlencode
 
 from ..base import (
     error_response,
@@ -105,6 +106,7 @@ class TeamsWorkspaceHandler(SecureHandler):
         query_params: dict,
         handler: Any,
         method: str = "GET",
+        user: Any = None,
     ) -> HandlerResult | None:
         """Route Teams workspace requests to appropriate methods."""
         # Rate limit check
@@ -116,37 +118,35 @@ class TeamsWorkspaceHandler(SecureHandler):
         # Determine HTTP method from handler if not provided
         if hasattr(handler, "command"):
             method = handler.command
+        if user is None and hasattr(handler, "user"):
+            user = handler.user
 
         # Handle static routes
         if path in ("/api/v1/sme/teams/workspaces", "/api/v1/sme/teams/tenants"):
             if method == "GET":
-                return self._list_workspaces(handler, query_params)
+                return self._list_workspaces(handler, query_params, user=user)
             if method == "POST":
-                return self._create_tenant(handler, query_params)
+                return self._create_tenant(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/teams/oauth/start":
             if method == "GET":
-                return self._handle_oauth_start(handler, query_params)
+                return self._handle_oauth_start(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/teams/oauth/callback":
             if method == "GET":
-                code = query_params.get("code")
-                state = query_params.get("state")
-                if not code:
-                    return error_response("Missing OAuth code", 400)
-                return self._handle_oauth_callback(code, state, handler)
+                return self._handle_oauth_callback(query_params, handler)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/teams/subscribe":
             if method == "POST":
-                return self._subscribe_channel(handler, query_params)
+                return self._subscribe_channel(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         if path == "/api/v1/sme/teams/subscriptions":
             if method == "GET":
-                return self._list_subscriptions(handler, query_params)
+                return self._list_subscriptions(handler, query_params, user=user)
             return error_response("Method not allowed", 405)
 
         # Handle parameterized routes
@@ -154,26 +154,26 @@ class TeamsWorkspaceHandler(SecureHandler):
         if route_name:
             if route_name == "workspace_detail":
                 if method == "GET":
-                    return self._get_workspace(handler, query_params, param_id)
+                    return self._get_workspace(handler, query_params, param_id, user=user)
                 elif method == "PATCH":
-                    return self._update_tenant(handler, query_params, param_id)
+                    return self._update_tenant(handler, query_params, param_id, user=user)
                 elif method == "DELETE":
-                    return self._disconnect_workspace(handler, query_params, param_id)
+                    return self._disconnect_workspace(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name == "workspace_test":
                 if method == "POST":
-                    return self._test_connection(handler, query_params, param_id)
+                    return self._test_connection(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name in ("workspace_channels", "channels"):
                 if method == "GET":
-                    return self._list_channels(handler, query_params, param_id)
+                    return self._list_channels(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
             if route_name == "subscription_detail":
                 if method == "DELETE":
-                    return self._delete_subscription(handler, query_params, param_id)
+                    return self._delete_subscription(handler, query_params, param_id, user=user)
                 return error_response("Method not allowed", 405)
 
         return error_response("Not found", 404)
@@ -809,27 +809,52 @@ class TeamsWorkspaceHandler(SecureHandler):
         query_params: dict,
         user: Any = None,
     ) -> HandlerResult:
-        """Start Teams OAuth flow (placeholder for SME flow)."""
-        return json_response(
-            {
-                "status": "oauth_start",
-                "message": "Teams OAuth flow not configured for SME endpoint",
-            }
+        """Start Teams OAuth flow by delegating to the canonical install route."""
+        db_user, org, error = self._get_user_and_org(handler, user)
+        if error:
+            return error
+
+        redirect_params: dict[str, Any] = {"org_id": org.id}
+        host = query_params.get("host")
+        if host:
+            redirect_params["host"] = host
+
+        location = f"/api/integrations/teams/install?{urlencode(redirect_params, doseq=True)}"
+        return HandlerResult(
+            status_code=302,
+            content_type="text/html",
+            body=b"",
+            headers={
+                "Location": location,
+                "Cache-Control": "no-store",
+            },
         )
 
     @handle_errors("Teams OAuth callback")
-    @require_permission("sme:workspaces:write")
     def _handle_oauth_callback(
         self,
-        code: str,
-        state: str | None,
+        query_params: dict[str, Any],
         handler: Any,
         user: Any = None,
     ) -> HandlerResult:
-        """Handle Teams OAuth callback (placeholder)."""
-        if not code:
+        """Delegate Teams OAuth callback handling to the canonical integration route."""
+        if not query_params.get("code") and not query_params.get("error"):
             return error_response("Missing OAuth code", 400)
-        return json_response({"status": "oauth_callback", "code": code, "state": state})
+
+        encoded = urlencode(query_params, doseq=True)
+        location = "/api/integrations/teams/callback"
+        if encoded:
+            location = f"{location}?{encoded}"
+
+        return HandlerResult(
+            status_code=302,
+            content_type="text/html",
+            body=b"",
+            headers={
+                "Location": location,
+                "Cache-Control": "no-store",
+            },
+        )
 
 
 __all__ = ["TeamsWorkspaceHandler"]

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -351,9 +351,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector and SME OAuth helpers now delegate into the canonical Slack install/callback flow | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied and SME OAuth helpers now delegate into the canonical Teams install/callback flow | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -73,8 +73,8 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
 - `aragora/server/handlers/goal_canvas.py` still returns placeholder data for advancing a canvas into the actions stage.
 - `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
-- `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, but the SME OAuth start/callback endpoints are still placeholder-backed.
-- `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, but the SME OAuth start/callback endpoints are still placeholder-backed.
+- `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, and the SME OAuth helper endpoints delegate into the canonical Slack install/callback flow.
+- `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, and the SME OAuth helper endpoints delegate into the canonical Teams install/callback flow.
 - `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.
 - `aragora/server/handlers/gauntlet/receipts.py` and the compliance UI still have placeholder or optional anchor-verification paths.
 - `aragora/server/handlers/security_debate.py` exposes an async-status endpoint that is explicitly a placeholder because debates are synchronous and not persisted.
@@ -91,7 +91,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 
 ### Documentation Positioning Needed
 
-- Slack and Teams integration docs should distinguish between shipped general integrations and still-partial SME workspace onboarding/OAuth helper surfaces.
+- Slack and Teams integration docs should distinguish between shipped general integrations and the remaining partial SME setup/onboarding surfaces outside the now-live channel/OAuth helpers.
 - `docs/status/FEATURE_DISCOVERY.md` still contains some optimistic `Stable` labels for backend-conditional or placeholder-backed surfaces and should continue to be tightened.
 - RLM and unified memory inventory entries need to reference current file paths (`aragora/server/handlers/rlm.py`, `aragora/memory/gateway.py`, related modules) rather than stale package layouts.
 - Knowledge Mound adapter counts need a dedicated normalization sweep: many current docs still say `45`, while the current factory registry exposes `42` adapter specs.

--- a/docs/status/FEATURE_DISCOVERY.md
+++ b/docs/status/FEATURE_DISCOVERY.md
@@ -349,9 +349,9 @@ Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored a
 
 | Platform | Status | Features | Key Files |
 |----------|--------|----------|-----------|
-| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector and SME OAuth helpers now delegate into the canonical Slack install/callback flow | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
 | **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
-| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied, but SME OAuth helper endpoints are still placeholder-backed | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied and SME OAuth helpers now delegate into the canonical Teams install/callback flow | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
 | **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
 | **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
 | **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |

--- a/tests/handlers/sme/test_slack_workspace.py
+++ b/tests/handlers/sme/test_slack_workspace.py
@@ -319,6 +319,45 @@ class TestDisconnectWorkspace:
         mock_workspace_store.deactivate.assert_called_once_with("T12345678")
 
 
+class TestOAuth:
+    """Tests for SME Slack OAuth helpers."""
+
+    def test_oauth_start_redirects_to_canonical_install(self, handler):
+        """Test OAuth start delegates to the canonical Slack install route."""
+        request = MockRequest(command="GET", query_params={"host": "localhost:8080"})
+
+        result = handler._handle_oauth_start(request, request, user=MockUser())
+
+        assert result.status_code == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/slack/install?tenant_id=org-456&host=localhost%3A8080"
+        )
+
+    def test_oauth_callback_redirects_to_canonical_callback(self, handler):
+        """Test OAuth callback delegates to the canonical Slack callback route."""
+        request = MockRequest(command="GET")
+
+        result = handler._handle_oauth_callback(
+            {"code": "auth-code-123", "state": "state-123"},
+            request,
+        )
+
+        assert result.status_code == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/slack/callback?code=auth-code-123&state=state-123"
+        )
+
+    def test_oauth_callback_requires_code_or_error(self, handler):
+        """Test OAuth callback rejects empty helper callbacks."""
+        request = MockRequest(command="GET")
+
+        result = handler._handle_oauth_callback({"state": "state-123"}, request)
+
+        assert result.status_code == 400
+
+
 class TestListChannels:
     """Tests for listing channels."""
 

--- a/tests/handlers/sme/test_teams_workspace.py
+++ b/tests/handlers/sme/test_teams_workspace.py
@@ -367,6 +367,45 @@ class TestDisconnectWorkspace:
         mock_subscription_store.deactivate.assert_called_once_with("sub-123")
 
 
+class TestOAuth:
+    """Tests for SME Teams OAuth helpers."""
+
+    def test_oauth_start_redirects_to_canonical_install(self, handler):
+        """Test OAuth start delegates to the canonical Teams install route."""
+        request = MockRequest(command="GET", query_params={"host": "localhost:8080"})
+
+        result = handler._handle_oauth_start(request, request, user=MockUser())
+
+        assert result.status_code == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/teams/install?org_id=org-456&host=localhost%3A8080"
+        )
+
+    def test_oauth_callback_redirects_to_canonical_callback(self, handler):
+        """Test OAuth callback delegates to the canonical Teams callback route."""
+        request = MockRequest(command="GET")
+
+        result = handler._handle_oauth_callback(
+            {"code": "auth-code-123", "state": "state-123"},
+            request,
+        )
+
+        assert result.status_code == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/teams/callback?code=auth-code-123&state=state-123"
+        )
+
+    def test_oauth_callback_requires_code_or_error(self, handler):
+        """Test OAuth callback rejects empty helper callbacks."""
+        request = MockRequest(command="GET")
+
+        result = handler._handle_oauth_callback({"state": "state-123"}, request)
+
+        assert result.status_code == 400
+
+
 class TestListChannels:
     """Tests for listing channels."""
 

--- a/tests/server/handlers/sme/test_slack_workspace.py
+++ b/tests/server/handlers/sme/test_slack_workspace.py
@@ -371,12 +371,7 @@ class TestDeleteWorkspace:
 
 
 class TestOAuth:
-    """Tests for OAuth flow.
-
-    Note: The SlackWorkspaceHandler does not currently expose dedicated
-    /oauth/* routes. These tests verify the subscribe endpoint which is
-    the handler's entry point for workspace configuration.
-    """
+    """Tests for OAuth flow."""
 
     def test_subscribe_endpoint_success(self, slack_handler, mock_user):
         """Test subscribe endpoint (used for workspace config)."""
@@ -387,10 +382,27 @@ class TestOAuth:
         )
         assert result is not None
 
-    def test_oauth_callback_success(self, slack_handler, mock_user):
-        """Test OAuth callback endpoint."""
-        http_handler = MockHandler(path="/api/v1/sme/slack/oauth/callback", method="GET")
+    def test_oauth_start_redirects_to_install(self, slack_handler, mock_user):
+        """Test OAuth start endpoint redirects into the canonical install flow."""
+        http_handler = MockHandler(path="/api/v1/sme/slack/oauth/start", method="GET")
         http_handler.user = mock_user
+
+        result = slack_handler.handle(
+            "/api/v1/sme/slack/oauth/start",
+            {"host": "localhost:8080"},
+            http_handler,
+            method="GET",
+        )
+        assert result is not None
+        assert result.status == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/slack/install?tenant_id=org-123&host=localhost%3A8080"
+        )
+
+    def test_oauth_callback_redirects_to_canonical_callback(self, slack_handler, mock_user):
+        """Test OAuth callback endpoint delegates to canonical callback route."""
+        http_handler = MockHandler(path="/api/v1/sme/slack/oauth/callback", method="GET")
 
         result = slack_handler.handle(
             "/api/v1/sme/slack/oauth/callback",
@@ -399,10 +411,11 @@ class TestOAuth:
             method="GET",
         )
         assert result is not None
-        assert result.status == 200
-        data = result.to_dict()
-        assert data["body"]["status"] == "oauth_callback"
-        assert data["body"]["code"] == "auth-code-123"
+        assert result.status == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/slack/callback?code=auth-code-123&state=state-123"
+        )
 
     def test_oauth_callback_missing_code(self, slack_handler):
         """Test OAuth callback without code."""

--- a/tests/server/handlers/sme/test_teams_workspace.py
+++ b/tests/server/handlers/sme/test_teams_workspace.py
@@ -351,12 +351,7 @@ class TestDeleteTenant:
 
 
 class TestOAuth:
-    """Tests for OAuth flow.
-
-    Note: The TeamsWorkspaceHandler does not currently expose dedicated
-    /oauth/* routes. These tests verify the subscribe endpoint which is
-    the handler's entry point for workspace configuration.
-    """
+    """Tests for OAuth flow."""
 
     def test_subscribe_endpoint_success(self, teams_handler, mock_user):
         """Test subscribe endpoint (used for workspace config)."""
@@ -367,10 +362,27 @@ class TestOAuth:
         )
         assert result is not None
 
-    def test_oauth_callback_success(self, teams_handler, mock_user):
-        """Test OAuth callback endpoint."""
-        http_handler = MockHandler(path="/api/v1/sme/teams/oauth/callback", method="GET")
+    def test_oauth_start_redirects_to_install(self, teams_handler, mock_user):
+        """Test OAuth start endpoint redirects into the canonical install flow."""
+        http_handler = MockHandler(path="/api/v1/sme/teams/oauth/start", method="GET")
         http_handler.user = mock_user
+
+        result = teams_handler.handle(
+            "/api/v1/sme/teams/oauth/start",
+            {"host": "localhost:8080"},
+            http_handler,
+            method="GET",
+        )
+        assert result is not None
+        assert result.status == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/teams/install?org_id=org-123&host=localhost%3A8080"
+        )
+
+    def test_oauth_callback_redirects_to_canonical_callback(self, teams_handler, mock_user):
+        """Test OAuth callback endpoint delegates to canonical callback route."""
+        http_handler = MockHandler(path="/api/v1/sme/teams/oauth/callback", method="GET")
 
         result = teams_handler.handle(
             "/api/v1/sme/teams/oauth/callback",
@@ -379,10 +391,11 @@ class TestOAuth:
             method="GET",
         )
         assert result is not None
-        assert result.status == 200
-        data = result.to_dict()
-        assert data["body"]["status"] == "oauth_callback"
-        assert data["body"]["code"] == "auth-code-123"
+        assert result.status == 302
+        assert (
+            result.headers["Location"]
+            == "/api/integrations/teams/callback?code=auth-code-123&state=state-123"
+        )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- replace the SME Slack and Teams OAuth helper placeholders with redirects into the canonical install/callback flows
- make the SME route wrappers consistently infer `handler.user` when present and pass it through to the internal workspace methods
- update focused SME handler tests and discovery docs to match the new adapter behavior

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/sme/test_slack_workspace.py tests/handlers/sme/test_teams_workspace.py tests/server/handlers/sme/test_slack_workspace.py tests/server/handlers/sme/test_teams_workspace.py
- ruff check aragora/server/handlers/sme/slack_workspace.py aragora/server/handlers/sme/teams_workspace.py tests/handlers/sme/test_slack_workspace.py tests/handlers/sme/test_teams_workspace.py tests/server/handlers/sme/test_slack_workspace.py tests/server/handlers/sme/test_teams_workspace.py
