### PR TITLE
fix(insights): cache flip detector bootstrap per database path

### DIFF
--- a/aragora/insights/flip_detector.py
+++ b/aragora/insights/flip_detector.py
@@ -12,6 +12,7 @@ Key components:
 
 import logging
 import sqlite3
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -123,6 +124,10 @@ class FlipDetector:
     semantic analysis to classify flip types.
     """
 
+    _database_cache: dict[str, InsightsDatabase] = {}
+    _initialized_paths: set[str] = set()
+    _init_lock = threading.Lock()
+
     def __init__(
         self,
         db_path: str | Path | None = None,
@@ -131,12 +136,12 @@ class FlipDetector:
     ):
         if db_path is None:
             db_path = get_db_path(DatabaseType.PERSONAS)
-        self.db_path = Path(db_path)
-        self.db = InsightsDatabase(str(db_path))
+        self.db_path = Path(db_path).resolve()
+        self.db = self._get_database(self.db_path)
         self.similarity_threshold = similarity_threshold
         self._km_adapter = km_adapter
         self._similarity_backend = None
-        self._init_tables()
+        self._ensure_tables_initialized()
 
     def set_km_adapter(self, adapter: "InsightsAdapter") -> None:
         """Set the Knowledge Mound adapter for bidirectional sync.
@@ -145,6 +150,36 @@ class FlipDetector:
             adapter: InsightsAdapter instance for KM integration
         """
         self._km_adapter = adapter
+
+    @classmethod
+    def _get_database(cls, db_path: Path) -> InsightsDatabase:
+        """Reuse the database wrapper for repeated access to the same DB file."""
+        path_key = str(db_path)
+        cached = cls._database_cache.get(path_key)
+        if cached is not None:
+            return cached
+        with cls._init_lock:
+            cached = cls._database_cache.get(path_key)
+            if cached is None:
+                cached = InsightsDatabase(str(db_path))
+                cls._database_cache[path_key] = cached
+            return cached
+
+    def _ensure_tables_initialized(self) -> None:
+        """Bootstrap tables once per resolved DB path.
+
+        Leaderboard reads may construct detectors on demand. Re-running DDL on
+        every request turns a read path into a write-heavy SQLite workload and
+        increases lock contention under concurrent traffic.
+        """
+        path_key = str(self.db_path)
+        if path_key in self._initialized_paths:
+            return
+        with self._init_lock:
+            if path_key in self._initialized_paths:
+                return
+            self._init_tables()
+            self._initialized_paths.add(path_key)
 
     def _init_tables(self) -> None:
         """Create flips and positions tables if not exist."""

--- a/tests/insights/test_flip_detector.py
+++ b/tests/insights/test_flip_detector.py
@@ -5,6 +5,7 @@ Tests flip detection, consistency scoring, and UI formatting.
 """
 
 import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -305,6 +306,53 @@ class TestFlipDetector:
 
         assert "detected_flips" in tables
         assert "positions" in tables
+
+    def test_initializes_tables_once_per_database_path(self, monkeypatch, temp_db):
+        """Concurrent instances should not rerun schema bootstrap for one DB."""
+        path_key = str(temp_db.resolve())
+        FlipDetector._database_cache.pop(path_key, None)
+        FlipDetector._initialized_paths.discard(path_key)
+
+        original_init_tables = FlipDetector._init_tables
+        init_calls = 0
+        init_calls_lock = threading.Lock()
+        barrier = threading.Barrier(4)
+        errors: list[Exception] = []
+
+        def wrapped(self):
+            nonlocal init_calls
+            with init_calls_lock:
+                init_calls += 1
+            return original_init_tables(self)
+
+        def create_detector():
+            try:
+                barrier.wait(timeout=5)
+                FlipDetector(db_path=temp_db, similarity_threshold=0.6)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        monkeypatch.setattr(FlipDetector, "_init_tables", wrapped)
+
+        threads = [threading.Thread(target=create_detector) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=5)
+
+        assert errors == []
+        assert init_calls == 1
+
+    def test_reuses_database_wrapper_per_database_path(self, temp_db):
+        """Repeated detectors for the same path should share one DB wrapper."""
+        path_key = str(temp_db.resolve())
+        FlipDetector._database_cache.pop(path_key, None)
+        FlipDetector._initialized_paths.discard(path_key)
+
+        first = FlipDetector(db_path=temp_db, similarity_threshold=0.6)
+        second = FlipDetector(db_path=temp_db, similarity_threshold=0.6)
+
+        assert first.db is second.db
 
     def test_get_agent_consistency_no_data(self, detector):
         """Test getting consistency for agent with no data."""


### PR DESCRIPTION
## Summary
- cache and reuse FlipDetector database/bootstrap state per resolved DB path
- stop leaderboard reads from re-running schema bootstrap on every detector construction
- lock the one-time bootstrap and shared wrapper behavior with concurrent regression tests

## Validation
- python3 -m ruff check aragora/insights/flip_detector.py tests/insights/test_flip_detector.py
- python3 -m pytest tests/insights/test_flip_detector.py -q
- repeated targeted concurrency loop: 10/10 passes

Supersedes #1600 for the unique flip-detector contention fix; the stale release-gate test overlap is already on `main` via #1599.