### PR TITLE
fix(memory): isolate trigger action exceptions

### DIFF
--- a/aragora/memory/triggers.py
+++ b/aragora/memory/triggers.py
@@ -78,7 +78,7 @@ class MemoryTriggerEngine:
                 try:
                     if not trigger.condition(context):
                         continue
-                except (RuntimeError, ValueError, TypeError, KeyError, AttributeError) as exc:
+                except Exception as exc:
                     logger.warning("Trigger %s condition failed: %s", trigger.name, exc)
                     self._fire_log.append(
                         TriggerResult(
@@ -96,14 +96,7 @@ class MemoryTriggerEngine:
                     self._fire_log.append(TriggerResult(trigger_name=trigger.name, success=True))
                     triggered.append(trigger.name)
                     _record_trigger_metric(trigger.name, True)
-                except (
-                    RuntimeError,
-                    ValueError,
-                    TypeError,
-                    KeyError,
-                    AttributeError,
-                    OSError,
-                ) as exc:
+                except Exception as exc:
                     logger.warning("Trigger %s action failed: %s", trigger.name, exc)
                     self._fire_log.append(
                         TriggerResult(

--- a/tests/memory/test_triggers.py
+++ b/tests/memory/test_triggers.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from aragora.knowledge.mound.validation import ValidationError
 from aragora.memory.triggers import (
     MemoryTrigger,
     MemoryTriggerEngine,
@@ -292,6 +293,22 @@ class TestErrorIsolation:
         assert len(log) == 1
         assert log[0].success is False
         assert "bad type" in log[0].error
+
+    @pytest.mark.asyncio
+    async def test_custom_action_error_doesnt_escape(
+        self, bare_engine: MemoryTriggerEngine
+    ) -> None:
+        failing = AsyncMock(
+            side_effect=ValidationError("Query cannot be empty", field="query", code="EMPTY_QUERY")
+        )
+        working = AsyncMock()
+        bare_engine.register(MemoryTrigger(name="fail", event="e", action=failing))
+        bare_engine.register(MemoryTrigger(name="ok", event="e", action=working))
+
+        triggered = await bare_engine.fire("e", {})
+        assert "fail" in triggered
+        assert "ok" in triggered
+        working.assert_called_once()
 
 
 # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- catch standard trigger action and condition exceptions inside the memory trigger engine
- add regression coverage for custom validation-style action failures
- keep trigger execution non-blocking as documented

## Testing
- python3 -m ruff check aragora/memory/triggers.py tests/memory/test_triggers.py
- python3 -m pytest tests/memory/test_triggers.py -q