### PR TITLE
feat(frontend): harvest duplicate live and popup improvements

### DIFF
--- a/aragora/live/browser-extension/background.js
+++ b/aragora/live/browser-extension/background.js
@@ -45,6 +45,49 @@ function sanitizeSelectionText(value) {
     .slice(0, SELECTION_LIMIT);
 }
 
+function resolveDebateAnswer(result) {
+  return (
+    result?.conclusion ||
+    result?.final_answer ||
+    result?.finalAnswer ||
+    result?.answer ||
+    result?.summary ||
+    result?.consensus?.conclusion ||
+    result?.consensus?.final_answer ||
+    result?.consensus?.finalAnswer ||
+    result?.consensus?.summary ||
+    result?.consensus?.answer ||
+    ""
+  );
+}
+
+function resolveDebateConfidence(result) {
+  const rawConfidence =
+    result?.confidence ??
+    result?.consensus?.confidence ??
+    result?.consensus?.agreement;
+  const confidence =
+    typeof rawConfidence === "string" ? Number(rawConfidence) : rawConfidence;
+
+  return typeof confidence === "number" && !Number.isNaN(confidence)
+    ? confidence
+    : null;
+}
+
+function buildStoredResult(result) {
+  const finalAnswer = resolveDebateAnswer(result);
+
+  return {
+    debateId: result?.debate_id || result?.id || null,
+    status: result?.status || "running",
+    message: result?.message || finalAnswer || null,
+    finalAnswer: finalAnswer || null,
+    confidence: resolveDebateConfidence(result),
+    consensus: result?.consensus || null,
+    task: result?.task || result?.environment?.task || "",
+  };
+}
+
 async function setBadge(text, color) {
   await chrome.action.setBadgeText({ text });
 
@@ -220,11 +263,7 @@ async function handleContextMenuClick(info, tab) {
       status: createdDebate.status || "running",
       debateId,
       error: null,
-      result: {
-        debateId,
-        status: createdDebate.status || "running",
-        message: createdDebate.message || null,
-      },
+      result: buildStoredResult(createdDebate),
       selectionText,
       source,
     });

