### PR TITLE
fix(testing): use repo-safe pytest defaults

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,20 +109,20 @@ make guard-strict  # includes untracked artifacts
 # Baseline command (same tooling and addopts as CI)
 python scripts/run_test_baseline.py
 
-# Run all tests
-pytest tests/ -v
+# Direct pytest invocation: disable pytest-rerunfailures to keep local and sandbox runs deterministic
+python -m pytest -p no:rerunfailures tests/ -v
 
 # Run specific test file
-pytest tests/test_orchestrator.py -v
+python -m pytest -p no:rerunfailures tests/test_orchestrator.py -v
 
 # Run tests matching pattern
-pytest tests/ -k "consensus" -v
+python -m pytest -p no:rerunfailures tests/ -k "consensus" -v
 
 # Run with coverage
-pytest tests/ --cov=aragora --cov-report=html
+python -m pytest -p no:rerunfailures tests/ --cov=aragora --cov-report=html
 
 # Run only fast tests (skip slow integration tests)
-pytest tests/ -v --timeout=10
+python -m pytest -p no:rerunfailures tests/ -v --timeout=10
 
 # Run mutation testing
 mutmut run --paths-to-mutate=aragora/debate/
@@ -217,7 +217,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 
 ### Pull Request Checklist
 
-- [ ] Tests pass locally (`pytest tests/ -v`)
+- [ ] Tests pass locally (`python -m pytest -p no:rerunfailures tests/ -v`)
 - [ ] Baseline gate passes locally (`python scripts/run_test_baseline.py`)
 - [ ] Code is formatted (`black .`)
 - [ ] Linting passes (`ruff check .`)

--- a/scripts/check_test_dependencies.py
+++ b/scripts/check_test_dependencies.py
@@ -6,8 +6,6 @@ from __future__ import annotations
 import argparse
 import importlib
 import re
-import subprocess
-import sys
 from importlib import metadata
 
 
@@ -47,18 +45,18 @@ def _check_module_import(module_name: str) -> tuple[bool, str]:
     return True, f"{module_name} importable"
 
 
