### PR TITLE
fix(ci): restore monorepo-safe release readiness bootstrap

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -74,10 +74,10 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install (dev)
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run release-readiness gate
         # Keep this gate deterministic: never rely on optional external

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -185,6 +185,27 @@ class TestAragoraReviewGateWorkflow:
         )
 
 
+class TestReleaseReadinessWorkflow:
+    """Validate release-readiness workflow bootstraps the monorepo correctly."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "release-readiness.yml"
+
+    def test_workflow_file_exists(self):
+        assert self.path.exists(), "release-readiness.yml does not exist"
+
+    def test_workflow_uses_monorepo_safe_installer(self):
+        data = _load_yaml(self.path)
+        jobs = data["jobs"]
+        workflow = jobs["release-readiness"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+
 class TestReleaseWorkflow:
     """Validate release.yml integrates all gates."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,13 +20,17 @@ import pytest
 from aragora.resilience import reset_all_circuit_breakers
 from tests.utils import managed_fixture
 
-# Ensure local Python SDK package imports resolve during test collection.
+# Ensure local monorepo package imports resolve during test collection.
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
-_SDK_PYTHON_ROOT = _PROJECT_ROOT / "sdk" / "python"
-if _SDK_PYTHON_ROOT.is_dir():
-    _sdk_python = str(_SDK_PYTHON_ROOT)
-    if _sdk_python not in sys.path:
-        sys.path.insert(0, _sdk_python)
+_MONOREPO_IMPORT_ROOTS = [
+    _PROJECT_ROOT / "sdk" / "python",
+    _PROJECT_ROOT / "aragora-debate" / "src",
+]
+for _import_root in _MONOREPO_IMPORT_ROOTS:
+    if _import_root.is_dir():
+        _import_root_str = str(_import_root)
+        if _import_root_str not in sys.path:
+            sys.path.insert(0, _import_root_str)
 
 # Register skip governance plugin for expiry checking
 pytest_plugins = ["tests.plugins.skip_governance"]

--- a/tests/test_monorepo_bootstrap.py
+++ b/tests/test_monorepo_bootstrap.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def test_aragora_debate_src_is_bootstrapped_for_repo_tests() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    expected = str(repo_root / "aragora-debate" / "src")
+    assert expected in sys.path


### PR DESCRIPTION
## Summary
- use the monorepo-safe CI installer in release-readiness instead of a bare editable install
- bootstrap repo tests with both sdk/python and aragora-debate/src on sys.path
- add regression tests for the workflow install command and monorepo bootstrap path

## Testing
- python3 -m pytest tests/ci/test_release_gates.py tests/test_monorepo_bootstrap.py tests/cli/test_demo_command.py -q
- python3 -m ruff check tests/conftest.py tests/ci/test_release_gates.py tests/test_monorepo_bootstrap.py