### PR TITLE
Add debate session cost calculation API endpoints

### DIFF
--- a/aragora/server/handlers/costs/handler.py
+++ b/aragora/server/handlers/costs/handler.py
@@ -66,6 +66,10 @@ class CostHandler:
         "/api/v1/costs/recommendations/*/dismiss",
         "/api/v1/costs/timeline",
         "/api/v1/costs/usage",
+        # Debate session cost endpoints (v1 canonical)
+        "/api/v1/costs/debates/*",
+        "/api/v1/costs/debates/*/line-items",
+        "/api/v1/costs/debates/*/performance",
         # Legacy paths (unversioned)
         "/api/costs",
         "/api/costs/alerts",
@@ -92,6 +96,10 @@ class CostHandler:
         "/api/costs/recommendations/*/dismiss",
         "/api/costs/timeline",
         "/api/costs/usage",
+        # Debate session cost endpoints (legacy)
+        "/api/costs/debates/*",
+        "/api/costs/debates/*/line-items",
+        "/api/costs/debates/*/performance",
     ]
 
     def __init__(self, ctx: dict | None = None):
@@ -214,6 +222,42 @@ class CostHandler:
         }
         dynamic_routes = {
             "GET": [
+                (
+                    "/api/v1/costs/debates/",
+                    "/line-items",
+                    "debate_id",
+                    "handle_get_debate_line_items",
+                ),
+                (
+                    "/api/costs/debates/",
+                    "/line-items",
+                    "debate_id",
+                    "handle_get_debate_line_items",
+                ),
+                (
+                    "/api/v1/costs/debates/",
+                    "/performance",
+                    "debate_id",
+                    "handle_get_debate_performance",
+                ),
+                (
+                    "/api/costs/debates/",
+                    "/performance",
+                    "debate_id",
+                    "handle_get_debate_performance",
+                ),
+                (
+                    "/api/v1/costs/debates/",
+                    "",
+                    "debate_id",
+                    "handle_get_debate_costs",
+                ),
+                (
+                    "/api/costs/debates/",
+                    "",
+                    "debate_id",
+                    "handle_get_debate_costs",
+                ),
                 (
                     "/api/v1/costs/recommendations/",
                     "",
@@ -2005,6 +2049,397 @@ class CostHandler:
             ImportError,
         ) as e:
             logger.exception("Failed to get debate breakdown: %s", e)
+            return web_error_response("Internal server error", 500)
+
+    # =========================================================================
+    # Debate Session Cost Calculation Endpoints
+    # =========================================================================
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/costs/debates/{debate_id}",
+        summary="Get debate session costs",
+        description="Get cost summary for a specific debate session.",
+    )
+    @rate_limit(requests_per_minute=60)
+    @require_permission("costs:read")
+    async def handle_get_debate_costs(self, request: web.Request) -> web.Response:
+        """
+        GET /api/v1/costs/debates/{debate_id}
+
+        Get cost summary for a specific debate session including total cost,
+        token usage, and budget status.
+
+        Path params:
+            - debate_id: Debate session ID
+        """
+        try:
+            debate_id = request.match_info.get("debate_id", "")
+            if not debate_id:
+                return web_error_response("debate_id is required", 400)
+
+            tracker = _models._get_cost_tracker()
+            if not tracker:
+                return web_error_response("Cost tracker not available", 503)
+
+            # Get debate cost from tracker
+            cost_data = await tracker.get_debate_cost(debate_id)
+
+            # Get budget status
+            budget_status = tracker.check_debate_budget(debate_id)
+
+            # Collect per-agent and per-model breakdowns from usage buffer
+            by_agent: dict[str, dict[str, Any]] = {}
+            by_model: dict[str, dict[str, Any]] = {}
+            call_count = 0
+            total_latency = 0.0
+
+            async with tracker._buffer_lock:
+                for usage in tracker._usage_buffer:
+                    if usage.debate_id != debate_id:
+                        continue
+                    call_count += 1
+                    total_latency += usage.latency_ms
+
+                    # Per-agent aggregation
+                    agent_key = usage.agent_name or usage.agent_id or "unknown"
+                    if agent_key not in by_agent:
+                        by_agent[agent_key] = {
+                            "agent": agent_key,
+                            "cost_usd": 0.0,
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "calls": 0,
+                        }
+                    by_agent[agent_key]["cost_usd"] += float(usage.cost_usd)
+                    by_agent[agent_key]["tokens_in"] += usage.tokens_in
+                    by_agent[agent_key]["tokens_out"] += usage.tokens_out
+                    by_agent[agent_key]["calls"] += 1
+
+                    # Per-model aggregation
+                    model_key = usage.model or "unknown"
+                    if model_key not in by_model:
+                        by_model[model_key] = {
+                            "model": model_key,
+                            "provider": usage.provider,
+                            "cost_usd": 0.0,
+                            "tokens_in": 0,
+                            "tokens_out": 0,
+                            "calls": 0,
+                        }
+                    by_model[model_key]["cost_usd"] += float(usage.cost_usd)
+                    by_model[model_key]["tokens_in"] += usage.tokens_in
+                    by_model[model_key]["tokens_out"] += usage.tokens_out
+                    by_model[model_key]["calls"] += 1
+
+            total_cost = float(cost_data.get("total_cost_usd", "0"))
+            agents_list = sorted(by_agent.values(), key=lambda x: x["cost_usd"], reverse=True)
+            models_list = sorted(by_model.values(), key=lambda x: x["cost_usd"], reverse=True)
+
+            # Round costs
+            for item in agents_list:
+                item["cost_usd"] = round(item["cost_usd"], 6)
+            for item in models_list:
+                item["cost_usd"] = round(item["cost_usd"], 6)
+
+            return web.json_response(
+                {
+                    "data": {
+                        "debate_id": debate_id,
+                        "total_cost_usd": round(total_cost, 6),
+                        "total_tokens_in": cost_data.get("total_tokens_in", 0),
+                        "total_tokens_out": cost_data.get("total_tokens_out", 0),
+                        "api_calls": cost_data.get("api_calls", call_count),
+                        "avg_latency_ms": round(total_latency / call_count, 2)
+                        if call_count > 0
+                        else 0,
+                        "by_agent": agents_list,
+                        "by_model": models_list,
+                        "budget": budget_status,
+                    }
+                }
+            )
+
+        except (
+            ValueError,
+            KeyError,
+            TypeError,
+            AttributeError,
+            RuntimeError,
+            OSError,
+            ImportError,
+        ) as e:
+            logger.exception("Failed to get debate costs: %s", e)
+            return web_error_response("Internal server error", 500)
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/costs/debates/{debate_id}/line-items",
+        summary="Get debate cost line items",
+        description="Get individual API call cost line items for a debate session.",
+    )
+    @rate_limit(requests_per_minute=60)
+    @require_permission("costs:read")
+    async def handle_get_debate_line_items(self, request: web.Request) -> web.Response:
+        """
+        GET /api/v1/costs/debates/{debate_id}/line-items
+
+        Get line-item breakdown of individual API calls for a debate session.
+
+        Path params:
+            - debate_id: Debate session ID
+        Query params:
+            - sort_by: Sort field (cost, timestamp, tokens). Default: timestamp
+            - order: Sort order (asc, desc). Default: desc
+            - limit: Max items to return (default: 100, max: 500)
+            - offset: Pagination offset (default: 0)
+        """
+        try:
+            debate_id = request.match_info.get("debate_id", "")
+            if not debate_id:
+                return web_error_response("debate_id is required", 400)
+
+            sort_by = request.query.get("sort_by", "timestamp")
+            order = request.query.get("order", "desc")
+            limit = safe_query_int(request.query, "limit", default=100, min_val=1, max_val=500)
+            offset = safe_query_int(request.query, "offset", default=0, min_val=0, max_val=100000)
+
+            if sort_by not in ("cost", "timestamp", "tokens"):
+                return web_error_response("sort_by must be one of: cost, timestamp, tokens", 400)
+            if order not in ("asc", "desc"):
+                return web_error_response("order must be 'asc' or 'desc'", 400)
+
+            tracker = _models._get_cost_tracker()
+            if not tracker:
+                return web_error_response("Cost tracker not available", 503)
+
+            # Collect line items from usage buffer
+            line_items: list[dict[str, Any]] = []
+
+            async with tracker._buffer_lock:
+                for usage in tracker._usage_buffer:
+                    if usage.debate_id != debate_id:
+                        continue
+                    line_items.append(
+                        {
+                            "id": usage.id,
+                            "timestamp": usage.timestamp.isoformat(),
+                            "agent": usage.agent_name or usage.agent_id or "unknown",
+                            "agent_id": usage.agent_id,
+                            "provider": usage.provider,
+                            "model": usage.model,
+                            "operation": usage.operation,
+                            "tokens_in": usage.tokens_in,
+                            "tokens_out": usage.tokens_out,
+                            "tokens_cached": usage.tokens_cached,
+                            "cost_usd": round(float(usage.cost_usd), 6),
+                            "latency_ms": round(usage.latency_ms, 2),
+                        }
+                    )
+
+            # Sort
+            sort_keys = {
+                "cost": lambda x: x["cost_usd"],
+                "timestamp": lambda x: x["timestamp"],
+                "tokens": lambda x: x["tokens_in"] + x["tokens_out"],
+            }
+            line_items.sort(
+                key=sort_keys[sort_by],
+                reverse=(order == "desc"),
+            )
+
+            total_count = len(line_items)
+            # Apply pagination
+            line_items = line_items[offset : offset + limit]
+
+            # Compute totals
+            total_cost = sum(item["cost_usd"] for item in line_items)
+            total_tokens = sum(item["tokens_in"] + item["tokens_out"] for item in line_items)
+
+            return web.json_response(
+                {
+                    "data": {
+                        "debate_id": debate_id,
+                        "line_items": line_items,
+                        "total_count": total_count,
+                        "returned_count": len(line_items),
+                        "offset": offset,
+                        "limit": limit,
+                        "page_total_cost_usd": round(total_cost, 6),
+                        "page_total_tokens": total_tokens,
+                    }
+                }
+            )
+
+        except (
+            ValueError,
+            KeyError,
+            TypeError,
+            AttributeError,
+            RuntimeError,
+            OSError,
+            ImportError,
+        ) as e:
+            logger.exception("Failed to get debate line items: %s", e)
+            return web_error_response("Internal server error", 500)
+
+    @api_endpoint(
+        method="GET",
+        path="/api/v1/costs/debates/{debate_id}/performance",
+        summary="Get debate cost performance",
+        description="Get performance metrics for a debate session's API usage.",
+    )
+    @rate_limit(requests_per_minute=60)
+    @require_permission("costs:read")
+    async def handle_get_debate_performance(self, request: web.Request) -> web.Response:
+        """
+        GET /api/v1/costs/debates/{debate_id}/performance
+
+        Get performance and efficiency metrics for a debate session's API usage.
+
+        Path params:
+            - debate_id: Debate session ID
+        """
+        try:
+            debate_id = request.match_info.get("debate_id", "")
+            if not debate_id:
+                return web_error_response("debate_id is required", 400)
+
+            tracker = _models._get_cost_tracker()
+            if not tracker:
+                return web_error_response("Cost tracker not available", 503)
+
+            # Collect per-call metrics from usage buffer
+            latencies: list[float] = []
+            costs: list[float] = []
+            tokens_per_call: list[int] = []
+            by_operation: dict[str, dict[str, Any]] = {}
+            first_ts: datetime | None = None
+            last_ts: datetime | None = None
+
+            async with tracker._buffer_lock:
+                for usage in tracker._usage_buffer:
+                    if usage.debate_id != debate_id:
+                        continue
+                    latencies.append(usage.latency_ms)
+                    costs.append(float(usage.cost_usd))
+                    tokens_per_call.append(usage.tokens_in + usage.tokens_out)
+
+                    # Track timestamps
+                    if first_ts is None or usage.timestamp < first_ts:
+                        first_ts = usage.timestamp
+                    if last_ts is None or usage.timestamp > last_ts:
+                        last_ts = usage.timestamp
+
+                    # Per-operation breakdown
+                    op = usage.operation or "unknown"
+                    if op not in by_operation:
+                        by_operation[op] = {
+                            "operation": op,
+                            "calls": 0,
+                            "total_cost_usd": 0.0,
+                            "total_latency_ms": 0.0,
+                            "total_tokens": 0,
+                        }
+                    by_operation[op]["calls"] += 1
+                    by_operation[op]["total_cost_usd"] += float(usage.cost_usd)
+                    by_operation[op]["total_latency_ms"] += usage.latency_ms
+                    by_operation[op]["total_tokens"] += usage.tokens_in + usage.tokens_out
+
+            call_count = len(latencies)
+            if call_count == 0:
+                return web.json_response(
+                    {
+                        "data": {
+                            "debate_id": debate_id,
+                            "api_calls": 0,
+                            "message": "No usage data found for this debate",
+                        }
+                    }
+                )
+
+            total_cost = sum(costs)
+            total_tokens = sum(tokens_per_call)
+
+            # Compute per-operation averages
+            operations_list = []
+            for op_data in by_operation.values():
+                op_calls = op_data["calls"]
+                operations_list.append(
+                    {
+                        "operation": op_data["operation"],
+                        "calls": op_calls,
+                        "total_cost_usd": round(op_data["total_cost_usd"], 6),
+                        "avg_cost_usd": round(op_data["total_cost_usd"] / op_calls, 6),
+                        "avg_latency_ms": round(op_data["total_latency_ms"] / op_calls, 2),
+                        "avg_tokens": round(op_data["total_tokens"] / op_calls),
+                    }
+                )
+            operations_list.sort(key=lambda x: x["total_cost_usd"], reverse=True)
+
+            # Duration
+            duration_seconds = (last_ts - first_ts).total_seconds() if first_ts and last_ts else 0
+
+            # Sorted latencies for percentiles
+            sorted_latencies = sorted(latencies)
+
+            def _percentile(data: list[float], pct: float) -> float:
+                if not data:
+                    return 0.0
+                idx = int(len(data) * pct / 100)
+                idx = min(idx, len(data) - 1)
+                return round(data[idx], 2)
+
+            return web.json_response(
+                {
+                    "data": {
+                        "debate_id": debate_id,
+                        "api_calls": call_count,
+                        "total_cost_usd": round(total_cost, 6),
+                        "total_tokens": total_tokens,
+                        "duration_seconds": round(duration_seconds, 2),
+                        "throughput": {
+                            "calls_per_minute": round(call_count / (duration_seconds / 60), 2)
+                            if duration_seconds > 0
+                            else 0,
+                            "tokens_per_minute": round(total_tokens / (duration_seconds / 60), 0)
+                            if duration_seconds > 0
+                            else 0,
+                        },
+                        "latency": {
+                            "avg_ms": round(sum(latencies) / call_count, 2),
+                            "min_ms": round(min(latencies), 2),
+                            "max_ms": round(max(latencies), 2),
+                            "p50_ms": _percentile(sorted_latencies, 50),
+                            "p90_ms": _percentile(sorted_latencies, 90),
+                            "p99_ms": _percentile(sorted_latencies, 99),
+                        },
+                        "cost_efficiency": {
+                            "cost_per_call_usd": round(total_cost / call_count, 6),
+                            "cost_per_1k_tokens": round(total_cost / total_tokens * 1000, 6)
+                            if total_tokens > 0
+                            else 0,
+                            "avg_tokens_per_call": round(total_tokens / call_count),
+                        },
+                        "by_operation": operations_list,
+                        "time_range": {
+                            "start": first_ts.isoformat() if first_ts else None,
+                            "end": last_ts.isoformat() if last_ts else None,
+                        },
+                    }
+                }
+            )
+
+        except (
+            ValueError,
+            KeyError,
+            TypeError,
+            AttributeError,
+            RuntimeError,
+            OSError,
+            ImportError,
+        ) as e:
+            logger.exception("Failed to get debate performance: %s", e)
             return web_error_response("Internal server error", 500)
 
     @api_endpoint(

--- a/aragora/server/handlers/costs/routes.py
+++ b/aragora/server/handlers/costs/routes.py
@@ -111,6 +111,34 @@ def register_routes(app: web.Application) -> None:
     app.router.add_post("/api/v1/costs/alerts", handler.handle_create_alert)
     app.router.add_post("/api/costs/alerts", handler.handle_create_alert)
 
+    # Debate session cost endpoints (v1 canonical)
+    app.router.add_get(
+        "/api/v1/costs/debates/{debate_id}",
+        handler.handle_get_debate_costs,
+    )
+    app.router.add_get(
+        "/api/v1/costs/debates/{debate_id}/line-items",
+        handler.handle_get_debate_line_items,
+    )
+    app.router.add_get(
+        "/api/v1/costs/debates/{debate_id}/performance",
+        handler.handle_get_debate_performance,
+    )
+
+    # Debate session cost endpoints (legacy)
+    app.router.add_get(
+        "/api/costs/debates/{debate_id}",
+        handler.handle_get_debate_costs,
+    )
+    app.router.add_get(
+        "/api/costs/debates/{debate_id}/line-items",
+        handler.handle_get_debate_line_items,
+    )
+    app.router.add_get(
+        "/api/costs/debates/{debate_id}/performance",
+        handler.handle_get_debate_performance,
+    )
+
     # Spend analytics dashboard (v1 canonical + legacy)
     app.router.add_get("/api/v1/costs/analytics/trend", handler.handle_get_spend_trend)
     app.router.add_get("/api/v1/costs/analytics/by-agent", handler.handle_get_spend_by_agent)

--- a/tests/server/handlers/costs/test_debate_session_costs.py
+++ b/tests/server/handlers/costs/test_debate_session_costs.py
@@ -1,0 +1,605 @@
+"""
+Tests for debate session cost calculation API endpoints.
+
+Covers:
+- GET /api/v1/costs/debates/{debate_id} - cost summary for a debate
+- GET /api/v1/costs/debates/{debate_id}/line-items - line-item breakdown
+- GET /api/v1/costs/debates/{debate_id}/performance - performance metrics
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from aragora.server.handlers.costs import CostHandler
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def handler():
+    return CostHandler()
+
+
+@pytest.fixture
+def mock_request():
+    request = MagicMock(spec=web.Request)
+    request.query = {}
+    request.match_info = {}
+    return request
+
+
+def _make_usage(
+    debate_id="debate_123",
+    agent_name="claude",
+    agent_id="agent_1",
+    provider="anthropic",
+    model="claude-opus-4",
+    tokens_in=1000,
+    tokens_out=500,
+    cost_usd="0.025",
+    latency_ms=350.0,
+    operation="debate_round",
+    usage_id="usage_1",
+    timestamp=None,
+):
+    """Build a mock TokenUsage object."""
+    usage = MagicMock()
+    usage.id = usage_id
+    usage.debate_id = debate_id
+    usage.agent_name = agent_name
+    usage.agent_id = agent_id
+    usage.provider = provider
+    usage.model = model
+    usage.tokens_in = tokens_in
+    usage.tokens_out = tokens_out
+    usage.tokens_cached = 0
+    usage.cost_usd = Decimal(cost_usd)
+    usage.latency_ms = latency_ms
+    usage.operation = operation
+    usage.timestamp = timestamp or datetime.now(timezone.utc)
+    usage.metadata = {}
+    return usage
+
+
+def _make_tracker(usage_items=None, debate_cost=None, budget_status=None):
+    """Build a mock CostTracker with an async context manager buffer lock."""
+    tracker = MagicMock()
+
+    # Create a real asyncio.Lock for _buffer_lock
+    tracker._buffer_lock = asyncio.Lock()
+    tracker._usage_buffer = usage_items or []
+
+    # get_debate_cost is async
+    default_cost = debate_cost or {
+        "debate_id": "debate_123",
+        "total_cost_usd": "0.075",
+        "total_tokens_in": 3000,
+        "total_tokens_out": 1500,
+        "api_calls": 3,
+    }
+    tracker.get_debate_cost = AsyncMock(return_value=default_cost)
+
+    # check_debate_budget is sync
+    default_budget = budget_status or {
+        "within_budget": True,
+        "current_cost": "0.075",
+        "limit": None,
+        "remaining": None,
+        "message": "No budget limit set",
+    }
+    tracker.check_debate_budget = MagicMock(return_value=default_budget)
+
+    return tracker
+
+
+# ===========================================================================
+# Debate cost summary tests
+# ===========================================================================
+
+
+class TestDebateCosts:
+    """Tests for GET /api/v1/costs/debates/{debate_id}."""
+
+    @pytest.mark.asyncio
+    async def test_get_debate_costs_success(self, handler, mock_request):
+        """Returns cost summary for a debate with agent and model breakdowns."""
+        now = datetime.now(timezone.utc)
+        usages = [
+            _make_usage(
+                usage_id="u1",
+                agent_name="claude",
+                model="claude-opus-4",
+                cost_usd="0.025",
+                tokens_in=1000,
+                tokens_out=500,
+                latency_ms=300.0,
+                timestamp=now,
+            ),
+            _make_usage(
+                usage_id="u2",
+                agent_name="gpt",
+                agent_id="agent_2",
+                provider="openai",
+                model="gpt-4o",
+                cost_usd="0.015",
+                tokens_in=800,
+                tokens_out=400,
+                latency_ms=250.0,
+                timestamp=now,
+            ),
+            _make_usage(
+                usage_id="u3",
+                agent_name="claude",
+                model="claude-opus-4",
+                cost_usd="0.035",
+                tokens_in=1200,
+                tokens_out=600,
+                latency_ms=400.0,
+                timestamp=now,
+            ),
+        ]
+        tracker = _make_tracker(usage_items=usages)
+
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_costs(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["debate_id"] == "debate_123"
+        assert data["api_calls"] == 3
+        assert len(data["by_agent"]) == 2
+        assert len(data["by_model"]) == 2
+        # claude should be first (higher cost)
+        assert data["by_agent"][0]["agent"] == "claude"
+        assert data["by_agent"][0]["calls"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_debate_costs_no_tracker(self, handler, mock_request):
+        """Returns 503 when tracker is unavailable."""
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=None):
+            response = await handler.handle_get_debate_costs(mock_request)
+
+        assert response.status == 503
+
+    @pytest.mark.asyncio
+    async def test_get_debate_costs_missing_id(self, handler, mock_request):
+        """Returns 400 when debate_id is empty."""
+        mock_request.match_info = {"debate_id": ""}
+
+        with patch(
+            "aragora.server.handlers.costs.models._get_cost_tracker",
+            return_value=_make_tracker(),
+        ):
+            response = await handler.handle_get_debate_costs(mock_request)
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_get_debate_costs_no_usage_data(self, handler, mock_request):
+        """Returns zeros when no usage data exists for debate."""
+        tracker = _make_tracker(
+            usage_items=[],
+            debate_cost={
+                "debate_id": "debate_empty",
+                "total_cost_usd": "0",
+                "total_tokens_in": 0,
+                "total_tokens_out": 0,
+                "api_calls": 0,
+            },
+        )
+        mock_request.match_info = {"debate_id": "debate_empty"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_costs(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["by_agent"] == []
+        assert data["by_model"] == []
+        assert data["avg_latency_ms"] == 0
+
+    @pytest.mark.asyncio
+    async def test_get_debate_costs_budget_included(self, handler, mock_request):
+        """Budget status is included in the response."""
+        budget = {
+            "within_budget": True,
+            "current_cost": "0.025",
+            "limit": "1.00",
+            "remaining": "0.975",
+            "message": "Within budget",
+        }
+        tracker = _make_tracker(
+            usage_items=[_make_usage()],
+            budget_status=budget,
+        )
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_costs(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["data"]["budget"]["within_budget"] is True
+
+
+# ===========================================================================
+# Line-items tests
+# ===========================================================================
+
+
+class TestDebateLineItems:
+    """Tests for GET /api/v1/costs/debates/{debate_id}/line-items."""
+
+    @pytest.mark.asyncio
+    async def test_line_items_success(self, handler, mock_request):
+        """Returns individual API call line items."""
+        now = datetime.now(timezone.utc)
+        usages = [
+            _make_usage(
+                usage_id=f"u{i}",
+                cost_usd=f"0.0{i + 1}0",
+                tokens_in=1000 * (i + 1),
+                tokens_out=500 * (i + 1),
+                timestamp=now + timedelta(seconds=i),
+            )
+            for i in range(3)
+        ]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+        mock_request.query = {}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["debate_id"] == "debate_123"
+        assert data["total_count"] == 3
+        assert data["returned_count"] == 3
+        assert len(data["line_items"]) == 3
+        # Each line item should have required fields
+        item = data["line_items"][0]
+        assert "id" in item
+        assert "provider" in item
+        assert "model" in item
+        assert "tokens_in" in item
+        assert "tokens_out" in item
+        assert "cost_usd" in item
+        assert "latency_ms" in item
+
+    @pytest.mark.asyncio
+    async def test_line_items_sort_by_cost(self, handler, mock_request):
+        """Line items can be sorted by cost."""
+        usages = [
+            _make_usage(usage_id="u1", cost_usd="0.010"),
+            _make_usage(usage_id="u2", cost_usd="0.050"),
+            _make_usage(usage_id="u3", cost_usd="0.030"),
+        ]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+        mock_request.query = {"sort_by": "cost", "order": "desc"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        items = body["data"]["line_items"]
+        assert items[0]["cost_usd"] >= items[1]["cost_usd"] >= items[2]["cost_usd"]
+
+    @pytest.mark.asyncio
+    async def test_line_items_pagination(self, handler, mock_request):
+        """Line items support limit/offset pagination."""
+        usages = [_make_usage(usage_id=f"u{i}") for i in range(10)]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+        mock_request.query = {"limit": "3", "offset": "2"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["total_count"] == 10
+        assert data["returned_count"] == 3
+        assert data["offset"] == 2
+        assert data["limit"] == 3
+
+    @pytest.mark.asyncio
+    async def test_line_items_invalid_sort(self, handler, mock_request):
+        """Returns 400 for invalid sort_by parameter."""
+        mock_request.match_info = {"debate_id": "debate_123"}
+        mock_request.query = {"sort_by": "invalid"}
+        tracker = _make_tracker()
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_line_items_invalid_order(self, handler, mock_request):
+        """Returns 400 for invalid order parameter."""
+        mock_request.match_info = {"debate_id": "debate_123"}
+        mock_request.query = {"order": "invalid"}
+        tracker = _make_tracker()
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_line_items_no_tracker(self, handler, mock_request):
+        """Returns 503 when tracker is unavailable."""
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=None):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 503
+
+    @pytest.mark.asyncio
+    async def test_line_items_empty(self, handler, mock_request):
+        """Returns empty list when debate has no usage."""
+        tracker = _make_tracker(usage_items=[])
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["data"]["line_items"] == []
+        assert body["data"]["total_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_line_items_filters_by_debate(self, handler, mock_request):
+        """Only returns items matching the requested debate_id."""
+        usages = [
+            _make_usage(usage_id="u1", debate_id="debate_123"),
+            _make_usage(usage_id="u2", debate_id="other_debate"),
+            _make_usage(usage_id="u3", debate_id="debate_123"),
+        ]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_line_items(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["data"]["total_count"] == 2
+
+
+# ===========================================================================
+# Performance tests
+# ===========================================================================
+
+
+class TestDebatePerformance:
+    """Tests for GET /api/v1/costs/debates/{debate_id}/performance."""
+
+    @pytest.mark.asyncio
+    async def test_performance_success(self, handler, mock_request):
+        """Returns performance metrics for a debate."""
+        base = datetime.now(timezone.utc)
+        usages = [
+            _make_usage(
+                usage_id="u1",
+                cost_usd="0.025",
+                latency_ms=300.0,
+                tokens_in=1000,
+                tokens_out=500,
+                operation="proposal",
+                timestamp=base,
+            ),
+            _make_usage(
+                usage_id="u2",
+                cost_usd="0.015",
+                latency_ms=200.0,
+                tokens_in=800,
+                tokens_out=400,
+                operation="critique",
+                timestamp=base + timedelta(seconds=30),
+            ),
+            _make_usage(
+                usage_id="u3",
+                cost_usd="0.035",
+                latency_ms=500.0,
+                tokens_in=1200,
+                tokens_out=600,
+                operation="proposal",
+                timestamp=base + timedelta(seconds=60),
+            ),
+        ]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+
+        assert data["debate_id"] == "debate_123"
+        assert data["api_calls"] == 3
+        assert data["total_tokens"] == (1000 + 500 + 800 + 400 + 1200 + 600)
+
+        # Latency metrics
+        lat = data["latency"]
+        assert lat["min_ms"] == 200.0
+        assert lat["max_ms"] == 500.0
+        assert lat["avg_ms"] == pytest.approx(333.33, rel=0.01)
+
+        # Cost efficiency
+        eff = data["cost_efficiency"]
+        assert eff["cost_per_call_usd"] == pytest.approx(0.025, rel=0.01)
+        assert eff["avg_tokens_per_call"] > 0
+
+        # Per-operation breakdown
+        assert len(data["by_operation"]) == 2
+        ops = {op["operation"]: op for op in data["by_operation"]}
+        assert ops["proposal"]["calls"] == 2
+        assert ops["critique"]["calls"] == 1
+
+        # Time range
+        assert data["time_range"]["start"] is not None
+        assert data["time_range"]["end"] is not None
+
+        # Duration
+        assert data["duration_seconds"] == pytest.approx(60.0, rel=0.1)
+
+    @pytest.mark.asyncio
+    async def test_performance_no_data(self, handler, mock_request):
+        """Returns message when no usage data exists."""
+        tracker = _make_tracker(usage_items=[])
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["api_calls"] == 0
+        assert "message" in data
+
+    @pytest.mark.asyncio
+    async def test_performance_no_tracker(self, handler, mock_request):
+        """Returns 503 when tracker is unavailable."""
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=None):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 503
+
+    @pytest.mark.asyncio
+    async def test_performance_missing_debate_id(self, handler, mock_request):
+        """Returns 400 when debate_id is empty."""
+        mock_request.match_info = {"debate_id": ""}
+
+        with patch(
+            "aragora.server.handlers.costs.models._get_cost_tracker",
+            return_value=_make_tracker(),
+        ):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 400
+
+    @pytest.mark.asyncio
+    async def test_performance_throughput(self, handler, mock_request):
+        """Throughput metrics are computed correctly."""
+        base = datetime.now(timezone.utc)
+        # 6 calls over 2 minutes = 3 calls/min
+        usages = [
+            _make_usage(
+                usage_id=f"u{i}",
+                tokens_in=100,
+                tokens_out=50,
+                latency_ms=100.0,
+                timestamp=base + timedelta(seconds=i * 20),
+            )
+            for i in range(6)
+        ]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        tp = body["data"]["throughput"]
+        # 100 seconds duration, 6 calls = 3.6 calls/min
+        assert tp["calls_per_minute"] > 0
+        assert tp["tokens_per_minute"] > 0
+
+    @pytest.mark.asyncio
+    async def test_performance_single_call(self, handler, mock_request):
+        """Performance works with a single API call (duration=0)."""
+        usages = [_make_usage(usage_id="u1")]
+        tracker = _make_tracker(usage_items=usages)
+        mock_request.match_info = {"debate_id": "debate_123"}
+
+        with patch("aragora.server.handlers.costs.models._get_cost_tracker", return_value=tracker):
+            response = await handler.handle_get_debate_performance(mock_request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = body["data"]
+        assert data["api_calls"] == 1
+        assert data["duration_seconds"] == 0
+        assert data["throughput"]["calls_per_minute"] == 0
+
+
+# ===========================================================================
+# Route registration tests
+# ===========================================================================
+
+
+class TestDebateCostRoutes:
+    """Tests for route registration of debate cost endpoints."""
+
+    def test_routes_registered(self):
+        """All debate cost routes are in the ROUTES list."""
+        routes = CostHandler.ROUTES
+        assert "/api/v1/costs/debates/*" in routes
+        assert "/api/v1/costs/debates/*/line-items" in routes
+        assert "/api/v1/costs/debates/*/performance" in routes
+        assert "/api/costs/debates/*" in routes
+        assert "/api/costs/debates/*/line-items" in routes
+        assert "/api/costs/debates/*/performance" in routes
+
+    def test_can_handle_debate_paths(self):
+        """CostHandler.can_handle returns True for debate cost paths."""
+        handler = CostHandler()
+        assert handler.can_handle("/api/v1/costs/debates/abc123")
+        assert handler.can_handle("/api/v1/costs/debates/abc123/line-items")
+        assert handler.can_handle("/api/v1/costs/debates/abc123/performance")
+        assert handler.can_handle("/api/costs/debates/abc123")
+
+    def test_resolve_registry_target(self):
+        """Dynamic route resolution maps debate paths to correct handlers."""
+        resolved = CostHandler._resolve_registry_target("/api/v1/costs/debates/abc123", "GET")
+        assert resolved is not None
+        handler_name, params = resolved
+        assert handler_name == "handle_get_debate_costs"
+        assert params["debate_id"] == "abc123"
+
+        resolved = CostHandler._resolve_registry_target(
+            "/api/v1/costs/debates/abc123/line-items", "GET"
+        )
+        assert resolved is not None
+        handler_name, params = resolved
+        assert handler_name == "handle_get_debate_line_items"
+        assert params["debate_id"] == "abc123"
+
+        resolved = CostHandler._resolve_registry_target(
+            "/api/v1/costs/debates/abc123/performance", "GET"
+        )
+        assert resolved is not None
+        handler_name, params = resolved
+        assert handler_name == "handle_get_debate_performance"
+        assert params["debate_id"] == "abc123"


### PR DESCRIPTION
Implements three new endpoints for per-debate cost visibility:
- GET /api/v1/costs/debates/{debate_id} — cost summary with per-agent and per-model breakdowns
- GET /api/v1/costs/debates/{debate_id}/line-items — individual API call line items with sorting and pagination
- GET /api/v1/costs/debates/{debate_id}/performance — latency percentiles, throughput, cost efficiency, per-operation breakdown

All endpoints support both v1 canonical and legacy path prefixes.
Includes 22 tests covering success, validation, pagination, sorting, empty data, and error cases.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
