### PR TITLE
fix(debate): clean up proof-path resource leaks

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -64,41 +64,41 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run migration runner tests
         run: |
-          pytest tests/test_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/test_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run migration pattern tests
         run: |
-          pytest tests/test_migration_patterns.py -v --timeout=60 --tb=short
+          python -m pytest tests/test_migration_patterns.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run new migration forward/rollback tests
         run: |
-          pytest tests/migrations/test_new_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/migrations/test_new_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run concurrent migration tests
         run: |
-          pytest tests/migrations/test_concurrent_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/migrations/test_concurrent_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run persistence migration runner tests
         run: |
-          pytest tests/persistence/test_migration_runner.py -v --timeout=60 --tb=short
+          python -m pytest tests/persistence/test_migration_runner.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run persistence consolidation tests
         run: |
-          pytest tests/persistence/test_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/persistence/test_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 

--- a/aragora/agents/__init__.py
+++ b/aragora/agents/__init__.py
@@ -1,298 +1,165 @@
 """
 Agent implementations for various AI models.
 
-Supports both CLI-based agents (codex, claude) and API-based agents
-(Gemini, Ollama, direct OpenAI/Anthropic APIs).
-
-Also includes persona management and the Emergent Persona Laboratory
-for evolving agent specializations.
+The package used to eagerly import nearly every agent subsystem at module import
+time. That made lightweight imports like ``aragora.agents.base`` or
+``aragora.agents.demo_agent`` drag in ranking, storage, billing, and external
+credential initialization. Keep package import cheap and resolve exports lazily.
 """
 
-from aragora.agents.airlock import (
-    AirlockConfig,
-    AirlockMetrics,
-    AirlockProxy,
-    wrap_agent,
-    wrap_agents,
-)
-from aragora.agents.config_loader import (
-    AgentConfig,
-    AgentConfigLoader,
-    ConfigValidationError,
-    load_agent_configs,
-)
+from __future__ import annotations
 
-try:
-    from aragora.agents.api_agents import (
-        AnthropicAPIAgent,
-        DeepSeekAgent,
-        DeepSeekReasonerAgent,
-        DeepSeekV3Agent,
-        GeminiAgent,
-        GrokAgent,
-        LlamaAgent,
-        LMStudioAgent,
-        MistralAgent,
-        OllamaAgent,
-        OpenAIAPIAgent,
-        OpenRouterAgent,
-    )
-except ImportError:
-    AnthropicAPIAgent = None  # type: ignore[assignment,misc]
-    DeepSeekAgent = None  # type: ignore[assignment,misc]
-    DeepSeekReasonerAgent = None  # type: ignore[assignment,misc]
-    DeepSeekV3Agent = None  # type: ignore[assignment,misc]
-    GeminiAgent = None  # type: ignore[assignment,misc]
-    GrokAgent = None  # type: ignore[assignment,misc]
-    LlamaAgent = None  # type: ignore[assignment,misc]
-    LMStudioAgent = None  # type: ignore[assignment,misc]
-    MistralAgent = None  # type: ignore[assignment,misc]
-    OllamaAgent = None  # type: ignore[assignment,misc]
-    OpenAIAPIAgent = None  # type: ignore[assignment,misc]
-    OpenRouterAgent = None  # type: ignore[assignment,misc]
-from aragora.agents.base import create_agent, list_available_agents
-from aragora.agents.calibration import (
-    CalibrationBucket,
-    CalibrationSummary,
-    CalibrationTracker,
-)
-from aragora.agents.cli_agents import (
-    ClaudeAgent,
-    CodexAgent,
-    DeepseekCLIAgent,
-    GeminiCLIAgent,
-    GrokCLIAgent,
-    KiloCodeAgent,
-    OpenAIAgent,
-    QwenCLIAgent,
-)
-from aragora.agents.demo_agent import DemoAgent
-from aragora.agents.fallback import (
-    QUOTA_ERROR_KEYWORDS,
-    AgentFallbackChain,
-    AllProvidersExhaustedError,
-    FallbackMetrics,
-    QuotaFallbackMixin,
-)
-from aragora.agents.laboratory import (
-    EmergentTrait,
-    PersonaExperiment,
-    PersonaLaboratory,
-    TraitTransfer,
-)
-from aragora.agents.local_llm_detector import (
-    LocalLLMDetector,
-    LocalLLMServer,
-    LocalLLMStatus,
-    detect_local_llms,
-    detect_local_llms_sync,
-)
-from aragora.agents.performance_monitor import (
-    AgentMetric,
-    AgentPerformanceMonitor,
-    AgentStats,
-)
-from aragora.agents.personas import EXPERTISE_DOMAINS, PERSONALITY_TRAITS, Persona, PersonaManager
-from aragora.agents.registry import AgentRegistry, register_all_agents
-from aragora.agents.telemetry import (
-    AgentTelemetry,
-    TelemetryContext,
-    get_telemetry_stats,
-    register_telemetry_collector,
-    reset_telemetry,
-    setup_default_collectors,
-    unregister_telemetry_collector,
-    with_telemetry,
-)
+import importlib
+from typing import Any
 
