### PR TITLE
fix: debate next_steps priority rendering + receipt merge order

### DIFF
--- a/aragora/live/src/app/(app)/debates/[id]/__tests__/normalizeDecisionPackage.test.ts
+++ b/aragora/live/src/app/(app)/debates/[id]/__tests__/normalizeDecisionPackage.test.ts
@@ -35,7 +35,10 @@ describe('normalizeDecisionPackage', () => {
     );
 
     expect(normalized.agents).toEqual(['claude', 'gpt-5']);
-    expect(normalized.next_steps).toEqual(['step one', 'step two']);
+    expect(normalized.next_steps).toEqual([
+      { action: 'step one', priority: 'medium' },
+      { action: 'step two', priority: 'medium' },
+    ]);
   });
 
   it('normalizes malformed receipt to null', () => {
@@ -91,7 +94,10 @@ describe('normalizeDecisionPackage', () => {
       { agent: 'claude', tokens: 0, cost: 0.002 },
       { agent: 'gpt-4', tokens: 0, cost: 0.0022 },
     ]);
-    expect(normalized.next_steps).toEqual(['Ship the release.', 'Monitor logs.']);
+    expect(normalized.next_steps).toEqual([
+      { action: 'Ship the release.', priority: 'high' },
+      { action: 'Monitor logs.', priority: 'medium' },
+    ]);
     expect(normalized.receipt).toEqual({
       hash: 'abc123',
       timestamp: '2026-03-25T12:34:56Z',

--- a/aragora/live/src/app/(app)/debates/[id]/normalizeDecisionPackage.ts
+++ b/aragora/live/src/app/(app)/debates/[id]/normalizeDecisionPackage.ts
@@ -25,7 +25,10 @@ export interface DecisionPackage {
     timestamp: string;
     signers: string[];
   } | null;
-  next_steps: string[];
+  next_steps: Array<{
+    action: string;
+    priority: 'high' | 'medium' | 'low';
+  }>;
   created_at: string;
   duration_seconds: number;
 }
@@ -113,15 +116,24 @@ function normalizeReceipt(value: unknown, fallbackTimestamp = ''): DecisionPacka
   };
 }
 
-function normalizeNextSteps(value: unknown): string[] {
+function normalizeNextSteps(value: unknown): DecisionPackage['next_steps'] {
   if (!Array.isArray(value)) return [];
   return value
     .map((item) => {
-      if (typeof item === 'string') return item;
+      if (typeof item === 'string') {
+        return { action: item, priority: 'medium' as const };
+      }
       const obj = asObject(item);
-      return obj ? asString(obj.action) : '';
+      if (!obj) return null;
+      const action = asString(obj.action);
+      if (!action) return null;
+      const rawPriority = asString(obj.priority, 'medium').toLowerCase();
+      const priority = (
+        rawPriority === 'high' || rawPriority === 'low' ? rawPriority : 'medium'
+      ) as 'high' | 'medium' | 'low';
+      return { action, priority };
     })
-    .filter(Boolean);
+    .filter((item): item is DecisionPackage['next_steps'][number] => item !== null);
 }
 
 export function normalizeDecisionPackage(raw: unknown, fallbackId: string): DecisionPackage {

--- a/aragora/live/src/components/debates/DecisionPackageView.tsx
+++ b/aragora/live/src/components/debates/DecisionPackageView.tsx
@@ -12,7 +12,10 @@ interface DecisionPackage {
     tokens: number;
     cost: number;
   }>;
-  next_steps: string[];
+  next_steps: Array<{
+    action: string;
+    priority: 'high' | 'medium' | 'low';
+  }>;
   duration_seconds: number;
 }
 
@@ -103,7 +106,16 @@ export function DecisionPackageView({ pkg }: DecisionPackageViewProps) {
                 <span className="text-xs font-mono text-[var(--acid-cyan)] mt-0.5">
                   {String(i + 1).padStart(2, '0')}.
                 </span>
-                <p className="text-sm font-mono text-[var(--text)]">{step}</p>
+                <span className={`text-[10px] font-mono mt-0.5 px-1 border ${
+                  step.priority === 'high'
+                    ? 'text-[var(--warning)] border-[var(--warning)]/40'
+                    : step.priority === 'low'
+                      ? 'text-[var(--text-muted)] border-[var(--border)]'
+                      : 'text-[var(--acid-cyan)] border-[var(--acid-cyan)]/30'
+                }`}>
+                  {step.priority.toUpperCase()}
+                </span>
+                <p className="text-sm font-mono text-[var(--text)]">{step.action}</p>
               </div>
             ))}
           </div>

