### PR TITLE
feat(swarm): verify and route local runners by live probe

### DIFF
--- a/aragora/cli/commands/build.py
+++ b/aragora/cli/commands/build.py
@@ -608,7 +608,13 @@ def _dispatch_owner_binding(*, repo: str) -> dict[str, str]:
 
 
 def _preflight_boss_routing(*, repo: str, worker_model: str) -> dict[str, Any]:
-    from aragora.swarm.runner_registry import LocalRunnerRegistry, authorization_context_from_env
+    from aragora.swarm.runner_registry import (
+        LocalRunnerRegistry,
+        authorization_context_from_env,
+        prioritized_probe_candidates,
+        probe_runner_execution,
+        refresh_discovered_runners,
+    )
 
     owner_binding = _dispatch_owner_binding(repo=repo)
     env = {
@@ -616,18 +622,82 @@ def _preflight_boss_routing(*, repo: str, worker_model: str) -> dict[str, Any]:
         "ARAGORA_USER_ID": owner_binding["user_id"],
         "ARAGORA_WORKSPACE_ID": owner_binding["workspace_id"],
     }
-    routing = (
-        LocalRunnerRegistry()
-        .resolve_boss_routing(
-            owner_context=authorization_context_from_env(env),
-            requested_runner_type=worker_model,
-        )
-        .to_dict()
+    owner_context = authorization_context_from_env(env)
+    registry = LocalRunnerRegistry()
+    discovered = refresh_discovered_runners(
+        worker_model,
+        registry=registry,
+        owner_context=owner_context,
+        env=env,
+        repo_root=Path.cwd(),
     )
+    routing = registry.resolve_boss_routing(
+        owner_context=owner_context,
+        requested_runner_type=worker_model,
+    ).to_dict()
+    probe_summary = {
+        "auto_probe_triggered": False,
+        "attempted": 0,
+        "passed": 0,
+        "failed": 0,
+        "verified_target": 0,
+        "results": [],
+    }
+    if worker_model == "claude":
+        try:
+            verified_target = max(
+                1,
+                int(str(os.environ.get("ARAGORA_BUILD_VERIFIED_RUNNER_TARGET", "3") or "3")),
+            )
+        except ValueError:
+            verified_target = 3
+        try:
+            probe_limit = max(
+                1,
+                int(str(os.environ.get("ARAGORA_BUILD_RUNNER_PROBE_LIMIT", "2") or "2")),
+            )
+        except ValueError:
+            probe_limit = 2
+        selected = [item for item in routing.get("selected_runners", []) if isinstance(item, dict)]
+        selected_verified = len(
+            [item for item in selected if str(item.get("probe_status", "")).strip() == "passed"]
+        )
+        probe_summary["verified_target"] = verified_target
+        if selected_verified < verified_target:
+            candidates = prioritized_probe_candidates(
+                registry=registry,
+                runner_type=worker_model,
+                discovered_inspections=discovered,
+                owner_context=owner_context,
+                selected_runners=selected,
+            )
+            for inspection in candidates[:probe_limit]:
+                probe = probe_runner_execution(
+                    inspection,
+                    repo_root=Path.cwd(),
+                )
+                registry.record_probe(
+                    inspection,
+                    probe,
+                    owner_context=owner_context,
+                )
+                probe_summary["results"].append(probe.to_dict())
+                probe_summary["attempted"] += 1
+                if probe.status == "passed":
+                    probe_summary["passed"] += 1
+                elif probe.status == "failed":
+                    probe_summary["failed"] += 1
+            if probe_summary["attempted"]:
+                probe_summary["auto_probe_triggered"] = True
+                routing = registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=worker_model,
+                ).to_dict()
     return {
         "owner_binding": owner_binding,
         "blocked": bool(routing.get("blocked_reason")),
         "routing": routing,
+        "probe": probe_summary,
     }
 
 

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -100,10 +100,13 @@ def _build_runner_report_payload(
     by_type: dict[str, dict[str, int]] = {}
     by_cost: dict[str, int] = {}
     fresh_count = 0
+    probe_failed = 0
+    execution_verified = 0
     for item in registrations:
         runner_type = str(item.get("runner_type", "") or "").strip() or "unknown"
         cost_class = str(item.get("cost_class", "") or "").strip() or "local"
         freshness = str(item.get("freshness_status", "") or "").strip() or "unknown"
+        probe_status = str(item.get("probe_status", "") or "").strip() or None
         capabilities = dict(item.get("capabilities") or {})
         max_parallel = int(capabilities.get("max_parallel_lanes") or 1)
         claimed_lanes = int(item.get("claimed_lanes") or 0)
@@ -112,13 +115,28 @@ def _build_runner_report_payload(
         available_capacity = max(0, max_parallel - active_lanes)
         if freshness == "fresh":
             fresh_count += 1
+        if probe_status == "passed":
+            execution_verified += 1
+        elif probe_status == "failed":
+            probe_failed += 1
         by_type.setdefault(
             runner_type,
-            {"registered": 0, "fresh": 0, "active_lanes": 0, "available_capacity": 0},
+            {
+                "registered": 0,
+                "fresh": 0,
+                "execution_verified": 0,
+                "probe_failed": 0,
+                "active_lanes": 0,
+                "available_capacity": 0,
+            },
         )
         by_type[runner_type]["registered"] += 1
         if freshness == "fresh":
             by_type[runner_type]["fresh"] += 1
+        if probe_status == "passed":
+            by_type[runner_type]["execution_verified"] += 1
+        elif probe_status == "failed":
+            by_type[runner_type]["probe_failed"] += 1
         by_type[runner_type]["active_lanes"] += active_lanes
         by_type[runner_type]["available_capacity"] += available_capacity
         by_cost[cost_class] = by_cost.get(cost_class, 0) + 1
@@ -128,6 +146,7 @@ def _build_runner_report_payload(
                 "runner_type": runner_type,
                 "freshness_status": freshness,
                 "cost_class": cost_class,
+                "probe_status": probe_status,
                 "active_lanes": active_lanes,
                 "available_capacity": available_capacity,
             }
@@ -142,15 +161,25 @@ def _build_runner_report_payload(
         for key, value in sorted(by_cost.items(), key=lambda item: item[0])
     ]
     discovered_rows = [dict(item) for item in discovered or [] if isinstance(item, dict)]
+    selected_runners = [
+        item for item in routing.get("selected_runners", []) if isinstance(item, dict)
+    ]
     return {
         "mode": "runner",
         "action": "report",
         "summary": {
             "registered": len(registrations),
             "fresh": fresh_count,
+            "execution_verified": execution_verified,
+            "probe_failed": probe_failed,
             "discovered": len(discovered_rows),
-            "selected_for_routing": len(
-                [item for item in routing.get("selected_runners", []) if isinstance(item, dict)]
+            "selected_for_routing": len(selected_runners),
+            "selected_verified": len(
+                [
+                    item
+                    for item in selected_runners
+                    if str(item.get("probe_status", "")).strip() == "passed"
+                ]
             ),
         },
         "by_runner_type": type_rows,
@@ -643,6 +672,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             LocalRunnerRegistry,
             authorization_context_from_env,
             discover_runner_inspections,
+            refresh_discovered_runners,
         )
 
         subaction = str(goal or "inspect").strip().lower()
@@ -658,12 +688,13 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             ).strip()
             or "codex"
         )
-        inspections = discover_runner_inspections(
-            runner_type,
-            env=os.environ,
-            repo_root=Path.cwd(),
-        )
+        inspections: list[object] = []
         if subaction == "register":
+            inspections = discover_runner_inspections(
+                runner_type,
+                env=os.environ,
+                repo_root=Path.cwd(),
+            )
             owner_context = authorization_context_from_env()
             payloads = [
                 LocalRunnerRegistry()
@@ -680,6 +711,11 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 else _build_multi_runner_payload(subaction=subaction, runners=payloads)
             )
         elif subaction == "heartbeat":
+            inspections = discover_runner_inspections(
+                runner_type,
+                env=os.environ,
+                repo_root=Path.cwd(),
+            )
             owner_context = authorization_context_from_env()
             payloads = [
                 LocalRunnerRegistry()
@@ -696,11 +732,27 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 else _build_multi_runner_payload(subaction=subaction, runners=payloads)
             )
         elif subaction == "report":
+            owner_context = authorization_context_from_env()
             registry = LocalRunnerRegistry()
+            inspections = (
+                refresh_discovered_runners(
+                    runner_type,
+                    registry=registry,
+                    owner_context=owner_context,
+                    env=os.environ,
+                    repo_root=Path.cwd(),
+                )
+                if owner_context is not None
+                else discover_runner_inspections(
+                    runner_type,
+                    env=os.environ,
+                    repo_root=Path.cwd(),
+                )
+            )
             payload = _build_runner_report_payload(
                 registrations=registry.list_registrations(),
                 routing=registry.resolve_boss_routing(
-                    owner_context=authorization_context_from_env(),
+                    owner_context=owner_context,
                     requested_runner_type=runner_type,
                     allowed_profiles=allowed_runner_profiles,
                     rotation_interval_seconds=runner_rotation_interval,
@@ -708,6 +760,11 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 discovered=[item.to_dict() for item in inspections],
             )
         else:
+            inspections = discover_runner_inspections(
+                runner_type,
+                env=os.environ,
+                repo_root=Path.cwd(),
+            )
             inspection_payloads = [item.to_dict() for item in inspections]
             payload = (
                 inspection_payloads[0]

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -278,6 +278,46 @@ def _build_multi_runner_payload(
     }
 
 
+def _build_runner_probe_payload(
+    *,
+    subaction: str,
+    runners: list[dict[str, object]],
+    discovered: list[dict[str, object]],
+    routing_before: dict[str, object] | None = None,
+    routing_after: dict[str, object] | None = None,
+) -> dict[str, object]:
+    attempted = len(runners)
+    passed = len(
+        [item for item in runners if str(item.get("probe_status", "")).strip() == "passed"]
+    )
+    failed = len(
+        [item for item in runners if str(item.get("probe_status", "")).strip() == "failed"]
+    )
+    payload: dict[str, object] = {
+        "mode": "runner",
+        "action": subaction,
+        "summary": {
+            "discovered": len(discovered),
+            "attempted": attempted,
+            "passed": passed,
+            "failed": failed,
+        },
+        "runners": runners,
+        "discovered_runners": discovered,
+    }
+    if routing_before is not None:
+        payload["routing_before"] = routing_before
+        payload["summary"]["selected_before"] = len(
+            [item for item in routing_before.get("selected_runners", []) if isinstance(item, dict)]
+        )
+    if routing_after is not None:
+        payload["routing_after"] = routing_after
+        payload["summary"]["selected_after"] = len(
+            [item for item in routing_after.get("selected_runners", []) if isinstance(item, dict)]
+        )
+    return payload
+
+
 def _render_tranche_queue_status(payload: dict[str, object]) -> None:
     print(
         "queue_id={queue_id} status={status} current_item_id={current_item_id}".format(
@@ -363,6 +403,14 @@ def _run_supervised_or_report(awaitable: object) -> object | None:
     except ValueError as exc:
         print(f"Error: {exc}")
         return None
+
+
+def _probe_limit_arg(args: argparse.Namespace, *, default: int = 1) -> int:
+    raw = getattr(args, "probe_limit", default)
+    try:
+        return max(1, int(raw or default))
+    except (TypeError, ValueError):
+        return default
 
 
 def _load_structured_object(source: str) -> dict[str, object]:
@@ -672,13 +720,16 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             LocalRunnerRegistry,
             authorization_context_from_env,
             discover_runner_inspections,
+            prioritized_probe_candidates,
+            probe_runner_execution,
             refresh_discovered_runners,
         )
 
         subaction = str(goal or "inspect").strip().lower()
-        if subaction not in {"inspect", "register", "heartbeat", "report"}:
+        if subaction not in {"inspect", "register", "heartbeat", "report", "probe", "maintain"}:
             print(
-                "Error: swarm runner action must be 'inspect', 'register', 'heartbeat', or 'report'"
+                "Error: swarm runner action must be 'inspect', 'register', 'heartbeat', "
+                "'report', 'probe', or 'maintain'"
             )
             return
 
@@ -689,6 +740,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             or "codex"
         )
         inspections: list[object] = []
+        probe_limit = _probe_limit_arg(args, default=1 if subaction == "maintain" else 2)
         if subaction == "register":
             inspections = discover_runner_inspections(
                 runner_type,
@@ -759,6 +811,129 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 ).to_dict(),
                 discovered=[item.to_dict() for item in inspections],
             )
+        elif subaction == "probe":
+            owner_context = authorization_context_from_env()
+            registry = LocalRunnerRegistry()
+            inspections = discover_runner_inspections(
+                runner_type,
+                env=os.environ,
+                repo_root=Path.cwd(),
+            )
+            routing_before = (
+                registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=runner_type,
+                    allowed_profiles=allowed_runner_profiles,
+                    rotation_interval_seconds=runner_rotation_interval,
+                ).to_dict()
+                if owner_context is not None
+                else None
+            )
+            probe_payloads: list[dict[str, object]] = []
+            for inspection in inspections[:probe_limit]:
+                probe = probe_runner_execution(
+                    inspection,
+                    repo_root=Path.cwd(),
+                )
+                probe_payloads.append(
+                    registry.record_probe(
+                        inspection,
+                        probe,
+                        owner_context=owner_context,
+                    )
+                )
+            routing_after = (
+                registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=runner_type,
+                    allowed_profiles=allowed_runner_profiles,
+                    rotation_interval_seconds=runner_rotation_interval,
+                ).to_dict()
+                if owner_context is not None
+                else None
+            )
+            payload = _build_runner_probe_payload(
+                subaction=subaction,
+                runners=probe_payloads,
+                discovered=[item.to_dict() for item in inspections],
+                routing_before=routing_before,
+                routing_after=routing_after,
+            )
+        elif subaction == "maintain":
+            owner_context = authorization_context_from_env()
+            registry = LocalRunnerRegistry()
+            inspections = (
+                refresh_discovered_runners(
+                    runner_type,
+                    registry=registry,
+                    owner_context=owner_context,
+                    env=os.environ,
+                    repo_root=Path.cwd(),
+                )
+                if owner_context is not None
+                else discover_runner_inspections(
+                    runner_type,
+                    env=os.environ,
+                    repo_root=Path.cwd(),
+                )
+            )
+            routing_before = (
+                registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=runner_type,
+                    allowed_profiles=allowed_runner_profiles,
+                    rotation_interval_seconds=runner_rotation_interval,
+                ).to_dict()
+                if owner_context is not None
+                else None
+            )
+            candidates = (
+                prioritized_probe_candidates(
+                    registry=registry,
+                    runner_type=runner_type,
+                    discovered_inspections=inspections,
+                    owner_context=owner_context,
+                    selected_runners=(
+                        list(routing_before.get("selected_runners", []))
+                        if isinstance(routing_before, dict)
+                        else None
+                    ),
+                )
+                if owner_context is not None
+                else list(inspections)
+            )
+            if not candidates:
+                candidates = list(inspections)
+            probe_payloads = []
+            for inspection in candidates[:probe_limit]:
+                probe = probe_runner_execution(
+                    inspection,
+                    repo_root=Path.cwd(),
+                )
+                probe_payloads.append(
+                    registry.record_probe(
+                        inspection,
+                        probe,
+                        owner_context=owner_context,
+                    )
+                )
+            routing_after = (
+                registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=runner_type,
+                    allowed_profiles=allowed_runner_profiles,
+                    rotation_interval_seconds=runner_rotation_interval,
+                ).to_dict()
+                if owner_context is not None
+                else None
+            )
+            payload = _build_runner_probe_payload(
+                subaction=subaction,
+                runners=probe_payloads,
+                discovered=[item.to_dict() for item in inspections],
+                routing_before=routing_before,
+                routing_after=routing_after,
+            )
         else:
             inspections = discover_runner_inspections(
                 runner_type,
@@ -779,6 +954,26 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         else:
             if subaction == "report":
                 _render_runner_report(payload)
+            elif subaction in {"probe", "maintain"}:
+                summary = (
+                    payload.get("summary", {}) if isinstance(payload.get("summary"), dict) else {}
+                )
+                print(
+                    "Runner {action} discovered={discovered} attempted={attempted} "
+                    "passed={passed} failed={failed}".format(
+                        action=subaction,
+                        discovered=summary.get("discovered", 0),
+                        attempted=summary.get("attempted", 0),
+                        passed=summary.get("passed", 0),
+                        failed=summary.get("failed", 0),
+                    )
+                )
+                print()
+                for item in [
+                    entry for entry in payload.get("runners", []) if isinstance(entry, dict)
+                ]:
+                    print(render_runner_registration_text(item))
+                    print()
             elif "runners" in payload:
                 summary = (
                     payload.get("summary", {}) if isinstance(payload.get("summary"), dict) else {}

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2524,6 +2524,12 @@ def _add_swarm_parser(subparsers) -> None:
         help="Seconds before a recently used runner profile becomes preferred again (default: 1800)",
     )
     swarm_parser.add_argument(
+        "--probe-limit",
+        type=int,
+        default=None,
+        help="Maximum runners to live-probe for 'swarm runner probe' or 'swarm runner maintain'",
+    )
+    swarm_parser.add_argument(
         "--allow-same-model-review",
         action="store_true",
         help="Allow worker and reviewer to use the same model for experiment runs",

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -383,6 +383,9 @@ def check_runner_freshness(
         authorization_context_from_env,
         configured_claude_runner_profiles,
         make_runner_inspector,
+        prioritized_probe_candidates,
+        probe_runner_execution,
+        refresh_discovered_runners,
     )
 
     now = datetime.now(UTC)
@@ -398,6 +401,15 @@ def check_runner_freshness(
         )
 
     registry = LocalRunnerRegistry(path=registry_path) if registry_path else LocalRunnerRegistry()
+    discovered: list[Any] = []
+    if requested_runner_type:
+        discovered = refresh_discovered_runners(
+            requested_runner_type,
+            registry=registry,
+            owner_context=owner_context,
+            env=env,
+            repo_root=Path.cwd(),
+        )
     allowed_profile_set = set(allowed_profiles or configured_claude_runner_profiles(env))
     routing = registry.resolve_boss_routing(
         owner_context=owner_context,
@@ -405,6 +417,67 @@ def check_runner_freshness(
         allowed_profiles=allowed_profile_set or None,
         rotation_interval_seconds=rotation_interval_seconds,
     )
+    probe_summary = {
+        "auto_probe_triggered": False,
+        "attempted": 0,
+        "passed": 0,
+        "failed": 0,
+        "verified_target": 0,
+        "results": [],
+    }
+    if requested_runner_type == "claude":
+        try:
+            verified_target = max(
+                1, int(str((env or os.environ).get("ARAGORA_BOSS_VERIFIED_RUNNER_TARGET", "2")))
+            )
+        except ValueError:
+            verified_target = 2
+        try:
+            probe_limit = max(
+                1, int(str((env or os.environ).get("ARAGORA_BOSS_RUNNER_PROBE_LIMIT", "1")))
+            )
+        except ValueError:
+            probe_limit = 1
+        selected_verified = len(
+            [
+                item
+                for item in routing.selected_runners
+                if isinstance(item, dict) and str(item.get("probe_status", "")).strip() == "passed"
+            ]
+        )
+        probe_summary["verified_target"] = verified_target
+        if selected_verified < verified_target:
+            candidates = prioritized_probe_candidates(
+                registry=registry,
+                runner_type=requested_runner_type,
+                discovered_inspections=discovered,
+                owner_context=owner_context,
+                selected_runners=routing.selected_runners,
+            )
+            for inspection in candidates[:probe_limit]:
+                probe = probe_runner_execution(
+                    inspection,
+                    repo_root=Path.cwd(),
+                )
+                registry.record_probe(
+                    inspection,
+                    probe,
+                    owner_context=owner_context,
+                )
+                probe_summary["results"].append(probe.to_dict())
+                probe_summary["attempted"] += 1
+                if probe.status == "passed":
+                    probe_summary["passed"] += 1
+                elif probe.status == "failed":
+                    probe_summary["failed"] += 1
+            if probe_summary["attempted"]:
+                probe_summary["auto_probe_triggered"] = True
+                routing = registry.resolve_boss_routing(
+                    owner_context=owner_context,
+                    requested_runner_type=requested_runner_type,
+                    allowed_profiles=allowed_profile_set or None,
+                    rotation_interval_seconds=rotation_interval_seconds,
+                )
 
     if routing.is_blocked:
         return RunnerFreshnessResult(
@@ -412,7 +485,7 @@ def check_runner_freshness(
             runner_ids=[],
             checked_at=checked_at,
             blocked_reason=routing.blocked_reason,
-            details={"routing": routing.to_dict()},
+            details={"routing": routing.to_dict(), "probe": probe_summary},
         )
 
     # Live re-inspection: is a selected CLI runner still responding?
@@ -437,6 +510,7 @@ def check_runner_freshness(
             blocked_reason="runner_not_responding",
             details={
                 "routing": routing.to_dict(),
+                "probe": probe_summary,
                 "live_inspections": live_inspections,
             },
         )
@@ -471,6 +545,8 @@ def check_runner_freshness(
             checked_at=checked_at,
             blocked_reason="all_runners_stale",
             details={
+                "routing": routing.to_dict(),
+                "probe": probe_summary,
                 "stale_ids": stale_ids,
                 "freshness_ttl_seconds": freshness_ttl_seconds,
             },
@@ -482,6 +558,7 @@ def check_runner_freshness(
         checked_at=checked_at,
         details={
             "routing": routing.to_dict(),
+            "probe": probe_summary,
             "live_runner_ids": live_runner_ids,
             "live_inspections": live_inspections,
         },

--- a/aragora/swarm/runner_registry.py
+++ b/aragora/swarm/runner_registry.py
@@ -20,6 +20,15 @@ UTC = timezone.utc
 VERIFIED_AUTH_MODES = {"chatgpt_login", "api_key", "subscription"}
 DEFAULT_RUNNER_STALE_AFTER_SECONDS = 3600
 DEFAULT_RUNNER_ROTATION_INTERVAL_SECONDS = 1800.0
+DEFAULT_RUNNER_PROBE_TTL_SECONDS = 3600
+RUNNER_PROBE_TOKEN = "ARAGORA_RUNNER_PROBE_OK"
+RUNNER_PROBE_FIELD_KEYS = (
+    "probe_status",
+    "probe_checked_at",
+    "probe_detail",
+    "probe_latency_seconds",
+    "probe_ttl_seconds",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +160,11 @@ class RunnerInspection:
     priority_weight: int = 0
     codex_path: str | None = None  # legacy compatibility for older callers/tests
     profile: str | None = None
+    probe_status: str | None = None
+    probe_checked_at: str | None = None
+    probe_detail: str | None = None
+    probe_latency_seconds: float | None = None
+    probe_ttl_seconds: int | None = None
 
     def __post_init__(self) -> None:
         if self.command_path is None and self.codex_path is not None:
@@ -185,10 +199,44 @@ class RunnerInspection:
             "cost_class": self.cost_class,
             "priority_weight": self.priority_weight,
             "profile": self.profile,
+            "probe_status": self.probe_status,
+            "probe_checked_at": self.probe_checked_at,
+            "probe_detail": self.probe_detail,
+            "probe_latency_seconds": self.probe_latency_seconds,
+            "probe_ttl_seconds": self.probe_ttl_seconds,
         }
 
 
 CodexRunnerInspection = RunnerInspection
+
+
+@dataclass(slots=True)
+class RunnerProbeResult:
+    runner_id: str
+    runner_type: str
+    status: str
+    checked_at: str
+    detail: str | None = None
+    latency_seconds: float | None = None
+    profile: str | None = None
+    ttl_seconds: int = DEFAULT_RUNNER_PROBE_TTL_SECONDS
+
+    def to_runner_fields(self) -> dict[str, Any]:
+        return {
+            "probe_status": self.status,
+            "probe_checked_at": self.checked_at,
+            "probe_detail": self.detail,
+            "probe_latency_seconds": self.latency_seconds,
+            "probe_ttl_seconds": self.ttl_seconds,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "runner_id": self.runner_id,
+            "runner_type": self.runner_type,
+            "profile": self.profile,
+            **self.to_runner_fields(),
+        }
 
 
 @dataclass(slots=True)
@@ -609,6 +657,282 @@ def discover_runner_inspections(
     ]
 
 
+def refresh_discovered_runners(
+    runner_type: str,
+    *,
+    registry: LocalRunnerRegistry,
+    owner_context: AuthorizationContext | None,
+    config: LaunchConfig | None = None,
+    env: dict[str, str] | None = None,
+    repo_root: str | Path | None = None,
+) -> list[RunnerInspection]:
+    if owner_context is None:
+        return []
+    inspections = discover_runner_inspections(
+        runner_type,
+        config=config,
+        env=env,
+        repo_root=repo_root,
+    )
+    for inspection in inspections:
+        registry.refresh(
+            inspection,
+            owner_context=owner_context,
+        )
+    return inspections
+
+
+def prioritized_probe_candidates(
+    *,
+    registry: LocalRunnerRegistry,
+    runner_type: str,
+    discovered_inspections: list[RunnerInspection],
+    owner_context: AuthorizationContext | None,
+    selected_runners: list[dict[str, Any]] | None = None,
+) -> list[RunnerInspection]:
+    inspection_by_id = {
+        _text(inspection.runner_id): inspection
+        for inspection in discovered_inspections
+        if _text(inspection.runner_id)
+    }
+    selected_ids = {
+        _text(item.get("runner_id"))
+        for item in selected_runners or []
+        if isinstance(item, dict) and _text(item.get("runner_id"))
+    }
+    registrations = [item for item in registry.list_registrations() if isinstance(item, dict)]
+    raw_failed_ids: list[str] = []
+    selected_unverified_ids: list[str] = []
+    other_unverified_ids: list[str] = []
+
+    def _append_unique(target: list[str], runner_id: object) -> None:
+        normalized = _text(runner_id)
+        if not normalized or normalized not in inspection_by_id:
+            return
+        if (
+            normalized in raw_failed_ids
+            or normalized in selected_unverified_ids
+            or normalized in other_unverified_ids
+        ):
+            return
+        target.append(normalized)
+
+    for item in registrations:
+        if _text(item.get("runner_type")) != runner_type:
+            continue
+        if owner_context is not None and not registry._is_owner_compatible(
+            item,
+            owner_context=owner_context,
+        ):
+            continue
+        runner_id = item.get("runner_id")
+        raw_probe_status = _text(item.get("probe_status")).lower()
+        live_probe_status = registry._probe_status(item)
+        if raw_probe_status == "failed":
+            _append_unique(raw_failed_ids, runner_id)
+            continue
+        if live_probe_status == "passed":
+            continue
+        if _text(runner_id) in selected_ids:
+            _append_unique(selected_unverified_ids, runner_id)
+        else:
+            _append_unique(other_unverified_ids, runner_id)
+
+    ordered_ids = [*raw_failed_ids, *selected_unverified_ids, *other_unverified_ids]
+    return [inspection_by_id[item] for item in ordered_ids]
+
+
+def probe_runner_execution(
+    inspection: RunnerInspection,
+    *,
+    repo_root: str | Path | None = None,
+    timeout_seconds: float = 30.0,
+) -> RunnerProbeResult:
+    checked_at = _utcnow()
+    ttl_seconds = DEFAULT_RUNNER_PROBE_TTL_SECONDS
+
+    if inspection.runner_type != "claude":
+        return RunnerProbeResult(
+            runner_id=inspection.runner_id,
+            runner_type=inspection.runner_type,
+            status="unsupported",
+            checked_at=checked_at,
+            detail="Active exec probe is currently implemented for Claude runners only.",
+            profile=inspection.profile,
+            ttl_seconds=ttl_seconds,
+        )
+
+    command = _probe_command_for_inspection(inspection, repo_root=repo_root)
+    if not command:
+        return RunnerProbeResult(
+            runner_id=inspection.runner_id,
+            runner_type=inspection.runner_type,
+            status="failed",
+            checked_at=checked_at,
+            detail="No runnable Claude probe command could be constructed for this runner.",
+            profile=inspection.profile,
+            ttl_seconds=ttl_seconds,
+        )
+
+    try:
+        started = datetime.now(UTC)
+        proc = subprocess.run(
+            command,
+            cwd=str(Path(repo_root or Path.cwd()).resolve()),
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        latency_seconds = max(0.0, (datetime.now(UTC) - started).total_seconds())
+    except subprocess.TimeoutExpired:
+        return RunnerProbeResult(
+            runner_id=inspection.runner_id,
+            runner_type=inspection.runner_type,
+            status="failed",
+            checked_at=checked_at,
+            detail=f"Probe timed out after {timeout_seconds:.0f}s.",
+            latency_seconds=timeout_seconds,
+            profile=inspection.profile,
+            ttl_seconds=ttl_seconds,
+        )
+    except (FileNotFoundError, OSError) as exc:
+        return RunnerProbeResult(
+            runner_id=inspection.runner_id,
+            runner_type=inspection.runner_type,
+            status="failed",
+            checked_at=checked_at,
+            detail=f"Probe launch failed: {exc}",
+            profile=inspection.profile,
+            ttl_seconds=ttl_seconds,
+        )
+
+    combined = "\n".join(part for part in (proc.stdout, proc.stderr) if part).strip()
+    if proc.returncode == 0 and RUNNER_PROBE_TOKEN in combined:
+        return RunnerProbeResult(
+            runner_id=inspection.runner_id,
+            runner_type=inspection.runner_type,
+            status="passed",
+            checked_at=checked_at,
+            detail="Live prompt probe succeeded.",
+            latency_seconds=latency_seconds,
+            profile=inspection.profile,
+            ttl_seconds=ttl_seconds,
+        )
+
+    return RunnerProbeResult(
+        runner_id=inspection.runner_id,
+        runner_type=inspection.runner_type,
+        status="failed",
+        checked_at=checked_at,
+        detail=_probe_failure_detail(combined, returncode=proc.returncode),
+        latency_seconds=latency_seconds,
+        profile=inspection.profile,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def _probe_command_for_inspection(
+    inspection: RunnerInspection,
+    *,
+    repo_root: str | Path | None = None,
+) -> list[str] | None:
+    prompt = f"Reply with exactly: {RUNNER_PROBE_TOKEN}"
+    if inspection.runner_type != "claude":
+        return None
+    if inspection.profile:
+        script = _text(inspection.command_path)
+        if not script:
+            candidate = (Path(repo_root or Path.cwd()) / "scripts" / "claude_profile.sh").resolve()
+            script = str(candidate) if candidate.exists() else ""
+        if not script:
+            return None
+        return [script, "exec", inspection.profile, "--", "claude", "-p", prompt]
+    command_path = _text(inspection.command_path) or "claude"
+    return [command_path, "-p", prompt]
+
+
+def _probe_failure_detail(text: str, *, returncode: int) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    for line in lines:
+        lowered = line.lower()
+        if any(
+            marker in lowered
+            for marker in ("authentication", "oauth", "expired", "401", "error", "failed")
+        ):
+            return f"Probe failed (exit {returncode}): {line[:240]}"
+    for line in lines:
+        if line.startswith("Using profile home:") or line.startswith("Command:"):
+            continue
+        return f"Probe failed (exit {returncode}): {line[:240]}"
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return f"Probe failed (exit {returncode}): {stripped[:240]}"
+    return f"Probe failed (exit {returncode})."
+
+
+def _probe_next_action(
+    inspection: RunnerInspection,
+    probe: RunnerProbeResult,
+) -> str | None:
+    runner_type = _text(getattr(inspection, "runner_type", ""))
+    profile = _text(getattr(inspection, "profile", "")) or None
+    command_path = _text(getattr(inspection, "command_path", ""))
+    if probe.status == "passed":
+        return "Runner execution probe passed. Boss-mode routing can prefer this runner."
+    if probe.status != "failed":
+        return None
+
+    detail = _text(probe.detail).lower()
+    if runner_type == "claude" and profile:
+        script = command_path
+        if not script:
+            candidate = (Path.cwd() / "scripts" / "claude_profile.sh").resolve()
+            if candidate.exists():
+                script = str(candidate)
+        if any(marker in detail for marker in ("oauth", "authenticate", "401", "expired")):
+            if script:
+                return f"Refresh the local Claude profile login: {script} login {profile}"
+            return f"Refresh the local Claude profile login for {profile}."
+        return (
+            "Re-probe this Claude profile after local inspection: "
+            f"ARAGORA_CLAUDE_RUNNER_PROFILES={profile} python3 -m aragora.cli.main "
+            "swarm runner probe --runner-type claude --json"
+        )
+    return "Re-run the local runner probe after fixing the underlying runner issue."
+
+
+def _inspection_payload(inspection: RunnerInspection) -> dict[str, Any]:
+    to_dict = getattr(inspection, "to_dict", None)
+    if callable(to_dict):
+        payload = to_dict()
+        if isinstance(payload, dict):
+            return dict(payload)
+    payload: dict[str, Any] = {}
+    for key in (
+        "runner_id",
+        "runner_type",
+        "profile",
+        "available",
+        "availability",
+        "auth_mode",
+        "command_path",
+        "codex_path",
+        "owner_binding",
+        "capabilities",
+        "cost_class",
+        "priority_weight",
+        "status_summary",
+        "freshness_status",
+        "stale_after_seconds",
+    ):
+        value = getattr(inspection, key, None)
+        if value is not None:
+            payload[key] = value
+    return payload
+
+
 class LocalRunnerRegistry:
     """Minimal local registry for user-owned CLI runners."""
 
@@ -655,15 +979,26 @@ class LocalRunnerRegistry:
         records = self._load()
         now = _utcnow()
         freshness_status = self._freshness_for_inspection(inspection)
-        entry = {
-            **inspection.to_dict(),
-            "owner_binding": owner_binding_from_context(owner_context),
-            "registered": True,
-            "registered_at": now,
-            "heartbeat_at": now,
-            "freshness_status": freshness_status,
-            "updated_at": now,
-        }
+        existing = next(
+            (
+                dict(item)
+                for item in records.get("registrations", [])
+                if isinstance(item, dict) and item.get("runner_id") == inspection.runner_id
+            ),
+            None,
+        )
+        entry = self._preserve_probe_fields(
+            existing,
+            {
+                **inspection.to_dict(),
+                "owner_binding": owner_binding_from_context(owner_context),
+                "registered": True,
+                "registered_at": now,
+                "heartbeat_at": now,
+                "freshness_status": freshness_status,
+                "updated_at": now,
+            },
+        )
         records["registrations"] = [
             item
             for item in records.get("registrations", [])
@@ -723,16 +1058,19 @@ class LocalRunnerRegistry:
         now = _utcnow()
         freshness_status = self._freshness_for_inspection(inspection)
         owner_binding = owner_binding_from_context(owner_context)
-        updated_entry = {
-            **existing,
-            **inspection.to_dict(),
-            "registered": True,
-            "owner_binding": owner_binding,
-            "registered_at": existing.get("registered_at"),
-            "heartbeat_at": now,
-            "freshness_status": freshness_status,
-            "updated_at": now,
-        }
+        updated_entry = self._preserve_probe_fields(
+            existing,
+            {
+                **existing,
+                **inspection.to_dict(),
+                "registered": True,
+                "owner_binding": owner_binding,
+                "registered_at": existing.get("registered_at"),
+                "heartbeat_at": now,
+                "freshness_status": freshness_status,
+                "updated_at": now,
+            },
+        )
         records["registrations"] = [
             updated_entry if item.get("runner_id") == inspection.runner_id else item
             for item in registrations
@@ -748,6 +1086,74 @@ class LocalRunnerRegistry:
             freshness_status, runner_type=inspection.runner_type
         )
         return inspection
+
+    def refresh(
+        self,
+        inspection: RunnerInspection,
+        *,
+        owner_context: AuthorizationContext | None,
+    ) -> RunnerInspection:
+        if owner_context is None:
+            inspection.registered = False
+            inspection.registry_path = str(self.path)
+            inspection.next_action = (
+                "Set `ARAGORA_USER_ID` and optional `ARAGORA_WORKSPACE_ID` before refreshing this "
+                "runner in the local registry."
+            )
+            return inspection
+        existing = next(
+            (
+                item
+                for item in self.list_registrations()
+                if _text(item.get("runner_id")) == _text(inspection.runner_id)
+                and self._is_owner_compatible(item, owner_context=owner_context)
+            ),
+            None,
+        )
+        if existing is None:
+            return self.register(inspection, owner_context=owner_context)
+        return self.heartbeat(inspection, owner_context=owner_context)
+
+    def record_probe(
+        self,
+        inspection: RunnerInspection,
+        probe: RunnerProbeResult,
+        *,
+        owner_context: AuthorizationContext | None,
+    ) -> dict[str, Any]:
+        runner_payload = {
+            **_inspection_payload(inspection),
+            **probe.to_runner_fields(),
+            "next_action": _probe_next_action(inspection, probe),
+        }
+        if owner_context is None:
+            return runner_payload
+
+        records = self._load()
+        registrations = [
+            dict(item) for item in records.get("registrations", []) if isinstance(item, dict)
+        ]
+        updated = False
+        for index, item in enumerate(registrations):
+            if item.get("runner_id") != inspection.runner_id:
+                continue
+            if not self._is_owner_compatible(item, owner_context=owner_context):
+                continue
+            registrations[index] = {
+                **item,
+                **probe.to_runner_fields(),
+                "next_action": _probe_next_action(inspection, probe) or item.get("next_action"),
+                "updated_at": _utcnow(),
+            }
+            runner_payload = dict(registrations[index])
+            updated = True
+            break
+
+        if updated:
+            records["registrations"] = registrations
+            self._save(records)
+
+        return runner_payload
 
     def list_registrations(self) -> list[dict[str, Any]]:
         return [
@@ -769,8 +1175,9 @@ class LocalRunnerRegistry:
         allowed_profile_set = {item for item in (allowed_profiles or set()) if _text(item)}
         selection_basis = (
             "registered=true, freshness_status=fresh, availability=available, auth_mode verified, "
-            "owner_binding compatible, capacity available, ordered by requested runner type, "
-            "priority_weight, cost preference, and rotation-aware profile balancing"
+            "owner_binding compatible, live probe healthy, capacity available, ordered by "
+            "requested runner type, probe health, priority_weight, cost preference, and "
+            "rotation-aware profile balancing"
         )
         if owner_context is None or not _text(owner_context.user_id):
             return BossRoutingDecision(
@@ -833,6 +1240,7 @@ class LocalRunnerRegistry:
         eligible.sort(
             key=lambda item: (
                 0 if requested and item["runner_type"] == requested else 1,
+                self._probe_rank(item.get("probe_status")),
                 -int(item.get("priority_weight", 0)),
                 self._cost_rank(_text(item.get("cost_class"))),
                 self._rotation_rank(
@@ -950,6 +1358,7 @@ class LocalRunnerRegistry:
         max_parallel = int(capabilities.get("max_parallel_lanes") or 1)
         claimed_lanes = _optional_int(runner.get("claimed_lanes"))
         active_lanes = self._effective_active_lanes(runner)
+        probe_status = self._probe_status(runner)
         return {
             "runner_id": _text(runner.get("runner_id")),
             "runner_type": _text(runner.get("runner_type")),
@@ -970,6 +1379,19 @@ class LocalRunnerRegistry:
             "available_capacity": max(0, max_parallel - active_lanes),
             "active_lanes": active_lanes,
             "command_path": _text(runner.get("command_path") or runner.get("codex_path")) or None,
+            "probe_status": probe_status,
+            "probe_checked_at": (
+                _text(runner.get("probe_checked_at")) or None if probe_status else None
+            ),
+            "probe_detail": _text(runner.get("probe_detail")) or None if probe_status else None,
+            "probe_latency_seconds": (
+                runner.get("probe_latency_seconds") if probe_status else None
+            ),
+            "probe_ttl_seconds": (
+                int(runner.get("probe_ttl_seconds") or DEFAULT_RUNNER_PROBE_TTL_SECONDS)
+                if probe_status
+                else None
+            ),
         }
 
     def _is_runner_eligible(
@@ -989,6 +1411,8 @@ class LocalRunnerRegistry:
         if self._freshness_status(runner) != "fresh":
             return False
         if not self._is_owner_compatible(runner, owner_context=owner_context):
+            return False
+        if self._probe_status(runner) == "failed":
             return False
         capabilities = dict(runner.get("capabilities") or {})
         max_parallel = int(capabilities.get("max_parallel_lanes") or 1)
@@ -1086,6 +1510,46 @@ class LocalRunnerRegistry:
         if age_seconds > stale_after_seconds:
             return "stale"
         return "fresh"
+
+    def _probe_status(self, runner: dict[str, Any]) -> str | None:
+        status = _text(runner.get("probe_status")).lower() or None
+        if not status:
+            return None
+        checked_at = _text(runner.get("probe_checked_at"))
+        if not checked_at:
+            return None
+        checked_dt = self._parse_timestamp(checked_at)
+        if checked_dt is None:
+            return None
+        if checked_dt.tzinfo is None:
+            checked_dt = checked_dt.replace(tzinfo=UTC)
+        ttl_seconds = int(runner.get("probe_ttl_seconds") or DEFAULT_RUNNER_PROBE_TTL_SECONDS)
+        age_seconds = max(0.0, (datetime.now(UTC) - checked_dt).total_seconds())
+        if age_seconds > ttl_seconds:
+            return None
+        return status
+
+    @staticmethod
+    def _probe_rank(status: Any) -> int:
+        normalized = _text(status).lower()
+        if normalized == "passed":
+            return 0
+        if normalized == "failed":
+            return 2
+        return 1
+
+    @staticmethod
+    def _preserve_probe_fields(
+        existing: dict[str, Any] | None,
+        updated: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not existing:
+            return updated
+        merged = dict(updated)
+        for key in RUNNER_PROBE_FIELD_KEYS:
+            if merged.get(key) is None and existing.get(key) is not None:
+                merged[key] = existing.get(key)
+        return merged
 
     @staticmethod
     def _heartbeat_next_action(freshness_status: str, *, runner_type: str) -> str:

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aragora.cli.commands.build import (
     _create_issues,
     _decompose_tasks,
+    _dispatch_owner_binding,
     _dispatch_to_boss_loop,
     _generate_spec,
     _preflight_boss_routing,
@@ -243,11 +244,70 @@ def test_preflight_boss_routing_uses_dispatch_owner_binding(monkeypatch) -> None
         "selected_runner_ids": ["claude-runner-1"],
     }
 
-    with patch("aragora.swarm.runner_registry.LocalRunnerRegistry", return_value=registry):
+    with (
+        patch("aragora.swarm.runner_registry.LocalRunnerRegistry", return_value=registry),
+        patch("aragora.swarm.runner_registry.refresh_discovered_runners", return_value=[]),
+    ):
         payload = _preflight_boss_routing(repo="synaptent/aragora", worker_model="claude")
 
     assert payload["blocked"] is False
     assert payload["owner_binding"] == {"user_id": "founder-1", "workspace_id": "workspace-9"}
+
+
+def test_preflight_boss_routing_probes_toward_verified_target(monkeypatch) -> None:
+    monkeypatch.setenv("ARAGORA_USER_ID", "founder-1")
+    monkeypatch.setenv("ARAGORA_WORKSPACE_ID", "workspace-9")
+    monkeypatch.setenv("ARAGORA_BUILD_VERIFIED_RUNNER_TARGET", "2")
+    monkeypatch.setenv("ARAGORA_BUILD_RUNNER_PROBE_LIMIT", "1")
+    registry = MagicMock()
+    inspection = SimpleNamespace(runner_id="claude-runner-2", profile="max-02")
+    probe = SimpleNamespace(
+        status="passed",
+        to_dict=lambda: {
+            "runner_id": "claude-runner-2",
+            "runner_type": "claude",
+            "probe_status": "passed",
+        },
+    )
+    registry.resolve_boss_routing.side_effect = [
+        SimpleNamespace(
+            to_dict=lambda: {
+                "blocked_reason": None,
+                "selected_runner_ids": ["claude-runner-1", "claude-runner-2"],
+                "selected_runners": [
+                    {"runner_id": "claude-runner-1", "probe_status": "passed"},
+                    {"runner_id": "claude-runner-2", "probe_status": None},
+                ],
+            }
+        ),
+        SimpleNamespace(
+            to_dict=lambda: {
+                "blocked_reason": None,
+                "selected_runner_ids": ["claude-runner-1", "claude-runner-2"],
+                "selected_runners": [
+                    {"runner_id": "claude-runner-1", "probe_status": "passed"},
+                    {"runner_id": "claude-runner-2", "probe_status": "passed"},
+                ],
+            }
+        ),
+    ]
+
+    with (
+        patch("aragora.swarm.runner_registry.LocalRunnerRegistry", return_value=registry),
+        patch(
+            "aragora.swarm.runner_registry.refresh_discovered_runners", return_value=[inspection]
+        ),
+        patch(
+            "aragora.swarm.runner_registry.prioritized_probe_candidates", return_value=[inspection]
+        ),
+        patch("aragora.swarm.runner_registry.probe_runner_execution", return_value=probe),
+    ):
+        payload = _preflight_boss_routing(repo="synaptent/aragora", worker_model="claude")
+
+    assert payload["blocked"] is False
+    assert payload["probe"]["auto_probe_triggered"] is True
+    assert payload["probe"]["attempted"] == 1
+    assert payload["probe"]["passed"] == 1
 
 
 def test_generate_spec_marks_unanswered_questions_as_needing_clarification() -> None:

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -167,12 +167,22 @@ class TestSwarmParser:
 
         parser = build_parser()
         args = parser.parse_args(
-            ["swarm", "runner", "register", "--runner-type", "claude", "--json"]
+            [
+                "swarm",
+                "runner",
+                "probe",
+                "--runner-type",
+                "claude",
+                "--probe-limit",
+                "2",
+                "--json",
+            ]
         )
         assert args.command == "swarm"
         assert args.swarm_action_or_goal == "runner"
-        assert args.swarm_goal == "register"
+        assert args.swarm_goal == "probe"
         assert args.runner_type == "claude"
+        assert args.probe_limit == 2
         assert args.json is True
 
     def test_swarm_boss_parser_accepts_issue_list(self):
@@ -1327,6 +1337,142 @@ class TestSwarmCommand:
         assert '"execution_verified": 1' in out
         assert '"discovered_runners": [' in out
         assert '"selected_runner_ids": [' in out
+
+    def test_cmd_swarm_runner_probe_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="runner",
+            swarm_goal="probe",
+            runner_type="claude",
+            probe_limit=1,
+            json=True,
+        )
+        inspection = SimpleNamespace(
+            runner_id="claude-runner-123",
+            profile="max-02",
+            to_dict=lambda: {
+                "runner_id": "claude-runner-123",
+                "runner_type": "claude",
+                "profile": "max-02",
+                "auth_mode": "subscription",
+                "availability": "available",
+            },
+        )
+        probe = SimpleNamespace(
+            status="passed",
+            to_runner_fields=lambda: {
+                "probe_status": "passed",
+                "probe_checked_at": "2026-03-09T12:05:00+00:00",
+                "probe_detail": "Live prompt probe succeeded.",
+                "probe_latency_seconds": 1.2,
+                "probe_ttl_seconds": 3600,
+            },
+        )
+
+        with (
+            patch("aragora.swarm.runner_registry.discover_runner_inspections") as discover,
+            patch("aragora.swarm.runner_registry.authorization_context_from_env") as auth_ctx,
+            patch("aragora.swarm.runner_registry.probe_runner_execution", return_value=probe),
+            patch("aragora.swarm.runner_registry.LocalRunnerRegistry") as registry_cls,
+        ):
+            discover.return_value = [inspection]
+            auth_ctx.return_value = object()
+            registry_cls.return_value.resolve_boss_routing.return_value = SimpleNamespace(
+                to_dict=lambda: {
+                    "selected_runners": [],
+                    "selected_runner_ids": [],
+                    "blocked_reason": None,
+                }
+            )
+            registry_cls.return_value.record_probe.return_value = {
+                "runner_id": "claude-runner-123",
+                "runner_type": "claude",
+                "profile": "max-02",
+                "probe_status": "passed",
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"action": "probe"' in out
+        assert '"attempted": 1' in out
+        assert '"passed": 1' in out
+        assert '"probe_status": "passed"' in out
+
+    def test_cmd_swarm_runner_maintain_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="runner",
+            swarm_goal="maintain",
+            runner_type="claude",
+            probe_limit=1,
+            json=True,
+        )
+        inspection = SimpleNamespace(
+            runner_id="claude-runner-123",
+            profile="max-02",
+            to_dict=lambda: {
+                "runner_id": "claude-runner-123",
+                "runner_type": "claude",
+                "profile": "max-02",
+                "auth_mode": "subscription",
+                "availability": "available",
+            },
+        )
+        probe = SimpleNamespace(
+            status="failed",
+            to_runner_fields=lambda: {
+                "probe_status": "failed",
+                "probe_checked_at": "2026-03-09T12:05:00+00:00",
+                "probe_detail": "Probe failed",
+                "probe_latency_seconds": 2.4,
+                "probe_ttl_seconds": 3600,
+            },
+        )
+        routing_before = SimpleNamespace(
+            to_dict=lambda: {
+                "selected_runners": [{"runner_id": "claude-runner-123"}],
+                "selected_runner_ids": ["claude-runner-123"],
+                "blocked_reason": None,
+            }
+        )
+        routing_after = SimpleNamespace(
+            to_dict=lambda: {
+                "selected_runners": [],
+                "selected_runner_ids": [],
+                "blocked_reason": "no_eligible_registered_runners",
+            }
+        )
+
+        with (
+            patch(
+                "aragora.swarm.runner_registry.refresh_discovered_runners",
+                return_value=[inspection],
+            ),
+            patch(
+                "aragora.swarm.runner_registry.prioritized_probe_candidates",
+                return_value=[inspection],
+            ),
+            patch("aragora.swarm.runner_registry.authorization_context_from_env") as auth_ctx,
+            patch("aragora.swarm.runner_registry.probe_runner_execution", return_value=probe),
+            patch("aragora.swarm.runner_registry.LocalRunnerRegistry") as registry_cls,
+        ):
+            auth_ctx.return_value = object()
+            registry_cls.return_value.resolve_boss_routing.side_effect = [
+                routing_before,
+                routing_after,
+            ]
+            registry_cls.return_value.record_probe.return_value = {
+                "runner_id": "claude-runner-123",
+                "runner_type": "claude",
+                "profile": "max-02",
+                "probe_status": "failed",
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"action": "maintain"' in out
+        assert '"attempted": 1' in out
+        assert '"failed": 1' in out
+        assert '"selected_before": 1' in out
+        assert '"selected_after": 0' in out
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1297,10 +1297,12 @@ class TestSwarmCommand:
 
         with (
             patch("aragora.swarm.runner_registry.discover_runner_inspections") as discover,
+            patch("aragora.swarm.runner_registry.refresh_discovered_runners") as refresh,
             patch("aragora.swarm.runner_registry.authorization_context_from_env") as auth_ctx,
             patch("aragora.swarm.runner_registry.LocalRunnerRegistry") as registry_cls,
         ):
             discover.return_value = [inspection]
+            refresh.return_value = [inspection]
             auth_ctx.return_value = object()
             registry_cls.return_value.list_registrations.return_value = [
                 {
@@ -1308,6 +1310,7 @@ class TestSwarmCommand:
                     "runner_type": "claude",
                     "cost_class": "subscription",
                     "freshness_status": "fresh",
+                    "probe_status": "passed",
                     "active_lanes": 1,
                     "capabilities": {"max_parallel_lanes": 3, "active_lanes": 1},
                 }
@@ -1320,6 +1323,8 @@ class TestSwarmCommand:
         assert '"mode": "runner"' in out
         assert '"runner_type": "claude"' in out
         assert '"cost_class": "subscription"' in out
+        assert '"selected_verified": 0' in out
+        assert '"execution_verified": 1' in out
         assert '"discovered_runners": [' in out
         assert '"selected_runner_ids": [' in out
 

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -501,6 +502,113 @@ class TestRunnerFreshness:
 
         assert result.fresh is True
         inspector_factory.assert_called_with("claude", env=ANY, profile="max-01")
+
+    def test_runner_freshness_probes_toward_verified_target(self, tmp_path, monkeypatch):
+        registry_path = tmp_path / "runners.json"
+        now = datetime.now(UTC).isoformat()
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "claude-runner-1",
+                            "runner_type": "claude",
+                            "profile": "max-01",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "owner_binding": {"user_id": "user-1", "workspace_id": "ws-1"},
+                            "capabilities": {"max_parallel_lanes": 1},
+                            "updated_at": now,
+                            "heartbeat_at": now,
+                            "freshness_status": "fresh",
+                            "probe_status": "passed",
+                            "probe_checked_at": now,
+                            "probe_ttl_seconds": 3600,
+                        },
+                        {
+                            "runner_id": "claude-runner-2",
+                            "runner_type": "claude",
+                            "profile": "max-02",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "owner_binding": {"user_id": "user-1", "workspace_id": "ws-1"},
+                            "capabilities": {"max_parallel_lanes": 1},
+                            "updated_at": now,
+                            "heartbeat_at": now,
+                            "freshness_status": "fresh",
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARAGORA_BOSS_VERIFIED_RUNNER_TARGET", "2")
+        monkeypatch.setenv("ARAGORA_BOSS_RUNNER_PROBE_LIMIT", "1")
+        inspection = SimpleNamespace(runner_id="claude-runner-2", profile="max-02")
+        probe = SimpleNamespace(
+            status="passed",
+            to_runner_fields=lambda: {
+                "probe_status": "passed",
+                "probe_checked_at": now,
+                "probe_detail": "Live prompt probe succeeded.",
+                "probe_latency_seconds": 1.0,
+                "probe_ttl_seconds": 3600,
+            },
+            to_dict=lambda: {
+                "runner_id": "claude-runner-2",
+                "runner_type": "claude",
+                "probe_status": "passed",
+            },
+        )
+
+        class _Inspector:
+            def __init__(self, runner_id: str) -> None:
+                self._runner_id = runner_id
+
+            def inspect(self) -> MagicMock:
+                inspected = MagicMock()
+                inspected.available = True
+                inspected.auth_mode = "subscription"
+                inspected.runner_id = self._runner_id
+                inspected.to_dict.return_value = {
+                    "runner_id": self._runner_id,
+                    "available": True,
+                    "auth_mode": "subscription",
+                }
+                return inspected
+
+        def _make_inspector(runner_type: str, *, env=None, profile=None):
+            runner_id = "claude-runner-1" if profile == "max-01" else "claude-runner-2"
+            return _Inspector(runner_id)
+
+        with (
+            patch(
+                "aragora.swarm.runner_registry.refresh_discovered_runners",
+                return_value=[inspection],
+            ),
+            patch(
+                "aragora.swarm.runner_registry.prioritized_probe_candidates",
+                return_value=[inspection],
+            ),
+            patch("aragora.swarm.runner_registry.probe_runner_execution", return_value=probe),
+            patch(
+                "aragora.swarm.runner_registry.make_runner_inspector", side_effect=_make_inspector
+            ),
+        ):
+            result = check_runner_freshness(
+                freshness_ttl_seconds=3600.0,
+                registry_path=str(registry_path),
+                env={"ARAGORA_USER_ID": "user-1", "ARAGORA_WORKSPACE_ID": "ws-1"},
+                requested_runner_type="claude",
+            )
+
+        assert result.fresh is True
+        assert result.details["probe"]["auto_probe_triggered"] is True
+        assert result.details["probe"]["passed"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_runner_registry.py
+++ b/tests/swarm/test_runner_registry.py
@@ -486,9 +486,9 @@ class TestLocalRunnerRegistry:
             owner_binding={"user_id": None, "workspace_id": None, "org_id": None},
             selection_basis=(
                 "registered=true, freshness_status=fresh, availability=available, auth_mode "
-                "verified, owner_binding compatible, capacity available, ordered by requested "
-                "runner type, priority_weight, cost preference, and rotation-aware profile "
-                "balancing"
+                "verified, owner_binding compatible, live probe healthy, capacity available, "
+                "ordered by requested runner type, probe health, priority_weight, cost "
+                "preference, and rotation-aware profile balancing"
             ),
             blocked_reason="missing_owner_context",
             next_action=(


### PR DESCRIPTION
## Summary
- add live Claude runner probe primitives to the local runner registry and persist probe state
- make build preflight, boss freshness, and runner reporting refresh/probe local runners before routing
- prefer execution-verified runners in routing and exclude recent failed probes from the eligible pool

## Validation
- `python3 -m pytest tests/cli/test_build_command.py tests/swarm/test_boss_loop.py tests/swarm/test_runner_registry.py tests/cli/test_swarm_command.py -q`
- `python3 -m ruff check aragora/cli/commands/build.py aragora/cli/commands/swarm.py aragora/swarm/boss_loop.py aragora/swarm/runner_registry.py tests/cli/test_build_command.py tests/cli/test_swarm_command.py tests/swarm/test_boss_loop.py tests/swarm/test_runner_registry.py`
- live smoke: `swarm runner report --runner-type claude --json` showed `selected_for_routing=11`
- live smoke: `_preflight_boss_routing(... worker_model='claude')` returned `blocked=false`, `selected=11`

## Notes
- live probing still surfaced one expired Claude profile (`max-01`), which is now excluded from routing until relogin
