### PR TITLE
fix: 11 test failures + email handler KeyError

### DIFF
--- a/aragora/server/handlers/email_services.py
+++ b/aragora/server/handlers/email_services.py
@@ -581,6 +581,7 @@ async def handle_apply_snooze(
             OSError,
             AttributeError,
             ValueError,
+            KeyError,  # Malformed OAuth response
         ) as gmail_error:
             logger.warning("Could not apply Gmail snooze: %s", gmail_error)
 

--- a/tests/debate/test_compliance_auto_attach.py
+++ b/tests/debate/test_compliance_auto_attach.py
@@ -28,6 +28,7 @@ def _make_state(domain: str = "healthcare"):
     state = MagicMock()
     state.debate_id = "test-compliance"
     state.debate_status = "completed"
+    state.debate_start_time = 0.0
     state.gupp_bead_id = None
     state.gupp_hook_entries = []
 

--- a/tests/debate/test_post_debate_workflow_fallback.py
+++ b/tests/debate/test_post_debate_workflow_fallback.py
@@ -49,6 +49,7 @@ class _FakeState:
     ctx: _FakeCtx = field(default_factory=_FakeCtx)
     debate_id: str = "debate-001"
     debate_status: str = "completed"
+    debate_start_time: float = 0.0
     gupp_bead_id: str | None = None
     gupp_hook_entries: list = field(default_factory=list)
 


### PR DESCRIPTION
Round 10: debate_start_time in 2 test files (10 failures), KeyError in Gmail handler. 13 tests restored.