### PR TITLE
fix(core): restore baseline feedback and rlm semantics

### DIFF
--- a/aragora/debate/phases/feedback_elo.py
+++ b/aragora/debate/phases/feedback_elo.py
@@ -71,8 +71,8 @@ class EloFeedback:
         event_emitter = self.event_emitter
         elo_system = self.elo_system
         result = ctx.result
-        loop_id = self.loop_id
-        if event_emitter is None or elo_system is None or result is None or loop_id is None:
+        loop_id = self.loop_id or getattr(ctx, "loop_id", "")
+        if event_emitter is None or elo_system is None or result is None:
             return
 
         try:

--- a/aragora/rlm/bridge.py
+++ b/aragora/rlm/bridge.py
@@ -1267,8 +1267,9 @@ Please provide an improved answer based on the feedback."""
     def __enter__(self) -> "AragoraRLM":
         return self
 
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> bool:
         self.close()
+        return False
 
     def get_trajectory_log_path(self) -> str | None:
         """Get the trajectory log directory path."""


### PR DESCRIPTION
## Summary
- allow ELO match-recorded events to emit without requiring an explicit loop id
- fall back to the debate context loop id when available for event correlation
- make AragoraRLM.__exit__ explicitly return false after cleanup

## Validation
- python3 -m pytest tests/debate/phases/test_feedback_elo.py tests/rlm/test_deep_integration.py -q
- python3 -m pytest tests/events/test_culture_integration.py::TestOrchestratorCultureIntegration::test_orchestrator_gets_culture_hints tests/agents/test_session_circuit_breaker_integration.py::TestCircuitBreakerNotification::test_fallback_generate_notifies_on_401 tests/agents/test_session_circuit_breaker_integration.py::TestCircuitBreakerNotification::test_fallback_generate_stream_notifies_on_429 tests/agents/test_session_circuit_breaker_integration.py::TestCircuitBreakerUnavailable::test_fallback_generate_works_without_cb tests/agents/test_session_circuit_breaker_integration.py::TestProviderPinnedCheck::test_subsequent_calls_use_fallback tests/debate/phases/test_feedback_elo.py::TestEmitMatchRecordedEvent::test_missing_rating_defaults_to_1500 tests/rlm/test_deep_integration.py::TestLifecycleMethods::test_context_manager_exit_returns_false -q
- python3 -m ruff check aragora/debate/phases/feedback_elo.py aragora/rlm/bridge.py
