### PR TITLE
fix(goals): materialize action canvas on advance

### DIFF
--- a/aragora/server/handlers/goal_canvas.py
+++ b/aragora/server/handlers/goal_canvas.py
@@ -209,6 +209,11 @@ class GoalCanvasHandler(SecureHandler):
 
         return get_goal_canvas_store()
 
+    def _get_action_store(self):
+        from aragora.canvas.action_store import get_action_canvas_store
+
+        return get_action_canvas_store()
+
     def _get_canvas_manager(self):
         from aragora.canvas import get_canvas_manager
 
@@ -224,6 +229,142 @@ class GoalCanvasHandler(SecureHandler):
                 return future.result(timeout=30)
         except RuntimeError:
             return asyncio.run(coro)
+
+    def _goal_canvas_to_goal_graph(self, canvas):
+        from aragora.canvas import EdgeType
+        from aragora.canvas.stages import GoalNodeType
+        from aragora.goals.extractor import GoalGraph, GoalNode
+
+        goal_ids = set(canvas.nodes)
+        dependencies_by_target: dict[str, list[str]] = {}
+
+        for edge in canvas.edges.values():
+            if edge.source_id not in goal_ids or edge.target_id not in goal_ids:
+                continue
+
+            edge_type = getattr(edge.edge_type, "value", edge.edge_type)
+            stage_edge_type = str(edge.data.get("stage_edge_type", "")).lower()
+            edge_label = str(edge.label or "").lower()
+            if (
+                edge_type != EdgeType.DEPENDENCY.value
+                and stage_edge_type != "requires"
+                and edge_label not in {"requires", "after"}
+            ):
+                continue
+
+            deps = dependencies_by_target.setdefault(edge.target_id, [])
+            if edge.source_id not in deps:
+                deps.append(edge.source_id)
+
+        goals = []
+        for node in canvas.nodes.values():
+            if node.node_type.value != "decision" and node.data.get("stage") != "goals":
+                continue
+
+            goal_type_str = str(node.data.get("goal_type", "goal")).lower()
+            try:
+                goal_type = GoalNodeType(goal_type_str)
+            except ValueError:
+                goal_type = GoalNodeType.GOAL
+
+            source_node_id = node.data.get("source_node_id")
+            confidence = node.data.get("confidence", 0.0)
+            try:
+                confidence_value = float(confidence)
+            except (TypeError, ValueError):
+                confidence_value = 0.0
+
+            goals.append(
+                GoalNode(
+                    id=node.id,
+                    title=node.label or "Untitled Goal",
+                    description=node.data.get("description", ""),
+                    goal_type=goal_type,
+                    priority=str(node.data.get("priority", "medium")).lower(),
+                    measurable=str(node.data.get("measurable", "")),
+                    dependencies=dependencies_by_target.get(node.id, []),
+                    source_idea_ids=[source_node_id] if source_node_id else [],
+                    confidence=confidence_value,
+                    metadata={
+                        key: value
+                        for key, value in node.data.items()
+                        if key
+                        not in {
+                            "stage",
+                            "goal_type",
+                            "description",
+                            "priority",
+                            "measurable",
+                            "source_node_id",
+                            "content_hash",
+                            "rf_type",
+                            "confidence",
+                        }
+                    },
+                )
+            )
+
+        return GoalGraph(
+            id=canvas.id,
+            goals=goals,
+            metadata={"source_canvas_id": canvas.id, "source_stage": "goals"},
+        )
+
+    def _build_actions_canvas(self, canvas, canvas_meta: dict[str, Any], body: dict[str, Any]):
+        from aragora.canvas import workflow_to_actions_canvas
+        from aragora.pipeline.idea_to_execution import IdeaToExecutionPipeline
+
+        goal_graph = self._goal_canvas_to_goal_graph(canvas)
+        if not goal_graph.goals:
+            raise ValueError("Goal canvas has no goal nodes to advance")
+
+        pipeline = IdeaToExecutionPipeline()
+        workflow_data = pipeline._goals_to_workflow(goal_graph)
+
+        target_canvas_id = (
+            body.get("target_canvas_id") or body.get("id") or f"actions-{uuid.uuid4().hex[:8]}"
+        )
+        target_canvas_name = (
+            body.get("name") or f"Action Plan for {canvas_meta.get('name', 'Goals')}"
+        )
+
+        action_canvas = workflow_to_actions_canvas(
+            workflow_data,
+            canvas_id=target_canvas_id,
+            canvas_name=target_canvas_name,
+        )
+        action_canvas.owner_id = canvas.owner_id or canvas_meta.get("owner_id")
+        action_canvas.workspace_id = canvas.workspace_id or canvas_meta.get("workspace_id")
+        action_canvas.metadata.update(
+            {
+                "stage": "actions",
+                "source_canvas_id": canvas.id,
+                "source_stage": "goals",
+                "workflow_step_count": len(workflow_data.get("steps", [])),
+            }
+        )
+        return action_canvas, workflow_data
+
+    def _persist_canvas_state(self, canvas):
+        manager = self._get_canvas_manager()
+
+        async def _persist():
+            live_canvas = await manager.get_or_create_canvas(
+                canvas.id,
+                name=canvas.name,
+                owner_id=canvas.owner_id,
+                workspace_id=canvas.workspace_id,
+                **canvas.metadata,
+            )
+            live_canvas.name = canvas.name
+            live_canvas.owner_id = canvas.owner_id
+            live_canvas.workspace_id = canvas.workspace_id
+            live_canvas.metadata = dict(canvas.metadata)
+            live_canvas.nodes = dict(canvas.nodes)
+            live_canvas.edges = dict(canvas.edges)
+            return live_canvas
+
+        return self._run_async(_persist())
 
     # ------------------------------------------------------------------
     # Canvas CRUD
