### PR TITLE
fix(ci): restore shared frontend and spec gates

### DIFF
--- a/aragora/live/src/app/(app)/system-intelligence/page.tsx
+++ b/aragora/live/src/app/(app)/system-intelligence/page.tsx
@@ -12,6 +12,7 @@ import {
   useAgentPerformance,
   useInstitutionalMemory,
   useImprovementQueue,
+  type SystemOverview,
 } from '@/hooks/useSystemIntelligence';
 import {
   useSystemHealth,

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -188261,7 +188261,7 @@
           "SME",
           "Slack"
         ],
-        "description": "List available channels for a Slack workspace.\n\nPath Parameters:\n    workspace_id: Slack workspace ID\n\nQuery Parameters:\n    types: Channel types to include (public_channel, private_channel)\n\nReturns:\n    JSON response with channel list:\n    {\n        \"channels\": [\n            {\n                \"id\": \"C123...\",\n                \"name\": \"general\",\n                \"is_private\": false,\n                \"num_members\": 42\n            }\n        ],\n        \"workspace_id\": \"...\"\n    }",
+        "description": "List available channels for a Slack workspace.\n\nPath Parameters:\n    workspace_id: Slack workspace ID\n\nQuery Parameters:\n    types: Channel types to include (public_channel, private_channel)\n    limit: Maximum number of channels to return (default: 100)\n\nReturns:\n    JSON response with channel list:\n    {\n        \"channels\": [\n            {\n                \"id\": \"C123...\",\n                \"name\": \"general\",\n                \"is_private\": false,\n                \"num_members\": 42\n            }\n        ],\n        \"workspace_id\": \"...\"\n    }",
         "operationId": "_list_channels",
         "parameters": [
           {

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -107968,10 +107968,11 @@ paths:
       - SME
       - Slack
       description: "List available channels for a Slack workspace.\n\nPath Parameters:\n    workspace_id: Slack workspace\
-        \ ID\n\nQuery Parameters:\n    types: Channel types to include (public_channel, private_channel)\n\nReturns:\n   \
-        \ JSON response with channel list:\n    {\n        \"channels\": [\n            {\n                \"id\": \"C123...\"\
-        ,\n                \"name\": \"general\",\n                \"is_private\": false,\n                \"num_members\"\
-        : 42\n            }\n        ],\n        \"workspace_id\": \"...\"\n    }"
+        \ ID\n\nQuery Parameters:\n    types: Channel types to include (public_channel, private_channel)\n    limit: Maximum\
+        \ number of channels to return (default: 100)\n\nReturns:\n    JSON response with channel list:\n    {\n        \"\
+        channels\": [\n            {\n                \"id\": \"C123...\",\n                \"name\": \"general\",\n     \
+        \           \"is_private\": false,\n                \"num_members\": 42\n            }\n        ],\n        \"workspace_id\"\
+        : \"...\"\n    }"
       operationId: _list_channels
       parameters:
       - name: workspace_id


### PR DESCRIPTION
## Summary
- import the missing `SystemOverview` type in the system intelligence page so frontend typecheck stops failing on main
- refresh the checked-in generated OpenAPI artifacts to match current generator output

## Validation
- cd aragora/live && npm ci && npx tsc --noEmit
- eslint src/app/(app)/system-intelligence/page.tsx --max-warnings 0
- exact version-alignment reproduction: generate temp OpenAPI JSON/YAML, add operation ids/descriptions, and diff against docs/api/openapi_generated.json and docs/api/openapi_generated.yaml