-def _check_pytest_reruns_flag() -> tuple[bool, str]:
-    proc = subprocess.run(
-        [sys.executable, "-m", "pytest", "--help"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        return False, "pytest --help failed"
-    if "--reruns" not in proc.stdout:
-        return False, "pytest-rerunfailures plugin not active (--reruns flag missing)"
-    return True, "pytest --reruns flag available"
+def _check_pytest_reruns_entrypoint() -> tuple[bool, str]:
+    entries = metadata.entry_points()
+    if hasattr(entries, "select"):
+        plugins = entries.select(group="pytest11")
+    else:
+        plugins = [entry for entry in entries if entry.group == "pytest11"]
+
+    for entry in plugins:
+        if entry.name == "rerunfailures" and entry.value == "pytest_rerunfailures":
+            return True, "pytest-rerunfailures entrypoint registered"
+
+    return False, "pytest-rerunfailures pytest11 entrypoint missing"
 
 
 def main() -> int:
@@ -72,7 +70,7 @@ def main() -> int:
 
     checks.append(_check_module_import("jwt"))
     checks.append(_check_module_import("pytest_rerunfailures"))
-    checks.append(_check_pytest_reruns_flag())
+    checks.append(_check_pytest_reruns_entrypoint())
 
     failures = [msg for ok, msg in checks if not ok]
 

--- a/scripts/nomic/config.py
+++ b/scripts/nomic/config.py
@@ -68,7 +68,7 @@ NOMIC_TESTFIXER_ENABLED = os.environ.get("NOMIC_TESTFIXER_ENABLED", "1") == "1"
 
 # Test command to run inside TestFixer
 NOMIC_TESTFIXER_TEST_COMMAND = os.environ.get(
-    "NOMIC_TESTFIXER_TEST_COMMAND", "pytest tests/ -q --maxfail=1"
+    "NOMIC_TESTFIXER_TEST_COMMAND", "python -m pytest -p no:rerunfailures tests/ -q --maxfail=1"
 )
 
 # Per-test run timeout (seconds)

--- a/scripts/nomic_loop.py
+++ b/scripts/nomic_loop.py
@@ -256,7 +256,7 @@ NOMIC_AUTO_CHECKPOINT = os.environ.get("NOMIC_AUTO_CHECKPOINT", "1") == "1"
 
 NOMIC_TESTFIXER_ENABLED = os.environ.get("NOMIC_TESTFIXER_ENABLED", "1") == "1"
 NOMIC_TESTFIXER_TEST_COMMAND = os.environ.get(
-    "NOMIC_TESTFIXER_TEST_COMMAND", "pytest tests/ -q --maxfail=1"
+    "NOMIC_TESTFIXER_TEST_COMMAND", "python -m pytest -p no:rerunfailures tests/ -q --maxfail=1"
 )
 NOMIC_TESTFIXER_TEST_TIMEOUT = int(os.environ.get("NOMIC_TESTFIXER_TEST_TIMEOUT", "600"))
 NOMIC_TESTFIXER_MAX_ITERATIONS = int(os.environ.get("NOMIC_TESTFIXER_MAX_ITERATIONS", "5"))

--- a/scripts/run_test_baseline.py
+++ b/scripts/run_test_baseline.py
@@ -13,6 +13,7 @@ DEFAULT_MARKERS = (
     "and not integration_minimal and not benchmark and not performance"
 )
 DEFAULT_PATHS = ["tests/"]
+DEFAULT_PYTEST_ARGS = ["-p", "no:rerunfailures"]
 DEFAULT_IGNORE_PATHS = (
     "tests/benchmarks/test_debate_perf.py",
     "tests/cli/test_demo_command.py",
@@ -30,6 +31,7 @@ def _build_pytest_command(args: argparse.Namespace) -> list[str]:
         sys.executable,
         "-m",
         "pytest",
+        *DEFAULT_PYTEST_ARGS,
         *args.paths,
         "-m",
         args.markers,


### PR DESCRIPTION
## Summary
- make baseline and TestFixer pytest invocations explicitly disable rerunfailures autoload instead of relying on ambient plugin state
- change dependency verification to check the pytest entrypoint directly instead of parsing usage: pytest [options] [file_or_dir] [file_or_dir] [...]

positional arguments:
  file_or_dir

general:
  -k EXPRESSION         Only run tests which match the given substring
                        expression. An expression is a Python evaluable
                        expression where all names are substring-matched against
                        test names and their parent classes. Example: -k
                        'test_method or test_other' matches all test functions
                        and classes whose name contains 'test_method' or
                        'test_other', while -k 'not test_method' matches those
                        that don't contain 'test_method' in their names. -k 'not
                        test_method and not test_other' will eliminate the
                        matches. Additionally keywords are matched to classes
                        and functions containing extra names in their
                        'extra_keyword_matches' set, as well as functions which
                        have names assigned directly to them. The matching is
                        case-insensitive.
  -m MARKEXPR           Only run tests matching given mark expression. For
                        example: -m 'mark1 and not mark2'.
  --markers             show markers (builtin, plugin and per-project ones).
  -x, --exitfirst       Exit instantly on first error or failed test
  --fixtures, --funcargs
                        Show available fixtures, sorted by plugin appearance
                        (fixtures with leading '_' are only shown with '-v')
  --fixtures-per-test   Show fixtures per test
  --pdb                 Start the interactive Python debugger on errors or
                        KeyboardInterrupt
  --pdbcls=modulename:classname
                        Specify a custom interactive Python debugger for use
                        with --pdb.For example:
                        --pdbcls=IPython.terminal.debugger:TerminalPdb
  --trace               Immediately break when running each test
  --capture=method      Per-test capturing method: one of fd|sys|no|tee-sys
  -s                    Shortcut for --capture=no
  --runxfail            Report the results of xfail tests as if they were not
                        marked
  --lf, --last-failed   Rerun only the tests that failed at the last run (or all
                        if none failed)
  --ff, --failed-first  Run all tests, but run the last failures first. This may
                        re-order tests and thus lead to repeated fixture
                        setup/teardown.
  --nf, --new-first     Run tests from new files first, then the rest of the
                        tests sorted by file mtime
  --cache-show=[CACHESHOW]
                        Show cache contents, don't perform collection or tests.
                        Optional argument: glob (default: '*').
  --cache-clear         Remove all cache contents at start of test run
  --lfnf, --last-failed-no-failures={all,none}
                        With ``--lf``, determines whether to execute tests when
                        there are no previously (known) failures or when no
                        cached ``lastfailed`` data was found. ``all`` (the
                        default) runs the full test suite again. ``none`` just
                        emits a message about no known failures and exits
                        successfully.
  --sw, --stepwise      Exit on test failure and continue from last failing test
                        next time
  --sw-skip, --stepwise-skip
                        Ignore the first failing test but stop on the next
                        failing test. Implicitly enables --stepwise.

Reporting:
  --durations=N         Show N slowest setup/test durations (N=0 for all)
  --durations-min=N     Minimal duration in seconds for inclusion in slowest
                        list. Default: 0.005.
  -v, --verbose         Increase verbosity
  --no-header           Disable header
  --no-summary          Disable summary
  --no-fold-skipped     Do not fold skipped tests in short summary.
  -q, --quiet           Decrease verbosity
  --verbosity=VERBOSE   Set verbosity. Default: 0.
  -r chars              Show extra test summary info as specified by chars:
                        (f)ailed, (E)rror, (s)kipped, (x)failed, (X)passed,
                        (p)assed, (P)assed with output, (a)ll except passed
                        (p/P), or (A)ll. (w)arnings are enabled by default (see
                        --disable-warnings), 'N' can be used to reset the list.
                        (default: 'fE').
  --disable-warnings, --disable-pytest-warnings
                        Disable warnings summary
  -l, --showlocals      Show locals in tracebacks (disabled by default)
  --no-showlocals       Hide locals in tracebacks (negate --showlocals passed
                        through addopts)
  --tb=style            Traceback print mode (auto/long/short/line/native/no)
  --xfail-tb            Show tracebacks for xfail (as long as --tb != no)
  --show-capture={no,stdout,stderr,log,all}
                        Controls how captured stdout/stderr/log is shown on
                        failed tests. Default: all.
  --full-trace          Don't cut any tracebacks (default is to cut)
  --color=color         Color terminal output (yes/no/auto)
  --code-highlight={yes,no}
                        Whether code should be highlighted (only if --color is
                        also enabled). Default: yes.
  --pastebin=mode       Send failed|all info to bpaste.net pastebin service
  --junitxml, --junit-xml=path
                        Create junit-xml style report file at given path
  --junitprefix, --junit-prefix=str
                        Prepend prefix to classnames in junit-xml output
  --html=path           create html report file at given path.
  --self-contained-html
                        create a self-contained html file containing all
                        necessary styles, scripts, and images - this means that
                        the report may not render or function where CSP
                        restrictions are in place (see
                        https://developer.mozilla.org/docs/Web/Security/CSP)
  --css=path            append given css file content to report style file.

pytest-warnings:
  -W, --pythonwarnings PYTHONWARNINGS
                        Set which warnings to report, see -W option of Python
                        itself
  --maxfail=num         Exit after first num failures or errors
  --strict-config       Any warnings encountered while parsing the `pytest`
                        section of the configuration file raise errors
  --strict-markers      Markers not registered in the `markers` section of the
                        configuration file raise errors
  --strict              (Deprecated) alias to --strict-markers
  -c, --config-file FILE
                        Load configuration from `FILE` instead of trying to
                        locate one of the implicit configuration files.
  --continue-on-collection-errors
                        Force test execution even if collection errors occur
  --rootdir=ROOTDIR     Define root directory for tests. Can be relative path:
                        'root_dir', './root_dir', 'root_dir/another_dir/';
                        absolute path: '/home/user/root_dir'; path with
                        variables: '$HOME/root_dir'.

collection:
  --collect-only, --co  Only collect tests, don't execute them
  --pyargs              Try to interpret all arguments as Python packages
  --ignore=path         Ignore path during collection (multi-allowed)
  --ignore-glob=path    Ignore path pattern during collection (multi-allowed)
  --deselect=nodeid_prefix
                        Deselect item (via node id prefix) during collection
                        (multi-allowed)
  --confcutdir=dir      Only load conftest.py's relative to specified dir
  --noconftest          Don't load any conftest.py files
  --keep-duplicates     Keep duplicate tests
  --collect-in-virtualenv
                        Don't ignore tests in a local virtualenv directory
  --import-mode={prepend,append,importlib}
                        Prepend/append to sys.path when importing test modules
                        and conftest files. Default: prepend.
  --doctest-modules     Run doctests in all .py modules
  --doctest-report={none,cdiff,ndiff,udiff,only_first_failure}
                        Choose another output format for diffs on doctest
                        failure
  --doctest-glob=pat    Doctests file matching pattern, default: test*.txt
  --doctest-ignore-import-errors
                        Ignore doctest collection errors
  --doctest-continue-on-failure
                        For a given doctest, continue to run after the first
                        failure

test session debugging and configuration:
  --basetemp=dir        Base temporary directory for this test run. (Warning:
                        this directory is removed if it exists.)
  -V, --version         Display pytest version and information about plugins.
                        When given twice, also display information about
                        plugins.
  -h, --help            Show help message and configuration info
  -p name               Early-load given plugin module name or entry point
                        (multi-allowed). To avoid loading of plugins, use the
                        `no:` prefix, e.g. `no:doctest`.
  --trace-config        Trace considerations of conftest.py files
  --debug=[DEBUG_FILE_NAME]
                        Store internal tracing debug information in this log
                        file. This file is opened with 'w' and truncated as a
                        result, care advised. Default: pytestdebug.log.
  -o, --override-ini OVERRIDE_INI
                        Override ini option with "option=value" style, e.g. `-o
                        xfail_strict=True -o cache_dir=cache`.
  --assert=MODE         Control assertion debugging tools.
                        'plain' performs no assertion debugging.
                        'rewrite' (the default) rewrites assert statements in
                        test modules on import to provide assert expression
                        information.
  --setup-only          Only setup fixtures, do not execute tests
  --setup-show          Show setup of fixtures while executing tests
  --setup-plan          Show what fixtures and tests would be executed but don't
                        execute anything

logging:
  --log-level=LEVEL     Level of messages to catch/display. Not set by default,
                        so it depends on the root/parent log handler's effective
                        level, where it is "WARNING" by default.
  --log-format=LOG_FORMAT
                        Log format used by the logging module
  --log-date-format=LOG_DATE_FORMAT
                        Log date format used by the logging module
  --log-cli-level=LOG_CLI_LEVEL
                        CLI logging level
  --log-cli-format=LOG_CLI_FORMAT
                        Log format used by the logging module
  --log-cli-date-format=LOG_CLI_DATE_FORMAT
                        Log date format used by the logging module
  --log-file=LOG_FILE   Path to a file when logging will be written to
  --log-file-mode={w,a}
                        Log file open mode
  --log-file-level=LOG_FILE_LEVEL
                        Log file logging level
  --log-file-format=LOG_FILE_FORMAT
                        Log format used by the logging module
  --log-file-date-format=LOG_FILE_DATE_FORMAT
                        Log date format used by the logging module
  --log-auto-indent=LOG_AUTO_INDENT
                        Auto-indent multiline messages passed to the logging
                        module. Accepts true|on, false|off or an integer.
  --log-disable=LOGGER_DISABLE
                        Disable a logger by name. Can be passed multiple times.

LangSmith:
  --langsmith-output    Use LangSmith output (requires 'rich').

distributed and subprocess testing:
  -n, --numprocesses numprocesses
                        Shortcut for '--dist=load --tx=NUM*popen'.
                        With 'logical', attempt to detect logical CPU count
                        (requires psutil, falls back to 'auto').
                        With 'auto', attempt to detect physical CPU count. If
                        physical CPU count cannot be determined, falls back to
                        1.
                        Forced to 0 (disabled) when used with --pdb.
  --maxprocesses=maxprocesses
                        Limit the maximum number of workers to process the tests
                        when using --numprocesses with 'auto' or 'logical'
  --max-worker-restart=MAXWORKERRESTART
                        Maximum number of workers that can be restarted when
                        crashed (set to zero to disable this feature)
  --dist=distmode       Set mode for distributing tests to exec environments.
                        each: Send each test to all available environments.
                        load: Load balance by sending any pending test to any
                        available environment.
                        loadscope: Load balance by sending pending groups of
                        tests in the same scope to any available environment.
                        loadfile: Load balance by sending test grouped by file
                        to any available environment.
                        loadgroup: Like 'load', but sends tests marked with
                        'xdist_group' to the same worker.
                        worksteal: Split the test suite between available
                        environments, then re-balance when any worker runs out
                        of tests.
                        (default) no: Run tests inprocess, don't distribute.
  --loadscope-reorder   Pytest-xdist will default reorder tests by number of
                        tests per scope when used in conjunction with loadscope.
                        This option will enable loadscope reorder which will
                        improve the parallelism of the test suite.
                        However, the partial order of tests might not be
                        retained.
  --no-loadscope-reorder
                        Pytest-xdist will default reorder tests by number of
                        tests per scope when used in conjunction with loadscope.
                        This option will disable loadscope reorder, and the
                        partial order of tests can be retained.
                        This is useful when pytest-xdist is used together with
                        other plugins that specify tests in a specific order.
  --tx=xspec            Add a test execution environment. Some examples:
                        --tx popen//python=python2.5 --tx
                        socket=192.168.1.102:8888
                        --tx ssh=user@codespeak.net//chdir=testcache
  --px=xspec            Add a proxy gateway to pass to test execution
                        environments using `via`. Example:
                        --px id=my_proxy//socket=192.168.1.102:8888 --tx
                        5*popen//via=my_proxy
  -d                    Load-balance tests. Shortcut for '--dist=load'.
  --rsyncdir=DIR        Add directory for rsyncing to remote tx nodes
  --rsyncignore=GLOB    Add expression for ignores when rsyncing to remote tx
                        nodes
  --testrunuid=TESTRUNUID
                        Provide an identifier shared amongst all workers as the
                        value of the 'testrun_uid' fixture.
                        If not provided, 'testrun_uid' is filled with a new
                        unique string on every test run.
  --maxschedchunk=MAXSCHEDCHUNK
                        Maximum number of tests scheduled in one step for
                        --dist=load.
                        Setting it to 1 will force pytest to send tests to
                        workers one by one - might be useful for a small number
                        of slow tests.
                        Larger numbers will allow the scheduler to submit
                        consecutive chunks of tests to workers - allows reusing
                        fixtures.
                        Due to implementation reasons, at least 2 tests are
                        scheduled per worker at the start. Only later tests can
                        be scheduled one by one.
                        Unlimited if not set.
  -f, --looponfail      Run tests in subprocess: wait for files to be modified,
                        then re-run failing test set until all pass.

Interrupt test run and dump stacks of all threads after a test times out:
  --timeout=TIMEOUT     Timeout in seconds before dumping the stacks.  Default
                        is 0 which
                        means no timeout.
  --timeout_method={signal,thread}
                        Deprecated, use --timeout-method
  --timeout-method={signal,thread}
                        Timeout mechanism to use.  'signal' uses SIGALRM,
                        'thread' uses a timer
                        thread.  If unspecified 'signal' is used on platforms
                        which support
                        SIGALRM, otherwise 'thread' is used.
  --timeout-disable-debugger-detection
                        When specified, disables debugger detection.
                        breakpoint(), pdb.set_trace(), etc.
                        will be interrupted by the timeout.
  --session-timeout=SECONDS
                        Timeout in seconds for entire session.  Default is None
                        which
                        means no timeout. Timeout is checked between tests, and
                        will not interrupt a test
                        in progress.

re-run failing tests to eliminate flaky failures:
  --only-rerun=ONLY_RERUN
                        If passed, only rerun errors matching the regex
                        provided. Pass this flag multiple times to accumulate a
                        list of regexes to match
  --reruns=RERUNS       number of times to re-run failed tests. defaults to 0.
  --reruns-delay=RERUNS_DELAY
                        add time (seconds) delay between reruns.
  --rerun-except=RERUN_EXCEPT
                        If passed, only rerun errors other than matching the
                        regex provided. Pass this flag multiple times to
                        accumulate a list of regexes to match

pytest-randomly:
  --randomly-seed=RANDOMLY_SEED
                        Set the seed that pytest-randomly uses (int), or pass
                        the
                        special value 'last' to reuse the seed from the previous
                        run.
                        Default behaviour: use random.Random().getrandbits(32),
                        so the seed is
                        different on each run.
  --randomly-dont-reset-seed
                        Stop pytest-randomly from resetting random.seed() at the
                        start of every test context (e.g. TestCase) and
                        individual
                        test.
  --randomly-dont-reorganize
                        Stop pytest-randomly from randomly reorganizing the test
                        order.

typeguard:
  --typeguard-packages=TYPEGUARD_PACKAGES
                        comma separated name list of packages and modules to
                        instrument for type checking, or :all: to instrument all
                        modules loaded after typeguard
  --typeguard-debug-instrumentation
                        print all instrumented code to stderr
  --typeguard-typecheck-fail-callback=TYPEGUARD_TYPECHECK_FAIL_CALLBACK
                        a module:varname (e.g. typeguard:warn_on_error)
                        reference to a function that is called (with the
                        exception, and memo object as arguments) to handle a
                        TypeCheckError
  --typeguard-forward-ref-policy={ERROR,WARN,IGNORE}
                        determines how to deal with unresolveable forward
                        references in type annotations
  --typeguard-collection-check-strategy={FIRST_ITEM,ALL_ITEMS}
                        determines how thoroughly to check collections (list,
                        dict, etc)

benchmark:
  --benchmark-min-time=SECONDS
                        Minimum time per round in seconds. Default: '0.000005'
  --benchmark-max-time=SECONDS
                        Maximum run time per test - it will be repeated until
                        this total time is reached. It may be exceeded if test
                        function is very slow or --benchmark-min-rounds is large
                        (it takes precedence). Default: '1.0'
  --benchmark-min-rounds=NUM
                        Minimum rounds, even if total time would exceed `--max-
                        time`. Default: 5
  --benchmark-timer=FUNC
                        Timer to use when measuring time. Default:
                        'time.perf_counter'
  --benchmark-calibration-precision=NUM
                        Precision to use when calibrating number of iterations.
                        Precision of 10 will make the timer look 10 times more
                        accurate, at a cost of less precise measure of
                        deviations. Default: 10
  --benchmark-warmup=[KIND]
                        Activates warmup. Will run the test function up to
                        number of times in the calibration phase. See
                        `--benchmark-warmup-iterations`. Note: Even the warmup
                        phase obeys --benchmark-max-time. Available KIND:
                        'auto', 'off', 'on'. Default: 'auto' (automatically
                        activate on PyPy).
  --benchmark-warmup-iterations=NUM
                        Max number of iterations to run in the warmup phase.
                        Default: 100000
  --benchmark-disable-gc
                        Disable GC during benchmarks.
  --benchmark-skip      Skip running any tests that contain benchmarks.
  --benchmark-disable   Disable benchmarks. Benchmarked functions are only ran
                        once and no stats are reported. Use this is you want to
                        run the test but don't do any benchmarking.
  --benchmark-enable    Forcibly enable benchmarks. Use this option to override
                        --benchmark-disable (in case you have it in pytest
                        configuration).
  --benchmark-only      Only run benchmarks. This overrides --benchmark-skip.
  --benchmark-save=NAME
                        Save the current run into 'STORAGE-
                        PATH/counter_NAME.json'.
  --benchmark-autosave  Autosave the current run into 'STORAGE-PATH/counter_ada1
                        28e49b862bcc68085dc0bfada51714728325_20260326_200129_unc
                        ommited-changes.json
  --benchmark-save-data
                        Use this to make --benchmark-save and --benchmark-
                        autosave include all the timing data, not just the
                        stats.
  --benchmark-json=PATH
                        Dump a JSON report into PATH. Note that this will
                        include the complete data (all the timings, not just the
                        stats).
  --benchmark-compare=[NUM|_ID]
                        Compare the current run against run NUM (or prefix of
                        _id in elasticsearch) or the latest saved run if
                        unspecified.
  --benchmark-compare-fail=EXPR [EXPR ...]
                        Fail test if performance regresses according to given
                        EXPR (eg: min:5% or mean:0.001 for number of seconds).
                        Can be used multiple times.
  --benchmark-cprofile=COLUMN
                        If specified measure one run with cProfile and stores 25
                        top functions. Argument is a column to sort by.
                        Available columns: 'ncallls_recursion', 'ncalls',
                        'tottime', 'tottime_per', 'cumtime', 'cumtime_per',
                        'function_name'.
  --benchmark-storage=URI
                        Specify a path to store the runs as uri in form
                        file://path or elasticsearch+http[s]://host1,host2/[inde
                        x/doctype?project_name=Project] (when --benchmark-save
                        or --benchmark-autosave are used). For backwards
                        compatibility unexpected values are converted to
                        file://<value>. Default: 'file://./.benchmarks'.
  --benchmark-netrc=[BENCHMARK_NETRC]
                        Load elasticsearch credentials from a netrc file.
                        Default: ''.
  --benchmark-verbose   Dump diagnostic and progress information.
  --benchmark-quiet     Disable reporting. Verbose mode takes precedence.
  --benchmark-sort=COL  Column to sort on. Can be one of: 'min', 'max', 'mean',
                        'stddev', 'name', 'fullname'. Default: 'min'
  --benchmark-group-by=LABEL
                        How to group tests. Can be one of: 'group', 'name',
                        'fullname', 'func', 'fullfunc', 'param' or 'param:NAME',
                        where NAME is the name passed to @pytest.parametrize.
                        Default: 'group'
  --benchmark-columns=LABELS
                        Comma-separated list of columns to show in the result
                        table. Default: 'min, max, mean, stddev, median, iqr,
                        outliers, ops, rounds, iterations'
  --benchmark-name=FORMAT
                        How to format names in results. Can be one of 'short',
                        'normal', 'long', or 'trial'. Default: 'normal'
  --benchmark-histogram=[FILENAME-PREFIX]
                        Plot graphs of min/max/avg/stddev over time in FILENAME-
                        PREFIX-test_name.svg. If FILENAME-PREFIX contains
                        slashes ('/') then directories will be created. Default:
                        'benchmark_20260326_200129'

asyncio:
  --asyncio-mode=MODE   'auto' - for automatically handling all async functions
                        by the plugin
                        'strict' - for autoprocessing disabling (useful if
                        different async frameworks should be tested together,
                        e.g. both pytest-asyncio and pytest-trio are used in the
                        same project)

coverage reporting with distributed testing support:
  --cov=[SOURCE]        Path or package name to measure during execution (multi-
                        allowed). Use --cov= to not do any source filtering and
                        record everything.
  --cov-reset           Reset cov sources accumulated in options so far.
  --cov-report=TYPE     Type of report to generate: term, term-missing,
                        annotate, html, xml, json, lcov (multi-allowed). term,
                        term-missing may be followed by ":skip-covered".
                        annotate, html, xml, json and lcov may be followed by
                        ":DEST" where DEST specifies the output location. Use
                        --cov-report= to not generate any output.
  --cov-config=PATH     Config file for coverage. Default: .coveragerc
  --no-cov-on-fail      Do not report coverage if test run fails. Default: False
  --no-cov              Disable coverage report completely (useful for
                        debuggers). Default: False
  --cov-fail-under=MIN  Fail if the total coverage is less than MIN.
  --cov-append          Do not delete coverage but append to current. Default:
                        False
  --cov-branch          Enable branch coverage.
  --cov-precision=COV_PRECISION
                        Override the reporting precision.
  --cov-context=CONTEXT
                        Dynamic contexts to use. "test" for now.

pytest-metadata:
  --metadata=key value  additional metadata.
  --metadata-from-json=METADATA_FROM_JSON
                        additional metadata from a json string.
  --metadata-from-json-file=METADATA_FROM_JSON_FILE
                        additional metadata from a json file.

[pytest] ini-options in the first pytest.ini|tox.ini|setup.cfg|pyproject.toml file found:

  markers (linelist):   Register new markers for test functions
  empty_parameter_set_mark (string):
                        Default marker for empty parametersets
  norecursedirs (args): Directory patterns to avoid for recursion
  testpaths (args):     Directories to search for tests when no files or
                        directories are given on the command line
  filterwarnings (linelist):
                        Each line specifies a pattern for
                        warnings.filterwarnings. Processed after
                        -W/--pythonwarnings.
  consider_namespace_packages (bool):
                        Consider namespace packages when resolving module names
                        during import
  usefixtures (args):   List of default fixtures to be used with this project
  python_files (args):  Glob-style file patterns for Python test module
                        discovery
  python_classes (args):
                        Prefixes or glob names for Python test class discovery
  python_functions (args):
                        Prefixes or glob names for Python test function and
                        method discovery
  disable_test_id_escaping_and_forfeit_all_rights_to_community_support (bool):
                        Disable string escape non-ASCII characters, might cause
                        unwanted side effects(use at your own risk)
  console_output_style (string):
                        Console output: "classic", or with additional progress
                        information ("progress" (percentage) | "count" |
                        "progress-even-when-capture-no" (forces progress even
                        when capture=no)
  verbosity_test_cases (string):
                        Specify a verbosity level for test case execution,
                        overriding the main level. Higher levels will provide
                        more detailed information about each test case executed.
  xfail_strict (bool):  Default for the strict parameter of xfail markers when
                        not given explicitly (default: False)
  tmp_path_retention_count (string):
                        How many sessions should we keep the `tmp_path`
                        directories, according to `tmp_path_retention_policy`.
  tmp_path_retention_policy (string):
                        Controls which directories created by the `tmp_path`
                        fixture are kept around, based on test outcome.
                        (all/failed/none)
  enable_assertion_pass_hook (bool):
                        Enables the pytest_assertion_pass hook. Make sure to
                        delete any previously generated pyc cache files.
  verbosity_assertions (string):
                        Specify a verbosity level for assertions, overriding the
                        main level. Higher levels will provide more detailed
                        explanation when an assertion fails.
  junit_suite_name (string):
                        Test suite name for JUnit report
  junit_logging (string):
                        Write captured log messages to JUnit report: one of
                        no|log|system-out|system-err|out-err|all
  junit_log_passing_tests (bool):
                        Capture log information for passing tests to JUnit
                        report:
  junit_duration_report (string):
                        Duration time to report: one of total|call
  junit_family (string):
                        Emit XML for schema: one of legacy|xunit1|xunit2
  doctest_optionflags (args):
                        Option flags for doctests
  doctest_encoding (string):
                        Encoding used for doctest files
  cache_dir (string):   Cache directory path
  log_level (string):   Default value for --log-level
  log_format (string):  Default value for --log-format
  log_date_format (string):
                        Default value for --log-date-format
  log_cli (bool):       Enable log display during test run (also known as "live
                        logging")
  log_cli_level (string):
                        Default value for --log-cli-level
  log_cli_format (string):
                        Default value for --log-cli-format
  log_cli_date_format (string):
                        Default value for --log-cli-date-format
  log_file (string):    Default value for --log-file
  log_file_mode (string):
                        Default value for --log-file-mode
  log_file_level (string):
                        Default value for --log-file-level
  log_file_format (string):
                        Default value for --log-file-format
  log_file_date_format (string):
                        Default value for --log-file-date-format
  log_auto_indent (string):
                        Default value for --log-auto-indent
  pythonpath (paths):   Add paths to sys.path
  faulthandler_timeout (string):
                        Dump the traceback of all threads if a test takes more
                        than TIMEOUT seconds to finish
  addopts (args):       Extra command line options
  minversion (string):  Minimally required pytest version
  required_plugins (args):
                        Plugins that must be present for pytest to run
  rsyncdirs (paths):    list of (relative) paths to be rsynced for remote
                        distributed testing.
  rsyncignore (paths):  list of (relative) glob-style paths to be ignored for
                        rsyncing.
  looponfailroots (paths):
                        directories to check for changes. Default: current
                        directory.
  timeout (string):     Timeout in seconds before dumping the stacks.  Default
                        is 0 which means no timeout.
  timeout_method (string):
                        Timeout mechanism to use.  'signal' uses SIGALRM,
                        'thread' uses a timer thread.  If unspecified 'signal'
                        is used on platforms which support SIGALRM, otherwise
                        'thread' is used.
  timeout_func_only (bool):
                        When set to True, defers the timeout evaluation to only
                        the test function body, ignoring the time it takes when
                        evaluating any fixtures used in the test.
  timeout_disable_debugger_detection (bool):
                        When specified, disables debugger detection.
                        breakpoint(), pdb.set_trace(), etc. will be interrupted
                        by the timeout.
  session_timeout (string):
                        Timeout in seconds for entire session.  Default is None
                        which means no timeout. Timeout is checked between
                        tests, and will not interrupt a test in progress.
  reruns (string):      number of times to re-run failed tests. defaults to 0.
  reruns_delay (string):
                        add time (seconds) delay between reruns.
  typeguard-packages (linelist):
                        comma separated name list of packages and modules to
                        instrument for type checking, or :all: to instrument all
                        modules loaded after typeguard
  typeguard-debug-instrumentation (bool):
                        print all instrumented code to stderr
  typeguard-typecheck-fail-callback (string):
                        a module:varname (e.g. typeguard:warn_on_error)
                        reference to a function that is called (with the
                        exception, and memo object as arguments) to handle a
                        TypeCheckError
  typeguard-forward-ref-policy (string):
                        determines how to deal with unresolveable forward
                        references in type annotations
  typeguard-collection-check-strategy (string):
                        determines how thoroughly to check collections (list,
                        dict, etc)
  asyncio_mode (string):
                        default value for --asyncio-mode
  asyncio_default_fixture_loop_scope (string):
                        default scope of the asyncio event loop used to execute
                        async fixtures
  render_collapsed (string):
                        row(s) to render collapsed on open.
  max_asset_filename_length (string):
                        set the maximum filename length for assets attached to
                        the html report.
  environment_table_redact_list (linelist):
                        a list of regexes corresponding to environment table
                        variables whose values should be redacted from the
                        report
  initial_sort (string):
                        column to initially sort on.
  generate_report_on_test (bool):
                        the HTML report will be generated after each test
                        instead of at the end of the run.

Environment variables:
  CI                       When set (regardless of value), pytest knows it is running in a CI process and does not truncate summary info
  BUILD_NUMBER             Equivalent to CI
  PYTEST_ADDOPTS           Extra command line options
  PYTEST_PLUGINS           Comma-separated plugins to load during startup
  PYTEST_DISABLE_PLUGIN_AUTOLOAD Set to disable plugin auto-loading
  PYTEST_DEBUG             Set to enable debug tracing of pytest's internals


to see available markers type: pytest --markers
to see available fixtures type: pytest --fixtures
(shown according to specified file_or_dir or current dir if not specified; fixtures with leading '_' are only shown with the '-v' option
- update development docs to use the deterministic pytest invocation

## Validation
- python3 scripts/check_test_dependencies.py
- python3 scripts/run_test_baseline.py --help