--- a/aragora/live/browser-extension/popup.js
+++ b/aragora/live/browser-extension/popup.js
@@ -36,21 +36,36 @@ function humanizeStatus(status) {
 
 function isTerminalState(state) {
   const normalized = String(state?.status || "").toLowerCase();
-  return TERMINAL_STATUSES.has(normalized) || Boolean(state?.result?.finalAnswer);
+  return TERMINAL_STATUSES.has(normalized) || Boolean(resolveFinalAnswer(state?.result));
 }
 
 function resolveFinalAnswer(result) {
   return (
+    result?.conclusion ||
     result?.final_answer ||
     result?.finalAnswer ||
     result?.answer ||
     result?.summary ||
+    result?.consensus?.conclusion ||
     result?.consensus?.final_answer ||
     result?.consensus?.finalAnswer ||
     result?.consensus?.summary ||
     result?.consensus?.answer ||
     ""
   );
+}
+
+function resolveConfidence(result) {
+  const rawConfidence =
+    result?.confidence ??
+    result?.consensus?.confidence ??
+    result?.consensus?.agreement;
+  const confidence =
+    typeof rawConfidence === "string" ? Number(rawConfidence) : rawConfidence;
+
+  return typeof confidence === "number" && !Number.isNaN(confidence)
+    ? confidence
+    : null;
 }
 
 async function getStoredState() {
@@ -107,6 +122,7 @@ function renderError(errorMessage) {
 
 function renderState(state) {
   const activeState = state || {};
+  const result = activeState.result || {};
   setStatusPill(activeState.status || "idle");
 
   elements.selectionPreview.textContent =
@@ -114,17 +130,17 @@ function renderState(state) {
   renderSource(activeState.source);
 
   elements.debateId.textContent = activeState.debateId || "-";
-  elements.resultStatus.textContent = humanizeStatus(activeState.result?.status || activeState.status || "idle");
+  elements.resultStatus.textContent = humanizeStatus(result.status || activeState.status || "idle");
 
-  const confidence = activeState.result?.confidence;
+  const confidence = resolveConfidence(result);
   elements.resultConfidence.textContent =
     typeof confidence === "number" && !Number.isNaN(confidence)
       ? `${Math.round(confidence * 100)}%`
       : "-";
 
   const answer =
-    activeState.result?.finalAnswer ||
-    activeState.result?.message ||
+    resolveFinalAnswer(result) ||
+    result.message ||
     (activeState.status === "submitting"
       ? "Submitting selection to Aragora."
       : activeState.status === "running"
@@ -194,18 +210,9 @@ async function fetchDebate(apiUrl, apiKey, debateId) {
 }
 
 function buildResultState(previousState, debate) {
-  const confidence = Number(debate?.consensus?.confidence);
+  const confidence = resolveConfidence(debate);
   const nextStatus = String(debate?.status || previousState.status || "running").toLowerCase();
-  const finalAnswer =
-    debate.final_answer ||
-    debate.finalAnswer ||
-    debate.answer ||
-    debate.summary ||
-    debate.consensus?.final_answer ||
-    debate.consensus?.finalAnswer ||
-    debate.consensus?.summary ||
-    debate.consensus?.answer ||
-    resolveFinalAnswer(debate);
+  const finalAnswer = resolveFinalAnswer(debate);
 
   return {
     ...previousState,
@@ -215,7 +222,7 @@ function buildResultState(previousState, debate) {
       debateId: debate.id || debate.debate_id || previousState.debateId,
       status: debate.status || previousState.status || "running",
       finalAnswer,
-      confidence: Number.isNaN(confidence) ? null : confidence,
+      confidence,
       task: debate.task || debate.environment?.task || "",
     },
     updatedAt: new Date().toISOString(),

--- a/aragora/live/src/components/landing/LiveDemoSection.tsx
+++ b/aragora/live/src/components/landing/LiveDemoSection.tsx
@@ -294,6 +294,9 @@ export function LiveDemoSection() {
     ? liveTranscript
     : FALLBACK_STREAM.slice(0, demoVisibleCount);
   const debateTask = hasLiveTranscript ? deriveTask(focusedLiveEvents) : FALLBACK_TASK;
+  const spectateHref = dominantDebateId
+    ? `/spectate/${encodeURIComponent(dominantDebateId)}`
+    : '/spectate';
   const activeRound = transcriptEvents[transcriptEvents.length - 1]?.roundNumber ?? null;
   const participants = Array.from(
     new Set(
@@ -673,7 +676,7 @@ export function LiveDemoSection() {
 
         <div className="text-center mt-12 flex flex-wrap justify-center gap-4">
           <Link
-            href="/spectate"
+            href={spectateHref}
             className="text-sm font-semibold transition-all hover:scale-[1.02] cursor-pointer"
             style={{
               display: 'inline-block',
@@ -685,7 +688,7 @@ export function LiveDemoSection() {
               padding: '18px 32px',
             }}
           >
-            Open full spectate view
+            {hasLiveTranscript ? 'Watch this debate live' : 'Open full spectate view'}
           </Link>
           <Link
             href="/demo"

--- a/aragora/live/src/components/landing/__tests__/LiveDemoSection.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/LiveDemoSection.test.tsx
@@ -45,6 +45,10 @@ describe('LiveDemoSection', () => {
         'Should a fast-growing software org split the monolith now or sequence the migration later?',
       ),
     ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Open full spectate view' })).toHaveAttribute(
+      'href',
+      '/spectate',
+    );
   });
 
   it('shows a live transcript when recent debate events are available', () => {
@@ -126,5 +130,9 @@ describe('LiveDemoSection', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getAllByTestId('live-debate-event')).toHaveLength(3);
+    expect(screen.getByRole('link', { name: 'Watch this debate live' })).toHaveAttribute(
+      'href',
+      '/spectate/debate-1',
+    );
   });
 });

--- a/tests/test_browser_extension_context_menu.py
+++ b/tests/test_browser_extension_context_menu.py
@@ -30,9 +30,10 @@ def test_manifest_registers_popup_service_worker_and_content_script() -> None:
     manifest = json.loads(_read_file("manifest.json"))
 
     assert manifest["manifest_version"] == 3
-    assert manifest["name"] == "Aragora Adversarial Review"
-    assert "adversarial review" in manifest["description"]
-    assert "popup" in manifest["description"]
+    assert manifest["name"].startswith("Aragora")
+    description = manifest["description"].lower()
+    assert "adversarial review" in description
+    assert "popup" in description
     assert manifest["background"]["service_worker"] == "background.js"
     assert manifest["action"]["default_title"] == "Aragora"
     assert manifest["action"]["default_popup"] == "popup.html"
@@ -65,6 +66,11 @@ def test_background_script_handles_context_menu_selection_and_api_submission() -
     assert 'status: "error"' in background_script
     assert 'status: createdDebate.status || "running"' in background_script
     assert 'error: "Add an Aragora API key in the popup before sending text."' in background_script
+    assert "function resolveDebateAnswer(result)" in background_script
+    assert "function resolveDebateConfidence(result)" in background_script
+    assert "function buildStoredResult(result)" in background_script
+    assert "confidence: resolveDebateConfidence(result)" in background_script
+    assert "result: buildStoredResult(createdDebate)" in background_script
 
 
 def test_popup_assets_render_saved_selection_and_latest_result() -> None:
@@ -86,21 +92,27 @@ def test_popup_assets_render_saved_selection_and_latest_result() -> None:
     assert 'id="result-confidence"' in popup_html
     assert 'id="result-answer"' in popup_html
     assert 'id="result-error"' in popup_html
-    assert "Latest review" in popup_html
+    assert "Latest result" in popup_html
     assert 'id="save-settings"' in popup_html
 
     assert "chrome.storage.onChanged.addListener" in popup_js
     assert "window.setInterval" in popup_js
     assert "resolveFinalAnswer" in popup_js
+    assert "resolveConfidence" in popup_js
     assert "humanizeStatus" in popup_js
     assert "buildResultState" in popup_js
     assert "result?.answer" in popup_js
     assert "result?.consensus?.summary" in popup_js
     assert "result?.consensus?.final_answer" in popup_js
+    assert "result?.consensus?.conclusion" in popup_js
     assert "finalAnswer" in popup_js
     assert "fetch(`${normalizeApiUrl(apiUrl)}/api/v2/debates/${debateId}`" in popup_js
     assert "result?.final_answer" in popup_js
     assert "result?.finalAnswer" in popup_js
+    assert "const result = activeState.result || {}" in popup_js
+    assert "resolveFinalAnswer(result) ||" in popup_js
+    assert "resolveConfidence(result)" in popup_js
+    assert "result?.consensus?.agreement" in popup_js
     assert "elements.resultConfidence.textContent =" in popup_js
     assert "elements.resultAnswer.textContent = answer" in popup_js
     assert "elements.selectionPreview.textContent =" in popup_js


### PR DESCRIPTION
## Summary
- harvest the remaining valuable popup-result fallback patterns from the duplicate browser-extension PRs
- preserve the best landing-page duplicate idea by deep-linking directly to the active live debate when one is visible
- update the extension and landing-page tests to the real current contract on main

## What this keeps from the duplicate lanes
- store richer debate result payloads in the extension background worker as soon as a debate is created
- normalize popup answer/confidence fallbacks across `final_answer`, `summary`, `conclusion`, and consensus agreement/confidence fields
- send landing-page visitors to the specific live debate instead of the generic spectate index when a public debate is already streaming

## Validation
- `python3 -m pytest tests/test_browser_extension_context_menu.py -q`
- `python3 -m ruff check tests/test_browser_extension_context_menu.py`
- `cd aragora/live && npm test -- --runInBand --runTestsByPath 'src/components/landing/__tests__/LiveDemoSection.test.tsx'`
