### PR TITLE
fix(oauth-wizard): normalize store record types

### DIFF
--- a/aragora/server/handlers/oauth_wizard.py
+++ b/aragora/server/handlers/oauth_wizard.py
@@ -546,6 +546,19 @@ class OAuthWizardHandler(SecureHandler):
                 return value
         return value
 
+    def _record_value(self, record: Any, *field_names: str, default: Any = None) -> Any:
+        """Return the first matching field from a dict-like or attribute-based record."""
+        if isinstance(record, dict):
+            for field_name in field_names:
+                if field_name in record:
+                    return record[field_name]
+            return default
+
+        for field_name in field_names:
+            if hasattr(record, field_name):
+                return getattr(record, field_name)
+        return default
+
     def _normalize_mock_side_effect(self, func: Any) -> None:
         """Ensure mock side_effect lists behave as iterators for AsyncMock."""
         side_effect = getattr(func, "side_effect", None)
@@ -699,7 +712,7 @@ class OAuthWizardHandler(SecureHandler):
                 return {"success": False, "error": "No active workspaces configured"}
 
             workspace = workspaces[0]
-            token = workspace.get("access_token")
+            token = self._record_value(workspace, "access_token")
             if not token:
                 return {"success": False, "error": "No access token available"}
 
@@ -744,7 +757,7 @@ class OAuthWizardHandler(SecureHandler):
                 return {"success": False, "error": "No active tenants configured"}
 
             tenant = tenants[0]
-            token = tenant.get("access_token")
+            token = self._record_value(tenant, "access_token")
             if not token:
                 return {"success": False, "error": "No access token available"}
 
@@ -852,10 +865,10 @@ class OAuthWizardHandler(SecureHandler):
         workspaces = store.list_active(limit=100)
         return [
             {
-                "id": ws.get("workspace_id"),
-                "name": ws.get("name", "Unknown"),
-                "is_active": ws.get("is_active", True),
-                "connected_at": ws.get("created_at"),
+                "id": self._record_value(ws, "workspace_id", "id"),
+                "name": self._record_value(ws, "workspace_name", "name", default="Unknown"),
+                "is_active": self._record_value(ws, "is_active", default=True),
+                "connected_at": self._record_value(ws, "created_at", "installed_at"),
             }
             for ws in workspaces
         ]
@@ -868,10 +881,10 @@ class OAuthWizardHandler(SecureHandler):
         tenants = store.list_active(limit=100)
         return [
             {
-                "id": t.get("tenant_id"),
-                "name": t.get("name", "Unknown"),
-                "is_active": t.get("is_active", True),
-                "connected_at": t.get("created_at"),
+                "id": self._record_value(t, "tenant_id", "id"),
+                "name": self._record_value(t, "tenant_name", "name", default="Unknown"),
+                "is_active": self._record_value(t, "is_active", default=True),
+                "connected_at": self._record_value(t, "created_at", "installed_at"),
             }
             for t in tenants
         ]

--- a/tests/handlers/test_oauth_wizard.py
+++ b/tests/handlers/test_oauth_wizard.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import os
 import socket
+import time
 from collections import defaultdict
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -32,6 +33,8 @@ from aragora.server.handlers.oauth_wizard import (
     PROVIDERS,
     create_oauth_wizard_handler,
 )
+from aragora.storage.slack_workspace_store import SlackWorkspace
+from aragora.storage.teams_tenant_store import TeamsTenant
 
 
 # ---------------------------------------------------------------------------
@@ -1401,6 +1404,45 @@ class TestSlackApiTest:
         assert result["success"] is False
 
     @pytest.mark.asyncio
