### PR TITLE
fix(spectate): make public bridge endpoints truly public

### DIFF
--- a/aragora/server/auth_checks.py
+++ b/aragora/server/auth_checks.py
@@ -312,6 +312,10 @@ class AuthChecksMixin:
             "/api/v1/playground/status",
             # Public demo — no auth, no API credits (offline fixture mode)
             "/api/v1/demo/adversarial",
+            # Public spectate bridge surfaces for landing/watch mode
+            "/api/v1/spectate/recent",
+            "/api/v1/spectate/status",
+            "/api/v1/spectate/stream",
             # OAuth callbacks from external providers (redirects carry no auth headers)
             "/api/integrations/slack/callback",
             "/api/integrations/teams/callback",

--- a/aragora/server/auth_requirements.py
+++ b/aragora/server/auth_requirements.py
@@ -134,6 +134,12 @@ PUBLIC_ENDPOINTS = [
         AuthLevel.PUBLIC,
         description="Spectate bridge status (redacted for unauthenticated)",
     ),
+    EndpointAuth(
+        "/api/v1/spectate/stream",
+        "get",
+        AuthLevel.PUBLIC,
+        description="Spectate SSE snapshot / JSON preview",
+    ),
     # Onboarding - public for first-time users
     EndpointAuth(
         "/api/v1/onboarding/templates",

--- a/aragora/server/http_utils.py
+++ b/aragora/server/http_utils.py
@@ -22,6 +22,7 @@ ALLOWED_QUERY_PARAMS = {
     # Pagination (numeric, validated by int parsing)
     "limit": None,
     "offset": None,
+    "count": None,
     "min_debates": None,
     "since": None,
     # Filtering (string, need length limits)
@@ -46,6 +47,7 @@ ALLOWED_QUERY_PARAMS = {
     "prioritized": 10,
     "scopes": 500,
     "debate_id": 100,
+    "pipeline_id": 100,
     "org_id": 100,
     "organization_id": 100,
     "user_id": 100,

--- a/tests/server/test_auth_exemptions.py
+++ b/tests/server/test_auth_exemptions.py
@@ -70,6 +70,9 @@ class TestAuthExemptPaths:
             "/api/leaderboard",
             "/api/leaderboard-view",
             "/api/agents",
+            "/api/v1/spectate/recent",
+            "/api/v1/spectate/status",
+            "/api/v1/spectate/stream",
         ]
         for endpoint in public_endpoints:
             assert endpoint in exempt_paths, f"Public endpoint {endpoint} should be exempt"

--- a/tests/test_http_utils_security.py
+++ b/tests/test_http_utils_security.py
@@ -110,6 +110,7 @@ class TestQueryParamValidation:
         expected_params = {
             "limit",
             "offset",
+            "count",
             "domain",
             "loop_id",
             "topic",
@@ -118,6 +119,8 @@ class TestQueryParamValidation:
             "agent",
             "agent_a",
             "agent_b",
+            "debate_id",
+            "pipeline_id",
             "sections",
             "buckets",
             "tiers",
@@ -357,7 +360,13 @@ class TestQueryParamWhitelistCompleteness:
         """Pagination params should be allowed."""
         assert "limit" in ALLOWED_QUERY_PARAMS
         assert "offset" in ALLOWED_QUERY_PARAMS
+        assert "count" in ALLOWED_QUERY_PARAMS
         assert "since" in ALLOWED_QUERY_PARAMS
+
+    def test_spectate_params_allowed(self):
+        """Public spectate polling params should be allowed."""
+        assert "debate_id" in ALLOWED_QUERY_PARAMS
+        assert "pipeline_id" in ALLOWED_QUERY_PARAMS
 
     def test_search_params_allowed(self):
         """Search params should be allowed."""


### PR DESCRIPTION
## Summary
- exempt the public spectate bridge endpoints from auth checks
- allow spectate polling query params through the unified server whitelist
- lock the public spectate contract with auth/query tests

## Testing
- python3 -m ruff check aragora/server/auth_checks.py aragora/server/auth_requirements.py aragora/server/http_utils.py tests/server/test_auth_exemptions.py tests/test_http_utils_security.py tests/contract/test_auth_requirements.py
- python3 -m pytest tests/server/test_auth_exemptions.py tests/test_http_utils_security.py tests/contract/test_auth_requirements.py tests/handlers/test_spectate_ws.py -q

Closes #1504