### PR TITLE
fix(frontend): honor selected backend on public pages

### DIFF
--- a/aragora/live/src/app/(standalone)/demo/page.tsx
+++ b/aragora/live/src/app/(standalone)/demo/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
-import { API_BASE_URL } from "@/config";
+import { getRuntimeBackendConfig } from "@/components/BackendSelector";
 
 interface RecordedEvent {
   type: "proposal" | "critique" | "vote" | "consensus";
@@ -1448,7 +1448,8 @@ export default function PublicDemoPage() {
       timers.forEach((timer) => window.clearTimeout(timer));
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/playground/debate`, {
+      const { config } = getRuntimeBackendConfig();
+      const response = await fetch(`${config.api}/api/v1/playground/debate`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import PublicDemoPage from '../(standalone)/demo/page';
+import TryPage from '../try/page';
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as typeof fetch;
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => ({
+    get: () => null,
+  }),
+}));
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('@/components/MatrixRain', () => ({
+  Scanlines: () => <div data-testid="scanlines" />,
+  CRTVignette: () => <div data-testid="crt-vignette" />,
+}));
+
+jest.mock('@/components/try/TeaserResult', () => ({
+  TeaserResult: ({ verdict }: { verdict: string }) => <div>{verdict}</div>,
+}));
+
+jest.mock('react-markdown', () => {
+  return function MockMarkdown({
+    children,
+  }: {
+    children: React.ReactNode;
+  }) {
+    return <div>{children}</div>;
+  };
+});
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: async () => data,
+  } as Response;
+}
+
+describe('runtime backend selection for public debate surfaces', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    localStorage.setItem('aragora-backend', 'production');
+    mockFetch.mockReset();
+    window.scrollTo = jest.fn();
+  });
+
+  it('uses the selected backend for /try debate requests', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        verdict: 'Use the selected backend',
+        confidence: 0.91,
+        explanation: 'Production path confirmed.',
+      }),
+    );
+
+    render(<TryPage />);
+    fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
+      target: {
+        value: 'Should we use the production backend for public try flows?',
+      },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /analyze/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/v1/playground/debate',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+
+  it('uses the selected backend for the standalone live demo run', async () => {
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        id: 'debate-demo-1',
+        topic: 'Demo topic',
+        status: 'completed',
+        rounds_used: 2,
+        consensus_reached: true,
+        confidence: 0.88,
+        verdict: 'Proceed carefully',
+        duration_seconds: 12,
+        participants: ['claude', 'gpt'],
+        proposals: { claude: 'yes', gpt: 'yes' },
+        final_answer: 'Proceed carefully',
+        receipt_hash: 'hash-123',
+      }),
+    );
+
+    render(<PublicDemoPage />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/v1/playground/debate',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+  });
+});

--- a/aragora/live/src/app/try/page.tsx
+++ b/aragora/live/src/app/try/page.tsx
@@ -4,8 +4,8 @@ import { useState, useRef, useEffect, Suspense } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { getRuntimeBackendConfig } from '@/components/BackendSelector';
 import { TeaserResult } from '@/components/try/TeaserResult';
-import { API_BASE_URL } from '@/config';
 
 const EXAMPLE_QUESTIONS = [
   'Should we migrate our monolithic app to microservices?',
@@ -99,7 +99,8 @@ function TryPageInner() {
     };
 
     try {
-      const response = await fetch(`${API_BASE_URL}/api/v1/playground/debate`, {
+      const { config } = getRuntimeBackendConfig();
+      const response = await fetch(`${config.api}/api/v1/playground/debate`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ question: question.trim(), source: 'try' }),


### PR DESCRIPTION
## Summary
- use the runtime-selected backend for /try analyze requests
- use the runtime-selected backend for the standalone demo live run
- add focused regression coverage for both public debate surfaces

## Validation
- PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules jest --runInBand --runTestsByPath src/app/__tests__/runtimeBackendSelection.test.tsx src/components/__tests__/BackendSelector.test.tsx
- PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH eslint src/app/try/page.tsx src/app/(standalone)/demo/page.tsx src/app/__tests__/runtimeBackendSelection.test.tsx --max-warnings 0