--- a/aragora/storage/receipt_store.py
+++ b/aragora/storage/receipt_store.py
@@ -186,9 +186,14 @@ class StoredReceipt:
         return result
 
     def to_full_dict(self) -> dict[str, Any]:
-        """Convert to full dictionary including data payload."""
-        result = self.to_dict()
-        result.update(self.data)
+        """Convert to full dictionary including data payload.
+
+        The data blob (from data_json) provides the base, then the
+        authoritative structured DB column values from to_dict() are
+        layered on top so they always win if the blob is stale.
+        """
+        result = dict(self.data)
+        result.update(self.to_dict())
         return result
 
 

--- a/tests/storage/test_receipt_store.py
+++ b/tests/storage/test_receipt_store.py
@@ -195,6 +195,47 @@ class TestStoredReceipt:
         assert result["extra_field"] == "value"
         assert result["receipt_id"] == "receipt-001"
 
+    def test_to_full_dict_structured_fields_win_over_stale_data(self):
+        """Authoritative DB column values must override stale data_json blob values.
+
+        When a receipt is signed after initial save, the structured
+        ``verdict``/``confidence`` columns may differ from the original
+        ``data_json`` blob.  ``to_full_dict()`` must prefer the column
+        values so callers always see the authoritative state.
+        """
+        receipt = StoredReceipt(
+            receipt_id="receipt-002",
+            gauntlet_id="gauntlet-002",
+            debate_id="debate-002",
+            created_at=1700000000.0,
+            expires_at=1700086400.0,
+            verdict="APPROVED",  # authoritative column value
+            confidence=0.95,  # updated after initial save
+            risk_level="LOW",
+            risk_score=0.05,
+            checksum="sha256:xyz",
+            data={
+                # Stale blob values from original save
+                "verdict": "NEEDS_REVIEW",
+                "confidence": 0.5,
+                "risk_level": "HIGH",
+                "timestamp": "2023-11-15T00:00:00Z",
+                "input_summary": "Original question",
+            },
+        )
+
+        result = receipt.to_full_dict()
+
+        # Structured fields must win
+        assert result["verdict"] == "APPROVED"
+        assert result["confidence"] == 0.95
+        assert result["risk_level"] == "LOW"
+        assert result["receipt_id"] == "receipt-002"
+        assert result["debate_id"] == "debate-002"
+        # Data-only fields are preserved
+        assert result["timestamp"] == "2023-11-15T00:00:00Z"
+        assert result["input_summary"] == "Original question"
+
 
 class TestSignatureVerificationResult:
     """Tests for SignatureVerificationResult dataclass."""


### PR DESCRIPTION
## Summary
Two data contract fixes:

1. **Debate detail next_steps**: Backend returns `{action, priority}` objects but frontend was flattening to plain strings, losing priority annotations. Now renders with color-coded priority badges (HIGH/MEDIUM/LOW).

2. **Receipt to_full_dict merge order**: `to_dict()` column values were being overridden by stale `data_json` blob values. Reversed merge so authoritative DB columns always win.

Also investigated spectate streaming — confirmed it's an intentional architectural gap, not a bug.

## Test plan
- [x] 759 related tests pass (receipt store, handlers, decision package, spectate, export, CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)