### PR TITLE
fix(ci): pin production monitoring to hetzner runners

### DIFF
--- a/.github/workflows/production-monitor.yml
+++ b/.github/workflows/production-monitor.yml
@@ -18,7 +18,10 @@ env:
 jobs:
   production-health:
     name: Production Health Check
-    runs-on: aragora
+    # Pin production browser checks to the Ubuntu Hetzner pool. The generic
+    # `aragora` fleet also includes Amazon Linux hosts without apt-get, which
+    # breaks the current Playwright `--with-deps` bootstrap path.
+    runs-on: [self-hosted, Linux, X64, aragora, hetzner]
     timeout-minutes: 15
 
     steps:
@@ -97,7 +100,7 @@ jobs:
 
   production-auth:
     name: Production Auth Flow
-    runs-on: aragora
+    runs-on: [self-hosted, Linux, X64, aragora, hetzner]
     timeout-minutes: 15
     needs: production-health
 
@@ -183,7 +186,7 @@ jobs:
 
   production-full:
     name: Full Production Suite
-    runs-on: aragora
+    runs-on: [self-hosted, Linux, X64, aragora, hetzner]
     timeout-minutes: 30
     needs: production-auth
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
- pin the Production Monitoring workflow to the explicit Hetzner self-hosted pool
- avoid the mixed generic `aragora` runner pool that can land on Amazon Linux hosts without `apt-get`
- keep the existing Playwright bootstrap path intact on the Ubuntu runners we already proved

## Root cause
Production Monitoring failed on run `23679810388` because the generic `aragora` runner label landed the job on an Amazon Linux host. The workflow then skipped `playwright install --with-deps` and Chromium crashed at launch with missing shared libraries like `libatk-1.0.so.0`.

## Verification
- validated the workflow YAML parses
- confirmed the explicit `hetzner` label exists on the online Ubuntu self-hosted runners
- matched the failure log against the current runner inventory
