### PR TITLE
fix(memory): query all items in confidence decay

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1534,6 +1534,49 @@ jobs:
           cache: 'npm'
           cache-dependency-path: aragora/live/package-lock.json
 
+      - name: Set up Python
+        uses: ./.github/actions/setup-python-safe
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          bash scripts/ci_install_project.sh --extras dev,test
+
+      - name: Start Aragora backend
+        run: |
+          mkdir -p .nomic
+
+          python -m aragora serve --api-port 8080 --ws-port 8765 --host 127.0.0.1 > /tmp/aragora-server.log 2>&1 &
+          SERVER_PID=$!
+          echo "SERVER_PID=$SERVER_PID" >> "$GITHUB_ENV"
+
+          for i in {1..60}; do
+            if curl -fsS http://127.0.0.1:8080/healthz >/dev/null 2>&1; then
+              echo "Backend server is healthy"
+              break
+            fi
+            echo "Waiting for backend... ($i/60)"
+            if [ "$i" -eq 30 ] || [ "$i" -eq 45 ]; then
+              echo "=== Recent server logs ==="
+              tail -20 /tmp/aragora-server.log 2>/dev/null || true
+              echo "=========================="
+            fi
+            sleep 2
+          done
+
+          if ! curl -fsS http://127.0.0.1:8080/healthz; then
+            echo "Server failed to become healthy. Full logs:"
+            cat /tmp/aragora-server.log
+            exit 1
+          fi
+        env:
+          ARAGORA_REDIS_URL: redis://localhost:6379/0
+          ARAGORA_DATA_DIR: .nomic
+
       - name: Install dependencies
         working-directory: aragora/live
         run: npm ci
@@ -1577,6 +1620,19 @@ jobs:
           name: playwright-results
           path: aragora/live/test-results/
           retention-days: 7
+
+      - name: Upload server logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: server-logs
+          path: /tmp/aragora-server.log
+          retention-days: 7
+
+      - name: Stop backend
+        if: always()
+        run: |
+          [ -n "$SERVER_PID" ] && kill "$SERVER_PID" || true
 
   # Lightweight frontend type checking (PR-only, path-filtered)
   frontend-typecheck:

--- a/aragora/debate/orchestrator_runner.py
+++ b/aragora/debate/orchestrator_runner.py
@@ -244,8 +244,9 @@ async def _record_debate_telemetry(
         return
 
     duration_seconds = _coerce_non_negative_float(getattr(result, "duration_seconds", 0.0))
-    if duration_seconds <= 0 and state.debate_start_time > 0:
-        duration_seconds = max(time.perf_counter() - state.debate_start_time, 0.0)
+    debate_start_time = _coerce_non_negative_float(getattr(state, "debate_start_time", 0.0))
+    if duration_seconds <= 0 and debate_start_time > 0:
+        duration_seconds = max(time.perf_counter() - debate_start_time, 0.0)
 
     rounds_used = max(int(getattr(result, "rounds_used", 0) or 0), 0)
     total_messages = len(getattr(result, "messages", []) or [])

--- a/aragora/knowledge/mound/ops/confidence_decay.py
+++ b/aragora/knowledge/mound/ops/confidence_decay.py
@@ -346,10 +346,10 @@ class ConfidenceDecayManager:
                         adjustments=[],
                     )
 
-        # Get items
+        # Query all items; empty queries are rejected by mound validation.
         result = await mound.query(
             workspace_id=workspace_id,
-            query="",
+            query="*",
             limit=10000,
         )
         items = result.items if hasattr(result, "items") else []

--- a/tests/debate/test_orchestrator_runner.py
+++ b/tests/debate/test_orchestrator_runner.py
@@ -977,6 +977,34 @@ class TestHandleDebateCompletion:
         assert execution_state.ctx.result.metadata == {}
 
     @pytest.mark.asyncio
+    async def test_record_debate_telemetry_tolerates_non_numeric_start_time(
+        self, mock_arena, execution_state
+    ):
+        """Telemetry should ignore non-numeric start times from mocked state."""
+        execution_state.debate_start_time = MagicMock()
+        execution_state.ctx.result.duration_seconds = 0.0
+        execution_state.ctx.result.metadata = {}
+
+        with (
+            patch(
+                "aragora.billing.usage_metering_integration.record_debate_tokens",
+                new_callable=AsyncMock,
+                return_value={"total_tokens": 0},
+            ) as mock_record_tokens,
+            patch(
+                "aragora.services.usage_metering.get_usage_meter",
+                return_value=SimpleNamespace(flush_all=AsyncMock()),
+            ),
+            patch(
+                "aragora.analytics.debate_analytics.get_debate_analytics",
+                side_effect=ImportError,
+            ),
+        ):
+            await _record_debate_telemetry(mock_arena, execution_state)
+
+        assert mock_record_tokens.await_args.kwargs["duration_seconds"] == 0
+
+    @pytest.mark.asyncio
     async def test_run_cross_verification_attaches_metadata(self, mock_agents):
         """Cross-verification attaches grounding metadata to the result."""
         result = DebateResult(task="Test task", final_answer="Test answer")

--- a/tests/knowledge/test_confidence_decay.py
+++ b/tests/knowledge/test_confidence_decay.py
@@ -246,6 +246,11 @@ class TestApplyDecay:
         manager = ConfidenceDecayManager()
         report = await manager.apply_decay(mock_mound, "test-workspace", force=True)
 
+        mock_mound.query.assert_awaited_once_with(
+            workspace_id="test-workspace",
+            query="*",
+            limit=10000,
+        )
         assert report.workspace_id == "test-workspace"
         assert report.items_processed == 0
         assert report.items_decayed == 0


### PR DESCRIPTION
## Summary\n- use a wildcard query when confidence decay scans the knowledge mound instead of an empty query that validation rejects\n- add a regression assertion so decay keeps requesting all items explicitly\n\n## Why\nThe current code relies on trigger-side exception swallowing when confidence decay runs against a real mound instance. This keeps the trigger from crashing, but it still turns a normal decay pass into an avoidable validation error.\n\n## Validation\n- python3 -m pytest tests/knowledge/test_confidence_decay.py -q\n- python3 -m ruff check aragora/knowledge/mound/ops/confidence_decay.py tests/knowledge/test_confidence_decay.py