### PR TITLE
fix(ci): keep offline and shadow smoke workflows running

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -37,8 +37,8 @@ jobs:
             const sweepDelayMs = 10000;
 
             // Required checks are produced by these workflows, and we also keep
-            // Tests so PR CI reflects real test outcomes instead of looking
-            // cancelled after prioritization sweeps.
+            // Tests plus offline/shadow smoke workflows so PR CI reflects real
+            // outcomes instead of looking cancelled after prioritization sweeps.
             const alwaysKeepWorkflowPaths = new Set([
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
@@ -53,7 +53,9 @@ jobs:
               '.github/workflows/quality-smoke.yml',
               '.github/workflows/release-readiness.yml',
               '.github/workflows/security-gate.yml',
+              '.github/workflows/self-hosted-shadow.yml',
               '.github/workflows/smoke.yml',
+              '.github/workflows/smoke-offline.yml',
               '.github/workflows/self-host-readiness.yml',
               '.github/workflows/required-check-priority.yml',
             ]);
@@ -61,6 +63,7 @@ jobs:
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Core Suites (Decision Integrity)',
+              'Offline Golden Path',
               'Required Check Priority',
               'Lint',
               'Live Deploy Mode Gate',
@@ -68,6 +71,7 @@ jobs:
               'Quality Pipeline Smoke',
               'Release Readiness Gate',
               'Security Gate',
+              'Self-Hosted Shadow CI',
               'SDK Parity Check',
               'SDK Tests',
               'Smoke Tests',

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -32,13 +32,16 @@ REQUIRED_KEEP_WORKFLOW_PATHS = {
     ".github/workflows/required-check-priority.yml",
     ".github/workflows/release-readiness.yml",
     ".github/workflows/security-gate.yml",
+    ".github/workflows/self-hosted-shadow.yml",
     ".github/workflows/smoke.yml",
+    ".github/workflows/smoke-offline.yml",
 }
 
 REQUIRED_KEEP_WORKFLOW_NAMES = {
     "Aragora Code Review",
     "Autopilot Worktree E2E",
     "Core Suites (Decision Integrity)",
+    "Offline Golden Path",
     "Required Check Priority",
     "Lint",
     "Live Deploy Mode Gate",
@@ -46,6 +49,7 @@ REQUIRED_KEEP_WORKFLOW_NAMES = {
     "Quality Pipeline Smoke",
     "Release Readiness Gate",
     "Security Gate",
+    "Self-Hosted Shadow CI",
     "SDK Parity Check",
     "SDK Tests",
     "Smoke Tests",

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -31,13 +31,16 @@ jobs:
               '.github/workflows/quality-smoke.yml',
               '.github/workflows/release-readiness.yml',
               '.github/workflows/security-gate.yml',
+              '.github/workflows/self-hosted-shadow.yml',
               '.github/workflows/smoke.yml',
+              '.github/workflows/smoke-offline.yml',
               '.github/workflows/required-check-priority.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Core Suites (Decision Integrity)',
+              'Offline Golden Path',
               'Live Deploy Mode Gate',
               'PR Admission Controller',
               'Quality Pipeline Smoke',
@@ -45,6 +48,7 @@ jobs:
               'Release Readiness Gate',
               'Security Gate',
               'Lint',
+              'Self-Hosted Shadow CI',
               'SDK Parity Check',
               'SDK Tests',
               'Smoke Tests',
@@ -161,8 +165,16 @@ def test_policy_detects_missing_context_marker_in_mapped_workflow(tmp_path: Path
         "name: Security Gate\njobs:\n  summary:\n    name: Security Gate Summary\n",
         encoding="utf-8",
     )
+    (wf_dir / "self-hosted-shadow.yml").write_text(
+        "name: Self-Hosted Shadow CI\njobs:\n  shadow:\n    name: Mac TypeScript SDK Shadow\n",
+        encoding="utf-8",
+    )
     (wf_dir / "smoke.yml").write_text(
         "name: Smoke Tests\njobs:\n  smoke:\n    name: Smoke Tests\n",
+        encoding="utf-8",
+    )
+    (wf_dir / "smoke-offline.yml").write_text(
+        "name: Offline Golden Path\njobs:\n  offline:\n    name: Offline Demo Smoke\n",
         encoding="utf-8",
     )
 
@@ -189,12 +201,15 @@ jobs:
               '.github/workflows/required-check-priority.yml',
               '.github/workflows/release-readiness.yml',
               '.github/workflows/security-gate.yml',
+              '.github/workflows/self-hosted-shadow.yml',
               '.github/workflows/smoke.yml',
+              '.github/workflows/smoke-offline.yml',
             ]);
             const alwaysKeepWorkflowNames = new Set([
               'Aragora Code Review',
               'Autopilot Worktree E2E',
               'Core Suites (Decision Integrity)',
+              'Offline Golden Path',
               'Live Deploy Mode Gate',
               'PR Admission Controller',
               'Quality Pipeline Smoke',
@@ -202,6 +217,7 @@ jobs:
               'Release Readiness Gate',
               'Security Gate',
               'Lint',
+              'Self-Hosted Shadow CI',
               'SDK Parity Check',
               'SDK Tests',
               'Smoke Tests',


### PR DESCRIPTION
## Summary
- keep the offline golden path and self-hosted shadow workflows out of required-check-priority cancellations
- extend the priority-policy guard script so the keep-list cannot silently drift back
- add test coverage for the updated keep-list contract

## Why
These workflows were being cancelled almost immediately on active PRs, which made PR check surfaces look red even when no product code was failing.

## Validation
- python3 -m pytest tests/scripts/test_check_required_check_priority_policy.py -q
- python3 scripts/check_required_check_priority_policy.py
- python3 -m ruff check scripts/check_required_check_priority_policy.py tests/scripts/test_check_required_check_priority_policy.py
