### PR TITLE
docs(api): refresh stale generated OpenAPI spec

### DIFF
--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -223970,6 +223970,110 @@
               }
             }
           },
+          "comparison_config": {
+            "type": "object",
+            "description": "Run the same debate across multiple candidate agent/model combinations and keep the best result.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "description": "Enable comparison mode (default true when this object is present)",
+                "default": true
+              },
+              "pick_best_result": {
+                "type": "boolean",
+                "description": "Automatically select the strongest result after all combinations finish",
+                "default": true
+              },
+              "selection_strategy": {
+                "type": "string",
+                "description": "Optional strategy name for choosing the winning result",
+                "example": "llm_judge"
+              },
+              "agent_combinations": {
+                "type": "array",
+                "description": "Candidate lineups to run against the same debate question",
+                "minItems": 1,
+                "maxItems": 10,
+                "items": {
+                  "type": "array",
+                  "minItems": 2,
+                  "maxItems": 10,
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "provider": {
+                            "type": "string"
+                          },
+                          "model": {
+                            "type": "string"
+                          },
+                          "persona": {
+                            "type": "string"
+                          },
+                          "role": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string"
+                          },
+                          "hierarchy_role": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "provider"
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "example": [
+                  [
+                    "claude",
+                    "openai-api",
+                    "gemini"
+                  ],
+                  [
+                    "claude",
+                    "grok",
+                    "qwen"
+                  ]
+                ]
+              }
+            }
+          },
+          "model_comparison": {
+            "type": "object",
+            "description": "Deprecated alias for comparison_config.",
+            "deprecated": true
+          },
+          "agent_combinations": {
+            "type": "array",
+            "description": "Deprecated alias for comparison_config.agent_combinations.",
+            "deprecated": true,
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "model_combinations": {
+            "type": "array",
+            "description": "Deprecated human-facing alias for comparison_config.agent_combinations.",
+            "deprecated": true,
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
           "enable_verticals": {
             "type": "boolean",
             "description": "Enable vertical specialist injection for the task domain (default set by ARAGORA_ENABLE_VERTICALS)",

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -127367,6 +127367,77 @@ components:
             diversity_preference:
               type: number
               default: 0.5
+        comparison_config:
+          type: object
+          description: Run the same debate across multiple candidate agent/model combinations and keep the best result.
+          properties:
+            enabled:
+              type: boolean
+              description: Enable comparison mode (default true when this object is present)
+              default: true
+            pick_best_result:
+              type: boolean
+              description: Automatically select the strongest result after all combinations finish
+              default: true
+            selection_strategy:
+              type: string
+              description: Optional strategy name for choosing the winning result
+              example: llm_judge
+            agent_combinations:
+              type: array
+              description: Candidate lineups to run against the same debate question
+              minItems: 1
+              maxItems: 10
+              items:
+                type: array
+                minItems: 2
+                maxItems: 10
+                items:
+                  oneOf:
+                  - type: string
+                  - type: object
+                    properties:
+                      provider:
+                        type: string
+                      model:
+                        type: string
+                      persona:
+                        type: string
+                      role:
+                        type: string
+                      name:
+                        type: string
+                      hierarchy_role:
+                        type: string
+                    required:
+                    - provider
+              example:
+              - - claude
+                - openai-api
+                - gemini
+              - - claude
+                - grok
+                - qwen
+        model_comparison:
+          type: object
+          description: Deprecated alias for comparison_config.
+          deprecated: true
+        agent_combinations:
+          type: array
+          description: Deprecated alias for comparison_config.agent_combinations.
+          deprecated: true
+          items:
+            type: array
+            items:
+              type: string
+        model_combinations:
+          type: array
+          description: Deprecated human-facing alias for comparison_config.agent_combinations.
+          deprecated: true
+          items:
+            type: array
+            items:
+              type: string
         enable_verticals:
           type: boolean
           description: Enable vertical specialist injection for the task domain (default set by ARAGORA_ENABLE_VERTICALS)


### PR DESCRIPTION
## Summary
- regenerate `docs/api/openapi_generated.json`
- regenerate `docs/api/openapi_generated.yaml`
- clear the stale `Version Alignment` failure affecting unrelated PRs

## Validation
- `TMPDIR=$(mktemp -d) && python3 scripts/generate_openapi.py --output "$TMPDIR/openapi_generated.json" && python3 scripts/generate_openapi.py --output "$TMPDIR/openapi_generated.yaml" --format yaml && python3 scripts/add_openapi_operation_ids.py --spec "$TMPDIR/openapi_generated.json" && python3 scripts/add_openapi_param_descriptions.py --spec "$TMPDIR/openapi_generated.json" && python3 scripts/add_openapi_descriptions.py --spec "$TMPDIR/openapi_generated.json" && diff -q "$TMPDIR/openapi_generated.json" docs/api/openapi_generated.json && diff -q "$TMPDIR/openapi_generated.yaml" docs/api/openapi_generated.yaml`

## Context
`#1618` showed the failure clearly: the checked-in generated spec was stale relative to current source, so unrelated PRs were tripping `Version Alignment` even when their own diffs were clean.