### PR TITLE
fix(memory): query all items in confidence decay

### DIFF
--- a/aragora/knowledge/mound/ops/confidence_decay.py
+++ b/aragora/knowledge/mound/ops/confidence_decay.py
@@ -347,9 +347,10 @@ class ConfidenceDecayManager:
                     )
 
         # Get items
+        # Query all items explicitly; empty queries are rejected by mound validation.
         result = await mound.query(
             workspace_id=workspace_id,
-            query="",
+            query="*",
             limit=10000,
         )
         items = result.items if hasattr(result, "items") else []

--- a/tests/knowledge/test_confidence_decay.py
+++ b/tests/knowledge/test_confidence_decay.py
@@ -25,6 +25,7 @@ from aragora.knowledge.mound.ops.confidence_decay import (
     DecayReport,
     get_decay_manager,
 )
+from aragora.knowledge.mound import KnowledgeMound, MoundBackend, MoundConfig
 
 
 # =============================================================================
@@ -250,6 +251,30 @@ class TestApplyDecay:
         assert report.items_processed == 0
         assert report.items_decayed == 0
         assert report.adjustments == []
+        mock_mound.query.assert_awaited_once_with(
+            workspace_id="test-workspace",
+            query="*",
+            limit=10000,
+        )
+
+    @pytest.mark.asyncio
+    async def test_apply_decay_initialized_mound_uses_non_empty_query(self, tmp_path):
+        """Should work against a real initialized mound without validation errors."""
+        config = MoundConfig(
+            backend=MoundBackend.SQLITE,
+            sqlite_path=tmp_path / "confidence_decay.db",
+        )
+        mound = KnowledgeMound(config=config, workspace_id="test-workspace")
+        await mound.initialize()
+        manager = ConfidenceDecayManager()
+
+        try:
+            report = await manager.apply_decay(mound, "test-workspace", force=True)
+        finally:
+            await mound.close()
+
+        assert report.workspace_id == "test-workspace"
+        assert report.items_processed == 0
 
     @pytest.mark.asyncio
     async def test_apply_decay_single_item(self):


### PR DESCRIPTION
## Summary
- use an explicit wildcard query when confidence decay scans a workspace
- add a focused regression that proves decay works against a real initialized KnowledgeMound
- assert the manager requests all items via a non-empty query

## Repro
On current main, running confidence decay against an initialized mound raises `ValidationError: Query cannot be empty` because `apply_decay()` calls `mound.query(query="")`.

## Validation
- python3 -m pytest tests/knowledge/test_confidence_decay.py -q
- python3 -m ruff check aragora/knowledge/mound/ops/confidence_decay.py tests/knowledge/test_confidence_decay.py
- direct repro: initialized `KnowledgeMound` + `ConfidenceDecayManager().apply_decay(...)` now returns `OK 0 0` instead of raising validation