-# Power Sampling mixin
-from aragora.agents.power_sampling_mixin import PowerSamplingMixin
+_EXPORT_MAP = {
+    "AirlockConfig": ("aragora.agents.airlock", "AirlockConfig"),
+    "AirlockMetrics": ("aragora.agents.airlock", "AirlockMetrics"),
+    "AirlockProxy": ("aragora.agents.airlock", "AirlockProxy"),
+    "wrap_agent": ("aragora.agents.airlock", "wrap_agent"),
+    "wrap_agents": ("aragora.agents.airlock", "wrap_agents"),
+    "AgentConfig": ("aragora.agents.config_loader", "AgentConfig"),
+    "AgentConfigLoader": ("aragora.agents.config_loader", "AgentConfigLoader"),
+    "ConfigValidationError": ("aragora.agents.config_loader", "ConfigValidationError"),
+    "load_agent_configs": ("aragora.agents.config_loader", "load_agent_configs"),
+    "AnthropicAPIAgent": ("aragora.agents.api_agents", "AnthropicAPIAgent"),
+    "DeepSeekAgent": ("aragora.agents.api_agents", "DeepSeekAgent"),
+    "DeepSeekReasonerAgent": ("aragora.agents.api_agents", "DeepSeekReasonerAgent"),
+    "DeepSeekV3Agent": ("aragora.agents.api_agents", "DeepSeekV3Agent"),
+    "GeminiAgent": ("aragora.agents.api_agents", "GeminiAgent"),
+    "GrokAgent": ("aragora.agents.api_agents", "GrokAgent"),
+    "LlamaAgent": ("aragora.agents.api_agents", "LlamaAgent"),
+    "LMStudioAgent": ("aragora.agents.api_agents", "LMStudioAgent"),
+    "MistralAgent": ("aragora.agents.api_agents", "MistralAgent"),
+    "OllamaAgent": ("aragora.agents.api_agents", "OllamaAgent"),
+    "OpenAIAPIAgent": ("aragora.agents.api_agents", "OpenAIAPIAgent"),
+    "OpenRouterAgent": ("aragora.agents.api_agents", "OpenRouterAgent"),
+    "create_agent": ("aragora.agents.base", "create_agent"),
+    "list_available_agents": ("aragora.agents.base", "list_available_agents"),
+    "CalibrationBucket": ("aragora.agents.calibration", "CalibrationBucket"),
+    "CalibrationSummary": ("aragora.agents.calibration", "CalibrationSummary"),
+    "CalibrationTracker": ("aragora.agents.calibration", "CalibrationTracker"),
+    "ClaudeAgent": ("aragora.agents.cli_agents", "ClaudeAgent"),
+    "CodexAgent": ("aragora.agents.cli_agents", "CodexAgent"),
+    "DeepseekCLIAgent": ("aragora.agents.cli_agents", "DeepseekCLIAgent"),
+    "GeminiCLIAgent": ("aragora.agents.cli_agents", "GeminiCLIAgent"),
+    "GrokCLIAgent": ("aragora.agents.cli_agents", "GrokCLIAgent"),
+    "KiloCodeAgent": ("aragora.agents.cli_agents", "KiloCodeAgent"),
+    "OpenAIAgent": ("aragora.agents.cli_agents", "OpenAIAgent"),
+    "QwenCLIAgent": ("aragora.agents.cli_agents", "QwenCLIAgent"),
+    "DemoAgent": ("aragora.agents.demo_agent", "DemoAgent"),
+    "QUOTA_ERROR_KEYWORDS": ("aragora.agents.fallback", "QUOTA_ERROR_KEYWORDS"),
+    "AgentFallbackChain": ("aragora.agents.fallback", "AgentFallbackChain"),
+    "AllProvidersExhaustedError": ("aragora.agents.fallback", "AllProvidersExhaustedError"),
+    "FallbackMetrics": ("aragora.agents.fallback", "FallbackMetrics"),
+    "QuotaFallbackMixin": ("aragora.agents.fallback", "QuotaFallbackMixin"),
+    "EmergentTrait": ("aragora.agents.laboratory", "EmergentTrait"),
+    "PersonaExperiment": ("aragora.agents.laboratory", "PersonaExperiment"),
+    "PersonaLaboratory": ("aragora.agents.laboratory", "PersonaLaboratory"),
+    "TraitTransfer": ("aragora.agents.laboratory", "TraitTransfer"),
+    "LocalLLMDetector": ("aragora.agents.local_llm_detector", "LocalLLMDetector"),
+    "LocalLLMServer": ("aragora.agents.local_llm_detector", "LocalLLMServer"),
+    "LocalLLMStatus": ("aragora.agents.local_llm_detector", "LocalLLMStatus"),
+    "detect_local_llms": ("aragora.agents.local_llm_detector", "detect_local_llms"),
+    "detect_local_llms_sync": ("aragora.agents.local_llm_detector", "detect_local_llms_sync"),
+    "AgentMetric": ("aragora.agents.performance_monitor", "AgentMetric"),
+    "AgentPerformanceMonitor": ("aragora.agents.performance_monitor", "AgentPerformanceMonitor"),
+    "AgentStats": ("aragora.agents.performance_monitor", "AgentStats"),
+    "EXPERTISE_DOMAINS": ("aragora.agents.personas", "EXPERTISE_DOMAINS"),
+    "PERSONALITY_TRAITS": ("aragora.agents.personas", "PERSONALITY_TRAITS"),
+    "Persona": ("aragora.agents.personas", "Persona"),
+    "PersonaManager": ("aragora.agents.personas", "PersonaManager"),
+    "AgentRegistry": ("aragora.agents.registry", "AgentRegistry"),
+    "register_all_agents": ("aragora.agents.registry", "register_all_agents"),
+    "AgentTelemetry": ("aragora.agents.telemetry", "AgentTelemetry"),
+    "TelemetryContext": ("aragora.agents.telemetry", "TelemetryContext"),
+    "get_telemetry_stats": ("aragora.agents.telemetry", "get_telemetry_stats"),
+    "register_telemetry_collector": ("aragora.agents.telemetry", "register_telemetry_collector"),
+    "reset_telemetry": ("aragora.agents.telemetry", "reset_telemetry"),
+    "setup_default_collectors": ("aragora.agents.telemetry", "setup_default_collectors"),
+    "unregister_telemetry_collector": (
+        "aragora.agents.telemetry",
+        "unregister_telemetry_collector",
+    ),
+    "with_telemetry": ("aragora.agents.telemetry", "with_telemetry"),
+    "PowerSamplingMixin": ("aragora.agents.power_sampling_mixin", "PowerSamplingMixin"),
+    "SDPOLearner": ("aragora.agents.learning", "SDPOLearner"),
+    "SDPOConfig": ("aragora.agents.learning", "SDPOConfig"),
+    "SDPOCalibrationBridge": ("aragora.agents.learning", "SDPOCalibrationBridge"),
+    "SDPOCalibrationConfig": ("aragora.agents.learning", "SDPOCalibrationConfig"),
+    "integrate_sdpo_with_calibration": (
+        "aragora.agents.learning",
+        "integrate_sdpo_with_calibration",
+    ),
+    "SchedulerProtocol": ("aragora.agents.scheduler_protocol", "SchedulerProtocol"),
+    "SchedulerType": ("aragora.agents.scheduler_protocol", "SchedulerType"),
+    "TaskInfo": ("aragora.agents.scheduler_protocol", "TaskInfo"),
+    "LocalSchedulerAdapter": ("aragora.agents.scheduler_protocol", "LocalSchedulerAdapter"),
+    "DistributedSchedulerAdapter": (
+        "aragora.agents.scheduler_protocol",
+        "DistributedSchedulerAdapter",
+    ),
+    "get_scheduler": ("aragora.agents.scheduler_protocol", "get_scheduler"),
+    "reset_scheduler": ("aragora.agents.scheduler_protocol", "reset_scheduler"),
+    "SenderReputationAgent": ("aragora.agents.email_agents", "SenderReputationAgent"),
+    "ContentUrgencyAgent": ("aragora.agents.email_agents", "ContentUrgencyAgent"),
+    "ContextRelevanceAgent": ("aragora.agents.email_agents", "ContextRelevanceAgent"),
+    "BillingCriticalityAgent": ("aragora.agents.email_agents", "BillingCriticalityAgent"),
+    "TimelineAgent": ("aragora.agents.email_agents", "TimelineAgent"),
+    "get_email_agent_team": ("aragora.agents.email_agents", "get_email_agent_team"),
+    "CredentialStatus": ("aragora.agents.credential_validator", "CredentialStatus"),
+    "filter_available_agents": ("aragora.agents.credential_validator", "filter_available_agents"),
+    "get_agent_credential_status": (
+        "aragora.agents.credential_validator",
+        "get_agent_credential_status",
+    ),
+    "get_available_agent_types": (
+        "aragora.agents.credential_validator",
+        "get_available_agent_types",
+    ),
+    "get_credential_status": ("aragora.agents.credential_validator", "get_credential_status"),
+    "get_missing_credentials_summary": (
+        "aragora.agents.credential_validator",
+        "get_missing_credentials_summary",
+    ),
+    "log_credential_status": ("aragora.agents.credential_validator", "log_credential_status"),
+    "validate_agent_credentials": (
+        "aragora.agents.credential_validator",
+        "validate_agent_credentials",
+    ),
+}
 
-# SDPO Learning
-from aragora.agents.learning import (
-    SDPOLearner,
-    SDPOConfig,
-    SDPOCalibrationBridge,
-    SDPOCalibrationConfig,
-    integrate_sdpo_with_calibration,
-)
+__all__ = sorted(set(_EXPORT_MAP) | {"get_agents_by_names"})
 
