### PR TITLE
perf(debate): reduce interactive debate latency (target sub-20s)

### DIFF
--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -1176,67 +1176,91 @@ async def handle_debate_completion(
         except (AttributeError, TypeError, ValueError, RuntimeError) as e:
             logger.debug("Context taint metadata propagation skipped: %s", e)
     if not getattr(arena, "disable_post_debate_pipeline", False) and ctx.result:
-        try:
-            from aragora.debate.post_debate_coordinator import PostDebateCoordinator
+        # Perf optimization: run the post-debate coordinator pipeline as a
+        # fire-and-forget background task.  The pipeline performs non-critical
+        # enrichment (explanation, canvas, LLM-as-Judge, improvement queueing)
+        # that should not block the debate response.  Receipt persistence is
+        # already handled above via _km_ingest_background and the KM ingestion
+        # task.  Only when `ARAGORA_SYNC_POST_DEBATE=1` is set (e.g. for tests
+        # or CI) do we run it synchronously on the critical path.
+        _sync_post_debate = os.environ.get("ARAGORA_SYNC_POST_DEBATE", "0") == "1"
 
-            settlement_tracker = None
-            if getattr(effective_config, "auto_settlement_tracking", False):
-                try:
-                    settlement_tracker = getattr(arena, "settlement_tracker", None)
-                    if settlement_tracker is None:
-                        from aragora.debate.settlement import SettlementTracker
-                        from aragora.debate.settlement_hooks import (
-                            EventBusSettlementHook,
-                            LoggingSettlementHook,
-                            SettlementHookRegistry,
-                        )
+        def _run_post_debate_pipeline() -> None:
+            try:
+                from aragora.debate.post_debate_coordinator import PostDebateCoordinator
 
-                        hook_registry = SettlementHookRegistry()
-                        hook_registry.register(LoggingSettlementHook())
-                        event_bus = getattr(arena, "event_bus", None)
-                        if event_bus is not None:
-                            hook_registry.register(EventBusSettlementHook(event_bus))
+                settlement_tracker = None
+                if getattr(effective_config, "auto_settlement_tracking", False):
+                    try:
+                        settlement_tracker = getattr(arena, "settlement_tracker", None)
+                        if settlement_tracker is None:
+                            from aragora.debate.settlement import SettlementTracker
+                            from aragora.debate.settlement_hooks import (
+                                EventBusSettlementHook,
+                                LoggingSettlementHook,
+                                SettlementHookRegistry,
+                            )
 
-                        settlement_tracker = SettlementTracker(
-                            elo_system=getattr(arena, "elo_system", None),
-                            calibration_tracker=getattr(arena, "calibration_tracker", None),
-                            knowledge_mound=getattr(arena, "knowledge_mound", None),
-                            hooks=hook_registry,
-                        )
-                        setattr(arena, "settlement_tracker", settlement_tracker)
-                except ImportError:
-                    logger.debug("Settlement tracker wiring unavailable")
-                except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as st_err:
-                    logger.debug("Settlement tracker wiring unavailable: %s", st_err)
-                    settlement_tracker = None
+                            hook_registry = SettlementHookRegistry()
+                            hook_registry.register(LoggingSettlementHook())
+                            event_bus = getattr(arena, "event_bus", None)
+                            if event_bus is not None:
+                                hook_registry.register(EventBusSettlementHook(event_bus))
 
-            coordinator = PostDebateCoordinator(
-                config=effective_config,
-                settlement_tracker=settlement_tracker,
-                knowledge_mound=getattr(arena, "knowledge_mound", None),
-            )
-            task = getattr(ctx.env, "task", "") if ctx.env else ""
-            confidence = getattr(ctx.result, "confidence", 0.0)
-            post_result = coordinator.run(
-                debate_id=state.debate_id,
-                debate_result=ctx.result,
-                agents=arena.agents,
-                confidence=confidence,
-                task=task,
-            )
-            if not post_result.success:
-                logger.warning(
-                    "post_debate_coordinator_errors debate_id=%s errors=%s",
-                    state.debate_id,
-                    post_result.errors,
+                            settlement_tracker = SettlementTracker(
+                                elo_system=getattr(arena, "elo_system", None),
+                                calibration_tracker=getattr(arena, "calibration_tracker", None),
+                                knowledge_mound=getattr(arena, "knowledge_mound", None),
+                                hooks=hook_registry,
+                            )
+                            setattr(arena, "settlement_tracker", settlement_tracker)
+                    except ImportError:
+                        logger.debug("Settlement tracker wiring unavailable")
+                    except (RuntimeError, ValueError, TypeError, AttributeError, OSError) as st_err:
+                        logger.debug("Settlement tracker wiring unavailable: %s", st_err)
+                        settlement_tracker = None
+
+                coordinator = PostDebateCoordinator(
+                    config=effective_config,
+                    settlement_tracker=settlement_tracker,
+                    knowledge_mound=getattr(arena, "knowledge_mound", None),
                 )
-            else:
-                logger.info(
-                    "post_debate_coordinator_complete debate_id=%s",
-                    state.debate_id,
+                task = getattr(ctx.env, "task", "") if ctx.env else ""
+                confidence = getattr(ctx.result, "confidence", 0.0)
+                post_result = coordinator.run(
+                    debate_id=state.debate_id,
+                    debate_result=ctx.result,
+                    agents=arena.agents,
+                    confidence=confidence,
+                    task=task,
                 )
-        except (ImportError, RuntimeError, ValueError, TypeError, AttributeError, OSError) as e:
-            logger.debug("Post-debate coordinator pipeline failed (non-critical): %s", e)
+                if not post_result.success:
+                    logger.warning(
+                        "post_debate_coordinator_errors debate_id=%s errors=%s",
+                        state.debate_id,
+                        post_result.errors,
+                    )
+                else:
+                    logger.info(
+                        "post_debate_coordinator_complete debate_id=%s",
+                        state.debate_id,
+                    )
+            except (ImportError, RuntimeError, ValueError, TypeError, AttributeError, OSError) as e:
+                logger.debug("Post-debate coordinator pipeline failed (non-critical): %s", e)
+
+        if _sync_post_debate:
+            _run_post_debate_pipeline()
+        else:
+            # Fire-and-forget: run in thread pool so it doesn't block the response
+            loop = asyncio.get_running_loop()
+            _post_debate_future = loop.run_in_executor(None, _run_post_debate_pipeline)
+            _post_debate_future.add_done_callback(
+                lambda f: logger.warning(
+                    "[post-debate] Background pipeline error: %s", f.exception()
+                )
+                if not f.cancelled() and f.exception()
+                else None
+            )
 
     # Attach active introspection summary to result
     introspection_tracker = getattr(arena, "active_introspection_tracker", None)

--- a/aragora/debate/phases/context_init.py
+++ b/aragora/debate/phases/context_init.py
@@ -293,22 +293,30 @@ class ContextInitializer:
         # 7. Inject trending topic context (provided or auto-fetched)
         self._inject_trending_topic(ctx)
 
-        # 8-9d. Gather independent async context enrichment tasks concurrently
+        # 8-9d. Gather independent async context enrichment tasks concurrently.
         # Each task is wrapped in _safe_async to isolate failures.
+        # Perf: skip KM-dependent tasks when no knowledge_mound is configured
+        # to avoid unnecessary coroutine overhead and timeout waits.
+        _has_km = self.knowledge_mound is not None
         _concurrent_tasks: list[Any] = [
             self._safe_async(self._fetch_historical(ctx), "historical"),
-            self._safe_async(self._inject_knowledge_context(ctx), "knowledge_mound"),
-            self._safe_async(self._inject_receipt_conclusions(ctx), "receipt_conclusions"),
             self._safe_async(self._inject_supermemory_context(ctx), "supermemory"),
-            self._safe_async(self._inject_debate_knowledge(ctx), "debate_knowledge"),
-            self._safe_async(self._inject_cross_adapter_synthesis(ctx), "km_synthesis"),
             self._safe_async(self._inject_insight_patterns(ctx), "insight_patterns"),
         ]
+        if _has_km:
+            _concurrent_tasks.extend(
+                [
+                    self._safe_async(self._inject_knowledge_context(ctx), "knowledge_mound"),
+                    self._safe_async(self._inject_receipt_conclusions(ctx), "receipt_conclusions"),
+                    self._safe_async(self._inject_debate_knowledge(ctx), "debate_knowledge"),
+                    self._safe_async(self._inject_cross_adapter_synthesis(ctx), "km_synthesis"),
+                ]
+            )
         if self.enable_cross_debate_memory:
             _concurrent_tasks.append(
                 self._safe_async(self._inject_cross_debate_context(ctx), "cross_debate"),
             )
-        if self.enable_outcome_context:
+        if self.enable_outcome_context and _has_km:
             _concurrent_tasks.append(
                 self._safe_async(self._inject_outcome_context(ctx), "outcome_context"),
             )
@@ -381,9 +389,10 @@ class ContextInitializer:
             )
             provider = CodebaseContextProvider(config=config)
 
+            # Reduced from 30s to 10s for interactive latency.
             context = await asyncio.wait_for(
                 provider.build_context(ctx.env.task),
-                timeout=30.0,
+                timeout=10.0,
             )
 
             if context and hasattr(ctx, "_prompt_builder") and ctx._prompt_builder:
@@ -502,8 +511,9 @@ class ContextInitializer:
             return
 
         try:
+            # Reduced from 10s to 5s for interactive latency.
             ctx.historical_context_cache = await asyncio.wait_for(
-                self._fetch_historical_context(ctx.env.task, limit=2), timeout=10.0
+                self._fetch_historical_context(ctx.env.task, limit=2), timeout=5.0
             )
         except asyncio.TimeoutError:
             logger.warning("Historical context fetch timed out")
@@ -552,9 +562,11 @@ class ContextInitializer:
                 return
 
             # Fetch fresh knowledge context
+            # Reduced from 10s to 5s for interactive latency (issue #268 follow-up).
+            # If KM is slow, we skip rather than block the debate start.
             knowledge_context = await asyncio.wait_for(
                 self._fetch_knowledge_context(ctx.env.task, limit=10),
-                timeout=10.0,  # 10 second timeout
+                timeout=5.0,
             )
 
             # Cache the result (even if empty, to avoid re-fetching)
@@ -683,9 +695,10 @@ class ContextInitializer:
             topic = ctx.env.task if ctx.env else ""
             domain = getattr(ctx, "domain", "general") or "general"
 
+            # Reduced from 8s to 5s for interactive latency.
             synthesis = await asyncio.wait_for(
                 hub.synthesize_for_debate(topic, domain=domain, max_items=8),
-                timeout=8.0,
+                timeout=5.0,
             )
 
             if synthesis:
@@ -758,13 +771,14 @@ class ContextInitializer:
 
             filters = QueryFilters(tags=["decision_receipt"])
 
+            # Reduced from 8s to 5s for interactive latency.
             results = await asyncio.wait_for(
                 self.knowledge_mound.query(
                     query=task,
                     filters=filters,
                     limit=5,
                 ),
-                timeout=8.0,
+                timeout=5.0,
             )
 
             items = results.items if hasattr(results, "items") else []
@@ -1371,9 +1385,10 @@ class ContextInitializer:
             if not topic:
                 return
 
+            # Reduced from 8s to 5s for interactive latency.
             similar_outcomes = await asyncio.wait_for(
                 adapter.find_similar_outcomes(query=topic, limit=5),
-                timeout=8.0,
+                timeout=5.0,
             )
 
             if not similar_outcomes:
@@ -1487,9 +1502,11 @@ class ContextInitializer:
 
         try:
             logger.info("evidence_collection_start phase=evidence")
+            # Reduced from 15s to 8s -- evidence collection runs as a background
+            # task and the debate proceeds without it if slow.
             evidence_pack = await asyncio.wait_for(
                 self.evidence_collector.collect_evidence(ctx.env.task),
-                timeout=15.0,  # 15 second timeout for evidence collection
+                timeout=8.0,
             )
 
             if evidence_pack and evidence_pack.snippets:
@@ -1642,10 +1659,11 @@ class ContextInitializer:
         logger.info("awaiting_background_context tasks=%s", task_names)
 
         try:
-            # Wait up to 30s for background tasks to complete
+            # Wait for background tasks to complete before round 2.
+            # Reduced from 30s to 10s to avoid stalling the debate.
             await asyncio.wait_for(
                 asyncio.gather(*tasks, return_exceptions=True),
-                timeout=30.0,
+                timeout=10.0,
             )
             logger.info("background_context_complete")
         except asyncio.TimeoutError:

--- a/aragora/debate/phases/evidence_refresh.py
+++ b/aragora/debate/phases/evidence_refresh.py
@@ -18,8 +18,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Timeout for async callbacks (evidence refresh can be slow)
-DEFAULT_CALLBACK_TIMEOUT = 30.0
+# Timeout for async callbacks (evidence refresh can be slow).
+# Reduced from 30s to 10s for interactive latency -- if evidence refresh
+# takes longer than 10s, the debate continues without the extra evidence.
+DEFAULT_CALLBACK_TIMEOUT = 10.0
 
 
 async def _with_callback_timeout(

--- a/aragora/debate/post_debate_coordinator.py
+++ b/aragora/debate/post_debate_coordinator.py
@@ -32,7 +32,10 @@ from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
-ASYNC_RUN_TIMEOUT_SECONDS = float(os.getenv("ARAGORA_POST_DEBATE_ASYNC_TIMEOUT", "30.0"))
+# Per-step timeout for async callables run from the sync coordinator.
+# Reduced from 30s to 10s: the coordinator now runs in a background thread
+# (fire-and-forget) so individual steps should fail fast rather than stall.
+ASYNC_RUN_TIMEOUT_SECONDS = float(os.getenv("ARAGORA_POST_DEBATE_ASYNC_TIMEOUT", "10.0"))
 
 
 @dataclass

--- a/tests/debate/phases/test_evidence_refresh.py
+++ b/tests/debate/phases/test_evidence_refresh.py
@@ -47,7 +47,7 @@ class TestWithCallbackTimeout:
 
     @pytest.mark.asyncio
     async def test_default_timeout_value(self):
-        assert DEFAULT_CALLBACK_TIMEOUT == 30.0
+        assert DEFAULT_CALLBACK_TIMEOUT == 10.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Three changes to reduce live debate latency from 35-62s toward the sub-20s target:

1. **Fire-and-forget post-debate pipeline** — PostDebateCoordinator.run() moved from synchronous blocking to background executor. Debate result returns immediately after core completion. ~5-15s saved.
   - Escape hatch: `ARAGORA_SYNC_POST_DEBATE=1` for tests needing synchronous behavior.

2. **Reduced context enrichment timeouts** — Knowledge, historical, receipt, synthesis, evidence timeouts reduced from 8-30s to 5-10s. ~3-8s saved in worst-case scenarios.

3. **Skip KM queries when no KM configured** — 4 KM-dependent tasks plus outcome context skipped when knowledge_mound is None. Eliminates ~5s unnecessary timeout exposure.

## Test plan
- [x] 14/14 e2e user journey tests pass
- [x] 285/285 orchestrator/runner tests pass
- [x] 1632/1632 phase tests pass
- [x] 24/24 post-debate coordinator tests pass
- [x] 31/31 evidence refresh tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)