### PR TITLE
test(core): align stale defaults with current debate settings

### DIFF
--- a/tests/agents/api_agents/test_grok.py
+++ b/tests/agents/api_agents/test_grok.py
@@ -28,11 +28,14 @@ class TestGrokAgentInitialization:
     def test_init_with_defaults(self, mock_env_with_api_keys):
         """Should initialize with default values."""
         from aragora.agents.api_agents.grok import GrokAgent
+        from aragora.agents.registry import AgentRegistry
 
         agent = GrokAgent()
+        spec = AgentRegistry.get_spec("grok")
 
         assert agent.name == "grok"
-        assert agent.model == "grok-4-latest"
+        assert spec is not None
+        assert agent.model == spec.default_model
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "grok"
@@ -102,12 +105,13 @@ class TestGrokAgentInitialization:
 
     def test_agent_registry_registration(self, mock_env_with_api_keys):
         """Should be registered in agent registry."""
+        from aragora.agents.api_agents.grok import GrokAgent
         from aragora.agents.registry import AgentRegistry
 
         spec = AgentRegistry.get_spec("grok")
 
         assert spec is not None
-        assert spec.default_model == "grok-4-latest"
+        assert spec.default_model == GrokAgent().model
         assert spec.agent_type == "API"
 
     def test_base_url_is_xai_endpoint(self, mock_env_with_api_keys):

--- a/tests/agents/api_agents/test_openai.py
+++ b/tests/agents/api_agents/test_openai.py
@@ -26,11 +26,14 @@ class TestOpenAIAgentInitialization:
     def test_init_with_defaults(self, mock_env_with_api_keys):
         """Should initialize with default values."""
         from aragora.agents.api_agents.openai import OpenAIAPIAgent
+        from aragora.agents.registry import AgentRegistry
 
         agent = OpenAIAPIAgent()
+        spec = AgentRegistry.get_spec("openai-api")
 
         assert agent.name == "openai-api"
-        assert agent.model == "gpt-5.3"
+        assert spec is not None
+        assert agent.model == spec.default_model
         assert agent.role == "proposer"
         assert agent.timeout == 120
         assert agent.agent_type == "openai"
@@ -67,12 +70,13 @@ class TestOpenAIAgentInitialization:
 
     def test_agent_registry_registration(self, mock_env_with_api_keys):
         """Should be registered in agent registry."""
+        from aragora.agents.api_agents.openai import OpenAIAPIAgent
         from aragora.agents.registry import AgentRegistry
 
         spec = AgentRegistry.get_spec("openai-api")
 
         assert spec is not None
-        assert spec.default_model == "gpt-5.3"
+        assert spec.default_model == OpenAIAPIAgent().model
         assert spec.agent_type == "API"
 
 
@@ -287,7 +291,7 @@ class TestOpenAICompatibleMixin:
 
         payload = agent._build_payload(messages, stream=False)
 
-        assert payload["model"] == "gpt-5.3"
+        assert payload["model"] == agent.model
         assert payload["messages"] == messages
         assert "max_tokens" in payload
         assert "stream" not in payload or payload.get("stream") is False

--- a/tests/debate/config/test_defaults.py
+++ b/tests/debate/config/test_defaults.py
@@ -269,13 +269,13 @@ class TestDefaultsConsistency:
         )
 
     def test_fabric_config_uses_centralized_defaults(self):
-        """FabricDebateConfig should match DEBATE_DEFAULTS for agent limits."""
+        """FabricDebateConfig should use centralized minimums and fabric-specific caps."""
         from aragora.debate.config.defaults import DEBATE_DEFAULTS
-        from aragora.debate.fabric_integration import FabricDebateConfig
+        from aragora.debate.fabric_integration import FABRIC_DEFAULT_MAX_AGENTS, FabricDebateConfig
 
         config = FabricDebateConfig(pool_id="test-pool")
         assert config.min_agents == DEBATE_DEFAULTS.min_agents_per_debate
-        assert config.max_agents == DEBATE_DEFAULTS.max_agents_per_debate
+        assert config.max_agents == FABRIC_DEFAULT_MAX_AGENTS
 
     def test_byzantine_config_uses_centralized_defaults(self):
         """ByzantineConsensusConfig should match DEBATE_DEFAULTS."""

--- a/tests/debate/test_flywheel_integration.py
+++ b/tests/debate/test_flywheel_integration.py
@@ -1001,11 +1001,11 @@ class TestProtocolConvenienceMethods:
         assert protocol.plan_approval_mode == "always"
 
     def test_default_protocol_flywheel_flags_disabled(self):
-        """Default protocol has flywheel flags disabled (opt-in)."""
+        """Default protocol keeps adaptive consensus and synthesis opt-in."""
         protocol = DebateProtocol()
         assert protocol.enable_adaptive_consensus is False
         assert protocol.enable_synthesis is False
-        assert protocol.enable_knowledge_injection is False
+        assert protocol.enable_knowledge_injection is True
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- update OpenAI and Grok default-model tests to assert consistency with the registered defaults
- fix the fabric default-limit test to use the fabric-specific max agent cap
- update the flywheel protocol test to reflect knowledge injection being on by default

## Validation
- python3 -m pytest tests/agents/api_agents/test_openai.py tests/agents/api_agents/test_grok.py tests/debate/config/test_defaults.py tests/debate/test_flywheel_integration.py -q
- python3 -m ruff check tests/agents/api_agents/test_openai.py tests/agents/api_agents/test_grok.py tests/debate/config/test_defaults.py tests/debate/test_flywheel_integration.py
