### PR TITLE
fix: resolve playground timeout (125s→32s) and test mock staleness

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -353,7 +353,7 @@ _MOCK_CONFIDENCE: dict[str, float] = {
 _ORACLE_MODEL_ANTHROPIC = "claude-sonnet-4-6"
 _ORACLE_MODEL_OPENAI = "gpt-5.3-chat"
 _ORACLE_MODEL_OPENROUTER = "anthropic/claude-opus-4.6"  # OpenRouter fallback
-_ORACLE_CALL_TIMEOUT = 45.0  # seconds — focused essay + OpenRouter latency
+_ORACLE_CALL_TIMEOUT = 10.0  # seconds — tight timeout to keep playground responsive
 
 
 def _get_api_key(name: str) -> str | None:
@@ -1214,14 +1214,14 @@ def _try_oracle_tentacles(
             model_cfg["model"],
             prompt,
             max_tokens=800,
-            timeout=45.0,
+            timeout=_ORACLE_CALL_TIMEOUT,
             openrouter_model=model_cfg.get("openrouter_model"),
         )
         return model_cfg["name"], text
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=min(count, 6)) as pool:
         futures = [pool.submit(_call_tentacle, m, r) for m, r in assignments]
-        for future in concurrent.futures.as_completed(futures, timeout=60):
+        for future in concurrent.futures.as_completed(futures, timeout=_ORACLE_CALL_TIMEOUT + 2):
             try:
                 name, text = future.result()
                 if text:
@@ -2366,7 +2366,7 @@ class PlaygroundHandler(BaseHandler):
 # Live debate execution
 # ---------------------------------------------------------------------------
 
-_LIVE_TIMEOUT = 60  # seconds
+_LIVE_TIMEOUT = 15  # seconds — playground must respond quickly
 _LIVE_BUDGET_CAP = 0.05  # USD
 _LIVE_MAX_CONCURRENT = 2
 _LIVE_DEFAULT_AGENTS = ["anthropic-api", "openai-api"]

--- a/tests/debate/test_post_debate_workflow_fallback.py
+++ b/tests/debate/test_post_debate_workflow_fallback.py
@@ -27,6 +27,7 @@ class _FakeResult:
     confidence: float = 0.85
     predictions: dict = field(default_factory=dict)
     bead_id: str | None = None
+    final_answer: str = "Use rate limiting with token bucket algorithm"
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Playground timeouts reduced: _LIVE_TIMEOUT 60→15s, _ORACLE_CALL_TIMEOUT 45→10s, tentacle deadline 60→12s
- Worst case response time: 125s → 32s. Mock fallback triggers quickly when providers unavailable.
- Fixed `_FakeResult` missing `final_answer` attribute (6 test failures from cross-verification PR)
- 81 playground tests + 7 post-debate workflow tests pass

## Test plan
- [x] 81 playground handler tests pass
- [x] 7 post-debate workflow fallback tests pass (was 6 failures)
- [x] E2E user journey tests pass