@@ -547,11 +688,7 @@ class GoalCanvasHandler(SecureHandler):
         body: dict[str, Any],
         user_id: str | None,
     ) -> HandlerResult:
-        """Advance goal canvas to the actions stage (Stage 3).
-
-        Currently returns the goal canvas data as a placeholder.
-        The full actions stage conversion will be implemented separately.
-        """
+        """Advance goal canvas to the actions stage (Stage 3)."""
         try:
             store = self._get_store()
             canvas_meta = store.load_canvas(canvas_id)
@@ -560,25 +697,40 @@ class GoalCanvasHandler(SecureHandler):
 
             manager = self._get_canvas_manager()
             canvas = self._run_async(manager.get_canvas(canvas_id))
+            if not canvas:
+                return error_response("Goal canvas state unavailable", 409)
 
-            nodes = []
-            edges = []
-            if canvas:
-                nodes = [n.to_dict() for n in canvas.nodes.values()]
-                edges = [e.to_dict() for e in canvas.edges.values()]
+            action_canvas, workflow_data = self._build_actions_canvas(canvas, canvas_meta, body)
+            action_store = self._get_action_store()
+            saved_canvas = action_store.save_canvas(
+                canvas_id=action_canvas.id,
+                name=action_canvas.name,
+                owner_id=action_canvas.owner_id or user_id,
+                workspace_id=action_canvas.workspace_id,
+                description=body.get("description", canvas_meta.get("description", "")),
+                source_canvas_id=canvas_id,
+                metadata=action_canvas.metadata,
+            )
+            self._persist_canvas_state(action_canvas)
 
             return json_response(
                 {
+                    "canvas_id": action_canvas.id,
+                    "target_canvas_id": action_canvas.id,
                     "source_canvas_id": canvas_id,
                     "source_stage": "goals",
                     "target_stage": "actions",
-                    "nodes": nodes,
-                    "edges": edges,
-                    "metadata": canvas_meta.get("metadata", {}),
+                    "nodes": [n.to_dict() for n in action_canvas.nodes.values()],
+                    "edges": [e.to_dict() for e in action_canvas.edges.values()],
+                    "metadata": saved_canvas.get("metadata", action_canvas.metadata),
+                    "workflow_step_count": len(workflow_data.get("steps", [])),
                     "status": "ready",
                 },
                 status=201,
             )
+        except ValueError as e:
+            logger.warning("Cannot advance goal canvas %s: %s", canvas_id, e)
+            return error_response(str(e), 422)
         except (ImportError, KeyError, ValueError, TypeError, OSError, RuntimeError) as e:
             logger.error("Failed to advance goal canvas: %s", e)
             return error_response("Advance to actions failed", 500)

