### PR TITLE
feat(dev): externalize codex PR merges

### DIFF
--- a/scripts/merge_codex_automation_prs.py
+++ b/scripts/merge_codex_automation_prs.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Merge clearly safe codex automation PRs from a normal user shell.
+
+Codex desktop automations can inspect and summarize PRs from their sandboxed
+runtime, but reliable merging should happen from a normal user environment
+where ``gh`` auth and network access are available. This helper only auto-
+merges obviously safe codex PRs and leaves anything sensitive or ambiguous for
+the in-app PR shepherd or a human.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SAFE_CHECK_CONCLUSIONS = {"success", "neutral", "skipped"}
+SENSITIVE_PATH_TOKENS = (
+    "/auth/",
+    "/billing/",
+    "secret",
+    "kubernetes/",
+    "helm/",
+    "terraform/",
+    ".github/workflows/",
+    "deploy",
+)
+
+
+@dataclass(frozen=True)
+class PullRequestSnapshot:
+    number: int
+    title: str
+    head_ref: str
+    is_draft: bool
+    mergeable: str
+    body: str
+    url: str
+    changed_files: list[str]
+    status_rollup: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class MergeDecision:
+    number: int
+    title: str
+    head_ref: str
+    eligible: bool
+    reason: str
+    url: str
+    changed_files: list[str]
+
+
+def _run(
+    args: list[str],
+    *,
+    cwd: Path,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        check=check,
+    )
+
+
+def _repo_root(path: Path) -> Path:
+    proc = _run(["git", "rev-parse", "--show-toplevel"], cwd=path)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "not a git repository")
+    return Path(proc.stdout.strip()).resolve()
+
+
+def _ensure_gh_auth(repo_root: Path) -> None:
+    proc = _run(["gh", "auth", "status"], cwd=repo_root)
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh auth failed")
+
+
+def _open_codex_prs(repo_root: Path, repo: str, limit: int) -> list[dict[str, Any]]:
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,headRefName,isDraft,url",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or "failed to list open PRs")
+    payload = json.loads(proc.stdout or "[]")
+    return [
+        item
+        for item in payload
+        if isinstance(item, dict) and str(item.get("headRefName", "")).startswith("codex/")
+    ]
+
+
+def _pr_metadata(repo_root: Path, repo: str, number: int) -> dict[str, Any]:
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo,
+            "--json",
+            "mergeable,body,statusCheckRollup",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"failed to inspect PR #{number}")
+    payload = json.loads(proc.stdout or "{}")
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"unexpected PR payload for #{number}")
+    return payload
+
+
+def _pr_changed_files(repo_root: Path, repo: str, number: int) -> list[str]:
+    proc = _run(
+        ["gh", "pr", "diff", str(number), "--repo", repo, "--name-only"],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(proc.stderr.strip() or f"failed to inspect files for PR #{number}")
+    return [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+
+
+def collect_pull_requests(repo_root: Path, repo: str, *, limit: int) -> list[PullRequestSnapshot]:
+    snapshots: list[PullRequestSnapshot] = []
+    for pr in _open_codex_prs(repo_root, repo, limit):
+        number = int(pr["number"])
+        metadata = _pr_metadata(repo_root, repo, number)
+        snapshots.append(
+            PullRequestSnapshot(
+                number=number,
+                title=str(pr.get("title", "")),
+                head_ref=str(pr.get("headRefName", "")),
+                is_draft=bool(pr.get("isDraft", False)),
+                mergeable=str(metadata.get("mergeable", "")),
+                body=str(metadata.get("body", "") or ""),
+                url=str(pr.get("url", "")),
+                changed_files=_pr_changed_files(repo_root, repo, number),
+                status_rollup=list(metadata.get("statusCheckRollup") or []),
+            )
+        )
+    return snapshots
+
+
+def _status_reason(items: list[dict[str, Any]]) -> str:
+    if not items:
+        return "no_status_checks"
+    for item in items:
+        status = str(item.get("status", "") or "").lower()
+        conclusion = str(item.get("conclusion", "") or "").lower()
+        if status != "completed":
+            return "checks_pending"
+        if conclusion not in SAFE_CHECK_CONCLUSIONS:
+            return "checks_failed"
+    return "checks_clear"
+
+
+def _path_is_sensitive(path: str) -> bool:
+    lowered = f"/{path.lower().lstrip('/')}"
+    return any(token in lowered for token in SENSITIVE_PATH_TOKENS)
+
+
+def _has_validation_evidence(body: str) -> bool:
+    lowered = body.lower()
+    return "validation" in lowered or "validated" in lowered
+
+
+def select_mergeable_prs(
+    pull_requests: list[PullRequestSnapshot],
+    *,
+    max_files: int = 6,
+) -> list[MergeDecision]:
+    decisions: list[MergeDecision] = []
+
+    for pr in sorted(pull_requests, key=lambda item: item.number):
+        reason = "eligible"
+        if not pr.head_ref.startswith("codex/"):
+            reason = "not_codex_branch"
+        elif pr.is_draft:
+            reason = "draft"
+        elif pr.mergeable != "MERGEABLE":
+            reason = "not_mergeable"
+        else:
+            checks_reason = _status_reason(pr.status_rollup)
+            if checks_reason != "checks_clear":
+                reason = checks_reason
+            elif not pr.changed_files:
+                reason = "no_changed_files"
+            elif len(pr.changed_files) > max_files:
+                reason = "too_many_files"
+            elif any(_path_is_sensitive(path) for path in pr.changed_files):
+                reason = "sensitive_paths"
+            elif not _has_validation_evidence(pr.body):
+                reason = "missing_validation"
+
+        decisions.append(
+            MergeDecision(
+                number=pr.number,
+                title=pr.title,
+                head_ref=pr.head_ref,
+                eligible=reason == "eligible",
+                reason=reason,
+                url=pr.url,
+                changed_files=pr.changed_files,
+            )
+        )
+
+    return decisions
+
+
+def _merge_pr(repo_root: Path, repo: str, number: int) -> None:
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "merge",
+            str(number),
+            "--repo",
+            repo,
+            "--squash",
+            "--admin",
+            "--delete-branch=false",
+        ],
+        cwd=repo_root,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            proc.stderr.strip() or proc.stdout.strip() or f"failed to merge #{number}"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Merge clearly safe codex automation PRs from a normal shell."
+    )
+    parser.add_argument(
+        "--repo",
+        default="synaptent/aragora",
+        help="GitHub repository in OWNER/NAME form (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Path inside the repository to inspect (default: current directory)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Maximum number of open codex PRs to inspect and merge (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--max-files",
+        type=int,
+        default=6,
+        help="Maximum changed files allowed for auto-merge (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually merge eligible PRs instead of only reporting decisions",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON decisions and actions",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = _repo_root(Path(args.root).resolve())
+    _ensure_gh_auth(repo_root)
+
+    snapshots = collect_pull_requests(repo_root, args.repo, limit=args.limit)
+    decisions = select_mergeable_prs(snapshots, max_files=args.max_files)
+    merged_numbers: list[int] = []
+
+    if args.apply:
+        for decision in decisions:
+            if not decision.eligible:
+                continue
+            _merge_pr(repo_root, args.repo, decision.number)
+            merged_numbers.append(decision.number)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "repo": args.repo,
+                    "inspected": len(decisions),
+                    "merged": merged_numbers,
+                    "decisions": [asdict(decision) for decision in decisions],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for decision in decisions:
+            status = "MERGED" if decision.number in merged_numbers else decision.reason
+            print(f"#{decision.number} {decision.head_ref} {status} {decision.title}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - CLI guard
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/run_codex_pr_merge_shepherd.sh
+++ b/scripts/run_codex_pr_merge_shepherd.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOCK_DIR="${TMPDIR:-/tmp}/com.aragora.codex-pr-merge-shepherd.lock"
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+STAMP() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "$(STAMP) [codex-pr-merge-shepherd] already running; exiting"
+  exit 0
+fi
+
+cleanup() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$REPO_ROOT"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "$(STAMP) [codex-pr-merge-shepherd] gh CLI not found"
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "$(STAMP) [codex-pr-merge-shepherd] gh auth unavailable; skipping merge pass"
+  exit 0
+fi
+
+echo "$(STAMP) [codex-pr-merge-shepherd] starting merge pass"
+python3 scripts/merge_codex_automation_prs.py --apply --limit 5 --json
+echo "$(STAMP) [codex-pr-merge-shepherd] merge pass complete"

--- a/tests/scripts/test_merge_codex_automation_prs.py
+++ b/tests/scripts/test_merge_codex_automation_prs.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from scripts.merge_codex_automation_prs import (
+    MergeDecision,
+    PullRequestSnapshot,
+    select_mergeable_prs,
+)
+
+
+def _pr(
+    number: int,
+    *,
+    head_ref: str = "codex/safe-fix",
+    is_draft: bool = False,
+    mergeable: str = "MERGEABLE",
+    body: str = "## Validation\n- pytest -q",
+    changed_files: list[str] | None = None,
+    status_rollup: list[dict[str, str]] | None = None,
+) -> PullRequestSnapshot:
+    if changed_files is None:
+        changed_files = ["aragora/live/src/app/page.tsx"]
+    if status_rollup is None:
+        status_rollup = [{"status": "COMPLETED", "conclusion": "SUCCESS", "name": "tests"}]
+    return PullRequestSnapshot(
+        number=number,
+        title=f"PR {number}",
+        head_ref=head_ref,
+        is_draft=is_draft,
+        mergeable=mergeable,
+        body=body,
+        url=f"https://example.com/pr/{number}",
+        changed_files=changed_files,
+        status_rollup=status_rollup,
+    )
+
+
+def _decision(decisions: list[MergeDecision], number: int) -> MergeDecision:
+    for decision in decisions:
+        if decision.number == number:
+            return decision
+    raise AssertionError(f"missing decision for PR {number}")
+
+
+def test_select_mergeable_prs_marks_safe_codex_pr_eligible() -> None:
+    decisions = select_mergeable_prs([_pr(1)])
+
+    decision = _decision(decisions, 1)
+    assert decision.eligible is True
+    assert decision.reason == "eligible"
+
+
+def test_select_mergeable_prs_skips_non_codex_draft_and_missing_validation() -> None:
+    decisions = select_mergeable_prs(
+        [
+            _pr(1, head_ref="feature/not-codex"),
+            _pr(2, is_draft=True),
+            _pr(3, body="No evidence here"),
+        ]
+    )
+
+    assert _decision(decisions, 1).reason == "not_codex_branch"
+    assert _decision(decisions, 2).reason == "draft"
+    assert _decision(decisions, 3).reason == "missing_validation"
+
+
+def test_select_mergeable_prs_skips_pending_and_failed_checks() -> None:
+    decisions = select_mergeable_prs(
+        [
+            _pr(1, status_rollup=[{"status": "IN_PROGRESS", "conclusion": "", "name": "tests"}]),
+            _pr(
+                2, status_rollup=[{"status": "COMPLETED", "conclusion": "FAILURE", "name": "tests"}]
+            ),
+        ]
+    )
+
+    assert _decision(decisions, 1).reason == "checks_pending"
+    assert _decision(decisions, 2).reason == "checks_failed"
+
+
+def test_select_mergeable_prs_skips_sensitive_and_large_changes() -> None:
+    decisions = select_mergeable_prs(
+        [
+            _pr(1, changed_files=["aragora/billing/auth/config.py"]),
+            _pr(2, changed_files=[f"aragora/file_{idx}.py" for idx in range(7)]),
+        ]
+    )
+
+    assert _decision(decisions, 1).reason == "sensitive_paths"
+    assert _decision(decisions, 2).reason == "too_many_files"
+
+
+def test_select_mergeable_prs_skips_non_mergeable_or_unchecked_prs() -> None:
+    decisions = select_mergeable_prs(
+        [
+            _pr(1, mergeable="UNKNOWN"),
+            _pr(2, status_rollup=[]),
+        ]
+    )
+
+    assert _decision(decisions, 1).reason == "not_mergeable"
+    assert _decision(decisions, 2).reason == "no_status_checks"


### PR DESCRIPTION
## Summary
- add a conservative GitHub-side helper for merging clearly safe codex PRs
- add focused selector tests for draft, sensitive, pending-check, and bounded-safe cases
- add an external shell runner for launchd-based PR merge passes

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/scripts/test_merge_codex_automation_prs.py
- ruff check scripts/merge_codex_automation_prs.py tests/scripts/test_merge_codex_automation_prs.py
- python3 scripts/merge_codex_automation_prs.py --json
- bash -n scripts/run_codex_pr_merge_shepherd.sh