### PR TITLE
fix: inbox test receipt gates + audit async tests + triage error handling

### DIFF
--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -521,11 +521,20 @@ class InboxTriageRunner:
                     await self._execute_action(decision)
                 decisions.append(decision)
             except (RuntimeError, OSError, ValueError, TypeError) as exc:
-                logger.warning(
+                message_id = msg.get("id", "?")
+                logger.error(
                     "Triage failed for message %s: %s",
-                    msg.get("id", "?"),
+                    message_id,
                     exc,
                 )
+                blocked_decision = TriageDecision(
+                    final_action=InboxWedgeAction.IGNORE,
+                    confidence=0.0,
+                    dissent_summary=f"Triage dispatch error: {type(exc).__name__}",
+                    blocked_by_policy=True,
+                    receipt_state="blocked",
+                )
+                decisions.append(blocked_decision)
 
         self._triaged = decisions
         auto_count = sum(1 for d in decisions if d.receipt_state == ReceiptState.APPROVED.value)

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -1128,3 +1128,26 @@ async def test_triage_message_carries_execution_and_diagnostics_metadata(tmp_pat
     assert decision.escalation_reasons == ["low_confidence"]
     assert decision.suppressed_diagnostics_count == 1
     assert decision.blocked_by_policy is True
+
+
+@pytest.mark.asyncio
+async def test_debate_dispatch_error_produces_blocked_decision_not_silent_skip():
+    """When _triage_message raises, run_triage must produce a blocked
+    TriageDecision instead of silently dropping the message."""
+    gmail = _DummyGmail()
+    wedge_service = SimpleNamespace()
+    wedge_service.execute_receipt = AsyncMock()
+    wedge_service.create_receipt = MagicMock()
+
+    runner = InboxTriageRunner(gmail_connector=gmail, wedge_service=wedge_service)
+    runner._run_debate = AsyncMock(side_effect=RuntimeError("provider unreachable"))
+
+    decisions = await runner.run_triage(batch_size=1, auto_approve=False)
+
+    assert len(decisions) == 1, "Failed triage must still produce a decision"
+    decision = decisions[0]
+    assert decision.blocked_by_policy is True
+    assert decision.confidence == 0.0
+    assert decision.receipt_state == "blocked"
+    assert "RuntimeError" in decision.dissent_summary
+    assert decision.final_action == InboxWedgeAction.IGNORE

--- a/tests/server/handlers/inbox/test_email_actions.py
+++ b/tests/server/handlers/inbox/test_email_actions.py
@@ -369,8 +369,11 @@ class TestArchiveMessage:
     @pytest.mark.asyncio
     async def test_archive_message_success(self, mock_service):
         """Should archive message successfully."""
-        with patch.object(
-            email_actions, "get_email_actions_service_instance", return_value=mock_service
+        with (
+            patch.object(
+                email_actions, "get_email_actions_service_instance", return_value=mock_service
+            ),
+            patch.object(email_actions, "_maybe_handle_wedge_action", return_value=None),
         ):
             result = await email_actions.handle_archive_message(
                 data={},
@@ -575,8 +578,11 @@ class TestStarMessage:
     @pytest.mark.asyncio
     async def test_star_message_success(self, mock_service):
         """Should star message successfully."""
-        with patch.object(
-            email_actions, "get_email_actions_service_instance", return_value=mock_service
+        with (
+            patch.object(
+                email_actions, "get_email_actions_service_instance", return_value=mock_service
+            ),
+            patch.object(email_actions, "_maybe_handle_wedge_action", return_value=None),
         ):
             result = await email_actions.handle_star_message(
                 data={},
@@ -661,8 +667,11 @@ class TestAddLabel:
     @pytest.mark.asyncio
     async def test_add_label_success(self, mock_service):
         """Should add labels to message."""
-        with patch.object(
-            email_actions, "get_email_actions_service_instance", return_value=mock_service
+        with (
+            patch.object(
+                email_actions, "get_email_actions_service_instance", return_value=mock_service
+            ),
+            patch.object(email_actions, "_maybe_handle_wedge_action", return_value=None),
         ):
             result = await email_actions.handle_add_label(
                 data={"labels": ["Important", "Work"]},
@@ -677,8 +686,11 @@ class TestAddLabel:
     @pytest.mark.asyncio
     async def test_add_label_empty_labels(self, mock_service):
         """Should return 400 when labels is empty."""
-        with patch.object(
-            email_actions, "get_email_actions_service_instance", return_value=mock_service
+        with (
+            patch.object(
+                email_actions, "get_email_actions_service_instance", return_value=mock_service
+            ),
+            patch.object(email_actions, "_maybe_handle_wedge_action", return_value=None),
         ):
             result = await email_actions.handle_add_label(
                 data={"labels": []},

--- a/tests/server/handlers/test_audit_trail_async.py
+++ b/tests/server/handlers/test_audit_trail_async.py
@@ -1,0 +1,184 @@
+"""Async-safety regression tests for AuditTrailHandler.
+
+Verifies that _call_store_nonblocking offloads synchronous store
+operations to a thread so the event loop stays responsive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "0")
+
+from aragora.server.handlers.audit_trail import AuditTrailHandler
+
+
+# ---------------------------------------------------------------------------
+# Slow store stubs — simulate blocking I/O
+# ---------------------------------------------------------------------------
+
+
+class _SlowAuditTrailStore:
+    """Store whose sync methods sleep, proving _call_store_nonblocking
+    offloads them to a thread."""
+
+    def list_trails(self, **kwargs: Any) -> list[dict[str, Any]]:
+        time.sleep(0.2)
+        return [
+            {
+                "trail_id": "trail-1",
+                "gauntlet_id": "gauntlet-1",
+                "created_at": "2026-03-26T00:00:00Z",
+                "verdict": "APPROVED",
+                "confidence": 0.9,
+                "total_findings": 0,
+                "duration_seconds": 1.0,
+                "checksum": "abc",
+            }
+        ]
+
+    def count_trails(self, **kwargs: Any) -> int:
+        time.sleep(0.2)
+        return 1
+
+    def get_trail(self, trail_id: str) -> dict[str, Any] | None:
+        time.sleep(0.2)
+        return {
+            "trail_id": trail_id,
+            "gauntlet_id": "gauntlet-1",
+            "created_at": "2026-03-26T00:00:00Z",
+            "verdict": "APPROVED",
+            "confidence": 0.9,
+            "total_findings": 0,
+            "duration_seconds": 1.0,
+            "findings": [],
+            "agents_involved": ["claude"],
+            "checksum": "abc123",
+        }
+
+    def list_receipts(self, **kwargs: Any) -> list[dict[str, Any]]:
+        time.sleep(0.2)
+        return [
+            {
+                "receipt_id": "receipt-1",
+                "gauntlet_id": "gauntlet-1",
+                "timestamp": "2026-03-26T00:00:00Z",
+                "verdict": "APPROVED",
+                "confidence": 0.9,
+                "risk_level": "LOW",
+                "findings_count": 0,
+                "checksum": "abc",
+            }
+        ]
+
+    def count_receipts(self, **kwargs: Any) -> int:
+        time.sleep(0.2)
+        return 1
+
+    def get_receipt(self, receipt_id: str) -> dict[str, Any] | None:
+        time.sleep(0.2)
+        return {
+            "receipt_id": receipt_id,
+            "gauntlet_id": "gauntlet-1",
+            "timestamp": "2026-03-26T00:00:00Z",
+            "verdict": "APPROVED",
+            "confidence": 0.9,
+            "risk_level": "LOW",
+            "risk_score": 0.1,
+            "robustness_score": 0.9,
+            "findings": [],
+            "agents_involved": ["claude"],
+            "checksum": "abc123",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(store: Any) -> AuditTrailHandler:
+    """Build handler with injected slow store, bypassing real DB init."""
+    with patch(
+        "aragora.storage.audit_trail_store.get_audit_trail_store",
+        return_value=store,
+    ):
+        handler = AuditTrailHandler(server_context={})
+    return handler
+
+
+async def _ticker(duration: float = 0.35) -> int:
+    """Count event-loop ticks while other coroutines run."""
+    ticks = 0
+    start = time.perf_counter()
+    while time.perf_counter() - start < duration:
+        await asyncio.sleep(0.01)
+        ticks += 1
+    return ticks
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_receipts_does_not_block_event_loop() -> None:
+    handler = _make_handler(_SlowAuditTrailStore())
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)
+
+    result = await handler._call_store_nonblocking("list_receipts", limit=10, offset=0)
+    ticks = await task
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert ticks >= 10, f"Event loop was blocked (only {ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_get_receipt_does_not_block_event_loop() -> None:
+    handler = _make_handler(_SlowAuditTrailStore())
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)
+
+    result = await handler._call_store_nonblocking("get_receipt", "receipt-123")
+    ticks = await task
+
+    assert result is not None
+    assert result["receipt_id"] == "receipt-123"
+    assert ticks >= 10, f"Event loop was blocked (only {ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_list_audit_trails_does_not_block_event_loop() -> None:
+    handler = _make_handler(_SlowAuditTrailStore())
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)
+
+    result = await handler._call_store_nonblocking("list_trails", limit=10, offset=0)
+    ticks = await task
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert ticks >= 10, f"Event loop was blocked (only {ticks} ticks)"
+
+
+@pytest.mark.asyncio
+async def test_get_audit_trail_does_not_block_event_loop() -> None:
+    handler = _make_handler(_SlowAuditTrailStore())
+    task = asyncio.create_task(_ticker())
+    await asyncio.sleep(0)
+
+    result = await handler._call_store_nonblocking("get_trail", "trail-123")
+    ticks = await task
+
+    assert result is not None
+    assert result["trail_id"] == "trail-123"
+    assert ticks >= 10, f"Event loop was blocked (only {ticks} ticks)"


### PR DESCRIPTION
## Summary
Three fixes:

1. **Inbox email action tests** — 4 tests fixed (add_label, archive, star) by patching receipt gate. 35/35 pass.
2. **Audit trail async-safety** — 4 new regression tests verify _call_store_nonblocking offloads to threads. Event loop stays responsive.
3. **Triage runner error handling** — debate failures now produce blocked TriageDecision instead of silently dropping messages. Logs at error level with exception details.

## Test plan
- [x] 35/35 inbox handler tests pass
- [x] 4/4 audit async tests pass
- [x] 30/30 triage runner tests pass
- [x] 255 combined suite pass