### PR TITLE
fix(ci): use shared installer in migration tests

### DIFF
--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -63,8 +63,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run migration runner tests
         run: |

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -264,6 +264,23 @@ class TestDocsBuildWorkflow:
         assert "scripts/ci_install_project.sh --extras dev" in command
 
 
+class TestMigrationTestsWorkflow:
+    """Validate migration-tests workflow bootstrap policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "migration-tests.yml"
+
+    def test_migration_tests_uses_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["migration-tests"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+
 class TestFrontendE2EWorkflow:
     """Validate frontend E2E workflow backend bootstrap policy."""
 


### PR DESCRIPTION
## Summary
- switch migration-tests to the shared CI installer with dev and test extras
- lock that bootstrap policy with a release-gates regression test

## Testing
- python3 -m pytest tests/ci/test_release_gates.py -q
- python3 -m ruff check tests/ci/test_release_gates.py
- python3 scripts/check_workflow_pip_install_policy.py