### PR TITLE
fix(ci): stabilize nomic worktree concurrency tests

### DIFF
--- a/aragora/nomic/branch_coordinator.py
+++ b/aragora/nomic/branch_coordinator.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import subprocess
+import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -336,10 +337,7 @@ class BranchCoordinator:
         """
         base = base_branch or self.config.base_branch
 
-        # Generate branch name from goal
-        goal_slug = self._slugify(goal)[:30]
-        timestamp = datetime.now(timezone.utc).strftime("%m%d")
-        branch_name = f"{self.config.branch_prefix}/{track.value}-{goal_slug}-{timestamp}"
+        branch_name = self._generate_branch_name(track, goal)
 
         if self.config.use_worktrees:
             return await self._create_worktree_branch(branch_name, base)
@@ -870,6 +868,13 @@ class BranchCoordinator:
         slug = re.sub(r"[^a-z0-9]+", "-", slug)
         slug = slug.strip("-")
         return slug
+
+    def _generate_branch_name(self, track: Track, goal: str) -> str:
+        """Generate a collision-resistant branch name for a track/goal pair."""
+        goal_slug = self._slugify(goal)[:30] or "task"
+        timestamp = datetime.now(timezone.utc).strftime("%m%d-%H%M%S")
+        unique_suffix = uuid.uuid4().hex[:6]
+        return f"{self.config.branch_prefix}/{track.value}-{goal_slug}-{timestamp}-{unique_suffix}"
 
     def cleanup_worktrees(self) -> int:
         """Remove all active worktrees and prune stale entries.

--- a/tests/nomic/test_parallel_orchestrator.py
+++ b/tests/nomic/test_parallel_orchestrator.py
@@ -750,6 +750,7 @@ class TestSemaphoreEnforcement:
             workflow_engine=engine,
             task_decomposer=_mock_decomposer(_make_decomposition(subtasks)),
             max_parallel_tasks=2,
+            branch_coordinator=None,
         )
 
         await orch.execute_goal(goal="Test", max_cycles=1)

--- a/tests/nomic/test_worktree_isolation.py
+++ b/tests/nomic/test_worktree_isolation.py
@@ -144,6 +144,33 @@ class TestWorktreeBranchCreation:
             assert ".worktrees" in str(wt_path)
 
     @pytest.mark.asyncio
+    async def test_same_goal_gets_unique_branch_names(self):
+        """Repeated same-day goals should not reuse the same branch/worktree name."""
+        config = BranchCoordinatorConfig(use_worktrees=True)
+        coordinator = BranchCoordinator(
+            repo_path=Path("/tmp/test-repo"),
+            config=config,
+        )
+
+        with (
+            patch.object(coordinator, "_run_git") as mock_git,
+            patch.object(coordinator, "branch_exists", return_value=False),
+        ):
+            mock_git.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            first = await coordinator.create_track_branch(
+                track=Track.QA,
+                goal="do task 0",
+            )
+            second = await coordinator.create_track_branch(
+                track=Track.QA,
+                goal="do task 0",
+            )
+
+        assert first != second
+        assert coordinator.get_worktree_path(first) != coordinator.get_worktree_path(second)
+
+    @pytest.mark.asyncio
     async def test_worktree_add_uses_remote_base_when_local_branch_missing(self):
         """Should fall back to origin/<base> when no local base branch exists."""
         config = BranchCoordinatorConfig(use_worktrees=True)


### PR DESCRIPTION
## Summary
- make BranchCoordinator branch names collision-resistant for repeated same-day goals
- keep the semaphore concurrency test focused on semaphore behavior by disabling real branch coordination in that test
- add a regression covering repeated same-goal branch creation

## Testing
- python3 -m pytest tests/nomic/test_parallel_orchestrator.py -k semaphore_limits_concurrency -q
- python3 -m pytest tests/nomic/test_worktree_isolation.py -k "same_goal_gets_unique_branch_names or worktree_add_command or worktree_path_registered" -q
- python3 -m pytest tests/nomic/test_branch_coordinator.py tests/nomic/test_worktree_isolation.py tests/nomic/test_parallel_orchestrator.py -k "create_track_branch or slugify or same_goal_gets_unique_branch_names or semaphore_limits_concurrency" -q
- python3 -m ruff check aragora/nomic/branch_coordinator.py tests/nomic/test_parallel_orchestrator.py tests/nomic/test_worktree_isolation.py