### PR TITLE
fix(knowledge): tolerate sync metastore shutdown

### DIFF
--- a/aragora/knowledge/mound/core.py
+++ b/aragora/knowledge/mound/core.py
@@ -20,6 +20,7 @@ import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
+import inspect
 from typing import TYPE_CHECKING, Any
 from collections.abc import AsyncIterator
 
@@ -371,7 +372,9 @@ class KnowledgeMoundCore:
             except (RuntimeError, ConnectionError, OSError) as e:
                 logger.debug("Error closing vector store: %s", e)
         if hasattr(self._meta_store, "close"):
-            await self._meta_store.close()
+            close_result = self._meta_store.close()
+            if inspect.isawaitable(close_result):
+                await close_result
 
         self._initialized = False
         logger.info("Knowledge Mound closed")

--- a/tests/knowledge/test_mound_facade.py
+++ b/tests/knowledge/test_mound_facade.py
@@ -6,6 +6,7 @@ import pytest
 import tempfile
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.knowledge.mound import (
@@ -97,6 +98,19 @@ class TestKnowledgeMoundFacade:
 
         assert mound._initialized is True
         await mound.close()
+
+    @pytest.mark.asyncio
+    async def test_close_handles_sync_meta_store(self, config):
+        """Test close tolerates synchronous metastore shutdown."""
+        mound = KnowledgeMound(config=config, workspace_id="test")
+        await mound.initialize()
+
+        close_mock = MagicMock(return_value=None)
+        mound._meta_store = SimpleNamespace(close=close_mock)
+
+        await mound.close()
+
+        close_mock.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_store_knowledge(self, mound):


### PR DESCRIPTION
## Summary\n- make KnowledgeMound close tolerate synchronous metastore close methods\n- add a focused regression for sync metastore shutdown\n- restore the failing mound facade suite on current main\n\n## Testing\n- python3 -m ruff check aragora/knowledge/mound/core.py tests/knowledge/test_mound_facade.py\n- python3 -m pytest tests/knowledge/test_mound_facade.py::TestKnowledgeMoundFacade::test_close_handles_sync_meta_store tests/knowledge/test_mound_facade.py::TestKnowledgeMoundFacade::test_initialize_sqlite tests/knowledge/test_mound_facade.py::TestMoundEdgeCases::test_query_empty_mound -q\n- python3 -m pytest tests/knowledge/test_mound_facade.py -q