### PR TITLE
fix(wizard): make gmail and smtp tests truthful

### DIFF
--- a/aragora/server/handlers/oauth_wizard.py
+++ b/aragora/server/handlers/oauth_wizard.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import inspect
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from aragora.server.handlers.base import (
@@ -529,6 +529,8 @@ class OAuthWizardHandler(SecureHandler):
                 return await self._check_teams_connection()
             elif provider_id == "discord":
                 return await self._check_discord_connection()
+            elif provider_id == "gmail":
+                return await self._check_gmail_connection()
             elif provider_id == "email":
                 return await self._check_email_connection()
             else:
@@ -665,6 +667,32 @@ class OAuthWizardHandler(SecureHandler):
             logger.warning("Email connection check failed: %s", e)
             return {"status": "error", "error": "SMTP connection check failed"}
 
+    async def _check_gmail_connection(self) -> dict[str, Any]:
+        """Check Gmail connection status from the persisted token store."""
+        from aragora.storage.gmail_token_store import get_gmail_token_store
+
+        store = get_gmail_token_store()
+        states = await self._maybe_await(store.list_all())
+        if not states:
+            return {"status": "not_connected", "reason": "No Gmail accounts connected"}
+
+        connected_states = [
+            state
+            for state in states
+            if self._record_value(state, "refresh_token")
+            or self._record_value(state, "access_token")
+        ]
+        if not connected_states:
+            return {"status": "not_connected", "reason": "No active Gmail tokens available"}
+
+        primary = connected_states[0]
+        return {
+            "status": "connected",
+            "accounts": len(connected_states),
+            "email": self._record_value(primary, "email_address"),
+            "user_id": self._record_value(primary, "user_id"),
+        }
+
     async def _test_connection(self, provider_id: str) -> HandlerResult:
         """
         Test connection to a provider with an actual API call.
@@ -681,6 +709,10 @@ class OAuthWizardHandler(SecureHandler):
                 result = await self._test_teams_api()
             elif provider_id == "discord":
                 result = await self._test_discord_api()
+            elif provider_id == "gmail":
+                result = await self._test_gmail_api()
+            elif provider_id == "email":
+                result = await self._test_email_connection()
             else:
                 result = {"success": False, "error": f"Test not implemented for {provider_id}"}
 
@@ -822,6 +854,82 @@ class OAuthWizardHandler(SecureHandler):
         ) as e:
             logger.warning("Discord API test failed: %s", e)
             return {"success": False, "error": "Discord API test failed"}
+
+    async def _test_email_connection(self) -> dict[str, Any]:
+        """Test SMTP connectivity using the same low-level socket check as status."""
+        status = await self._check_email_connection()
+        state = status.get("status")
+        if state == "connected":
+            return {
+                "success": True,
+                "smtp_host": status.get("smtp_host"),
+                "smtp_port": status.get("smtp_port"),
+            }
+        if state == "not_configured":
+            return {"success": False, "error": "SMTP is not configured"}
+        if state == "unreachable":
+            return {
+                "success": False,
+                "error": "SMTP host is unreachable",
+                "smtp_host": status.get("smtp_host"),
+                "smtp_port": status.get("smtp_port"),
+            }
+        return {"success": False, "error": status.get("error", "SMTP connection check failed")}
+
+    async def _test_gmail_api(self) -> dict[str, Any]:
+        """Test Gmail connectivity using the first persisted Gmail account."""
+        from aragora.connectors.enterprise.communication.gmail import GmailConnector
+        from aragora.storage.gmail_token_store import get_gmail_token_store
+
+        store = get_gmail_token_store()
+        states = await self._maybe_await(store.list_all())
+        if not states:
+            return {"success": False, "error": "No Gmail accounts connected"}
+
+        state = next(
+            (
+                candidate
+                for candidate in states
+                if self._record_value(candidate, "refresh_token")
+                or self._record_value(candidate, "access_token")
+            ),
+            None,
+        )
+        if state is None:
+            return {"success": False, "error": "No Gmail tokens available"}
+
+        connector = GmailConnector()
+        connector._refresh_token = self._record_value(state, "refresh_token")
+        connector._access_token = self._record_value(state, "access_token")
+
+        token_expiry = self._record_value(state, "token_expiry")
+        if isinstance(token_expiry, datetime):
+            connector._token_expiry = token_expiry
+        elif connector._access_token:
+            connector._token_expiry = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+        if not connector._refresh_token and not connector._access_token:
+            return {"success": False, "error": "No Gmail tokens available"}
+
+        try:
+            profile = await connector.get_user_info()
+        except (
+            ConnectionError,
+            TimeoutError,
+            OSError,
+            ValueError,
+            RuntimeError,
+            KeyError,
+        ) as e:
+            logger.warning("Gmail API test failed: %s", e)
+            return {"success": False, "error": "Gmail API test failed"}
+
+        return {
+            "success": True,
+            "email": profile.get("emailAddress") or self._record_value(state, "email_address"),
+            "messages_total": profile.get("messagesTotal"),
+            "user_id": self._record_value(state, "user_id"),
+        }
 
     async def _list_workspaces(self, provider_id: str) -> HandlerResult:
         """

--- a/tests/handlers/test_oauth_wizard.py
+++ b/tests/handlers/test_oauth_wizard.py
@@ -20,6 +20,7 @@ import os
 import socket
 import time
 from collections import defaultdict
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -33,6 +34,7 @@ from aragora.server.handlers.oauth_wizard import (
     PROVIDERS,
     create_oauth_wizard_handler,
 )
+from aragora.storage.gmail_token_store import GmailUserState
 from aragora.storage.slack_workspace_store import SlackWorkspace
 from aragora.storage.teams_tenant_store import TeamsTenant
 
@@ -728,13 +730,15 @@ class TestTestConnection:
         assert body["test_result"]["success"] is True
 
     @pytest.mark.asyncio
-    async def test_unimplemented_provider_test(self, handler):
+    async def test_email_test_returns_result(self, handler):
         mock = _make_handler("POST", {})
-        result = await handler.handle("/api/v2/integrations/wizard/email/test", {}, mock)
+        with patch.object(handler, "_test_email_connection", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"success": True, "smtp_host": "smtp.example.com"}
+            result = await handler.handle("/api/v2/integrations/wizard/email/test", {}, mock)
         body = _body(result)
         assert body["provider"] == "email"
-        assert body["test_result"]["success"] is False
-        assert "not implemented" in body["test_result"]["error"].lower()
+        assert body["test_result"]["success"] is True
+        assert body["test_result"]["smtp_host"] == "smtp.example.com"
 
     @pytest.mark.asyncio
     async def test_test_connection_exception(self, handler):
@@ -758,11 +762,15 @@ class TestTestConnection:
         assert body["test_result"]["success"] is False
 
     @pytest.mark.asyncio
-    async def test_gmail_test_not_implemented(self, handler):
+    async def test_gmail_test_returns_result(self, handler):
         mock = _make_handler("POST", {})
-        result = await handler.handle("/api/v2/integrations/wizard/gmail/test", {}, mock)
+        with patch.object(handler, "_test_gmail_api", new_callable=AsyncMock) as mock_api:
+            mock_api.return_value = {"success": True, "email": "owner@example.com"}
+            result = await handler.handle("/api/v2/integrations/wizard/gmail/test", {}, mock)
         body = _body(result)
-        assert body["test_result"]["success"] is False
+        assert body["provider"] == "gmail"
+        assert body["test_result"]["success"] is True
+        assert body["test_result"]["email"] == "owner@example.com"
 
 
 # ============================================================================
@@ -1209,9 +1217,12 @@ class TestCheckConnection:
         assert result["smtp_port"] == 465
 
     @pytest.mark.asyncio
-    async def test_check_connection_unknown_provider(self, handler):
-        result = await handler._check_connection("gmail")
-        assert result["status"] == "unchecked"
+    async def test_check_connection_gmail(self, handler):
+        with patch.object(handler, "_check_gmail_connection", new_callable=AsyncMock) as mock_check:
+            mock_check.return_value = {"status": "connected", "accounts": 1}
+            result = await handler._check_connection("gmail")
+        assert result["status"] == "connected"
+        assert result["accounts"] == 1
 
     @pytest.mark.asyncio
     async def test_check_connection_exception(self, handler):
@@ -1663,6 +1674,78 @@ class TestDisconnectInternals:
         ):
             result = await handler._disconnect_gmail_account("unknown@example.com")
         assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_check_gmail_connection_connected(self, handler):
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [
+            GmailUserState(
+                user_id="user-1",
+                email_address="owner@example.com",
+                refresh_token="refresh-token",
+            )
+        ]
+        with patch(
+            "aragora.storage.gmail_token_store.get_gmail_token_store",
+            return_value=mock_store,
+        ):
+            result = await handler._check_gmail_connection()
+        assert result["status"] == "connected"
+        assert result["accounts"] == 1
+        assert result["email"] == "owner@example.com"
+
+    @pytest.mark.asyncio
+    async def test_check_gmail_connection_not_connected(self, handler):
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = []
+        with patch(
+            "aragora.storage.gmail_token_store.get_gmail_token_store",
+            return_value=mock_store,
+        ):
+            result = await handler._check_gmail_connection()
+        assert result["status"] == "not_connected"
+
+    @pytest.mark.asyncio
+    async def test_test_email_connection_connected(self, handler):
+        with patch.object(handler, "_check_email_connection", new_callable=AsyncMock) as mock_check:
+            mock_check.return_value = {
+                "status": "connected",
+                "smtp_host": "smtp.example.com",
+                "smtp_port": 587,
+            }
+            result = await handler._test_email_connection()
+        assert result["success"] is True
+        assert result["smtp_port"] == 587
+
+    @pytest.mark.asyncio
+    async def test_test_gmail_api_connected(self, handler):
+        state = GmailUserState(
+            user_id="user-1",
+            email_address="owner@example.com",
+            access_token="access-token",
+        )
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [state]
+        mock_connector = SimpleNamespace(
+            get_user_info=AsyncMock(
+                return_value={
+                    "emailAddress": "owner@example.com",
+                    "messagesTotal": 42,
+                }
+            )
+        )
+        with patch(
+            "aragora.storage.gmail_token_store.get_gmail_token_store",
+            return_value=mock_store,
+        ):
+            with patch(
+                "aragora.connectors.enterprise.communication.gmail.GmailConnector",
+                return_value=mock_connector,
+            ):
+                result = await handler._test_gmail_api()
+        assert result["success"] is True
+        assert result["email"] == "owner@example.com"
+        assert result["messages_total"] == 42
 
 
 # ============================================================================

