### PR TITLE
fix(debates): restore decision package detail contract

### DIFF
--- a/aragora/live/src/app/(app)/debates/[id]/__tests__/normalizeDecisionPackage.test.ts
+++ b/aragora/live/src/app/(app)/debates/[id]/__tests__/normalizeDecisionPackage.test.ts
@@ -51,4 +51,52 @@ describe('normalizeDecisionPackage', () => {
 
     expect(normalized.receipt).toBeNull();
   });
+
+  it('accepts the server decision-package shape used by completed debates', () => {
+    const normalized = normalizeDecisionPackage(
+      {
+        debate_id: 'debate-42',
+        question: 'Should we ship?',
+        verdict: 'APPROVED',
+        confidence: 0.91,
+        consensus_reached: true,
+        explanation_summary: 'Agents aligned on shipping with minor caveats.',
+        final_answer: 'Ship the release.',
+        participants: ['claude', 'gpt-4'],
+        cost: {
+          total_cost_usd: 0.0042,
+          per_agent_cost: {
+            claude: 0.002,
+            'gpt-4': 0.0022,
+          },
+        },
+        next_steps: [
+          { action: 'Ship the release.', priority: 'high' },
+          { action: 'Monitor logs.', priority: 'medium' },
+        ],
+        receipt: {
+          checksum: 'abc123',
+          created_at: '2026-03-25T12:34:56Z',
+        },
+        assembled_at: '2026-03-25T12:34:56Z',
+      },
+      'fallback-id'
+    );
+
+    expect(normalized.id).toBe('debate-42');
+    expect(normalized.explanation).toBe('Agents aligned on shipping with minor caveats.');
+    expect(normalized.agents).toEqual(['claude', 'gpt-4']);
+    expect(normalized.total_cost).toBe(0.0042);
+    expect(normalized.cost_breakdown).toEqual([
+      { agent: 'claude', tokens: 0, cost: 0.002 },
+      { agent: 'gpt-4', tokens: 0, cost: 0.0022 },
+    ]);
+    expect(normalized.next_steps).toEqual(['Ship the release.', 'Monitor logs.']);
+    expect(normalized.receipt).toEqual({
+      hash: 'abc123',
+      timestamp: '2026-03-25T12:34:56Z',
+      signers: [],
+    });
+    expect(normalized.created_at).toBe('2026-03-25T12:34:56Z');
+  });
 });

--- a/aragora/live/src/app/(app)/debates/[id]/normalizeDecisionPackage.ts
+++ b/aragora/live/src/app/(app)/debates/[id]/normalizeDecisionPackage.ts
@@ -40,7 +40,12 @@ function asString(value: unknown, fallback = ''): string {
 }
 
 function asNumber(value: unknown, fallback = 0): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
 }
 
 function asStringArray(value: unknown): string[] {
@@ -64,27 +69,41 @@ function normalizeArguments(value: unknown): DecisionPackage['arguments'] {
     .filter((item): item is DecisionPackage['arguments'][number] => item !== null);
 }
 
-function normalizeCostBreakdown(value: unknown): DecisionPackage['cost_breakdown'] {
-  if (!Array.isArray(value)) return [];
-  return value
-    .map((item) => {
-      const obj = asObject(item);
-      if (!obj) return null;
-      return {
-        agent: asString(obj.agent, 'unknown'),
-        tokens: asNumber(obj.tokens, 0),
-        cost: asNumber(obj.cost, 0),
-      };
-    })
-    .filter((item): item is DecisionPackage['cost_breakdown'][number] => item !== null);
+function normalizeCostBreakdown(
+  value: unknown,
+  tokenMap: Record<string, unknown> | null = null
+): DecisionPackage['cost_breakdown'] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        const obj = asObject(item);
+        if (!obj) return null;
+        return {
+          agent: asString(obj.agent, 'unknown'),
+          tokens: asNumber(obj.tokens, 0),
+          cost: asNumber(obj.cost, 0),
+        };
+      })
+      .filter((item): item is DecisionPackage['cost_breakdown'][number] => item !== null);
+  }
+
+  const obj = asObject(value);
+  const perAgentCost = asObject(obj?.per_agent_cost);
+  if (!perAgentCost) return [];
+
+  return Object.entries(perAgentCost).map(([agent, cost]) => ({
+    agent,
+    tokens: asNumber(tokenMap?.[agent], 0),
+    cost: asNumber(cost, 0),
+  }));
 }
 
