### PR TITLE
fix(slack): include receipt links in debate receipts

### DIFF
--- a/aragora/integrations/slack_debate.py
+++ b/aragora/integrations/slack_debate.py
@@ -753,6 +753,21 @@ class SlackDebateLifecycle:
         if self._session is not None and not self._session.closed:
             await self._session.close()
 
+    @staticmethod
+    def _build_receipt_url(receipt: Any, receipt_url: str = "") -> str:
+        """Return a canonical receipt URL when the receipt has an ID."""
+        if receipt_url:
+            return receipt_url
+
+        import os as _os
+
+        receipt_id = getattr(receipt, "receipt_id", "")
+        if not receipt_id:
+            return ""
+
+        base_url = _os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
+        return f"{base_url}/receipts/{receipt_id}"
+
     async def _post_to_thread(
         self,
         channel_id: str,
@@ -935,6 +950,7 @@ class SlackDebateLifecycle:
         Returns:
             True if posted successfully.
         """
+        receipt_url = self._build_receipt_url(receipt, receipt_url)
         blocks = _build_receipt_blocks(receipt, debate_id, receipt_url)
         verdict = getattr(receipt, "verdict", "UNKNOWN")
         text = f"Decision receipt: {verdict}"
@@ -1487,8 +1503,6 @@ class SlackDebateLifecycle:
         Returns:
             True if the receipt was delivered successfully.
         """
-        import os as _os
-
         # Load receipt if not provided
         if receipt is None:
             receipt = self._load_receipt(debate_id)
@@ -1497,11 +1511,7 @@ class SlackDebateLifecycle:
                 return False
 
         # Build receipt URL if not provided
-        if not receipt_url:
-            base_url = _os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
-            receipt_id = getattr(receipt, "receipt_id", "")
-            if receipt_id:
-                receipt_url = f"{base_url}/receipts/{receipt_id}"
+        receipt_url = self._build_receipt_url(receipt, receipt_url)
 
         blocks = _build_receipt_with_approval_blocks(
             receipt, debate_id=debate_id, receipt_url=receipt_url

--- a/tests/integrations/test_slack_debate.py
+++ b/tests/integrations/test_slack_debate.py
@@ -854,6 +854,31 @@ class TestPostReceipt:
             )
             assert result is False
 
+    @pytest.mark.asyncio
+    async def test_builds_default_receipt_url_when_missing(self, lifecycle):
+        receipt = _make_receipt(receipt_id="rcpt-slack-123")
+
+        with patch.dict(
+            "os.environ", {"ARAGORA_PUBLIC_URL": "https://app.aragora.ai"}, clear=False
+        ):
+            with patch.object(
+                lifecycle, "_post_to_thread", new_callable=AsyncMock, return_value=True
+            ) as mock_post:
+                result = await lifecycle.post_receipt(
+                    channel_id="C01ABC",
+                    thread_ts="123.456",
+                    receipt=receipt,
+                    debate_id="debate-slack-1",
+                )
+
+        assert result is True
+        mock_post.assert_called_once()
+        _, _, _, blocks = mock_post.call_args.args
+        assert any("View Full Receipt" in str(block) for block in blocks)
+        assert any(
+            "https://app.aragora.ai/receipts/rcpt-slack-123" in str(block) for block in blocks
+        )
+
 
 # =============================================================================
 # SlackDebateLifecycle.post_error Tests


### PR DESCRIPTION
## Summary
- synthesize the default public receipt URL inside the Slack debate lifecycle
- use the same receipt URL builder for standard and approval-style Slack receipt delivery
- add focused Slack integration coverage for receipt links in posted thread messages

## Testing
- python3 -m pytest tests/integrations/test_slack_debate.py -q
- python3 -m ruff check aragora/integrations/slack_debate.py tests/integrations/test_slack_debate.py