### PR TITLE
fix(ci): restore advisory test analytics reruns

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2078,7 +2078,7 @@ jobs:
         # Gating tests run in test-fast and test jobs above.
         continue-on-error: true
         run: |
-          pytest tests/debate tests/agents tests/server \
+          python -m pytest -o addopts='' tests/debate tests/agents tests/server \
             -m "not slow and not load and not e2e" \
             --timeout=60 \
             --reruns=2 \

--- a/scripts/analyze_test_results.py
+++ b/scripts/analyze_test_results.py
@@ -67,6 +67,62 @@ class TestAnalysis:
     by_module: dict[str, dict[str, int]] = field(default_factory=dict)
 
 
+def _empty_analysis_output(output_format: str, reason: str) -> str:
+    """Return a placeholder analysis when no results were produced."""
+    if output_format == "json":
+        return json.dumps(
+            {
+                "summary": {
+                    "total": 0,
+                    "passed": 0,
+                    "failed": 0,
+                    "skipped": 0,
+                    "xfailed": 0,
+                    "xpassed": 0,
+                    "flaky": 0,
+                    "pass_rate": 0,
+                },
+                "note": reason,
+                "flaky_tests": [],
+                "failed_tests": [],
+                "slowest_tests": [],
+                "skip_reasons": {},
+                "by_module": {},
+                "timestamp": datetime.utcnow().isoformat(),
+            },
+            indent=2,
+        )
+    if output_format == "markdown":
+        return "\n".join(
+            [
+                "## Test Results Summary",
+                "",
+                "⚠️ No test results were produced.",
+                "",
+                f"Reason: {reason}",
+            ]
+        )
+    return "\n".join(
+        [
+            "=" * 60,
+            "TEST RESULTS ANALYSIS",
+            "=" * 60,
+            "",
+            "No test results were produced.",
+            f"Reason: {reason}",
+        ]
+    )
+
+
+def _emit_output(output: str, output_path: Path | None) -> None:
+    """Write output to a file or stdout."""
+    if output_path:
+        output_path.write_text(output)
+        print(f"Wrote analysis to {output_path}")
+        return
+    print(output)
+
+
 def parse_junit_xml(xml_path: Path) -> list[TestResult]:
     """Parse JUnit XML report."""
     results = []
@@ -344,16 +400,28 @@ def main():
 
     # Parse results
     results = []
+    missing_reason = ""
     if args.junit and args.junit.exists():
         results = parse_junit_xml(args.junit)
     elif args.stdin:
         content = sys.stdin.read()
         results = parse_pytest_output(content)
     else:
-        print("Error: Provide --junit file or --stdin", file=sys.stderr)
+        missing_reason = (
+            f"JUnit report not found: {args.junit}" if args.junit else "Provide --junit file or --stdin"
+        )
+
+    if missing_reason:
+        if args.exit_zero:
+            _emit_output(_empty_analysis_output(args.format, missing_reason), args.output)
+            return 0
+        print(f"Error: {missing_reason}", file=sys.stderr)
         return 1
 
     if not results:
+        if args.exit_zero:
+            _emit_output(_empty_analysis_output(args.format, "No test results found"), args.output)
+            return 0
         print("No test results found", file=sys.stderr)
         return 1
 
@@ -369,11 +437,7 @@ def main():
         output = format_text(analysis)
 
     # Write output
-    if args.output:
-        args.output.write_text(output)
-        print(f"Wrote analysis to {args.output}")
-    else:
-        print(output)
+    _emit_output(output, args.output)
 
     if args.exit_zero:
         return 0

--- a/tests/scripts/test_analyze_test_results.py
+++ b/tests/scripts/test_analyze_test_results.py
@@ -56,3 +56,29 @@ def test_main_exit_zero_flag_makes_analysis_advisory(tmp_path: Path) -> None:
         ["analyze_test_results.py", "--junit", str(junit_path), "--exit-zero"],
     ):
         assert module.main() == 0
+
+
+def test_main_exit_zero_writes_placeholder_when_junit_missing(tmp_path: Path) -> None:
+    module = _load_script_module()
+    junit_path = tmp_path / "missing.xml"
+    output_path = tmp_path / "summary.md"
+
+    with patch.object(
+        module.sys,
+        "argv",
+        [
+            "analyze_test_results.py",
+            "--junit",
+            str(junit_path),
+            "--format",
+            "markdown",
+            "--output",
+            str(output_path),
+            "--exit-zero",
+        ],
+    ):
+        assert module.main() == 0
+
+    output = output_path.read_text(encoding="utf-8")
+    assert "No test results were produced." in output
+    assert f"Reason: JUnit report not found: {junit_path}" in output


### PR DESCRIPTION
## Summary
- restore the advisory Test Analytics workflow's rerun support by clearing the repo-wide pytest addopts override for that job
- keep the analytics step non-fatal when the JUnit file is missing by writing a placeholder summary under `--exit-zero`
- add focused regression coverage for the missing-JUnit advisory path

## Verification
- `python3 -m pytest tests/scripts/test_analyze_test_results.py -q`
- `python3 -m ruff check scripts/analyze_test_results.py tests/scripts/test_analyze_test_results.py`
- `python3 scripts/analyze_test_results.py --junit /no/such/file.xml --format markdown --output /tmp/aragora-test-summary-missing.md --exit-zero`
- `python3 -m pytest -o addopts='' --help | rg -n "reruns=RERUNS|re-run failing tests" -n -C 1`
