### PR TITLE
fix(ci): restore main workflow bootstrap and sentinel env

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyyaml
+          bash scripts/ci_install_project.sh
 
       - name: Validate production compose + env example
         run: |
@@ -84,6 +84,7 @@ jobs:
           ARAGORA_REDIS_MODE=sentinel
           ARAGORA_REDIS_SENTINEL_HOSTS=sentinel-1:26379,sentinel-2:26379,sentinel-3:26379
           ARAGORA_REDIS_SENTINEL_MASTER=mymaster
+          REDIS_PASSWORD=aragora-ci-redis-password-0123456789
           ARAGORA_STRICT_DEPLOYMENT=true
           ARAGORA_SECRETS_STRICT=false
           ARAGORA_REPLICAS=1
@@ -194,13 +195,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
-          python -m pip install pytest-timeout
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run E2E harness tests
         run: |
           mkdir -p test-results
-          pytest tests/e2e/ -v --tb=short --timeout=180 \
+          python -m pytest tests/e2e/ -v --tb=short --timeout=180 \
             -m "smoke" \
             --junit-xml=test-results/e2e-results.xml
         env:
@@ -345,16 +345,15 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
-          python -m pip install pytest-timeout psycopg2-binary
+          bash scripts/ci_install_project.sh --extras dev,test
+          python -m pip install psycopg2-binary
 
       - name: Run integration tests with coverage
         run: |
-          python -m pip install pytest-cov
           mkdir -p test-results
           # Integration tests focus on specific scenarios, not comprehensive coverage
           # Override the global 45% threshold from pyproject.toml
-          pytest tests/integration/ -v --tb=short --timeout=120 \
+          python -m pytest tests/integration/ -v --tb=short --timeout=120 \
             -m "integration or integration_minimal" \
             --cov=aragora --cov-report=xml:coverage-integration.xml \
             --cov-report=term-missing \
@@ -487,13 +486,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev,test]"
-          python -m pip install pytest pytest-asyncio pytest-timeout redis
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run control plane tests
         run: |
           mkdir -p test-results
-          pytest tests/control_plane/ -v --tb=short --timeout=120 \
+          python -m pytest tests/control_plane/ -v --tb=short --timeout=120 \
             --junit-xml=test-results/control-plane-results.xml
         env:
           PYTHONPATH: .

--- a/.github/workflows/migration-tests.yml
+++ b/.github/workflows/migration-tests.yml
@@ -64,41 +64,41 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e ".[dev]"
+          bash scripts/ci_install_project.sh --extras dev,test
 
       - name: Run migration runner tests
         run: |
-          pytest tests/test_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/test_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run migration pattern tests
         run: |
-          pytest tests/test_migration_patterns.py -v --timeout=60 --tb=short
+          python -m pytest tests/test_migration_patterns.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run new migration forward/rollback tests
         run: |
-          pytest tests/migrations/test_new_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/migrations/test_new_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run concurrent migration tests
         run: |
-          pytest tests/migrations/test_concurrent_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/migrations/test_concurrent_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run persistence migration runner tests
         run: |
-          pytest tests/persistence/test_migration_runner.py -v --timeout=60 --tb=short
+          python -m pytest tests/persistence/test_migration_runner.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 
       - name: Run persistence consolidation tests
         run: |
-          pytest tests/persistence/test_migrations.py -v --timeout=60 --tb=short
+          python -m pytest tests/persistence/test_migrations.py -v --timeout=60 --tb=short
         env:
           PYTHONPATH: .
 

--- a/tests/ci/test_release_gates.py
+++ b/tests/ci/test_release_gates.py
@@ -298,6 +298,81 @@ class TestFrontendE2EWorkflow:
         assert env["ARAGORA_DATA_DIR"] == ".nomic"
 
 
+class TestCoverageWorkflow:
+    """Validate coverage workflow bootstrap policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "coverage.yml"
+
+    def test_coverage_workflow_uses_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["coverage"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+
+class TestIntegrationWorkflow:
+    """Validate integration workflow bootstrap and self-host env policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "integration.yml"
+
+    def test_integration_jobs_use_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        jobs = data["jobs"]
+
+        for job_name in ("e2e-harness", "integration-tests", "control-plane-tests"):
+            workflow = jobs[job_name]
+            install_step = next(
+                step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+            )
+            command = install_step["run"]
+            assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+    def test_integration_self_host_env_sets_sentinel_redis_password(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["self-host-readiness"]
+        prepare_step = next(
+            step
+            for step in workflow["steps"]
+            if step.get("name") == "Prepare CI production env file"
+        )
+        command = prepare_step["run"]
+        assert "ARAGORA_REDIS_MODE=sentinel" in command
+        assert "REDIS_PASSWORD=aragora-ci-redis-password-0123456789" in command
+
+
+class TestMigrationWorkflow:
+    """Validate migration workflow bootstrap policy."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.path = WORKFLOWS_DIR / "migration-tests.yml"
+
+    def test_migration_workflow_uses_shared_ci_installer(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["migration-tests"]
+        install_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Install dependencies"
+        )
+        command = install_step["run"]
+        assert "scripts/ci_install_project.sh --extras dev,test" in command
+
+    def test_migration_workflow_uses_python_module_pytest(self):
+        data = _load_yaml(self.path)
+        workflow = data["jobs"]["migration-tests"]
+        runner_step = next(
+            step for step in workflow["steps"] if step.get("name") == "Run migration runner tests"
+        )
+        command = runner_step["run"]
+        assert "python -m pytest tests/test_migrations.py" in command
+
+
 class TestReleaseWorkflow:
     """Validate release.yml integrates all gates."""
 


### PR DESCRIPTION
## Summary
- switch coverage, integration, e2e, control-plane, and migration test jobs to the shared CI installer so pytest plugins and legacy control-plane deps are present
- run the heavy workflow test steps via `python -m pytest` for consistency with the installed environment
- set `REDIS_PASSWORD` in integration self-host readiness when sentinel mode is enabled and lock these workflow contracts with regression tests

## Root cause
Recent `main` failures were coming from workflow bootstrap drift, not product code:
- `Coverage Gate` failed because pytest was invoked with coverage/timeout flags before those plugins were installed
- `Integration Tests`, `E2E Harness Tests`, and `Control Plane Tests` failed on missing deps such as `defusedxml`, `aiohttp`, and `numpy`
- `Migration Tests` failed because the workflow installed only `.[dev]` and then invoked bare `pytest`
- integration self-host readiness failed because the generated CI env enabled sentinel mode without `REDIS_PASSWORD`

## Testing
- `python3 -m pytest tests/ci/test_release_gates.py -q`
- `python3 -m ruff check tests/ci/test_release_gates.py`
- `python3 scripts/check_workflow_pip_install_policy.py`
- YAML parse for `.github/workflows/coverage.yml`, `.github/workflows/integration.yml`, and `.github/workflows/migration-tests.yml`