### PR TITLE
chore(sdk): refresh generated OpenAPI types

### DIFF
--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -50456,6 +50456,7 @@ export interface paths {
          *
          *     Query Parameters:
          *         types: Channel types to include (public_channel, private_channel)
+         *         limit: Maximum number of channels to return (default: 100)
          *
          *     Returns:
          *         JSON response with channel list:


### PR DESCRIPTION
## Summary
- refresh generated TypeScript SDK types from the current OpenAPI spec
- restore Version Alignment on main after the spec description update

## Validation
- python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check