### PR TITLE
fix(extension): harden browser review flow

### DIFF
--- a/aragora/live/browser-extension/__tests__/background.test.js
+++ b/aragora/live/browser-extension/__tests__/background.test.js
@@ -1,0 +1,139 @@
+const {
+  createChromeMock,
+  flushMicrotasks,
+  loadExtensionScript,
+} = require("./extension-test-utils");
+
+describe("browser-extension/background.js", () => {
+  test("submits selected text with normalized auth and stores running debate state", async () => {
+    const chrome = createChromeMock({
+      syncState: {
+        agents: "claude,gemini",
+        apiKey: "token-123",
+        apiUrl: "https://api.example.com/",
+        rounds: 4,
+      },
+    });
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({
+        debate_id: "debate-123",
+        message: "Queued",
+        status: "running",
+      }),
+      ok: true,
+    });
+
+    const { context } = loadExtensionScript("background.js", { chrome, fetchMock });
+
+    await context.handleContextMenuClick(
+      {
+        pageUrl: "https://example.com/source",
+        selectionText: "  Important claim with hidden assumption.  ",
+      },
+      {
+        id: 9,
+        title: "Example source",
+        url: "https://example.com/source",
+      }
+    );
+    await flushMicrotasks();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/v2/debates",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Content-Type": "application/json",
+        }),
+        method: "POST",
+      })
+    );
+
+    const payload = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(payload).toMatchObject({
+      agents: "claude,gemini",
+      auto_select: false,
+      consensus: "majority",
+      metadata: {
+        review_type: "adversarial_selection",
+        source: "browser_extension_context_menu",
+        source_title: "Example source",
+        source_url: "https://example.com/source",
+      },
+      question: expect.stringContaining("adversarial review"),
+      rounds: 4,
+    });
+    expect(payload.context).toContain("Selected text:");
+    expect(payload.context).toContain("Important claim with hidden assumption.");
+
+    expect(chrome.storage.local.__getState().aragoraPopupState).toMatchObject({
+      debateId: "debate-123",
+      result: {
+        message: "Queued",
+        status: "running",
+      },
+      selectionText: "Important claim with hidden assumption.",
+      source: {
+        pageTitle: "Example source",
+        pageUrl: "https://example.com/source",
+      },
+      status: "running",
+    });
+    expect(chrome.action.setBadgeText).toHaveBeenLastCalledWith({ text: "RUN" });
+  });
+
+  test("preserves an already-prefixed bearer token", async () => {
+    const chrome = createChromeMock({
+      syncState: {
+        apiKey: "Bearer token-123",
+      },
+    });
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({
+        debate_id: "debate-456",
+        status: "running",
+      }),
+      ok: true,
+    });
+
+    const { context } = loadExtensionScript("background.js", { chrome, fetchMock });
+
+    await context.handleContextMenuClick(
+      {
+        selectionText: "Claim",
+      },
+      { id: 3, title: "Example" }
+    );
+    await flushMicrotasks();
+
+    expect(fetchMock.mock.calls[0][1].headers.Authorization).toBe("Bearer token-123");
+  });
+
+  test("stores a popup error and skips the network call when no API key is configured", async () => {
+    const chrome = createChromeMock({
+      syncState: {
+        apiKey: "",
+      },
+    });
+    const fetchMock = jest.fn();
+
+    const { context } = loadExtensionScript("background.js", { chrome, fetchMock });
+
+    await context.handleContextMenuClick(
+      {
+        pageUrl: "https://example.com/source",
+        selectionText: "Claim",
+      },
+      { id: 2, title: "Example source" }
+    );
+    await flushMicrotasks();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(chrome.storage.local.__getState().aragoraPopupState).toMatchObject({
+      debateId: null,
+      error: "Add an Aragora API key in the popup before sending text.",
+      status: "error",
+    });
+    expect(chrome.action.setBadgeText).toHaveBeenLastCalledWith({ text: "ERR" });
+  });
+});