--- a/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
+++ b/docs/status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md
@@ -71,7 +71,7 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](ACTIVE_EXE
 - OpenAPI drift remains: `9` handler routes are missing from the spec and `11` OpenAPI routes have no handler according to `scripts/validate_openapi_routes.py`.
 - OpenAPI and SDK parity claims are still inflated by spec-only endpoints defined in `aragora/server/openapi/endpoints/sdk_missing.py`.
 - `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
-- `aragora/server/handlers/goal_canvas.py` still returns placeholder data for advancing a canvas into the actions stage.
+- `aragora/server/handlers/goal_canvas.py` now materializes a persisted Stage 3 action canvas from live goal-canvas state; metadata-only goal canvases still fail closed once the in-memory graph is gone.
 - `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
 - `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, and the SME OAuth helper endpoints delegate into the canonical Slack install/callback flow.
 - `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, and the SME OAuth helper endpoints delegate into the canonical Teams install/callback flow.

--- a/tests/handlers/test_goal_canvas.py
+++ b/tests/handlers/test_goal_canvas.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 
+from aragora.canvas.models import Canvas, CanvasNode, CanvasNodeType, Position
 from aragora.server.handlers.goal_canvas import GoalCanvasHandler
 
 
@@ -1124,41 +1125,73 @@ class TestAdvanceToActions:
         result = handler._advance_to_actions(ctx, "missing", {}, "u1")
         assert _status(result) == 404
 
+    @patch("aragora.canvas.action_store.get_action_canvas_store")
     @patch("aragora.canvas.goal_store.get_goal_canvas_store")
-    def test_advance_success_with_nodes(self, mock_get_store, handler):
+    def test_advance_success_with_nodes(self, mock_get_store, mock_get_action_store, handler):
         mock_store = MagicMock()
         mock_store.load_canvas.return_value = {
             "id": "gc-1",
             "name": "Goals",
             "metadata": {"stage": "goals"},
+            "workspace_id": "ws-1",
         }
         mock_get_store.return_value = mock_store
+        action_store = MagicMock()
+        action_store.save_canvas.side_effect = lambda **kwargs: {
+            "id": kwargs["canvas_id"],
+            "name": kwargs["name"],
+            "metadata": kwargs["metadata"],
+            "source_canvas_id": kwargs["source_canvas_id"],
+        }
+        mock_get_action_store.return_value = action_store
 
-        mock_node = MagicMock()
-        mock_node.to_dict.return_value = {"id": "n1", "label": "Goal 1"}
-        mock_edge = MagicMock()
-        mock_edge.to_dict.return_value = {"id": "e1"}
-
-        canvas_mock = MagicMock()
-        canvas_mock.nodes = {"n1": mock_node}
-        canvas_mock.edges = {"e1": mock_edge}
-
+        canvas = Canvas(
+            id="gc-1",
+            name="Goals",
+            owner_id="u1",
+            workspace_id="ws-1",
+            metadata={"stage": "goals"},
+        )
+        canvas.nodes["goal-1"] = CanvasNode(
+            id="goal-1",
+            node_type=CanvasNodeType.DECISION,
+            position=Position(0, 0),
+            label="Ship receipts",
+            data={
+                "stage": "goals",
+                "goal_type": "goal",
+                "description": "Make receipts trustworthy",
+                "priority": "high",
+                "rf_type": "goalNode",
+            },
+        )
         with patch.object(handler, "_get_canvas_manager") as mock_mgr:
             mock_mgr.return_value = MagicMock()
-            with patch.object(handler, "_run_async", return_value=canvas_mock):
-                ctx = MagicMock()
-                result = handler._advance_to_actions(ctx, "gc-1", {}, "u1")
-                assert _status(result) == 201
-                body = _parse_body(result)
-                assert body["source_canvas_id"] == "gc-1"
-                assert body["source_stage"] == "goals"
-                assert body["target_stage"] == "actions"
-                assert body["status"] == "ready"
-                assert len(body["nodes"]) == 1
-                assert len(body["edges"]) == 1
+            with patch.object(handler, "_run_async", return_value=canvas):
+                with patch.object(handler, "_persist_canvas_state") as mock_persist:
+                    ctx = MagicMock()
+                    result = handler._advance_to_actions(ctx, "gc-1", {}, "u1")
+                    assert _status(result) == 201
+                    body = _parse_body(result)
+                    assert body["source_canvas_id"] == "gc-1"
+                    assert body["source_stage"] == "goals"
+                    assert body["target_stage"] == "actions"
+                    assert body["status"] == "ready"
+                    assert body["canvas_id"].startswith("actions-")
+                    assert body["metadata"]["stage"] == "actions"
+                    assert body["workflow_step_count"] == 4
+                    assert len(body["nodes"]) == 4
+                    assert any(
+                        node["data"]["step_type"] == "verification" for node in body["nodes"]
+                    )
+                    assert all(node["data"]["stage"] == "actions" for node in body["nodes"])
+                    saved_kwargs = action_store.save_canvas.call_args.kwargs
+                    assert saved_kwargs["source_canvas_id"] == "gc-1"
+                    assert saved_kwargs["workspace_id"] == "ws-1"
+                    mock_persist.assert_called_once()
 
     @patch("aragora.canvas.goal_store.get_goal_canvas_store")
-    def test_advance_success_no_live_canvas(self, mock_get_store, handler):
+    def test_advance_requires_live_canvas(self, mock_get_store, handler):
         mock_store = MagicMock()
         mock_store.load_canvas.return_value = {
             "id": "gc-1",
@@ -1172,11 +1205,9 @@ class TestAdvanceToActions:
             with patch.object(handler, "_run_async", return_value=None):
                 ctx = MagicMock()
                 result = handler._advance_to_actions(ctx, "gc-1", {}, "u1")
-                assert _status(result) == 201
+                assert _status(result) == 409
                 body = _parse_body(result)
-                assert body["nodes"] == []
-                assert body["edges"] == []
-                assert body["metadata"] == {"stage": "goals"}
+                assert "state unavailable" in body["error"].lower()
 
     @patch("aragora.canvas.goal_store.get_goal_canvas_store")
     def test_advance_error(self, mock_get_store, handler):

--- a/tests/pipeline/test_pipeline_e2e.py
+++ b/tests/pipeline/test_pipeline_e2e.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import pytest
 
+from aragora.canvas.models import Canvas, CanvasNode, CanvasNodeType, Position
 from aragora.server.handlers.idea_canvas import IdeaCanvasHandler
 from aragora.server.handlers.goal_canvas import GoalCanvasHandler
 from aragora.server.handlers.action_canvas import ActionCanvasHandler
@@ -142,8 +143,9 @@ class TestStageTypes:
 class TestGoalsToActions:
     """Stage 2 → Stage 3 transition via GoalCanvasHandler.advance."""
 
+    @patch("aragora.canvas.action_store.get_action_canvas_store")
     @patch("aragora.canvas.goal_store.get_goal_canvas_store")
-    def test_advance_returns_action_stage_metadata(self, mock_get_store):
+    def test_advance_returns_action_stage_metadata(self, mock_get_store, mock_get_action_store):
         handler = GoalCanvasHandler(ctx={})
 
         mock_store = MagicMock()
@@ -151,24 +153,53 @@ class TestGoalsToActions:
             "id": "goals-1",
             "name": "Q1 Goals",
             "metadata": {"stage": "goals"},
+            "workspace_id": "ws-1",
         }
         mock_get_store.return_value = mock_store
+        action_store = MagicMock()
+        action_store.save_canvas.side_effect = lambda **kwargs: {
+            "id": kwargs["canvas_id"],
+            "metadata": kwargs["metadata"],
+        }
+        mock_get_action_store.return_value = action_store
 
         with patch.object(handler, "_get_canvas_manager"):
             with patch.object(handler, "_run_async") as mock_run:
-                canvas_mock = MagicMock()
-                canvas_mock.nodes = {}
-                canvas_mock.edges = {}
-                mock_run.return_value = canvas_mock
+                canvas = Canvas(
+                    id="goals-1",
+                    name="Q1 Goals",
+                    owner_id="u1",
+                    workspace_id="ws-1",
+                    metadata={"stage": "goals"},
+                )
+                canvas.nodes["goal-1"] = CanvasNode(
+                    id="goal-1",
+                    node_type=CanvasNodeType.DECISION,
+                    position=Position(0, 0),
+                    label="Ship receipts",
+                    data={
+                        "stage": "goals",
+                        "goal_type": "goal",
+                        "description": "Make receipts easy to trust",
+                        "priority": "high",
+                        "rf_type": "goalNode",
+                    },
+                )
+                mock_run.return_value = canvas
 
                 ctx = MagicMock()
-                result = handler._advance_to_actions(ctx, "goals-1", {}, "u1")
-                assert result is not None
+                with patch.object(handler, "_persist_canvas_state"):
+                    result = handler._advance_to_actions(ctx, "goals-1", {}, "u1")
+                    assert result is not None
 
-                body = _parse_result(result)
-                assert body.get("source_stage") == "goals"
-                assert body.get("target_stage") == "actions"
-                assert body.get("source_canvas_id") == "goals-1"
+                    body = _parse_result(result)
+                    assert body.get("source_stage") == "goals"
+                    assert body.get("target_stage") == "actions"
+                    assert body.get("source_canvas_id") == "goals-1"
+                    assert body.get("canvas_id", "").startswith("actions-")
+                    assert body.get("metadata", {}).get("stage") == "actions"
+                    assert body.get("workflow_step_count") == 4
+                    assert all(node["data"]["stage"] == "actions" for node in body["nodes"])
 
 
 class TestActionsToOrchestration:


### PR DESCRIPTION
## Summary
- turn `POST /api/v1/goals/{canvas_id}/advance` into a real Stage 3 transition that builds and persists an action canvas
- reuse the existing goal-to-workflow decomposition so goal nodes become action-step nodes with action-stage metadata
- fail closed when the source goal canvas has no live graph state, and lock the new behavior in focused handler/pipeline tests
- update the documentation gap register entry to match the new runtime behavior

## Repro
Before this change, advancing a goal canvas returned the original goal-stage nodes and edges back to the caller and never created an action canvas.

Focused repro:
```bash
ARAGORA_USE_SECRETS_MANAGER=false python3 - <<'PY'
from unittest.mock import MagicMock, patch
import json
from aragora.server.handlers.goal_canvas import GoalCanvasHandler
from aragora.canvas.models import Canvas, CanvasNode, CanvasNodeType, Position

handler = GoalCanvasHandler(ctx={})
mock_store = MagicMock()
mock_store.load_canvas.return_value = {
    'id': 'goals-1',
    'name': 'Q1 Goals',
    'owner_id': 'u1',
    'workspace_id': 'ws1',
    'metadata': {'stage': 'goals'},
    'description': 'demo',
}
canvas = Canvas(id='goals-1', name='Q1 Goals', owner_id='u1', workspace_id='ws1', metadata={'stage': 'goals'})
canvas.nodes['goal-1'] = CanvasNode(
    id='goal-1',
    node_type=CanvasNodeType.DECISION,
    position=Position(0, 0),
    label='Ship receipts',
    data={'stage': 'goals', 'goal_type': 'goal', 'description': 'Make receipts trustworthy', 'priority': 'high', 'rf_type': 'goalNode'},
)
with patch.object(handler, '_get_store', return_value=mock_store), patch.object(handler, '_get_canvas_manager'):
    with patch.object(handler, '_run_async', return_value=canvas):
        body = json.loads(handler._advance_to_actions(MagicMock(), 'goals-1', {}, 'u1').body.decode())
        print(body)
PY
```

Before the fix, the payload came back with goal-stage nodes (`"stage": "goals"`) and no target action-canvas ID.

## Validation
- `ARAGORA_USE_SECRETS_MANAGER=false pytest -q tests/handlers/test_goal_canvas.py tests/pipeline/test_pipeline_e2e.py::TestGoalsToActions::test_advance_returns_action_stage_metadata -q`
- `python3 -m ruff check aragora/server/handlers/goal_canvas.py tests/handlers/test_goal_canvas.py tests/pipeline/test_pipeline_e2e.py`
- direct repro after the fix now returns a real action-canvas payload with Stage 3 nodes, a new `canvas_id`, and `workflow_step_count=4`

## Cleanup
- committed on branch `codex/codex-20260330-021000-goal-canvas-actions`
- attempted `aragora review` as an extra pass, but the local sandbox blocked its Hugging Face embedding download path; no product code changes were needed for that tooling failure

## Next Recommended Task
Make `POST /api/v1/actions/{canvas_id}/advance` mirror this behavior so the actions→orchestration transition also materializes its target canvas instead of returning placeholder metadata.
