### PR TITLE
test(sdk): align gauntlet receipts with v1 routes

### DIFF
--- a/sdk/python/tests/test_receipts.py
+++ b/sdk/python/tests/test_receipts.py
@@ -22,7 +22,7 @@ class TestReceiptsGauntlet:
 
             mock_request.assert_called_once_with(
                 "GET",
-                "/api/v2/gauntlet/results",
+                "/api/v1/gauntlet/results",
                 params={"limit": 10, "offset": 0, "verdict": "PASS"},
             )
             client.close()
@@ -35,7 +35,7 @@ class TestReceiptsGauntlet:
             client = AragoraClient(base_url="https://api.aragora.ai")
             client.receipts.get_gauntlet("gnt_123")
 
-            mock_request.assert_called_once_with("GET", "/api/v2/gauntlet/gnt_123/receipt")
+            mock_request.assert_called_once_with("GET", "/api/v1/gauntlet/gnt_123/receipt")
             client.close()
 
     def test_verify_gauntlet(self) -> None:
@@ -46,7 +46,7 @@ class TestReceiptsGauntlet:
             client = AragoraClient(base_url="https://api.aragora.ai")
             client.receipts.verify_gauntlet("gnt_123")
 
-            mock_request.assert_called_once_with("POST", "/api/v2/gauntlet/gnt_123/receipt/verify")
+            mock_request.assert_called_once_with("POST", "/api/v1/gauntlet/gnt_123/receipt/verify")
             client.close()
 
     def test_export_gauntlet_markdown(self) -> None:
@@ -59,7 +59,7 @@ class TestReceiptsGauntlet:
 
             mock_request.assert_called_once_with(
                 "GET",
-                "/api/v2/gauntlet/gnt_123/receipt",
+                "/api/v1/gauntlet/gnt_123/receipt",
                 params={"format": "md"},
             )
             client.close()

--- a/tests/sdk/test_sdk_coverage_expansion.py
+++ b/tests/sdk/test_sdk_coverage_expansion.py
@@ -56,7 +56,7 @@ class TestReceiptsNamespace:
         mock_sync_client.request.assert_called_once()
         args = mock_sync_client.request.call_args
         assert args[0][0] == "GET"
-        assert args[0][1] == "/api/v2/gauntlet/results"
+        assert args[0][1] == "/api/v1/gauntlet/results"
 
     def test_receipts_verify_gauntlet(self, mock_sync_client):
         from aragora_sdk.namespaces.receipts import ReceiptsAPI


### PR DESCRIPTION
## Summary
- align Python SDK gauntlet receipt tests with the actual v1 server and SDK routes
- fix the stale receipts namespace coverage check that was expecting a nonexistent /api/v2 gauntlet path
- keep the runtime surface unchanged and narrow this to baseline test truthfulness

## Testing
- python3 -m ruff check sdk/python/tests/test_receipts.py tests/sdk/test_sdk_coverage_expansion.py
- cd sdk/python && python3 -m pytest tests/test_receipts.py -q
- python3 -m pytest tests/sdk/test_sdk_coverage_expansion.py -k receipts -q