### PR TITLE
Verify elapsed_seconds in outcome signal serialization

### DIFF
--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -74,7 +74,9 @@ class OutcomeSignal:
             self.timestamp = datetime.now(UTC).isoformat()
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        data["elapsed_seconds"] = self.elapsed_seconds
+        return data
 
     @property
     def is_success(self) -> bool:

--- a/tests/swarm/test_outcome_signals.py
+++ b/tests/swarm/test_outcome_signals.py
@@ -52,6 +52,12 @@ class TestOutcomeSignal:
         # Should be JSON-serializable
         json.dumps(d)
 
+    def test_to_dict_includes_elapsed_seconds(self):
+        s = _make_signal(elapsed_seconds=12.5)
+        d = s.to_dict()
+        assert "elapsed_seconds" in d
+        assert d["elapsed_seconds"] == 12.5
+
 
 class TestOutcomeSignalBus:
     def test_emit_persists_to_jsonl(self):


### PR DESCRIPTION
Automated worker output for #1662. Adds explicit elapsed_seconds to OutcomeSignal.to_dict() and test coverage.