### PR TITLE
fix(typecheck): reduce core module drift

### DIFF
--- a/aragora/config/secrets.py
+++ b/aragora/config/secrets.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 # These are optional - if not installed, we use Exception as fallback
 _BOTOCORE_AVAILABLE = False
 try:
-    from botocore.exceptions import BotoCoreError, ClientError
+    from botocore.exceptions import BotoCoreError, ClientError  # type: ignore[import-untyped]
 
     _BOTOCORE_AVAILABLE = True
 except ImportError:
@@ -322,7 +322,7 @@ class SecretManager:
             return self._aws_clients[region]
 
         try:
-            import boto3
+            import boto3  # type: ignore[import-untyped]
 
             client = boto3.client("secretsmanager", region_name=region)
             self._aws_clients[region] = client

--- a/aragora/connectors/chat/models.py
+++ b/aragora/connectors/chat/models.py
@@ -161,7 +161,7 @@ class ChatMessage:
     edited_at: datetime | None = None
 
     # Rich content
-    blocks: list[dict[str, Any] | None] = None  # Platform-specific rich content
+    blocks: list[dict[str, Any] | None] | None = None  # Platform-specific rich content
     attachments: list[dict[str, Any]] = field(default_factory=list)
 
     # Platform-specific
@@ -281,7 +281,7 @@ class SendMessageRequest:
 
     channel_id: str
     text: str
-    blocks: list[dict[str, Any] | None] = None
+    blocks: list[dict[str, Any] | None] | None = None
     thread_id: str | None = None
     reply_to_id: str | None = None
     attachments: list[dict[str, Any]] = field(default_factory=list)

--- a/aragora/debate/consensus.py
+++ b/aragora/debate/consensus.py
@@ -291,10 +291,13 @@ class ConsensusProof:
             sort_keys=True,
         )
         # Cache the computed checksum
+        checksum = hashlib.sha256(content.encode()).hexdigest()[:16]
         object.__setattr__(
-            self, "_cached_checksum", hashlib.sha256(content.encode()).hexdigest()[:16]
+            self,
+            "_cached_checksum",
+            checksum,
         )
-        return self._cached_checksum
+        return checksum
 
     @property
     def agreement_ratio(self) -> float:

--- a/aragora/debate/orchestrator.py
+++ b/aragora/debate/orchestrator.py
@@ -130,7 +130,7 @@ _KNOWLEDGE_MOUND_UNSET = _INIT_KNOWLEDGE_MOUND_UNSET
 
 # TYPE_CHECKING imports for type hints without runtime import overhead
 if TYPE_CHECKING:
-    from aragora.debate.checkpoint_manager import CheckpointManager
+    from aragora.debate.checkpoint import CheckpointManager
     from aragora.debate.checkpoint_ops import CheckpointOperations
     from aragora.debate.context_gatherer import ContextGatherer
     from aragora.debate.event_emission import EventEmitter as _EventEmitter
@@ -147,15 +147,15 @@ if TYPE_CHECKING:
         VotingPhase,
     )
     from aragora.debate.prompt_builder import PromptBuilder
-    from aragora.debate.revalidation_scheduler import RevalidationScheduler
+    from aragora.debate.ml_integration import MLDelegationStrategy
+    from aragora.debate.cognitive_limiter_rlm import RLMCognitiveLoadLimiter
     from aragora.debate.strategy import DebateStrategy
+    from aragora.knowledge.mound.revalidation_scheduler import RevalidationScheduler
     from aragora.memory.consensus import ConsensusMemory
     from aragora.memory.continuum import ContinuumMemory
-    from aragora.ml.delegation import MLDelegationStrategy
     from aragora.ranking.elo import EloSystem
     from aragora.reasoning.citations import CitationExtractor
     from aragora.reasoning.evidence_grounding import EvidenceGrounder
-    from aragora.rlm.cognitive_limiter import RLMCognitiveLoadLimiter
     from aragora.types.protocols import EventEmitterProtocol
     from aragora.workflow.engine import Workflow
 

