### PR TITLE
fix(ux): doctor crash + review error message

### DIFF
--- a/aragora/cli/doctor.py
+++ b/aragora/cli/doctor.py
@@ -17,8 +17,6 @@ import os
 import sys
 from pathlib import Path
 
-from aragora.exceptions import REDIS_CONNECTION_ERRORS
-
 
 def check_icon(ok: bool | None) -> str:
     """Return status icon."""
@@ -163,7 +161,7 @@ async def check_server() -> list[tuple[str, str, bool | None]]:
                     checks.append(
                         ("Server (localhost:8080)", f"unhealthy ({resp.status_code})", False)
                     )
-        except REDIS_CONNECTION_ERRORS:
+        except Exception:  # noqa: BLE001 — diagnostic tool must never crash
             checks.append(("Server (localhost:8080)", "not running", None))
     except ImportError:
         checks.append(("Server check", "http pool not available", None))
@@ -244,8 +242,8 @@ def main() -> int:
             print(f"  {check_icon(ok)} {name}: {status}")
             if ok is False:
                 all_ok = False
-    except (OSError, ConnectionError, RuntimeError) as e:
-        print(f"  {check_icon(None)} Server check: skipped ({e})")
+    except Exception as e:  # noqa: BLE001 — doctor must never crash
+        print(f"  {check_icon(None)} Server check: skipped ({type(e).__name__}: {e})")
 
     # Summary
     passed = sum(1 for _, _, ok in all_checks if ok is True)

--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -977,7 +977,11 @@ def cmd_review(args: argparse.Namespace) -> int:
         return 1
 
     if not diff.strip():
-        print("Error: Empty diff", file=sys.stderr)
+        print("Error: Empty diff — no changes to review.", file=sys.stderr)
+        print("  Make some code changes first, then run:", file=sys.stderr)
+        print("    aragora review                    # Review unstaged changes", file=sys.stderr)
+        print("    aragora review --diff-file d.patch # Review a diff file", file=sys.stderr)
+        print("    aragora review <PR-URL>           # Review a GitHub PR", file=sys.stderr)
         return 1
 
     # Determine which agents to use


### PR DESCRIPTION
Doctor no longer crashes when server isn't running. Review shows helpful usage examples instead of bare 'Empty diff'.