### PR TITLE
fix(dev): ignore non-codex PRs in publish cap

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -20,6 +20,7 @@ from typing import Any
 
 UTC = timezone.utc
 DEFAULT_SINCE_HOURS = 72
+CODEX_BRANCH_PREFIX = "codex/"
 ACTIVE_SESSION_FILES = (
     ".claude-session-active",
     ".codex_session_active",
@@ -213,7 +214,9 @@ def _open_pr_heads(repo_root: Path, repo: str) -> set[str]:
     return {
         item["headRefName"]
         for item in payload
-        if isinstance(item, dict) and isinstance(item.get("headRefName"), str)
+        if isinstance(item, dict)
+        and isinstance(item.get("headRefName"), str)
+        and item["headRefName"].startswith(CODEX_BRANCH_PREFIX)
     }
 
 

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -128,6 +128,30 @@ def test_select_publishable_branches_skips_branches_with_historical_prs() -> Non
     assert decisions[0].reason == "historical_pr_exists"
 
 
+def test_open_pr_heads_counts_only_codex_branches(monkeypatch: Any, tmp_path: Path) -> None:
+    payload = """
+    [
+      {"headRefName": "codex/fix-one"},
+      {"headRefName": "dependabot/npm_and_yarn/picomatch-4.0.4"},
+      {"headRefName": "feature/manual-branch"},
+      {"headRefName": "codex/fix-two"}
+    ]
+    """.strip()
+
+    monkeypatch.setattr(
+        mod,
+        "_run",
+        lambda args, cwd, check=False: subprocess.CompletedProcess(
+            args=args, returncode=0, stdout=payload, stderr=""
+        ),
+    )
+
+    assert mod._open_pr_heads(tmp_path, "synaptent/aragora") == {
+        "codex/fix-one",
+        "codex/fix-two",
+    }
+
+
 def test_worktree_is_dirty_ignores_untracked_files(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     repo.mkdir()


### PR DESCRIPTION
## Summary
- ignore non-codex open PRs when enforcing the codex publisher cap
- keep the publisher focused on codex-owned branches instead of Dependabot noise
- add regression coverage for open PR head filtering

## Testing
- pytest -q tests/scripts/test_publish_codex_automation_branches.py
- python3 scripts/publish_codex_automation_branches.py --json
