### PR TITLE
fix(cli): stabilize offline golden proof path

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -344,6 +344,11 @@ async def _shutdown_cmd_ask_resources() -> None:
     except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
         logger.debug("Ask dispatcher shutdown skipped: %s", exc)
 
+    # Give async transport/connector close callbacks one loop turn before
+    # asyncio.run() tears the loop down. This avoids intermittent unclosed
+    # socket warnings in CLI proof-path tests.
+    await asyncio.sleep(0)
+
 
 async def _run_coro_with_cmd_ask_cleanup(coro: Any) -> Any:
     """Await a CLI ask coroutine and close shared resources on the same loop."""

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -1137,12 +1137,22 @@ If settlement hook error rate exceeds 2% over a sustained 10 minute window, roll
     )
 
     result = DebateResult(task=args.task, final_answer=weak_answer, metadata={})
-    timed_out_agent = MagicMock()
-    timed_out_agent.generate = AsyncMock(side_effect=TimeoutError("request timed out"))
-    low_quality_agent = MagicMock()
-    low_quality_agent.generate = AsyncMock(return_value=weak_answer)
-    upgraded_agent = MagicMock()
-    upgraded_agent.generate = AsyncMock(return_value=upgraded_answer)
+
+    class _FakeRepairAgent:
+        def __init__(self, behavior: str):
+            self.behavior = behavior
+            self.system_prompt = ""
+
+        async def generate(self, _prompt: str) -> str:
+            if self.behavior == "timeout":
+                raise TimeoutError("request timed out")
+            if self.behavior == "weak":
+                return weak_answer
+            return upgraded_answer
+
+    timed_out_agent = _FakeRepairAgent("timeout")
+    low_quality_agent = _FakeRepairAgent("weak")
+    upgraded_agent = _FakeRepairAgent("good")
     created_specs: list[tuple[str, str | None]] = []
 
     def _fake_create_agent(*, model_type, name, role, model=None, **_kwargs):
@@ -1160,9 +1170,12 @@ If settlement hook error rate exceeds 2% over a sustained 10 minute window, roll
     def _no_timeout(_seconds: float):
         yield
 
+    async def _fake_run_debate(**_kwargs):
+        return result
+
     with (
         patch.object(debate_cmd, "_strict_wall_clock_timeout", _no_timeout),
-        patch.object(debate_cmd, "run_debate", new_callable=AsyncMock, return_value=result),
+        patch.object(debate_cmd, "run_debate", new=_fake_run_debate),
         patch.object(debate_cmd, "create_agent", side_effect=_fake_create_agent),
     ):
         debate_cmd.cmd_ask(args)


### PR DESCRIPTION
## Summary
- close CLI ask shared resources on the same event loop that ran the debate
- give transport cleanup one loop tick before asyncio.run tears the loop down
- stabilize offline golden path tests around timeout and retry cleanup behavior

## Testing
- python3 -m ruff check aragora/cli/commands/debate.py tests/cli/test_offline_golden_path.py
- python3 -m pytest tests/cli/test_offline_golden_path.py -v --timeout=60 --tb=short --randomly-seed=710226767 -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning