### PR TITLE
fix(swarm): add missing lane telemetry modules

### DIFF
--- a/aragora/swarm/lane_telemetry.py
+++ b/aragora/swarm/lane_telemetry.py
@@ -1,0 +1,336 @@
+"""Telemetry for terminal swarm/autonomy lanes.
+
+Records one terminal telemetry row per canonical lane outcome so autonomous
+execution can be measured like product infrastructure.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from aragora.persistence.db_config import get_default_data_dir
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class LaneTelemetryRecord:
+    """Telemetry row for one terminal autonomous lane."""
+
+    lane_kind: str
+    lane_id: str
+    run_id: str = ""
+    task_id: str = ""
+    work_order_id: str = ""
+    project_id: str = ""
+    terminal_outcome: str = ""
+    worker_outcome: str = ""
+    deliverable_type: str = ""
+    receipt_id: str = ""
+    human_intervention_required: bool = False
+    duration_seconds: float = 0.0
+    pr_url: str = ""
+    pr_number: int | None = None
+    merge_ref: str = ""
+    merged_at: str = ""
+    time_to_pr_seconds: float | None = None
+    time_to_merge_seconds: float | None = None
+    false_success_candidate: bool = False
+    timestamp: float = field(default_factory=time.time)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> LaneTelemetryRecord:
+        return cls(
+            lane_kind=str(row["lane_kind"] or ""),
+            lane_id=str(row["lane_id"] or ""),
+            run_id=str(row["run_id"] or ""),
+            task_id=str(row["task_id"] or ""),
+            work_order_id=str(row["work_order_id"] or ""),
+            project_id=str(row["project_id"] or ""),
+            terminal_outcome=str(row["terminal_outcome"] or ""),
+            worker_outcome=str(row["worker_outcome"] or ""),
+            deliverable_type=str(row["deliverable_type"] or ""),
+            receipt_id=str(row["receipt_id"] or ""),
+            human_intervention_required=bool(row["human_intervention_required"]),
+            duration_seconds=float(row["duration_seconds"] or 0.0),
+            pr_url=str(row["pr_url"] or ""),
+            pr_number=row["pr_number"],
+            merge_ref=str(row["merge_ref"] or ""),
+            merged_at=str(row["merged_at"] or ""),
+            time_to_pr_seconds=row["time_to_pr_seconds"],
+            time_to_merge_seconds=row["time_to_merge_seconds"],
+            false_success_candidate=bool(row["false_success_candidate"]),
+            timestamp=float(row["timestamp"] or 0.0),
+            metadata=json.loads(str(row["metadata_json"] or "{}")),
+        )
+
+
+class LaneTelemetryCollector:
+    """SQLite-backed collector for terminal swarm lane telemetry."""
+
+    def __init__(self, db_path: str | None = None) -> None:
+        if db_path is None:
+            data_dir = get_default_data_dir()
+            data_dir.mkdir(parents=True, exist_ok=True)
+            db_path = str(data_dir / "swarm_lane_telemetry.db")
+
+        self.db_path = db_path
+        self._persistent_conn: sqlite3.Connection | None = None
+        if db_path == ":memory:":
+            self._persistent_conn = sqlite3.connect(":memory:")
+        self._init_schema()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._persistent_conn is not None:
+            return self._persistent_conn
+        return sqlite3.connect(self.db_path)
+
+    def _close_conn(self, conn: sqlite3.Connection) -> None:
+        if conn is not self._persistent_conn:
+            conn.close()
+
+    def _init_schema(self) -> None:
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS lane_telemetry (
+                    lane_kind TEXT NOT NULL,
+                    lane_id TEXT NOT NULL,
+                    run_id TEXT NOT NULL DEFAULT '',
+                    task_id TEXT NOT NULL DEFAULT '',
+                    work_order_id TEXT NOT NULL DEFAULT '',
+                    project_id TEXT NOT NULL DEFAULT '',
+                    terminal_outcome TEXT NOT NULL DEFAULT '',
+                    worker_outcome TEXT NOT NULL DEFAULT '',
+                    deliverable_type TEXT NOT NULL DEFAULT '',
+                    receipt_id TEXT NOT NULL DEFAULT '',
+                    human_intervention_required INTEGER NOT NULL DEFAULT 0,
+                    duration_seconds REAL NOT NULL DEFAULT 0,
+                    pr_url TEXT NOT NULL DEFAULT '',
+                    pr_number INTEGER,
+                    merge_ref TEXT NOT NULL DEFAULT '',
+                    merged_at TEXT NOT NULL DEFAULT '',
+                    time_to_pr_seconds REAL,
+                    time_to_merge_seconds REAL,
+                    false_success_candidate INTEGER NOT NULL DEFAULT 0,
+                    timestamp REAL NOT NULL DEFAULT 0,
+                    metadata_json TEXT NOT NULL DEFAULT '{}',
+                    PRIMARY KEY (lane_kind, lane_id)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_lane_telemetry_timestamp
+                ON lane_telemetry(timestamp DESC)
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_lane_telemetry_outcome
+                ON lane_telemetry(terminal_outcome)
+                """
+            )
+            conn.commit()
+        finally:
+            self._close_conn(conn)
+
+    def record_lane(self, record: LaneTelemetryRecord) -> None:
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO lane_telemetry (
+                    lane_kind,
+                    lane_id,
+                    run_id,
+                    task_id,
+                    work_order_id,
+                    project_id,
+                    terminal_outcome,
+                    worker_outcome,
+                    deliverable_type,
+                    receipt_id,
+                    human_intervention_required,
+                    duration_seconds,
+                    pr_url,
+                    pr_number,
+                    merge_ref,
+                    merged_at,
+                    time_to_pr_seconds,
+                    time_to_merge_seconds,
+                    false_success_candidate,
+                    timestamp,
+                    metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record.lane_kind,
+                    record.lane_id,
+                    record.run_id,
+                    record.task_id,
+                    record.work_order_id,
+                    record.project_id,
+                    record.terminal_outcome,
+                    record.worker_outcome,
+                    record.deliverable_type,
+                    record.receipt_id,
+                    1 if record.human_intervention_required else 0,
+                    record.duration_seconds,
+                    record.pr_url,
+                    record.pr_number,
+                    record.merge_ref,
+                    record.merged_at,
+                    record.time_to_pr_seconds,
+                    record.time_to_merge_seconds,
+                    1 if record.false_success_candidate else 0,
+                    record.timestamp,
+                    json.dumps(record.metadata, sort_keys=True),
+                ),
+            )
+            conn.commit()
+        finally:
+            self._close_conn(conn)
+
+    def get_recent_lanes(self, n: int = 20) -> list[LaneTelemetryRecord]:
+        conn = self._get_conn()
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT * FROM lane_telemetry ORDER BY timestamp DESC LIMIT ?",
+                (n,),
+            ).fetchall()
+            return [LaneTelemetryRecord.from_row(row) for row in rows]
+        finally:
+            self._close_conn(conn)
+
+    def get_lane(self, lane_kind: str, lane_id: str) -> LaneTelemetryRecord | None:
+        conn = self._get_conn()
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT * FROM lane_telemetry
+                WHERE lane_kind = ? AND lane_id = ?
+                LIMIT 1
+                """,
+                (lane_kind, lane_id),
+            ).fetchone()
+            return LaneTelemetryRecord.from_row(row) if row is not None else None
+        finally:
+            self._close_conn(conn)
+
+    def get_throughput(self, window_days: int = 7) -> int:
+        row = self._aggregate_scalar(
+            "SELECT COUNT(*) FROM lane_telemetry WHERE timestamp >= ?",
+            window_days,
+        )
+        return int(row or 0)
+
+    def get_success_rate(self, window_days: int = 7) -> float:
+        row = self._aggregate_row(
+            """
+            SELECT COUNT(*) AS total,
+                   SUM(CASE WHEN terminal_outcome IN ('deliverable_created', 'pr_adopted')
+                            AND false_success_candidate = 0
+                            THEN 1 ELSE 0 END) AS successes
+            FROM lane_telemetry
+            WHERE timestamp >= ?
+              AND COALESCE(TRIM(terminal_outcome), '') NOT IN ('', 'unknown')
+            """,
+            window_days,
+        )
+        total = int(row["total"] or 0)
+        successes = int(row["successes"] or 0)
+        return successes / total if total else 0.0
+
+    def get_false_success_candidate_count(self, window_days: int = 7) -> int:
+        row = self._aggregate_scalar(
+            """
+            SELECT SUM(false_success_candidate)
+            FROM lane_telemetry
+            WHERE timestamp >= ?
+            """,
+            window_days,
+        )
+        return int(row or 0)
+
+    def get_human_intervention_rate(self, window_days: int = 7) -> float:
+        row = self._aggregate_row(
+            """
+            SELECT COUNT(*) AS total,
+                   SUM(human_intervention_required) AS human_required
+            FROM lane_telemetry
+            WHERE timestamp >= ?
+              AND COALESCE(TRIM(terminal_outcome), '') NOT IN ('', 'unknown')
+            """,
+            window_days,
+        )
+        total = int(row["total"] or 0)
+        human_required = int(row["human_required"] or 0)
+        return human_required / total if total else 0.0
+
+    def get_merge_yield(self, window_days: int = 7) -> float:
+        row = self._aggregate_row(
+            """
+            SELECT
+                SUM(CASE WHEN deliverable_type != '' THEN 1 ELSE 0 END) AS deliverable_count,
+                SUM(CASE WHEN merged_at != '' OR merge_ref != '' THEN 1 ELSE 0 END) AS merged_count
+            FROM lane_telemetry
+            WHERE timestamp >= ?
+            """,
+            window_days,
+        )
+        deliverable_count = int(row["deliverable_count"] or 0)
+        merged_count = int(row["merged_count"] or 0)
+        return merged_count / deliverable_count if deliverable_count else 0.0
+
+    def get_avg_time_to_pr(self, window_days: int = 7) -> float:
+        row = self._aggregate_scalar(
+            """
+            SELECT AVG(time_to_pr_seconds)
+            FROM lane_telemetry
+            WHERE timestamp >= ? AND time_to_pr_seconds IS NOT NULL
+            """,
+            window_days,
+        )
+        return float(row or 0.0)
+
+    def get_avg_time_to_merge(self, window_days: int = 7) -> float:
+        row = self._aggregate_scalar(
+            """
+            SELECT AVG(time_to_merge_seconds)
+            FROM lane_telemetry
+            WHERE timestamp >= ? AND time_to_merge_seconds IS NOT NULL
+            """,
+            window_days,
+        )
+        return float(row or 0.0)
+
+    def _aggregate_scalar(self, query: str, window_days: int) -> Any:
+        row = self._aggregate_row(query, window_days)
+        if row is None:
+            return 0
+        return row[0]
+
+    def _aggregate_row(self, query: str, window_days: int) -> sqlite3.Row | tuple[Any, ...] | None:
+        cutoff = time.time() - (window_days * 86400)
+        conn = self._get_conn()
+        conn.row_factory = sqlite3.Row
+        try:
+            return conn.execute(query, (cutoff,)).fetchone()
+        finally:
+            self._close_conn(conn)
+
+
+__all__ = ["LaneTelemetryCollector", "LaneTelemetryRecord"]

--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -1,0 +1,449 @@
+"""Shared terminal-truth qualification for swarm autonomous lanes.
+
+Normalizes concrete deliverable detection, truthful terminal outcomes, and
+receipt expectations so boss, campaign, and reporter surfaces agree on what a
+terminal lane actually produced.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+_IN_FLIGHT_STATUSES: frozenset[str] = frozenset(
+    {
+        "",
+        "active",
+        "planned",
+        "queued",
+        "leased",
+        "dispatched",
+        "integrating",
+        "running",
+        "waiting_conflict",
+        "waiting_resource",
+        "pending",
+        "ready",
+        "delivered",
+        "waiting_for_pr",
+        "waiting_for_merge",
+        "needs_revision",
+    }
+)
+
+_WORKER_OUTCOME_TO_TERMINAL: dict[str, str] = {
+    "completed": "deliverable_created",
+    "clean_exit_no_effect": "clean_exit_no_deliverable",
+    "crash": "crash",
+    "crash_with_salvage": "crash",
+    "timeout_no_progress": "timeout",
+    "timeout_with_salvage": "timeout",
+    "scope_violation": "blocked",
+    "merge_gate_failed": "needs_human",
+}
+
+_SUCCESS_OUTCOMES: frozenset[str] = frozenset({"deliverable_created", "pr_adopted"})
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _text_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    return [_text(item) for item in value if _text(item)]
+
+
+def _ordered_unique(items: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for item in items:
+        text = _text(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+@dataclass(slots=True)
+class TerminalQualification:
+    """Normalized terminal truth for a run or lane."""
+
+    terminal_outcome: str
+    deliverable: dict[str, Any] | None
+    worker_outcome: str | None = None
+    blocked_reason: str | None = None
+    reasons: list[str] = field(default_factory=list)
+    receipt_expected: bool = False
+    human_intervention_required: bool = False
+
+    @property
+    def deliverable_type(self) -> str | None:
+        if not isinstance(self.deliverable, dict):
+            return None
+        deliverable_type = _text(self.deliverable.get("type"))
+        return deliverable_type or None
+
+    @property
+    def receipt_outcome(self) -> str:
+        if self.terminal_outcome in _SUCCESS_OUTCOMES:
+            return "pass"
+        if self.deliverable and self.terminal_outcome in {"crash", "timeout"}:
+            return "blocked"
+        if self.terminal_outcome in {
+            "blocked",
+            "needs_human",
+            "clean_exit_no_deliverable",
+        }:
+            return "blocked"
+        if self.terminal_outcome in {"crash", "timeout"}:
+            return "fail"
+        return "unknown"
+
+
+def extract_work_order_deliverable(
+    work_order: dict[str, Any],
+    *,
+    require_terminal_status: bool = True,
+) -> dict[str, Any] | None:
+    """Extract a concrete deliverable from a work-order-like mapping."""
+    if not isinstance(work_order, dict):
+        return None
+
+    status = _text(work_order.get("status")).lower()
+    if require_terminal_status and status in _IN_FLIGHT_STATUSES:
+        return None
+
+    work_order_id = work_order.get("work_order_id")
+
+    pr_url = _text(work_order.get("pr_url"))
+    if pr_url:
+        return {"type": "pr", "pr_url": pr_url, "work_order_id": work_order_id}
+
+    adopted_pr = _text(work_order.get("adopted_pr"))
+    if adopted_pr:
+        return {
+            "type": "adopted_pr",
+            "adopted_pr": adopted_pr,
+            "work_order_id": work_order_id,
+        }
+
+    branch = _text(work_order.get("branch"))
+    commit_shas = _text_list(work_order.get("commit_shas"))
+    if branch and commit_shas:
+        return {
+            "type": "branch",
+            "branch": branch,
+            "commit_shas": commit_shas,
+            "work_order_id": work_order_id,
+        }
+    return None
+
+
+def extract_run_deliverable(run_dict: dict[str, Any]) -> dict[str, Any] | None:
+    """Extract the first concrete deliverable from a terminal run."""
+    for work_order in run_dict.get("work_orders", []):
+        deliverable = extract_work_order_deliverable(work_order)
+        if deliverable is not None:
+            return deliverable
+    return None
+
+
+def extract_run_worker_outcome(run_dict: dict[str, Any]) -> str | None:
+    """Return the first structured worker outcome on the run, if any."""
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        outcome = _text(work_order.get("worker_outcome"))
+        if outcome:
+            return outcome
+    return None
+
+
+def collect_work_order_blockers(work_order: dict[str, Any]) -> list[str]:
+    """Collect blocker/failure strings from a work-order-like mapping."""
+    if not isinstance(work_order, dict):
+        return []
+
+    blockers: list[str] = []
+    blockers.extend(_text_list(work_order.get("blockers")))
+    blockers.extend(
+        _text_list(
+            [
+                work_order.get("dispatch_error"),
+                work_order.get("failure_reason"),
+                work_order.get("blocking_question"),
+            ]
+        )
+    )
+    blocker = work_order.get("blocker")
+    if isinstance(blocker, dict):
+        blockers.extend(_text_list([blocker.get("reason"), blocker.get("question")]))
+    return _ordered_unique(blockers)
+
+
+def collect_run_blockers(run_dict: dict[str, Any]) -> list[str]:
+    """Collect truthful blocker/failure strings from run metadata and work orders."""
+    blockers: list[str] = []
+    metadata = run_dict.get("metadata")
+    if isinstance(metadata, dict):
+        blockers.extend(_text_list(metadata.get("campaign_blockers")))
+
+    for work_order in run_dict.get("work_orders", []):
+        if not isinstance(work_order, dict):
+            continue
+        blockers.extend(collect_work_order_blockers(work_order))
+    return _ordered_unique(blockers)
+
+
+def qualify_work_order_terminal_state(work_order: dict[str, Any]) -> TerminalQualification:
+    """Normalize truthful terminal state for one work-order-like mapping."""
+    status = _text(work_order.get("status")).lower()
+    deliverable = extract_work_order_deliverable(work_order, require_terminal_status=False)
+    worker_outcome = _text(work_order.get("worker_outcome")) or None
+    blockers = collect_work_order_blockers(work_order)
+    mapped_outcome = _WORKER_OUTCOME_TO_TERMINAL.get(_text(worker_outcome).lower())
+
+    if status in {"completed", "merged"}:
+        if mapped_outcome and mapped_outcome not in _SUCCESS_OUTCOMES:
+            terminal_outcome = mapped_outcome
+        elif deliverable:
+            terminal_outcome = (
+                "pr_adopted"
+                if _text(deliverable.get("type")) == "adopted_pr"
+                else "deliverable_created"
+            )
+        else:
+            terminal_outcome = mapped_outcome or "clean_exit_no_deliverable"
+    elif status in {"needs_human", "changes_requested"}:
+        terminal_outcome = mapped_outcome or "needs_human"
+    elif status in {"blocked", "scope_violation"}:
+        terminal_outcome = mapped_outcome or "blocked"
+    elif status in {"timed_out", "timeout"}:
+        terminal_outcome = mapped_outcome or "timeout"
+    elif status in {"failed", "dispatch_failed"}:
+        terminal_outcome = mapped_outcome or _keyword_terminal_outcome(work_order)
+    elif status in _IN_FLIGHT_STATUSES:
+        terminal_outcome = "unknown"
+    else:
+        terminal_outcome = mapped_outcome or _keyword_terminal_outcome(work_order)
+
+    blocked_reason = (
+        blockers[0]
+        if blockers
+        else _default_blocked_reason(
+            terminal_outcome=terminal_outcome,
+            deliverable=deliverable,
+            worker_outcome=worker_outcome,
+        )
+    )
+
+    human_intervention_required = terminal_outcome not in _SUCCESS_OUTCOMES
+    receipt_expected = (
+        terminal_outcome != "unknown" or deliverable is not None or bool(blocked_reason)
+    )
+
+    return TerminalQualification(
+        terminal_outcome=terminal_outcome,
+        deliverable=deliverable,
+        worker_outcome=worker_outcome,
+        blocked_reason=blocked_reason,
+        reasons=blockers,
+        receipt_expected=receipt_expected,
+        human_intervention_required=human_intervention_required,
+    )
+
+
+def qualify_run_terminal_state(run_dict: dict[str, Any]) -> TerminalQualification:
+    """Normalize the truthful terminal outcome for a supervisor-style run dict."""
+    status = _text(run_dict.get("status")).lower()
+    blockers = collect_run_blockers(run_dict)
+    work_order_qualifications = [
+        qualify_work_order_terminal_state(work_order)
+        for work_order in run_dict.get("work_orders", [])
+        if isinstance(work_order, dict)
+    ]
+
+    deliverable = next(
+        (
+            qualification.deliverable
+            for qualification in work_order_qualifications
+            if qualification.deliverable is not None
+        ),
+        extract_run_deliverable(run_dict),
+    )
+    worker_outcome = next(
+        (
+            qualification.worker_outcome
+            for qualification in work_order_qualifications
+            if qualification.worker_outcome
+        ),
+        extract_run_worker_outcome(run_dict),
+    )
+    qualification_outcomes = {
+        qualification.terminal_outcome
+        for qualification in work_order_qualifications
+        if qualification.terminal_outcome != "unknown"
+    }
+
+    if not qualification_outcomes:
+        mapped_outcome = _WORKER_OUTCOME_TO_TERMINAL.get(_text(worker_outcome).lower())
+        if status in {"completed", "merged"}:
+            if deliverable:
+                terminal_outcome = (
+                    "pr_adopted"
+                    if _text(deliverable.get("type")) == "adopted_pr"
+                    else "deliverable_created"
+                )
+            else:
+                terminal_outcome = mapped_outcome or "clean_exit_no_deliverable"
+        elif status in {"needs_human", "blocked", "changes_requested"}:
+            terminal_outcome = mapped_outcome or "needs_human"
+        elif status in {"timed_out", "timeout"}:
+            terminal_outcome = mapped_outcome or "timeout"
+        elif status in {"failed", "dispatch_failed"}:
+            terminal_outcome = mapped_outcome or _keyword_terminal_outcome(run_dict)
+        elif status in _IN_FLIGHT_STATUSES:
+            terminal_outcome = "unknown"
+        else:
+            terminal_outcome = mapped_outcome or _keyword_terminal_outcome(run_dict)
+    elif "blocked" in qualification_outcomes:
+        terminal_outcome = "blocked"
+    elif "crash" in qualification_outcomes:
+        terminal_outcome = "crash"
+    elif "timeout" in qualification_outcomes:
+        terminal_outcome = "timeout"
+    elif (
+        status in {"needs_human", "blocked", "changes_requested"}
+        or "needs_human" in qualification_outcomes
+    ):
+        terminal_outcome = "needs_human"
+    elif status in {"completed", "merged"}:
+        if deliverable:
+            terminal_outcome = (
+                "pr_adopted"
+                if _text(deliverable.get("type")) == "adopted_pr"
+                else "deliverable_created"
+            )
+        else:
+            terminal_outcome = "clean_exit_no_deliverable"
+    elif "pr_adopted" in qualification_outcomes:
+        terminal_outcome = "pr_adopted"
+    elif "deliverable_created" in qualification_outcomes:
+        terminal_outcome = "deliverable_created"
+    elif "clean_exit_no_deliverable" in qualification_outcomes:
+        terminal_outcome = "clean_exit_no_deliverable"
+    elif status in _IN_FLIGHT_STATUSES:
+        terminal_outcome = "unknown"
+    else:
+        terminal_outcome = _keyword_terminal_outcome(run_dict)
+
+    blocked_reason = (
+        blockers[0]
+        if blockers
+        else _default_blocked_reason(
+            terminal_outcome=terminal_outcome,
+            deliverable=deliverable,
+            worker_outcome=worker_outcome,
+        )
+    )
+
+    human_intervention_required = terminal_outcome not in _SUCCESS_OUTCOMES
+    receipt_expected = (
+        terminal_outcome != "unknown" or deliverable is not None or bool(blocked_reason)
+    )
+
+    return TerminalQualification(
+        terminal_outcome=terminal_outcome,
+        deliverable=deliverable,
+        worker_outcome=worker_outcome,
+        blocked_reason=blocked_reason,
+        reasons=blockers,
+        receipt_expected=receipt_expected,
+        human_intervention_required=human_intervention_required,
+    )
+
+
+def receipt_expected_for_lane(
+    *,
+    status: str,
+    queue_status: str,
+    lane_in_flight: bool,
+    decision_type: str,
+    terminal_outcome: str | None,
+) -> bool:
+    """Return whether a lane should already have an authoritative receipt."""
+    normalized_status = _text(status).lower()
+    normalized_queue_status = _text(queue_status).lower()
+    normalized_decision = _text(decision_type).lower()
+    normalized_outcome = _text(terminal_outcome).lower()
+
+    if (
+        lane_in_flight
+        and not normalized_decision
+        and normalized_queue_status in {"", "queued"}
+        and not normalized_outcome
+    ):
+        return False
+    if normalized_queue_status in {"validating", "integrating", "needs_human", "merged", "failed"}:
+        return True
+    if normalized_decision:
+        return True
+    if normalized_outcome and normalized_outcome != "unknown":
+        return True
+    return normalized_status in {
+        "completed",
+        "merged",
+        "failed",
+        "timed_out",
+        "needs_human",
+        "blocked",
+        "changes_requested",
+        "salvage",
+        "stalled",
+    }
+
+
+def _default_blocked_reason(
+    *,
+    terminal_outcome: str,
+    deliverable: dict[str, Any] | None,
+    worker_outcome: str | None,
+) -> str | None:
+    deliverable_present = deliverable is not None
+    normalized_worker_outcome = _text(worker_outcome).lower()
+    if terminal_outcome == "clean_exit_no_deliverable":
+        return "Run ended without a concrete deliverable."
+    if terminal_outcome == "needs_human" and deliverable_present:
+        return "Run produced a deliverable but still requires human judgment before integration."
+    if terminal_outcome == "crash" and deliverable_present:
+        return "Worker exited non-zero after producing a recoverable deliverable; human review is required."
+    if terminal_outcome == "timeout" and deliverable_present:
+        return (
+            "Worker timed out after producing a recoverable deliverable; human review is required."
+        )
+    if terminal_outcome == "blocked":
+        if normalized_worker_outcome == "scope_violation":
+            return "Worker touched files outside the allowed lane scope."
+        return "Run blocked before safe integration."
+    if terminal_outcome == "needs_human":
+        return "Run requires human judgment before continuing."
+    if terminal_outcome == "crash":
+        return "Worker crashed before producing an acceptable terminal result."
+    if terminal_outcome == "timeout":
+        return "Worker timed out before producing an acceptable terminal result."
+    return None
+
+
+def _keyword_terminal_outcome(run_dict: dict[str, Any]) -> str:
+    details = json.dumps(run_dict, sort_keys=True).lower()
+    if "timeout" in details:
+        return "timeout"
+    if "exit_code" in details or "traceback" in details or "crash" in details:
+        return "crash"
+    if "needs_human" in details or "blocked" in details:
+        return "needs_human"
+    return "blocked"

--- a/tests/swarm/test_lane_telemetry.py
+++ b/tests/swarm/test_lane_telemetry.py
@@ -1,0 +1,334 @@
+"""Regression coverage for swarm lane telemetry."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+from aragora.nomic.dev_coordination import DevCoordinationStore
+from aragora.swarm.boss_loop import BossLoop, BossLoopConfig
+from aragora.swarm.campaign import (
+    CampaignExecutor,
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    CampaignReviewGate,
+    CampaignReviewStatus,
+    save_campaign_manifest,
+)
+from aragora.swarm.lane_telemetry import LaneTelemetryCollector, LaneTelemetryRecord
+from aragora.swarm.supervisor import SwarmSupervisor
+
+UTC = timezone.utc
+
+
+class TestLaneTelemetryCollector:
+    def test_queries_cover_success_false_success_and_merge_metrics(self) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        now = datetime.now(UTC).timestamp()
+
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="boss_dispatch",
+                lane_id="boss-1",
+                terminal_outcome="deliverable_created",
+                deliverable_type="branch",
+                receipt_id="lane-1",
+                duration_seconds=12.0,
+                time_to_pr_seconds=30.0,
+                false_success_candidate=False,
+                timestamp=now,
+            )
+        )
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="campaign_project",
+                lane_id="proj-1",
+                terminal_outcome="pr_adopted",
+                deliverable_type="adopted_pr",
+                receipt_id="receipt-1",
+                human_intervention_required=False,
+                merge_ref="main@abc123",
+                merged_at="2026-03-29T12:00:00+00:00",
+                time_to_merge_seconds=120.0,
+                false_success_candidate=False,
+                timestamp=now,
+            )
+        )
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="supervisor_work_order",
+                lane_id="wo-1",
+                terminal_outcome="deliverable_created",
+                deliverable_type="",
+                human_intervention_required=False,
+                false_success_candidate=True,
+                timestamp=now,
+            )
+        )
+
+        assert collector.get_throughput(window_days=7) == 3
+        assert collector.get_success_rate(window_days=7) == 2 / 3
+        assert collector.get_false_success_candidate_count(window_days=7) == 1
+        assert collector.get_human_intervention_rate(window_days=7) == 0.0
+        assert collector.get_merge_yield(window_days=7) == 0.5
+        assert collector.get_avg_time_to_pr(window_days=7) == 30.0
+        assert collector.get_avg_time_to_merge(window_days=7) == 120.0
+
+    def test_rates_ignore_unclassified_terminal_rows(self) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        now = datetime.now(UTC).timestamp()
+
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="boss_dispatch",
+                lane_id="boss-1",
+                terminal_outcome="deliverable_created",
+                deliverable_type="branch",
+                false_success_candidate=False,
+                timestamp=now,
+            )
+        )
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="boss_dispatch",
+                lane_id="boss-2",
+                terminal_outcome="needs_human",
+                human_intervention_required=True,
+                timestamp=now,
+            )
+        )
+        collector.record_lane(
+            LaneTelemetryRecord(
+                lane_kind="boss_dispatch",
+                lane_id="boss-3",
+                terminal_outcome="",
+                human_intervention_required=False,
+                timestamp=now,
+            )
+        )
+
+        assert collector.get_throughput(window_days=7) == 3
+        assert collector.get_success_rate(window_days=7) == 0.5
+        assert collector.get_human_intervention_rate(window_days=7) == 0.5
+
+
+class TestBossDispatchTelemetry:
+    def test_emit_lane_receipt_records_boss_dispatch_terminal_event(self) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        loop = BossLoop(config=BossLoopConfig(max_iterations=1, iteration_interval_seconds=0.0))
+        worker_result = {
+            "run_id": "run-123",
+            "lease_id": "lease-123",
+            "agent_id": "boss-loop",
+            "outcome": "needs_human",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/recovered",
+                "commit_shas": ["abc123"],
+            },
+            "reasons": ["Recovered deliverable requires review."],
+        }
+
+        with (
+            patch("aragora.swarm.boss_loop._LANE_TELEMETRY", collector),
+            patch("aragora.receipts.lane.emit_lane_receipt", return_value="lane-receipt-1"),
+        ):
+            receipt_id = loop._emit_lane_receipt(
+                worker_result, {"number": 42, "title": "Fix lane"}, 3.5
+            )
+
+        assert receipt_id == "lane-receipt-1"
+        records = collector.get_recent_lanes()
+        assert len(records) == 1
+        assert records[0].lane_kind == "boss_dispatch"
+        assert records[0].lane_id == "run-123"
+        assert records[0].terminal_outcome == "needs_human"
+        assert records[0].deliverable_type == "branch"
+        assert records[0].receipt_id == "lane-receipt-1"
+        assert records[0].human_intervention_required is True
+
+    def test_missing_outcome_falls_back_to_deliverable_created(self) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        loop = BossLoop(config=BossLoopConfig(max_iterations=1, iteration_interval_seconds=0.0))
+        worker_result = {
+            "run_id": "run-124",
+            "status": "completed",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/recovered",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with patch("aragora.swarm.boss_loop._LANE_TELEMETRY", collector):
+            loop._record_lane_telemetry(
+                worker_result, {"number": 43, "title": "Fix lane"}, 2.0, None
+            )
+
+        records = collector.get_recent_lanes()
+        assert len(records) == 1
+        assert records[0].terminal_outcome == "deliverable_created"
+        assert records[0].deliverable_type == "branch"
+
+
+class TestSupervisorTelemetry:
+    def test_terminal_work_order_records_supervisor_event(self, tmp_path: Path) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-b", "main"], cwd=repo, check=True, capture_output=True)
+        supervisor = SwarmSupervisor(repo_root=repo, store=DevCoordinationStore(repo_root=repo))
+        item = {
+            "task_key": "run-1:wo-1",
+            "work_order_id": "wo-1",
+            "status": "needs_human",
+            "worker_outcome": "crash_with_salvage",
+            "branch": "codex/recovered",
+            "commit_shas": ["abc123"],
+            "failure_reason": "worker_crash_with_salvage",
+            "blocking_question": "Should the recovered deliverable be adopted?",
+            "dispatched_at": "2026-03-29T12:00:00+00:00",
+            "completed_at": "2026-03-29T12:01:00+00:00",
+        }
+
+        with patch("aragora.swarm.supervisor._LANE_TELEMETRY", collector):
+            supervisor._record_terminal_work_order_telemetry("run-1", [item])
+
+        records = collector.get_recent_lanes()
+        assert len(records) == 1
+        assert records[0].lane_kind == "supervisor_work_order"
+        assert records[0].lane_id == "run-1:wo-1"
+        assert records[0].terminal_outcome == "crash"
+        assert records[0].worker_outcome == "crash_with_salvage"
+        assert records[0].deliverable_type == "branch"
+        assert records[0].human_intervention_required is True
+        assert records[0].duration_seconds == 60.0
+
+
+class TestCampaignTelemetry:
+    def test_emit_receipt_records_campaign_project_terminal_event(self, tmp_path: Path) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        manifest_path = repo / ".aragora" / "campaign_manifest.yaml"
+        manifest_path.parent.mkdir(parents=True)
+
+        project = CampaignProject(
+            project_id="proj-1",
+            title="ADR lane",
+            status=CampaignProjectStatus.COMPLETED.value,
+            last_run_outcome="deliverable_created",
+            run_id="run-1",
+            branch="codex/adr",
+            commit_shas=["abc123"],
+            worker_receipt_id="worker-receipt-1",
+            review=CampaignReviewGate(
+                required=True,
+                review_model="claude",
+                status=CampaignReviewStatus.PASSED.value,
+                findings=[],
+            ),
+        )
+        manifest = CampaignManifest(
+            campaign_id="campaign-1",
+            created_at="2026-03-29T12:00:00+00:00",
+            source_kind="manual",
+            source_ref="spec",
+            projects=[project],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+
+        executor = CampaignExecutor(
+            manifest_path=manifest_path,
+            repo_root=repo,
+        )
+        run_dict = {
+            "run_id": "run-1",
+            "status": "completed",
+            "work_orders": [
+                {
+                    "work_order_id": "wo-1",
+                    "status": "completed",
+                    "branch": "codex/adr",
+                    "commit_shas": ["abc123"],
+                    "worker_outcome": "completed",
+                    "receipt_id": "worker-receipt-1",
+                }
+            ],
+        }
+
+        with patch("aragora.swarm.campaign._LANE_TELEMETRY", collector):
+            receipt_path = executor._emit_receipt(manifest, project, run_dict)
+
+        assert receipt_path.exists()
+        records = collector.get_recent_lanes()
+        assert len(records) == 1
+        assert records[0].lane_kind == "campaign_project"
+        assert records[0].lane_id == "campaign-1:proj-1"
+        assert records[0].run_id == "run-1"
+        assert records[0].terminal_outcome == "deliverable_created"
+        assert records[0].deliverable_type == "branch"
+        assert records[0].receipt_id == project.receipt_id
+        assert records[0].human_intervention_required is False
+
+    def test_emit_receipt_falls_back_to_qualified_outcome_when_project_outcome_missing(
+        self, tmp_path: Path
+    ) -> None:
+        collector = LaneTelemetryCollector(db_path=":memory:")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        manifest_path = repo / ".aragora" / "campaign_manifest.yaml"
+        manifest_path.parent.mkdir(parents=True)
+
+        project = CampaignProject(
+            project_id="proj-2",
+            title="ADR lane",
+            status=CampaignProjectStatus.COMPLETED.value,
+            last_run_outcome=None,
+            run_id="run-2",
+            branch="codex/adr",
+            commit_shas=["abc123"],
+            review=CampaignReviewGate(
+                required=True,
+                review_model="claude",
+                status=CampaignReviewStatus.PENDING.value,
+                findings=[],
+            ),
+        )
+        manifest = CampaignManifest(
+            campaign_id="campaign-2",
+            created_at="2026-03-29T12:00:00+00:00",
+            source_kind="manual",
+            source_ref="spec",
+            projects=[project],
+        )
+        save_campaign_manifest(manifest_path, manifest)
+
+        executor = CampaignExecutor(
+            manifest_path=manifest_path,
+            repo_root=repo,
+        )
+        run_dict = {
+            "run_id": "run-2",
+            "status": "completed",
+            "work_orders": [
+                {
+                    "work_order_id": "wo-2",
+                    "status": "completed",
+                    "branch": "codex/adr",
+                    "commit_shas": ["abc123"],
+                    "worker_outcome": "completed",
+                }
+            ],
+        }
+
+        with patch("aragora.swarm.campaign._LANE_TELEMETRY", collector):
+            executor._emit_receipt(manifest, project, run_dict)
+
+        records = collector.get_recent_lanes()
+        assert len(records) == 1
+        assert records[0].terminal_outcome == "deliverable_created"
+        assert records[0].deliverable_type == "branch"


### PR DESCRIPTION
## Summary
- add the missing swarm lane telemetry and terminal-truth modules referenced by the current supervisor/reporter/boss code
- add focused regression coverage for collector queries plus boss, supervisor, and campaign telemetry recording
- restore swarm-related test collection on current main where supervisor imports currently fail without these modules

## Repro
On current , .....                                                                    [100%]
5 passed in 0.65s fails during collection with .

## Validation
- python3 -m pytest tests/cli/commands/test_review_pr.py -q
- python3 -m pytest tests/swarm/test_lane_telemetry.py -q
- python3 -m pytest tests/swarm/test_reporter.py -q -k lane_telemetry
- python3 -m pytest tests/nomic/test_dev_coordination.py -q -k lane_telemetry
- python3 -m ruff check aragora/swarm/lane_telemetry.py aragora/swarm/terminal_truth.py tests/swarm/test_lane_telemetry.py