-function normalizeReceipt(value: unknown): DecisionPackage['receipt'] {
+function normalizeReceipt(value: unknown, fallbackTimestamp = ''): DecisionPackage['receipt'] {
   const obj = asObject(value);
   if (!obj) return null;
 
-  const hash = asString(obj.hash);
-  const timestamp = asString(obj.timestamp);
+  const hash = asString(obj.hash, asString(obj.checksum));
+  const timestamp = asString(obj.timestamp, asString(obj.created_at, fallbackTimestamp));
   if (!hash || !timestamp) return null;
 
   return {
@@ -94,25 +113,45 @@ function normalizeReceipt(value: unknown): DecisionPackage['receipt'] {
   };
 }
 
+function normalizeNextSteps(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (typeof item === 'string') return item;
+      const obj = asObject(item);
+      return obj ? asString(obj.action) : '';
+    })
+    .filter(Boolean);
+}
+
 export function normalizeDecisionPackage(raw: unknown, fallbackId: string): DecisionPackage {
   const obj = asObject(raw) ?? {};
+  const agents = asStringArray(obj.agents);
+  const participants = asStringArray(obj.participants);
+  const argumentsList = normalizeArguments(obj.arguments ?? obj.messages);
+  const cost = asObject(obj.cost);
+  const tokenMap = asObject(obj.per_agent_tokens);
+  const createdAt = asString(obj.created_at, asString(obj.assembled_at, new Date().toISOString()));
 
   return {
-    id: asString(obj.id, fallbackId),
-    question: asString(obj.question),
-    verdict: asString(obj.verdict),
-    confidence: asNumber(obj.confidence, 0),
+    id: asString(obj.id, asString(obj.debate_id, fallbackId)),
+    question: asString(obj.question, asString(obj.task)),
+    verdict: asString(obj.verdict, asString(asObject(obj.receipt)?.verdict)),
+    confidence: asNumber(obj.confidence, asNumber(asObject(obj.receipt)?.confidence, 0)),
     consensus_reached: Boolean(obj.consensus_reached),
-    explanation: asString(obj.explanation),
+    explanation: asString(obj.explanation, asString(obj.explanation_summary)),
     final_answer: asString(obj.final_answer),
-    agents: asStringArray(obj.agents),
-    rounds: asNumber(obj.rounds, 0),
-    arguments: normalizeArguments(obj.arguments),
-    cost_breakdown: normalizeCostBreakdown(obj.cost_breakdown),
-    total_cost: asNumber(obj.total_cost, 0),
-    receipt: normalizeReceipt(obj.receipt),
-    next_steps: asStringArray(obj.next_steps),
-    created_at: asString(obj.created_at, new Date().toISOString()),
+    agents: agents.length > 0 ? agents : participants,
+    rounds: asNumber(
+      obj.rounds,
+      argumentsList.reduce((maxRound, arg) => Math.max(maxRound, arg.round), 0)
+    ),
+    arguments: argumentsList,
+    cost_breakdown: normalizeCostBreakdown(obj.cost_breakdown ?? cost, tokenMap),
+    total_cost: asNumber(obj.total_cost, asNumber(cost?.total_cost_usd, 0)),
+    receipt: normalizeReceipt(obj.receipt, createdAt),
+    next_steps: normalizeNextSteps(obj.next_steps),
+    created_at: createdAt,
     duration_seconds: asNumber(obj.duration_seconds, 0),
   };
 }

