### PR TITLE
fix(swarm): canonicalize and dedupe claude runner registrations

### DIFF
--- a/aragora/swarm/runner_registry.py
+++ b/aragora/swarm/runner_registry.py
@@ -521,10 +521,45 @@ class CLIRunnerInspector:
         return self._run_command([base_command_path, "--help"])
 
     def _claude_profile_script(self) -> str | None:
-        script = (self.repo_root / "scripts" / "claude_profile.sh").resolve()
+        script = (self._canonical_repo_root() / "scripts" / "claude_profile.sh").resolve()
         if not script.exists():
             return None
         return str(script)
+
+    def _canonical_repo_root(self) -> Path:
+        common_git_dir = self._git_common_dir(self.repo_root)
+        if common_git_dir is not None and common_git_dir.name == ".git":
+            return common_git_dir.parent.resolve()
+        return self.repo_root
+
+    @staticmethod
+    def _git_common_dir(repo_root: Path) -> Path | None:
+        dot_git = repo_root / ".git"
+        if dot_git.is_dir():
+            return dot_git.resolve()
+        if not dot_git.is_file():
+            return None
+        try:
+            text = dot_git.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        if not text.startswith("gitdir:"):
+            return None
+        gitdir = text.split(":", 1)[1].strip()
+        resolved = (dot_git.parent / gitdir).resolve()
+        if not resolved.is_dir():
+            return None
+        commondir_file = resolved / "commondir"
+        if commondir_file.is_file():
+            try:
+                commondir = commondir_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                commondir = ""
+            if commondir:
+                common = (resolved / commondir).resolve()
+                if common.is_dir():
+                    return common
+        return resolved
 
     @staticmethod
     def _run_command(command: list[str]) -> dict[str, Any]:
@@ -1156,9 +1191,32 @@ class LocalRunnerRegistry:
         return runner_payload
 
     def list_registrations(self) -> list[dict[str, Any]]:
