### PR TITLE
test(swarm): align integrator needs-human counts

### DIFF
--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1749,7 +1749,7 @@ class TestSwarmCommand:
 
         out = capsys.readouterr().out
         assert "runs=1 queued=0 leased=0 completed=1" in out
-        assert "integrator ready=0 review=1 blocked=0" in out
+        assert "integrator ready=0 review=0 blocked=1" in out
         assert (
             "next: Write operator guide: Review the validated lane and decide whether it should merge."
             in out


### PR DESCRIPTION
## Summary
- align the swarm status expectation with the current integrator readiness classification
- keep needs_human merge-queue items counted as blocked lanes

## Testing
- python3 -m pytest tests/cli/test_swarm_command.py::TestSwarmCommand::test_cmd_swarm_status_uses_supervisor -q
- python3 -m pytest tests/observability/test_config.py::TestConfigHelpers::test_is_metrics_enabled_true_by_default -q
- python3 -m ruff check tests/cli/test_swarm_command.py