### PR TITLE
test(nomic): isolate semaphore concurrency from git worktrees

### DIFF
--- a/tests/nomic/test_parallel_orchestrator.py
+++ b/tests/nomic/test_parallel_orchestrator.py
@@ -741,6 +741,10 @@ class TestSemaphoreEnforcement:
 
         engine = MagicMock()
         engine.execute = AsyncMock(side_effect=tracking_execute)
+        bc = MagicMock(spec=BranchCoordinator)
+        bc.create_track_branch = AsyncMock(return_value="dev/sme-task-001")
+        bc.cleanup_all_worktrees = MagicMock()
+        bc._worktree_paths = {}
 
         subtasks = [
             _make_subtask(str(i), f"Task {i}", file_scope=[f"tests/t{i}.py"]) for i in range(5)
@@ -749,6 +753,7 @@ class TestSemaphoreEnforcement:
         orch = AutonomousOrchestrator(
             workflow_engine=engine,
             task_decomposer=_mock_decomposer(_make_decomposition(subtasks)),
+            branch_coordinator=bc,
             max_parallel_tasks=2,
         )
 


### PR DESCRIPTION
## Summary
- inject a mocked branch coordinator into the semaphore concurrency test
- keep the test focused on concurrency limits instead of real git worktree setup
- preserve the existing orchestrator behavior while removing CI/environment coupling

## Testing
- python3 -m pytest tests/nomic/test_parallel_orchestrator.py -q
- python3 -m pytest tests/nomic/test_parallel_orchestrator.py -k semaphore_limits_concurrency -q
- python3 -m ruff check tests/nomic/test_parallel_orchestrator.py