### PR TITLE
fix(debates): share public standalone debate links

### DIFF
--- a/aragora/live/src/app/(app)/debates/[id]/DebateDetailClient.tsx
+++ b/aragora/live/src/app/(app)/debates/[id]/DebateDetailClient.tsx
@@ -154,10 +154,13 @@ export default function DebateDetailClient() {
         throw new Error(`Failed to create share link (HTTP ${res.status})`);
       }
       const data = (await res.json()) as DebateShareResponse;
-      const url =
-        typeof data.full_url === 'string' && data.full_url.length > 0
+      const sharePath =
+        typeof data.share_url === 'string' && data.share_url.length > 0 ? data.share_url : null;
+      const url = sharePath
+        ? new URL(sharePath, window.location.origin).toString()
+        : typeof data.full_url === 'string' && data.full_url.length > 0
           ? data.full_url
-          : new URL(data.share_url || `/debate/${id}`, window.location.origin).toString();
+          : new URL(`/debate/${id}`, window.location.origin).toString();
       await navigator.clipboard.writeText(url);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/aragora/live/src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx
+++ b/aragora/live/src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx
@@ -156,6 +156,7 @@ describe('DebateDetailClient bridge actions', () => {
             debate_id: 'debate-123',
             public_spectate: true,
             share_url: '/debate/debate-123',
+            full_url: 'https://backend.test/debate/debate-123',
           }),
         );
       }


### PR DESCRIPTION
## Summary
- make debate detail share actions call the existing share API before copying a link
- copy the public `/debate/{id}` URL instead of the authenticated `/debates/{id}` route
- add focused frontend coverage for the public share flow

## Testing
- cd aragora/live && npx jest --ci --runTestsByPath 'src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx'\n- cd aragora/live && npx eslint 'src/app/(app)/debates/[id]/DebateDetailClient.tsx' 'src/app/(app)/debates/[id]/__tests__/DebateDetailClient.test.tsx'