--- a/tests/server/handlers/test_oauth_wizard.py
+++ b/tests/server/handlers/test_oauth_wizard.py
@@ -26,6 +26,7 @@ from aragora.server.handlers.oauth_wizard import (
     create_oauth_wizard_handler,
 )
 from aragora.rbac.models import AuthorizationContext
+from aragora.storage.gmail_token_store import GmailUserState
 
 
 # -----------------------------------------------------------------------------
@@ -597,6 +598,60 @@ class TestTestConnection:
                         assert data["test_result"]["success"] is True
                         assert data["provider"] == "slack"
 
+    @pytest.mark.asyncio
+    async def test_test_email_success(self, oauth_handler, mock_handler, auth_context):
+        """Test SMTP provider returns a truthful test result."""
+        mock_handler.command = "POST"
+
+        with patch.object(
+            oauth_handler, "get_auth_context", new_callable=AsyncMock, return_value=auth_context
+        ):
+            with patch.object(oauth_handler, "check_permission"):
+                with patch.object(oauth_handler, "read_json_body", return_value={}):
+                    with patch.object(
+                        oauth_handler,
+                        "_test_email_connection",
+                        new_callable=AsyncMock,
+                        return_value={"success": True, "smtp_host": "smtp.example.com"},
+                    ):
+                        result = await oauth_handler.handle(
+                            "/api/v2/integrations/wizard/email/test",
+                            {},
+                            mock_handler,
+                        )
+
+                        assert result.status_code == 200
+                        data = json.loads(result.body)
+                        assert data["test_result"]["success"] is True
+                        assert data["provider"] == "email"
+
+    @pytest.mark.asyncio
+    async def test_test_gmail_success(self, oauth_handler, mock_handler, auth_context):
+        """Test Gmail provider returns a live-token based result."""
+        mock_handler.command = "POST"
+
+        with patch.object(
+            oauth_handler, "get_auth_context", new_callable=AsyncMock, return_value=auth_context
+        ):
+            with patch.object(oauth_handler, "check_permission"):
+                with patch.object(oauth_handler, "read_json_body", return_value={}):
+                    with patch.object(
+                        oauth_handler,
+                        "_test_gmail_api",
+                        new_callable=AsyncMock,
+                        return_value={"success": True, "email": "owner@example.com"},
+                    ):
+                        result = await oauth_handler.handle(
+                            "/api/v2/integrations/wizard/gmail/test",
+                            {},
+                            mock_handler,
+                        )
+
+                        assert result.status_code == 200
+                        data = json.loads(result.body)
+                        assert data["test_result"]["success"] is True
+                        assert data["provider"] == "gmail"
+
 
 # -----------------------------------------------------------------------------
 # GET /api/v2/integrations/wizard/{provider}/workspaces Tests
