### PR TITLE
fix(ci): pin live deploy mode gate to hetzner

### DIFF
--- a/.github/workflows/live-deploy-mode-gate.yml
+++ b/.github/workflows/live-deploy-mode-gate.yml
@@ -24,7 +24,7 @@ jobs:
   gate:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Validate Live Deploy Mode
-    runs-on: aragora
+    runs-on: [self-hosted, Linux, X64, aragora, hetzner]
     timeout-minutes: 30
     env:
       NODE_VERSION: '20'

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -150,6 +150,20 @@ class TestIntegrationGateWorkflow:
         assert "needs" in summary_job
 
 
+class TestLiveDeployModeGateWorkflow:
+    """Validate live-deploy-mode-gate.yml runner policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "live-deploy-mode-gate.yml"
+
+    def test_gate_uses_linux_hetzner_runner_pool(self):
+        data = _load_yaml(self.path)
+        job = data["jobs"]["gate"]
+        runs_on = job["runs-on"]
+        assert runs_on == ["self-hosted", "Linux", "X64", "aragora", "hetzner"]
+
+
 class TestAragoraReviewGateWorkflow:
     """Validate Aragora PR review gate structure."""
 


### PR DESCRIPTION
## Summary
- pin the Live Deploy Mode Gate to the Linux Hetzner self-hosted pool
- avoid mixed self-hosted runners that lack apt-get for Playwright --with-deps
- add workflow-policy coverage for the runner selection

## Testing
- python3 -m pytest tests/ci/test_release_gates.py -q
- python3 -m ruff check tests/ci/test_release_gates.py
- python3 scripts/check_required_check_priority_policy.py