### PR TITLE
fix(ci): use shared installer in autopilot worktree e2e

### DIFF
--- a/.github/workflows/autopilot-worktree-e2e.yml
+++ b/.github/workflows/autopilot-worktree-e2e.yml
@@ -113,9 +113,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
-          python -m pip install pytest-timeout
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run autopilot API end-to-end test
         env:

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -227,6 +227,26 @@ class TestReleaseReadinessBootstrapWorkflow:
         assert "scripts/ci_install_project.sh --extras dev,test" in command
 
 
+class TestAutopilotWorktreeE2EWorkflow:
+    """Validate autopilot-worktree-e2e workflow bootstrap policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "autopilot-worktree-e2e.yml"
+
+    def test_workflow_file_exists(self):
+        assert self.path.exists(), "autopilot-worktree-e2e.yml does not exist"
+
+    def test_autopilot_api_e2e_uses_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["autopilot-api-e2e"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+
 class TestReleaseWorkflow:
     """Validate release.yml integrates all gates."""
 


### PR DESCRIPTION
## Summary
- switch the autopilot API E2E workflow to the shared CI installer
- stop relying on raw `pip install -e "[dev,test]"` for that gate
- add a release-gate regression test that locks the installer policy

## Validation
- `python3 -m pytest tests/ci/test_release_gates.py -q`
- `python3 -m ruff check tests/ci/test_release_gates.py`
- `python3 scripts/check_workflow_pip_install_policy.py`