### PR TITLE
fix(dev): cap codex automation publish queue

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -397,6 +397,8 @@ def _publish_decisions(
     decisions: list[PublishDecision],
     *,
     limit: int,
+    open_pr_count: int,
+    max_open_prs: int,
     labels: list[str],
 ) -> list[dict[str, Any]]:
     _ensure_gh_auth(repo_root)
@@ -407,6 +409,8 @@ def _publish_decisions(
         if not decision.eligible:
             continue
         if published >= limit:
+            break
+        if open_pr_count + published >= max_open_prs:
             break
 
         _push_branch(repo_root, decision.branch, decision.upstream)
@@ -449,6 +453,12 @@ def _build_parser() -> argparse.ArgumentParser:
         type=int,
         default=5,
         help="Maximum number of eligible branches to publish in one apply run",
+    )
+    parser.add_argument(
+        "--max-open-prs",
+        type=int,
+        default=3,
+        help="Maximum number of open codex PRs allowed before publishing pauses",
     )
     parser.add_argument(
         "--branch",
@@ -525,6 +535,8 @@ def main(argv: list[str] | None = None) -> int:
         "repo": str(repo_root),
         "base": args.base,
         "cutoff": cutoff.isoformat(),
+        "open_pr_count": len(open_pr_heads),
+        "max_open_prs": args.max_open_prs,
         "decisions": [asdict(decision) for decision in decisions],
     }
 
@@ -535,6 +547,8 @@ def main(argv: list[str] | None = None) -> int:
             args.base,
             decisions,
             limit=args.limit,
+            open_pr_count=len(open_pr_heads),
+            max_open_prs=args.max_open_prs,
             labels=list(dict.fromkeys(args.labels)),
         )
         payload["published"] = published

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
+import scripts.publish_codex_automation_branches as mod
 from scripts.publish_codex_automation_branches import (
     BranchSnapshot,
     WorktreeSnapshot,
@@ -164,3 +166,99 @@ def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
 
     tracked.write_text("changed\n", encoding="utf-8")
     assert _worktree_is_dirty(repo) is True
+
+
+def test_publish_decisions_respects_open_pr_cap(monkeypatch: Any, tmp_path: Path) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
+    monkeypatch.setattr(
+        mod, "_push_branch", lambda repo_root, branch, upstream: calls.append(f"push:{branch}")
+    )
+    monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
+    monkeypatch.setattr(mod, "_create_pr", lambda repo_root, repo, branch, base: 1234)
+    monkeypatch.setattr(
+        mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
+    )
+
+    results = mod._publish_decisions(
+        tmp_path,
+        "synaptent/aragora",
+        "main",
+        [
+            mod.PublishDecision(
+                branch="codex/ready-1",
+                eligible=True,
+                reason="eligible",
+                subject="fix one",
+                head_sha="abc1234",
+                unique_commit_count=1,
+                upstream=None,
+                committed_at=datetime.now(UTC).isoformat(),
+                worktree_paths=[],
+            )
+        ],
+        limit=5,
+        open_pr_count=3,
+        max_open_prs=3,
+        labels=["codex"],
+    )
+
+    assert results == []
+    assert calls == []
+
+
+def test_publish_decisions_uses_remaining_open_pr_capacity(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+    created_numbers = iter([2001, 2002])
+
+    monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
+    monkeypatch.setattr(
+        mod, "_push_branch", lambda repo_root, branch, upstream: calls.append(f"push:{branch}")
+    )
+    monkeypatch.setattr(mod, "_existing_pr_number", lambda repo_root, repo, branch, base: None)
+    monkeypatch.setattr(
+        mod, "_create_pr", lambda repo_root, repo, branch, base: next(created_numbers)
+    )
+    monkeypatch.setattr(
+        mod, "_add_labels", lambda repo_root, repo, number, labels: calls.append(f"label:{number}")
+    )
+
+    results = mod._publish_decisions(
+        tmp_path,
+        "synaptent/aragora",
+        "main",
+        [
+            mod.PublishDecision(
+                branch="codex/ready-1",
+                eligible=True,
+                reason="eligible",
+                subject="fix one",
+                head_sha="abc1234",
+                unique_commit_count=1,
+                upstream=None,
+                committed_at=datetime.now(UTC).isoformat(),
+                worktree_paths=[],
+            ),
+            mod.PublishDecision(
+                branch="codex/ready-2",
+                eligible=True,
+                reason="eligible",
+                subject="fix two",
+                head_sha="def5678",
+                unique_commit_count=1,
+                upstream=None,
+                committed_at=datetime.now(UTC).isoformat(),
+                worktree_paths=[],
+            ),
+        ],
+        limit=5,
+        open_pr_count=2,
+        max_open_prs=3,
+        labels=["codex"],
+    )
+
+    assert [item["branch"] for item in results] == ["codex/ready-1"]
+    assert calls == ["push:codex/ready-1", "label:2001"]


### PR DESCRIPTION
## Summary
- stop the external codex publisher from opening new PRs once the open codex queue reaches the configured cap
- surface the current open codex PR count in the JSON output
- add focused tests for full-cap and one-slot-remaining behavior

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/scripts/test_publish_codex_automation_branches.py
- ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py