### PR TITLE
fix(receipts): harden share expiry checks

### DIFF
--- a/aragora/server/auth_requirements.py
+++ b/aragora/server/auth_requirements.py
@@ -339,13 +339,6 @@ PERMISSION_ENDPOINTS = [
         permission="apikeys:delete",
         description="Revoke API key",
     ),
-    EndpointAuth(
-        "/api/v2/receipts/{receipt_id}/share",
-        "post",
-        AuthLevel.PERMISSION,
-        permission="receipts:share",
-        description="Create a shared receipt link",
-    ),
 ]
 
 # =============================================================================

--- a/aragora/storage/receipt_share_store.py
+++ b/aragora/storage/receipt_share_store.py
@@ -217,9 +217,10 @@ class ReceiptShareStore:
             UPDATE receipt_shares
             SET access_count = access_count + 1
             WHERE token = ?
+              AND expires_at >= ?
               AND (max_accesses IS NULL OR access_count < max_accesses)
             """,
-            (token,),
+            (token, now),
         )
         conn.commit()
 

--- a/tests/contract/test_auth_requirements.py
+++ b/tests/contract/test_auth_requirements.py
@@ -270,6 +270,18 @@ class TestPermissionRequirements:
             f"Permissions with invalid format (should be category:action): {invalid_format}"
         )
 
+    def test_receipt_share_route_is_listed_once(self) -> None:
+        """The receipt share POST route should have a single manifest entry."""
+        from aragora.server.auth_requirements import PERMISSION_ENDPOINTS
+
+        matches = [
+            req
+            for req in PERMISSION_ENDPOINTS
+            if req.path == "/api/v2/receipts/{receipt_id}/share" and req.method == "post"
+        ]
+
+        assert len(matches) == 1
+
 
 # =============================================================================
 # Consistency Tests

--- a/tests/storage/test_receipt_share_store.py
+++ b/tests/storage/test_receipt_share_store.py
@@ -45,3 +45,20 @@ def test_consume_access_is_atomic_under_race(tmp_path) -> None:
 
     assert sorted(result["status"] for result in results) == ["limit_reached", "ok"]
     assert store.get_by_token("limited-token")["access_count"] == 1
+
+
+def test_consume_access_does_not_increment_expired_token(tmp_path) -> None:
+    """Expired tokens should be rejected without incrementing access_count."""
+    store = ReceiptShareStore(tmp_path / "receipt_shares.db")
+    store.save(
+        token="expired-token",
+        receipt_id="receipt-123",
+        expires_at=time.time() - 60,
+        max_accesses=2,
+    )
+
+    result = store.consume_access("expired-token")
+
+    assert result["status"] == "expired"
+    assert result["share_info"]["access_count"] == 0
+    assert store.get_by_token("expired-token")["access_count"] == 0


### PR DESCRIPTION
## Summary
- enforce receipt-share expiry inside the atomic access-consumption update
- remove the duplicate receipt-share auth manifest entry
- add focused storage and auth-contract regressions

## Validation
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/storage/test_receipt_share_store.py tests/contract/test_auth_requirements.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -p pytest_asyncio.plugin -q tests/server/fastapi/test_receipts_routes.py
- ruff check aragora/storage/receipt_share_store.py aragora/server/auth_requirements.py tests/storage/test_receipt_share_store.py tests/contract/test_auth_requirements.py
