### PR TITLE
fix: stabilize checkpoint test + optimize triage to sub-10s target

### DIFF
--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -47,8 +47,12 @@ logger = logging.getLogger(__name__)
 _SUPPORTED_TRIAGE_PROFILES = {"baseline", "staged_v1"}
 _DEFAULT_TRIAGE_PROFILE = "staged_v1"
 _FAST_TIER_CONFIDENCE_THRESHOLD = 0.85
-_FAST_TIER_TIMEOUT_SECONDS = 12.0
+_FAST_TIER_TIMEOUT_SECONDS = 8.0
 _ESCALATED_TIER_ROUNDS = 1
+_TRIAGE_DEBATE_TIMEOUT_SECONDS = 15
+_TRIAGE_ROUND_TIMEOUT_SECONDS = 10
+_TRIAGE_DEBATE_ROUNDS_TIMEOUT_SECONDS = 12
+_TRIAGE_MAX_AGENTS = 2
 _HIGH_RISK_ACTIONS = {InboxWedgeAction.LABEL, InboxWedgeAction.STAR}
 _DEGRADED_DIAGNOSTIC_SEVERITIES = {
     DiagnosticSeverity.BLOCKING.value,
@@ -797,8 +801,8 @@ class InboxTriageRunner:
         baseline_result = await self._run_debate_once(
             msg,
             tier="baseline",
-            rounds=2,
-            max_agents=None,
+            rounds=1,
+            max_agents=_TRIAGE_MAX_AGENTS,
         )
         return _attach_triage_execution_metadata(
             baseline_result,
@@ -908,13 +912,22 @@ class InboxTriageRunner:
                 env = Environment(task=question)
                 protocol = DebateProtocol(
                     rounds=rounds,
-                    consensus="judge",
+                    consensus="majority",
                     enable_research=False,
                     convergence_detection=False,
                     vote_grouping=False,
                     enable_trickster=False,
                     role_rotation=False,
                     role_matching=False,
+                    enable_calibration=False,
+                    enable_rhetorical_observer=False,
+                    enable_evolution=False,
+                    verify_claims_during_consensus=False,
+                    enable_evidence_weighting=False,
+                    enable_breakpoints=False,
+                    timeout_seconds=_TRIAGE_DEBATE_TIMEOUT_SECONDS,
+                    round_timeout_seconds=_TRIAGE_ROUND_TIMEOUT_SECONDS,
+                    debate_rounds_timeout_seconds=_TRIAGE_DEBATE_ROUNDS_TIMEOUT_SECONDS,
                 )
 
                 record_triage_diagnostic(
@@ -927,10 +940,8 @@ class InboxTriageRunner:
                     tier=tier,
                 )
 
-                if max_agents is None:
-                    agents = _create_triage_agents()
-                else:
-                    agents = _create_triage_agents(max_agents=max_agents)
+                effective_max = max_agents if max_agents is not None else _TRIAGE_MAX_AGENTS
+                agents = _create_triage_agents(max_agents=effective_max)
 
                 if len(agents) < 2:
                     logger.warning(

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -545,7 +545,7 @@ async def test_run_debate_uses_fast_agent_subset_and_explicit_action_prompt(monk
 
     monkeypatch.setattr(
         "aragora.inbox.triage_runner._create_triage_agents",
-        lambda: [
+        lambda **kwargs: [
             SimpleNamespace(name="triage-proposer", role="proposer", model_type="anthropic-api"),
             SimpleNamespace(name="triage-critic", role="critic", model_type="openrouter"),
         ],
@@ -596,7 +596,7 @@ async def test_run_debate_disables_trending_and_post_debate_pipeline(monkeypatch
     monkeypatch.delenv("ARAGORA_DISABLE_TRENDING", raising=False)
     monkeypatch.setattr(
         "aragora.inbox.triage_runner._create_triage_agents",
-        lambda: [
+        lambda **kwargs: [
             SimpleNamespace(name="triage-proposer", role="proposer", model_type="openai-api"),
             SimpleNamespace(name="triage-critic", role="critic", model_type="openrouter"),
         ],
@@ -633,7 +633,7 @@ async def test_run_debate_returns_blocked_result_when_fewer_than_two_agents(monk
 
     monkeypatch.setattr(
         "aragora.inbox.triage_runner._create_triage_agents",
-        lambda: [
+        lambda **kwargs: [
             SimpleNamespace(name="triage-proposer", role="proposer", model_type="anthropic-api")
         ],
     )
@@ -765,7 +765,9 @@ async def test_stub_debate_result_is_blocked_instead_of_silent_ignore(monkeypatc
 
     monkeypatch.setattr(
         "aragora.inbox.triage_runner._create_triage_agents",
-        lambda: [SimpleNamespace(name="triage-proposer", role="proposer", model_type="openai-api")],
+        lambda **kwargs: [
+            SimpleNamespace(name="triage-proposer", role="proposer", model_type="openai-api")
+        ],
     )
     monkeypatch.setattr(core_mod, "Environment", lambda **kwargs: SimpleNamespace(**kwargs))
     monkeypatch.setattr(proto_mod, "DebateProtocol", lambda **kwargs: SimpleNamespace(**kwargs))

--- a/tests/workflow/nodes/test_human_checkpoint.py
+++ b/tests/workflow/nodes/test_human_checkpoint.py
@@ -22,13 +22,26 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def clear_pending_approvals():
-    """Clear pending approvals before each test for isolation."""
-    from aragora.workflow.nodes.human_checkpoint import _pending_approvals
+def clear_pending_approvals(monkeypatch):
+    """Clear pending approvals and reset all module-level state for isolation.
 
-    _pending_approvals.clear()
+    Without resetting ``_governance_store`` and ``_approvals_recovered``, a
+    governance store initialised by an earlier test can leak recovered
+    approvals into later tests, causing order-dependent failures.  We also
+    patch ``_get_governance_store`` to always return ``None`` so that no real
+    database connection (asyncpg) is opened during unit tests — stale
+    connections cause ``InterfaceError`` under ``--timeout`` runs.
+    """
+    import aragora.workflow.nodes.human_checkpoint as _hc
+
+    _hc._pending_approvals.clear()
+    _hc._approvals_recovered = False
+    _hc._governance_store = None
+    monkeypatch.setattr(_hc, "_get_governance_store", lambda: None)
     yield
-    _pending_approvals.clear()
+    _hc._pending_approvals.clear()
+    _hc._approvals_recovered = False
+    _hc._governance_store = None
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

**1. Checkpoint test isolation** — Fixed intermittent `test_approval_with_missing_checklist_items_rejected` failure. Root cause: stale `_governance_store` singleton opening real asyncpg connections during unit tests. Fixture now resets all module-level state and monkeypatches the store factory.

**2. Triage latency optimization** (18s → ~10s target):
- Baseline rounds: 2→1, max agents: unlimited→2
- Consensus: `judge`→`majority` (skip synthesis step)
- Debate timeout: 1200s→15s, round timeout: 90s→10s
- Disabled: calibration, rhetorical observer, prompt evolution, claim verification, evidence weighting, breakpoints
- Fast-tier timeout: 12s→8s

## Test plan
- [x] Checkpoint tests pass in isolation and under full-suite conditions
- [x] 30/30 triage runner tests pass
- [x] E2E user journey tests pass