@@ -883,11 +938,40 @@ class TestConnectionChecks:
     """Tests for connection check methods."""
 
     @pytest.mark.asyncio
-    async def test_check_connection_unchecked_provider(self, oauth_handler):
-        """Check connection for provider without health check."""
-        result = await oauth_handler._check_connection("gmail")
+    async def test_check_connection_gmail(self, oauth_handler):
+        """Check connection for Gmail uses the token-store health path."""
+        with patch.object(
+            oauth_handler,
+            "_check_gmail_connection",
+            new_callable=AsyncMock,
+            return_value={"status": "connected", "accounts": 1},
+        ):
+            result = await oauth_handler._check_connection("gmail")
 
-        assert result["status"] == "unchecked"
+        assert result["status"] == "connected"
+        assert result["accounts"] == 1
+
+    @pytest.mark.asyncio
+    async def test_check_gmail_connection_connected(self, oauth_handler):
+        """Check Gmail connection with a stored account returns connected."""
+        mock_store = AsyncMock()
+        mock_store.list_all.return_value = [
+            GmailUserState(
+                user_id="user-123",
+                email_address="owner@example.com",
+                refresh_token="refresh-token",
+            )
+        ]
+
+        with patch(
+            "aragora.storage.gmail_token_store.get_gmail_token_store",
+            return_value=mock_store,
+        ):
+            result = await oauth_handler._check_gmail_connection()
+
+        assert result["status"] == "connected"
+        assert result["accounts"] == 1
+        assert result["email"] == "owner@example.com"
 
     @pytest.mark.asyncio
     async def test_check_slack_connection_no_workspaces(self, oauth_handler):


### PR DESCRIPTION
## Summary
- replace placeholder wizard test responses for Gmail and SMTP email with real connectivity checks
- surface Gmail token-store status in the wizard status path
- add focused regression coverage for the new Gmail and SMTP behavior

## Repro
- `/api/v2/integrations/wizard/email/test` returned `Test not implemented for email` even though the handler already had a real SMTP connectivity check
- `/api/v2/integrations/wizard/gmail/test` returned `Test not implemented for gmail` even though Gmail tokens and disconnect flow already existed
- configured Gmail accounts also appeared `unchecked` in wizard status instead of connected or not connected

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/handlers/test_oauth_wizard.py tests/server/handlers/test_oauth_wizard.py`
- `ruff check aragora/server/handlers/oauth_wizard.py tests/handlers/test_oauth_wizard.py tests/server/handlers/test_oauth_wizard.py`
- `python3 -m compileall aragora/server/handlers/oauth_wizard.py`

## Next
- harden the remaining GitHub and email disconnect paths so every provider the wizard advertises has equally truthful management semantics
