### PR TITLE
fix(cli): keep placeholder ideas out of the queue

### DIFF
--- a/aragora/cli/commands/build.py
+++ b/aragora/cli/commands/build.py
@@ -34,6 +34,11 @@ from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
 
+_PLACEHOLDER_TASK_TITLES = {
+    "untitled task",
+    "task",
+}
+
 
 def cmd_build(args: argparse.Namespace) -> None:
     """Turn a vague idea into executed, reviewed, merged code."""
@@ -162,11 +167,10 @@ async def _run_build_pipeline(
     if not tasks:
         _progress(
             emit_progress,
-            "  ! Founder review produced no queueable tasks, falling back to bounded task decomposition.",
+            "  ! Founder review produced no queueable tasks. Generating a preview only; no boss-ready issues will be created.",
         )
-        fallback_tasks = await _decompose_tasks(spec, max_tasks=max_tasks)
-        tasks = _annotate_tasks(
-            fallback_tasks,
+        result["stages"]["fallback_tasks"] = _annotate_tasks(
+            await _decompose_tasks(spec, max_tasks=max_tasks),
             spec=spec,
             idea=idea,
             repo=repo_name,
@@ -176,8 +180,21 @@ async def _run_build_pipeline(
             worker_model=worker_model,
             review_model=review_model,
         )
+        result["status"] = "triage_required"
+        result["elapsed_seconds"] = time.monotonic() - start
+        return result
 
     result["stages"]["tasks"] = tasks
+    task_validation = _validate_queueable_tasks(tasks)
+    result["stages"]["task_validation"] = task_validation
+    if task_validation["invalid"]:
+        result["status"] = "invalid_tasks"
+        result["elapsed_seconds"] = time.monotonic() - start
+        _progress(
+            emit_progress,
+            f"  ! Refusing to create queue items with invalid metadata ({task_validation['invalid_count']} invalid task(s)).",
+        )
+        return result
     _progress(emit_progress, f"  ✓ {len(tasks)} tasks identified")
     for i, task in enumerate(tasks, 1):
         _progress(emit_progress, f"    {i}. {task['title']}")
@@ -461,12 +478,68 @@ def _string_list(value: Any) -> list[str]:
     return []
 
 
+def _collapse_whitespace(value: Any) -> str:
+    return " ".join(str(value or "").split()).strip()
+
+
+def _is_placeholder_task_title(value: Any) -> bool:
+    title = _collapse_whitespace(value).strip(" -:_")
+    if not title:
+        return True
+    normalized = title.lower()
+    if normalized in _PLACEHOLDER_TASK_TITLES:
+        return True
+    return normalized.startswith("untitled ")
+
+
+def _task_persistence_errors(task: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if _is_placeholder_task_title(task.get("title")):
+        errors.append("title must be non-empty and not a placeholder")
+    if not _collapse_whitespace(task.get("description")):
+        errors.append("description is required")
+    if not _string_list(task.get("acceptance_criteria", [])):
+        errors.append("acceptance criteria are required")
+    if not _collapse_whitespace(task.get("verification")):
+        errors.append("verification is required")
+    if not _collapse_whitespace(task.get("merge_class")):
+        errors.append("merge class is required")
+    if not _collapse_whitespace(task.get("autonomy_mode")):
+        errors.append("autonomy mode is required")
+    return errors
+
+
+def _validate_queueable_tasks(tasks: list[dict[str, Any]]) -> dict[str, Any]:
+    invalid: list[dict[str, Any]] = []
+    for index, task in enumerate(tasks, start=1):
+        errors = _task_persistence_errors(task)
+        if errors:
+            invalid.append(
+                {
+                    "index": index,
+                    "title": _collapse_whitespace(task.get("title")) or "<missing>",
+                    "errors": errors,
+                }
+            )
+    return {
+        "invalid": invalid,
+        "invalid_count": len(invalid),
+        "valid_count": max(0, len(tasks) - len(invalid)),
+    }
+
+
 async def _create_issues(tasks: list[dict[str, Any]], *, repo: str) -> list[int]:
     """Create GitHub issues for each task."""
     import subprocess
 
     issue_numbers = []
     for task in tasks:
+        errors = _task_persistence_errors(task)
+        if errors:
+            raise ValueError(
+                f"Cannot persist boss-ready issue for {task.get('title', 'unknown task')!r}: "
+                + "; ".join(errors)
+            )
         labels = [
             "boss-ready",
             *[str(item).strip() for item in task.get("labels", []) if str(item).strip()],

--- a/aragora/cli/commands/idea.py
+++ b/aragora/cli/commands/idea.py
@@ -25,6 +25,15 @@ from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
 
+_PLACEHOLDER_TITLES = {
+    "untitled initiative",
+    "untitled handoff",
+    "untitled task",
+    "initiative",
+    "handoff",
+    "task",
+}
+
 
 def cmd_idea(args: argparse.Namespace) -> None:
     """Dispatch idea subcommands."""
@@ -110,6 +119,147 @@ def _read_idea_text(args: argparse.Namespace) -> str:
 def _text(value: Any) -> str | None:
     text = str(value or "").strip()
     return text or None
+
+
+def _collapse_whitespace(value: Any) -> str:
+    return " ".join(str(value or "").split()).strip()
+
+
+def _is_placeholder_title(value: Any) -> bool:
+    title = _collapse_whitespace(value).strip(" -:_")
+    if not title:
+        return True
+    normalized = title.lower()
+    if normalized in _PLACEHOLDER_TITLES:
+        return True
+    return normalized.startswith("untitled ")
+
+
+def _derive_initiative_title(*, idea: str, spec: dict[str, Any]) -> str:
+    for candidate in (
+        spec.get("title"),
+        spec.get("user_goal"),
+        spec.get("desired_outcome"),
+        spec.get("raw"),
+        idea,
+    ):
+        title = _collapse_whitespace(candidate).strip(" -:_")
+        if title and not _is_placeholder_title(title):
+            return title[:120]
+    return ""
+
+
+def _derive_initiative_summary(*, idea: str, spec: dict[str, Any], title: str) -> str:
+    candidates = [
+        spec.get("desired_outcome"),
+        spec.get("proposed_solution"),
+        spec.get("user_goal"),
+        spec.get("raw"),
+        idea,
+    ]
+    for candidate in candidates:
+        summary = _collapse_whitespace(candidate)
+        if summary:
+            if summary == title:
+                continue
+            return summary[:300]
+    return title[:300]
+
+
+def _initiative_acceptance_criteria(
+    *,
+    success_criteria: list[str],
+    clarification_status: str,
+    open_questions: list[str],
+) -> list[str]:
+    criteria = [item for item in success_criteria if item]
+    if criteria:
+        return criteria
+    fallback = ["A usable initiative brief exists with explicit summary and queue metadata."]
+    if clarification_status == "decision_complete":
+        fallback.append(
+            "Founder triage can decompose the initiative into bounded work with file scope and validation."
+        )
+    else:
+        fallback.append("Open questions remain captured before any boss-ready work is created.")
+    if open_questions:
+        fallback.append(
+            f"{len(open_questions)} open question(s) are explicitly preserved in the intake artifact."
+        )
+    return fallback
+
+
+def _initiative_validation_steps(
+    *,
+    clarification_status: str,
+    open_questions: list[str],
+) -> list[str]:
+    validation = [
+        "Brief includes title, summary, merge class, autonomy mode, and preferred worker/reviewer defaults."
+    ]
+    if clarification_status == "decision_complete":
+        validation.append(
+            "Founder triage yields bounded handoffs with acceptance criteria, validation, and file scope."
+        )
+    else:
+        validation.append(
+            "Artifact remains `idea-intake` only until clarification reaches decision_complete."
+        )
+    if open_questions:
+        validation.append(
+            "Open questions are visible on the issue and block queue-ready execution."
+        )
+    return validation
+
+
+def _brief_issue_prefix(brief: dict[str, Any]) -> str:
+    completeness = str(brief.get("clarification_completeness_status", "")).strip().lower()
+    return "Initiative" if completeness == "decision_complete" else "Idea Intake"
+
+
+def _brief_issue_labels(brief: dict[str, Any]) -> list[str]:
+    completeness = str(brief.get("clarification_completeness_status", "")).strip().lower()
+    if completeness != "decision_complete":
+        return ["idea-intake"]
+    return [
+        "initiative",
+        f"risk:{brief.get('risk', 'medium')}",
+        f"merge:{brief.get('merge_class', 'manual')}",
+        f"track:{brief.get('track', '1')}",
+        f"autonomy:{brief.get('autonomy_mode', 'checkpoint')}",
+    ]
+
+
+def _brief_persistence_errors(brief: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if _is_placeholder_title(brief.get("title")):
+        errors.append("title must be non-empty and not a placeholder")
+    if not _text(brief.get("summary")):
+        errors.append("summary is required")
+    if not [item for item in brief.get("acceptance_criteria", []) if _text(item)]:
+        errors.append("acceptance criteria are required")
+    if not [item for item in brief.get("validation", []) if _text(item)]:
+        errors.append("validation steps are required")
+    if not _text(brief.get("merge_class")):
+        errors.append("merge class is required")
+    if not _text(brief.get("autonomy_mode")):
+        errors.append("autonomy mode is required")
+    return errors
+
+
+def _handoff_persistence_errors(handoff: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if _is_placeholder_title(handoff.get("task_title")):
+        errors.append("task title must be non-empty and not a placeholder")
+    if not [item for item in handoff.get("acceptance_criteria", []) if _text(item)]:
+        errors.append("acceptance criteria are required")
+    if not [item for item in handoff.get("validation", []) if _text(item)]:
+        errors.append("validation steps are required")
+    if not _text(handoff.get("merge_class")):
+        errors.append("merge class is required")
+    if not _text(handoff.get("autonomy_mode")):
+        errors.append("autonomy mode is required")
+    return errors
 
 
 async def _run_idea_intake_with_cleanup(**kwargs: Any) -> dict[str, Any]:
@@ -337,23 +487,40 @@ def _compose_initiative_brief(
                 part.strip() for part in criteria_section.split(";") if part.strip()
             ]
 
-    title = _text(spec.get("title")) or idea[:80]
+    open_questions = [
+        str(item).strip() for item in spec.get("open_questions", []) if str(item).strip()
+    ]
+    clarification_status = _text(spec.get("clarification_status")) or "draft"
+    title = _derive_initiative_title(idea=idea, spec=spec)
     desired_outcome = _text(spec.get("desired_outcome")) or title
+    summary = _derive_initiative_summary(idea=idea, spec=spec, title=title)
     proof_expected = "Acceptance criteria satisfied, targeted validation attached, and adversarial review notes recorded."
+    acceptance_criteria = _initiative_acceptance_criteria(
+        success_criteria=success_criteria,
+        clarification_status=clarification_status,
+        open_questions=open_questions,
+    )
+    validation = _initiative_validation_steps(
+        clarification_status=clarification_status,
+        open_questions=open_questions,
+    )
 
     return {
         "title": title,
+        "summary": summary,
         "user_goal": _text(spec.get("user_goal")) or idea,
         "desired_business_outcome": desired_outcome,
         "success_criteria": success_criteria,
+        "acceptance_criteria": acceptance_criteria,
+        "validation": validation,
         "constraints": [],
         "explicit_non_goals": [],
         "affected_product_surfaces": surfaces,
         "affected_surfaces": surfaces,
         "proof_evidence_expected": proof_expected,
         "sequencing_priority": priority,
-        "clarification_completeness_status": _text(spec.get("clarification_status")) or "draft",
-        "open_questions": list(spec.get("open_questions", []) or []),
+        "clarification_completeness_status": clarification_status,
+        "open_questions": open_questions,
         "risk": risk,
         "merge_class": merge_class,
         "autonomy_mode": autonomy_mode,
@@ -1175,18 +1342,15 @@ def _slug(value: str) -> str:
 
 async def _create_intake_issue(brief: dict[str, Any], *, repo: str) -> dict[str, Any]:
     """Persist an initiative brief as a GitHub issue."""
+    errors = _brief_persistence_errors(brief)
+    if errors:
+        raise ValueError(f"Cannot persist intake brief: {'; '.join(errors)}")
+    prefix = _brief_issue_prefix(brief)
     return await _create_issue_with_optional_labels(
         repo=repo,
-        title=f"[Initiative] {brief.get('title', 'Untitled initiative')}",
+        title=f"[{prefix}] {brief.get('title', '').strip()}",
         body=_issue_body_for_brief(brief),
-        requested_labels=[
-            "idea-intake",
-            "initiative",
-            f"risk:{brief.get('risk', 'medium')}",
-            f"merge:{brief.get('merge_class', 'manual')}",
-            f"track:{brief.get('track', '1')}",
-            f"autonomy:{brief.get('autonomy_mode', 'checkpoint')}",
-        ],
+        requested_labels=_brief_issue_labels(brief),
     )
 
 
@@ -1199,10 +1363,16 @@ async def _create_triage_issues(
     """Persist founder handoffs as boss-ready GitHub issues."""
     created: list[dict[str, Any]] = []
     for handoff in handoffs:
+        errors = _handoff_persistence_errors(handoff)
+        if errors:
+            raise ValueError(
+                f"Cannot persist boss-ready issue for {handoff.get('task_title', 'unknown task')!r}: "
+                + "; ".join(errors)
+            )
         created.append(
             await _create_issue_with_optional_labels(
                 repo=repo,
-                title=str(handoff.get("task_title", "Untitled handoff")).strip(),
+                title=str(handoff.get("task_title", "")).strip(),
                 body=_triage_issue_body_for_handoff(handoff, brief=brief),
                 requested_labels=list(handoff.get("labels", []) or []),
             )
@@ -1255,9 +1425,20 @@ async def _create_issue_with_optional_labels(
 def _issue_body_for_brief(brief: dict[str, Any]) -> str:
     """Render the intake issue body."""
     success_criteria = list(brief.get("success_criteria", []) or [])
+    acceptance_criteria = [
+        str(item).strip() for item in brief.get("acceptance_criteria", []) if str(item).strip()
+    ]
+    validation = [str(item).strip() for item in brief.get("validation", []) if str(item).strip()]
     open_questions = list(brief.get("open_questions", []) or [])
     surfaces = list(brief.get("affected_product_surfaces", []) or [])
+    next_step = (
+        "Run founder triage to decompose this initiative into bounded `boss-ready` issues with "
+        "explicit acceptance criteria, validation commands, file scope, and merge policy."
+        if str(brief.get("clarification_completeness_status", "")).strip() == "decision_complete"
+        else "Keep this as `idea-intake` only. Resolve the open questions before any `boss-ready` issue is created."
+    )
     return f"""## Initiative Brief
+- Summary: {brief.get("summary", "")[:300]}
 - User goal: {brief.get("user_goal", "")[:300]}
 - Desired business outcome: {brief.get("desired_business_outcome", "")[:300]}
 - Success criteria: {", ".join(success_criteria) or "to be refined"}
@@ -1277,9 +1458,14 @@ def _issue_body_for_brief(brief: dict[str, Any]) -> str:
 - Preferred Worker Agent: {brief.get("preferred_worker_agent", "claude")}
 - Preferred Reviewer Agent: {brief.get("preferred_reviewer_agent", "codex")}
 
+## Acceptance Criteria
+{chr(10).join(f"- [ ] {item}" for item in acceptance_criteria) or "- [ ] Clarification requirements captured"}
+
+## Validation
+{chr(10).join(f"- {item}" for item in validation) or "- Validation still needs to be defined"}
+
 ## Next Step
-Run founder triage to decompose this initiative into bounded `boss-ready` issues with explicit
-acceptance criteria, validation commands, file scope, and merge policy.
+{next_step}
 """
 
 

--- a/tests/cli/test_build_command.py
+++ b/tests/cli/test_build_command.py
@@ -174,6 +174,8 @@ def test_run_build_pipeline_blocks_before_dispatch_when_routing_is_blocked() -> 
                             "description": "Implement thing",
                             "acceptance_criteria": ["It works"],
                             "verification": "pytest tests/a.py -q",
+                            "merge_class": "manual",
+                            "autonomy_mode": "checkpoint",
                         }
                     ],
                 }
@@ -205,6 +207,110 @@ def test_run_build_pipeline_blocks_before_dispatch_when_routing_is_blocked() -> 
     assert result["status"] == "blocked_no_runner"
     assert result["stages"]["routing"]["blocked"] is True
     dispatch.assert_not_awaited()
+
+
+def test_run_build_pipeline_stops_when_founder_review_has_no_queueable_tasks() -> None:
+    with (
+        patch(
+            "aragora.cli.commands.build._generate_spec",
+            AsyncMock(return_value={"title": "Spec", "sections": [], "raw": "spec"}),
+        ),
+        patch(
+            "aragora.cli.commands.build._plan_reviewed_tasks",
+            AsyncMock(
+                return_value={
+                    "brief": {"clarification_completeness_status": "decision_complete"},
+                    "handoffs": [],
+                    "review": {
+                        "status": "approved",
+                        "summary": "No queueable handoffs.",
+                        "findings": [],
+                        "followups": [],
+                    },
+                    "tasks": [],
+                }
+            ),
+        ),
+        patch(
+            "aragora.cli.commands.build._decompose_tasks",
+            AsyncMock(
+                return_value=[
+                    {
+                        "title": "Preview task",
+                        "description": "Preview only",
+                        "acceptance_criteria": ["Preview exists"],
+                        "verification": "pytest tests/a.py -q",
+                    }
+                ]
+            ),
+        ),
+        patch("aragora.cli.commands.build._create_issues", AsyncMock()) as create_issues,
+    ):
+        result = asyncio.run(
+            _run_build_pipeline(
+                idea="Ship thing",
+                dry_run=False,
+                skip_clarify=True,
+                repo="synaptent/aragora",
+                worker_model="claude",
+                review_model="codex",
+                emit_progress=False,
+            )
+        )
+
+    assert result["status"] == "triage_required"
+    assert result["stages"]["fallback_tasks"][0]["title"] == "Preview task"
+    create_issues.assert_not_awaited()
+
+
+def test_run_build_pipeline_rejects_placeholder_queue_tasks() -> None:
+    with (
+        patch(
+            "aragora.cli.commands.build._generate_spec",
+            AsyncMock(return_value={"title": "Spec", "sections": [], "raw": "spec"}),
+        ),
+        patch(
+            "aragora.cli.commands.build._plan_reviewed_tasks",
+            AsyncMock(
+                return_value={
+                    "brief": {"clarification_completeness_status": "decision_complete"},
+                    "handoffs": [],
+                    "review": {
+                        "status": "approved",
+                        "summary": "No findings.",
+                        "findings": [],
+                        "followups": [],
+                    },
+                    "tasks": [
+                        {
+                            "title": "Untitled task",
+                            "description": "Implement thing",
+                            "acceptance_criteria": ["It works"],
+                            "verification": "pytest tests/a.py -q",
+                            "merge_class": "manual",
+                            "autonomy_mode": "checkpoint",
+                        }
+                    ],
+                }
+            ),
+        ),
+        patch("aragora.cli.commands.build._create_issues", AsyncMock()) as create_issues,
+    ):
+        result = asyncio.run(
+            _run_build_pipeline(
+                idea="Ship thing",
+                dry_run=False,
+                skip_clarify=True,
+                repo="synaptent/aragora",
+                worker_model="claude",
+                review_model="codex",
+                emit_progress=False,
+            )
+        )
+
+    assert result["status"] == "invalid_tasks"
+    assert result["stages"]["task_validation"]["invalid_count"] == 1
+    create_issues.assert_not_awaited()
 
 
 def test_generate_spec_reads_conductor_result() -> None:

--- a/tests/cli/test_idea_command.py
+++ b/tests/cli/test_idea_command.py
@@ -6,6 +6,8 @@ import json
 from unittest.mock import AsyncMock, patch
 
 from aragora.cli.commands.idea import (
+    _create_intake_issue,
+    _create_triage_issues,
     _compose_initiative_brief,
     _issue_body_for_brief,
     _run_idea_intake,
@@ -146,6 +148,11 @@ def test_compose_initiative_brief_uses_spec_metadata() -> None:
     assert brief["preferred_reviewer_agent"] == "codex"
     assert brief["success_criteria"] == ["The system asks clarifying questions before execution."]
     assert brief["open_questions"] == ["Should intake always create a GitHub issue?"]
+    assert brief["summary"] == "A structured intake brief exists before coding starts."
+    assert brief["acceptance_criteria"] == [
+        "The system asks clarifying questions before execution."
+    ]
+    assert brief["validation"]
 
 
 def test_run_idea_intake_returns_brief_without_issue_creation() -> None:
@@ -473,6 +480,9 @@ def test_issue_body_mentions_queue_metadata() -> None:
 
     assert "## Initiative Brief" in body
     assert "## Queue Metadata" in body
+    assert "- Summary: " in body
+    assert "## Acceptance Criteria" in body
+    assert "## Validation" in body
     assert "Preferred Worker Agent: claude" in body
     assert "Open questions: Should intake always create a GitHub issue?" in body
 
@@ -504,3 +514,75 @@ def test_triage_issue_body_mentions_scope_and_policy() -> None:
     assert "## File Scope" in body
     assert "server/auth/oidc.py" in body
     assert "Policy Notes: sensitive_scope:auth_rbac" in body
+
+
+def test_create_intake_issue_keeps_incomplete_brief_as_idea_intake_only() -> None:
+    brief = {
+        "title": "Founder intake",
+        "summary": "Clarify founder notes before queue creation.",
+        "user_goal": "Turn vague founder notes into executable work.",
+        "desired_business_outcome": "A structured intake brief exists before coding starts.",
+        "success_criteria": ["Open questions are captured before execution."],
+        "acceptance_criteria": ["Open questions are captured before execution."],
+        "validation": [
+            "Artifact remains `idea-intake` only until clarification reaches decision_complete."
+        ],
+        "constraints": [],
+        "explicit_non_goals": [],
+        "affected_product_surfaces": ["frontend", "server"],
+        "proof_evidence_expected": "Validation and review notes recorded.",
+        "sequencing_priority": "high",
+        "clarification_completeness_status": "needs_clarification",
+        "open_questions": ["Should intake always create a GitHub issue?"],
+        "risk": "medium",
+        "merge_class": "manual",
+        "autonomy_mode": "checkpoint",
+        "track": "2",
+        "preferred_worker_agent": "claude",
+        "preferred_reviewer_agent": "codex",
+    }
+    proc = type(
+        "Proc",
+        (),
+        {
+            "returncode": 0,
+            "stdout": "https://github.com/synaptent/aragora/issues/321\n",
+            "stderr": "",
+        },
+    )()
+
+    with patch("subprocess.run", return_value=proc) as run:
+        issue = asyncio.run(_create_intake_issue(brief, repo="synaptent/aragora"))
+
+    assert issue["number"] == 321
+    cmd = run.call_args.args[0]
+    assert "[Idea Intake] Founder intake" in cmd
+    assert "idea-intake" in cmd
+    assert "initiative" not in cmd
+
+
+def test_create_triage_issues_rejects_placeholder_handoff_titles() -> None:
+    with patch("subprocess.run") as run:
+        try:
+            asyncio.run(
+                _create_triage_issues(
+                    [
+                        {
+                            "task_title": "Untitled handoff",
+                            "acceptance_criteria": ["Done"],
+                            "validation": ["pytest tests/a.py -q"],
+                            "merge_class": "manual",
+                            "autonomy_mode": "checkpoint",
+                            "labels": ["boss-ready"],
+                        }
+                    ],
+                    brief={"title": "Founder intake"},
+                    repo="synaptent/aragora",
+                )
+            )
+        except ValueError as exc:
+            assert "placeholder" in str(exc)
+        else:
+            raise AssertionError("Expected triage issue creation to reject placeholder title")
+
+    run.assert_not_called()


### PR DESCRIPTION
## Summary
- keep incomplete intake artifacts as `idea-intake` instead of fake-ready `initiative` issues
- require real title/summary/acceptance/validation metadata before persisting initiative or boss-ready issues
- stop `aragora build` from auto-creating boss-ready work from heuristic fallback when founder triage yields no queueable tasks

## Validation
- `ARAGORA_DATA_DIR=/var/folders/8v/4jm9btw12dddtv8tnn7rbwk40000gn/T/aragora-intake-tests-cacuem60 python3 -m pytest tests/cli/test_idea_command.py tests/cli/test_build_command.py -q`
- `python3 -m ruff check aragora/cli/commands/idea.py aragora/cli/commands/build.py tests/cli/test_idea_command.py tests/cli/test_build_command.py`

## Queue Cleanup
- closed placeholder initiative issues #1530 #1531 #1532 #1535 #1536 #1537 #1539 #1540 after confirming they contained no usable initiative data