### PR TITLE
fix(inbox): sync gmail auth state and advance unread triage

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -292,6 +292,7 @@ async def _run_triage(
                     file=sys.stderr,
                 )
                 sys.exit(1)
+            await _sync_gmail_connector_to_token_store(gmail)
 
             from aragora.inbox.trust_wedge import get_inbox_trust_wedge_service
 
@@ -429,6 +430,7 @@ async def _run_gmail_auth() -> None:
     if not success:
         print("Failed to exchange authorization code for tokens.", file=sys.stderr)
         sys.exit(1)
+    await _sync_gmail_connector_to_token_store(connector)
 
     refresh_token = getattr(connector, "_refresh_token", None)
     if refresh_token:
@@ -470,6 +472,27 @@ def _get_gmail_connector():
     except ImportError:
         logger.warning("GmailConnector not available")
         return None
+
+
+async def _sync_gmail_connector_to_token_store(connector: object | None) -> None:
+    """Mirror CLI Gmail auth state into the durable Gmail token store."""
+    refresh_token = str(getattr(connector, "_refresh_token", "") or "").strip()
+    if not refresh_token:
+        return
+
+    try:
+        from aragora.storage.gmail_token_store import GmailUserState, get_gmail_token_store
+
+        user_id = str(getattr(connector, "user_id", "") or "me")
+        store = get_gmail_token_store()
+        existing = await store.get(user_id)
+        state = existing or GmailUserState(user_id=user_id)
+        state.refresh_token = refresh_token
+        state.access_token = str(getattr(connector, "_access_token", "") or state.access_token)
+        state.token_expiry = getattr(connector, "_token_expiry", None) or state.token_expiry
+        await store.save(state)
+    except Exception as exc:  # noqa: BLE001 - best-effort CLI auth sync
+        logger.debug("Gmail token-store sync skipped: %s", exc)
 
 
 def _print_decisions(decisions: list) -> None:

--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -558,7 +558,7 @@ class InboxTriageRunner:
 
         try:
             message_ids, next_page_token = await self._gmail.list_messages(
-                query="is:unread",
+                query="in:inbox is:unread",
                 max_results=batch_size,
                 page_token=page_token,
             )

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -14,6 +14,11 @@ import pytest
 from aragora.cli.commands import triage as triage_cmd
 from aragora.inbox.triage_diagnostics import DiagnosticSeverity, record_triage_diagnostic
 from aragora.inbox.trust_wedge import InboxWedgeAction, TriageDecision
+from aragora.storage.gmail_token_store import (
+    InMemoryGmailTokenStore,
+    reset_gmail_token_store,
+    set_gmail_token_store,
+)
 
 
 def test_add_triage_parser_supports_auth_and_dry_run():
@@ -153,6 +158,37 @@ async def test_run_triage_defaults_to_staged_profile(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_run_triage_syncs_connector_state_before_execution(tmp_path, monkeypatch):
+    decision = TriageDecision.create(
+        final_action="archive",
+        confidence=0.92,
+        dissent_summary="",
+        receipt_id="receipt-auth-sync",
+    )
+    gmail = SimpleNamespace(_refresh_token="refresh-token", user_id="me")
+    monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
+    fake_runner = SimpleNamespace(run_triage=AsyncMock(return_value=[decision]), next_page_token=None)
+    fake_service = SimpleNamespace(review_receipt=object())
+
+    with (
+        patch.object(triage_cmd, "_get_gmail_connector", return_value=gmail),
+        patch.object(
+            triage_cmd,
+            "_sync_gmail_connector_to_token_store",
+            AsyncMock(),
+        ) as sync_token_store,
+        patch("aragora.inbox.triage_runner.InboxTriageRunner", return_value=fake_runner),
+        patch(
+            "aragora.inbox.trust_wedge.get_inbox_trust_wedge_service",
+            return_value=fake_service,
+        ),
+    ):
+        await triage_cmd._run_triage(batch_size=1, auto_approve=False, dry_run=True)
+
+    sync_token_store.assert_awaited_once_with(gmail)
+
+
+@pytest.mark.asyncio
 async def test_run_triage_footer_shows_diagnostics_path(capsys, tmp_path, monkeypatch):
     decision = TriageDecision.create(
         final_action="archive",
@@ -196,6 +232,28 @@ async def test_run_triage_footer_shows_diagnostics_path(capsys, tmp_path, monkey
     assert len(meta_files) == 1
     meta = json.loads(meta_files[0].read_text())
     assert meta["severity_counts"]["degraded"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_gmail_connector_to_token_store_saves_connector_tokens():
+    store = InMemoryGmailTokenStore()
+    connector = SimpleNamespace(
+        user_id="me",
+        _refresh_token="refresh-token-123",
+        _access_token="access-token-456",
+        _token_expiry="expiry-marker",
+    )
+    set_gmail_token_store(store)
+    try:
+        await triage_cmd._sync_gmail_connector_to_token_store(connector)
+        state = await store.get("me")
+    finally:
+        reset_gmail_token_store()
+
+    assert state is not None
+    assert state.refresh_token == "refresh-token-123"
+    assert state.access_token == "access-token-456"
+    assert state.token_expiry == "expiry-marker"
 
 
 def test_print_decisions_formats_enum_values(capsys):
@@ -433,6 +491,11 @@ async def test_run_gmail_auth_saves_refresh_token(tmp_path, monkeypatch, capsys)
             "aragora.connectors.enterprise.communication.gmail.GmailConnector",
             _FakeConnector,
         ),
+        patch.object(
+            triage_cmd,
+            "_sync_gmail_connector_to_token_store",
+            AsyncMock(),
+        ) as sync_token_store,
         patch("webbrowser.open", side_effect=opened_urls.append),
         patch("http.server.HTTPServer", _FakeHTTPServer),
     ):
@@ -447,3 +510,4 @@ async def test_run_gmail_auth_saves_refresh_token(tmp_path, monkeypatch, capsys)
     assert "Opening browser for Gmail authorization..." in out
     assert "Gmail authenticated successfully!" in out
     assert str(token_path) in out
+    sync_token_store.assert_awaited_once()

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -155,7 +155,7 @@ async def test_run_triage_tracks_next_page_token():
 
     assert len(decisions) == 1
     gmail.list_messages.assert_awaited_once_with(
-        query="is:unread",
+        query="in:inbox is:unread",
         max_results=1,
         page_token="cursor-1",
     )


### PR DESCRIPTION
## Root cause

Founder triage had two real execution gaps:

1. `triage auth` and `_get_gmail_connector()` only populated the CLI token file, while `EmailActionsService` executes against `gmail_token_store`.
2. Inbox triage fetched `is:unread`, so successfully archived Gmail messages could still resurface if they remained unread outside the inbox.

## Fix

- sync CLI Gmail connector state into `gmail_token_store` after successful auth and before triage execution
- narrow triage fetch to `in:inbox is:unread` so executed archive actions advance the founder inbox head truthfully
- add focused CLI and runner coverage for the new wiring

## Proof

- `python3 -m ruff check aragora/cli/commands/triage.py aragora/inbox/triage_runner.py tests/cli/test_triage_command.py tests/inbox/test_triage_runner.py`
- `python3 -m pytest tests/inbox/test_triage_runner.py tests/cli/test_triage_command.py -q`
  - `44 passed`
- real founder execution before fix:
  - `Approved: 1  Executed: 0`
  - `Email archive failed: Gmail connector not authenticated for user: me`
- real founder execution after auth sync:
  - `Executed: 1`
  - no Gmail auth failure
- founder dry-run after query fix advanced to a new subject instead of resurfacing the just-archived message
