### PR TITLE
test(costs): remove brittle route count assertions

### DIFF
--- a/tests/handlers/costs/test_handler.py
+++ b/tests/handlers/costs/test_handler.py
@@ -193,12 +193,16 @@ class TestInit:
 class TestRoutes:
     """ROUTES list completeness."""
 
-    def test_total_count_is_50(self):
-        assert len(CostHandler.ROUTES) == 50
+    def test_total_count_matches_versioned_legacy_pairs(self):
+        versioned = [r for r in CostHandler.ROUTES if r.startswith("/api/v1/")]
+        legacy = [
+            r for r in CostHandler.ROUTES if r.startswith("/api/") and not r.startswith("/api/v1/")
+        ]
+        assert len(CostHandler.ROUTES) == len(versioned) + len(legacy)
+        assert len(versioned) == len(legacy)
 
     def test_versioned_routes_have_legacy_counterparts(self):
         versioned = [r for r in CostHandler.ROUTES if r.startswith("/api/v1/")]
-        assert len(versioned) == 25
         for v in versioned:
             legacy = v.replace("/api/v1/", "/api/")
             assert legacy in CostHandler.ROUTES, f"Missing legacy: {legacy}"
@@ -227,6 +231,9 @@ class TestRoutes:
             "/api/v1/costs/recommendations/*",
             "/api/v1/costs/recommendations/*/apply",
             "/api/v1/costs/recommendations/*/dismiss",
+            "/api/v1/costs/debates/*",
+            "/api/v1/costs/debates/*/line-items",
+            "/api/v1/costs/debates/*/performance",
             "/api/v1/costs/timeline",
             "/api/v1/costs/usage",
         ],


### PR DESCRIPTION
## Summary
- replace brittle hard-coded route totals with versioned/legacy symmetry checks
- add explicit coverage for the new debate cost endpoints
- unblock unrelated PRs whose integration smoke currently fails on stale route-count expectations

## Validation
- python3 -m pytest tests/handlers/costs/test_handler.py -q
- python3 -m ruff check tests/handlers/costs/test_handler.py