### PR TITLE
fix(receipts): refresh SDK types and UI receipt test

### DIFF
--- a/aragora/live/__tests__/ReceiptsPage.test.tsx
+++ b/aragora/live/__tests__/ReceiptsPage.test.tsx
@@ -211,7 +211,7 @@ describe('ReceiptsPage', () => {
     });
   });
 
-  it('opens receipt detail through the versioned gauntlet endpoint and normalizes the payload', async () => {
+  it('opens receipt detail through the v2 receipt endpoint and normalizes the payload', async () => {
     queueHookResponses([
       hookResult({
         data: {
@@ -270,7 +270,7 @@ describe('ReceiptsPage', () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:8080/api/v1/gauntlet/gauntlet-123/receipt',
+        'http://localhost:8080/api/v2/receipts/receipt-123',
         expect.any(Object)
       );
       expect(screen.getByText('Decision Receipt')).toBeInTheDocument();

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -55821,6 +55821,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v2/receipts/share/{token}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get shared receipt
+         * @description Access a receipt via public share token.
+         */
+        get: operations["getSharedReceipt"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v2/receipts/stats": {
         parameters: {
             query?: never;
@@ -167832,6 +167852,66 @@ export interface operations {
             };
         };
     };
+    getSharedReceipt: {
+        parameters: {
+            query?: {
+                /** @description Output format (e.g., json, yaml, csv) */
+                format?: string;
+            };
+            header?: never;
+            path: {
+                /** @description The token */
+                token: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shared receipt payload */
+            200: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        receipt?: Record<string, never>;
+                        shared?: boolean;
+                        access_count?: number;
+                    };
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Share link expired or access limit reached */
+            410: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getReceiptStats: {
         parameters: {
             query?: never;
@@ -168250,9 +168330,12 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
+                        success?: boolean;
                         receipt_id?: string;
-                        shared?: boolean;
                         share_url?: string;
+                        token?: string;
+                        expires_at?: string;
+                        max_accesses?: number | null;
                     };
                 };
             };


### PR DESCRIPTION
## Root cause
- `Version Alignment` was failing because `sdk/typescript/src/openapi-types.ts` had drifted behind the checked-in OpenAPI spec.
- `Frontend E2E Tests` were failing because `aragora/live/__tests__/ReceiptsPage.test.tsx` still expected the old gauntlet receipt detail route, while the page now fetches receipt details from `/api/v2/receipts/{id}`.

## What changed
- regenerated `sdk/typescript/src/openapi-types.ts`
- updated the stale receipt detail fetch expectation in `aragora/live/__tests__/ReceiptsPage.test.tsx`

## Verification
- `python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check`
- `cd aragora/live && npm ci && npx jest --ci --runTestsByPath '__tests__/ReceiptsPage.test.tsx'`
