### PR TITLE
fix(ci): guard governance summary on cancelled runs

### DIFF
--- a/.github/workflows/contract-drift-governance.yml
+++ b/.github/workflows/contract-drift-governance.yml
@@ -84,7 +84,7 @@ jobs:
           python scripts/check_contract_drift_ratchet.py --strict --json > /tmp/contract-drift-ratchet.json
 
       - name: Write ratchet summary
-        if: always()
+        if: ${{ always() && !cancelled() }}
         run: |
           python - <<'PY'
           import json
@@ -116,12 +116,12 @@ jobs:
           print(summary.read_text())
           PY
 
-          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ] && [ -f ratchet-summary.md ]; then
             cat ratchet-summary.md >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload governance artifacts
-        if: always()
+        if: ${{ always() && !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: contract-drift-governance


### PR DESCRIPTION
## Summary
- skip governance summary and artifact upload steps when the workflow has already been cancelled
- only append `ratchet-summary.md` to `$GITHUB_STEP_SUMMARY` when the file actually exists

## Why
The contract-drift governance workflow could turn a cancelled checkout into a hard red failure by running its `always()` summary step against files that were never generated.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- local missing-ratchet-output shell simulation exits cleanly
