### PR TITLE
fix(bridge): use real integration config and auth headers

### DIFF
--- a/aragora/integrations/decision_bridge.py
+++ b/aragora/integrations/decision_bridge.py
@@ -17,6 +17,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
+from aragora.connectors.credentials import get_credential_provider
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,6 +63,44 @@ class DecisionBridge:
             return list(explicit)
         return list(self._default_targets)
 
+    @staticmethod
+    def _get_metadata_value(plan: Any, key: str) -> str | None:
+        metadata = getattr(plan, "metadata", None) or {}
+        value = metadata.get(key)
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    async def _get_config_value(self, plan: Any, key: str) -> str | None:
+        metadata_value = self._get_metadata_value(plan, key.lower())
+        if metadata_value:
+            return metadata_value
+
+        provider = get_credential_provider()
+        value = await provider.get_credential(key)
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    async def _resolve_jira_config(self, plan: Any) -> tuple[str, str]:
+        base_url = await self._get_config_value(plan, "JIRA_BASE_URL")
+        project_key = await self._get_config_value(plan, "JIRA_PROJECT_KEY")
+        if not base_url or not project_key:
+            raise ValueError(
+                "Jira bridge requires JIRA_BASE_URL and JIRA_PROJECT_KEY configuration"
+            )
+        return base_url, project_key
+
+    async def _resolve_linear_config(self, plan: Any) -> tuple[str, str, str | None]:
+        api_key = await self._get_config_value(plan, "LINEAR_API_KEY")
+        base_url = await self._get_config_value(plan, "LINEAR_BASE_URL")
+        team_id = await self._get_config_value(plan, "LINEAR_TEAM_ID")
+        if not api_key:
+            raise ValueError("Linear bridge requires LINEAR_API_KEY configuration")
+        return api_key, (base_url or "https://api.linear.app/graphql"), team_id
+
     async def handle_decision_plan(self, plan: Any) -> BridgeResult:
         """Route a DecisionPlan to configured integrations.
 
@@ -96,7 +136,7 @@ class DecisionBridge:
                 ValueError,
                 RuntimeError,
             ) as e:
-                error_msg = f"Decision bridge failed for {target}"
+                error_msg = f"Decision bridge failed for {target}: {e}"
                 logger.warning("%s: %s", error_msg, e)
                 result.errors.append(error_msg)
 
@@ -106,7 +146,8 @@ class DecisionBridge:
         """Create Jira issues from DecisionPlan tasks."""
         from aragora.connectors.enterprise.collaboration.jira import JiraConnector
 
-        connector = JiraConnector(base_url="")
+        base_url, project_key = await self._resolve_jira_config(plan)
+        connector = JiraConnector(base_url=base_url, projects=[project_key])
         created: list[dict[str, Any]] = []
 
         implement_plan = getattr(plan, "implement_plan", None)
@@ -118,6 +159,7 @@ class DecisionBridge:
             description = getattr(task, "description", "")
             issue_data = {
                 "fields": {
+                    "project": {"key": project_key},
                     "summary": f"[Aragora] {title}",
                     "description": (
                         f"Auto-created from decision plan: {plan_title}\n\n{description}"
@@ -127,7 +169,7 @@ class DecisionBridge:
             }
             try:
                 response = await connector._api_request(
-                    "/rest/api/3/issue", method="POST", json_data=issue_data
+                    "/issue", method="POST", json_data=issue_data
                 )
                 created.append(
                     {"key": response.get("key", ""), "id": response.get("id", ""), "summary": title}
@@ -145,7 +187,10 @@ class DecisionBridge:
             LinearCredentials,
         )
 
-        connector = LinearConnector(credentials=LinearCredentials(api_key=""))
+        api_key, base_url, team_id = await self._resolve_linear_config(plan)
+        connector = LinearConnector(
+            credentials=LinearCredentials(api_key=api_key, base_url=base_url)
+        )
         created: list[dict[str, Any]] = []
 
         implement_plan = getattr(plan, "implement_plan", None)
@@ -157,7 +202,7 @@ class DecisionBridge:
         if not teams:
             logger.warning("No Linear teams found; cannot create issues")
             return created
-        default_team_id = teams[0].id
+        default_team_id = team_id or teams[0].id
 
         for task in tasks:
             title = getattr(task, "title", "") or getattr(task, "description", "Untitled task")

--- a/aragora/live/src/app/(app)/debates/[id]/DebateDetailClient.tsx
+++ b/aragora/live/src/app/(app)/debates/[id]/DebateDetailClient.tsx
@@ -12,6 +12,7 @@ import { ArgumentGraph } from '@/components/debates/ArgumentGraph';
 import { ExplanationPanel } from '@/components/ExplanationPanel';
 import { RelatedKnowledge } from '@/components/debates/RelatedKnowledge';
 import { InterventionPanel } from '@/components/debate-viewer/InterventionPanel';
+import { useAuthFetch } from '@/hooks/useAuthenticatedFetch';
 import { useDebateWebSocket } from '@/hooks/debate-websocket';
 import { LiveDebateStream } from '@/components/debate/LiveDebateStream';
 import { logger } from '@/utils/logger';
@@ -24,6 +25,7 @@ export default function DebateDetailClient() {
   const rawId = params?.id;
   const id = Array.isArray(rawId) ? rawId[0] || '' : rawId || '';
   const { config: backendConfig } = useBackend();
+  const { getAuthHeaders } = useAuthFetch();
 
   const [pkg, setPkg] = useState<DecisionPackage | null>(null);
   const [loading, setLoading] = useState(true);
@@ -665,7 +667,7 @@ export default function DebateDetailClient() {
                             `${backendConfig.api}/api/v1/debates/${pkg.id}/bridge`,
                             {
                               method: 'POST',
-                              headers: { 'Content-Type': 'application/json' },
+                              headers: getAuthHeaders(),
                               body: JSON.stringify({ target }),
                             }
                           );

--- a/aragora/live/src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx
+++ b/aragora/live/src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import DebateDetailClient from '../DebateDetailClient';
+
+const mockFetch = jest.fn();
+const mockSetContext = jest.fn();
+const mockClearContext = jest.fn();
+const mockGetAuthHeaders = jest.fn(() => ({
+  'Content-Type': 'application/json',
+  Authorization: 'Bearer test-token',
+}));
+
+global.fetch = mockFetch as unknown as typeof fetch;
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'debate-123' }),
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+jest.mock('@/components/MatrixRain', () => ({
+  Scanlines: () => null,
+  CRTVignette: () => null,
+}));
+
+jest.mock('@/context/RightSidebarContext', () => ({
+  useRightSidebar: () => ({
+    setContext: mockSetContext,
+    clearContext: mockClearContext,
+  }),
+}));
+
+jest.mock('@/components/BackendSelector', () => ({
+  useBackend: () => ({
+    config: {
+      api: 'http://backend.test',
+      ws: 'ws://backend.test',
+    },
+  }),
+}));
+
+jest.mock('@/hooks/useAuthenticatedFetch', () => ({
+  useAuthFetch: () => ({
+    getAuthHeaders: mockGetAuthHeaders,
+  }),
+}));
+
+jest.mock('@/components/debates/DecisionPackageView', () => ({
+  DecisionPackageView: () => <div data-testid="decision-package" />,
+}));
+
+jest.mock('@/components/debates/CostBreakdown', () => ({
+  CostBreakdown: () => <div data-testid="cost-breakdown" />,
+}));
+
+jest.mock('@/components/debates/ArgumentGraph', () => ({
+  ArgumentGraph: () => <div data-testid="argument-graph" />,
+}));
+
+jest.mock('@/components/ExplanationPanel', () => ({
+  ExplanationPanel: () => <div data-testid="explanation-panel" />,
+}));
+
+jest.mock('@/components/debates/RelatedKnowledge', () => ({
+  RelatedKnowledge: () => <div data-testid="related-knowledge" />,
+}));
+
+jest.mock('@/components/debate-viewer/InterventionPanel', () => ({
+  InterventionPanel: () => <div data-testid="intervention-panel" />,
+}));
+
+jest.mock('@/hooks/debate-websocket', () => ({
+  useDebateWebSocket: () => ({
+    messages: [],
+    status: 'closed',
+  }),
+}));
+
+jest.mock('@/components/debate/LiveDebateStream', () => ({
+  LiveDebateStream: () => <div data-testid="live-debate-stream" />,
+}));
+
+jest.mock('../normalizeDecisionPackage', () => ({
+  normalizeDecisionPackage: (data: unknown) => data,
+}));
+
+function jsonResponse(data: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+describe('DebateDetailClient bridge actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFetch.mockImplementation((input: string | URL | Request) => {
+      const url = String(input);
+
+      if (url === 'http://backend.test/api/v1/debates/debate-123') {
+        return Promise.resolve(jsonResponse({ status: 'completed' }));
+      }
+
+      if (url === 'http://backend.test/api/v1/debates/debate-123/package') {
+        return Promise.resolve(
+          jsonResponse({
+            id: 'debate-123',
+            question: 'Should we bridge this decision?',
+            verdict: 'Yes',
+            confidence: 0.93,
+            consensus_reached: true,
+            agents: ['claude', 'codex'],
+            rounds: 3,
+            duration_seconds: 42,
+            final_answer: 'Bridge it.',
+            receipt: { signers: ['sig-1'] },
+            cost_breakdown: null,
+            total_cost: 0,
+          }),
+        );
+      }
+
+      if (url === 'http://backend.test/api/v1/debates/debate-123/bridge') {
+        return Promise.resolve(jsonResponse({ success: true }));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+  });
+
+  it('sends authenticated headers when triggering the bridge action', async () => {
+    const user = userEvent.setup();
+
+    render(<DebateDetailClient />);
+
+    await user.click(await screen.findByRole('button', { name: /export/i }));
+    await user.click(screen.getByRole('button', { name: /create jira issues/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://backend.test/api/v1/debates/debate-123/bridge',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ target: 'jira' }),
+        }),
+      );
+    });
+
+    expect(mockGetAuthHeaders).toHaveBeenCalled();
+    expect(await screen.findByText(/jira triggered/i)).toBeInTheDocument();
+  });
+});

--- a/tests/integrations/test_decision_bridge.py
+++ b/tests/integrations/test_decision_bridge.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.integrations.decision_bridge import DecisionBridge
+
+
+class _CredentialProvider:
+    def __init__(self, values: dict[str, str]):
+        self._values = values
+
+    async def get_credential(self, key: str) -> str | None:
+        return self._values.get(key)
+
+    async def set_credential(self, key: str, value: str) -> None:
+        self._values[key] = value
+
+
+def _plan(*, metadata: dict[str, str] | None = None, tasks: list[object] | None = None) -> object:
+    return SimpleNamespace(
+        id="plan-123",
+        title="Bridge decision",
+        metadata=metadata or {},
+        implement_plan=SimpleNamespace(tasks=tasks or []),
+    )
+
+
+class TestDecisionBridgeConfig:
+    @pytest.mark.asyncio
+    async def test_jira_requires_real_config(self) -> None:
+        bridge = DecisionBridge(default_targets=["jira"])
+
+        with patch(
+            "aragora.integrations.decision_bridge.get_credential_provider",
+            return_value=_CredentialProvider({}),
+        ):
+            result = await bridge.handle_decision_plan(
+                _plan(tasks=[SimpleNamespace(title="Ship bridge route")])
+            )
+
+        assert result.jira_issues == []
+        assert result.errors == [
+            "Decision bridge failed for jira: Jira bridge requires JIRA_BASE_URL and JIRA_PROJECT_KEY configuration"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_linear_requires_real_api_key(self) -> None:
+        bridge = DecisionBridge(default_targets=["linear"])
+
+        with patch(
+            "aragora.integrations.decision_bridge.get_credential_provider",
+            return_value=_CredentialProvider({}),
+        ):
+            result = await bridge.handle_decision_plan(
+                _plan(tasks=[SimpleNamespace(title="Ship bridge route")])
+            )
+
+        assert result.linear_issues == []
+        assert result.errors == [
+            "Decision bridge failed for linear: Linear bridge requires LINEAR_API_KEY configuration"
+        ]
+
+
+class TestDecisionBridgeDispatch:
+    @pytest.mark.asyncio
+    async def test_jira_uses_configured_base_url_project_and_issue_endpoint(self) -> None:
+        provider = _CredentialProvider(
+            {
+                "JIRA_BASE_URL": "https://example.atlassian.net",
+                "JIRA_PROJECT_KEY": "ENG",
+            }
+        )
+        connector = MagicMock()
+        connector._api_request = AsyncMock(return_value={"id": "1001", "key": "ENG-1"})
+
+        with (
+            patch(
+                "aragora.integrations.decision_bridge.get_credential_provider",
+                return_value=provider,
+            ),
+            patch(
+                "aragora.connectors.enterprise.collaboration.jira.JiraConnector",
+                return_value=connector,
+            ) as mock_connector_cls,
+        ):
+            result = await DecisionBridge(default_targets=["jira"]).handle_decision_plan(
+                _plan(
+                    tasks=[SimpleNamespace(title="Ship bridge route", description="Implement it")]
+                )
+            )
+
+        assert result.errors == []
+        assert result.jira_issues == [
+            {"id": "1001", "key": "ENG-1", "summary": "Ship bridge route"}
+        ]
+        mock_connector_cls.assert_called_once_with(
+            base_url="https://example.atlassian.net",
+            projects=["ENG"],
+        )
+        connector._api_request.assert_awaited_once()
+        call = connector._api_request.await_args
+        assert call.args[0] == "/issue"
+        assert call.kwargs["method"] == "POST"
+        assert call.kwargs["json_data"]["fields"]["project"] == {"key": "ENG"}
+
+    @pytest.mark.asyncio
+    async def test_linear_uses_configured_api_key_and_team(self) -> None:
+        provider = _CredentialProvider(
+            {
+                "LINEAR_API_KEY": "lin_api_key_123",
+                "LINEAR_TEAM_ID": "team-42",
+            }
+        )
+        connector = MagicMock()
+        connector.get_teams = AsyncMock(return_value=[SimpleNamespace(id="team-other")])
+        connector.create_issue = AsyncMock(
+            return_value=SimpleNamespace(id="issue-1", identifier="LIN-1")
+        )
+
+        with (
+            patch(
+                "aragora.integrations.decision_bridge.get_credential_provider",
+                return_value=provider,
+            ),
+            patch(
+                "aragora.connectors.enterprise.collaboration.linear.LinearConnector",
+                return_value=connector,
+            ) as mock_connector_cls,
+        ):
+            result = await DecisionBridge(default_targets=["linear"]).handle_decision_plan(
+                _plan(tasks=[SimpleNamespace(title="Wire auth headers", description="Use auth")])
+            )
+
+        assert result.errors == []
+        assert result.linear_issues == [
+            {"id": "issue-1", "identifier": "LIN-1", "title": "Wire auth headers"}
+        ]
+        credentials = mock_connector_cls.call_args.kwargs["credentials"]
+        assert credentials.api_key == "lin_api_key_123"
+        assert credentials.base_url == "https://api.linear.app/graphql"
+        connector.create_issue.assert_awaited_once_with(
+            team_id="team-42",
+            title="[Aragora] Wire auth headers",
+            description="Auto-created from decision plan: Bridge decision\n\nUse auth",
+        )


### PR DESCRIPTION
## Summary
- use real Jira and Linear bridge configuration instead of placeholder credentials
- send authenticated headers from the debate detail bridge action
- add focused backend and frontend regression coverage

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/integrations/test_decision_bridge.py tests/handlers/debates/test_bridge.py
- jest --runInBand --runTestsByPath /Users/armand/.codex/worktrees/bridge-config-auth/aragora/live/src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx
- ruff check aragora/integrations/decision_bridge.py aragora/server/handlers/debates/bridge.py tests/integrations/test_decision_bridge.py tests/handlers/debates/test_bridge.py
- python3 -m compileall aragora/integrations/decision_bridge.py aragora/server/handlers/debates/bridge.py