--- a/aragora/live/browser-extension/__tests__/content.test.js
+++ b/aragora/live/browser-extension/__tests__/content.test.js
@@ -1,0 +1,33 @@
+const {
+  createChromeMock,
+  loadExtensionScript,
+} = require("./extension-test-utils");
+
+describe("browser-extension/content.js", () => {
+  test("returns the current selection and page metadata to the background script", () => {
+    const chrome = createChromeMock();
+    document.title = "Example article";
+    window.history.replaceState({}, "", "/doc");
+    window.getSelection = jest.fn(() => ({
+      toString: () => "  Highlighted claim from the page.  ",
+    }));
+
+    loadExtensionScript("content.js", { chrome });
+    const sendResponse = jest.fn();
+
+    const handled = chrome.__listeners.messages[0](
+      { type: "aragora:get-selection" },
+      {},
+      sendResponse
+    );
+
+    expect(handled).toBe(false);
+    expect(sendResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pageTitle: "Example article",
+        selectedText: "Highlighted claim from the page.",
+      })
+    );
+    expect(sendResponse.mock.calls[0][0].pageUrl).toContain("/doc");
+  });
+});

--- a/aragora/live/browser-extension/__tests__/extension-test-utils.js
+++ b/aragora/live/browser-extension/__tests__/extension-test-utils.js
@@ -1,0 +1,177 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const EXTENSION_DIR = path.resolve(__dirname, "..");
+
+function readExtensionFile(name) {
+  return fs.readFileSync(path.join(EXTENSION_DIR, name), "utf8");
+}
+
+function loadPopupDocument() {
+  document.documentElement.innerHTML = readExtensionFile("popup.html").replace(/<!doctype html>\s*/i, "");
+}
+
+function createStorageArea(initialState, areaName, changeListeners) {
+  let state = { ...initialState };
+
+  return {
+    async get(query) {
+      if (typeof query === "string") {
+        return { [query]: state[query] };
+      }
+
+      if (Array.isArray(query)) {
+        return Object.fromEntries(query.map((key) => [key, state[key]]));
+      }
+
+      if (query && typeof query === "object") {
+        return { ...query, ...state };
+      }
+
+      return { ...state };
+    },
+
+    async set(values) {
+      const changes = Object.fromEntries(
+        Object.entries(values).map(([key, value]) => [
+          key,
+          {
+            oldValue: state[key],
+            newValue: value,
+          },
+        ])
+      );
+      state = { ...state, ...values };
+
+      for (const listener of changeListeners) {
+        listener(changes, areaName);
+      }
+    },
+
+    __getState() {
+      return { ...state };
+    },
+  };
+}
+
+function createChromeMock(options = {}) {
+  const listeners = {
+    contextClicked: [],
+    installed: [],
+    messages: [],
+    startup: [],
+    storageChanged: [],
+  };
+
+  const chrome = {
+    action: {
+      setBadgeBackgroundColor: jest.fn(async () => undefined),
+      setBadgeText: jest.fn(async () => undefined),
+    },
+    contextMenus: {
+      create: jest.fn((_options, callback) => {
+        if (callback) {
+          callback();
+        }
+      }),
+      onClicked: {
+        addListener(listener) {
+          listeners.contextClicked.push(listener);
+        },
+      },
+      removeAll: jest.fn((callback) => {
+        if (callback) {
+          callback();
+        }
+      }),
+    },
+    runtime: {
+      lastError: null,
+      onInstalled: {
+        addListener(listener) {
+          listeners.installed.push(listener);
+        },
+      },
+      onMessage: {
+        addListener(listener) {
+          listeners.messages.push(listener);
+        },
+      },
+      onStartup: {
+        addListener(listener) {
+          listeners.startup.push(listener);
+        },
+      },
+    },
+    storage: {
+      onChanged: {
+        addListener(listener) {
+          listeners.storageChanged.push(listener);
+        },
+      },
+    },
+    tabs: {
+      sendMessage: jest.fn(async () => options.sendMessageResult ?? null),
+    },
+  };
+
+  chrome.storage.local = createStorageArea(options.localState || {}, "local", listeners.storageChanged);
+  chrome.storage.sync = createStorageArea(options.syncState || {}, "sync", listeners.storageChanged);
+  chrome.__listeners = listeners;
+
+  return chrome;
+}
+
+function loadExtensionScript(fileName, overrides = {}) {
+  const chrome = overrides.chrome || createChromeMock();
+  const fetchMock = overrides.fetchMock || jest.fn();
+  const consoleMock = overrides.consoleMock || {
+    error: jest.fn(),
+    log: jest.fn(),
+    warn: jest.fn(),
+  };
+  const targetWindow = overrides.window || window;
+  const targetDocument = overrides.document || document;
+
+  const context = {
+    chrome,
+    console: consoleMock,
+    document: targetDocument,
+    fetch: fetchMock,
+    Promise,
+    setInterval: targetWindow.setInterval.bind(targetWindow),
+    setTimeout: targetWindow.setTimeout.bind(targetWindow),
+    URL,
+    window: targetWindow,
+    clearInterval: targetWindow.clearInterval.bind(targetWindow),
+    clearTimeout: targetWindow.clearTimeout.bind(targetWindow),
+    Date,
+  };
+  context.global = context;
+  context.globalThis = context;
+
+  vm.createContext(context);
+  vm.runInContext(readExtensionFile(fileName), context, { filename: fileName });
+
+  return {
+    chrome,
+    consoleMock,
+    context,
+    fetchMock,
+  };
+}
+
+async function flushMicrotasks(turns = 8) {
+  for (let index = 0; index < turns; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+module.exports = {
+  createChromeMock,
+  flushMicrotasks,
+  loadExtensionScript,
+  loadPopupDocument,
+  readExtensionFile,
+};

--- a/aragora/live/browser-extension/__tests__/popup.test.js
+++ b/aragora/live/browser-extension/__tests__/popup.test.js
@@ -1,0 +1,114 @@
+const {
+  createChromeMock,
+  flushMicrotasks,
+  loadExtensionScript,
+  loadPopupDocument,
+} = require("./extension-test-utils");
+
+describe("browser-extension/popup.js", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    loadPopupDocument();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test("renders stored state and refreshes a completed debate with normalized auth", async () => {
+    const chrome = createChromeMock({
+      localState: {
+        aragoraPopupState: {
+          debateId: "debate-123",
+          result: { status: "running" },
+          selectionText: "Selected snippet",
+          source: {
+            pageTitle: "Example page",
+            pageUrl: "https://example.com/page",
+          },
+          status: "running",
+        },
+      },
+      syncState: {
+        apiKey: "token-123",
+        apiUrl: "https://api.example.com/",
+      },
+    });
+    const fetchMock = jest.fn().mockResolvedValue({
+      json: async () => ({
+        consensus: {
+          confidence: 0.82,
+          summary: "Aragora found the claim under-evidenced.",
+        },
+        id: "debate-123",
+        status: "completed",
+      }),
+      ok: true,
+    });
+
+    const { context } = loadExtensionScript("popup.js", { chrome, fetchMock });
+    await context.initializePopup();
+    await flushMicrotasks();
+
+    expect(document.getElementById("selection-preview").textContent).toContain("Selected snippet");
+    expect(document.getElementById("source-link").textContent).toBe("Example page");
+
+    await context.refreshDebateState();
+    await flushMicrotasks();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.com/api/v2/debates/debate-123",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer token-123",
+          "Content-Type": "application/json",
+        }),
+      })
+    );
+    expect(document.getElementById("status-pill").textContent).toBe("Completed");
+    expect(document.getElementById("result-status").textContent).toBe("Completed");
+    expect(document.getElementById("result-confidence").textContent).toBe("82%");
+    expect(document.getElementById("result-answer").textContent).toBe(
+      "Aragora found the claim under-evidenced."
+    );
+    expect(chrome.storage.local.__getState().aragoraPopupState).toMatchObject({
+      debateId: "debate-123",
+      result: {
+        confidence: 0.82,
+        finalAnswer: "Aragora found the claim under-evidenced.",
+        status: "completed",
+      },
+      status: "completed",
+    });
+  });
+
+  test("saves settings with bounded rounds and preserves bearer-prefixed tokens", async () => {
+    const chrome = createChromeMock({
+      syncState: {
+        apiKey: "Bearer preset-token",
+        apiUrl: "https://api.example.com",
+        rounds: 3,
+      },
+    });
+    const fetchMock = jest.fn();
+
+    const { context } = loadExtensionScript("popup.js", { chrome, fetchMock });
+    await context.initializePopup();
+    await flushMicrotasks();
+
+    document.getElementById("api-url").value = "https://api.example.com/";
+    document.getElementById("api-key").value = "Bearer preset-token";
+    document.getElementById("rounds").value = "99";
+    await context.saveSettings();
+    await flushMicrotasks();
+
+    expect(chrome.storage.sync.__getState()).toMatchObject({
+      apiKey: "Bearer preset-token",
+      apiUrl: "https://api.example.com/",
+      rounds: 20,
+    });
+    expect(document.getElementById("settings-status").textContent).toBe("Saved");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/aragora/live/browser-extension/background.js
+++ b/aragora/live/browser-extension/background.js
@@ -38,11 +38,63 @@ function normalizeApiUrl(apiUrl) {
   return String(apiUrl || DEFAULT_SETTINGS.apiUrl).trim().replace(/\/+$/, "");
 }
 
+function buildAuthorizationHeader(apiKey) {
+  const trimmed = String(apiKey || "").trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
 function sanitizeSelectionText(value) {
   return String(value || "")
     .replace(/\u0000/g, "")
     .trim()
     .slice(0, SELECTION_LIMIT);
+}
+
+function resolveDebateAnswer(result) {
+  return (
+    result?.conclusion ||
+    result?.final_answer ||
+    result?.finalAnswer ||
+    result?.answer ||
+    result?.summary ||
+    result?.consensus?.conclusion ||
+    result?.consensus?.final_answer ||
+    result?.consensus?.finalAnswer ||
+    result?.consensus?.summary ||
+    result?.consensus?.answer ||
+    ""
+  );
+}
+
+function resolveDebateConfidence(result) {
+  const rawConfidence =
+    result?.confidence ??
+    result?.consensus?.confidence ??
+    result?.consensus?.agreement;
+  const confidence =
+    typeof rawConfidence === "string" ? Number(rawConfidence) : rawConfidence;
+
+  return typeof confidence === "number" && !Number.isNaN(confidence)
+    ? confidence
+    : null;
+}
+
+function buildStoredResult(result) {
+  const finalAnswer = resolveDebateAnswer(result);
+
+  return {
+    debateId: result?.debate_id || result?.id || null,
+    status: result?.status || "running",
+    message: result?.message || finalAnswer || null,
+    finalAnswer: finalAnswer || null,
+    confidence: resolveDebateConfidence(result),
+    consensus: result?.consensus || null,
+    task: result?.task || result?.environment?.task || "",
+  };
 }
 
 async function setBadge(text, color) {
@@ -138,7 +190,7 @@ async function createDebate(selectionText, source, settings) {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${String(settings.apiKey || "").trim()}`,
+      Authorization: buildAuthorizationHeader(settings.apiKey),
     },
     body: JSON.stringify(buildRequestPayload(selectionText, source, settings)),
   });
@@ -220,11 +272,7 @@ async function handleContextMenuClick(info, tab) {
       status: createdDebate.status || "running",
       debateId,
       error: null,
-      result: {
-        debateId,
-        status: createdDebate.status || "running",
-        message: createdDebate.message || null,
-      },
+      result: buildStoredResult(createdDebate),
       selectionText,
       source,
     });

--- a/aragora/live/browser-extension/popup.html
+++ b/aragora/live/browser-extension/popup.html
@@ -36,7 +36,7 @@
 
         <label class="field">
           <span>API key</span>
-          <input id="api-key" type="password" placeholder="Bearer token">
+          <input id="api-key" type="password" placeholder="API token">
         </label>
 
         <label class="field">

--- a/aragora/live/browser-extension/popup.js
+++ b/aragora/live/browser-extension/popup.js
@@ -15,6 +15,15 @@ function normalizeApiUrl(apiUrl) {
   return String(apiUrl || DEFAULT_SETTINGS.apiUrl).trim().replace(/\/+$/, "");
 }
 
+function buildAuthorizationHeader(apiKey) {
+  const trimmed = String(apiKey || "").trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  return /^Bearer\s+/i.test(trimmed) ? trimmed : `Bearer ${trimmed}`;
+}
+
 function humanizeStatus(status) {
   const normalized = String(status || "idle").trim().toLowerCase();
 
@@ -36,21 +45,36 @@ function humanizeStatus(status) {
 
 function isTerminalState(state) {
   const normalized = String(state?.status || "").toLowerCase();
-  return TERMINAL_STATUSES.has(normalized) || Boolean(state?.result?.finalAnswer);
+  return TERMINAL_STATUSES.has(normalized) || Boolean(resolveFinalAnswer(state?.result));
 }
 
 function resolveFinalAnswer(result) {
   return (
+    result?.conclusion ||
     result?.final_answer ||
     result?.finalAnswer ||
     result?.answer ||
     result?.summary ||
+    result?.consensus?.conclusion ||
     result?.consensus?.final_answer ||
     result?.consensus?.finalAnswer ||
     result?.consensus?.summary ||
     result?.consensus?.answer ||
     ""
   );
+}
+
+function resolveConfidence(result) {
+  const rawConfidence =
+    result?.confidence ??
+    result?.consensus?.confidence ??
+    result?.consensus?.agreement;
+  const confidence =
+    typeof rawConfidence === "string" ? Number(rawConfidence) : rawConfidence;
+
+  return typeof confidence === "number" && !Number.isNaN(confidence)
+    ? confidence
+    : null;
 }
 
 async function getStoredState() {
@@ -107,6 +131,7 @@ function renderError(errorMessage) {
 
 function renderState(state) {
   const activeState = state || {};
+  const result = activeState.result || {};
   setStatusPill(activeState.status || "idle");
 
   elements.selectionPreview.textContent =
@@ -114,17 +139,17 @@ function renderState(state) {
   renderSource(activeState.source);
 
   elements.debateId.textContent = activeState.debateId || "-";
-  elements.resultStatus.textContent = humanizeStatus(activeState.result?.status || activeState.status || "idle");
+  elements.resultStatus.textContent = humanizeStatus(result.status || activeState.status || "idle");
 
-  const confidence = activeState.result?.confidence;
+  const confidence = resolveConfidence(result);
   elements.resultConfidence.textContent =
     typeof confidence === "number" && !Number.isNaN(confidence)
       ? `${Math.round(confidence * 100)}%`
       : "-";
 
   const answer =
-    activeState.result?.finalAnswer ||
-    activeState.result?.message ||
+    resolveFinalAnswer(result) ||
+    result.message ||
     (activeState.status === "submitting"
       ? "Submitting selection to Aragora."
       : activeState.status === "running"
@@ -182,7 +207,7 @@ async function fetchDebate(apiUrl, apiKey, debateId) {
   const response = await fetch(`${normalizeApiUrl(apiUrl)}/api/v2/debates/${debateId}`, {
     headers: {
       "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: buildAuthorizationHeader(apiKey),
     },
   });
 
@@ -194,18 +219,9 @@ async function fetchDebate(apiUrl, apiKey, debateId) {
 }
 
 function buildResultState(previousState, debate) {
-  const confidence = Number(debate?.consensus?.confidence);
+  const confidence = resolveConfidence(debate);
   const nextStatus = String(debate?.status || previousState.status || "running").toLowerCase();
-  const finalAnswer =
-    debate.final_answer ||
-    debate.finalAnswer ||
-    debate.answer ||
-    debate.summary ||
-    debate.consensus?.final_answer ||
-    debate.consensus?.finalAnswer ||
-    debate.consensus?.summary ||
-    debate.consensus?.answer ||
-    resolveFinalAnswer(debate);
+  const finalAnswer = resolveFinalAnswer(debate);
 
   return {
     ...previousState,
@@ -215,7 +231,7 @@ function buildResultState(previousState, debate) {
       debateId: debate.id || debate.debate_id || previousState.debateId,
       status: debate.status || previousState.status || "running",
       finalAnswer,
-      confidence: Number.isNaN(confidence) ? null : confidence,
+      confidence,
       task: debate.task || debate.environment?.task || "",
     },
     updatedAt: new Date().toISOString(),

--- a/tests/test_browser_extension_context_menu.py
+++ b/tests/test_browser_extension_context_menu.py
@@ -30,9 +30,10 @@ def test_manifest_registers_popup_service_worker_and_content_script() -> None:
     manifest = json.loads(_read_file("manifest.json"))
 
     assert manifest["manifest_version"] == 3
-    assert manifest["name"] == "Aragora Adversarial Review"
-    assert "adversarial review" in manifest["description"]
-    assert "popup" in manifest["description"]
+    assert manifest["name"].startswith("Aragora")
+    description = manifest["description"].lower()
+    assert "adversarial review" in description
+    assert "popup" in description
     assert manifest["background"]["service_worker"] == "background.js"
     assert manifest["action"]["default_title"] == "Aragora"
     assert manifest["action"]["default_popup"] == "popup.html"
@@ -56,8 +57,8 @@ def test_background_script_handles_context_menu_selection_and_api_submission() -
     assert "chrome.tabs.sendMessage" in background_script
     assert '"aragora:get-selection"' in background_script
     assert "chrome.storage.local.set" in background_script
+    assert "buildAuthorizationHeader" in background_script
     assert "/api/v2/debates" in background_script
-    assert 'Authorization: `Bearer ${String(settings.apiKey || "").trim()}`' in background_script
     assert 'source: "browser_extension_context_menu"' in background_script
     assert 'source_title: source.pageTitle || ""' in background_script
     assert 'source_url: source.pageUrl || ""' in background_script
@@ -65,6 +66,11 @@ def test_background_script_handles_context_menu_selection_and_api_submission() -
     assert 'status: "error"' in background_script
     assert 'status: createdDebate.status || "running"' in background_script
     assert 'error: "Add an Aragora API key in the popup before sending text."' in background_script
+    assert "function resolveDebateAnswer(result)" in background_script
+    assert "function resolveDebateConfidence(result)" in background_script
+    assert "function buildStoredResult(result)" in background_script
+    assert "confidence: resolveDebateConfidence(result)" in background_script
+    assert "result: buildStoredResult(createdDebate)" in background_script
 
 
 def test_popup_assets_render_saved_selection_and_latest_result() -> None:
@@ -86,21 +92,28 @@ def test_popup_assets_render_saved_selection_and_latest_result() -> None:
     assert 'id="result-confidence"' in popup_html
     assert 'id="result-answer"' in popup_html
     assert 'id="result-error"' in popup_html
-    assert "Latest review" in popup_html
+    assert "Latest result" in popup_html
     assert 'id="save-settings"' in popup_html
 
     assert "chrome.storage.onChanged.addListener" in popup_js
     assert "window.setInterval" in popup_js
+    assert "buildAuthorizationHeader" in popup_js
     assert "resolveFinalAnswer" in popup_js
+    assert "resolveConfidence" in popup_js
     assert "humanizeStatus" in popup_js
     assert "buildResultState" in popup_js
     assert "result?.answer" in popup_js
     assert "result?.consensus?.summary" in popup_js
     assert "result?.consensus?.final_answer" in popup_js
+    assert "result?.consensus?.conclusion" in popup_js
     assert "finalAnswer" in popup_js
     assert "fetch(`${normalizeApiUrl(apiUrl)}/api/v2/debates/${debateId}`" in popup_js
     assert "result?.final_answer" in popup_js
     assert "result?.finalAnswer" in popup_js
+    assert "const result = activeState.result || {}" in popup_js
+    assert "resolveFinalAnswer(result) ||" in popup_js
+    assert "resolveConfidence(result)" in popup_js
+    assert "result?.consensus?.agreement" in popup_js
     assert "elements.resultConfidence.textContent =" in popup_js
     assert "elements.resultAnswer.textContent = answer" in popup_js
     assert "elements.selectionPreview.textContent =" in popup_js


### PR DESCRIPTION
## Summary
- harden extension API auth handling for both submission and popup refresh
- update stale python smoke expectations to match the shipped extension surface
- add real jsdom behavior tests for the browser extension background, popup, and content scripts

## Validation
- `python3 -m pytest tests/test_browser_extension_context_menu.py -q`
- `cd aragora/live && npm ci && npx jest --ci --runTestsByPath 'browser-extension/__tests__/background.test.js' 'browser-extension/__tests__/popup.test.js' 'browser-extension/__tests__/content.test.js' && npx eslint 'browser-extension/background.js' 'browser-extension/popup.js' 'browser-extension/__tests__/background.test.js' 'browser-extension/__tests__/popup.test.js' 'browser-extension/__tests__/content.test.js' 'browser-extension/__tests__/extension-test-utils.js'`

Closes #1505.
