### PR TITLE
fix(receipts): read explorer list from adapter singleton

### DIFF
--- a/aragora/server/handlers/pipeline/receipts.py
+++ b/aragora/server/handlers/pipeline/receipts.py
@@ -53,6 +53,20 @@ def register_receipt(receipt: dict[str, Any]) -> None:
         _receipt_store[receipt_id] = receipt
 
 
+def _receipt_matches_filters(
+    receipt: dict[str, Any],
+    *,
+    pipeline_id: str | None,
+    status: str | None,
+) -> bool:
+    """Apply list filters to both in-memory and KM-backed receipt records."""
+    if pipeline_id and receipt.get("pipeline_id") != pipeline_id:
+        return False
+    if status and receipt.get("execution", {}).get("status") != status:
+        return False
+    return True
+
+
 class ReceiptExplorerHandler(BaseHandler):
     """HTTP handler for pipeline receipt exploration and verification."""
 
@@ -112,30 +126,32 @@ class ReceiptExplorerHandler(BaseHandler):
         status = get_string_param(params, "status")
         limit = get_int_param(params, "limit", 50)
 
-        receipts = list(_receipt_store.values())
+        receipts_by_id: dict[str, dict[str, Any]] = {
+            receipt.get("receipt_id"): receipt
+            for receipt in _receipt_store.values()
+            if receipt.get("receipt_id")
+        }
 
-        if pipeline_id:
-            receipts = [r for r in receipts if r.get("pipeline_id") == pipeline_id]
-        if status:
-            receipts = [r for r in receipts if r.get("execution", {}).get("status") == status]
-
-        # Merge KM-stored historical receipts into listing
+        # Merge KM-stored historical receipts into listing using the same singleton
+        # adapter that post-debate persistence writes into.
         try:
-            from aragora.knowledge.mound.adapters.receipt_adapter import ReceiptAdapter
+            from aragora.knowledge.mound.adapters.receipt_adapter import get_receipt_adapter
 
-            adapter = ReceiptAdapter()
+            adapter = get_receipt_adapter()
             km_receipts = adapter.list_receipts(limit=limit)
             if km_receipts:
-                # Deduplicate by receipt_id (in-memory takes precedence)
-                existing_ids = {r.get("receipt_id") for r in receipts}
                 for km_receipt in km_receipts:
                     rid = km_receipt.get("receipt_id")
-                    if rid and rid not in existing_ids:
-                        receipts.append(km_receipt)
-                        existing_ids.add(rid)
+                    if rid and rid not in receipts_by_id:
+                        receipts_by_id[rid] = km_receipt
         except (ImportError, RuntimeError, AttributeError, TypeError) as e:
             logger.debug("KM receipt lookup skipped: %s", type(e).__name__)
 
+        receipts = [
+            receipt
+            for receipt in receipts_by_id.values()
+            if _receipt_matches_filters(receipt, pipeline_id=pipeline_id, status=status)
+        ]
         receipts = receipts[:limit]
         return json_response(
             {

--- a/tests/handlers/pipeline/test_receipt_explorer.py
+++ b/tests/handlers/pipeline/test_receipt_explorer.py
@@ -222,6 +222,39 @@ class TestListReceipts:
         assert "r1" in ids
         assert "r2" in ids
 
+    def test_list_includes_receipts_from_singleton_adapter(self):
+        class FakeReceiptAdapter:
+            def list_receipts(self, limit: int = 50) -> list[dict[str, Any]]:
+                return [
+                    {
+                        "receipt_id": "km-rcpt-1",
+                        "pipeline_id": "pipe-km",
+                        "generated_at": "2026-03-29T20:00:00Z",
+                        "execution": {"status": "completed"},
+                        "content_hash": "hash-km-1",
+                    }
+                ]
+
+        h = _make_handler()
+        http = _make_http_handler()
+        with patch(
+            "aragora.knowledge.mound.adapters.receipt_adapter.get_receipt_adapter",
+            return_value=FakeReceiptAdapter(),
+        ):
+            result = h.handle_get("/api/v1/receipts", {}, http)
+
+        body = _body(result)
+        assert body["count"] == 1
+        assert body["receipts"] == [
+            {
+                "receipt_id": "km-rcpt-1",
+                "pipeline_id": "pipe-km",
+                "generated_at": "2026-03-29T20:00:00Z",
+                "status": "completed",
+                "content_hash": "hash-km-1",
+            }
+        ]
+
     def test_list_filter_by_pipeline_id(self):
         register_receipt(_make_receipt("r1", pipeline_id="pipe-A"))
         register_receipt(_make_receipt("r2", pipeline_id="pipe-B"))
@@ -233,6 +266,42 @@ class TestListReceipts:
         assert body["count"] == 2
         for r in body["receipts"]:
             assert r["pipeline_id"] == "pipe-A"
+
+    def test_list_filters_singleton_adapter_receipts(self):
+        class FakeReceiptAdapter:
+            def list_receipts(self, limit: int = 50) -> list[dict[str, Any]]:
+                return [
+                    {
+                        "receipt_id": "km-rcpt-1",
+                        "pipeline_id": "pipe-A",
+                        "generated_at": "2026-03-29T20:00:00Z",
+                        "execution": {"status": "completed"},
+                        "content_hash": "hash-km-1",
+                    },
+                    {
+                        "receipt_id": "km-rcpt-2",
+                        "pipeline_id": "pipe-B",
+                        "generated_at": "2026-03-29T20:01:00Z",
+                        "execution": {"status": "failed"},
+                        "content_hash": "hash-km-2",
+                    },
+                ]
+
+        h = _make_handler()
+        http = _make_http_handler()
+        with patch(
+            "aragora.knowledge.mound.adapters.receipt_adapter.get_receipt_adapter",
+            return_value=FakeReceiptAdapter(),
+        ):
+            result = h.handle_get(
+                "/api/v1/receipts",
+                {"pipeline_id": "pipe-A", "status": "completed"},
+                http,
+            )
+
+        body = _body(result)
+        assert body["count"] == 1
+        assert body["receipts"][0]["receipt_id"] == "km-rcpt-1"
 
     def test_list_filter_by_status(self):
         register_receipt(_make_receipt("r1", status="completed"))


### PR DESCRIPTION
## Summary
- switch the v1 receipt explorer to read from `get_receipt_adapter()` instead of a fresh `ReceiptAdapter()`
- merge KM-backed receipts before filtering so post-debate receipts show up in `/api/v1/receipts`
- add regressions proving singleton-backed receipts are listed and filtered correctly

## Validation
- python3 -m pytest tests/handlers/pipeline/test_receipt_explorer.py -q
- python3 -m ruff check aragora/server/handlers/pipeline/receipts.py tests/handlers/pipeline/test_receipt_explorer.py
- direct repro: singleton `adapter.ingest(...)` followed by `ReceiptExplorerHandler.handle_get("/api/v1/receipts", ...)` now returns the receipt