### PR TITLE
chore(openapi): expose matrix comparison contract

### DIFF
--- a/sdk/python/aragora/generated_types.py
+++ b/sdk/python/aragora/generated_types.py
@@ -256,6 +256,48 @@ class AutoSelectConfig(BaseModel):
     diversity_preference: float | None = 0.5
 
 
+class AgentCombination1(BaseModel):
+    provider: str
+    model: str | None = None
+    persona: str | None = None
+    role: str | None = None
+    name: str | None = None
+    hierarchy_role: str | None = None
+
+
+class AgentCombination(BaseModel):
+    __root__: Annotated[list[str | AgentCombination1], Field(max_items=10, min_items=2)]
+
+
+class ComparisonConfig(BaseModel):
+    enabled: Annotated[
+        bool | None,
+        Field(description="Enable comparison mode (default true when this object is present)"),
+    ] = True
+    pick_best_result: Annotated[
+        bool | None,
+        Field(
+            description="Automatically select the strongest result after all combinations finish"
+        ),
+    ] = True
+    selection_strategy: Annotated[
+        str | None,
+        Field(
+            description="Optional strategy name for choosing the winning result",
+            example="llm_judge",
+        ),
+    ] = None
+    agent_combinations: Annotated[
+        list[AgentCombination] | None,
+        Field(
+            description="Candidate lineups to run against the same debate question",
+            example=[["claude", "openai-api", "gemini"], ["claude", "grok", "qwen"]],
+            max_items=10,
+            min_items=1,
+        ),
+    ] = None
+
+
 class TrendingCategory(StrEnum):
     tech = "tech"
     science = "science"
@@ -361,6 +403,30 @@ class DebateCreateRequest(BaseModel):
     auto_select_config: Annotated[
         AutoSelectConfig | None,
         Field(description="Configuration for auto-selection algorithm"),
+    ] = None
+    comparison_config: Annotated[
+        ComparisonConfig | None,
+        Field(
+            description="Run the same debate across multiple candidate agent/model combinations and keep the best result."
+        ),
+    ] = None
+    model_comparison: Annotated[
+        dict[str, Any] | None,
+        Field(deprecated=True, description="Deprecated alias for comparison_config."),
+    ] = None
+    agent_combinations: Annotated[
+        list[list[str]] | None,
+        Field(
+            deprecated=True,
+            description="Deprecated alias for comparison_config.agent_combinations.",
+        ),
+    ] = None
+    model_combinations: Annotated[
+        list[list[str]] | None,
+        Field(
+            deprecated=True,
+            description="Deprecated human-facing alias for comparison_config.agent_combinations.",
+        ),
     ] = None
     enable_verticals: Annotated[
         bool | None,

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -58022,6 +58022,62 @@ export interface components {
                 /** @default 0.5 */
                 diversity_preference: number;
             };
+            /** @description Run the same debate across multiple candidate agent/model combinations and keep the best result. */
+            comparison_config?: {
+                /**
+                 * @description Enable comparison mode (default true when this object is present)
+                 * @default true
+                 */
+                enabled: boolean;
+                /**
+                 * @description Automatically select the strongest result after all combinations finish
+                 * @default true
+                 */
+                pick_best_result: boolean;
+                /**
+                 * @description Optional strategy name for choosing the winning result
+                 * @example llm_judge
+                 */
+                selection_strategy?: string;
+                /**
+                 * @description Candidate lineups to run against the same debate question
+                 * @example [
+                 *       [
+                 *         "claude",
+                 *         "openai-api",
+                 *         "gemini"
+                 *       ],
+                 *       [
+                 *         "claude",
+                 *         "grok",
+                 *         "qwen"
+                 *       ]
+                 *     ]
+                 */
+                agent_combinations?: (string | {
+                    provider: string;
+                    model?: string;
+                    persona?: string;
+                    role?: string;
+                    name?: string;
+                    hierarchy_role?: string;
+                })[][];
+            };
+            /**
+             * @deprecated
+             * @description Deprecated alias for comparison_config.
+             */
+            model_comparison?: Record<string, never>;
+            /**
+             * @deprecated
+             * @description Deprecated alias for comparison_config.agent_combinations.
+             */
+            agent_combinations?: string[][];
+            /**
+             * @deprecated
+             * @description Deprecated human-facing alias for comparison_config.agent_combinations.
+             */
+            model_combinations?: string[][];
             /**
              * @description Enable vertical specialist injection for the task domain (default set by ARAGORA_ENABLE_VERTICALS)
              * @default true


### PR DESCRIPTION
## Summary
- refresh generated OpenAPI artifacts for the existing matrix comparison feature
- add comparison_config and best-result selection fields back to the committed API contract
- refresh Python and TypeScript SDK generated types to match runtime behavior

## Validation
- python3 scripts/check_version_alignment.py
- python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check
- python3 scripts/generate_python_sdk_types.py --openapi docs/api/openapi_generated.json --check
- python3 scripts/check_capability_matrix_sync.py
- python3 scripts/check_legacy_entrypoints.py
- python3 scripts/check_legacy_collab_flags.py
- python3 scripts/generate_cli_reference.py --check

## Context
Runtime matrix debates already support running the same question across agent/model combinations and selecting the best result. The generated OpenAPI and SDK surfaces were stale and omitted that contract.