### PR TITLE
fix(ci): preserve contract drift governance checks

### DIFF
--- a/.github/workflows/required-check-priority.yml
+++ b/.github/workflows/required-check-priority.yml
@@ -42,6 +42,7 @@ jobs:
             const alwaysKeepWorkflowPaths = new Set([
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
+              '.github/workflows/contract-drift-governance.yml',
               '.github/workflows/core-suites.yml',
               '.github/workflows/lint.yml',
               '.github/workflows/live-deploy-mode-gate.yml',
@@ -62,6 +63,7 @@ jobs:
             const alwaysKeepWorkflowNames = new Set([
               'Aragora Code Review',
               'Autopilot Worktree E2E',
+              'Contract Drift Governance',
               'Core Suites (Decision Integrity)',
               'Offline Golden Path',
               'Required Check Priority',

--- a/scripts/check_required_check_priority_policy.py
+++ b/scripts/check_required_check_priority_policy.py
@@ -20,6 +20,7 @@ WORKFLOW_PATH = Path(".github/workflows/required-check-priority.yml")
 REQUIRED_KEEP_WORKFLOW_PATHS = {
     ".github/workflows/aragora-review-gate.yml",
     ".github/workflows/autopilot-worktree-e2e.yml",
+    ".github/workflows/contract-drift-governance.yml",
     ".github/workflows/core-suites.yml",
     ".github/workflows/lint.yml",
     ".github/workflows/live-deploy-mode-gate.yml",
@@ -40,6 +41,7 @@ REQUIRED_KEEP_WORKFLOW_PATHS = {
 REQUIRED_KEEP_WORKFLOW_NAMES = {
     "Aragora Code Review",
     "Autopilot Worktree E2E",
+    "Contract Drift Governance",
     "Core Suites (Decision Integrity)",
     "Offline Golden Path",
     "Required Check Priority",

--- a/tests/scripts/test_check_required_check_priority_policy.py
+++ b/tests/scripts/test_check_required_check_priority_policy.py
@@ -20,6 +20,7 @@ jobs:
             const alwaysKeepWorkflowPaths = new Set([
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
+              '.github/workflows/contract-drift-governance.yml',
               '.github/workflows/core-suites.yml',
               '.github/workflows/lint.yml',
               '.github/workflows/live-deploy-mode-gate.yml',
@@ -39,6 +40,7 @@ jobs:
             const alwaysKeepWorkflowNames = new Set([
               'Aragora Code Review',
               'Autopilot Worktree E2E',
+              'Contract Drift Governance',
               'Core Suites (Decision Integrity)',
               'Offline Golden Path',
               'Live Deploy Mode Gate',
@@ -122,6 +124,10 @@ def test_policy_detects_missing_context_marker_in_mapped_workflow(tmp_path: Path
         "name: Autopilot Worktree E2E\njobs:\n  scope:\n    name: Autopilot Scope\n",
         encoding="utf-8",
     )
+    (wf_dir / "contract-drift-governance.yml").write_text(
+        "name: Contract Drift Governance\njobs:\n  governance:\n    name: governance\n",
+        encoding="utf-8",
+    )
     (wf_dir / "core-suites.yml").write_text(
         "name: Core Suites (Decision Integrity)\njobs:\n  core:\n    runs-on: ubuntu-latest\n",
         encoding="utf-8",
@@ -189,6 +195,7 @@ jobs:
             const alwaysKeepWorkflowPaths = new Set([
               '.github/workflows/aragora-review-gate.yml',
               '.github/workflows/autopilot-worktree-e2e.yml',
+              '.github/workflows/contract-drift-governance.yml',
               '.github/workflows/core-suites.yml',
               '.github/workflows/lint.yml',
               '.github/workflows/live-deploy-mode-gate.yml',
@@ -208,6 +215,7 @@ jobs:
             const alwaysKeepWorkflowNames = new Set([
               'Aragora Code Review',
               'Autopilot Worktree E2E',
+              'Contract Drift Governance',
               'Core Suites (Decision Integrity)',
               'Offline Golden Path',
               'Live Deploy Mode Gate',


### PR DESCRIPTION
## Summary
- keep Contract Drift Governance in the required-check prioritizer allowlist
- extend the required-check-priority policy guard to cover that workflow
- add regression coverage so the keep-list cannot drift again

## Testing
- python3 -m pytest tests/scripts/test_check_required_check_priority_policy.py -q
- python3 scripts/check_required_check_priority_policy.py
- python3 -m ruff check scripts/check_required_check_priority_policy.py tests/scripts/test_check_required_check_priority_policy.py