+    async def test_slack_api_accepts_dataclass_workspace(self, handler):
+        mock_store = MagicMock()
+        mock_store.list_active.return_value = [
+            SlackWorkspace(
+                workspace_id="W1",
+                workspace_name="Acme Workspace",
+                access_token="xoxb-test",
+                bot_user_id="B1",
+                installed_at=time.time(),
+            )
+        ]
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "team": "Acme Workspace",
+            "user": "aragora-bot",
+            "team_id": "W1",
+        }
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        session = AsyncMock()
+        session.__aenter__.return_value = mock_client
+        session.__aexit__.return_value = False
+        mock_pool = MagicMock()
+        mock_pool.get_session.return_value = session
+
+        with (
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_store,
+            ),
+            patch("aragora.server.http_client_pool.get_http_pool", return_value=mock_pool),
+        ):
+            result = await handler._test_slack_api()
+
+        assert result["success"] is True
+        assert result["team"] == "Acme Workspace"
+
+    @pytest.mark.asyncio
     async def test_discord_no_bot_token(self, handler):
         result = await handler._test_discord_api()
         assert result["success"] is False
@@ -1445,6 +1487,105 @@ class TestSlackApiTest:
             result = await handler._test_teams_api()
         assert result["success"] is False
         assert "No access token" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_teams_api_accepts_dataclass_tenant(self, handler):
+        mock_store = MagicMock()
+        mock_store.list_active.return_value = [
+            TeamsTenant(
+                tenant_id="T1",
+                tenant_name="Contoso",
+                access_token="teams-token",
+                bot_id="bot-1",
+                installed_at=time.time(),
+            )
+        ]
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"displayName": "Contoso Bot"}
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        session = AsyncMock()
+        session.__aenter__.return_value = mock_client
+        session.__aexit__.return_value = False
+        mock_pool = MagicMock()
+        mock_pool.get_session.return_value = session
+
+        with (
+            patch(
+                "aragora.storage.teams_tenant_store.get_teams_tenant_store",
+                return_value=mock_store,
+            ),
+            patch("aragora.server.http_client_pool.get_http_pool", return_value=mock_pool),
+        ):
+            result = await handler._test_teams_api()
+
+        assert result["success"] is True
+        assert result["display_name"] == "Contoso Bot"
+
+
+class TestWorkspaceRecordNormalization:
+    """Tests for mapping real store records into wizard workspace payloads."""
+
+    @pytest.mark.asyncio
+    async def test_get_slack_workspaces_accepts_dataclass_records(self, handler):
+        mock_store = MagicMock()
+        installed_at = time.time()
+        mock_store.list_active.return_value = [
+            SlackWorkspace(
+                workspace_id="W1",
+                workspace_name="Acme Workspace",
+                access_token="xoxb-test",
+                bot_user_id="B1",
+                installed_at=installed_at,
+                is_active=False,
+            )
+        ]
+
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_store,
+        ):
+            result = await handler._get_slack_workspaces()
+
+        assert result == [
+            {
+                "id": "W1",
+                "name": "Acme Workspace",
+                "is_active": False,
+                "connected_at": installed_at,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_get_teams_tenants_accepts_dataclass_records(self, handler):
+        mock_store = MagicMock()
+        installed_at = time.time()
+        mock_store.list_active.return_value = [
+            TeamsTenant(
+                tenant_id="T1",
+                tenant_name="Contoso",
+                access_token="teams-token",
+                bot_id="bot-1",
+                installed_at=installed_at,
+                is_active=False,
+            )
+        ]
+
+        with patch(
+            "aragora.storage.teams_tenant_store.get_teams_tenant_store",
+            return_value=mock_store,
+        ):
+            result = await handler._get_teams_tenants()
+
+        assert result == [
+            {
+                "id": "T1",
+                "name": "Contoso",
+                "is_active": False,
+                "connected_at": installed_at,
+            }
+        ]
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- normalize Slack and Teams wizard helpers so they accept real dataclass store records as well as mocked dict records
- map live store field names (`workspace_name`, `tenant_name`, `installed_at`) into the wizard payload shape
- add regression coverage for the dataclass-backed API test and workspace listing paths

## Repro
Before this change, the live setup wizard helper methods crashed with `AttributeError` because real `SlackWorkspace` and `TeamsTenant` records do not implement `.get(...)`.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/test_oauth_wizard.py tests/server/handlers/test_oauth_wizard.py`
- `ruff check aragora/server/handlers/oauth_wizard.py tests/handlers/test_oauth_wizard.py`