### PR TITLE
test(inbox): align shared inbox handler contract

### DIFF
--- a/tests/handlers/test_shared_inbox_handler.py
+++ b/tests/handlers/test_shared_inbox_handler.py
@@ -258,10 +258,12 @@ class TestSharedInboxHandlerCanHandle:
         assert not handler.can_handle("/api/v1/inbox/other")
         assert not handler.can_handle("/unknown")
 
-    def test_handle_returns_none(self, handler):
-        """The base handle() stub returns None (not yet dispatched)."""
+    def test_handle_requires_workspace_id(self, handler):
+        """Listing shared inboxes fails closed when workspace_id is missing."""
         result = handler.handle("/api/v1/inbox/shared", {}, MagicMock())
-        assert result is None
+        assert result is not None
+        assert result.status_code == 400
+        assert result.body == b'{"error": "workspace_id required"}'
 
 
 class TestSharedInboxHandlerInit:


### PR DESCRIPTION
## Summary
- update the shared inbox handler test to match the current request contract
- assert missing workspace_id returns a 400 handler result instead of None

## Why
Current main already requires workspace_id for GET /api/v1/inbox/shared. The old integration smoke failure on #1637 was carrying this stale expectation, not a matrix-debate regression.

## Testing
- python3 -m pytest tests/handlers/test_shared_inbox_handler.py::TestSharedInboxHandlerCanHandle::test_handle_requires_workspace_id -q
- python3 -m pytest tests/handlers/test_shared_inbox_handler.py -q
- python3 -m ruff check tests/handlers/test_shared_inbox_handler.py