--- a/aragora/server/handlers/debates/decision_package.py
+++ b/aragora/server/handlers/debates/decision_package.py
@@ -31,6 +31,93 @@ from aragora.server.handlers.base import (
 logger = logging.getLogger(__name__)
 
 
+def _coerce_non_negative_int(value: Any) -> int:
+    """Best-effort int coercion for round/token metadata."""
+
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _normalize_string_list(values: Any) -> list[str]:
+    """Return only string items from a list-like payload."""
+
+    if not isinstance(values, list):
+        return []
+    return [item for item in values if isinstance(item, str)]
+
+
+def _build_arguments(messages: Any) -> tuple[list[dict[str, Any]], int]:
+    """Convert stored debate messages into detail-page argument entries."""
+
+    if not isinstance(messages, list):
+        return [], 0
+
+    arguments: list[dict[str, Any]] = []
+    rounds = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+
+        round_num = _coerce_non_negative_int(message.get("round"))
+        rounds = max(rounds, round_num)
+
+        agent = message.get("agent") or message.get("author") or message.get("role") or "unknown"
+        if not isinstance(agent, str):
+            agent = str(agent)
+
+        position = message.get("position") or message.get("role") or ""
+        if not isinstance(position, str):
+            position = str(position)
+
+        content = message.get("content", "")
+        if not isinstance(content, str):
+            content = str(content)
+
+        arguments.append(
+            {
+                "agent": agent,
+                "round": round_num,
+                "position": position,
+                "content": content,
+            }
+        )
+
+    return arguments, rounds
+
+
+def _build_cost_breakdown(
+    per_agent_cost: Any,
+    per_agent_tokens: Any | None = None,
+) -> list[dict[str, Any]]:
+    """Convert per-agent cost maps into the live UI's array form."""
+
+    if not isinstance(per_agent_cost, dict):
+        return []
+
+    token_map = per_agent_tokens if isinstance(per_agent_tokens, dict) else {}
+    breakdown: list[dict[str, Any]] = []
+    for agent_name, cost in per_agent_cost.items():
+        breakdown.append(
+            {
+                "agent": str(agent_name),
+                "tokens": _coerce_non_negative_int(token_map.get(agent_name, 0)),
+                "cost": float(cost) if isinstance(cost, int | float) else 0.0,
+            }
+        )
+
+    return breakdown
+
+
 def _generate_next_steps(
     verdict: str,
     confidence: float,
@@ -279,6 +366,7 @@ class DecisionPackageHandler(BaseHandler):
             store = get_receipt_store()
             receipt = store.get_by_gauntlet(f"debate-{debate_id}")
             if receipt:
+                receipt_created_at = str(receipt.created_at) if receipt.created_at else None
                 receipt_dict = {
                     "receipt_id": receipt.receipt_id,
                     "verdict": receipt.verdict,
@@ -286,7 +374,11 @@ class DecisionPackageHandler(BaseHandler):
                     "risk_level": receipt.risk_level,
                     "risk_score": getattr(receipt, "risk_score", None),
                     "checksum": receipt.checksum,
-                    "created_at": str(receipt.created_at) if receipt.created_at else None,
+                    "created_at": receipt_created_at,
+                    # Frontend compatibility aliases for the live receipt tab.
+                    "hash": receipt.checksum,
+                    "timestamp": receipt_created_at,
+                    "signers": [],
                 }
         except (
             ImportError,
@@ -344,18 +436,28 @@ class DecisionPackageHandler(BaseHandler):
             logger.debug("Argument map not available for %s: %s", debate_id, exc)
 
         # -- Cost --
+        per_agent_cost = result_data.get("per_agent_cost", {})
         cost = {
             "total_cost_usd": result_data.get("total_cost_usd", 0.0),
-            "per_agent_cost": result_data.get("per_agent_cost", {}),
+            "per_agent_cost": per_agent_cost,
         }
+        cost_breakdown = _build_cost_breakdown(per_agent_cost, result_data.get("per_agent_tokens"))
 
         # -- Next steps --
         consensus_reached = result_data.get("consensus_reached", False)
         question = debate.get("question", "")
         next_steps = _generate_next_steps(verdict, confidence, consensus_reached, question)
+        participants = _normalize_string_list(
+            result_data.get("participants", debate.get("agents", []))
+        )
+        arguments, rounds = _build_arguments(debate.get("messages", []))
+        assembled_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+        created_at = debate.get("created_at") or result_data.get("created_at") or assembled_at
 
         package: dict[str, Any] = {
             "debate_id": debate_id,
+            # Frontend-compatible aliases kept alongside the historical contract.
+            "id": debate_id,
             "question": question,
             "status": status,
             "verdict": verdict,
@@ -363,13 +465,23 @@ class DecisionPackageHandler(BaseHandler):
             "consensus_reached": consensus_reached,
             "final_answer": result_data.get("final_answer", ""),
             "explanation_summary": result_data.get("explanation_summary", ""),
-            "participants": result_data.get("participants", debate.get("agents", [])),
+            "explanation": result_data.get("explanation_summary", ""),
+            "participants": participants,
+            "agents": participants,
+            "rounds": result_data.get("rounds", rounds),
+            "arguments": arguments,
             "receipt": receipt_dict,
             "cost": cost,
+            "cost_breakdown": cost_breakdown,
+            "total_cost": cost["total_cost_usd"],
             "argument_map": argument_map,
             "next_steps": next_steps,
             "export_formats": ["json", "markdown", "csv", "html", "txt"],
-            "assembled_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "created_at": created_at,
+            "duration_seconds": result_data.get(
+                "duration_seconds", debate.get("duration_seconds", 0.0)
+            ),
+            "assembled_at": assembled_at,
         }
 
         return package, None

--- a/tests/handlers/debates/test_decision_package.py
+++ b/tests/handlers/debates/test_decision_package.py
@@ -769,6 +769,24 @@ class TestAssemblePackageCompleted:
         assert body["cost"]["total_cost_usd"] == 0.0042
         assert "claude" in body["cost"]["per_agent_cost"]
 
+    def test_frontend_compatibility_fields_present(self, handler_with_storage, http_handler):
+        result = handler_with_storage.handle(
+            "/api/v1/debates/test-debate-001/package",
+            {},
+            http_handler,
+        )
+        body = _body(result)
+        assert body["id"] == "test-debate-001"
+        assert body["explanation"] == "All agents agreed on microservices."
+        assert body["agents"] == ["claude", "gpt-4", "gemini"]
+        assert body["rounds"] == 1
+        assert len(body["arguments"]) == 2
+        assert body["total_cost"] == 0.0042
+        assert body["cost_breakdown"] == [
+            {"agent": "claude", "tokens": 0, "cost": 0.002},
+            {"agent": "gpt-4", "tokens": 0, "cost": 0.0022},
+        ]
+
     def test_export_formats_listed(self, handler_with_storage, http_handler):
         result = handler_with_storage.handle(
             "/api/v1/debates/test-debate-001/package",
@@ -1251,6 +1269,9 @@ class TestEdgeCases:
 
         body = _body(result)
         assert body["receipt"]["created_at"] is None
+        assert body["receipt"]["hash"] == "abc"
+        assert body["receipt"]["timestamp"] is None
+        assert body["receipt"]["signers"] == []
 
     def test_debate_status_is_included(self, handler_with_storage, http_handler):
         result = handler_with_storage.handle(
@@ -1349,6 +1370,7 @@ class TestJSONStructure:
         body = _body(result)
         expected_keys = {
             "debate_id",
+            "id",
             "question",
             "status",
             "verdict",
@@ -1356,11 +1378,19 @@ class TestJSONStructure:
             "consensus_reached",
             "final_answer",
             "explanation_summary",
+            "explanation",
             "participants",
+            "agents",
+            "rounds",
+            "arguments",
             "receipt",
             "cost",
+            "cost_breakdown",
+            "total_cost",
             "argument_map",
             "next_steps",
+            "created_at",
+            "duration_seconds",
             "export_formats",
             "assembled_at",
         }


### PR DESCRIPTION
## Summary
- normalize the live decision package payload shape for the debate detail page
- restore missing backend aliases and derived fields needed by the receipt/cost/arguments tabs
- add focused backend and frontend regression coverage

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/debates/test_decision_package.py
- jest --runInBand --runTestsByPath aragora/live/src/app/(app)/debates/[id]/__tests__/normalizeDecisionPackage.test.ts