### PR TITLE
test(ci): fix post-1433 lint and archive test harness

### DIFF
--- a/aragora/live/src/app/__tests__/debatesBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/debatesBackendSelection.test.tsx
@@ -19,6 +19,9 @@ jest.mock('next/navigation', () => ({
   useParams: () => ({
     id: 'debate-123',
   }),
+  useSearchParams: () => ({
+    get: () => null,
+  }),
 }));
 
 jest.mock('next/link', () => {
@@ -55,6 +58,15 @@ jest.mock('@/utils/logger', () => ({
     error: jest.fn(),
     debug: jest.fn(),
   },
+}));
+
+jest.mock('@/hooks/useAuthenticatedFetch', () => ({
+  useAuthFetch: () => ({
+    getAuthHeaders: () => ({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer test-token',
+    }),
+  }),
 }));
 
 jest.mock('@/utils/supabase', () => ({

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -136,7 +136,9 @@ async def test_run_triage_defaults_to_staged_profile(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
     monkeypatch.delenv("ARAGORA_TRIAGE_PROFILE", raising=False)
-    fake_runner = SimpleNamespace(run_triage=AsyncMock(return_value=[decision]), next_page_token=None)
+    fake_runner = SimpleNamespace(
+        run_triage=AsyncMock(return_value=[decision]), next_page_token=None
+    )
     fake_service = SimpleNamespace(review_receipt=object())
     captured: dict[str, object] = {}
 
@@ -167,7 +169,9 @@ async def test_run_triage_syncs_connector_state_before_execution(tmp_path, monke
     )
     gmail = SimpleNamespace(_refresh_token="refresh-token", user_id="me")
     monkeypatch.setenv("ARAGORA_TRIAGE_DIAGNOSTICS_DIR", str(tmp_path / "triage-runs"))
-    fake_runner = SimpleNamespace(run_triage=AsyncMock(return_value=[decision]), next_page_token=None)
+    fake_runner = SimpleNamespace(
+        run_triage=AsyncMock(return_value=[decision]), next_page_token=None
+    )
     fake_service = SimpleNamespace(review_receipt=object())
 
     with (

--- a/tests/inbox/test_auto_approval.py
+++ b/tests/inbox/test_auto_approval.py
@@ -6,7 +6,9 @@ from aragora.inbox.auto_approval import AutoApprovalPolicy
 from aragora.inbox.trust_wedge import InboxWedgeAction, ReceiptState, TriageDecision
 
 
-def _decision(*, subject: str, action: InboxWedgeAction = InboxWedgeAction.ARCHIVE) -> TriageDecision:
+def _decision(
+    *, subject: str, action: InboxWedgeAction = InboxWedgeAction.ARCHIVE
+) -> TriageDecision:
     decision = TriageDecision.create(
         final_action=action,
         confidence=0.95,


### PR DESCRIPTION
## Summary
- add the current `useSearchParams` and auth-fetch mocks to the debate archive backend-selection test
- apply Ruff formatting to the two inbox tests that broke `lint-run`
- keep the scope to the concrete post-merge failures exposed after #1433

## Verification
- `python3 -m ruff format --check aragora/ tests/ scripts/`
- `python3 -m pytest tests/cli/test_triage_command.py tests/inbox/test_auto_approval.py -q`
- `cd aragora/live && npx jest --ci --runTestsByPath 'src/app/__tests__/debatesBackendSelection.test.tsx'