### PR TITLE
fix(inbox): hold finance subjects for manual review

### DIFF
--- a/aragora/inbox/auto_approval.py
+++ b/aragora/inbox/auto_approval.py
@@ -15,6 +15,7 @@ Rules:
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
 from aragora.inbox.trust_wedge import (
@@ -35,6 +36,14 @@ _AUTO_APPROVABLE_ACTIONS: frozenset[str] = frozenset(
 )
 
 _DEFAULT_CONFIDENCE_THRESHOLD = 0.85
+_MANUAL_REVIEW_SUBJECT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\breceipt\b", re.IGNORECASE),
+    re.compile(r"\bstatement\b", re.IGNORECASE),
+    re.compile(r"\bpayment\b", re.IGNORECASE),
+    re.compile(r"\binvoice\b", re.IGNORECASE),
+    re.compile(r"\bportfolio\b", re.IGNORECASE),
+    re.compile(r"\bbilling\b", re.IGNORECASE),
+)
 
 
 class AutoApprovalPolicy:
@@ -56,6 +65,21 @@ class AutoApprovalPolicy:
     @property
     def confidence_threshold(self) -> float:
         return self._confidence_threshold
+
+    def _subject_requires_manual_review(self, decision: TriageDecision) -> bool:
+        subject = str(getattr(getattr(decision, "intent", None), "_subject", "") or "").strip()
+        if not subject:
+            return False
+
+        for pattern in _MANUAL_REVIEW_SUBJECT_PATTERNS:
+            if pattern.search(subject):
+                logger.debug(
+                    "Auto-approval blocked: subject requires manual review (%s)",
+                    subject[:120],
+                )
+                return True
+
+        return False
 
     def can_auto_approve(self, decision: TriageDecision) -> bool:
         """Check whether *decision* is eligible for auto-approval.
@@ -94,6 +118,9 @@ class AutoApprovalPolicy:
                 "Auto-approval blocked: receipt state %s (expected CREATED)",
                 decision.receipt_state,
             )
+            return False
+
+        if self._subject_requires_manual_review(decision):
             return False
 
         return True

--- a/tests/inbox/test_auto_approval.py
+++ b/tests/inbox/test_auto_approval.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from aragora.inbox.auto_approval import AutoApprovalPolicy
+from aragora.inbox.trust_wedge import InboxWedgeAction, ReceiptState, TriageDecision
+
+
+def _decision(*, subject: str, action: InboxWedgeAction = InboxWedgeAction.ARCHIVE) -> TriageDecision:
+    decision = TriageDecision.create(
+        final_action=action,
+        confidence=0.95,
+        dissent_summary="",
+    )
+    decision.receipt_state = ReceiptState.CREATED.value
+    decision.intent = SimpleNamespace(_subject=subject)
+    return decision
+
+
+def test_auto_approval_allows_routine_promotional_archive():
+    policy = AutoApprovalPolicy()
+
+    assert policy.can_auto_approve(_decision(subject="Game on. Your next trip = $25"))
+
+
+def test_auto_approval_blocks_financial_receipt_subjects():
+    policy = AutoApprovalPolicy()
+
+    assert not policy.can_auto_approve(_decision(subject="Your receipt from Loom, Inc."))
+    assert not policy.can_auto_approve(_decision(subject="Your Statement is Ready"))
+    assert not policy.can_auto_approve(_decision(subject="Thank you for your payment"))

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -226,6 +226,42 @@ async def test_run_triage_executes_auto_approved_receipts():
 
 
 @pytest.mark.asyncio
+async def test_financial_subject_forces_manual_review_even_with_high_confidence_archive():
+    wedge_service = SimpleNamespace()
+    wedge_service.execute_receipt = AsyncMock()
+    wedge_service.create_receipt = MagicMock(
+        side_effect=lambda intent, decision, auto_approve=False: _make_envelope(
+            decision,
+            receipt_id="receipt-finance-guard",
+            state=ReceiptState.APPROVED if auto_approve else ReceiptState.CREATED,
+        )
+    )
+
+    runner = InboxTriageRunner(gmail_connector=None, wedge_service=wedge_service)
+    runner._run_debate = AsyncMock(
+        return_value={
+            "final_answer": "archive",
+            "confidence": 0.99,
+            "debate_id": "debate-finance-guard",
+        }
+    )
+
+    decision = await runner._triage_message(
+        {
+            "id": "msg-finance-guard",
+            "subject": "Your receipt from Loom, Inc.",
+            "from": "billing@example.com",
+            "body": "Payment confirmed.",
+        },
+        auto_approve=True,
+    )
+
+    assert wedge_service.create_receipt.call_args.kwargs["auto_approve"] is False
+    assert decision.receipt_state == ReceiptState.CREATED.value
+    wedge_service.execute_receipt.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_dissent_blocks_auto_approval_before_receipt_execution():
     gmail = _DummyGmail()
     wedge_service = SimpleNamespace()


### PR DESCRIPTION
## Root cause

Founder batch auto-approve was still unsafe for mixed unread heads.

Real preflight on merged `main` showed subjects like:
- `Your Statement is Ready`
- `Your receipt from Loom, Inc.`
- `Thank you for your payment`

Those are not obviously safe archive candidates, but the previous auto-approval policy would still approve them because it only checked action, confidence, dissent, and receipt state.

## Fix

- keep the founder fast path intact
- add a narrow manual-review guard for finance/receipt-like subjects in `AutoApprovalPolicy`
- cover both the policy and the triage runner wiring with focused tests

## Verification

- `python3 -m ruff check aragora/inbox/auto_approval.py tests/inbox/test_auto_approval.py tests/inbox/test_triage_runner.py`
- `python3 -m pytest tests/inbox/test_auto_approval.py tests/inbox/test_triage_runner.py -q`
  - `31 passed`

## Live proof

Real `--batch 5 --auto-approve` on the mixed founder head after the patch:
- held for manual review:
  - `Your Statement is Ready`
  - `Your receipt from Loom, Inc.`
  - `Thank you for your payment`
- executed automatically:
  - `Open to options? Explore this`
  - `Neil deGrasse Tyson + Bill Ny`
- runtime: `12.97s`

Follow-up dry-run confirmed the financial subjects remained queued while the safe promotional subjects were removed.
