### PR TITLE
fix(sdk): drop stale users invite TS surface

### DIFF
--- a/sdk/typescript/examples/auth-enterprise.ts
+++ b/sdk/typescript/examples/auth-enterprise.ts
@@ -228,14 +228,6 @@ async function main() {
     }
     console.log('');
 
-    // Invite a new user
-    console.log('To invite a new user:');
-    console.log('  const { invitation_id } = await client.rbac.inviteUser(');
-    console.log("    'newuser@example.com',");
-    console.log("    'analyst' // role");
-    console.log('  );');
-    console.log('');
-
     // =========================================================================
     // 8. Audit and Compliance
     // =========================================================================

--- a/sdk/typescript/src/namespaces/rbac.ts
+++ b/sdk/typescript/src/namespaces/rbac.ts
@@ -288,17 +288,6 @@ export class RBACAPI {
   }
 
   /**
-   * Invite a new user to organization.
-   *
-   * @param email - User email address
-   * @param role - Optional role to assign on acceptance
-   * @returns Invitation details
-   */
-  async inviteUser(email: string, role?: string): Promise<{ invitation_id: string; email: string }> {
-    return this.client.request('POST', '/api/users/invite', { json: { email, role } });
-  }
-
-  /**
    * Remove a user from organization.
    *
    * @param userId - User ID to remove


### PR DESCRIPTION
## Summary
- remove the stale TypeScript RBAC `inviteUser` method for `/api/users/invite`
- remove the matching enterprise SDK example snippet
- restore cross-SDK parity after the privacy contract truthfulness change on `main`

## Verification
- `python3 scripts/check_cross_sdk_parity.py --strict --baseline scripts/baselines/cross_sdk_parity.json`
- `cd sdk/typescript && npm run typecheck`