### PR TITLE
fix(live): accept leaderboard payload in agent pickers

### DIFF
--- a/aragora/live/src/components/AgentNetworkPanel.tsx
+++ b/aragora/live/src/components/AgentNetworkPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { withErrorBoundary } from './PanelErrorBoundary';
 import { API_BASE_URL } from '@/config';
+import { extractLeaderboardAgentNames } from '@/lib/leaderboard';
 
 interface RelationshipEntry {
   agent: string;
@@ -251,8 +252,8 @@ function AgentNetworkPanelComponent({
         if (res.status === 429) return { agents: [] };
         return res.json();
       })
-      .then((data: { agents?: Array<{ name: string }> }) => {
-        const agents = (data.agents || []).map((a) => a.name);
+      .then((data: { agents?: Array<{ name: string }>; leaderboard?: Array<{ name: string }> }) => {
+        const agents = extractLeaderboardAgentNames(data);
         setAvailableAgents(agents);
         if (agents.length > 0 && !agentInput) {
           setAgentInput(agents[0]);

--- a/aragora/live/src/components/CapabilityProbePanel.tsx
+++ b/aragora/live/src/components/CapabilityProbePanel.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { withErrorBoundary } from './PanelErrorBoundary';
 import { fetchWithRetry } from '@/utils/retry';
 import { API_BASE_URL } from '@/config';
+import { extractLeaderboardAgentNames } from '@/lib/leaderboard';
 
 interface ProbeResult {
   probe_id: string;
@@ -104,8 +105,8 @@ function CapabilityProbePanelComponent({
         if (res.status === 429) return { agents: [] };
         return res.json();
       })
-      .then((data: { agents?: Array<{ name: string }> }) => {
-        const agents = (data.agents || []).map((a) => a.name);
+      .then((data: { agents?: Array<{ name: string }>; leaderboard?: Array<{ name: string }> }) => {
+        const agents = extractLeaderboardAgentNames(data);
         setAvailableAgents(agents);
         if (agents.length > 0 && !selectedAgent) {
           setSelectedAgent(agents[0]);

--- a/aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx
+++ b/aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx
@@ -1,0 +1,33 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AgentNetworkPanel } from '../AgentNetworkPanel';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('AgentNetworkPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ leaderboard: [{ name: 'claude' }, { name: 'gpt-4' }] }),
+    });
+  });
+
+  it('loads selectable agents from leaderboard payloads', async () => {
+    const user = userEvent.setup();
+    render(<AgentNetworkPanel />);
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /expand agent network panel/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toHaveValue('claude');
+    });
+
+    expect(screen.getByRole('option', { name: 'claude' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'gpt-4' })).toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/components/__tests__/CapabilityProbePanel.test.tsx
+++ b/aragora/live/src/components/__tests__/CapabilityProbePanel.test.tsx
@@ -1,0 +1,33 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CapabilityProbePanel } from '../CapabilityProbePanel';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('CapabilityProbePanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ leaderboard: [{ name: 'claude' }, { name: 'gpt-4' }] }),
+    });
+  });
+
+  it('loads target agents from leaderboard payloads', async () => {
+    const user = userEvent.setup();
+    render(<CapabilityProbePanel />);
+
+    await act(async () => {
+      await user.click(screen.getByRole('button', { name: /expand capability probes panel/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toHaveValue('claude');
+    });
+
+    expect(screen.getByRole('option', { name: 'claude' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'gpt-4' })).toBeInTheDocument();
+  });
+});

--- a/aragora/live/src/lib/leaderboard.ts
+++ b/aragora/live/src/lib/leaderboard.ts
@@ -1,0 +1,15 @@
+interface LeaderboardAgentLike {
+  name?: string;
+}
+
+interface LeaderboardAgentsPayload {
+  agents?: LeaderboardAgentLike[];
+  leaderboard?: LeaderboardAgentLike[];
+}
+
+export function extractLeaderboardAgentNames(data: LeaderboardAgentsPayload): string[] {
+  const entries = data.leaderboard ?? data.agents ?? [];
+  return entries
+    .map((entry) => entry.name?.trim())
+    .filter((name): name is string => Boolean(name));
+}


### PR DESCRIPTION
## Summary
- accept leaderboard payloads that use  instead of 
- reuse a shared helper for agent-name extraction in live picker panels
- add focused frontend regressions for the network and probe panels

## Validation
- jest --runInBand --runTestsByPath aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx aragora/live/src/components/__tests__/CapabilityProbePanel.test.tsx