### PR TITLE
ci: add self-hosted fleet probe workflow

### DIFF
--- a/.github/workflows/self-hosted-fleet-probe.yml
+++ b/.github/workflows/self-hosted-fleet-probe.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: probe-repo
 
       - name: Runner fingerprint
         shell: bash
@@ -57,6 +59,7 @@ jobs:
       - name: Repo smoke
         shell: bash
         run: |
+          cd probe-repo
           test -f pyproject.toml
           test -f scripts/check_version_alignment.py
           test -f aragora/__version__.py
@@ -82,6 +85,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          path: probe-repo
 
       - name: Runner fingerprint
         shell: bash
@@ -107,6 +112,7 @@ jobs:
       - name: Repo smoke
         shell: bash
         run: |
+          cd probe-repo
           test -f pyproject.toml
           test -f scripts/check_version_alignment.py
           test -f aragora/__version__.py


### PR DESCRIPTION
## Summary
- add a dedicated mac studio self-hosted runner probe
- add a dedicated hetzner self-hosted runner probe
- keep the probe on same-repo PRs and manual dispatch so it does not widen required CI risk

## Verification
- python yaml parse of the workflow file
- git diff --check