-        return [
-            dict(item) for item in self._load().get("registrations", []) if isinstance(item, dict)
+        records = self._load()
+        registrations = [
+            dict(item) for item in records.get("registrations", []) if isinstance(item, dict)
         ]
+        valid_registrations: list[dict[str, Any]] = []
+        dedupe_indexes: dict[tuple[str, ...], int] = {}
+        pruned = False
+        for item in registrations:
+            if self._invalid_registration_reason(item) is not None:
+                pruned = True
+                continue
+            dedupe_key = self._registration_dedupe_key(item)
+            if dedupe_key is not None:
+                existing_index = dedupe_indexes.get(dedupe_key)
+                if existing_index is not None:
+                    pruned = True
+                    current = valid_registrations[existing_index]
+                    if self._prefer_registration(item, over=current):
+                        valid_registrations[existing_index] = item
+                    continue
+                dedupe_indexes[dedupe_key] = len(valid_registrations)
+            valid_registrations.append(item)
+        if pruned:
+            records["registrations"] = valid_registrations
+            self._save(records)
+        return valid_registrations
 
     def resolve_boss_routing(
         self,
@@ -1420,6 +1478,89 @@ class LocalRunnerRegistry:
         if active_lanes >= max_parallel:
             return False
         return True
+
+    def _invalid_registration_reason(self, runner: dict[str, Any]) -> str | None:
+        command_path = _text(runner.get("command_path") or runner.get("codex_path"))
+        if not command_path:
+            return None
+        if not self._command_path_exists(command_path):
+            return "missing_command_executable"
+        return None
+
+    @staticmethod
+    def _registration_dedupe_key(runner: dict[str, Any]) -> tuple[str, ...] | None:
+        runner_type = _text(runner.get("runner_type"))
+        profile = _text(runner.get("profile"))
+        if runner_type == "claude" and profile:
+            owner_binding = dict(runner.get("owner_binding") or {})
+            return (
+                "claude_profile",
+                profile,
+                _text(owner_binding.get("user_id")),
+                _text(owner_binding.get("workspace_id")),
+                _text(owner_binding.get("org_id")),
+            )
+        return None
+
+    def _prefer_registration(
+        self,
+        candidate: dict[str, Any],
+        *,
+        over: dict[str, Any],
+    ) -> bool:
+        return self._registration_rank(candidate) < self._registration_rank(over)
+
+    def _registration_rank(self, runner: dict[str, Any]) -> tuple[int, int, float, float, str]:
+        command_path = _text(runner.get("command_path") or runner.get("codex_path"))
+        return (
+            self._command_path_stability_rank(command_path),
+            self._dedupe_probe_rank(self._probe_status(runner)),
+            -self._timestamp_rank(_text(runner.get("probe_checked_at"))),
+            -self._timestamp_rank(_text(runner.get("heartbeat_at"))),
+            _text(runner.get("runner_id")),
+        )
+
+    @staticmethod
+    def _command_path_stability_rank(command_path: str) -> int:
+        normalized = _text(command_path)
+        if not normalized:
+            return 1
+        marker = f"{os.sep}.worktrees{os.sep}"
+        if marker in normalized or (
+            os.altsep and f"{os.altsep}.worktrees{os.altsep}" in normalized
+        ):
+            return 1
+        return 0
+
+    @staticmethod
+    def _dedupe_probe_rank(status: Any) -> int:
+        normalized = _text(status).lower()
+        if normalized == "passed":
+            return 0
+        if normalized == "failed":
+            return 1
+        return 2
+
+    def _timestamp_rank(self, value: str) -> float:
+        parsed = self._parse_timestamp(value)
+        if parsed is None:
+            return 0.0
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return parsed.timestamp()
+
+    @staticmethod
+    def _command_path_exists(command_path: str) -> bool:
+        normalized = _text(command_path)
+        if not normalized:
+            return False
+        if (
+            Path(normalized).is_absolute()
+            or os.sep in normalized
+            or (os.altsep and os.altsep in normalized)
+        ):
+            return Path(normalized).exists()
+        return shutil.which(normalized) is not None
 
     @staticmethod
     def _effective_active_lanes(runner: dict[str, Any]) -> int:

--- a/tests/swarm/test_runner_registry.py
+++ b/tests/swarm/test_runner_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 import json
+import os
 from pathlib import Path
 
 from aragora.swarm.runner_registry import (
@@ -183,6 +184,53 @@ class TestClaudeRunnerInspector:
         assert inspection.auth_mode == "subscription"
         assert inspection.command_path == str(script.resolve())
         assert inspection.status_summary == "loggedIn=True subscriptionType=max"
+
+    def test_profile_runner_uses_canonical_repo_root_script_from_worktree(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        repo_root = tmp_path / "aragora"
+        worktree_root = repo_root / ".worktrees" / "codex-auto" / "session-123"
+        canonical_script = repo_root / "scripts" / "claude_profile.sh"
+        worktree_script = worktree_root / "scripts" / "claude_profile.sh"
+        canonical_script.parent.mkdir(parents=True)
+        worktree_script.parent.mkdir(parents=True)
+        canonical_script.write_text("#!/bin/bash\n", encoding="utf-8")
+        worktree_script.write_text("#!/bin/bash\n", encoding="utf-8")
+        gitdir = repo_root / ".git" / "worktrees" / "session-123"
+        gitdir.mkdir(parents=True)
+        (gitdir / "commondir").write_text("../..\n", encoding="utf-8")
+        (worktree_root / ".git").write_text(
+            f"gitdir: {os.path.relpath(gitdir, worktree_root)}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.runner_registry.shutil.which",
+            lambda _name: "/usr/local/bin/claude",
+        )
+
+        def _run(command: list[str]) -> dict[str, object]:
+            joined = " ".join(command)
+            if joined.endswith("--version"):
+                return {"returncode": 0, "stdout": "claude 2.1.85\n", "stderr": ""}
+            if joined.endswith("--help"):
+                return {"returncode": 0, "stdout": "Commands:\n  review\n  login\n", "stderr": ""}
+            if command[:3] == [str(canonical_script.resolve()), "status", "max-01"]:
+                return {
+                    "returncode": 0,
+                    "stdout": '{"loggedIn":true,"subscriptionType":"max"}\n',
+                    "stderr": "",
+                }
+            raise AssertionError(f"unexpected command: {command}")
+
+        monkeypatch.setattr(ClaudeRunnerInspector, "_run_command", staticmethod(_run))
+        inspection = ClaudeRunnerInspector(
+            env={},
+            profile="max-01",
+            repo_root=worktree_root,
+        ).inspect()
+
+        assert inspection.available is True
+        assert inspection.command_path == str(canonical_script.resolve())
 
     def test_profile_list_prefers_runner_profiles_env(self) -> None:
         profiles = configured_claude_runner_profiles(
@@ -476,6 +524,140 @@ class TestLocalRunnerRegistry:
 
         assert decision.is_blocked is True
         assert decision.blocked_reason == "no_eligible_registered_runners"
+
+    def test_resolve_boss_routing_prunes_missing_command_path_registrations(
+        self, tmp_path: Path
+    ) -> None:
+        now = datetime.now(UTC).isoformat()
+        valid_script = tmp_path / "scripts" / "claude_profile.sh"
+        valid_script.parent.mkdir(parents=True)
+        valid_script.write_text("#!/bin/sh\n", encoding="utf-8")
+        stale_script = tmp_path / "deleted-worktree" / "scripts" / "claude_profile.sh"
+        registry_path = tmp_path / "swarm-runners.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "claude-runner-stale",
+                            "runner_type": "claude",
+                            "profile": "max-02",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "command_path": str(stale_script),
+                            "cost_class": "subscription",
+                            "priority_weight": 100,
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "heartbeat_at": now,
+                            "stale_after_seconds": 3600,
+                            "capabilities": {"max_parallel_lanes": 1, "active_lanes": 0},
+                        },
+                        {
+                            "runner_id": "claude-runner-live",
+                            "runner_type": "claude",
+                            "profile": "max-04",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "command_path": str(valid_script),
+                            "cost_class": "subscription",
+                            "priority_weight": 100,
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "heartbeat_at": now,
+                            "stale_after_seconds": 3600,
+                            "capabilities": {"max_parallel_lanes": 1, "active_lanes": 0},
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        decision = LocalRunnerRegistry(path=registry_path).resolve_boss_routing(
+            owner_context=authorization_context_from_env(
+                {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
+            ),
+            requested_runner_type="claude",
+        )
+
+        assert decision.is_blocked is False
+        assert decision.selected_runner_ids == ["claude-runner-live"]
+
+        stored = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert [item["runner_id"] for item in stored["registrations"]] == ["claude-runner-live"]
+
+    def test_resolve_boss_routing_dedupes_claude_profile_registrations(
+        self, tmp_path: Path
+    ) -> None:
+        now = datetime.now(UTC).isoformat()
+        repo_script = tmp_path / "scripts" / "claude_profile.sh"
+        worktree_script = (
+            tmp_path / ".worktrees" / "codex-auto" / "lane-1" / "scripts" / "claude_profile.sh"
+        )
+        repo_script.parent.mkdir(parents=True)
+        worktree_script.parent.mkdir(parents=True)
+        repo_script.write_text("#!/bin/sh\n", encoding="utf-8")
+        worktree_script.write_text("#!/bin/sh\n", encoding="utf-8")
+        registry_path = tmp_path / "swarm-runners.json"
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "claude-runner-root",
+                            "runner_type": "claude",
+                            "profile": "max-02",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "command_path": str(repo_script),
+                            "cost_class": "subscription",
+                            "priority_weight": 100,
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "heartbeat_at": now,
+                            "stale_after_seconds": 3600,
+                            "capabilities": {"max_parallel_lanes": 1, "active_lanes": 0},
+                            "probe_status": "passed",
+                            "probe_checked_at": now,
+                        },
+                        {
+                            "runner_id": "claude-runner-worktree",
+                            "runner_type": "claude",
+                            "profile": "max-02",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "command_path": str(worktree_script),
+                            "cost_class": "subscription",
+                            "priority_weight": 100,
+                            "owner_binding": {"user_id": "user-123", "workspace_id": "ws-456"},
+                            "heartbeat_at": now,
+                            "stale_after_seconds": 3600,
+                            "capabilities": {"max_parallel_lanes": 1, "active_lanes": 0},
+                        },
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        decision = LocalRunnerRegistry(path=registry_path).resolve_boss_routing(
+            owner_context=authorization_context_from_env(
+                {"ARAGORA_USER_ID": "user-123", "ARAGORA_WORKSPACE_ID": "ws-456"}
+            ),
+            requested_runner_type="claude",
+        )
+
+        assert decision.is_blocked is False
+        assert decision.selected_runner_ids == ["claude-runner-root"]
+
+        stored = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert [item["runner_id"] for item in stored["registrations"]] == ["claude-runner-root"]
 
     def test_resolve_boss_routing_blocks_without_owner_context(self, tmp_path: Path) -> None:
         decision = LocalRunnerRegistry(path=tmp_path / "swarm-runners.json").resolve_boss_routing(


### PR DESCRIPTION
## Summary
- canonicalize profile-backed Claude runner discovery to the repo-root `scripts/claude_profile.sh` even when discovery runs from a disposable worktree
- prune registrations whose recorded executable path no longer exists and dedupe duplicate Claude registrations by owner/profile, preferring the stable repo-root launcher record
- add regressions for stale-path pruning, worktree-to-root launcher canonicalization, and duplicate-profile collapse

## Validation
- `python3 -m pytest tests/swarm/test_runner_registry.py tests/cli/test_swarm_command.py -q`
- `python3 -m pytest tests/cli/test_build_command.py tests/swarm/test_boss_loop.py tests/swarm/test_runner_registry.py tests/cli/test_swarm_command.py -q`
- `python3 -m ruff check aragora/swarm/runner_registry.py tests/swarm/test_runner_registry.py`

## Live impact
- removed stale deleted-worktree runner registrations from `/Users/armand/.aragora/swarm_runners.json`
- collapsed the live Claude registry from 24 duplicate registrations down to 12 profile-backed registrations with zero duplicate profiles
- current routed Claude pool is 9 runners because `max-01` and `max-03` have expired OAuth and `max-02` is currently at capacity
