### PR TITLE
fix(frontend): honor selected backend in SWR fetches

### DIFF
--- a/aragora/live/src/__tests__/hooks/useSWRFetch.test.ts
+++ b/aragora/live/src/__tests__/hooks/useSWRFetch.test.ts
@@ -37,9 +37,12 @@ jest.mock('swr', () => {
 });
 
 describe('useSWRFetch', () => {
+  const mockUseSWR = jest.requireMock('swr').default as jest.Mock;
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockFetch.mockReset();
+    localStorage.clear();
   });
 
   describe('swrFetcher', () => {
@@ -79,6 +82,27 @@ describe('useSWRFetch', () => {
         expect((error as { status: number }).status).toBe(500);
       }
     });
+
+    it('sends auth headers to the selected backend api origin', async () => {
+      localStorage.setItem('aragora-backend', 'production');
+      localStorage.setItem('aragora_tokens', JSON.stringify({ access_token: 'token-123' }));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      });
+
+      await swrFetcher('https://api.aragora.ai/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/test',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+            Authorization: 'Bearer token-123',
+          }),
+        }),
+      );
+    });
   });
 
   describe('useSWRFetch hook', () => {
@@ -106,6 +130,18 @@ describe('useSWRFetch', () => {
       const { result } = renderHook(() => useSWRFetch('/api/test'));
 
       expect(typeof result.current.mutate).toBe('function');
+    });
+
+    it('uses the selected backend api base by default', () => {
+      localStorage.setItem('aragora-backend', 'production');
+
+      renderHook(() => useSWRFetch('/api/test'));
+
+      expect(mockUseSWR).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/test',
+        swrFetcher,
+        expect.any(Object),
+      );
     });
   });
 
@@ -138,6 +174,21 @@ describe('useSWRFetch', () => {
       updateCache('/api/test', updater);
 
       expect(mutate).toHaveBeenCalled();
+    });
+
+    it('prefetchData uses the selected backend api base by default', async () => {
+      localStorage.setItem('aragora-backend', 'production');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ data: 'prefetched' }),
+      });
+
+      await prefetchData('/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/test',
+        expect.any(Object),
+      );
     });
   });
 

--- a/aragora/live/src/components/BackendSelector.tsx
+++ b/aragora/live/src/components/BackendSelector.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react';
 
 export type BackendType = 'production' | 'development';
 
