### PR TITLE
feat(build): carry initiative issue linkage into queued tasks

### DIFF
--- a/aragora/cli/commands/build.py
+++ b/aragora/cli/commands/build.py
@@ -194,11 +194,29 @@ async def _run_build_pipeline(
 
     # Stage 3: Create GitHub issues
     _progress(emit_progress, "\n[3/5] Creating GitHub issues...")
-    issues = await _create_issues(tasks, repo=repo_name)
-    result["stages"]["issues"] = issues
-    _progress(emit_progress, f"  ✓ {len(issues)} issues created")
+    initiative_issue: dict[str, Any] | None = None
+    try:
+        from aragora.cli.commands.idea import _create_intake_issue
 
-    if not issues:
+        initiative_issue = await _create_intake_issue(result["stages"]["brief"], repo=repo_name)
+    except Exception as exc:
+        logger.warning("Initiative issue creation failed: %s", exc)
+    if initiative_issue is not None:
+        result["stages"]["initiative_issue"] = initiative_issue
+
+    issues_raw = await _create_issues(tasks, repo=repo_name, initiative_issue=initiative_issue)
+    if issues_raw and isinstance(issues_raw[0], int):
+        issue_numbers = [int(item) for item in issues_raw]
+        issues = [{"number": int(item)} for item in issues_raw]
+    else:
+        issues = [dict(item) for item in issues_raw if isinstance(item, dict)]
+        issue_numbers = [
+            int(item["number"]) for item in issues if str(item.get("number", "")).strip()
+        ]
+    result["stages"]["issues"] = issues
+    _progress(emit_progress, f"  ✓ {len(issue_numbers)} issues created")
+
+    if not issue_numbers:
         result["status"] = "issue_creation_failed"
         result["elapsed_seconds"] = time.monotonic() - start
         return result
@@ -217,7 +235,7 @@ async def _run_build_pipeline(
     # Stage 4: Dispatch to boss loop
     _progress(emit_progress, f"\n[4/5] Dispatching to boss loop (--autonomy {autonomy_mode})...")
     dispatch_result = await _dispatch_to_boss_loop(
-        issues,
+        issue_numbers,
         repo=repo_name,
         worker_model=worker_model,
         review_model=review_model,
@@ -230,7 +248,7 @@ async def _run_build_pipeline(
     result["status"] = "dispatched"
     result["elapsed_seconds"] = time.monotonic() - start
     _progress(emit_progress, "\n[5/5] Pipeline complete!")
-    _progress(emit_progress, f"  Issues: {', '.join(f'#{i}' for i in issues)}")
+    _progress(emit_progress, f"  Issues: {', '.join(f'#{i}' for i in issue_numbers)}")
     _progress(
         emit_progress,
         f"  Monitor: tail -f {dispatch_result.get('log', '.aragora/overnight/code-improvements.log')}",
@@ -461,17 +479,28 @@ def _string_list(value: Any) -> list[str]:
     return []
 
 
-async def _create_issues(tasks: list[dict[str, Any]], *, repo: str) -> list[int]:
+async def _create_issues(
+    tasks: list[dict[str, Any]],
+    *,
+    repo: str,
+    initiative_issue: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     """Create GitHub issues for each task."""
     from aragora.cli.commands.idea import _create_issue_with_optional_labels
 
-    issue_numbers = []
+    created_issues: list[dict[str, Any]] = []
     for task in tasks:
         labels = [
             "boss-ready",
             *[str(item).strip() for item in task.get("labels", []) if str(item).strip()],
         ]
         deduped_labels = list(dict.fromkeys(labels))
+        initiative_line = "- Initiative issue: none"
+        if isinstance(initiative_issue, dict) and initiative_issue.get("number"):
+            initiative_line = (
+                f"- Initiative issue: #{initiative_issue.get('number')} "
+                f"{initiative_issue.get('url', '')}".strip()
+            )
         body = f"""## Initiative Brief
 - User goal: {task.get("user_goal", "")[:200]}
 - Desired outcome: {task.get("desired_outcome", "")[:200]}
@@ -480,6 +509,7 @@ async def _create_issues(tasks: list[dict[str, Any]], *, repo: str) -> list[int]
 - Proof/evidence expected: {task.get("proof_expected", "")[:200]}
 - Clarification completeness: {task.get("clarification_status", "draft")}
 - Open questions: {", ".join(task.get("open_questions", [])) or "none"}
+{initiative_line}
 
 ## Queue Metadata
 - Risk: {task.get("risk", "medium")}
@@ -512,13 +542,20 @@ Implementation complete, tests pass, PR opened with evidence.
                 body=body,
                 requested_labels=deduped_labels,
             )
-            num = int(issue["number"])
-            issue_numbers.append(num)
+            issue_record = {
+                **issue,
+                "title": task["title"],
+                "initiative_issue_number": initiative_issue.get("number")
+                if isinstance(initiative_issue, dict)
+                else None,
+            }
+            num = int(issue_record["number"])
+            created_issues.append(issue_record)
             logger.info("Created issue #%d: %s", num, task["title"])
         except Exception as exc:
             logger.warning("Issue creation failed: %s", exc)
 
-    return issue_numbers
+    return created_issues
 
 
 async def _dispatch_to_boss_loop(

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -207,6 +207,104 @@ def test_run_build_pipeline_blocks_before_dispatch_when_routing_is_blocked() -> 
     dispatch.assert_not_awaited()
 
 
+def test_run_build_pipeline_preserves_rich_issue_records_and_dispatches_numbers() -> None:
+    with (
+        patch(
+            "aragora.cli.commands.build._generate_spec",
+            AsyncMock(return_value={"title": "Spec", "sections": [], "raw": "spec"}),
+        ),
+        patch(
+            "aragora.cli.commands.build._plan_reviewed_tasks",
+            AsyncMock(
+                return_value={
+                    "brief": {
+                        "title": "Ship thing",
+                        "clarification_completeness_status": "decision_complete",
+                    },
+                    "handoffs": [],
+                    "review": {
+                        "status": "approved",
+                        "summary": "",
+                        "findings": [],
+                        "followups": [],
+                    },
+                    "tasks": [
+                        {
+                            "title": "Task A",
+                            "description": "Implement thing",
+                            "acceptance_criteria": ["It works"],
+                            "verification": "pytest tests/a.py -q",
+                        }
+                    ],
+                }
+            ),
+        ),
+        patch(
+            "aragora.cli.commands.idea._create_intake_issue",
+            AsyncMock(
+                return_value={
+                    "number": 500,
+                    "url": "https://github.com/synaptent/aragora/issues/500",
+                }
+            ),
+        ),
+        patch(
+            "aragora.cli.commands.build._create_issues",
+            AsyncMock(
+                return_value=[
+                    {
+                        "number": 11,
+                        "url": "https://github.com/synaptent/aragora/issues/11",
+                        "title": "Task A",
+                        "initiative_issue_number": 500,
+                    }
+                ]
+            ),
+        ),
+        patch(
+            "aragora.cli.commands.build._preflight_boss_routing",
+            return_value={
+                "owner_binding": {"user_id": "armand", "workspace_id": "aragora"},
+                "blocked": False,
+                "routing": {"blocked_reason": None},
+            },
+        ),
+        patch(
+            "aragora.cli.commands.build._dispatch_to_boss_loop",
+            AsyncMock(return_value={"pid": 4242, "log": ".aragora/builds/run.log"}),
+        ) as dispatch,
+    ):
+        result = asyncio.run(
+            _run_build_pipeline(
+                idea="Ship thing",
+                dry_run=False,
+                skip_clarify=True,
+                repo="synaptent/aragora",
+                worker_model="claude",
+                review_model="codex",
+                emit_progress=False,
+            )
+        )
+
+    assert result["status"] == "dispatched"
+    assert result["stages"]["initiative_issue"]["number"] == 500
+    assert result["stages"]["issues"] == [
+        {
+            "number": 11,
+            "url": "https://github.com/synaptent/aragora/issues/11",
+            "title": "Task A",
+            "initiative_issue_number": 500,
+        }
+    ]
+    dispatch.assert_awaited_once_with(
+        [11],
+        repo="synaptent/aragora",
+        worker_model="claude",
+        review_model="codex",
+        autonomy_mode="full-auto",
+    )
+
+
 def test_generate_spec_reads_conductor_result() -> None:
     conductor_result = ConductorResult(
         specification=Specification(
@@ -408,12 +506,33 @@ def test_create_issues_includes_queue_metadata() -> None:
             }
         ),
     ) as create_issue:
-        issue_numbers = asyncio.run(_create_issues(tasks, repo="synaptent/aragora"))
+        issues = asyncio.run(
+            _create_issues(
+                tasks,
+                repo="synaptent/aragora",
+                initiative_issue={
+                    "number": 321,
+                    "url": "https://github.com/synaptent/aragora/issues/321",
+                },
+            )
+        )
 
-    assert issue_numbers == [999]
+    assert issues == [
+        {
+            "number": 999,
+            "url": "https://github.com/synaptent/aragora/issues/999",
+            "labels_requested": ["boss-ready", "review-followup", "risk:high"],
+            "labels_applied": ["boss-ready", "review-followup", "risk:high"],
+            "labels_ensured": [],
+            "fallback_reason": "",
+            "title": "Task A",
+            "initiative_issue_number": 321,
+        }
+    ]
     body = create_issue.await_args.kwargs["body"]
     assert "## Initiative Brief" in body
     assert "## Queue Metadata" in body
+    assert "Initiative issue: #321 https://github.com/synaptent/aragora/issues/321" in body
     assert "Preferred Worker Agent: claude" in body
     assert "Preferred Reviewer Agent: codex" in body
     assert "Open questions: Should this ship behind a flag?" in body


### PR DESCRIPTION
## Summary
- create the initiative issue before task issue creation in the build pipeline
- link each generated task issue back to that parent initiative and preserve rich issue metadata
- keep boss-loop dispatch scoped to numeric issue IDs with regression coverage

## Testing
- python3 -m pytest tests/cli/test_build_command.py tests/cli/test_idea_command.py -q
- python3 -m pytest tests/cli/test_idea_command.py tests/cli/test_build_command.py tests/swarm/test_boss_loop.py tests/swarm/test_runner_registry.py tests/cli/test_swarm_command.py -q
- python3 -m ruff check aragora/cli/commands/build.py tests/cli/test_build_command.py tests/cli/test_idea_command.py