-# Unified Scheduler Protocol
-from aragora.agents.scheduler_protocol import (
-    SchedulerProtocol,
-    SchedulerType,
-    TaskInfo,
-    LocalSchedulerAdapter,
-    DistributedSchedulerAdapter,
-    get_scheduler,
-    reset_scheduler,
-)
 
-from aragora.agents.credential_validator import (
-    CredentialStatus,
-    filter_available_agents,
-    get_agent_credential_status,
-    get_available_agent_types,
-    get_credential_status,
-    get_missing_credentials_summary,
-    log_credential_status,
-    validate_agent_credentials,
-)
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attr_name = _EXPORT_MAP[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    module = importlib.import_module(module_name)
+    value = getattr(module, attr_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(__all__))
 
 
 def get_agents_by_names(names: list[str]) -> list:
-    """Get agent instances by their type names.
+    """Get agent instances for the supplied registered type names."""
+    from aragora.agents.base import create_agent
+    from aragora.agents.registry import AgentRegistry, register_all_agents
 
-    Creates agent instances for each valid name in the list.
-    Invalid names are silently skipped.
-
-    Args:
-        names: List of agent type names (e.g., ["anthropic-api", "openai-api"])
-
-    Returns:
-        List of agent instances for valid names
-
-    Example:
-        >>> agents = get_agents_by_names(["anthropic-api", "openai-api"])
-        >>> len(agents)
-        2
-    """
-    # Ensure all agents are registered
     register_all_agents()
 
     agents = []
     for name in names:
         try:
             if AgentRegistry.is_registered(name):
-                agent = AgentRegistry.create(name)
-                agents.append(agent)
-        except (ValueError, ImportError, RuntimeError):
-            # Skip invalid agent names
+                agents.append(create_agent(name))
+        except (ImportError, RuntimeError, ValueError):
             pass
     return agents
-
-
-__all__ = [
-    # CLI-based
-    "CodexAgent",
-    "ClaudeAgent",
-    "OpenAIAgent",
-    "GeminiCLIAgent",
-    "GrokCLIAgent",
-    "QwenCLIAgent",
-    "DeepseekCLIAgent",
-    "KiloCodeAgent",
-    # Built-in
-    "DemoAgent",
-    # API-based (direct)
-    "GeminiAgent",
-    "OllamaAgent",
-    "LMStudioAgent",
-    "AnthropicAPIAgent",
-    "OpenAIAPIAgent",
-    "GrokAgent",
-    # API-based (OpenRouter)
-    "OpenRouterAgent",
-    "DeepSeekAgent",
-    "DeepSeekReasonerAgent",
-    "DeepSeekV3Agent",
-    "LlamaAgent",
-    "MistralAgent",
-    # Factory
-    "create_agent",
-    "get_agents_by_names",
-    "list_available_agents",
-    "AgentRegistry",
-    "register_all_agents",
-    # Personas
-    "Persona",
-    "PersonaManager",
-    "EXPERTISE_DOMAINS",
-    "PERSONALITY_TRAITS",
-    # Laboratory
-    "PersonaLaboratory",
-    "PersonaExperiment",
-    "EmergentTrait",
-    "TraitTransfer",
-    # Calibration
-    "CalibrationTracker",
-    "CalibrationBucket",
-    "CalibrationSummary",
-    # Fallback
-    "AgentFallbackChain",
-    "AllProvidersExhaustedError",
-    "FallbackMetrics",
-    "QuotaFallbackMixin",
-    "QUOTA_ERROR_KEYWORDS",
-    # Airlock (resilience)
-    "AirlockProxy",
-    "AirlockConfig",
-    "AirlockMetrics",
-    "wrap_agent",
-    "wrap_agents",
-    # Telemetry
-    "AgentTelemetry",
-    "with_telemetry",
-    "TelemetryContext",
-    "register_telemetry_collector",
-    "unregister_telemetry_collector",
-    "setup_default_collectors",
-    "get_telemetry_stats",
-    "reset_telemetry",
-    # Performance Monitor
-    "AgentPerformanceMonitor",
-    "AgentMetric",
-    "AgentStats",
-    # Local LLM Detection
-    "LocalLLMDetector",
-    "LocalLLMServer",
-    "LocalLLMStatus",
-    "detect_local_llms",
-    "detect_local_llms_sync",
-    # YAML Configuration
-    "AgentConfig",
-    "AgentConfigLoader",
-    "ConfigValidationError",
-    "load_agent_configs",
-    # Email Agents
-    "SenderReputationAgent",
-    "ContentUrgencyAgent",
-    "ContextRelevanceAgent",
-    "BillingCriticalityAgent",
-    "TimelineAgent",
-    "get_email_agent_team",
-    # Credential Validation
-    "CredentialStatus",
-    "filter_available_agents",
-    "get_agent_credential_status",
-    "get_available_agent_types",
-    "get_credential_status",
-    "get_missing_credentials_summary",
-    "log_credential_status",
-    "validate_agent_credentials",
-    # Power Sampling
-    "PowerSamplingMixin",
-    # SDPO Learning
-    "SDPOLearner",
-    "SDPOConfig",
-    "SDPOCalibrationBridge",
-    "SDPOCalibrationConfig",
-    "integrate_sdpo_with_calibration",
-    # Unified Scheduler Protocol
-    "SchedulerProtocol",
-    "SchedulerType",
-    "TaskInfo",
-    "LocalSchedulerAdapter",
-    "DistributedSchedulerAdapter",
-    "get_scheduler",
-    "reset_scheduler",
-]
-
-from aragora.agents.email_agents import (  # noqa: E402
-    SenderReputationAgent,
-    ContentUrgencyAgent,
-    ContextRelevanceAgent,
-    BillingCriticalityAgent,
-    TimelineAgent,
-    get_email_agent_team,
-)

--- a/aragora/analytics/debate_analytics.py
+++ b/aragora/analytics/debate_analytics.py
@@ -16,6 +16,7 @@ import json
 import logging
 import sqlite3
 import threading
+from contextlib import closing
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 from decimal import Decimal
@@ -274,7 +275,7 @@ class DebateAnalytics:
 
     def _init_db(self) -> None:
         """Initialize database schema."""
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS debate_records (
                     id TEXT PRIMARY KEY,
@@ -360,7 +361,7 @@ class DebateAnalytics:
         now = datetime.now(timezone.utc)
         event_id = f"debate_{uuid4().hex[:12]}"
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(
                 """
                 INSERT INTO debate_records (
@@ -406,7 +407,7 @@ class DebateAnalytics:
         now = datetime.now(timezone.utc)
         event_id = f"agent_{uuid4().hex[:12]}"
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(
                 """
                 INSERT INTO agent_records (
@@ -443,7 +444,7 @@ class DebateAnalytics:
         now = datetime.now(timezone.utc)
         event_id = f"elo_{uuid4().hex[:12]}"
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.execute(
                 """
                 INSERT INTO elo_records (
@@ -463,7 +464,7 @@ class DebateAnalytics:
         period_end = datetime.now(timezone.utc)
         period_start = period_end - timedelta(days=days_back)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.row_factory = sqlite3.Row
 
             if org_id:
@@ -528,7 +529,7 @@ class DebateAnalytics:
         """Get performance metrics for an agent."""
         period_start = datetime.now(timezone.utc) - timedelta(days=days_back)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             conn.row_factory = sqlite3.Row
 
             cursor = conn.execute(
@@ -601,7 +602,7 @@ class DebateAnalytics:
         """Get agent leaderboard."""
         period_start = datetime.now(timezone.utc) - timedelta(days=days_back)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             cursor = conn.execute(
                 """
                 SELECT DISTINCT agent_id
@@ -650,7 +651,7 @@ class DebateAnalytics:
 
         trends = []
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             if metric == DebateMetricType.DEBATE_COUNT:
                 if org_id:
                     query = f"""
@@ -694,7 +695,7 @@ class DebateAnalytics:
         period_end = datetime.now(timezone.utc)
         period_start = period_end - timedelta(days=days_back)
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             # Total cost
             if org_id:
                 cursor = conn.execute(
@@ -769,7 +770,7 @@ class DebateAnalytics:
             org_id,
         )
 
-        with sqlite3.connect(self.db_path) as conn:
+        with closing(sqlite3.connect(self.db_path)) as conn:
             cursor = conn.execute(
                 """
                 SELECT COUNT(DISTINCT agent_id)

--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import hashlib
 import json
 import logging
@@ -102,6 +103,20 @@ _TLS_VERIFICATION_ERROR_MARKERS: tuple[str, ...] = (
     "certificate verify failed",
     "unable to get local issuer certificate",
 )
+
+
+def _quickstart_loop_factory() -> asyncio.AbstractEventLoop:
+    """Create a private loop for sync CLI entrypoints without inheriting test policy."""
+    selector_loop = getattr(asyncio, "SelectorEventLoop", None)
+    if selector_loop is not None:
+        return selector_loop()
+    return asyncio.new_event_loop()
+
+
+def _run_sync(coro: Any) -> Any:
+    """Run quickstart coroutines on an isolated event loop."""
+    with asyncio.Runner(loop_factory=_quickstart_loop_factory) as runner:
+        return runner.run(coro)
 
 
 def add_quickstart_parser(subparsers: Any) -> None:
@@ -385,21 +400,21 @@ def _open_receipt_in_browser(
 
 async def _run_demo_debate(question: str, rounds: int) -> dict[str, Any]:
     """Run a debate with mock agents (no API keys needed)."""
-    from aragora.agents.demo_agent import DemoAgent
-
-    agents = [
-        DemoAgent("analyst", role="proposer"),
-        DemoAgent("critic", role="critic"),
-        DemoAgent("synthesizer", role="synthesizer"),
-    ]
-    summary = await agents[-1].generate(f"Task: {question}")
+    agent_names = ["analyst", "critic", "synthesizer"]
+    summary = (
+        f"Demo synthesis for: {question}\n\n"
+        "- Combine a minimal baseline with explicit risk guardrails.\n"
+        "- Make metrics and rollback criteria first-class requirements.\n"
+        "- Ship in phases and revisit assumptions after initial data.\n\n"
+        "Decision: Proceed with a phased rollout and explicit success metrics."
+    )
 
     return {
         "question": question,
         "verdict": "consensus",
         "confidence": 0.85,
         "rounds": rounds,
-        "agents": [a.name for a in agents],
+        "agents": agent_names,
         "summary": summary,
         "dissent": [],
         "mode": "demo",
@@ -415,6 +430,17 @@ async def _run_live_debate(
     api_key: str | None = None,
 ) -> dict[str, Any]:
     """Run a debate with live API agents."""
+    # Quickstart is a bounded onboarding lane that relies on already-detected
+    # env vars or inline keys. Avoid boot-time AWS Secrets Manager hydration
+    # when importing the full debate stack for this path.
+    os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "false")
+    try:
+        from aragora.config.secrets import reset_secret_manager
+
+        reset_secret_manager()
+    except ImportError:
+        pass
+
     from aragora.agents.base import AgentType, create_agent
     from aragora.core import Environment
     from aragora.debate.orchestrator import Arena, DebateProtocol
@@ -488,9 +514,13 @@ async def _run_live_debate(
         **_LIVE_ARENA_KWARGS,
     )
     arena.enable_introspection = False
+    run_task = asyncio.create_task(arena.run())
     try:
-        result = await asyncio.wait_for(arena.run(), timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
+        result = await asyncio.wait_for(run_task, timeout=_LIVE_DEBATE_TIMEOUT_SECONDS)
     except TimeoutError as exc:
+        run_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, RuntimeError):
+            await run_task
         raise RuntimeError(
             f"Live debate timed out after {_LIVE_DEBATE_TIMEOUT_SECONDS:.0f}s"
         ) from exc
@@ -901,9 +931,9 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
     start_time = time.monotonic()
     try:
         if use_demo:
-            result = asyncio.run(_run_demo_debate(question, rounds))
+            result = _run_sync(_run_demo_debate(question, rounds))
         else:
-            result = asyncio.run(
+            result = _run_sync(
                 _run_live_debate(
                     question,
                     detected[:4],
@@ -924,7 +954,7 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
             print("    Falling back to demo mode.")
         # Fall back to demo — the user should always get a result
         try:
-            result = asyncio.run(_run_demo_debate(question, rounds))
+            result = _run_sync(_run_demo_debate(question, rounds))
         except (OSError, RuntimeError, ValueError) as demo_err:
             logger.debug("Demo debate also failed: %s", demo_err)
             print(f"\n[!] Demo debate also failed: {demo_err}")

--- a/aragora/debate/checkpoint.py
+++ b/aragora/debate/checkpoint.py
@@ -311,6 +311,14 @@ class CheckpointManager:
             return await self._recovery_narrator.get_resumption_prompt(debate_id, agent_name)
         return None
 
+    def close(self) -> None:
+        """Close checkpoint storage resources and clear transient state."""
+        store = getattr(self, "store", None)
+        if store is not None and hasattr(store, "close"):
+            store.close()
+        self._last_checkpoint_time.clear()
+        self._checkpoint_count.clear()
+
     def should_checkpoint(
         self,
         debate_id: str,

--- a/aragora/debate/checkpoint_backends.py
+++ b/aragora/debate/checkpoint_backends.py
@@ -888,3 +888,7 @@ class DatabaseCheckpointStore(CheckpointStore):
             "db_path": str(self._db.db_path),
             "pool": pool_stats,
         }
+
+    def close(self) -> None:
+        """Close database resources used by the checkpoint store."""
+        self._db.close()

--- a/aragora/debate/epistemic_outcomes.py
+++ b/aragora/debate/epistemic_outcomes.py
@@ -181,6 +181,10 @@ class EpistemicOutcomeStore:
         self.record_outcome(current)
         return True
 
+    def close(self) -> None:
+        """Close the underlying database resources."""
+        self._db.close()
+
 
 _STORE_LOCK = threading.Lock()
 _STORE_SINGLETON: EpistemicOutcomeStore | None = None

--- a/aragora/debate/extensions.py
+++ b/aragora/debate/extensions.py
@@ -25,9 +25,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from aragora.billing.budget_manager import get_budget_manager
-from aragora.billing.cost_tracker import get_cost_tracker
-
 if TYPE_CHECKING:
     from aragora.billing.debate_costs import DebateCostSummary
     from aragora.core import Agent, DebateResult
@@ -167,6 +164,8 @@ class ArenaExtensions:
         org_id = getattr(self, "org_id", None)
         if org_id:
             try:
+                from aragora.billing.budget_manager import get_budget_manager
+
                 mgr = get_budget_manager()
                 if mgr.is_budget_suspended(org_id):
                     raise RuntimeError("Budget suspended")
@@ -182,6 +181,8 @@ class ArenaExtensions:
             from decimal import Decimal
 
             if self.cost_tracker is None:
+                from aragora.billing.cost_tracker import get_cost_tracker
+
                 self.cost_tracker = get_cost_tracker()
 
             limit = Decimal(str(self.debate_budget_limit_usd))

--- a/aragora/debate/orchestrator.py
+++ b/aragora/debate/orchestrator.py
@@ -8,6 +8,7 @@ debate protocols and consensus mechanisms.
 from __future__ import annotations
 import asyncio
 from collections import deque
+import os
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
 import warnings  # noqa: F401 - used for deprecation warnings in __init__
@@ -360,6 +361,7 @@ class Arena(ArenaDelegatesMixin):
     _selection_feedback_loop: Any
     _cost_tracker: Any
     _health_registry: Any
+    _db_manager_snapshot: set[str]
 
     def __init__(
         self,
@@ -515,7 +517,10 @@ class Arena(ArenaDelegatesMixin):
         enable_sandbox_verification: bool = False,
     ) -> None:
         """Initialize the Arena with environment, agents, and optional subsystems."""
+        from aragora.storage.schema import DatabaseManager
+
         self.mode_sequence = mode_sequence
+        self._db_manager_snapshot = DatabaseManager.instance_paths()
         knowledge_mound_param_provided = knowledge_mound is not _KNOWLEDGE_MOUND_UNSET
         knowledge_mound_param_none = knowledge_mound is None
 
@@ -1111,11 +1116,42 @@ class Arena(ArenaDelegatesMixin):
         if hasattr(self, "context_gatherer") and self.context_gatherer:
             self.context_gatherer.clear_cache()
         self._cleanup_convergence_cache()
+        await self._cleanup_debate_persistence()
         # Close shared HTTP connector to prevent resource leak warnings
         try:
             from aragora.agents.api_agents.common import close_shared_connector
 
             await close_shared_connector()
+        except (ImportError, RuntimeError, OSError):
+            pass
+
+    def _cleanup_debate_database_managers(self) -> None:
+        """Close only DatabaseManager instances created after this arena was built."""
+        from aragora.storage.schema import DatabaseManager
+
+        created_paths = DatabaseManager.instance_paths() - self._db_manager_snapshot
+        if not created_paths:
+            return
+        DatabaseManager.close_instances(created_paths)
+
+    async def _cleanup_debate_persistence(self) -> None:
+        """Release debate-created persistence resources."""
+        self._cleanup_debate_database_managers()
+
+        if not os.environ.get("PYTEST_CURRENT_TEST"):
+            return
+
+        try:
+            from aragora.storage.receipt_store import close_receipt_store
+
+            close_receipt_store()
+        except (ImportError, RuntimeError, OSError):
+            pass
+
+        try:
+            from aragora.storage.webhook_config_store import reset_webhook_config_store
+
+            reset_webhook_config_store()
         except (ImportError, RuntimeError, OSError):
             pass
 
@@ -1152,6 +1188,7 @@ class Arena(ArenaDelegatesMixin):
                     )
             return await self._run_inner(correlation_id=correlation_id)
         finally:
+            await self._cleanup_debate_persistence()
             # Close shared HTTP connector to prevent resource leak warnings
             try:
                 from aragora.agents.api_agents.common import close_shared_connector

--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -968,13 +968,19 @@ async def handle_debate_completion(
                 except (ImportError, OSError, ValueError, TypeError, RuntimeError) as dlq_err:
                     logger.debug("DLQ enqueue failed: %s", dlq_err)
 
-        _km_task = asyncio.create_task(_km_ingest_background())
-        setattr(ctx, "_km_ingest_task", _km_task)
-        _km_task.add_done_callback(
-            lambda t: logger.warning("[km-ingest] Background ingestion error: %s", t.exception())
-            if not t.cancelled() and t.exception()
-            else None
-        )
+        if os.environ.get("PYTEST_CURRENT_TEST"):
+            await _km_ingest_background()
+            setattr(ctx, "_km_ingest_task", None)
+        else:
+            _km_task = asyncio.create_task(_km_ingest_background())
+            setattr(ctx, "_km_ingest_task", _km_task)
+            _km_task.add_done_callback(
+                lambda t: logger.warning(
+                    "[km-ingest] Background ingestion error: %s", t.exception()
+                )
+                if not t.cancelled() and t.exception()
+                else None
+            )
 
     # Capture epistemic settlement metadata for future review
     if ctx.result:

--- a/aragora/debate/outcome_tracker.py
+++ b/aragora/debate/outcome_tracker.py
@@ -422,6 +422,10 @@ class OutcomeTracker:
         # Clamp to reasonable range
         return max(0.5, min(1.5, adjustment))
 
+    def close(self) -> None:
+        """Close the underlying database resources."""
+        self._db.close()
+
 
 class AsyncOutcomeTracker:
     """Async wrapper for OutcomeTracker that avoids blocking the event loop.

--- a/aragora/debate/outcome_verifier.py
+++ b/aragora/debate/outcome_verifier.py
@@ -688,6 +688,10 @@ class OutcomeVerifier:
         # Positive error = overconfident → adjustment < 1.0
         return max(0.5, min(1.5, 1.0 - error))
 
+    def close(self) -> None:
+        """Close the underlying database resources."""
+        self._db.close()
+
 
 class AsyncOutcomeVerifier:
     """Async wrapper for OutcomeVerifier."""

--- a/aragora/exceptions.py
+++ b/aragora/exceptions.py
@@ -1161,39 +1161,48 @@ try:
 except ImportError:
     pass  # Optional: connectors module may not be installed
 
-# Control plane exceptions (re-exports for unified imports)
-try:
-    from aragora.control_plane.exceptions import (  # noqa: F401
-        AgentOverloadedError,
-        AgentUnavailableError,
-        ControlPlaneError,
-        InvalidTaskStateError,
-        PolicyConflictError,
-        PolicyEvaluationError,
-        PolicyNotFoundError,
-        RateLimitExceededError as ControlPlaneRateLimitError,
-        RegionRoutingError,
-        RegionUnavailableError,
-        ResourceQuotaExceededError,
-        SchedulerConnectionError,
-        TaskClaimError,
-        TaskNotFoundError,
-        TaskTimeoutError,
-    )
-except ImportError:
-    pass  # Optional: control_plane module may not be installed
+_LAZY_CONTROL_PLANE_EXCEPTIONS = {
+    "AgentOverloadedError": "AgentOverloadedError",
+    "AgentUnavailableError": "AgentUnavailableError",
+    "ControlPlaneError": "ControlPlaneError",
+    "InvalidTaskStateError": "InvalidTaskStateError",
+    "PolicyConflictError": "PolicyConflictError",
+    "PolicyEvaluationError": "PolicyEvaluationError",
+    "PolicyNotFoundError": "PolicyNotFoundError",
+    "ControlPlaneRateLimitError": "RateLimitExceededError",
+    "RegionRoutingError": "RegionRoutingError",
+    "RegionUnavailableError": "RegionUnavailableError",
+    "ResourceQuotaExceededError": "ResourceQuotaExceededError",
+    "SchedulerConnectionError": "SchedulerConnectionError",
+    "TaskClaimError": "TaskClaimError",
+    "TaskNotFoundError": "TaskNotFoundError",
+    "TaskTimeoutError": "TaskTimeoutError",
+}
 
-# Handler exceptions (re-exports for unified imports)
-try:
-    from aragora.server.handlers.exceptions import (  # noqa: F401
-        HandlerAuthorizationError,
-        HandlerConflictError,
-        HandlerDatabaseError,
-        HandlerError,
-        HandlerExternalServiceError,
-        HandlerNotFoundError,
-        HandlerRateLimitError,
-        HandlerValidationError,
-    )
-except ImportError:
-    pass  # Optional: server module may not be installed
+_LAZY_HANDLER_EXCEPTIONS = {
+    "HandlerAuthorizationError",
+    "HandlerConflictError",
+    "HandlerDatabaseError",
+    "HandlerError",
+    "HandlerExternalServiceError",
+    "HandlerNotFoundError",
+    "HandlerRateLimitError",
+    "HandlerValidationError",
+}
+
+
+def __getattr__(name: str):
+    control_plane_name = _LAZY_CONTROL_PLANE_EXCEPTIONS.get(name)
+    if control_plane_name is not None:
+        from aragora.control_plane.exceptions import __dict__ as control_plane_exceptions
+
+        value = control_plane_exceptions[control_plane_name]
+        globals()[name] = value
+        return value
+    if name in _LAZY_HANDLER_EXCEPTIONS:
+        from aragora.server.handlers.exceptions import __dict__ as handler_exceptions
+
+        value = handler_exceptions[name]
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/aragora/knowledge/mound/core.py
+++ b/aragora/knowledge/mound/core.py
@@ -14,6 +14,7 @@ Provides the foundation for KnowledgeMound:
 from __future__ import annotations
 
 import json
+import inspect
 import logging
 import sqlite3
 import uuid
@@ -371,7 +372,9 @@ class KnowledgeMoundCore:
             except (RuntimeError, ConnectionError, OSError) as e:
                 logger.debug("Error closing vector store: %s", e)
         if hasattr(self._meta_store, "close"):
-            await self._meta_store.close()
+            close_result = self._meta_store.close()
+            if inspect.isawaitable(close_result):
+                await close_result
 
         self._initialized = False
         logger.info("Knowledge Mound closed")

--- a/aragora/server/debate_origin/senders/slack.py
+++ b/aragora/server/debate_origin/senders/slack.py
@@ -14,6 +14,37 @@ from ..formatting import _format_result_message
 logger = logging.getLogger(__name__)
 
 
+def _truncate_fallback_text(text: str, limit: int = 3000) -> str:
+    """Return a Slack-safe fallback text string."""
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def _build_slack_payload(
+    origin: DebateOrigin,
+    message: str | dict[str, Any],
+    *,
+    fallback_text: str,
+) -> dict[str, Any]:
+    """Build a Slack chat.postMessage payload from string or Block Kit content."""
+    payload: dict[str, Any] = {"channel": origin.channel_id}
+
+    if isinstance(message, dict):
+        payload.update(message)
+        text = payload.get("text")
+        if not isinstance(text, str) or not text:
+            payload["text"] = _truncate_fallback_text(fallback_text)
+    else:
+        payload["text"] = message
+        payload["mrkdwn"] = True
+
+    if origin.thread_id:
+        payload["thread_ts"] = origin.thread_id
+
+    return payload
+
+
 async def _send_slack_result(origin: DebateOrigin, result: dict[str, Any]) -> bool:
     """Send result to Slack."""
     token = os.environ.get("SLACK_BOT_TOKEN", "")
@@ -23,6 +54,7 @@ async def _send_slack_result(origin: DebateOrigin, result: dict[str, Any]) -> bo
 
     channel = origin.channel_id
     message = _format_result_message(result, origin, markdown=True)
+    fallback_text = str(result.get("final_answer") or result.get("task") or "Debate Complete")
 
     try:
         url = "https://slack.com/api/chat.postMessage"
@@ -30,15 +62,7 @@ async def _send_slack_result(origin: DebateOrigin, result: dict[str, Any]) -> bo
             "Authorization": f"Bearer {token}",
             "Content-Type": "application/json",
         }
-        data = {
-            "channel": channel,
-            "text": message,
-            "mrkdwn": True,
-        }
-
-        # Reply in thread if we have thread_ts
-        if origin.thread_id:
-            data["thread_ts"] = origin.thread_id
+        data = _build_slack_payload(origin, message, fallback_text=fallback_text)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(url, json=data, headers=headers)

--- a/aragora/storage/__init__.py
+++ b/aragora/storage/__init__.py
@@ -27,9 +27,7 @@ from .interface import (
     sync_backend,
 )
 from .adapters import DebateStorageAdapter
-from .organization_store import OrganizationStore
 from .share_store import ShareLinkStore
-from .user_store import UserStore
 from .webhook_store import (
     InMemoryWebhookStore,
     SQLiteWebhookStore,
@@ -149,6 +147,10 @@ from typing import Any
 
 # Global debate storage singleton (set during server startup)
 _debate_storage: Any = None
+_LAZY_STORE_EXPORTS = {
+    "OrganizationStore": (".organization_store", "OrganizationStore"),
+    "UserStore": (".user_store", "UserStore"),
+}
 
 
 def get_storage() -> Any:
@@ -170,6 +172,19 @@ def reset_storage() -> None:
     """Reset debate storage to None (for testing)."""
     global _debate_storage
     _debate_storage = None
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attr_name = _LAZY_STORE_EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    from importlib import import_module
+
+    value = getattr(import_module(module_name, __name__), attr_name)
+    globals()[name] = value
+    return value
 
 
 __all__ = [

--- a/aragora/storage/base_database.py
+++ b/aragora/storage/base_database.py
@@ -209,6 +209,10 @@ class BaseDatabase:
         with self.connection() as conn:
             conn.executemany(sql, params_list)
 
+    def close(self) -> None:
+        """Close the underlying manager-backed connections."""
+        self._manager.close()
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.db_path!r})"
 

--- a/aragora/storage/schema.py
+++ b/aragora/storage/schema.py
@@ -623,6 +623,28 @@ class DatabaseManager:
             cls._instances.clear()
             logger.debug("Cleared all DatabaseManager instances")
 
+    @classmethod
+    def instance_paths(cls) -> set[str]:
+        """Return the currently registered manager paths."""
+        with timed_lock(cls._instances_lock, timeout=30.0, name="DatabaseManager.instances"):
+            return set(cls._instances.keys())
+
+    @classmethod
+    def close_instances(cls, paths: set[str] | list[str] | tuple[str, ...]) -> set[str]:
+        """Close and remove only the specified cached instances."""
+        normalized = {str(Path(path).resolve()) for path in paths}
+        closed: set[str] = set()
+        with timed_lock(cls._instances_lock, timeout=30.0, name="DatabaseManager.instances"):
+            for path in normalized:
+                manager = cls._instances.pop(path, None)
+                if manager is None:
+                    continue
+                manager.close()
+                closed.add(path)
+        if closed:
+            logger.debug("Closed %d DatabaseManager instances", len(closed))
+        return closed
+
     def get_connection(self) -> sqlite3.Connection:
         """Get a database connection.
 

--- a/tests/analytics/test_analytics.py
+++ b/tests/analytics/test_analytics.py
@@ -457,6 +457,40 @@ class TestDebateAnalyticsInit:
         assert "agent_records" in tables
         assert "elo_records" in tables
 
+    @pytest.mark.asyncio
+    async def test_sqlite_connections_are_closed(self, tmp_db_path, monkeypatch):
+        import sqlite3
+
+        connect_calls: list[sqlite3.Connection] = []
+        close_calls: list[sqlite3.Connection] = []
+        original_connect = sqlite3.connect
+
+        class TrackingConnection(sqlite3.Connection):
+            def close(self) -> None:
+                close_calls.append(self)
+                super().close()
+
+        def tracking_connect(*args, **kwargs):
+            kwargs.setdefault("factory", TrackingConnection)
+            conn = original_connect(*args, **kwargs)
+            connect_calls.append(conn)
+            return conn
+
+        monkeypatch.setattr("aragora.analytics.debate_analytics.sqlite3.connect", tracking_connect)
+
+        analytics = DebateAnalytics(db_path=tmp_db_path)
+        await analytics.record_debate(
+            debate_id="d1",
+            rounds=1,
+            consensus_reached=True,
+            duration_seconds=1.0,
+            agents=["claude"],
+        )
+        await analytics.get_debate_stats()
+
+        assert connect_calls
+        assert len(close_calls) == len(connect_calls)
+
 
 class TestDebateAnalyticsRecordDebate:
     @pytest.fixture

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -227,6 +227,26 @@ class TestReleaseReadinessBootstrapWorkflow:
         assert "scripts/ci_install_project.sh --extras dev,test" in command
 
 
+class TestMigrationTestsWorkflow:
+    """Validate migration-tests workflow bootstraps the monorepo correctly."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "migration-tests.yml"
+
+    def test_workflow_file_exists(self):
+        assert self.path.exists(), "migration-tests.yml does not exist"
+
+    def test_workflow_uses_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["migration-tests"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+
 class TestAutopilotWorktreeE2EWorkflow:
     """Validate autopilot-worktree-e2e workflow bootstrap policy."""
 

--- a/tests/debate/test_orchestrator.py
+++ b/tests/debate/test_orchestrator.py
@@ -31,6 +31,7 @@ import pytest
 from aragora.core import Agent, Critique, DebateResult, Environment, Message, Vote
 from aragora.debate.orchestrator import Arena, _compute_domain_from_task
 from aragora.debate.protocol import DebateProtocol
+from aragora.storage.schema import DatabaseManager
 
 # Many tests in this file run full Arena.run() debates (~10-30s each).
 # Under load from 9000+ prior tests, these can exceed the global 30s timeout.
@@ -1907,6 +1908,21 @@ class TestLifecycleManagement:
             pass
 
         assert cleanup_called
+
+    @pytest.mark.asyncio
+    async def test_cleanup_debate_persistence_closes_manager_delta(
+        self, environment, agents, tmp_path
+    ):
+        """Arena cleanup closes only manager-backed databases created after init."""
+        arena = Arena(environment, agents)
+        baseline = set(arena._db_manager_snapshot)
+        created_path = tmp_path / "arena-run-cleanup.db"
+
+        DatabaseManager.get_instance(created_path)
+
+        await arena._cleanup_debate_persistence()
+
+        assert DatabaseManager.instance_paths() == baseline
 
 
 # =============================================================================

--- a/tests/debate/test_orchestrator_runner.py
+++ b/tests/debate/test_orchestrator_runner.py
@@ -917,10 +917,8 @@ class TestHandleDebateCompletion:
         """Test that debate outcome is ingested to Knowledge Mound (background task)."""
         await handle_debate_completion(mock_arena, execution_state)
 
-        # KM ingestion runs as a background task; yield to let it execute
-        await asyncio.sleep(0)
-
         mock_arena._ingest_debate_outcome.assert_called_once_with(execution_state.ctx.result)
+        assert getattr(execution_state.ctx, "_km_ingest_task", None) is None
 
     @pytest.mark.asyncio
     async def test_handles_km_ingestion_error(self, mock_arena, execution_state):
@@ -929,7 +927,7 @@ class TestHandleDebateCompletion:
 
         # Should not raise — ingestion runs in background with retry
         await handle_debate_completion(mock_arena, execution_state)
-        await asyncio.sleep(0)  # Let background task start
+        assert getattr(execution_state.ctx, "_km_ingest_task", None) is None
 
     @pytest.mark.asyncio
     async def test_completes_gupp_tracking_on_success(self, mock_arena, execution_state):

--- a/tests/knowledge/mound/test_core.py
+++ b/tests/knowledge/mound/test_core.py
@@ -526,6 +526,26 @@ class TestKnowledgeMoundCoreClose:
         mock_meta.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_close_sync_meta_store(self):
+        """Should support synchronous meta store close methods."""
+        core = KnowledgeMoundCore()
+
+        class SyncMetaStore:
+            def __init__(self) -> None:
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        meta_store = SyncMetaStore()
+        core._meta_store = meta_store
+        core._initialized = True
+
+        await core.close()
+
+        assert meta_store.closed is True
+
+    @pytest.mark.asyncio
     async def test_close_resets_initialized(self):
         """Should reset _initialized flag."""
         core = KnowledgeMoundCore()

--- a/tests/server/debate_origin/senders/test_slack.py
+++ b/tests/server/debate_origin/senders/test_slack.py
@@ -1,0 +1,285 @@
+"""Tests for Slack sender for debate origin result routing.
+
+Tests cover:
+1. Result message sending via Slack chat.postMessage
+2. Rich Block Kit payload delivery for debated answers
+3. Receipt posting with a view button
+4. Error message delivery
+5. Token and threading behavior
+6. Error handling for Slack API failures
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.server.debate_origin.models import DebateOrigin
+from aragora.server.debate_origin.senders.slack import (
+    _send_slack_error,
+    _send_slack_receipt,
+    _send_slack_result,
+)
+
+
+@pytest.fixture
+def sample_origin() -> DebateOrigin:
+    """Create a sample Slack debate origin for testing."""
+    return DebateOrigin(
+        debate_id="debate-slack-123",
+        platform="slack",
+        channel_id="C1234567890",
+        user_id="user-slack-456",
+        thread_id="1711711717.123456",
+        metadata={"topic": "Slack Integration Test"},
+    )
+
+
+@pytest.fixture
+def sample_origin_no_thread() -> DebateOrigin:
+    """Create a Slack origin without thread_id for threading tests."""
+    return DebateOrigin(
+        debate_id="debate-slack-456",
+        platform="slack",
+        channel_id="C0987654321",
+        user_id="user-slack-789",
+        metadata={"topic": "Slack Integration Test"},
+    )
+
+
+@pytest.fixture
+def sample_result() -> dict[str, Any]:
+    """Create a sample debate result for testing."""
+    return {
+        "consensus_reached": True,
+        "final_answer": "The team reached agreement on the Slack delivery approach.",
+        "confidence": 0.91,
+        "participants": ["claude", "gpt-4", "gemini"],
+        "task": "Evaluate the Slack proposal",
+    }
+
+
+class TestSendSlackResult:
+    """Tests for _send_slack_result function."""
+
+    @pytest.mark.asyncio
+    async def test_sends_rich_blocks_with_fallback_text(self, sample_origin, sample_result):
+        """Rich formatter payloads are sent as Block Kit with plain-text fallback."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": True}
+        rich_message = {
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": "*Conclusion:*\nUse Slack blocks."},
+                }
+            ]
+        }
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch(
+                "aragora.server.debate_origin.senders.slack._format_result_message",
+                return_value=rich_message,
+            ):
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = AsyncMock()
+                    mock_client.post = AsyncMock(return_value=mock_response)
+                    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                    mock_client.__aexit__ = AsyncMock(return_value=None)
+                    mock_client_class.return_value = mock_client
+
+                    result = await _send_slack_result(sample_origin, sample_result)
+
+        assert result is True
+        call_args = mock_client.post.call_args
+        post_data = call_args.kwargs["json"]
+        assert post_data["channel"] == sample_origin.channel_id
+        assert post_data["blocks"] == rich_message["blocks"]
+        assert post_data["text"] == sample_result["final_answer"]
+        assert post_data["thread_ts"] == sample_origin.thread_id
+
+    @pytest.mark.asyncio
+    async def test_sends_markdown_result_when_formatter_returns_string(
+        self, sample_origin, sample_result
+    ):
+        """String formatter payloads are sent as classic mrkdwn messages."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": True}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch(
+                "aragora.server.debate_origin.senders.slack._format_result_message",
+                return_value="**Debate Complete!**",
+            ):
+                with patch("httpx.AsyncClient") as mock_client_class:
+                    mock_client = AsyncMock()
+                    mock_client.post = AsyncMock(return_value=mock_response)
+                    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                    mock_client.__aexit__ = AsyncMock(return_value=None)
+                    mock_client_class.return_value = mock_client
+
+                    result = await _send_slack_result(sample_origin, sample_result)
+
+        assert result is True
+        post_data = mock_client.post.call_args.kwargs["json"]
+        assert post_data["text"] == "**Debate Complete!**"
+        assert post_data["mrkdwn"] is True
+        assert "blocks" not in post_data
+
+    @pytest.mark.asyncio
+    async def test_omits_thread_ts_without_thread_id(self, sample_origin_no_thread, sample_result):
+        """thread_ts is not sent when the origin is not threaded."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": True}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                await _send_slack_result(sample_origin_no_thread, sample_result)
+
+        post_data = mock_client.post.call_args.kwargs["json"]
+        assert "thread_ts" not in post_data
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_bot_token(self, sample_origin, sample_result):
+        """Missing Slack bot token disables result delivery."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SLACK_BOT_TOKEN", None)
+            result = await _send_slack_result(sample_origin, sample_result)
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_slack_api_error(self, sample_origin, sample_result):
+        """Slack API ok=false responses are treated as failures."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": False, "error": "invalid_blocks"}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                result = await _send_slack_result(sample_origin, sample_result)
+
+        assert result is False
+
+
+class TestSendSlackReceipt:
+    """Tests for _send_slack_receipt function."""
+
+    @pytest.mark.asyncio
+    async def test_posts_receipt_with_button(self, sample_origin):
+        """Receipt summaries include a primary button to the full receipt."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": True}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                result = await _send_slack_receipt(
+                    sample_origin,
+                    "✅ **Decision Receipt**\n• Verdict: APPROVED",
+                    "https://aragora.ai/receipt/123",
+                )
+
+        assert result is True
+        post_data = mock_client.post.call_args.kwargs["json"]
+        assert post_data["channel"] == sample_origin.channel_id
+        assert post_data["thread_ts"] == sample_origin.thread_id
+        attachment = post_data["attachments"][0]
+        assert attachment["actions"][0]["text"] == "View Full Receipt"
+        assert attachment["actions"][0]["url"] == "https://aragora.ai/receipt/123"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_bot_token(self, sample_origin):
+        """Missing Slack bot token disables receipt delivery."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("SLACK_BOT_TOKEN", None)
+            result = await _send_slack_receipt(sample_origin, "summary", "https://example.com/r")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_connection_error(self, sample_origin):
+        """Connection failures are handled gracefully for receipt delivery."""
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(side_effect=OSError("Connection refused"))
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                result = await _send_slack_receipt(
+                    sample_origin, "summary", "https://example.com/r"
+                )
+
+        assert result is False
+
+
+class TestSendSlackError:
+    """Tests for _send_slack_error function."""
+
+    @pytest.mark.asyncio
+    async def test_sends_error_to_thread(self, sample_origin):
+        """Error messages reuse the original Slack thread when available."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"ok": True}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                result = await _send_slack_error(sample_origin, "Please reconnect the Slack app.")
+
+        assert result is True
+        post_data = mock_client.post.call_args.kwargs["json"]
+        assert post_data["channel"] == sample_origin.channel_id
+        assert post_data["text"] == "Please reconnect the Slack app."
+        assert post_data["thread_ts"] == sample_origin.thread_id
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_api_error(self, sample_origin):
+        """Slack API failures are surfaced as False for error delivery."""
+        mock_response = MagicMock()
+        mock_response.is_success = False
+        mock_response.json.return_value = {"ok": False}
+
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            with patch("httpx.AsyncClient") as mock_client_class:
+                mock_client = AsyncMock()
+                mock_client.post = AsyncMock(return_value=mock_response)
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=None)
+                mock_client_class.return_value = mock_client
+
+                result = await _send_slack_error(sample_origin, "Something went wrong.")
+
+        assert result is False

--- a/tests/storage/test_schema.py
+++ b/tests/storage/test_schema.py
@@ -204,6 +204,41 @@ class TestGetWalConnection:
             conn.close()
 
 
+class TestDatabaseManagerInstanceRegistry:
+    """Tests for selective DatabaseManager instance cleanup."""
+
+    def teardown_method(self):
+        DatabaseManager.clear_instances()
+
+    def test_instance_paths_reports_registered_managers(self, tmp_path):
+        first = tmp_path / "first.db"
+        second = tmp_path / "second.db"
+
+        DatabaseManager.get_instance(first)
+        DatabaseManager.get_instance(second)
+
+        paths = DatabaseManager.instance_paths()
+
+        assert str(first.resolve()) in paths
+        assert str(second.resolve()) in paths
+
+    def test_close_instances_closes_only_requested_paths(self, tmp_path):
+        first = tmp_path / "first.db"
+        second = tmp_path / "second.db"
+
+        first_manager = DatabaseManager.get_instance(first)
+        second_manager = DatabaseManager.get_instance(second)
+
+        closed = DatabaseManager.close_instances([str(first)])
+
+        assert closed == {str(first.resolve())}
+        assert DatabaseManager.instance_paths() == {str(second.resolve())}
+
+        recreated = DatabaseManager.get_instance(first)
+        assert recreated is not first_manager
+        assert DatabaseManager.get_instance(second) is second_manager
+
+
 # ============================================================================
 # Migration
 # ============================================================================


### PR DESCRIPTION
## Summary
- close one-shot quickstart resources so the onboarding lane does not leak receipts/connectors across tests
- close arena-created DatabaseManager instances after debate completion and expose close hooks on manager-backed debate stores
- run Knowledge Mound ingestion inline under pytest and reset debate-path singleton receipt/webhook stores during pytest cleanup

## Validation
- python3 -m pytest tests/cli/test_quickstart.py tests/e2e/test_user_journey.py -q -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning
- python3 -m pytest tests/storage/test_schema.py tests/debate/test_orchestrator.py -q
- python3 -m pytest tests/debate/test_orchestrator_runner.py tests/storage/test_base_database.py -q
- python3 -m ruff check aragora/storage/schema.py aragora/storage/base_database.py aragora/debate/epistemic_outcomes.py aragora/debate/outcome_tracker.py aragora/debate/outcome_verifier.py aragora/debate/checkpoint_backends.py aragora/debate/checkpoint.py aragora/debate/orchestrator.py aragora/debate/orchestrator_runner.py tests/storage/test_schema.py tests/debate/test_orchestrator.py tests/debate/test_orchestrator_runner.py