--- a/aragora/debate/orchestrator_setup.py
+++ b/aragora/debate/orchestrator_setup.py
@@ -30,8 +30,8 @@ from aragora.utils.cache_registry import register_lru_cache
 if TYPE_CHECKING:
     from aragora.core import Agent, DebateResult
     from aragora.debate.context import DebateContext
+    from aragora.debate.cognitive_limiter_rlm import RLMCognitiveLoadLimiter
     from aragora.debate.orchestrator import Arena
-    from aragora.rlm.cognitive_limiter import RLMCognitiveLoadLimiter
 
 logger = get_structured_logger(__name__)
 

--- a/aragora/debate/phases/feedback_elo.py
+++ b/aragora/debate/phases/feedback_elo.py
@@ -68,29 +68,33 @@ class EloFeedback:
 
     def _emit_match_recorded_event(self, ctx: DebateContext, participants: list[str]) -> None:
         """Emit MATCH_RECORDED event for real-time leaderboard updates."""
-        if not self.event_emitter or not self.elo_system:
+        event_emitter = self.event_emitter
+        elo_system = self.elo_system
+        result = ctx.result
+        loop_id = self.loop_id
+        if event_emitter is None or elo_system is None or result is None or loop_id is None:
             return
 
         try:
             from aragora.events.types import StreamEvent, StreamEventType
 
             # Batch fetch all ratings
-            ratings_batch = self.elo_system.get_ratings_batch(participants)
+            ratings_batch = elo_system.get_ratings_batch(participants)
             elo_changes = {
                 name: ratings_batch[name].elo if name in ratings_batch else 1500.0
                 for name in participants
             }
 