-interface BackendConfig {
+export interface BackendConfig {
   api: string;
   ws: string;
   controlPlaneWs?: string;
@@ -94,6 +94,16 @@ function resolveBackendConfig(
     };
   }
   return config;
+}
+
+export function getRuntimeBackendConfig(): { backend: BackendType; config: BackendConfig } {
+  const localHost =
+    typeof window !== 'undefined' && isLocalHost(window.location.hostname);
+  const backend = getDefaultBackend();
+  return {
+    backend,
+    config: resolveBackendConfig(backend, localHost ? 'localhost' : null),
+  };
 }
 
 interface BackendSelectorProps {
@@ -265,7 +275,7 @@ export function BackendSelector({ onChange, compact = false }: BackendSelectorPr
 export function useBackend(): { backend: BackendType; config: BackendConfig } {
   const localHost =
     typeof window !== 'undefined' && isLocalHost(window.location.hostname);
-  const [backend, setBackend] = useState<BackendType>(getDefaultBackend);
+  const [backend, setBackend] = useState<BackendType>(() => getRuntimeBackendConfig().backend);
 
   useEffect(() => {
     const saved = getSavedBackend();

--- a/aragora/live/src/hooks/useSWRFetch.ts
+++ b/aragora/live/src/hooks/useSWRFetch.ts
@@ -2,6 +2,7 @@
 
 import useSWR, { SWRConfiguration, mutate, useSWRConfig } from 'swr';
 import { API_BASE_URL } from '@/config';
+import { getRuntimeBackendConfig } from '@/components/BackendSelector';
 
 const TOKENS_KEY = 'aragora_tokens';
 
@@ -17,11 +18,18 @@ function getAccessToken(): string | null {
   }
 }
 
+function resolveApiBaseUrl(baseUrl?: string): string {
+  if (baseUrl !== undefined) return baseUrl;
+
+  const runtimeBaseUrl = getRuntimeBackendConfig().config.api;
+  return runtimeBaseUrl ?? API_BASE_URL;
+}
+
 function isInternalApiRequest(url: string): boolean {
   if (typeof window === 'undefined') return false;
   try {
     const parsed = new URL(url, window.location.origin);
-    const apiOrigin = new URL(API_BASE_URL, window.location.origin).origin;
+    const apiOrigin = new URL(resolveApiBaseUrl(), window.location.origin).origin;
     const isApiPath = parsed.pathname.startsWith('/api/');
     const isTrustedOrigin = parsed.origin === window.location.origin || parsed.origin === apiOrigin;
     return isApiPath && isTrustedOrigin;
@@ -105,12 +113,12 @@ export function useSWRFetch<T = unknown>(
   options: UseSWRFetchOptions<T> = {}
 ) {
   const {
-    baseUrl = API_BASE_URL,
+    baseUrl,
     enabled = true,
     ...swrOptions
   } = options;
 
-  const url = endpoint && enabled ? `${baseUrl}${endpoint}` : null;
+  const url = endpoint && enabled ? `${resolveApiBaseUrl(baseUrl)}${endpoint}` : null;
 
   const {
     data,
@@ -158,10 +166,11 @@ export function useSWRFetchMultiple<T = unknown>(
   endpoints: (string | null)[],
   options: UseSWRFetchOptions<T> = {}
 ) {
-  const { baseUrl = API_BASE_URL, enabled = true } = options;
+  const { baseUrl, enabled = true } = options;
+  const resolvedBaseUrl = resolveApiBaseUrl(baseUrl);
 
   const results = endpoints.map((endpoint) => {
-    const url = endpoint && enabled ? `${baseUrl}${endpoint}` : null;
+    const url = endpoint && enabled ? `${resolvedBaseUrl}${endpoint}` : null;
     // eslint-disable-next-line react-hooks/rules-of-hooks
     return useSWR<T>(url, swrFetcher);
   });
@@ -185,8 +194,8 @@ export function useSWRFetchMultiple<T = unknown>(
  *   onMouseEnter={() => prefetchData('/api/debates/123')}
  * >
  */
-export function prefetchData(endpoint: string, baseUrl: string = API_BASE_URL) {
-  const url = `${baseUrl}${endpoint}`;
+export function prefetchData(endpoint: string, baseUrl?: string) {
+  const url = `${resolveApiBaseUrl(baseUrl)}${endpoint}`;
   return mutate(url, swrFetcher(url));
 }
 
@@ -199,8 +208,8 @@ export function prefetchData(endpoint: string, baseUrl: string = API_BASE_URL) {
  * await createDebate(data);
  * invalidateCache('/api/debates');
  */
-export function invalidateCache(endpoint: string, baseUrl: string = API_BASE_URL) {
-  const url = `${baseUrl}${endpoint}`;
+export function invalidateCache(endpoint: string, baseUrl?: string) {
+  const url = `${resolveApiBaseUrl(baseUrl)}${endpoint}`;
   return mutate(url);
 }
 
@@ -230,9 +239,9 @@ export function invalidateCachePattern(pattern: RegExp) {
 export function updateCache<T>(
   endpoint: string,
   updater: (current: T | undefined) => T,
-  baseUrl: string = API_BASE_URL
+  baseUrl?: string
 ) {
-  const url = `${baseUrl}${endpoint}`;
+  const url = `${resolveApiBaseUrl(baseUrl)}${endpoint}`;
   return mutate(url, updater, { revalidate: false });
 }
 


### PR DESCRIPTION
## Summary
- make `useSWRFetch` and its cache helpers honor the selected runtime backend by default
- expose a small `getRuntimeBackendConfig()` helper so the selected backend can be reused consistently
- add focused hook coverage for selected-backend URL resolution and auth header behavior

## Validation
- cd aragora/live && npm test -- --runTestsByPath src/__tests__/hooks/useSWRFetch.test.ts
- cd aragora/live && npx eslint src/hooks/useSWRFetch.ts src/components/BackendSelector.tsx src/__tests__/hooks/useSWRFetch.test.ts --max-warnings 0
