### PR TITLE
fix(frontend): restore unified DAG type safety

### DIFF
--- a/aragora/live/src/components/command/NodeContextPanel.tsx
+++ b/aragora/live/src/components/command/NodeContextPanel.tsx
@@ -33,6 +33,16 @@ const STAGE_CONFIG: Record<DAGStage, { color: string; bg: string; border: string
       { label: 'Find Precedents', action: 'precedents', icon: '\uD83D\uDD0D' },
     ],
   },
+  principles: {
+    color: 'text-violet-400',
+    bg: 'bg-violet-500/10',
+    border: 'border-violet-500/30',
+    actions: [
+      { label: 'Debate This', action: 'debate', icon: '\u2694' },
+      { label: 'Validate', action: 'validate', icon: '\uD83D\uDEE1' },
+      { label: 'Find Precedents', action: 'precedents', icon: '\uD83D\uDD0D' },
+    ],
+  },
   goals: {
     color: 'text-emerald-400',
     bg: 'bg-emerald-500/10',

--- a/aragora/live/src/hooks/useUnifiedDAG.ts
+++ b/aragora/live/src/hooks/useUnifiedDAG.ts
@@ -436,7 +436,10 @@ function serverEdgeToReactFlow(
     target,
     type: crossStage ? 'crossStage' : String(edge.type ?? 'default'),
     label: edge.label ? String(edge.label) : edgeType || undefined,
-    animated: Boolean(edge.animated ?? crossStage || edgeType.toLowerCase() === 'similarity'),
+    animated: Boolean(
+      edge.animated
+      ?? (crossStage || edgeType.toLowerCase() === 'similarity'),
+    ),
     data: {
       edgeType,
       crossStage,


### PR DESCRIPTION
## Summary
- add the missing `principles` stage config in the command node context panel
- make unified DAG edge animation typing explicit so TypeScript accepts the expression

## Verification
- cd aragora/live && npm ci && npx tsc --noEmit
- cd aragora/live && npx jest --ci --runTestsByPath "src/hooks/__tests__/useUnifiedDAG.test.ts"
- cd aragora/live && npx eslint "src/components/command/NodeContextPanel.tsx" "src/hooks/useUnifiedDAG.ts"