-            self.event_emitter.emit(
+            event_emitter.emit(
                 StreamEvent(
                     type=StreamEventType.MATCH_RECORDED,
-                    loop_id=self.loop_id,
+                    loop_id=loop_id,
                     data={
                         "debate_id": ctx.debate_id,
                         "participants": participants,
                         "elo_changes": elo_changes,
                         "domain": ctx.domain,
-                        "winner": ctx.result.winner,
+                        "winner": result.winner,
                     },
                 )
             )
@@ -99,17 +103,17 @@ class EloFeedback:
             for agent_name in participants:
                 rating = ratings_batch.get(agent_name)
                 if rating:
-                    self.event_emitter.emit(
+                    event_emitter.emit(
                         StreamEvent(
                             type=StreamEventType.AGENT_ELO_UPDATED,
-                            loop_id=self.loop_id,
+                            loop_id=loop_id,
                             agent=agent_name,
                             data={
                                 "agent": agent_name,
                                 "new_elo": rating.elo,
                                 "debate_id": ctx.debate_id,
                                 "domain": ctx.domain,
-                                "is_winner": agent_name == ctx.result.winner,
+                                "is_winner": agent_name == result.winner,
                             },
                         )
                     )

--- a/aragora/debate/phases/feedback_evolution.py
+++ b/aragora/debate/phases/feedback_evolution.py
@@ -281,8 +281,12 @@ class EvolutionFeedback:
 
         This is a fire-and-forget task so it doesn't block debate completion.
         """
+        population_manager = self.population_manager
+        if population_manager is None:
+            return
+
         try:
-            evolved = self.population_manager.evolve_population(population)
+            evolved = population_manager.evolve_population(population)
             logger.info(
                 "[genesis] Population evolved to generation %d with %d genomes",
                 evolved.generation,
@@ -290,13 +294,14 @@ class EvolutionFeedback:
             )
 
             # Emit event if event_emitter available
-            if self.event_emitter:
+            loop_id = self.loop_id
+            if self.event_emitter and loop_id is not None:
                 from aragora.events.types import StreamEvent, StreamEventType
 
                 self.event_emitter.emit(
                     StreamEvent(
                         type=StreamEventType.GENESIS_EVOLUTION,
-                        loop_id=self.loop_id,
+                        loop_id=loop_id,
                         data={
                             "generation": evolved.generation,
                             "genome_count": len(evolved.genomes),

--- a/aragora/debate/phases/feedback_persona.py
+++ b/aragora/debate/phases/feedback_persona.py
@@ -32,18 +32,19 @@ class PersonaFeedback:
 
     def update_persona_performance(self, ctx: DebateContext) -> None:
         """Update PersonaManager with performance feedback."""
-        if not self.persona_manager:
+        persona_manager = self.persona_manager
+        result = ctx.result
+        if persona_manager is None or result is None:
             return
 
         try:
             from aragora.agents.errors import _build_error_action
 
-            result = ctx.result
             for agent in ctx.agents:
                 success = (agent.name == result.winner) or (
                     result.consensus_reached and result.confidence > 0.7
                 )
-                self.persona_manager.record_performance(
+                persona_manager.record_performance(
                     agent_name=agent.name,
                     domain=ctx.domain,
                     success=success,
@@ -65,7 +66,10 @@ class PersonaFeedback:
         - Consistent prediction accuracy
         - Distinct communication styles
         """
-        if not self.persona_manager or not self.event_emitter:
+        persona_manager = self.persona_manager
+        event_emitter = self.event_emitter
+        loop_id = self.loop_id
+        if persona_manager is None or event_emitter is None or loop_id is None:
             return
 
         try:
@@ -73,7 +77,7 @@ class PersonaFeedback:
 
             for agent in ctx.agents:
                 # Get agent's current traits
-                persona = self.persona_manager.get_persona(agent.name)
+                persona = persona_manager.get_persona(agent.name)
                 if not persona:
                     continue
 
@@ -84,10 +88,10 @@ class PersonaFeedback:
                     new_traits = self.detect_emerging_traits(agent.name, ctx)
 
                 for trait in new_traits:
-                    self.event_emitter.emit(
+                    event_emitter.emit(
                         StreamEvent(
                             type=StreamEventType.TRAIT_EMERGED,
-                            loop_id=self.loop_id,
+                            loop_id=loop_id,
                             data={
                                 "agent": agent.name,
                                 "trait": trait.get("name", "unknown"),
@@ -114,12 +118,17 @@ class PersonaFeedback:
         """
         traits: list[dict[str, Any]] = []
 
+        persona_manager = self.persona_manager
+        if persona_manager is None:
+            return traits
+
         try:
             # Get performance stats if available
-            if not hasattr(self.persona_manager, "get_performance_stats"):
+            stats_getter = getattr(persona_manager, "get_performance_stats", None)
+            if not callable(stats_getter):
                 return traits
 
-            stats = self.persona_manager.get_performance_stats(agent_name)
+            stats = stats_getter(agent_name)
             if not stats:
                 return traits
 

--- a/aragora/debate/prompt_builder.py
+++ b/aragora/debate/prompt_builder.py
@@ -22,17 +22,17 @@ from .prompt_context_providers import PromptContextMixin
 
 if TYPE_CHECKING:
     from aragora.agents.calibration import CalibrationTracker
-    from aragora.agents.flip_detector import FlipDetector
     from aragora.agents.personas import PersonaManager
     from aragora.core import Agent, Environment
     from aragora.debate.protocol import DebateProtocol
     from aragora.debate.roles import RoleAssignment, RoleRotator
     from aragora.evidence.collector import EvidencePack
+    from aragora.insights.flip_detector import FlipDetector
     from aragora.knowledge.mound.adapters import SupermemoryAdapter, ContextInjectionResult
     from aragora.memory.consensus import DissentRetriever
     from aragora.memory.continuum import ContinuumMemory
     from aragora.memory.store import CritiqueStore
-    from aragora.pulse.types import TrendingTopic
+    from aragora.pulse.ingestor import TrendingTopic
     from aragora.ranking.elo import EloSystem
     from aragora.server.question_classifier import QuestionClassification, QuestionClassifier
     from aragora.rlm.types import RLMContext

--- a/aragora/debate/prompt_context_providers.py
+++ b/aragora/debate/prompt_context_providers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from aragora.core import Agent
     from aragora.evidence.collector import EvidencePack
     from aragora.knowledge.mound.adapters import SupermemoryAdapter
-    from aragora.pulse.types import TrendingTopic
+    from aragora.pulse.ingestor import TrendingTopic
     from aragora.rlm.types import RLMContext
 
 # Check for RLM availability

--- a/aragora/debate/prompts/context_formatters.py
+++ b/aragora/debate/prompts/context_formatters.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from aragora.evidence.collector import EvidenceSnippet
-    from aragora.pulse.types import TrendingTopic
+    from aragora.pulse.ingestor import TrendingTopic
 
 logger = logging.getLogger(__name__)
 

--- a/aragora/debate/team_selector.py
+++ b/aragora/debate/team_selector.py
@@ -618,9 +618,13 @@ class TeamSelector:
                 ]
                 if cheap_agents:
                     # Apply max_agents limit if configured
-                    max_agents = self.config.budget_warn_max_agents
-                    if max_agents and len(cheap_agents) > max_agents:
-                        cheap_agents = cheap_agents[:max_agents]
+                    warn_max_agents = self.config.budget_warn_max_agents
+                    if (
+                        warn_max_agents is not None
+                        and warn_max_agents > 0
+                        and len(cheap_agents) > warn_max_agents
+                    ):
+                        cheap_agents = cheap_agents[:warn_max_agents]
                     logger.info(
                         "budget_warn_prefer_cheap org=%s cheap_agents=%s from=%s",
                         self.org_id,
@@ -1019,8 +1023,12 @@ class TeamSelector:
         """
         import math
 
+        elo_system = self.elo_system
+        if elo_system is None:
+            return 1.0
+
         try:
-            rating = self.elo_system.get_rating(agent.name)
+            rating = elo_system.get_rating(agent.name)
             agent_debates = getattr(rating, "total_matches", 0)
             if isinstance(rating, (int, float)):
                 agent_debates = 0
@@ -1265,6 +1273,8 @@ class TeamSelector:
             agent_name = getattr(agent, "name", str(agent))
             # AgentRegistry.get() may be sync or async; handle both
             registry = self.control_plane_registry
+            if registry is None:
+                return 0.0
             info = None
             if hasattr(registry, "get_sync"):
                 info = registry.get_sync(agent_name)
@@ -1301,8 +1311,12 @@ class TeamSelector:
         this fires in the background; subsequent calls in the same
         debate will hit the warm cache.
         """
+        knowledge_mound = self.knowledge_mound
+        if knowledge_mound is None:
+            self._culture_recommendations_cache[cache_key] = []
+            return
         try:
-            recommendations = await self.knowledge_mound.recommend_agents(task_type)
+            recommendations = await knowledge_mound.recommend_agents(task_type)
             self._culture_recommendations_cache[cache_key] = recommendations or []
         except (AttributeError, TypeError, ValueError, RuntimeError, OSError) as e:
             logger.debug("Culture cache warm-up failed for %s: %s", task_type, e)

--- a/aragora/ranking/elo.py
+++ b/aragora/ranking/elo.py
@@ -677,7 +677,7 @@ class EloSystem(KMAdapterMixin):
         winner: str | None,
         domain: str | None,
         debate_id: str,
-    ) -> tuple[list[AgentRating], list[tuple[str, float, str]]]:
+    ) -> tuple[list[AgentRating], list[tuple[str, float, str | None]]]:
         """Apply ELO changes to ratings and prepare for batch save."""
         return apply_elo_changes(elo_changes, ratings, winner, domain, debate_id, DEFAULT_ELO)
 
@@ -760,7 +760,15 @@ class EloSystem(KMAdapterMixin):
         elo_changes: dict[str, float],
     ) -> None:
         """Save match to history."""
-        save_match(self._db, debate_id, winner, participants, domain, scores, elo_changes)
+        if debate_id is None:
+            logger.warning(
+                "Skipping ELO match persistence without debate_id participants=%s winner=%s",
+                participants,
+                winner,
+            )
+            return
+        match_scores = scores if scores is not None else {}
+        save_match(self._db, debate_id, winner, participants, domain, match_scores, elo_changes)
 
     def _write_snapshot(self) -> None:
         """Write JSON snapshot for fast reads."""

--- a/aragora/reasoning/belief.py
+++ b/aragora/reasoning/belief.py
@@ -727,10 +727,13 @@ class BeliefNetwork:
                 },
             )
 
-            if hasattr(self._event_emitter, "emit"):
-                self._event_emitter.emit(event)
-            elif hasattr(self._event_emitter, "notify"):
-                self._event_emitter.notify("belief_converged", event.data)
+            event_emitter = self._event_emitter
+            if event_emitter is None:
+                return
+            if hasattr(event_emitter, "emit"):
+                event_emitter.emit(event)
+            elif hasattr(event_emitter, "notify"):
+                event_emitter.notify("belief_converged", event.data)
 
         except ImportError:
             pass  # Events module not available

--- a/aragora/resilience/circuit_breaker.py
+++ b/aragora/resilience/circuit_breaker.py
@@ -138,12 +138,15 @@ class CircuitBreaker:
         """
         # Support both old (timeout_seconds, half_open_max_calls) and
         # new (cooldown_seconds, half_open_max_requests) config field names
-        cooldown = getattr(config, "cooldown_seconds", None) or getattr(
-            config, "timeout_seconds", 30.0
-        )
-        half_open_max = getattr(config, "half_open_max_requests", None) or getattr(
-            config, "half_open_max_calls", 3
-        )
+        cooldown_raw = getattr(config, "cooldown_seconds", None)
+        if cooldown_raw is None:
+            cooldown_raw = getattr(config, "timeout_seconds", 30.0)
+        cooldown = float(cooldown_raw if cooldown_raw is not None else 30.0)
+
+        half_open_max_raw = getattr(config, "half_open_max_requests", None)
+        if half_open_max_raw is None:
+            half_open_max_raw = getattr(config, "half_open_max_calls", 3)
+        half_open_max = int(half_open_max_raw if half_open_max_raw is not None else 3)
         return cls(
             name=name,
             failure_threshold=config.failure_threshold,

--- a/aragora/server/stream/servers.py
+++ b/aragora/server/stream/servers.py
@@ -134,7 +134,7 @@ WS_MAX_CONNECTIONS_PER_IP = max(1, min(_raw_max_per_ip, 100))
 
 
 # Mixin method signatures intentionally differ from ServerBase
-class AiohttpUnifiedServer(  # type: ignore[override]
+class AiohttpUnifiedServer(  # type: ignore[misc,override]
     ServerBase,
     StreamAPIHandlersMixin,
     WebSocketHandlerMixin,
@@ -273,7 +273,7 @@ class AiohttpUnifiedServer(  # type: ignore[override]
 
         # PersonaManager for agent specialization
         try:
-            from aragora.personas.manager import PersonaManager
+            from aragora.agents.personas import PersonaManager
 
             personas_path = nomic_dir / DB_PERSONAS_PATH
             if personas_path.exists():

--- a/aragora/workflow/engine.py
+++ b/aragora/workflow/engine.py
@@ -639,7 +639,7 @@ class WorkflowEngine:
         completed_steps: set[str],
     ) -> Any:
         """Execute workflow starting from a specific step."""
-        current_step_id = start_step
+        current_step_id: str | None = start_step
         final_output = None
         step_count = 0
         workflow_start_time = time.time()

--- a/docs-site/docs/contributing/capability-matrix.md
+++ b/docs-site/docs/contributing/capability-matrix.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 87 commands | 43.2% |
+| **CLI** | 88 commands | 43.2% |
 | **SDK (Python)** | 186 namespaces | 70.3% |
 | **SDK (TypeScript)** | 185 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,7 +8,7 @@
 | Surface | Inventory | Capability Coverage |
 |---------|-----------|---------------------|
 | **HTTP API** | 1772 paths / 2100 operations | 81.1% |
-| **CLI** | 87 commands | 43.2% |
+| **CLI** | 88 commands | 43.2% |
 | **SDK (Python)** | 186 namespaces | 70.3% |
 | **SDK (TypeScript)** | 185 namespaces | 70.3% |
 | **UI** | tracked in capability surfaces | 86.5% |

--- a/tests/debate/test_budget_aware_selection.py
+++ b/tests/debate/test_budget_aware_selection.py
@@ -216,6 +216,21 @@ class TestBudgetWarn:
         # 4 cheap agents: gemini, llama, deepseek, mistral
         assert len(result) == 4
 
+    def test_warn_zero_max_agents_treated_as_no_cap(self, agents, budget_manager):
+        """WARN preserves the legacy 0 == no cap semantics."""
+        budget_manager.check_budget.return_value = (True, "Warning", BudgetAction.WARN)
+        selector = TeamSelector(
+            budget_manager=budget_manager,
+            org_id="org-test",
+            config=TeamSelectionConfig(
+                enable_domain_filtering=False,
+                enable_cv_selection=False,
+                budget_warn_max_agents=0,
+            ),
+        )
+        result = selector.select(agents)
+        assert len(result) == 4
+
 
 # =========================================================================
 # SOFT_LIMIT action tests

--- a/tests/ranking/test_elo.py
+++ b/tests/ranking/test_elo.py
@@ -899,3 +899,23 @@ class TestVerificationIntegration:
 
         impact = elo_system.get_verification_impact("impact_agent")
         assert isinstance(impact, dict)
+
+
+class TestMatchPersistence:
+    """Tests for ELO match persistence helpers."""
+
+    def test_save_match_logs_when_debate_id_missing(self, elo_system, caplog):
+        """Missing debate IDs should be logged instead of silently skipped."""
+        with patch("aragora.ranking.elo.save_match") as mock_save_match:
+            with caplog.at_level("WARNING"):
+                elo_system._save_match(
+                    debate_id=None,
+                    winner="winner",
+                    participants=["winner", "loser"],
+                    domain="architecture",
+                    scores={"winner": 1.0, "loser": 0.0},
+                    elo_changes={"winner": 12.0, "loser": -12.0},
+                )
+
+        mock_save_match.assert_not_called()
+        assert "Skipping ELO match persistence without debate_id" in caplog.text


### PR DESCRIPTION
## Summary
- fix stale import paths to moved debate, pulse, persona, and insight modules
- align the stream server optional PersonaManager import and class-level mypy suppression with current inheritance behavior
- fix the first low-risk nullability and untyped-import issues in chat models, consensus checksums, AWS secrets, and circuit-breaker config coercion
- remove the current feedback-phase nullability/protocol issues in ELO, persona, and evolution feedback helpers
- fix the current team-selector optional guard and budget-limit typing issues
- remove the current nullable-value drift in ELO match persistence, belief event emission, and workflow step transitions

## Verification
- python3 -m ruff check aragora/debate/prompt_builder.py aragora/debate/prompts/context_formatters.py aragora/debate/prompt_context_providers.py aragora/debate/orchestrator.py aragora/debate/orchestrator_setup.py aragora/server/stream/servers.py aragora/connectors/chat/models.py aragora/debate/consensus.py aragora/config/secrets.py aragora/resilience/circuit_breaker.py aragora/debate/phases/feedback_evolution.py aragora/debate/phases/feedback_persona.py aragora/debate/phases/feedback_elo.py aragora/debate/team_selector.py aragora/ranking/elo.py aragora/reasoning/belief.py aragora/workflow/engine.py
- python3 -m mypy aragora/connectors/chat/models.py aragora/debate/consensus.py aragora/config/secrets.py aragora/resilience/circuit_breaker.py aragora/debate/prompt_builder.py aragora/debate/orchestrator.py aragora/server/stream/servers.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m mypy aragora/debate/phases/feedback_evolution.py aragora/debate/phases/feedback_persona.py aragora/debate/phases/feedback_elo.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m mypy aragora/debate/team_selector.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- python3 -m mypy aragora/ranking/elo.py aragora/reasoning/belief.py aragora/workflow/engine.py --config-file pyproject.toml --no-error-summary --follow-imports=silent
- rg -n "from aragora\.(pulse\.types|agents\.flip_detector|debate\.checkpoint_manager|debate\.revalidation_scheduler|ml\.delegation|rlm\.cognitive_limiter|personas\.manager)" aragora