### PR TITLE
chore(openapi): refresh generated spec artifacts

### DIFF
--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -71480,6 +71480,60 @@
         "x-aragora-stability": "stable"
       }
     },
+    "/api/v1/canvas/pipeline": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Get latest pipeline or list pipelines",
+        "operationId": "listOrLatestPipeline",
+        "description": "Return the latest canvas pipeline by default. Pass `list=true` to return pipeline summaries instead.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "list",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Return pipeline summaries instead of the latest pipeline."
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional status filter when list mode is enabled."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            },
+            "description": "Maximum number of pipeline summaries to return in list mode."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Latest pipeline payload or pipeline list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
     "/api/v1/canvas/pipeline/advance": {
       "post": {
         "tags": [
@@ -71621,6 +71675,376 @@
           }
         },
         "x-aragora-stability": "stable"
+      }
+    },
+    "/api/v1/canvas/pipeline/approve-transition": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Approve stage transition by body",
+        "operationId": "approvePipelineTransitionByBody",
+        "description": "Approve or reject a pending stage transition when the pipeline ID is sent in the request body.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "pipeline_id",
+                  "from_stage",
+                  "to_stage"
+                ],
+                "properties": {
+                  "from_stage": {
+                    "type": "string"
+                  },
+                  "to_stage": {
+                    "type": "string"
+                  },
+                  "approved": {
+                    "type": "boolean",
+                    "description": "Defaults to true when omitted; set to false to reject."
+                  },
+                  "comment": {
+                    "type": "string"
+                  },
+                  "pipeline_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transition result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/auto-run": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Auto-run pipeline from freeform text",
+        "operationId": "autoRunPipeline",
+        "description": "Start an asynchronous pipeline from freeform text and return a pipeline identifier immediately.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "automation_level": {
+                    "type": "string",
+                    "enum": [
+                      "full",
+                      "guided",
+                      "manual"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Auto-run pipeline start status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/demo": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Create demo pipeline",
+        "operationId": "createDemoPipeline",
+        "description": "Create a pre-populated demo pipeline with all stages completed.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ideas": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Demo pipeline created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/canvas/pipeline/extract-goals": {
@@ -71785,6 +72209,287 @@
           }
         },
         "x-aragora-stability": "stable"
+      }
+    },
+    "/api/v1/canvas/pipeline/extract-principles": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Extract principles from ideas canvas",
+        "operationId": "extractPipelinePrinciples",
+        "description": "Extract principles and themes from an ideas canvas.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "ideas_canvas"
+                ],
+                "properties": {
+                  "ideas_canvas": {
+                    "type": "object"
+                  },
+                  "themes": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Principles canvas",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/from-braindump": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Create pipeline from brain dump",
+        "operationId": "createPipelineFromBrainDump",
+        "description": "Parse unstructured text into ideas and immediately create a pipeline from the extracted ideas.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "text"
+                ],
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "context": {
+                    "type": "string"
+                  },
+                  "auto_advance": {
+                    "type": "boolean"
+                  },
+                  "use_unified_orchestrator": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Pipeline created from a parsed brain dump",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/canvas/pipeline/from-debate": {
@@ -72086,6 +72791,78 @@
           }
         },
         "x-aragora-stability": "stable"
+      }
+    },
+    "/api/v1/canvas/pipeline/from-system-metrics": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Create pipeline from system metrics",
+        "operationId": "createPipelineFromSystemMetrics",
+        "description": "Auto-generate a pipeline from system health analysis.",
+        "security": [
+          {}
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Pipeline created from system metrics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/canvas/pipeline/from-template": {
@@ -72562,17 +73339,21 @@
               "schema": {
                 "type": "object",
                 "required": [
-                  "transition_id",
-                  "approved"
+                  "from_stage",
+                  "to_stage"
                 ],
                 "properties": {
-                  "transition_id": {
+                  "from_stage": {
+                    "type": "string"
+                  },
+                  "to_stage": {
                     "type": "string"
                   },
                   "approved": {
-                    "type": "boolean"
+                    "type": "boolean",
+                    "description": "Defaults to true when omitted; set to false to reject."
                   },
-                  "reason": {
+                  "comment": {
                     "type": "string"
                   }
                 }
@@ -72685,6 +73466,306 @@
         "x-aragora-stability": "stable"
       }
     },
+    "/api/v1/canvas/pipeline/{id}/beliefs": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Get pipeline beliefs",
+        "operationId": "getPipelineBeliefs",
+        "description": "Return belief-network-style confidence data for pipeline nodes.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline beliefs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/{id}/execute": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Execute completed pipeline",
+        "operationId": "executeCanvasPipeline",
+        "description": "Queue execution for a completed pipeline or return a dry-run summary of the planned work.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "dry_run": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Dry-run execution summary",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Pipeline execution queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/{id}/explanations": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Get pipeline explanations",
+        "operationId": "getPipelineExplanations",
+        "description": "Return explainability factors for pipeline nodes.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline explanations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
     "/api/v1/canvas/pipeline/{id}/graph": {
       "get": {
         "tags": [
@@ -72767,6 +73848,154 @@
         "x-aragora-stability": "stable"
       }
     },
+    "/api/v1/canvas/pipeline/{id}/intelligence": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Get pipeline intelligence rollup",
+        "operationId": "getPipelineIntelligence",
+        "description": "Return beliefs, explanations, and precedents for nodes in the pipeline.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline intelligence",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/canvas/pipeline/{id}/precedents": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Get pipeline precedents",
+        "operationId": "getPipelinePrecedents",
+        "description": "Return similar goals or precedents linked to the pipeline.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline precedents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
     "/api/v1/canvas/pipeline/{id}/receipt": {
       "get": {
         "tags": [
@@ -72841,6 +74070,111 @@
         "x-aragora-stability": "stable"
       }
     },
+    "/api/v1/canvas/pipeline/{id}/self-improve": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Feed pipeline into self-improvement",
+        "operationId": "selfImprovePipeline",
+        "description": "Trigger the self-improvement system using a pipeline as the source task definition.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "budget_limit": {
+                    "type": "number"
+                  },
+                  "require_approval": {
+                    "type": "boolean"
+                  },
+                  "dry_run": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Self-improvement preview",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Self-improvement run started",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
     "/api/v1/canvas/pipeline/{id}/stage/{stage}": {
       "get": {
         "tags": [
@@ -72870,6 +74204,7 @@
               "type": "string",
               "enum": [
                 "ideas",
+                "principles",
                 "goals",
                 "actions",
                 "orchestration"
@@ -113204,6 +114539,134 @@
             "bearerAuth": []
           }
         ],
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/debates/{id}/to-pipeline": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Convert debate to pipeline",
+        "operationId": "convertDebateToPipeline",
+        "description": "Load a completed debate's argument graph and create a pipeline from it.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Debate ID"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "use_universal": {
+                    "type": "boolean"
+                  },
+                  "auto_advance": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Pipeline created from debate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found - The requested resource does not exist",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "not_found": {
+                    "summary": "Resource not found",
+                    "value": {
+                      "error": "Debate not found",
+                      "code": "NOT_FOUND",
+                      "resource_type": "debate",
+                      "resource_id": "deb_abc123",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error - Unexpected error occurred",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "internal_error": {
+                    "summary": "Internal server error",
+                    "value": {
+                      "error": "An unexpected error occurred",
+                      "code": "INTERNAL_ERROR",
+                      "trace_id": "req_abc123xyz",
+                      "support_url": "https://github.com/synaptent/aragora/issues"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "x-aragora-stability": "experimental"
       }
     },
@@ -175148,6 +176611,221 @@
         "x-aragora-stability": "experimental",
         "operationId": "createPipelineTransitions",
         "description": "Autogenerated placeholder (spec pending)"
+      }
+    },
+    "/api/v1/pipeline/{id}/agents": {
+      "get": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "List pipeline agents",
+        "operationId": "listPipelineAgents",
+        "description": "Return current agent assignments and statuses for a pipeline.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Pipeline agent assignments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/pipeline/{id}/agents/{agent_id}/approve": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Approve pipeline agent",
+        "operationId": "approvePipelineAgent",
+        "description": "Approve an assigned agent task for a pipeline.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          },
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Agent assignment ID"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent approval recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
+      }
+    },
+    "/api/v1/pipeline/{id}/agents/{agent_id}/reject": {
+      "post": {
+        "tags": [
+          "Pipeline"
+        ],
+        "summary": "Reject pipeline agent",
+        "operationId": "rejectPipelineAgent",
+        "description": "Reject an assigned agent task for a pipeline.",
+        "security": [
+          {}
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pipeline ID"
+          },
+          {
+            "name": "agent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Agent assignment ID"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "feedback"
+                ],
+                "properties": {
+                  "feedback": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Agent rejection recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - Invalid input or malformed JSON",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Unique request identifier for tracing and debugging",
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "X-Response-Time": {
+                "description": "Server processing time in milliseconds",
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                },
+                "examples": {
+                  "invalid_json": {
+                    "summary": "Invalid JSON body",
+                    "value": {
+                      "error": "Invalid JSON in request body",
+                      "code": "INVALID_JSON",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "missing_field": {
+                    "summary": "Missing required field",
+                    "value": {
+                      "error": "Missing required field: task",
+                      "code": "MISSING_FIELD",
+                      "field": "task",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  },
+                  "invalid_value": {
+                    "summary": "Invalid field value",
+                    "value": {
+                      "error": "Invalid value for 'rounds': must be between 1 and 12",
+                      "code": "INVALID_VALUE",
+                      "field": "rounds",
+                      "trace_id": "req_abc123xyz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "x-aragora-stability": "experimental"
       }
     },
     "/api/v1/plans": {

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -43152,6 +43152,41 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
+  /api/v1/canvas/pipeline:
+    get:
+      tags:
+      - Pipeline
+      summary: Get latest pipeline or list pipelines
+      operationId: listOrLatestPipeline
+      description: Return the latest canvas pipeline by default. Pass `list=true` to return pipeline summaries instead.
+      security:
+      - {}
+      parameters:
+      - name: list
+        in: query
+        schema:
+          type: boolean
+        description: Return pipeline summaries instead of the latest pipeline.
+      - name: status
+        in: query
+        schema:
+          type: string
+        description: Optional status filter when list mode is enabled.
+      - name: limit
+        in: query
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 100
+        description: Maximum number of pipeline summaries to return in list mode.
+      responses:
+        '200':
+          description: Latest pipeline payload or pipeline list
+          content:
+            application/json:
+              schema:
+                type: object
+      x-aragora-stability: experimental
   /api/v1/canvas/pipeline/advance:
     post:
       tags:
@@ -43240,13 +43275,13 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/canvas/pipeline/extract-goals:
+  /api/v1/canvas/pipeline/approve-transition:
     post:
       tags:
       - Pipeline
-      summary: Extract goals from ideas
-      operationId: extractGoals
-      description: Use AI to extract structured goals from an ideas canvas.
+      summary: Approve stage transition by body
+      operationId: approvePipelineTransitionByBody
+      description: Approve or reject a pending stage transition when the pipeline ID is sent in the request body.
       security:
       - {}
       requestBody:
@@ -43255,34 +43290,25 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+              - pipeline_id
+              - from_stage
+              - to_stage
               properties:
-                nodes:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      type:
-                        type: string
-                      summary:
-                        type: string
-                      content:
-                        type: string
-                edges:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      source_id:
-                        type: string
-                      target_id:
-                        type: string
-                      relation:
-                        type: string
+                from_stage:
+                  type: string
+                to_stage:
+                  type: string
+                approved:
+                  type: boolean
+                  description: Defaults to true when omitted; set to false to reject.
+                comment:
+                  type: string
+                pipeline_id:
+                  type: string
       responses:
         '200':
-          description: Extracted goals
+          description: Transition result
           content:
             application/json:
               schema:
@@ -43324,29 +43350,30 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
+        '404':
+          description: Not found - The requested resource does not exist
           headers: *id227
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
               examples:
-                internal_error:
-                  summary: Internal server error
+                not_found:
+                  summary: Resource not found
                   value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
                     trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/canvas/pipeline/from-debate:
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/auto-run:
     post:
       tags:
       - Pipeline
-      summary: Create pipeline from debate
-      operationId: createPipelineFromDebate
-      description: Create a pipeline from an ArgumentCartographer debate graph (nodes + edges).
+      summary: Auto-run pipeline from freeform text
+      operationId: autoRunPipeline
+      description: Start an asynchronous pipeline from freeform text and return a pipeline identifier immediately.
       security:
       - {}
       requestBody:
@@ -43355,34 +43382,20 @@ paths:
           application/json:
             schema:
               type: object
+              required:
+              - text
               properties:
-                nodes:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                      type:
-                        type: string
-                      summary:
-                        type: string
-                      content:
-                        type: string
-                edges:
-                  type: array
-                  items:
-                    type: object
-                    properties:
-                      source_id:
-                        type: string
-                      target_id:
-                        type: string
-                      relation:
-                        type: string
+                text:
+                  type: string
+                automation_level:
+                  type: string
+                  enum:
+                  - full
+                  - guided
+                  - manual
       responses:
         '200':
-          description: Pipeline result
+          description: Auto-run pipeline start status
           content:
             application/json:
               schema:
@@ -43439,14 +43452,66 @@ paths:
                     code: INTERNAL_ERROR
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-  /api/v1/canvas/pipeline/from-ideas:
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/demo:
     post:
       tags:
       - Pipeline
-      summary: Create pipeline from ideas
-      operationId: createPipelineFromIdeas
-      description: Create a full 4-stage pipeline from a list of raw idea strings.
+      summary: Create demo pipeline
+      operationId: createDemoPipeline
+      description: Create a pre-populated demo pipeline with all stages completed.
+      security:
+      - {}
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ideas:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '201':
+          description: Demo pipeline created
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/extract-goals:
+    post:
+      tags:
+      - Pipeline
+      summary: Extract goals from ideas
+      operationId: extractGoals
+      description: Use AI to extract structured goals from an ideas canvas.
       security:
       - {}
       requestBody:
@@ -43455,17 +43520,34 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-              - ideas
               properties:
-                ideas:
+                nodes:
                   type: array
                   items:
-                    type: string
-                  description: List of idea strings
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      summary:
+                        type: string
+                      content:
+                        type: string
+                edges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      source_id:
+                        type: string
+                      target_id:
+                        type: string
+                      relation:
+                        type: string
       responses:
         '200':
-          description: Pipeline result
+          description: Extracted goals
           content:
             application/json:
               schema:
@@ -43523,13 +43605,13 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: stable
-  /api/v1/canvas/pipeline/from-template:
+  /api/v1/canvas/pipeline/extract-principles:
     post:
       tags:
       - Pipeline
-      summary: Create pipeline from template
-      operationId: createPipelineFromTemplate
-      description: Create a pipeline from a named template.
+      summary: Extract principles from ideas canvas
+      operationId: extractPipelinePrinciples
+      description: Extract principles and themes from an ideas canvas.
       security:
       - {}
       requestBody:
@@ -43539,15 +43621,17 @@ paths:
             schema:
               type: object
               required:
-              - template_id
+              - ideas_canvas
               properties:
-                template_id:
-                  type: string
-                parameters:
+                ideas_canvas:
                   type: object
+                themes:
+                  type: array
+                  items:
+                    type: string
       responses:
         '200':
-          description: Pipeline result
+          description: Principles canvas
           content:
             application/json:
               schema:
@@ -43592,6 +43676,404 @@ paths:
         '500':
           description: Internal server error - Unexpected error occurred
           headers: *id230
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/from-braindump:
+    post:
+      tags:
+      - Pipeline
+      summary: Create pipeline from brain dump
+      operationId: createPipelineFromBrainDump
+      description: Parse unstructured text into ideas and immediately create a pipeline from the extracted ideas.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - text
+              properties:
+                text:
+                  type: string
+                context:
+                  type: string
+                auto_advance:
+                  type: boolean
+                use_unified_orchestrator:
+                  type: boolean
+      responses:
+        '201':
+          description: Pipeline created from a parsed brain dump
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id231
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id231
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/from-debate:
+    post:
+      tags:
+      - Pipeline
+      summary: Create pipeline from debate
+      operationId: createPipelineFromDebate
+      description: Create a pipeline from an ArgumentCartographer debate graph (nodes + edges).
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                nodes:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      type:
+                        type: string
+                      summary:
+                        type: string
+                      content:
+                        type: string
+                edges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      source_id:
+                        type: string
+                      target_id:
+                        type: string
+                      relation:
+                        type: string
+      responses:
+        '200':
+          description: Pipeline result
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id232
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id232
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/canvas/pipeline/from-ideas:
+    post:
+      tags:
+      - Pipeline
+      summary: Create pipeline from ideas
+      operationId: createPipelineFromIdeas
+      description: Create a full 4-stage pipeline from a list of raw idea strings.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - ideas
+              properties:
+                ideas:
+                  type: array
+                  items:
+                    type: string
+                  description: List of idea strings
+      responses:
+        '200':
+          description: Pipeline result
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id233
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id233
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+  /api/v1/canvas/pipeline/from-system-metrics:
+    post:
+      tags:
+      - Pipeline
+      summary: Create pipeline from system metrics
+      operationId: createPipelineFromSystemMetrics
+      description: Auto-generate a pipeline from system health analysis.
+      security:
+      - {}
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Pipeline created from system metrics
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/from-template:
+    post:
+      tags:
+      - Pipeline
+      summary: Create pipeline from template
+      operationId: createPipelineFromTemplate
+      description: Create a pipeline from a named template.
+      security:
+      - {}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - template_id
+              properties:
+                template_id:
+                  type: string
+                parameters:
+                  type: object
+      responses:
+        '200':
+          description: Pipeline result
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id234
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id234
           content:
             application/json:
               schema:
@@ -43688,10 +44170,10 @@ paths:
       summary: Get pipeline
       operationId: getPipeline
       description: Get a pipeline result by ID.
-      security: &id231
+      security: &id235
       - {}
       parameters:
-      - &id232
+      - &id236
         name: id
         in: path
         required: true
@@ -43705,9 +44187,9 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': &id233
+        '404': &id237
           description: Not found - The requested resource does not exist
-          headers: &id234
+          headers: &id238
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -43737,9 +44219,9 @@ paths:
       summary: Save pipeline canvas state
       operationId: savePipeline
       description: Save the current canvas state for a pipeline.
-      security: *id231
+      security: *id235
       parameters:
-      - *id232
+      - *id236
       requestBody:
         required: true
         content:
@@ -43753,10 +44235,10 @@ paths:
             application/json:
               schema:
                 type: object
-        '404': *id233
+        '404': *id237
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id234
+          headers: *id238
           content:
             application/json:
               schema:
@@ -43793,14 +44275,17 @@ paths:
             schema:
               type: object
               required:
-              - transition_id
-              - approved
+              - from_stage
+              - to_stage
               properties:
-                transition_id:
+                from_stage:
+                  type: string
+                to_stage:
                   type: string
                 approved:
                   type: boolean
-                reason:
+                  description: Defaults to true when omitted; set to false to reject.
+                comment:
                   type: string
       responses:
         '200':
@@ -43811,7 +44296,7 @@ paths:
                 type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: &id235
+          headers: &id239
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -43836,7 +44321,7 @@ paths:
                     trace_id: req_abc123xyz
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id235
+          headers: *id239
           content:
             application/json:
               schema:
@@ -43863,6 +44348,196 @@ paths:
                     field: rounds
                     trace_id: req_abc123xyz
       x-aragora-stability: stable
+  /api/v1/canvas/pipeline/{id}/beliefs:
+    get:
+      tags:
+      - Pipeline
+      summary: Get pipeline beliefs
+      operationId: getPipelineBeliefs
+      description: Return belief-network-style confidence data for pipeline nodes.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      responses:
+        '200':
+          description: Pipeline beliefs
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/{id}/execute:
+    post:
+      tags:
+      - Pipeline
+      summary: Execute completed pipeline
+      operationId: executeCanvasPipeline
+      description: Queue execution for a completed pipeline or return a dry-run summary of the planned work.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                dry_run:
+                  type: boolean
+      responses:
+        '200':
+          description: Dry-run execution summary
+          content:
+            application/json:
+              schema:
+                type: object
+        '202':
+          description: Pipeline execution queued
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id240
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id240
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/{id}/explanations:
+    get:
+      tags:
+      - Pipeline
+      summary: Get pipeline explanations
+      operationId: getPipelineExplanations
+      description: Return explainability factors for pipeline nodes.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      responses:
+        '200':
+          description: Pipeline explanations
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
   /api/v1/canvas/pipeline/{id}/graph:
     get:
       tags:
@@ -43917,6 +44592,104 @@ paths:
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
       x-aragora-stability: stable
+  /api/v1/canvas/pipeline/{id}/intelligence:
+    get:
+      tags:
+      - Pipeline
+      summary: Get pipeline intelligence rollup
+      operationId: getPipelineIntelligence
+      description: Return beliefs, explanations, and precedents for nodes in the pipeline.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      responses:
+        '200':
+          description: Pipeline intelligence
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
+  /api/v1/canvas/pipeline/{id}/precedents:
+    get:
+      tags:
+      - Pipeline
+      summary: Get pipeline precedents
+      operationId: getPipelinePrecedents
+      description: Return similar goals or precedents linked to the pipeline.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      responses:
+        '200':
+          description: Pipeline precedents
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
   /api/v1/canvas/pipeline/{id}/receipt:
     get:
       tags:
@@ -43966,6 +44739,74 @@ paths:
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
       x-aragora-stability: stable
+  /api/v1/canvas/pipeline/{id}/self-improve:
+    post:
+      tags:
+      - Pipeline
+      summary: Feed pipeline into self-improvement
+      operationId: selfImprovePipeline
+      description: Trigger the self-improvement system using a pipeline as the source task definition.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                budget_limit:
+                  type: number
+                require_approval:
+                  type: boolean
+                dry_run:
+                  type: boolean
+      responses:
+        '200':
+          description: Self-improvement preview
+          content:
+            application/json:
+              schema:
+                type: object
+        '201':
+          description: Self-improvement run started
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
   /api/v1/canvas/pipeline/{id}/stage/{stage}:
     get:
       tags:
@@ -43989,6 +44830,7 @@ paths:
           type: string
           enum:
           - ideas
+          - principles
           - goals
           - actions
           - orchestration
@@ -44167,7 +45009,7 @@ paths:
       responses:
         '200':
           description: Channel summary
-          headers: &id236
+          headers: &id241
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44183,7 +45025,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id236
+          headers: *id241
           content:
             application/json:
               schema:
@@ -44261,7 +45103,7 @@ paths:
       responses:
         '200':
           description: Injected context
-          headers: &id237
+          headers: &id242
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44277,7 +45119,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id237
+          headers: *id242
           content:
             application/json:
               schema:
@@ -44305,7 +45147,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id237
+          headers: *id242
           content:
             application/json:
               schema:
@@ -44356,7 +45198,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id238
+          headers: &id243
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44372,7 +45214,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id238
+          headers: *id243
           content:
             application/json:
               schema:
@@ -44400,7 +45242,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id238
+          headers: *id243
           content:
             application/json:
               schema:
@@ -44456,7 +45298,7 @@ paths:
       responses:
         '200':
           description: Knowledge stored
-          headers: &id239
+          headers: &id244
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44472,7 +45314,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id239
+          headers: *id244
           content:
             application/json:
               schema:
@@ -44500,7 +45342,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id239
+          headers: *id244
           content:
             application/json:
               schema:
@@ -44660,7 +45502,7 @@ paths:
       responses:
         '200':
           description: Classification result with level and confidence
-          headers: &id240
+          headers: &id245
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44683,7 +45525,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id240
+          headers: *id245
           content:
             application/json:
               schema:
@@ -44711,7 +45553,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id240
+          headers: *id245
           content:
             application/json:
               schema:
@@ -44753,7 +45595,7 @@ paths:
       responses:
         '200':
           description: Policy details for the sensitivity level
-          headers: &id241
+          headers: &id246
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -44780,7 +45622,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id241
+          headers: *id246
           content:
             application/json:
               schema:
@@ -44808,7 +45650,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id241
+          headers: *id246
           content:
             application/json:
               schema:
@@ -45181,7 +46023,7 @@ paths:
       responses:
         '200':
           description: Dependency analysis
-          headers: &id242
+          headers: &id247
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45197,7 +46039,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyAnalysisResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id242
+          headers: *id247
           content:
             application/json:
               schema:
@@ -45225,7 +46067,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id242
+          headers: *id247
           content:
             application/json:
               schema:
@@ -45245,7 +46087,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id242
+          headers: *id247
           content:
             application/json:
               schema:
@@ -45267,7 +46109,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id242
+          headers: *id247
           content:
             application/json:
               schema:
@@ -45362,7 +46204,7 @@ paths:
       responses:
         '200':
           description: License check
-          headers: &id243
+          headers: &id248
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45378,7 +46220,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseLicenseCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id243
+          headers: *id248
           content:
             application/json:
               schema:
@@ -45406,7 +46248,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id243
+          headers: *id248
           content:
             application/json:
               schema:
@@ -45426,7 +46268,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id243
+          headers: *id248
           content:
             application/json:
               schema:
@@ -45448,7 +46290,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id243
+          headers: *id248
           content:
             application/json:
               schema:
@@ -45474,7 +46316,7 @@ paths:
       responses:
         '200':
           description: Cache cleared
-          headers: &id244
+          headers: &id249
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45490,7 +46332,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id244
+          headers: *id249
           content:
             application/json:
               schema:
@@ -45510,7 +46352,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id244
+          headers: *id249
           content:
             application/json:
               schema:
@@ -45532,7 +46374,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id244
+          headers: *id249
           content:
             application/json:
               schema:
@@ -45776,7 +46618,7 @@ paths:
       responses:
         '200':
           description: Package vulnerabilities
-          headers: &id245
+          headers: &id250
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45792,7 +46634,7 @@ paths:
                 $ref: '#/components/schemas/CodebasePackageVulnerabilityResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id245
+          headers: *id250
           content:
             application/json:
               schema:
@@ -45812,7 +46654,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id245
+          headers: *id250
           content:
             application/json:
               schema:
@@ -45834,7 +46676,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id245
+          headers: *id250
           content:
             application/json:
               schema:
@@ -45891,7 +46733,7 @@ paths:
       responses:
         '200':
           description: Scan started
-          headers: &id246
+          headers: &id251
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45907,7 +46749,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id246
+          headers: *id251
           content:
             application/json:
               schema:
@@ -45935,7 +46777,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id246
+          headers: *id251
           content:
             application/json:
               schema:
@@ -45967,7 +46809,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id247
+          headers: &id252
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -45983,7 +46825,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id247
+          headers: *id252
           content:
             application/json:
               schema:
@@ -45999,7 +46841,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id247
+          headers: *id252
           content:
             application/json:
               schema:
@@ -46025,7 +46867,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id248
+          headers: &id253
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46041,7 +46883,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id248
+          headers: *id253
           content:
             application/json:
               schema:
@@ -46094,7 +46936,7 @@ paths:
       responses:
         '200':
           description: SBOM generated
-          headers: &id249
+          headers: &id254
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46110,7 +46952,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSBOMResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id249
+          headers: *id254
           content:
             application/json:
               schema:
@@ -46138,7 +46980,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id249
+          headers: *id254
           content:
             application/json:
               schema:
@@ -46158,7 +47000,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id249
+          headers: *id254
           content:
             application/json:
               schema:
@@ -46180,7 +47022,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id249
+          headers: *id254
           content:
             application/json:
               schema:
@@ -46233,7 +47075,7 @@ paths:
       responses:
         '200':
           description: Vulnerability scan
-          headers: &id250
+          headers: &id255
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46249,7 +47091,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDependencyScanResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id250
+          headers: *id255
           content:
             application/json:
               schema:
@@ -46277,7 +47119,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id250
+          headers: *id255
           content:
             application/json:
               schema:
@@ -46297,7 +47139,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id250
+          headers: *id255
           content:
             application/json:
               schema:
@@ -46319,7 +47161,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id250
+          headers: *id255
           content:
             application/json:
               schema:
@@ -46481,7 +47323,7 @@ paths:
       responses:
         '200':
           description: Analysis
-          headers: &id251
+          headers: &id256
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46497,7 +47339,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id251
+          headers: *id256
           content:
             application/json:
               schema:
@@ -46525,7 +47367,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id251
+          headers: *id256
           content:
             application/json:
               schema:
@@ -46585,7 +47427,7 @@ paths:
       responses:
         '200':
           description: Audit started
-          headers: &id252
+          headers: &id257
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46601,7 +47443,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id252
+          headers: *id257
           content:
             application/json:
               schema:
@@ -46629,7 +47471,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id252
+          headers: *id257
           content:
             application/json:
               schema:
@@ -46666,7 +47508,7 @@ paths:
       responses:
         '200':
           description: Audit status
-          headers: &id253
+          headers: &id258
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46682,7 +47524,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id253
+          headers: *id258
           content:
             application/json:
               schema:
@@ -46698,7 +47540,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id253
+          headers: *id258
           content:
             application/json:
               schema:
@@ -46730,7 +47572,7 @@ paths:
       responses:
         '200':
           description: Call graph
-          headers: &id254
+          headers: &id259
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46746,7 +47588,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id254
+          headers: *id259
           content:
             application/json:
               schema:
@@ -46778,7 +47620,7 @@ paths:
       responses:
         '200':
           description: Dead code
-          headers: &id255
+          headers: &id260
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46794,7 +47636,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id255
+          headers: *id260
           content:
             application/json:
               schema:
@@ -46836,7 +47678,7 @@ paths:
       responses:
         '200':
           description: Duplicates
-          headers: &id256
+          headers: &id261
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46852,7 +47694,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseDuplicateListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id256
+          headers: *id261
           content:
             application/json:
               schema:
@@ -46872,7 +47714,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id256
+          headers: *id261
           content:
             application/json:
               schema:
@@ -46894,7 +47736,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id256
+          headers: *id261
           content:
             application/json:
               schema:
@@ -46936,7 +47778,7 @@ paths:
       responses:
         '200':
           description: Hotspots
-          headers: &id257
+          headers: &id262
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -46952,7 +47794,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseHotspotListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id257
+          headers: *id262
           content:
             application/json:
               schema:
@@ -46972,7 +47814,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id257
+          headers: *id262
           content:
             application/json:
               schema:
@@ -46994,7 +47836,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id257
+          headers: *id262
           content:
             application/json:
               schema:
@@ -47046,7 +47888,7 @@ paths:
       responses:
         '200':
           description: Impact
-          headers: &id258
+          headers: &id263
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47062,7 +47904,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id258
+          headers: *id263
           content:
             application/json:
               schema:
@@ -47090,7 +47932,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id258
+          headers: *id263
           content:
             application/json:
               schema:
@@ -47122,7 +47964,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id259
+          headers: &id264
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47138,7 +47980,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id259
+          headers: *id264
           content:
             application/json:
               schema:
@@ -47158,7 +48000,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id259
+          headers: *id264
           content:
             application/json:
               schema:
@@ -47180,7 +48022,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id259
+          headers: *id264
           content:
             application/json:
               schema:
@@ -47196,7 +48038,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id259
+          headers: *id264
           content:
             application/json:
               schema:
@@ -47253,7 +48095,7 @@ paths:
       responses:
         '200':
           description: Metrics analysis started
-          headers: &id260
+          headers: &id265
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47269,7 +48111,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id260
+          headers: *id265
           content:
             application/json:
               schema:
@@ -47297,7 +48139,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id260
+          headers: *id265
           content:
             application/json:
               schema:
@@ -47317,7 +48159,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id260
+          headers: *id265
           content:
             application/json:
               schema:
@@ -47339,7 +48181,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id260
+          headers: *id265
           content:
             application/json:
               schema:
@@ -47376,7 +48218,7 @@ paths:
       responses:
         '200':
           description: File metrics
-          headers: &id261
+          headers: &id266
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47392,7 +48234,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseFileMetricsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id261
+          headers: *id266
           content:
             application/json:
               schema:
@@ -47412,7 +48254,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id261
+          headers: *id266
           content:
             application/json:
               schema:
@@ -47434,7 +48276,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id261
+          headers: *id266
           content:
             application/json:
               schema:
@@ -47450,7 +48292,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id261
+          headers: *id266
           content:
             application/json:
               schema:
@@ -47492,7 +48334,7 @@ paths:
       responses:
         '200':
           description: Metrics history
-          headers: &id262
+          headers: &id267
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47508,7 +48350,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsHistoryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id262
+          headers: *id267
           content:
             application/json:
               schema:
@@ -47528,7 +48370,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id262
+          headers: *id267
           content:
             application/json:
               schema:
@@ -47550,7 +48392,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id262
+          headers: *id267
           content:
             application/json:
               schema:
@@ -47587,7 +48429,7 @@ paths:
       responses:
         '200':
           description: Metrics report
-          headers: &id263
+          headers: &id268
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -47603,7 +48445,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseMetricsReportResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id263
+          headers: *id268
           content:
             application/json:
               schema:
@@ -47623,7 +48465,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id263
+          headers: *id268
           content:
             application/json:
               schema:
@@ -47645,7 +48487,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id263
+          headers: *id268
           content:
             application/json:
               schema:
@@ -47661,7 +48503,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id263
+          headers: *id268
           content:
             application/json:
               schema:
@@ -47711,567 +48553,6 @@ paths:
       responses:
         '200':
           description: SAST findings
-          headers: &id264
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id264
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id264
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id264
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/codebase/{repo}/sast/owasp-summary:
-    get:
-      tags:
-      - Codebase
-      summary: OWASP summary
-      operationId: getCodebaseSastOwaspSummary
-      description: Summarize SAST findings by OWASP category.
-      security:
-      - {}
-      parameters:
-      - name: repo
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: OWASP summary
-          headers: &id265
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id265
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id265
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id265
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/codebase/{repo}/scan:
-    post:
-      tags:
-      - Codebase
-      summary: Run dependency vulnerability scan
-      operationId: createCodebaseScan
-      description: Trigger a dependency vulnerability scan for a repository.
-      security:
-      - {}
-      parameters:
-      - name: repo
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - repo_path
-              properties:
-                repo_path:
-                  type: string
-                branch:
-                  type: string
-                commit_sha:
-                  type: string
-                workspace_id:
-                  type: string
-      responses:
-        '200':
-          description: Scan started
-          headers: &id266
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodebaseScanStartResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id266
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id266
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id266
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id266
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/codebase/{repo}/scan/latest:
-    get:
-      tags:
-      - Codebase
-      summary: Get latest scan
-      operationId: getCodebaseScanLatest
-      description: Fetch the most recent dependency scan result.
-      security:
-      - {}
-      parameters:
-      - name: repo
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Latest scan
-          headers: &id267
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CodebaseScanResultResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id267
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id267
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id267
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id267
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/codebase/{repo}/scan/sast:
-    post:
-      tags:
-      - Codebase
-      summary: Trigger SAST scan
-      operationId: createCodebaseScanSast
-      description: Trigger a SAST scan for a repository.
-      security:
-      - {}
-      parameters:
-      - name: repo
-        in: path
-        required: true
-        schema:
-          type: string
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                repo_path:
-                  type: string
-                rule_sets:
-                  type: array
-                  items:
-                    type: string
-                workspace_id:
-                  type: string
-              required:
-              - repo_path
-      responses:
-        '200':
-          description: SAST scan started
-          headers: &id268
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id268
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id268
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id268
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id268
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/codebase/{repo}/scan/sast/{scan_id}:
-    get:
-      tags:
-      - Codebase
-      summary: Get SAST scan status
-      operationId: getCodebaseScanSast
-      description: Fetch SAST scan status by scan ID.
-      security:
-      - {}
-      parameters:
-      - name: repo
-        in: path
-        required: true
-        schema:
-          type: string
-      - name: scan_id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: SAST scan status
           headers: &id269
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -48328,9 +48609,324 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id269
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/codebase/{repo}/sast/owasp-summary:
+    get:
+      tags:
+      - Codebase
+      summary: OWASP summary
+      operationId: getCodebaseSastOwaspSummary
+      description: Summarize SAST findings by OWASP category.
+      security:
+      - {}
+      parameters:
+      - name: repo
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OWASP summary
+          headers: &id270
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id270
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id270
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id270
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/codebase/{repo}/scan:
+    post:
+      tags:
+      - Codebase
+      summary: Run dependency vulnerability scan
+      operationId: createCodebaseScan
+      description: Trigger a dependency vulnerability scan for a repository.
+      security:
+      - {}
+      parameters:
+      - name: repo
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - repo_path
+              properties:
+                repo_path:
+                  type: string
+                branch:
+                  type: string
+                commit_sha:
+                  type: string
+                workspace_id:
+                  type: string
+      responses:
+        '200':
+          description: Scan started
+          headers: &id271
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodebaseScanStartResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id271
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id271
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id271
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id271
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/codebase/{repo}/scan/latest:
+    get:
+      tags:
+      - Codebase
+      summary: Get latest scan
+      operationId: getCodebaseScanLatest
+      description: Fetch the most recent dependency scan result.
+      security:
+      - {}
+      parameters:
+      - name: repo
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Latest scan
+          headers: &id272
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CodebaseScanResultResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id272
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id272
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id269
+          headers: *id272
           content:
             application/json:
               schema:
@@ -48346,7 +48942,253 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id269
+          headers: *id272
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/codebase/{repo}/scan/sast:
+    post:
+      tags:
+      - Codebase
+      summary: Trigger SAST scan
+      operationId: createCodebaseScanSast
+      description: Trigger a SAST scan for a repository.
+      security:
+      - {}
+      parameters:
+      - name: repo
+        in: path
+        required: true
+        schema:
+          type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                repo_path:
+                  type: string
+                rule_sets:
+                  type: array
+                  items:
+                    type: string
+                workspace_id:
+                  type: string
+              required:
+              - repo_path
+      responses:
+        '200':
+          description: SAST scan started
+          headers: &id273
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id273
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id273
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id273
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id273
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/codebase/{repo}/scan/sast/{scan_id}:
+    get:
+      tags:
+      - Codebase
+      summary: Get SAST scan status
+      operationId: getCodebaseScanSast
+      description: Fetch SAST scan status by scan ID.
+      security:
+      - {}
+      parameters:
+      - name: repo
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: scan_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: SAST scan status
+          headers: &id274
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id274
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id274
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id274
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id274
           content:
             application/json:
               schema:
@@ -48384,7 +49226,7 @@ paths:
       responses:
         '200':
           description: Secrets scan started
-          headers: &id270
+          headers: &id275
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48400,7 +49242,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanStartResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id270
+          headers: *id275
           content:
             application/json:
               schema:
@@ -48428,7 +49270,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id270
+          headers: *id275
           content:
             application/json:
               schema:
@@ -48448,7 +49290,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id270
+          headers: *id275
           content:
             application/json:
               schema:
@@ -48470,7 +49312,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id270
+          headers: *id275
           content:
             application/json:
               schema:
@@ -48502,7 +49344,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id271
+          headers: &id276
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48518,7 +49360,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id271
+          headers: *id276
           content:
             application/json:
               schema:
@@ -48538,7 +49380,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id271
+          headers: *id276
           content:
             application/json:
               schema:
@@ -48560,7 +49402,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id271
+          headers: *id276
           content:
             application/json:
               schema:
@@ -48576,7 +49418,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id271
+          headers: *id276
           content:
             application/json:
               schema:
@@ -48613,7 +49455,7 @@ paths:
       responses:
         '200':
           description: Secrets scan
-          headers: &id272
+          headers: &id277
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48629,7 +49471,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id272
+          headers: *id277
           content:
             application/json:
               schema:
@@ -48649,7 +49491,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id272
+          headers: *id277
           content:
             application/json:
               schema:
@@ -48671,7 +49513,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id272
+          headers: *id277
           content:
             application/json:
               schema:
@@ -48687,7 +49529,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id272
+          headers: *id277
           content:
             application/json:
               schema:
@@ -48724,7 +49566,7 @@ paths:
       responses:
         '200':
           description: Scan result
-          headers: &id273
+          headers: &id278
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48740,7 +49582,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanResultResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id273
+          headers: *id278
           content:
             application/json:
               schema:
@@ -48760,7 +49602,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id273
+          headers: *id278
           content:
             application/json:
               schema:
@@ -48782,7 +49624,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id273
+          headers: *id278
           content:
             application/json:
               schema:
@@ -48798,7 +49640,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id273
+          headers: *id278
           content:
             application/json:
               schema:
@@ -48844,7 +49686,7 @@ paths:
       responses:
         '200':
           description: Scan list
-          headers: &id274
+          headers: &id279
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48860,7 +49702,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id274
+          headers: *id279
           content:
             application/json:
               schema:
@@ -48880,7 +49722,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id274
+          headers: *id279
           content:
             application/json:
               schema:
@@ -48902,7 +49744,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id274
+          headers: *id279
           content:
             application/json:
               schema:
@@ -48934,7 +49776,7 @@ paths:
       responses:
         '200':
           description: Secrets scan list
-          headers: &id275
+          headers: &id280
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -48950,7 +49792,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsScanListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id275
+          headers: *id280
           content:
             application/json:
               schema:
@@ -48970,7 +49812,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id275
+          headers: *id280
           content:
             application/json:
               schema:
@@ -48992,7 +49834,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id275
+          headers: *id280
           content:
             application/json:
               schema:
@@ -49024,7 +49866,7 @@ paths:
       responses:
         '200':
           description: Secrets list
-          headers: &id276
+          headers: &id281
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49040,7 +49882,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseSecretsListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id276
+          headers: *id281
           content:
             application/json:
               schema:
@@ -49060,7 +49902,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id276
+          headers: *id281
           content:
             application/json:
               schema:
@@ -49082,7 +49924,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id276
+          headers: *id281
           content:
             application/json:
               schema:
@@ -49114,7 +49956,7 @@ paths:
       responses:
         '200':
           description: Symbols
-          headers: &id277
+          headers: &id282
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49130,7 +49972,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id277
+          headers: *id282
           content:
             application/json:
               schema:
@@ -49182,7 +50024,7 @@ paths:
       responses:
         '200':
           description: Answer
-          headers: &id278
+          headers: &id283
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49198,7 +50040,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id278
+          headers: *id283
           content:
             application/json:
               schema:
@@ -49226,7 +50068,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id278
+          headers: *id283
           content:
             application/json:
               schema:
@@ -49280,7 +50122,7 @@ paths:
       responses:
         '200':
           description: Vulnerability list
-          headers: &id279
+          headers: &id284
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49296,7 +50138,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseVulnerabilityListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id279
+          headers: *id284
           content:
             application/json:
               schema:
@@ -49316,7 +50158,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id279
+          headers: *id284
           content:
             application/json:
               schema:
@@ -49338,7 +50180,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id279
+          headers: *id284
           content:
             application/json:
               schema:
@@ -49911,9 +50753,9 @@ paths:
                     - string
                     - 'null'
                     format: date-time
-        '401': &id281
+        '401': &id286
           description: Unauthorized - Authentication required or token invalid
-          headers: &id280
+          headers: &id285
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -49940,9 +50782,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id282
+        '403': &id287
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id280
+          headers: *id285
           content:
             application/json:
               schema:
@@ -49962,9 +50804,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id283
+        '404': &id288
           description: Not found - The requested resource does not exist
-          headers: *id280
+          headers: *id285
           content:
             application/json:
               schema:
@@ -49978,9 +50820,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id284
+        '500': &id289
           description: Internal server error - Unexpected error occurred
-          headers: *id280
+          headers: *id285
           content:
             application/json:
               schema:
@@ -50055,7 +50897,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id280
+          headers: *id285
           content:
             application/json:
               schema:
@@ -50081,10 +50923,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id281
-        '403': *id282
-        '404': *id283
-        '500': *id284
+        '401': *id286
+        '403': *id287
+        '404': *id288
+        '500': *id289
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -50158,9 +51000,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id286
+        '401': &id291
           description: Unauthorized - Authentication required or token invalid
-          headers: &id285
+          headers: &id290
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50187,9 +51029,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id287
+        '500': &id292
           description: Internal server error - Unexpected error occurred
-          headers: *id285
+          headers: *id290
           content:
             application/json:
               schema:
@@ -50276,7 +51118,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id285
+          headers: *id290
           content:
             application/json:
               schema:
@@ -50302,10 +51144,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id286
+        '401': *id291
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id285
+          headers: *id290
           content:
             application/json:
               schema:
@@ -50325,7 +51167,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id287
+        '500': *id292
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -50362,7 +51204,7 @@ paths:
                         type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id288
+          headers: &id293
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50391,7 +51233,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id288
+          headers: *id293
           content:
             application/json:
               schema:
@@ -50453,9 +51295,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '401': &id290
+        '401': &id295
           description: Unauthorized - Authentication required or token invalid
-          headers: &id289
+          headers: &id294
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50482,9 +51324,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id291
+        '404': &id296
           description: Not found - The requested resource does not exist
-          headers: *id289
+          headers: *id294
           content:
             application/json:
               schema:
@@ -50498,9 +51340,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id292
+        '500': &id297
           description: Internal server error - Unexpected error occurred
-          headers: *id289
+          headers: *id294
           content:
             application/json:
               schema:
@@ -50541,9 +51383,9 @@ paths:
                     type: boolean
                   action_id:
                     type: string
-        '401': *id290
-        '404': *id291
-        '500': *id292
+        '401': *id295
+        '404': *id296
+        '500': *id297
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -50588,7 +51430,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id293
+          headers: &id298
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50625,7 +51467,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id293
+          headers: *id298
           content:
             application/json:
               schema:
@@ -50645,7 +51487,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id293
+          headers: *id298
           content:
             application/json:
               schema:
@@ -50667,7 +51509,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id293
+          headers: *id298
           content:
             application/json:
               schema:
@@ -50709,7 +51551,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id294
+          headers: &id299
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50738,7 +51580,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id294
+          headers: *id299
           content:
             application/json:
               schema:
@@ -50760,7 +51602,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id294
+          headers: *id299
           content:
             application/json:
               schema:
@@ -50776,7 +51618,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id294
+          headers: *id299
           content:
             application/json:
               schema:
@@ -50829,7 +51671,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id295
+          headers: &id300
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50858,7 +51700,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id295
+          headers: *id300
           content:
             application/json:
               schema:
@@ -50880,7 +51722,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id295
+          headers: *id300
           content:
             application/json:
               schema:
@@ -50896,7 +51738,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id295
+          headers: *id300
           content:
             application/json:
               schema:
@@ -50949,7 +51791,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id296
+          headers: &id301
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -50978,7 +51820,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id296
+          headers: *id301
           content:
             application/json:
               schema:
@@ -51000,7 +51842,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id296
+          headers: *id301
           content:
             application/json:
               schema:
@@ -51016,7 +51858,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id296
+          headers: *id301
           content:
             application/json:
               schema:
@@ -51069,9 +51911,9 @@ paths:
                             type: string
                   total:
                     type: integer
-        '401': &id298
+        '401': &id303
           description: Unauthorized - Authentication required or token invalid
-          headers: &id297
+          headers: &id302
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51098,9 +51940,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id299
+        '500': &id304
           description: Internal server error - Unexpected error occurred
-          headers: *id297
+          headers: *id302
           content:
             application/json:
               schema:
@@ -51176,7 +52018,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id297
+          headers: *id302
           content:
             application/json:
               schema:
@@ -51202,10 +52044,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id298
+        '401': *id303
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id297
+          headers: *id302
           content:
             application/json:
               schema:
@@ -51225,7 +52067,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id299
+        '500': *id304
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -51276,9 +52118,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id301
+        '401': &id306
           description: Unauthorized - Authentication required or token invalid
-          headers: &id300
+          headers: &id305
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51305,9 +52147,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id302
+        '404': &id307
           description: Not found - The requested resource does not exist
-          headers: *id300
+          headers: *id305
           content:
             application/json:
               schema:
@@ -51321,9 +52163,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id303
+        '500': &id308
           description: Internal server error - Unexpected error occurred
-          headers: *id300
+          headers: *id305
           content:
             application/json:
               schema:
@@ -51401,7 +52243,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id300
+          headers: *id305
           content:
             application/json:
               schema:
@@ -51427,10 +52269,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id301
-        '403': &id304
+        '401': *id306
+        '403': &id309
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id300
+          headers: *id305
           content:
             application/json:
               schema:
@@ -51450,8 +52292,8 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': *id302
-        '500': *id303
+        '404': *id307
+        '500': *id308
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -51480,10 +52322,10 @@ paths:
                     type: boolean
                   policy_id:
                     type: string
-        '401': *id301
-        '403': *id304
-        '404': *id302
-        '500': *id303
+        '401': *id306
+        '403': *id309
+        '404': *id307
+        '500': *id308
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -51558,9 +52400,9 @@ paths:
                               type: integer
                   total:
                     type: integer
-        '401': &id306
+        '401': &id311
           description: Unauthorized - Authentication required or token invalid
-          headers: &id305
+          headers: &id310
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51587,9 +52429,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id307
+        '500': &id312
           description: Internal server error - Unexpected error occurred
-          headers: *id305
+          headers: *id310
           content:
             application/json:
               schema:
@@ -51653,7 +52495,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id305
+          headers: *id310
           content:
             application/json:
               schema:
@@ -51679,10 +52521,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id306
+        '401': *id311
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id305
+          headers: *id310
           content:
             application/json:
               schema:
@@ -51704,7 +52546,7 @@ paths:
                     trace_id: req_abc123xyz
         '429':
           description: Too many requests - Rate limit exceeded
-          headers: *id305
+          headers: *id310
           content:
             application/json:
               schema:
@@ -51719,7 +52561,7 @@ paths:
                     window: 1 minute
                     retry_after: 45
                     trace_id: req_abc123xyz
-        '500': *id307
+        '500': *id312
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -51793,9 +52635,9 @@ paths:
                             type: string
                           steps_taken:
                             type: integer
-        '401': &id309
+        '401': &id314
           description: Unauthorized - Authentication required or token invalid
-          headers: &id308
+          headers: &id313
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51822,9 +52664,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id310
+        '404': &id315
           description: Not found - The requested resource does not exist
-          headers: *id308
+          headers: *id313
           content:
             application/json:
               schema:
@@ -51838,9 +52680,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id311
+        '500': &id316
           description: Internal server error - Unexpected error occurred
-          headers: *id308
+          headers: *id313
           content:
             application/json:
               schema:
@@ -51884,7 +52726,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id308
+          headers: *id313
           content:
             application/json:
               schema:
@@ -51910,9 +52752,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id309
-        '404': *id310
-        '500': *id311
+        '401': *id314
+        '404': *id315
+        '500': *id316
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -51943,7 +52785,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id312
+          headers: &id317
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -51980,7 +52822,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id312
+          headers: *id317
           content:
             application/json:
               schema:
@@ -52000,7 +52842,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id312
+          headers: *id317
           content:
             application/json:
               schema:
@@ -52022,7 +52864,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id312
+          headers: *id317
           content:
             application/json:
               schema:
@@ -52038,7 +52880,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id312
+          headers: *id317
           content:
             application/json:
               schema:
@@ -52846,170 +53688,11 @@ paths:
         schema:
           type: boolean
           default: true
-      security: &id314
+      security: &id319
       - bearerAuth: []
       responses:
         '200':
           description: Agent list
-          headers: &id313
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlPlaneAgentList'
-        '401': &id315
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id313
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403': &id316
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id313
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '500': &id317
-          description: Internal server error - Unexpected error occurred
-          headers: *id313
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: stable
-    post:
-      tags:
-      - Control Plane
-      summary: Register agent
-      operationId: createControlPlaneAgents
-      description: Register an agent with capabilities and model metadata.
-      security: *id314
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - agent_id
-              - capabilities
-              properties:
-                agent_id:
-                  type: string
-                capabilities:
-                  type: array
-                  items:
-                    type: string
-                model:
-                  type: string
-                provider:
-                  type: string
-                metadata:
-                  type: object
-      responses:
-        '201':
-          description: Agent registered
-          headers: *id313
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ControlPlaneAgent'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id313
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401': *id315
-        '403': *id316
-        '500': *id317
-      x-aragora-stability: stable
-  /api/v1/control-plane/agents/{agent_id}:
-    get:
-      tags:
-      - Control Plane
-      summary: Get agent
-      operationId: getControlPlaneAgent
-      description: Get a specific agent by ID.
-      security: &id319
-      - bearerAuth: []
-      parameters:
-      - name: agent_id
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Agent details
           headers: &id318
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -53023,7 +53706,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ControlPlaneAgent'
+                $ref: '#/components/schemas/ControlPlaneAgentList'
         '401': &id320
           description: Unauthorized - Authentication required or token invalid
           headers: *id318
@@ -53066,9 +53749,168 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id322
-          description: Not found - The requested resource does not exist
+        '500': &id322
+          description: Internal server error - Unexpected error occurred
           headers: *id318
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: stable
+    post:
+      tags:
+      - Control Plane
+      summary: Register agent
+      operationId: createControlPlaneAgents
+      description: Register an agent with capabilities and model metadata.
+      security: *id319
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - agent_id
+              - capabilities
+              properties:
+                agent_id:
+                  type: string
+                capabilities:
+                  type: array
+                  items:
+                    type: string
+                model:
+                  type: string
+                provider:
+                  type: string
+                metadata:
+                  type: object
+      responses:
+        '201':
+          description: Agent registered
+          headers: *id318
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlPlaneAgent'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id318
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401': *id320
+        '403': *id321
+        '500': *id322
+      x-aragora-stability: stable
+  /api/v1/control-plane/agents/{agent_id}:
+    get:
+      tags:
+      - Control Plane
+      summary: Get agent
+      operationId: getControlPlaneAgent
+      description: Get a specific agent by ID.
+      security: &id324
+      - bearerAuth: []
+      parameters:
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Agent details
+          headers: &id323
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ControlPlaneAgent'
+        '401': &id325
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id323
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403': &id326
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id323
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404': &id327
+          description: Not found - The requested resource does not exist
+          headers: *id323
           content:
             application/json:
               schema:
@@ -53082,9 +53924,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id323
+        '500': &id328
           description: Internal server error - Unexpected error occurred
-          headers: *id318
+          headers: *id323
           content:
             application/json:
               schema:
@@ -53104,7 +53946,7 @@ paths:
       summary: Unregister agent
       operationId: deleteControlPlaneAgent
       description: Unregister an agent by ID.
-      security: *id319
+      security: *id324
       parameters:
       - name: agent_id
         in: path
@@ -53114,7 +53956,7 @@ paths:
       responses:
         '200':
           description: Agent unregistered
-          headers: *id318
+          headers: *id323
           content:
             application/json:
               schema:
@@ -53124,10 +53966,10 @@ paths:
                     type: string
                   unregistered:
                     type: boolean
-        '401': *id320
-        '403': *id321
-        '404': *id322
-        '500': *id323
+        '401': *id325
+        '403': *id326
+        '404': *id327
+        '500': *id328
       x-aragora-stability: stable
   /api/v1/control-plane/agents/{agent_id}/heartbeat:
     post:
@@ -53156,7 +53998,7 @@ paths:
       responses:
         '200':
           description: Heartbeat accepted
-          headers: &id324
+          headers: &id329
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53179,7 +54021,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id324
+          headers: *id329
           content:
             application/json:
               schema:
@@ -53199,7 +54041,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id324
+          headers: *id329
           content:
             application/json:
               schema:
@@ -53221,7 +54063,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id324
+          headers: *id329
           content:
             application/json:
               schema:
@@ -53237,7 +54079,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id324
+          headers: *id329
           content:
             application/json:
               schema:
@@ -53374,7 +54216,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking completed
-          headers: &id325
+          headers: &id330
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53390,14 +54232,14 @@ paths:
                 $ref: '#/components/schemas/DeliberationSyncResponse'
         '202':
           description: Decisionmaking queued
-          headers: *id325
+          headers: *id330
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DeliberationQueuedResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id325
+          headers: *id330
           content:
             application/json:
               schema:
@@ -53425,7 +54267,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id325
+          headers: *id330
           content:
             application/json:
               schema:
@@ -53445,7 +54287,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id325
+          headers: *id330
           content:
             application/json:
               schema:
@@ -53467,7 +54309,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id325
+          headers: *id330
           content:
             application/json:
               schema:
@@ -53527,7 +54369,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking record
-          headers: &id326
+          headers: &id331
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53543,7 +54385,7 @@ paths:
                 $ref: '#/components/schemas/DeliberationRecord'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id326
+          headers: *id331
           content:
             application/json:
               schema:
@@ -53563,7 +54405,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id326
+          headers: *id331
           content:
             application/json:
               schema:
@@ -53585,7 +54427,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id326
+          headers: *id331
           content:
             application/json:
               schema:
@@ -53601,7 +54443,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id326
+          headers: *id331
           content:
             application/json:
               schema:
@@ -53633,7 +54475,7 @@ paths:
       responses:
         '200':
           description: Decisionmaking status
-          headers: &id327
+          headers: &id332
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53649,7 +54491,7 @@ paths:
                 $ref: '#/components/schemas/DeliberationStatus'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id327
+          headers: *id332
           content:
             application/json:
               schema:
@@ -53669,7 +54511,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id327
+          headers: *id332
           content:
             application/json:
               schema:
@@ -53691,7 +54533,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id327
+          headers: *id332
           content:
             application/json:
               schema:
@@ -53717,7 +54559,7 @@ paths:
       responses:
         '200':
           description: System health
-          headers: &id328
+          headers: &id333
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53733,7 +54575,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneHealth'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id328
+          headers: *id333
           content:
             application/json:
               schema:
@@ -53753,7 +54595,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id328
+          headers: *id333
           content:
             application/json:
               schema:
@@ -53775,7 +54617,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id328
+          headers: *id333
           content:
             application/json:
               schema:
@@ -53828,7 +54670,7 @@ paths:
       responses:
         '200':
           description: Agent health
-          headers: &id329
+          headers: &id334
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53856,7 +54698,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id329
+          headers: *id334
           content:
             application/json:
               schema:
@@ -53876,7 +54718,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id329
+          headers: *id334
           content:
             application/json:
               schema:
@@ -53898,7 +54740,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id329
+          headers: *id334
           content:
             application/json:
               schema:
@@ -53914,7 +54756,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id329
+          headers: *id334
           content:
             application/json:
               schema:
@@ -53940,7 +54782,7 @@ paths:
       responses:
         '200':
           description: Metrics snapshot
-          headers: &id330
+          headers: &id335
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -53956,7 +54798,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneMetrics'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id330
+          headers: *id335
           content:
             application/json:
               schema:
@@ -53976,7 +54818,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id330
+          headers: *id335
           content:
             application/json:
               schema:
@@ -53998,7 +54840,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id330
+          headers: *id335
           content:
             application/json:
               schema:
@@ -54114,7 +54956,7 @@ paths:
       responses:
         '200':
           description: Queue snapshot
-          headers: &id331
+          headers: &id336
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54130,7 +54972,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneQueue'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id331
+          headers: *id336
           content:
             application/json:
               schema:
@@ -54150,7 +54992,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id331
+          headers: *id336
           content:
             application/json:
               schema:
@@ -54172,7 +55014,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id331
+          headers: *id336
           content:
             application/json:
               schema:
@@ -54240,7 +55082,7 @@ paths:
       responses:
         '200':
           description: Control plane stats
-          headers: &id332
+          headers: &id337
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54256,7 +55098,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneStats'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id332
+          headers: *id337
           content:
             application/json:
               schema:
@@ -54276,7 +55118,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id332
+          headers: *id337
           content:
             application/json:
               schema:
@@ -54298,7 +55140,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id332
+          headers: *id337
           content:
             application/json:
               schema:
@@ -54373,7 +55215,7 @@ paths:
       responses:
         '201':
           description: Task submitted
-          headers: &id333
+          headers: &id338
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54389,7 +55231,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTaskCreated'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id333
+          headers: *id338
           content:
             application/json:
               schema:
@@ -54417,7 +55259,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id333
+          headers: *id338
           content:
             application/json:
               schema:
@@ -54437,7 +55279,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id333
+          headers: *id338
           content:
             application/json:
               schema:
@@ -54459,7 +55301,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id333
+          headers: *id338
           content:
             application/json:
               schema:
@@ -54503,7 +55345,7 @@ paths:
       responses:
         '200':
           description: Task claim result
-          headers: &id334
+          headers: &id339
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54519,7 +55361,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTaskClaimResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id334
+          headers: *id339
           content:
             application/json:
               schema:
@@ -54539,7 +55381,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id334
+          headers: *id339
           content:
             application/json:
               schema:
@@ -54561,7 +55403,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id334
+          headers: *id339
           content:
             application/json:
               schema:
@@ -54593,7 +55435,7 @@ paths:
       responses:
         '200':
           description: Task details
-          headers: &id335
+          headers: &id340
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54609,7 +55451,7 @@ paths:
                 $ref: '#/components/schemas/ControlPlaneTask'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id335
+          headers: *id340
           content:
             application/json:
               schema:
@@ -54629,7 +55471,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id335
+          headers: *id340
           content:
             application/json:
               schema:
@@ -54651,7 +55493,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id335
+          headers: *id340
           content:
             application/json:
               schema:
@@ -54667,7 +55509,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id335
+          headers: *id340
           content:
             application/json:
               schema:
@@ -54699,7 +55541,7 @@ paths:
       responses:
         '200':
           description: Task cancelled
-          headers: &id336
+          headers: &id341
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54723,7 +55565,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id336
+          headers: *id341
           content:
             application/json:
               schema:
@@ -54743,7 +55585,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id336
+          headers: *id341
           content:
             application/json:
               schema:
@@ -54765,7 +55607,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id336
+          headers: *id341
           content:
             application/json:
               schema:
@@ -54781,7 +55623,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id336
+          headers: *id341
           content:
             application/json:
               schema:
@@ -54826,7 +55668,7 @@ paths:
       responses:
         '200':
           description: Task completed
-          headers: &id337
+          headers: &id342
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54850,7 +55692,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id337
+          headers: *id342
           content:
             application/json:
               schema:
@@ -54870,7 +55712,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id337
+          headers: *id342
           content:
             application/json:
               schema:
@@ -54892,7 +55734,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id337
+          headers: *id342
           content:
             application/json:
               schema:
@@ -54908,7 +55750,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id337
+          headers: *id342
           content:
             application/json:
               schema:
@@ -54953,7 +55795,7 @@ paths:
       responses:
         '200':
           description: Task failed
-          headers: &id338
+          headers: &id343
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -54977,7 +55819,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id338
+          headers: *id343
           content:
             application/json:
               schema:
@@ -54997,7 +55839,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id338
+          headers: *id343
           content:
             application/json:
               schema:
@@ -55019,7 +55861,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id338
+          headers: *id343
           content:
             application/json:
               schema:
@@ -55035,7 +55877,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id338
+          headers: *id343
           content:
             application/json:
               schema:
@@ -55604,7 +56446,7 @@ paths:
       responses:
         '200':
           description: Cost summary
-          headers: &id339
+          headers: &id344
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55620,7 +56462,7 @@ paths:
                 $ref: '#/components/schemas/CostSummaryResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id339
+          headers: *id344
           content:
             application/json:
               schema:
@@ -55640,7 +56482,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id339
+          headers: *id344
           content:
             application/json:
               schema:
@@ -55662,7 +56504,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id339
+          headers: *id344
           content:
             application/json:
               schema:
@@ -55713,7 +56555,7 @@ paths:
       responses:
         '200':
           description: Alerts
-          headers: &id340
+          headers: &id345
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55729,7 +56571,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertsResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id340
+          headers: *id345
           content:
             application/json:
               schema:
@@ -55749,7 +56591,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id340
+          headers: *id345
           content:
             application/json:
               schema:
@@ -55771,7 +56613,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id340
+          headers: *id345
           content:
             application/json:
               schema:
@@ -55821,7 +56663,7 @@ paths:
       responses:
         '201':
           description: Alert created
-          headers: &id341
+          headers: &id346
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55837,7 +56679,7 @@ paths:
                 $ref: '#/components/schemas/CostAlertCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id341
+          headers: *id346
           content:
             application/json:
               schema:
@@ -55865,7 +56707,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id341
+          headers: *id346
           content:
             application/json:
               schema:
@@ -55885,7 +56727,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id341
+          headers: *id346
           content:
             application/json:
               schema:
@@ -55907,7 +56749,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id341
+          headers: *id346
           content:
             application/json:
               schema:
@@ -55939,7 +56781,7 @@ paths:
       responses:
         '200':
           description: Alert dismissed
-          headers: &id342
+          headers: &id347
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -55955,7 +56797,7 @@ paths:
                 $ref: '#/components/schemas/CostDismissAlertResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id342
+          headers: *id347
           content:
             application/json:
               schema:
@@ -55975,7 +56817,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id342
+          headers: *id347
           content:
             application/json:
               schema:
@@ -55997,7 +56839,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id342
+          headers: *id347
           content:
             application/json:
               schema:
@@ -56013,7 +56855,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id342
+          headers: *id347
           content:
             application/json:
               schema:
@@ -56252,7 +57094,7 @@ paths:
       responses:
         '200':
           description: Cost breakdown
-          headers: &id343
+          headers: &id348
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56268,7 +57110,7 @@ paths:
                 $ref: '#/components/schemas/CostBreakdownResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id343
+          headers: *id348
           content:
             application/json:
               schema:
@@ -56288,7 +57130,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id343
+          headers: *id348
           content:
             application/json:
               schema:
@@ -56310,7 +57152,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id343
+          headers: *id348
           content:
             application/json:
               schema:
@@ -56342,7 +57184,7 @@ paths:
       responses:
         '200':
           description: Budget updated
-          headers: &id344
+          headers: &id349
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56358,7 +57200,7 @@ paths:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id344
+          headers: *id349
           content:
             application/json:
               schema:
@@ -56386,7 +57228,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id344
+          headers: *id349
           content:
             application/json:
               schema:
@@ -56406,7 +57248,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id344
+          headers: *id349
           content:
             application/json:
               schema:
@@ -56428,7 +57270,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id344
+          headers: *id349
           content:
             application/json:
               schema:
@@ -56449,7 +57291,7 @@ paths:
       summary: List budgets
       operationId: listCostsBudgets
       description: List all budgets for the workspace.
-      security: &id346
+      security: &id351
       - {}
       parameters:
       - name: workspace_id
@@ -56464,7 +57306,7 @@ paths:
       responses:
         '200':
           description: Budgets list
-          headers: &id345
+          headers: &id350
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56478,9 +57320,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetsListResponse'
-        '401': &id347
+        '401': &id352
           description: Unauthorized - Authentication required or token invalid
-          headers: *id345
+          headers: *id350
           content:
             application/json:
               schema:
@@ -56498,9 +57340,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id348
+        '403': &id353
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id345
+          headers: *id350
           content:
             application/json:
               schema:
@@ -56520,9 +57362,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id349
+        '500': &id354
           description: Internal server error - Unexpected error occurred
-          headers: *id345
+          headers: *id350
           content:
             application/json:
               schema:
@@ -56542,7 +57384,7 @@ paths:
       summary: Create budget
       operationId: createCostsBudgets
       description: Create a new budget for the workspace.
-      security: *id346
+      security: *id351
       requestBody:
         required: true
         content:
@@ -56552,14 +57394,14 @@ paths:
       responses:
         '201':
           description: Budget created
-          headers: *id345
+          headers: *id350
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostBudgetResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id345
+          headers: *id350
           content:
             application/json:
               schema:
@@ -56585,9 +57427,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id347
-        '403': *id348
-        '500': *id349
+        '401': *id352
+        '403': *id353
+        '500': *id354
       x-aragora-stability: stable
   /api/v1/costs/constraints/check:
     post:
@@ -56616,7 +57458,7 @@ paths:
       responses:
         '200':
           description: Constraint check result
-          headers: &id350
+          headers: &id355
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56632,7 +57474,7 @@ paths:
                 $ref: '#/components/schemas/CostConstraintCheckResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id350
+          headers: *id355
           content:
             application/json:
               schema:
@@ -56660,7 +57502,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id350
+          headers: *id355
           content:
             application/json:
               schema:
@@ -56680,7 +57522,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id350
+          headers: *id355
           content:
             application/json:
               schema:
@@ -56702,7 +57544,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id350
+          headers: *id355
           content:
             application/json:
               schema:
@@ -56867,7 +57709,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id351
+          headers: &id356
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -56883,7 +57725,7 @@ paths:
                 $ref: '#/components/schemas/CostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id351
+          headers: *id356
           content:
             application/json:
               schema:
@@ -56911,7 +57753,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id351
+          headers: *id356
           content:
             application/json:
               schema:
@@ -56931,7 +57773,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id351
+          headers: *id356
           content:
             application/json:
               schema:
@@ -56953,7 +57795,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id351
+          headers: *id356
           content:
             application/json:
               schema:
@@ -57066,7 +57908,7 @@ paths:
       responses:
         '200':
           description: Detailed forecast
-          headers: &id352
+          headers: &id357
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57082,7 +57924,7 @@ paths:
                 $ref: '#/components/schemas/CostForecastDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id352
+          headers: *id357
           content:
             application/json:
               schema:
@@ -57102,7 +57944,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id352
+          headers: *id357
           content:
             application/json:
               schema:
@@ -57124,7 +57966,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id352
+          headers: *id357
           content:
             application/json:
               schema:
@@ -57241,7 +58083,7 @@ paths:
       responses:
         '200':
           description: Detailed recommendations
-          headers: &id353
+          headers: &id358
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57257,7 +58099,7 @@ paths:
                 $ref: '#/components/schemas/CostRecommendationsDetailedResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id353
+          headers: *id358
           content:
             application/json:
               schema:
@@ -57277,7 +58119,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id353
+          headers: *id358
           content:
             application/json:
               schema:
@@ -57299,7 +58141,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id353
+          headers: *id358
           content:
             application/json:
               schema:
@@ -57430,7 +58272,7 @@ paths:
       responses:
         '200':
           description: Cost timeline
-          headers: &id354
+          headers: &id359
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57446,7 +58288,7 @@ paths:
                 $ref: '#/components/schemas/CostTimelineResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id354
+          headers: *id359
           content:
             application/json:
               schema:
@@ -57466,7 +58308,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id354
+          headers: *id359
           content:
             application/json:
               schema:
@@ -57488,7 +58330,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id354
+          headers: *id359
           content:
             application/json:
               schema:
@@ -57536,7 +58378,7 @@ paths:
       responses:
         '200':
           description: Usage data
-          headers: &id355
+          headers: &id360
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -57552,7 +58394,7 @@ paths:
                 $ref: '#/components/schemas/CostUsageResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id355
+          headers: *id360
           content:
             application/json:
               schema:
@@ -57572,7 +58414,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id355
+          headers: *id360
           content:
             application/json:
               schema:
@@ -57594,7 +58436,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id355
+          headers: *id360
           content:
             application/json:
               schema:
@@ -58260,7 +59102,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker status with state and failure count
-          headers: &id356
+          headers: &id361
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58300,7 +59142,7 @@ paths:
       responses:
         '200':
           description: Circuit breaker reset confirmation
-          headers: *id356
+          headers: *id361
           content:
             application/json:
               schema:
@@ -58642,7 +59484,7 @@ paths:
       responses:
         '200':
           description: CVE details
-          headers: &id357
+          headers: &id362
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58658,7 +59500,7 @@ paths:
                 $ref: '#/components/schemas/CodebaseCVEResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id357
+          headers: *id362
           content:
             application/json:
               schema:
@@ -58678,7 +59520,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id357
+          headers: *id362
           content:
             application/json:
               schema:
@@ -58700,7 +59542,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id357
+          headers: *id362
           content:
             application/json:
               schema:
@@ -58716,7 +59558,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id357
+          headers: *id362
           content:
             application/json:
               schema:
@@ -58763,7 +59605,7 @@ paths:
       responses:
         '200':
           description: Activity feed
-          headers: &id358
+          headers: &id363
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58798,7 +59640,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id358
+          headers: *id363
           content:
             application/json:
               schema:
@@ -58818,7 +59660,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id358
+          headers: *id363
           content:
             application/json:
               schema:
@@ -58899,7 +59741,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id359
+          headers: &id364
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -58935,7 +59777,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id359
+          headers: *id364
           content:
             application/json:
               schema:
@@ -58955,7 +59797,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id359
+          headers: *id364
           content:
             application/json:
               schema:
@@ -58971,7 +59813,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id359
+          headers: *id364
           content:
             application/json:
               schema:
@@ -59123,7 +59965,7 @@ paths:
       responses:
         '200':
           description: Inbox summary
-          headers: &id360
+          headers: &id365
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59148,7 +59990,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id360
+          headers: *id365
           content:
             application/json:
               schema:
@@ -59168,7 +60010,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id360
+          headers: *id365
           content:
             application/json:
               schema:
@@ -59194,7 +60036,7 @@ paths:
       responses:
         '200':
           description: Labels list
-          headers: &id361
+          headers: &id366
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59224,7 +60066,7 @@ paths:
                           type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id361
+          headers: *id366
           content:
             application/json:
               schema:
@@ -59244,7 +60086,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id361
+          headers: *id366
           content:
             application/json:
               schema:
@@ -59270,7 +60112,7 @@ paths:
       responses:
         '200':
           description: Dashboard overview data
-          headers: &id362
+          headers: &id367
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59309,7 +60151,7 @@ paths:
                     - unhealthy
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id362
+          headers: *id367
           content:
             application/json:
               schema:
@@ -59329,7 +60171,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id362
+          headers: *id367
           content:
             application/json:
               schema:
@@ -59355,7 +60197,7 @@ paths:
       responses:
         '200':
           description: Pending actions
-          headers: &id363
+          headers: &id368
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59390,7 +60232,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id363
+          headers: *id368
           content:
             application/json:
               schema:
@@ -59410,7 +60252,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id363
+          headers: *id368
           content:
             application/json:
               schema:
@@ -59442,7 +60284,7 @@ paths:
       responses:
         '200':
           description: Action completed
-          headers: &id364
+          headers: &id369
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59466,7 +60308,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id364
+          headers: *id369
           content:
             application/json:
               schema:
@@ -59486,7 +60328,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id364
+          headers: *id369
           content:
             application/json:
               schema:
@@ -59502,7 +60344,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id364
+          headers: *id369
           content:
             application/json:
               schema:
@@ -59528,7 +60370,7 @@ paths:
       responses:
         '200':
           description: Quality metrics
-          headers: &id365
+          headers: &id370
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59553,7 +60395,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id365
+          headers: *id370
           content:
             application/json:
               schema:
@@ -59573,7 +60415,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id365
+          headers: *id370
           content:
             application/json:
               schema:
@@ -59599,7 +60441,7 @@ paths:
       responses:
         '200':
           description: Quick actions
-          headers: &id366
+          headers: &id371
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59629,7 +60471,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id366
+          headers: *id371
           content:
             application/json:
               schema:
@@ -59649,7 +60491,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id366
+          headers: *id371
           content:
             application/json:
               schema:
@@ -59681,7 +60523,7 @@ paths:
       responses:
         '200':
           description: Action executed
-          headers: &id367
+          headers: &id372
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59704,7 +60546,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id367
+          headers: *id372
           content:
             application/json:
               schema:
@@ -59724,7 +60566,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id367
+          headers: *id372
           content:
             application/json:
               schema:
@@ -59740,7 +60582,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id367
+          headers: *id372
           content:
             application/json:
               schema:
@@ -59772,7 +60614,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id368
+          headers: &id373
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59808,7 +60650,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id368
+          headers: *id373
           content:
             application/json:
               schema:
@@ -59828,7 +60670,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id368
+          headers: *id373
           content:
             application/json:
               schema:
@@ -59854,7 +60696,7 @@ paths:
       responses:
         '200':
           description: Stat cards
-          headers: &id369
+          headers: &id374
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59888,7 +60730,7 @@ paths:
                           - stable
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id369
+          headers: *id374
           content:
             application/json:
               schema:
@@ -59908,7 +60750,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id369
+          headers: *id374
           content:
             application/json:
               schema:
@@ -59934,7 +60776,7 @@ paths:
       responses:
         '200':
           description: Dashboard statistics
-          headers: &id370
+          headers: &id375
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -59961,7 +60803,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id370
+          headers: *id375
           content:
             application/json:
               schema:
@@ -59981,7 +60823,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id370
+          headers: *id375
           content:
             application/json:
               schema:
@@ -60007,7 +60849,7 @@ paths:
       responses:
         '200':
           description: Team performance
-          headers: &id371
+          headers: &id376
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60037,7 +60879,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id371
+          headers: *id376
           content:
             application/json:
               schema:
@@ -60057,7 +60899,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id371
+          headers: *id376
           content:
             application/json:
               schema:
@@ -60089,7 +60931,7 @@ paths:
       responses:
         '200':
           description: Team performance detail
-          headers: &id372
+          headers: &id377
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60120,7 +60962,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id372
+          headers: *id377
           content:
             application/json:
               schema:
@@ -60140,7 +60982,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id372
+          headers: *id377
           content:
             application/json:
               schema:
@@ -60156,7 +60998,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id372
+          headers: *id377
           content:
             application/json:
               schema:
@@ -60182,7 +61024,7 @@ paths:
       responses:
         '200':
           description: Top senders
-          headers: &id373
+          headers: &id378
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60212,7 +61054,7 @@ paths:
                           type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id373
+          headers: *id378
           content:
             application/json:
               schema:
@@ -60232,7 +61074,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id373
+          headers: *id378
           content:
             application/json:
               schema:
@@ -60258,7 +61100,7 @@ paths:
       responses:
         '200':
           description: Urgent items
-          headers: &id374
+          headers: &id379
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60293,7 +61135,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id374
+          headers: *id379
           content:
             application/json:
               schema:
@@ -60313,7 +61155,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id374
+          headers: *id379
           content:
             application/json:
               schema:
@@ -60345,7 +61187,7 @@ paths:
       responses:
         '200':
           description: Item dismissed
-          headers: &id375
+          headers: &id380
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60366,7 +61208,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id375
+          headers: *id380
           content:
             application/json:
               schema:
@@ -60386,7 +61228,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id375
+          headers: *id380
           content:
             application/json:
               schema:
@@ -60402,7 +61244,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id375
+          headers: *id380
           content:
             application/json:
               schema:
@@ -60463,7 +61305,7 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: &id376
+          headers: &id381
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60479,7 +61321,7 @@ paths:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id376
+          headers: *id381
           content:
             application/json:
               schema:
@@ -60507,7 +61349,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id376
+          headers: *id381
           content:
             application/json:
               schema:
@@ -60636,7 +61478,7 @@ paths:
       responses:
         '200':
           description: Meta-critique
-          headers: &id377
+          headers: &id382
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60675,7 +61517,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id377
+          headers: *id382
           content:
             application/json:
               schema:
@@ -60745,7 +61587,7 @@ paths:
       responses:
         '200':
           description: Paginated list of debates
-          headers: &id378
+          headers: &id383
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -60767,9 +61609,9 @@ paths:
                   count:
                     type: integer
                     description: Total number of debates matching filters
-        '401': &id379
+        '401': &id384
           description: Unauthorized - Authentication required or token invalid
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
@@ -60787,9 +61629,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '429': &id380
+        '429': &id385
           description: Too many requests - Rate limit exceeded
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
@@ -60865,14 +61707,14 @@ paths:
       responses:
         '200':
           description: Debate created successfully
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DebateCreateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
@@ -60898,10 +61740,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id379
+        '401': *id384
         '402':
           description: Payment required - Quota exceeded, upgrade required
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
@@ -60917,10 +61759,10 @@ paths:
                     resets_at: '2024-01-16T00:00:00Z'
                     upgrade_url: https://aragora.ai/pricing
                     trace_id: req_abc123xyz
-        '429': *id380
+        '429': *id385
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id378
+          headers: *id383
           content:
             application/json:
               schema:
@@ -61271,7 +62113,7 @@ paths:
       responses:
         '200':
           description: Batch submitted
-          headers: &id381
+          headers: &id386
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61298,7 +62140,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id381
+          headers: *id386
           content:
             application/json:
               schema:
@@ -61341,7 +62183,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id382
+          headers: &id387
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61372,7 +62214,7 @@ paths:
                       type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id382
+          headers: *id387
           content:
             application/json:
               schema:
@@ -61592,7 +62434,7 @@ paths:
       responses:
         '200':
           description: Cost estimate
-          headers: &id383
+          headers: &id388
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61608,7 +62450,7 @@ paths:
                 $ref: '#/components/schemas/DebateCostEstimateResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id383
+          headers: *id388
           content:
             application/json:
               schema:
@@ -61913,7 +62755,7 @@ paths:
       responses:
         '200':
           description: Debate graph
-          headers: &id384
+          headers: &id389
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -61940,7 +62782,7 @@ paths:
                     type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id384
+          headers: *id389
           content:
             application/json:
               schema:
@@ -62143,7 +62985,7 @@ paths:
       responses:
         '200':
           description: Matrix comparison
-          headers: &id385
+          headers: &id390
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62178,7 +63020,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id385
+          headers: *id390
           content:
             application/json:
               schema:
@@ -62397,7 +63239,7 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: &id386
+          headers: &id391
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62413,7 +63255,7 @@ paths:
                 $ref: '#/components/schemas/Debate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id386
+          headers: *id391
           content:
             application/json:
               schema:
@@ -62696,7 +63538,7 @@ paths:
       responses:
         '200':
           description: Counterfactuals
-          headers: &id387
+          headers: &id392
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62712,7 +63554,7 @@ paths:
                 $ref: '#/components/schemas/Counterfactuals'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id387
+          headers: *id392
           content:
             application/json:
               schema:
@@ -62750,7 +63592,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id388
+          headers: &id393
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62766,7 +63608,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id388
+          headers: *id393
           content:
             application/json:
               schema:
@@ -62880,7 +63722,7 @@ paths:
       responses:
         '200':
           description: Argument injected
-          headers: &id389
+          headers: &id394
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -62907,7 +63749,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id389
+          headers: *id394
           content:
             application/json:
               schema:
@@ -62935,7 +63777,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id389
+          headers: *id394
           content:
             application/json:
               schema:
@@ -62979,7 +63821,7 @@ paths:
       responses:
         '200':
           description: Intervention log
-          headers: &id390
+          headers: &id395
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63004,7 +63846,7 @@ paths:
                       type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id390
+          headers: *id395
           content:
             application/json:
               schema:
@@ -63042,7 +63884,7 @@ paths:
       responses:
         '200':
           description: Debate paused
-          headers: &id391
+          headers: &id396
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63068,7 +63910,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id391
+          headers: *id396
           content:
             application/json:
               schema:
@@ -63096,7 +63938,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id391
+          headers: *id396
           content:
             application/json:
               schema:
@@ -63134,7 +63976,7 @@ paths:
       responses:
         '200':
           description: Debate resumed
-          headers: &id392
+          headers: &id397
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63164,7 +64006,7 @@ paths:
                     - 'null'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id392
+          headers: *id397
           content:
             application/json:
               schema:
@@ -63192,7 +64034,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id392
+          headers: *id397
           content:
             application/json:
               schema:
@@ -63230,7 +64072,7 @@ paths:
       responses:
         '200':
           description: Intervention state
-          headers: &id393
+          headers: &id398
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63262,7 +64104,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id393
+          headers: *id398
           content:
             application/json:
               schema:
@@ -63306,7 +64148,7 @@ paths:
       responses:
         '200':
           description: Threshold updated
-          headers: &id394
+          headers: &id399
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63331,7 +64173,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id394
+          headers: *id399
           content:
             application/json:
               schema:
@@ -63359,7 +64201,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id394
+          headers: *id399
           content:
             application/json:
               schema:
@@ -63403,7 +64245,7 @@ paths:
       responses:
         '200':
           description: Weight updated
-          headers: &id395
+          headers: &id400
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63430,7 +64272,7 @@ paths:
                     type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id395
+          headers: *id400
           content:
             application/json:
               schema:
@@ -63458,7 +64300,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id395
+          headers: *id400
           content:
             application/json:
               schema:
@@ -63581,7 +64423,7 @@ paths:
       responses:
         '200':
           description: Summary
-          headers: &id396
+          headers: &id401
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63597,7 +64439,7 @@ paths:
                 $ref: '#/components/schemas/DebateSummary'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id396
+          headers: *id401
           content:
             application/json:
               schema:
@@ -63633,7 +64475,7 @@ paths:
       responses:
         '200':
           description: Vote pivots
-          headers: &id397
+          headers: &id402
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63649,7 +64491,7 @@ paths:
                 $ref: '#/components/schemas/VotePivots'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id397
+          headers: *id402
           content:
             application/json:
               schema:
@@ -63680,7 +64522,7 @@ paths:
       responses:
         '200':
           description: Delete result
-          headers: &id398
+          headers: &id403
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63697,9 +64539,9 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': &id399
+        '404': &id404
           description: Not found - The requested resource does not exist
-          headers: *id398
+          headers: *id403
           content:
             application/json:
               schema:
@@ -63748,15 +64590,15 @@ paths:
       responses:
         '200':
           description: Debate details
-          headers: *id398
+          headers: *id403
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Debate'
-        '404': *id399
+        '404': *id404
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id398
+          headers: *id403
           content:
             application/json:
               schema:
@@ -63842,7 +64684,7 @@ paths:
       responses:
         '200':
           description: Archive result
-          headers: &id400
+          headers: &id405
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63861,7 +64703,7 @@ paths:
                     type: boolean
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id400
+          headers: *id405
           content:
             application/json:
               schema:
@@ -63977,7 +64819,7 @@ paths:
       responses:
         '200':
           description: Cancel result
-          headers: &id401
+          headers: &id406
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -63998,7 +64840,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id401
+          headers: *id406
           content:
             application/json:
               schema:
@@ -64106,7 +64948,7 @@ paths:
       responses:
         '200':
           description: Clone result
-          headers: &id402
+          headers: &id407
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64125,7 +64967,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id402
+          headers: *id407
           content:
             application/json:
               schema:
@@ -64156,7 +64998,7 @@ paths:
       responses:
         '200':
           description: Consensus data
-          headers: &id403
+          headers: &id408
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64185,7 +65027,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id403
+          headers: *id408
           content:
             application/json:
               schema:
@@ -64351,7 +65193,7 @@ paths:
       responses:
         '200':
           description: Diagnostic report
-          headers: &id404
+          headers: &id409
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64467,7 +65309,7 @@ paths:
                   - Consider adding OPENROUTER_API_KEY as fallback for failed providers
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id404
+          headers: *id409
           content:
             application/json:
               schema:
@@ -64483,7 +65325,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id404
+          headers: *id409
           content:
             application/json:
               schema:
@@ -64564,7 +65406,7 @@ paths:
       responses:
         '200':
           description: Evidence chain
-          headers: &id405
+          headers: &id410
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64580,7 +65422,7 @@ paths:
                 $ref: '#/components/schemas/EvidenceChain'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id405
+          headers: *id410
           content:
             application/json:
               schema:
@@ -64611,7 +65453,7 @@ paths:
       responses:
         '200':
           description: Explainability data
-          headers: &id406
+          headers: &id411
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64638,7 +65480,7 @@ paths:
                     type: number
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id406
+          headers: *id411
           content:
             application/json:
               schema:
@@ -64669,7 +65511,7 @@ paths:
       responses:
         '200':
           description: Counterfactual scenarios
-          headers: &id407
+          headers: &id412
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64695,9 +65537,9 @@ paths:
                           type: string
                         probability:
                           type: number
-        '404': &id408
+        '404': &id413
           description: Not found - The requested resource does not exist
-          headers: *id407
+          headers: *id412
           content:
             application/json:
               schema:
@@ -64733,7 +65575,7 @@ paths:
       responses:
         '200':
           description: Counterfactual result
-          headers: *id407
+          headers: *id412
           content:
             application/json:
               schema:
@@ -64749,7 +65591,7 @@ paths:
                       type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id407
+          headers: *id412
           content:
             application/json:
               schema:
@@ -64775,7 +65617,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id408
+        '404': *id413
       x-aragora-stability: experimental
   /api/v1/debates/{id}/explainability/factors:
     get:
@@ -64793,7 +65635,7 @@ paths:
       responses:
         '200':
           description: Factors
-          headers: &id409
+          headers: &id414
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64825,7 +65667,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id409
+          headers: *id414
           content:
             application/json:
               schema:
@@ -64856,7 +65698,7 @@ paths:
       responses:
         '200':
           description: Narrative
-          headers: &id410
+          headers: &id415
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64881,7 +65723,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id410
+          headers: *id415
           content:
             application/json:
               schema:
@@ -64912,7 +65754,7 @@ paths:
       responses:
         '200':
           description: Provenance
-          headers: &id411
+          headers: &id416
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -64944,7 +65786,7 @@ paths:
                           type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id411
+          headers: *id416
           content:
             application/json:
               schema:
@@ -65033,7 +65875,7 @@ paths:
       responses:
         '200':
           description: Follow-up created
-          headers: &id412
+          headers: &id417
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65052,7 +65894,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id412
+          headers: *id417
           content:
             application/json:
               schema:
@@ -65095,7 +65937,7 @@ paths:
       responses:
         '201':
           description: Forked debate created
-          headers: &id413
+          headers: &id418
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65118,7 +65960,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id413
+          headers: *id418
           content:
             application/json:
               schema:
@@ -65291,7 +66133,7 @@ paths:
       responses:
         '200':
           description: Joined debate
-          headers: &id414
+          headers: &id419
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65316,7 +66158,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id414
+          headers: *id419
           content:
             application/json:
               schema:
@@ -65412,7 +66254,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id415
+          headers: &id420
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65428,7 +66270,7 @@ paths:
                 $ref: '#/components/schemas/Message'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id415
+          headers: *id420
           content:
             application/json:
               schema:
@@ -65456,7 +66298,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id415
+          headers: *id420
           content:
             application/json:
               schema:
@@ -65560,7 +66402,7 @@ paths:
       responses:
         '200':
           description: Pause result
-          headers: &id416
+          headers: &id421
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65581,7 +66423,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id416
+          headers: *id421
           content:
             application/json:
               schema:
@@ -65734,7 +66576,7 @@ paths:
       responses:
         '200':
           description: Resume result
-          headers: &id417
+          headers: &id422
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65755,7 +66597,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id417
+          headers: *id422
           content:
             application/json:
               schema:
@@ -65786,7 +66628,7 @@ paths:
       responses:
         '200':
           description: Rhetorical analysis
-          headers: &id418
+          headers: &id423
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65811,7 +66653,7 @@ paths:
                     type: object
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id418
+          headers: *id423
           content:
             application/json:
               schema:
@@ -65842,7 +66684,7 @@ paths:
       responses:
         '200':
           description: Start result
-          headers: &id419
+          headers: &id424
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65863,7 +66705,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id419
+          headers: *id424
           content:
             application/json:
               schema:
@@ -65894,7 +66736,7 @@ paths:
       responses:
         '200':
           description: Stop result
-          headers: &id420
+          headers: &id425
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65915,7 +66757,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id420
+          headers: *id425
           content:
             application/json:
               schema:
@@ -65952,7 +66794,7 @@ paths:
       responses:
         '200':
           description: Suggestion recorded
-          headers: &id421
+          headers: &id426
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -65975,7 +66817,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id421
+          headers: *id426
           content:
             application/json:
               schema:
@@ -66003,7 +66845,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id421
+          headers: *id426
           content:
             application/json:
               schema:
@@ -66019,6 +66861,81 @@ paths:
                     trace_id: req_abc123xyz
       security:
       - bearerAuth: []
+      x-aragora-stability: experimental
+  /api/v1/debates/{id}/to-pipeline:
+    post:
+      tags:
+      - Pipeline
+      summary: Convert debate to pipeline
+      operationId: convertDebateToPipeline
+      description: Load a completed debate's argument graph and create a pipeline from it.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Debate ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                use_universal:
+                  type: boolean
+                auto_advance:
+                  type: boolean
+      responses:
+        '201':
+          description: Pipeline created from debate
+          content:
+            application/json:
+              schema:
+                type: object
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: &id427
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id427
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
   /api/v1/debates/{id}/trickster:
     get:
@@ -66036,7 +66953,7 @@ paths:
       responses:
         '200':
           description: Trickster status
-          headers: &id422
+          headers: &id428
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66067,7 +66984,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id422
+          headers: *id428
           content:
             application/json:
               schema:
@@ -66104,7 +67021,7 @@ paths:
       responses:
         '200':
           description: Debate updated
-          headers: &id423
+          headers: &id429
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66129,7 +67046,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id423
+          headers: *id429
           content:
             application/json:
               schema:
@@ -66157,7 +67074,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id423
+          headers: *id429
           content:
             application/json:
               schema:
@@ -66207,7 +67124,7 @@ paths:
       responses:
         '200':
           description: User input added
-          headers: &id424
+          headers: &id430
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66228,7 +67145,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id424
+          headers: *id430
           content:
             application/json:
               schema:
@@ -66256,7 +67173,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id424
+          headers: *id430
           content:
             application/json:
               schema:
@@ -66287,7 +67204,7 @@ paths:
       responses:
         '200':
           description: Verification report
-          headers: &id425
+          headers: &id431
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66324,7 +67241,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id425
+          headers: *id431
           content:
             application/json:
               schema:
@@ -66367,7 +67284,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id426
+          headers: &id432
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66400,7 +67317,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id426
+          headers: *id432
           content:
             application/json:
               schema:
@@ -66428,7 +67345,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id426
+          headers: *id432
           content:
             application/json:
               schema:
@@ -66465,7 +67382,7 @@ paths:
       responses:
         '200':
           description: Vote recorded
-          headers: &id427
+          headers: &id433
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -66490,7 +67407,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id427
+          headers: *id433
           content:
             application/json:
               schema:
@@ -66518,7 +67435,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id427
+          headers: *id433
           content:
             application/json:
               schema:
@@ -67014,7 +67931,7 @@ paths:
       summary: List decisions
       operationId: listDecisions
       description: List recent decision records (most recent first).
-      security: &id429
+      security: &id435
       - {}
       parameters:
       - name: limit
@@ -67026,7 +67943,7 @@ paths:
       responses:
         '200':
           description: Decision list
-          headers: &id428
+          headers: &id434
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67040,9 +67957,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionList'
-        '500': &id430
+        '500': &id436
           description: Internal server error - Unexpected error occurred
-          headers: *id428
+          headers: *id434
           content:
             application/json:
               schema:
@@ -67062,7 +67979,7 @@ paths:
       summary: Create decision
       operationId: createDecisions
       description: Submit a decision request for debate, workflow, or gauntlet routing.
-      security: *id429
+      security: *id435
       requestBody:
         required: true
         content:
@@ -67072,14 +67989,14 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: *id428
+          headers: *id434
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DecisionResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id428
+          headers: *id434
           content:
             application/json:
               schema:
@@ -67105,7 +68022,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id430
+        '500': *id436
       x-aragora-stability: stable
   /api/v1/decisions/plans:
     post:
@@ -67258,7 +68175,7 @@ paths:
       responses:
         '200':
           description: Decision result
-          headers: &id431
+          headers: &id437
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67274,7 +68191,7 @@ paths:
                 $ref: '#/components/schemas/DecisionResult'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id431
+          headers: *id437
           content:
             application/json:
               schema:
@@ -67290,7 +68207,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id431
+          headers: *id437
           content:
             application/json:
               schema:
@@ -67322,7 +68239,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id432
+          headers: &id438
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67358,7 +68275,7 @@ paths:
                     description: Alternative outcomes under different conditions
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id432
+          headers: *id438
           content:
             application/json:
               schema:
@@ -67374,7 +68291,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id432
+          headers: *id438
           content:
             application/json:
               schema:
@@ -67406,7 +68323,7 @@ paths:
       responses:
         '200':
           description: Decision status
-          headers: &id433
+          headers: &id439
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67422,7 +68339,7 @@ paths:
                 $ref: '#/components/schemas/DecisionStatus'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id433
+          headers: *id439
           content:
             application/json:
               schema:
@@ -67687,7 +68604,7 @@ paths:
       responses:
         '200':
           description: Registered devices
-          headers: &id434
+          headers: &id440
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67722,7 +68639,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id434
+          headers: *id440
           content:
             application/json:
               schema:
@@ -67843,7 +68760,7 @@ paths:
       responses:
         '200':
           description: Shortcuts response
-          headers: &id435
+          headers: &id441
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -67864,7 +68781,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id435
+          headers: *id441
           content:
             application/json:
               schema:
@@ -68030,7 +68947,7 @@ paths:
       responses:
         '201':
           description: Device registered
-          headers: &id436
+          headers: &id442
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68054,7 +68971,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id436
+          headers: *id442
           content:
             application/json:
               schema:
@@ -68111,7 +69028,7 @@ paths:
       responses:
         '200':
           description: Device details
-          headers: &id437
+          headers: &id443
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -68140,9 +69057,9 @@ paths:
                     type: string
                   metadata:
                     type: object
-        '404': &id438
+        '404': &id444
           description: Not found - The requested resource does not exist
-          headers: *id437
+          headers: *id443
           content:
             application/json:
               schema:
@@ -68186,7 +69103,7 @@ paths:
       responses:
         '200':
           description: Device unregistered
-          headers: *id437
+          headers: *id443
           content:
             application/json:
               schema:
@@ -68194,7 +69111,7 @@ paths:
                 properties:
                   success:
                     type: boolean
-        '404': *id438
+        '404': *id444
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -71012,7 +71929,7 @@ paths:
       responses:
         '200':
           description: Decision explanation
-          headers: &id439
+          headers: &id445
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71028,7 +71945,7 @@ paths:
                 $ref: '#/components/schemas/DecisionExplanation'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id439
+          headers: *id445
           content:
             application/json:
               schema:
@@ -71044,7 +71961,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id439
+          headers: *id445
           content:
             application/json:
               schema:
@@ -71087,7 +72004,7 @@ paths:
       responses:
         '200':
           description: Batch created
-          headers: &id440
+          headers: &id446
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71103,7 +72020,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatch'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id440
+          headers: *id446
           content:
             application/json:
               schema:
@@ -71146,7 +72063,7 @@ paths:
       responses:
         '200':
           description: Batch results
-          headers: &id441
+          headers: &id447
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71162,7 +72079,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchResults'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id441
+          headers: *id447
           content:
             application/json:
               schema:
@@ -71213,7 +72130,7 @@ paths:
       responses:
         '200':
           description: Batch status
-          headers: &id442
+          headers: &id448
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -71229,7 +72146,7 @@ paths:
                 $ref: '#/components/schemas/ExplainabilityBatchStatus'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id442
+          headers: *id448
           content:
             application/json:
               schema:
@@ -72070,7 +72987,7 @@ paths:
                 properties:
                   channels:
                     type: array
-                    items: &id444
+                    items: &id450
                       type: object
                       properties:
                         name:
@@ -72084,9 +73001,9 @@ paths:
                           description: Channel availability status
                   total:
                     type: integer
-        '401': &id445
+        '401': &id451
           description: Unauthorized - Authentication required or token invalid
-          headers: &id443
+          headers: &id449
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72113,9 +73030,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id446
+        '403': &id452
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id443
+          headers: *id449
           content:
             application/json:
               schema:
@@ -72135,9 +73052,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id447
+        '500': &id453
           description: Internal server error - Unexpected error occurred
-          headers: *id443
+          headers: *id449
           content:
             application/json:
               schema:
@@ -72183,12 +73100,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  channel: *id444
+                  channel: *id450
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id443
+          headers: *id449
           content:
             application/json:
               schema:
@@ -72214,9 +73131,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id445
-        '403': *id446
-        '500': *id447
+        '401': *id451
+        '403': *id452
+        '500': *id453
       x-aragora-stability: experimental
   /api/v1/gateway/config:
     post:
@@ -72374,9 +73291,9 @@ paths:
                           description: Arbitrary key-value metadata
                   total:
                     type: integer
-        '401': &id449
+        '401': &id455
           description: Unauthorized - Authentication required or token invalid
-          headers: &id448
+          headers: &id454
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72403,9 +73320,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id450
+        '403': &id456
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id448
+          headers: *id454
           content:
             application/json:
               schema:
@@ -72425,9 +73342,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id451
+        '500': &id457
           description: Internal server error - Unexpected error occurred
-          headers: *id448
+          headers: *id454
           content:
             application/json:
               schema:
@@ -72494,7 +73411,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id448
+          headers: *id454
           content:
             application/json:
               schema:
@@ -72520,9 +73437,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id449
-        '403': *id450
-        '500': *id451
+        '401': *id455
+        '403': *id456
+        '500': *id457
       x-aragora-stability: stable
   /api/v1/gateway/devices/{device_id}:
     get:
@@ -72532,7 +73449,7 @@ paths:
       description: Retrieve full details for a specific registered device, including allowed channels and metadata.
       operationId: getGatewayDevice
       parameters:
-      - &id453
+      - &id459
         name: device_id
         in: path
         required: true
@@ -72547,7 +73464,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: &id454
+                  device: &id460
                     type: object
                     properties:
                       device_id:
@@ -72588,9 +73505,9 @@ paths:
                       metadata:
                         type: object
                         description: Arbitrary key-value metadata
-        '401': &id455
+        '401': &id461
           description: Unauthorized - Authentication required or token invalid
-          headers: &id452
+          headers: &id458
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72617,9 +73534,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id456
+        '403': &id462
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id452
+          headers: *id458
           content:
             application/json:
               schema:
@@ -72639,9 +73556,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id457
+        '404': &id463
           description: Not found - The requested resource does not exist
-          headers: *id452
+          headers: *id458
           content:
             application/json:
               schema:
@@ -72655,9 +73572,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id458
+        '500': &id464
           description: Internal server error - Unexpected error occurred
-          headers: *id452
+          headers: *id458
           content:
             application/json:
               schema:
@@ -72678,7 +73595,7 @@ paths:
       description: Update the configuration of an existing registered device.
       operationId: updateGatewayDevice
       parameters:
-      - *id453
+      - *id459
       requestBody:
         required: true
         content:
@@ -72713,12 +73630,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  device: *id454
+                  device: *id460
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id452
+          headers: *id458
           content:
             application/json:
               schema:
@@ -72744,10 +73661,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id455
-        '403': *id456
-        '404': *id457
-        '500': *id458
+        '401': *id461
+        '403': *id462
+        '404': *id463
+        '500': *id464
       x-aragora-stability: experimental
     delete:
       tags:
@@ -72756,7 +73673,7 @@ paths:
       description: Remove a device from the gateway registry. This is irreversible.
       operationId: deleteGatewayDevice
       parameters:
-      - *id453
+      - *id459
       responses:
         '200':
           description: Device unregistered
@@ -72767,10 +73684,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id455
-        '403': *id456
-        '404': *id457
-        '500': *id458
+        '401': *id461
+        '403': *id462
+        '404': *id463
+        '500': *id464
       x-aragora-stability: stable
   /api/v1/gateway/health:
     get:
@@ -72871,9 +73788,9 @@ paths:
                           description: Message delivery status
                   total:
                     type: integer
-        '401': &id460
+        '401': &id466
           description: Unauthorized - Authentication required or token invalid
-          headers: &id459
+          headers: &id465
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -72900,9 +73817,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id461
+        '403': &id467
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id459
+          headers: *id465
           content:
             application/json:
               schema:
@@ -72922,9 +73839,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id462
+        '500': &id468
           description: Internal server error - Unexpected error occurred
-          headers: *id459
+          headers: *id465
           content:
             application/json:
               schema:
@@ -72981,7 +73898,7 @@ paths:
                     description: Routing rule that matched
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id459
+          headers: *id465
           content:
             application/json:
               schema:
@@ -73007,9 +73924,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id460
-        '403': *id461
-        '500': *id462
+        '401': *id466
+        '403': *id467
+        '500': *id468
       x-aragora-stability: stable
   /api/v1/gateway/messages/route:
     delete:
@@ -73057,7 +73974,7 @@ paths:
       description: Retrieve the full details and routing information for a specific message.
       operationId: getGatewayMessage
       parameters:
-      - &id464
+      - &id470
         name: message_id
         in: path
         required: true
@@ -73102,9 +74019,9 @@ paths:
                         - delivered
                         - failed
                         description: Message delivery status
-        '401': &id465
+        '401': &id471
           description: Unauthorized - Authentication required or token invalid
-          headers: &id463
+          headers: &id469
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73131,9 +74048,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id466
+        '403': &id472
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id463
+          headers: *id469
           content:
             application/json:
               schema:
@@ -73153,9 +74070,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id467
+        '404': &id473
           description: Not found - The requested resource does not exist
-          headers: *id463
+          headers: *id469
           content:
             application/json:
               schema:
@@ -73169,9 +74086,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id468
+        '500': &id474
           description: Internal server error - Unexpected error occurred
-          headers: *id463
+          headers: *id469
           content:
             application/json:
               schema:
@@ -73192,7 +74109,7 @@ paths:
       description: Delete a routed message from the gateway message log.
       operationId: deleteGatewayMessage
       parameters:
-      - *id464
+      - *id470
       responses:
         '200':
           description: Message deleted
@@ -73203,10 +74120,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id465
-        '403': *id466
-        '404': *id467
-        '500': *id468
+        '401': *id471
+        '403': *id472
+        '404': *id473
+        '500': *id474
       x-aragora-stability: experimental
   /api/v1/gateway/openclaw/actions:
     delete:
@@ -73453,7 +74370,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id470
+                    items: &id476
                       type: object
                       properties:
                         id:
@@ -73486,9 +74403,9 @@ paths:
                       routing_errors:
                         type: integer
                     description: Aggregate routing statistics
-        '401': &id471
+        '401': &id477
           description: Unauthorized - Authentication required or token invalid
-          headers: &id469
+          headers: &id475
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73515,9 +74432,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id472
+        '403': &id478
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id469
+          headers: *id475
           content:
             application/json:
               schema:
@@ -73537,9 +74454,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id473
+        '500': &id479
           description: Internal server error - Unexpected error occurred
-          headers: *id469
+          headers: *id475
           content:
             application/json:
               schema:
@@ -73595,12 +74512,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id470
+                  rule: *id476
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id469
+          headers: *id475
           content:
             application/json:
               schema:
@@ -73626,9 +74543,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id471
-        '403': *id472
-        '500': *id473
+        '401': *id477
+        '403': *id478
+        '500': *id479
       x-aragora-stability: stable
   /api/v1/gateway/routing/rules:
     delete:
@@ -73714,7 +74631,7 @@ paths:
       description: Retrieve details for a specific routing rule.
       operationId: getGatewayRoutingRule
       parameters:
-      - &id475
+      - &id481
         name: route_id
         in: path
         required: true
@@ -73729,7 +74646,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: &id476
+                  rule: &id482
                     type: object
                     properties:
                       id:
@@ -73750,9 +74667,9 @@ paths:
                       enabled:
                         type: boolean
                         description: Whether the rule is active
-        '401': &id477
+        '401': &id483
           description: Unauthorized - Authentication required or token invalid
-          headers: &id474
+          headers: &id480
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -73779,9 +74696,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id478
+        '403': &id484
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id474
+          headers: *id480
           content:
             application/json:
               schema:
@@ -73801,9 +74718,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id479
+        '404': &id485
           description: Not found - The requested resource does not exist
-          headers: *id474
+          headers: *id480
           content:
             application/json:
               schema:
@@ -73817,9 +74734,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id480
+        '500': &id486
           description: Internal server error - Unexpected error occurred
-          headers: *id474
+          headers: *id480
           content:
             application/json:
               schema:
@@ -73840,7 +74757,7 @@ paths:
       description: Update an existing routing rule configuration.
       operationId: updateGatewayRoutingRule
       parameters:
-      - *id475
+      - *id481
       requestBody:
         required: true
         content:
@@ -73871,12 +74788,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id476
+                  rule: *id482
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id474
+          headers: *id480
           content:
             application/json:
               schema:
@@ -73902,10 +74819,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id477
-        '403': *id478
-        '404': *id479
-        '500': *id480
+        '401': *id483
+        '403': *id484
+        '404': *id485
+        '500': *id486
       x-aragora-stability: experimental
     delete:
       tags:
@@ -73914,7 +74831,7 @@ paths:
       description: Remove a routing rule from the gateway. Messages will no longer match this rule.
       operationId: deleteGatewayRoutingRule
       parameters:
-      - *id475
+      - *id481
       responses:
         '200':
           description: Routing rule deleted
@@ -73925,10 +74842,10 @@ paths:
                 properties:
                   message:
                     type: string
-        '401': *id477
-        '403': *id478
-        '404': *id479
-        '500': *id480
+        '401': *id483
+        '403': *id484
+        '404': *id485
+        '500': *id486
       x-aragora-stability: experimental
   /api/v1/gauntlet:
     get:
@@ -74003,7 +74920,7 @@ paths:
       responses:
         '200':
           description: Risk heatmap details
-          headers: &id481
+          headers: &id487
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74019,7 +74936,7 @@ paths:
                 $ref: '#/components/schemas/RiskHeatmap'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id481
+          headers: *id487
           content:
             application/json:
               schema:
@@ -74230,7 +75147,7 @@ paths:
       responses:
         '200':
           description: Bundle of exported receipts
-          headers: &id482
+          headers: &id488
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74255,7 +75172,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id482
+          headers: *id488
           content:
             application/json:
               schema:
@@ -74298,7 +75215,7 @@ paths:
       responses:
         '200':
           description: Decision receipt details
-          headers: &id483
+          headers: &id489
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74314,7 +75231,7 @@ paths:
                 $ref: '#/components/schemas/DecisionReceipt'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id483
+          headers: *id489
           content:
             application/json:
               schema:
@@ -74552,7 +75469,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run details
-          headers: &id484
+          headers: &id490
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74566,9 +75483,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GauntletRun'
-        '404': &id485
+        '404': &id491
           description: Not found - The requested resource does not exist
-          headers: *id484
+          headers: *id490
           content:
             application/json:
               schema:
@@ -74582,9 +75499,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id486
+        '500': &id492
           description: Internal server error - Unexpected error occurred
-          headers: *id484
+          headers: *id490
           content:
             application/json:
               schema:
@@ -74614,7 +75531,7 @@ paths:
       responses:
         '200':
           description: Gauntlet run deleted
-          headers: *id484
+          headers: *id490
           content:
             application/json:
               schema:
@@ -74624,8 +75541,8 @@ paths:
                     type: boolean
                   gauntlet_id:
                     type: string
-        '404': *id485
-        '500': *id486
+        '404': *id491
+        '500': *id492
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -74663,7 +75580,7 @@ paths:
       responses:
         '200':
           description: Gauntlet comparison results
-          headers: &id487
+          headers: &id493
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74679,7 +75596,7 @@ paths:
                 $ref: '#/components/schemas/GauntletComparison'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id487
+          headers: *id493
           content:
             application/json:
               schema:
@@ -74695,7 +75612,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id487
+          headers: *id493
           content:
             application/json:
               schema:
@@ -74929,7 +75846,7 @@ paths:
       responses:
         '200':
           description: Descendant genomes
-          headers: &id488
+          headers: &id494
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -74961,7 +75878,7 @@ paths:
                             type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id488
+          headers: *id494
           content:
             application/json:
               schema:
@@ -74977,7 +75894,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id488
+          headers: *id494
           content:
             application/json:
               schema:
@@ -75103,7 +76020,7 @@ paths:
       responses:
         '200':
           description: Genome details
-          headers: &id489
+          headers: &id495
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75131,7 +76048,7 @@ paths:
                     format: date-time
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id489
+          headers: *id495
           content:
             application/json:
               schema:
@@ -75147,7 +76064,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id489
+          headers: *id495
           content:
             application/json:
               schema:
@@ -75379,7 +76296,7 @@ paths:
       responses:
         '200':
           description: Issues created
-          headers: &id490
+          headers: &id496
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75395,7 +76312,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id490
+          headers: *id496
           content:
             application/json:
               schema:
@@ -75423,7 +76340,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id490
+          headers: *id496
           content:
             application/json:
               schema:
@@ -75443,7 +76360,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id490
+          headers: *id496
           content:
             application/json:
               schema:
@@ -75494,7 +76411,7 @@ paths:
       responses:
         '200':
           description: Issues created
-          headers: &id491
+          headers: &id497
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75510,7 +76427,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id491
+          headers: *id497
           content:
             application/json:
               schema:
@@ -75538,7 +76455,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id491
+          headers: *id497
           content:
             application/json:
               schema:
@@ -75558,7 +76475,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id491
+          headers: *id497
           content:
             application/json:
               schema:
@@ -75608,7 +76525,7 @@ paths:
       responses:
         '200':
           description: PR created
-          headers: &id492
+          headers: &id498
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75624,7 +76541,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id492
+          headers: *id498
           content:
             application/json:
               schema:
@@ -75652,7 +76569,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id492
+          headers: *id498
           content:
             application/json:
               schema:
@@ -75672,7 +76589,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id492
+          headers: *id498
           content:
             application/json:
               schema:
@@ -75693,7 +76610,7 @@ paths:
       summary: Get sync status
       operationId: getGithubAuditSync
       description: Get status of a GitHub audit sync.
-      security: &id494
+      security: &id500
       - {}
       parameters:
       - name: session_id
@@ -75704,7 +76621,7 @@ paths:
       responses:
         '200':
           description: Sync status
-          headers: &id493
+          headers: &id499
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75718,9 +76635,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id495
+        '401': &id501
           description: Unauthorized - Authentication required or token invalid
-          headers: *id493
+          headers: *id499
           content:
             application/json:
               schema:
@@ -75738,9 +76655,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id496
+        '404': &id502
           description: Not found - The requested resource does not exist
-          headers: *id493
+          headers: *id499
           content:
             application/json:
               schema:
@@ -75754,9 +76671,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id497
+        '500': &id503
           description: Internal server error - Unexpected error occurred
-          headers: *id493
+          headers: *id499
           content:
             application/json:
               schema:
@@ -75776,7 +76693,7 @@ paths:
       summary: Sync findings
       operationId: createGithubAuditSync
       description: Sync an audit session to GitHub.
-      security: *id494
+      security: *id500
       parameters:
       - name: session_id
         in: path
@@ -75786,14 +76703,14 @@ paths:
       responses:
         '200':
           description: Sync started
-          headers: *id493
+          headers: *id499
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id495
-        '404': *id496
-        '500': *id497
+        '401': *id501
+        '404': *id502
+        '500': *id503
       x-aragora-stability: experimental
   /api/v1/github/pr/review:
     post:
@@ -75813,7 +76730,7 @@ paths:
       responses:
         '200':
           description: Review started
-          headers: &id498
+          headers: &id504
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75829,7 +76746,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewTriggerResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id498
+          headers: *id504
           content:
             application/json:
               schema:
@@ -75857,7 +76774,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id498
+          headers: *id504
           content:
             application/json:
               schema:
@@ -75877,7 +76794,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id498
+          headers: *id504
           content:
             application/json:
               schema:
@@ -75899,7 +76816,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id498
+          headers: *id504
           content:
             application/json:
               schema:
@@ -75931,7 +76848,7 @@ paths:
       responses:
         '200':
           description: Review status
-          headers: &id499
+          headers: &id505
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -75947,7 +76864,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewStatusResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id499
+          headers: *id505
           content:
             application/json:
               schema:
@@ -75967,7 +76884,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id499
+          headers: *id505
           content:
             application/json:
               schema:
@@ -75989,7 +76906,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id499
+          headers: *id505
           content:
             application/json:
               schema:
@@ -76005,7 +76922,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id499
+          headers: *id505
           content:
             application/json:
               schema:
@@ -76042,7 +76959,7 @@ paths:
       responses:
         '200':
           description: PR details
-          headers: &id500
+          headers: &id506
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76058,7 +76975,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRDetailsResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id500
+          headers: *id506
           content:
             application/json:
               schema:
@@ -76086,7 +77003,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id500
+          headers: *id506
           content:
             application/json:
               schema:
@@ -76106,7 +77023,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id500
+          headers: *id506
           content:
             application/json:
               schema:
@@ -76128,7 +77045,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id500
+          headers: *id506
           content:
             application/json:
               schema:
@@ -76144,7 +77061,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id500
+          headers: *id506
           content:
             application/json:
               schema:
@@ -76182,7 +77099,7 @@ paths:
       responses:
         '200':
           description: Review submitted
-          headers: &id501
+          headers: &id507
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76198,7 +77115,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRSubmitReviewResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id501
+          headers: *id507
           content:
             application/json:
               schema:
@@ -76226,7 +77143,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id501
+          headers: *id507
           content:
             application/json:
               schema:
@@ -76246,7 +77163,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id501
+          headers: *id507
           content:
             application/json:
               schema:
@@ -76268,7 +77185,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id501
+          headers: *id507
           content:
             application/json:
               schema:
@@ -76305,7 +77222,7 @@ paths:
       responses:
         '200':
           description: Review list
-          headers: &id502
+          headers: &id508
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76321,7 +77238,7 @@ paths:
                 $ref: '#/components/schemas/GitHubPRReviewListResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id502
+          headers: *id508
           content:
             application/json:
               schema:
@@ -76349,7 +77266,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id502
+          headers: *id508
           content:
             application/json:
               schema:
@@ -76369,7 +77286,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id502
+          headers: *id508
           content:
             application/json:
               schema:
@@ -76391,7 +77308,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id502
+          headers: *id508
           content:
             application/json:
               schema:
@@ -76559,7 +77476,7 @@ paths:
       summary: List drafts
       operationId: listGmailDrafts
       description: List Gmail drafts.
-      security: &id504
+      security: &id510
       - {}
       parameters:
       - name: user_id
@@ -76577,7 +77494,7 @@ paths:
       responses:
         '200':
           description: Drafts
-          headers: &id503
+          headers: &id509
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76591,9 +77508,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id505
+        '401': &id511
           description: Unauthorized - Authentication required or token invalid
-          headers: *id503
+          headers: *id509
           content:
             application/json:
               schema:
@@ -76611,9 +77528,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id506
+        '500': &id512
           description: Internal server error - Unexpected error occurred
-          headers: *id503
+          headers: *id509
           content:
             application/json:
               schema:
@@ -76633,7 +77550,7 @@ paths:
       summary: Create draft
       operationId: createGmailDrafts
       description: Create a Gmail draft.
-      security: *id504
+      security: *id510
       requestBody:
         required: true
         content:
@@ -76675,14 +77592,14 @@ paths:
       responses:
         '200':
           description: Draft created
-          headers: *id503
+          headers: *id509
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id503
+          headers: *id509
           content:
             application/json:
               schema:
@@ -76708,8 +77625,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id505
-        '500': *id506
+        '401': *id511
+        '500': *id512
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}:
     get:
@@ -76718,7 +77635,7 @@ paths:
       summary: Get draft
       operationId: getGmailDraft
       description: Get a Gmail draft by ID.
-      security: &id508
+      security: &id514
       - {}
       parameters:
       - name: draft_id
@@ -76733,7 +77650,7 @@ paths:
       responses:
         '200':
           description: Draft
-          headers: &id507
+          headers: &id513
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76747,9 +77664,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id509
+        '401': &id515
           description: Unauthorized - Authentication required or token invalid
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
@@ -76767,9 +77684,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id510
+        '404': &id516
           description: Not found - The requested resource does not exist
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
@@ -76783,9 +77700,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id511
+        '500': &id517
           description: Internal server error - Unexpected error occurred
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
@@ -76805,7 +77722,7 @@ paths:
       summary: Update draft
       operationId: updateGmailDraft
       description: Update a Gmail draft.
-      security: *id508
+      security: *id514
       parameters:
       - name: draft_id
         in: path
@@ -76849,14 +77766,14 @@ paths:
       responses:
         '200':
           description: Draft updated
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
@@ -76882,9 +77799,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id509
-        '404': *id510
-        '500': *id511
+        '401': *id515
+        '404': *id516
+        '500': *id517
       x-aragora-stability: experimental
     delete:
       tags:
@@ -76892,7 +77809,7 @@ paths:
       summary: Delete draft
       operationId: deleteGmailDraft
       description: Delete a Gmail draft.
-      security: *id508
+      security: *id514
       parameters:
       - name: draft_id
         in: path
@@ -76906,14 +77823,14 @@ paths:
       responses:
         '200':
           description: Draft deleted
-          headers: *id507
+          headers: *id513
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id509
-        '404': *id510
-        '500': *id511
+        '401': *id515
+        '404': *id516
+        '500': *id517
       x-aragora-stability: experimental
   /api/v1/gmail/drafts/{draft_id}/send:
     post:
@@ -76933,7 +77850,7 @@ paths:
       responses:
         '200':
           description: Draft sent
-          headers: &id512
+          headers: &id518
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -76949,7 +77866,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id512
+          headers: *id518
           content:
             application/json:
               schema:
@@ -76969,7 +77886,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id512
+          headers: *id518
           content:
             application/json:
               schema:
@@ -76990,7 +77907,7 @@ paths:
       summary: List Gmail filters
       operationId: listGmailFilters
       description: List Gmail filters.
-      security: &id514
+      security: &id520
       - {}
       parameters:
       - name: user_id
@@ -77000,7 +77917,7 @@ paths:
       responses:
         '200':
           description: Filters
-          headers: &id513
+          headers: &id519
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77014,9 +77931,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id515
+        '401': &id521
           description: Unauthorized - Authentication required or token invalid
-          headers: *id513
+          headers: *id519
           content:
             application/json:
               schema:
@@ -77034,9 +77951,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id516
+        '500': &id522
           description: Internal server error - Unexpected error occurred
-          headers: *id513
+          headers: *id519
           content:
             application/json:
               schema:
@@ -77056,7 +77973,7 @@ paths:
       summary: Create Gmail filter
       operationId: createGmailFilters
       description: Create a Gmail filter.
-      security: *id514
+      security: *id520
       requestBody:
         required: true
         content:
@@ -77098,14 +78015,14 @@ paths:
       responses:
         '200':
           description: Filter created
-          headers: *id513
+          headers: *id519
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id513
+          headers: *id519
           content:
             application/json:
               schema:
@@ -77131,8 +78048,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id515
-        '500': *id516
+        '401': *id521
+        '500': *id522
       x-aragora-stability: experimental
   /api/v1/gmail/filters/{filter_id}:
     delete:
@@ -77156,7 +78073,7 @@ paths:
       responses:
         '200':
           description: Filter deleted
-          headers: &id517
+          headers: &id523
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77172,7 +78089,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id517
+          headers: *id523
           content:
             application/json:
               schema:
@@ -77192,7 +78109,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id517
+          headers: *id523
           content:
             application/json:
               schema:
@@ -77208,7 +78125,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id517
+          headers: *id523
           content:
             application/json:
               schema:
@@ -77271,7 +78188,7 @@ paths:
       summary: List Gmail labels
       operationId: listGmailLabels
       description: List Gmail labels for a connected account.
-      security: &id519
+      security: &id525
       - {}
       parameters:
       - name: user_id
@@ -77281,7 +78198,7 @@ paths:
       responses:
         '200':
           description: Labels
-          headers: &id518
+          headers: &id524
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77295,9 +78212,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id520
+        '401': &id526
           description: Unauthorized - Authentication required or token invalid
-          headers: *id518
+          headers: *id524
           content:
             application/json:
               schema:
@@ -77315,9 +78232,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id521
+        '500': &id527
           description: Internal server error - Unexpected error occurred
-          headers: *id518
+          headers: *id524
           content:
             application/json:
               schema:
@@ -77337,7 +78254,7 @@ paths:
       summary: Create Gmail label
       operationId: createGmailLabels
       description: Create a Gmail label.
-      security: *id519
+      security: *id525
       requestBody:
         required: true
         content:
@@ -77358,14 +78275,14 @@ paths:
       responses:
         '200':
           description: Label created
-          headers: *id518
+          headers: *id524
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id518
+          headers: *id524
           content:
             application/json:
               schema:
@@ -77391,8 +78308,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id520
-        '500': *id521
+        '401': *id526
+        '500': *id527
       x-aragora-stability: experimental
   /api/v1/gmail/labels/{label_id}:
     patch:
@@ -77401,7 +78318,7 @@ paths:
       summary: Update Gmail label
       operationId: patchGmailLabel
       description: Update a Gmail label.
-      security: &id523
+      security: &id529
       - {}
       parameters:
       - name: label_id
@@ -77427,7 +78344,7 @@ paths:
       responses:
         '200':
           description: Label updated
-          headers: &id522
+          headers: &id528
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77443,7 +78360,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id522
+          headers: *id528
           content:
             application/json:
               schema:
@@ -77469,9 +78386,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id524
+        '401': &id530
           description: Unauthorized - Authentication required or token invalid
-          headers: *id522
+          headers: *id528
           content:
             application/json:
               schema:
@@ -77489,9 +78406,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id525
+        '404': &id531
           description: Not found - The requested resource does not exist
-          headers: *id522
+          headers: *id528
           content:
             application/json:
               schema:
@@ -77505,9 +78422,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id526
+        '500': &id532
           description: Internal server error - Unexpected error occurred
-          headers: *id522
+          headers: *id528
           content:
             application/json:
               schema:
@@ -77527,7 +78444,7 @@ paths:
       summary: Delete Gmail label
       operationId: deleteGmailLabel
       description: Delete a Gmail label.
-      security: *id523
+      security: *id529
       parameters:
       - name: label_id
         in: path
@@ -77541,14 +78458,14 @@ paths:
       responses:
         '200':
           description: Label deleted
-          headers: *id522
+          headers: *id528
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id524
-        '404': *id525
-        '500': *id526
+        '401': *id530
+        '404': *id531
+        '500': *id532
       x-aragora-stability: experimental
   /api/v1/gmail/messages:
     post:
@@ -77589,7 +78506,7 @@ paths:
       responses:
         '200':
           description: Message archived
-          headers: &id527
+          headers: &id533
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77605,7 +78522,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id527
+          headers: *id533
           content:
             application/json:
               schema:
@@ -77625,7 +78542,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id527
+          headers: *id533
           content:
             application/json:
               schema:
@@ -77666,7 +78583,7 @@ paths:
       responses:
         '200':
           description: Attachment
-          headers: &id528
+          headers: &id534
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77682,7 +78599,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id528
+          headers: *id534
           content:
             application/json:
               schema:
@@ -77702,7 +78619,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id528
+          headers: *id534
           content:
             application/json:
               schema:
@@ -77718,7 +78635,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id528
+          headers: *id534
           content:
             application/json:
               schema:
@@ -77767,7 +78684,7 @@ paths:
       responses:
         '200':
           description: Labels updated
-          headers: &id529
+          headers: &id535
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77783,7 +78700,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id529
+          headers: *id535
           content:
             application/json:
               schema:
@@ -77811,7 +78728,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id529
+          headers: *id535
           content:
             application/json:
               schema:
@@ -77831,7 +78748,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id529
+          headers: *id535
           content:
             application/json:
               schema:
@@ -77874,7 +78791,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id530
+          headers: &id536
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77890,7 +78807,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id530
+          headers: *id536
           content:
             application/json:
               schema:
@@ -77910,7 +78827,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id530
+          headers: *id536
           content:
             application/json:
               schema:
@@ -77953,7 +78870,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id531
+          headers: &id537
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -77969,7 +78886,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id531
+          headers: *id537
           content:
             application/json:
               schema:
@@ -77989,7 +78906,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id531
+          headers: *id537
           content:
             application/json:
               schema:
@@ -78032,7 +78949,7 @@ paths:
       responses:
         '200':
           description: Message trashed
-          headers: &id532
+          headers: &id538
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78048,7 +78965,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id532
+          headers: *id538
           content:
             application/json:
               schema:
@@ -78068,7 +78985,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id532
+          headers: *id538
           content:
             application/json:
               schema:
@@ -78380,7 +79297,7 @@ paths:
       responses:
         '200':
           description: Threads
-          headers: &id533
+          headers: &id539
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78396,7 +79313,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id533
+          headers: *id539
           content:
             application/json:
               schema:
@@ -78416,7 +79333,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id533
+          headers: *id539
           content:
             application/json:
               schema:
@@ -78452,7 +79369,7 @@ paths:
       responses:
         '200':
           description: Thread
-          headers: &id534
+          headers: &id540
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78468,7 +79385,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id534
+          headers: *id540
           content:
             application/json:
               schema:
@@ -78488,7 +79405,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id534
+          headers: *id540
           content:
             application/json:
               schema:
@@ -78504,7 +79421,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id534
+          headers: *id540
           content:
             application/json:
               schema:
@@ -78536,7 +79453,7 @@ paths:
       responses:
         '200':
           description: Thread archived
-          headers: &id535
+          headers: &id541
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78552,7 +79469,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id535
+          headers: *id541
           content:
             application/json:
               schema:
@@ -78572,7 +79489,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id535
+          headers: *id541
           content:
             application/json:
               schema:
@@ -78624,7 +79541,7 @@ paths:
       responses:
         '200':
           description: Thread updated
-          headers: &id536
+          headers: &id542
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78640,7 +79557,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id536
+          headers: *id542
           content:
             application/json:
               schema:
@@ -78660,7 +79577,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id536
+          headers: *id542
           content:
             application/json:
               schema:
@@ -78705,7 +79622,7 @@ paths:
       responses:
         '200':
           description: Thread trashed
-          headers: &id537
+          headers: &id543
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78721,7 +79638,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id537
+          headers: *id543
           content:
             application/json:
               schema:
@@ -78741,7 +79658,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id537
+          headers: *id543
           content:
             application/json:
               schema:
@@ -78833,7 +79750,7 @@ paths:
       responses:
         '200':
           description: Graph debate details
-          headers: &id538
+          headers: &id544
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -78862,7 +79779,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id538
+          headers: *id544
           content:
             application/json:
               schema:
@@ -79938,7 +80855,7 @@ paths:
       summary: Create routing rule
       operationId: createInboxRoutingRules
       description: Create a routing rule for inbox automation.
-      security: &id540
+      security: &id546
       - {}
       requestBody:
         required: true
@@ -79949,7 +80866,7 @@ paths:
       responses:
         '200':
           description: Rule created
-          headers: &id539
+          headers: &id545
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -79965,7 +80882,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id539
+          headers: *id545
           content:
             application/json:
               schema:
@@ -79991,9 +80908,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id541
+        '401': &id547
           description: Unauthorized - Authentication required or token invalid
-          headers: *id539
+          headers: *id545
           content:
             application/json:
               schema:
@@ -80011,9 +80928,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id542
+        '403': &id548
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id539
+          headers: *id545
           content:
             application/json:
               schema:
@@ -80033,9 +80950,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id543
+        '500': &id549
           description: Internal server error - Unexpected error occurred
-          headers: *id539
+          headers: *id545
           content:
             application/json:
               schema:
@@ -80055,7 +80972,7 @@ paths:
       summary: List routing rules
       operationId: listInboxRoutingRules
       description: List routing rules for a workspace.
-      security: *id540
+      security: *id546
       parameters:
       - name: workspace_id
         in: query
@@ -80076,14 +80993,14 @@ paths:
       responses:
         '200':
           description: Rule list
-          headers: *id539
+          headers: *id545
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleListResponse'
-        '401': *id541
-        '403': *id542
-        '500': *id543
+        '401': *id547
+        '403': *id548
+        '500': *id549
       x-aragora-stability: stable
   /api/v1/inbox/routing/rules/{id}:
     patch:
@@ -80092,7 +81009,7 @@ paths:
       summary: Update routing rule
       operationId: patchInboxRoutingRule
       description: Update an inbox routing rule.
-      security: &id545
+      security: &id551
       - {}
       parameters:
       - name: id
@@ -80109,7 +81026,7 @@ paths:
       responses:
         '200':
           description: Rule updated
-          headers: &id544
+          headers: &id550
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80125,7 +81042,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
@@ -80151,9 +81068,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id546
+        '401': &id552
           description: Unauthorized - Authentication required or token invalid
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
@@ -80171,9 +81088,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id547
+        '403': &id553
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
@@ -80193,9 +81110,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id548
+        '404': &id554
           description: Not found - The requested resource does not exist
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
@@ -80209,9 +81126,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id549
+        '500': &id555
           description: Internal server error - Unexpected error occurred
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
@@ -80231,7 +81148,7 @@ paths:
       summary: Delete routing rule
       operationId: deleteInboxRoutingRule
       description: Delete an inbox routing rule.
-      security: *id545
+      security: *id551
       parameters:
       - name: id
         in: path
@@ -80241,15 +81158,15 @@ paths:
       responses:
         '200':
           description: Rule deleted
-          headers: *id544
+          headers: *id550
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoutingRuleDeleteResponse'
-        '401': *id546
-        '403': *id547
-        '404': *id548
-        '500': *id549
+        '401': *id552
+        '403': *id553
+        '404': *id554
+        '500': *id555
       x-aragora-stability: experimental
   /api/v1/inbox/routing/rules/{id}/test:
     post:
@@ -80275,7 +81192,7 @@ paths:
       responses:
         '200':
           description: Rule test
-          headers: &id550
+          headers: &id556
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80291,7 +81208,7 @@ paths:
                 $ref: '#/components/schemas/RoutingRuleTestResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id550
+          headers: *id556
           content:
             application/json:
               schema:
@@ -80319,7 +81236,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id550
+          headers: *id556
           content:
             application/json:
               schema:
@@ -80339,7 +81256,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id550
+          headers: *id556
           content:
             application/json:
               schema:
@@ -80361,7 +81278,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id550
+          headers: *id556
           content:
             application/json:
               schema:
@@ -80377,7 +81294,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id550
+          headers: *id556
           content:
             application/json:
               schema:
@@ -80398,7 +81315,7 @@ paths:
       summary: Create shared inbox
       operationId: createInboxShared
       description: Create a shared inbox for collaborative triage.
-      security: &id552
+      security: &id558
       - {}
       requestBody:
         required: true
@@ -80409,7 +81326,7 @@ paths:
       responses:
         '200':
           description: Inbox created
-          headers: &id551
+          headers: &id557
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80425,7 +81342,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id551
+          headers: *id557
           content:
             application/json:
               schema:
@@ -80451,9 +81368,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id553
+        '401': &id559
           description: Unauthorized - Authentication required or token invalid
-          headers: *id551
+          headers: *id557
           content:
             application/json:
               schema:
@@ -80471,9 +81388,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id554
+        '403': &id560
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id551
+          headers: *id557
           content:
             application/json:
               schema:
@@ -80493,9 +81410,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id555
+        '500': &id561
           description: Internal server error - Unexpected error occurred
-          headers: *id551
+          headers: *id557
           content:
             application/json:
               schema:
@@ -80515,7 +81432,7 @@ paths:
       summary: List shared inboxes
       operationId: listInboxShared
       description: List shared inboxes for a workspace.
-      security: *id552
+      security: *id558
       parameters:
       - name: workspace_id
         in: query
@@ -80528,14 +81445,14 @@ paths:
       responses:
         '200':
           description: Inbox list
-          headers: *id551
+          headers: *id557
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SharedInboxListResponse'
-        '401': *id553
-        '403': *id554
-        '500': *id555
+        '401': *id559
+        '403': *id560
+        '500': *id561
       x-aragora-stability: stable
   /api/v1/inbox/shared/{id}:
     get:
@@ -80555,7 +81472,7 @@ paths:
       responses:
         '200':
           description: Inbox detail
-          headers: &id556
+          headers: &id562
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80571,7 +81488,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id556
+          headers: *id562
           content:
             application/json:
               schema:
@@ -80591,7 +81508,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id556
+          headers: *id562
           content:
             application/json:
               schema:
@@ -80613,7 +81530,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id556
+          headers: *id562
           content:
             application/json:
               schema:
@@ -80629,7 +81546,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id556
+          headers: *id562
           content:
             application/json:
               schema:
@@ -80681,7 +81598,7 @@ paths:
       responses:
         '200':
           description: Inbox messages
-          headers: &id557
+          headers: &id563
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80697,7 +81614,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageListResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id557
+          headers: *id563
           content:
             application/json:
               schema:
@@ -80717,7 +81634,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id557
+          headers: *id563
           content:
             application/json:
               schema:
@@ -80739,7 +81656,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id557
+          headers: *id563
           content:
             application/json:
               schema:
@@ -80755,7 +81672,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id557
+          headers: *id563
           content:
             application/json:
               schema:
@@ -80798,7 +81715,7 @@ paths:
       responses:
         '200':
           description: Message assigned
-          headers: &id558
+          headers: &id564
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80814,7 +81731,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id558
+          headers: *id564
           content:
             application/json:
               schema:
@@ -80842,7 +81759,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id558
+          headers: *id564
           content:
             application/json:
               schema:
@@ -80862,7 +81779,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id558
+          headers: *id564
           content:
             application/json:
               schema:
@@ -80884,7 +81801,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id558
+          headers: *id564
           content:
             application/json:
               schema:
@@ -80900,7 +81817,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id558
+          headers: *id564
           content:
             application/json:
               schema:
@@ -80943,7 +81860,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id559
+          headers: &id565
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -80959,7 +81876,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id559
+          headers: *id565
           content:
             application/json:
               schema:
@@ -80987,7 +81904,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id559
+          headers: *id565
           content:
             application/json:
               schema:
@@ -81007,7 +81924,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id559
+          headers: *id565
           content:
             application/json:
               schema:
@@ -81029,7 +81946,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id559
+          headers: *id565
           content:
             application/json:
               schema:
@@ -81045,7 +81962,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id559
+          headers: *id565
           content:
             application/json:
               schema:
@@ -81088,7 +82005,7 @@ paths:
       responses:
         '200':
           description: Tag added
-          headers: &id560
+          headers: &id566
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81104,7 +82021,7 @@ paths:
                 $ref: '#/components/schemas/SharedInboxMessageResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id560
+          headers: *id566
           content:
             application/json:
               schema:
@@ -81132,7 +82049,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id560
+          headers: *id566
           content:
             application/json:
               schema:
@@ -81152,7 +82069,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id560
+          headers: *id566
           content:
             application/json:
               schema:
@@ -81174,7 +82091,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id560
+          headers: *id566
           content:
             application/json:
               schema:
@@ -81190,7 +82107,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id560
+          headers: *id566
           content:
             application/json:
               schema:
@@ -81756,9 +82673,9 @@ paths:
                     type: object
                   enabled:
                     type: boolean
-        '401': &id562
+        '401': &id568
           description: Unauthorized - Authentication required or token invalid
-          headers: &id561
+          headers: &id567
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81785,9 +82702,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id563
+        '404': &id569
           description: Not found - The requested resource does not exist
-          headers: *id561
+          headers: *id567
           content:
             application/json:
               schema:
@@ -81801,9 +82718,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id564
+        '500': &id570
           description: Internal server error - Unexpected error occurred
-          headers: *id561
+          headers: *id567
           content:
             application/json:
               schema:
@@ -81859,7 +82776,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id561
+          headers: *id567
           content:
             application/json:
               schema:
@@ -81885,9 +82802,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id562
-        '404': *id563
-        '500': *id564
+        '401': *id568
+        '404': *id569
+        '500': *id570
       x-aragora-stability: experimental
     delete:
       tags:
@@ -81916,9 +82833,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id562
-        '404': *id563
-        '500': *id564
+        '401': *id568
+        '404': *id569
+        '500': *id570
       x-aragora-stability: experimental
   /api/v1/integrations/discord/callback:
     get:
@@ -81946,7 +82863,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id565
+          headers: &id571
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -81983,7 +82900,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id565
+          headers: *id571
           content:
             application/json:
               schema:
@@ -82010,7 +82927,7 @@ paths:
           description: Redirect to Discord OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id566
+          headers: &id572
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82047,7 +82964,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id566
+          headers: *id572
           content:
             application/json:
               schema:
@@ -82067,7 +82984,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id566
+          headers: *id572
           content:
             application/json:
               schema:
@@ -82553,7 +83470,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id567
+          headers: &id573
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82590,7 +83507,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id567
+          headers: *id573
           content:
             application/json:
               schema:
@@ -82667,7 +83584,7 @@ paths:
           description: Redirect to Slack OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id568
+          headers: &id574
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82704,7 +83621,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id568
+          headers: *id574
           content:
             application/json:
               schema:
@@ -82724,7 +83641,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id568
+          headers: *id574
           content:
             application/json:
               schema:
@@ -82784,7 +83701,7 @@ paths:
                     format: uri
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id569
+          headers: &id575
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82813,7 +83730,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id569
+          headers: *id575
           content:
             application/json:
               schema:
@@ -82870,7 +83787,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id570
+          headers: &id576
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82899,7 +83816,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id570
+          headers: *id576
           content:
             application/json:
               schema:
@@ -82943,7 +83860,7 @@ paths:
                           type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id571
+          headers: &id577
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -82972,7 +83889,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id571
+          headers: *id577
           content:
             application/json:
               schema:
@@ -83038,7 +83955,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id572
+          headers: &id578
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83067,7 +83984,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id572
+          headers: *id578
           content:
             application/json:
               schema:
@@ -83107,7 +84024,7 @@ paths:
           description: Redirect to success page
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id573
+          headers: &id579
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83144,7 +84061,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id573
+          headers: *id579
           content:
             application/json:
               schema:
@@ -83293,7 +84210,7 @@ paths:
           description: Redirect to Microsoft OAuth
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id574
+          headers: &id580
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83330,7 +84247,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id574
+          headers: *id580
           content:
             application/json:
               schema:
@@ -83350,7 +84267,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id574
+          headers: *id580
           content:
             application/json:
               schema:
@@ -83565,7 +84482,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id575
+          headers: &id581
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -83594,7 +84511,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id575
+          headers: *id581
           content:
             application/json:
               schema:
@@ -84054,9 +84971,9 @@ paths:
                   connected_at:
                     type: string
                     format: date-time
-        '401': &id577
+        '401': &id583
           description: Unauthorized - Authentication required or token invalid
-          headers: &id576
+          headers: &id582
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84085,7 +85002,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id576
+          headers: *id582
           content:
             application/json:
               schema:
@@ -84099,9 +85016,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id578
+        '500': &id584
           description: Internal server error - Unexpected error occurred
-          headers: *id576
+          headers: *id582
           content:
             application/json:
               schema:
@@ -84158,9 +85075,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': &id579
+        '400': &id585
           description: Bad request - Invalid input or malformed JSON
-          headers: *id576
+          headers: *id582
           content:
             application/json:
               schema:
@@ -84186,8 +85103,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id577
-        '500': *id578
+        '401': *id583
+        '500': *id584
       x-aragora-stability: stable
     patch:
       tags:
@@ -84229,9 +85146,9 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '400': *id579
-        '401': *id577
-        '500': *id578
+        '400': *id585
+        '401': *id583
+        '500': *id584
       x-aragora-stability: stable
     delete:
       tags:
@@ -84260,8 +85177,8 @@ paths:
                     type: boolean
                   message:
                     type: string
-        '401': *id577
-        '500': *id578
+        '401': *id583
+        '500': *id584
       x-aragora-stability: stable
   /api/v1/integrations/{type}/test:
     post:
@@ -84295,7 +85212,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id580
+          headers: &id586
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84324,7 +85241,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id580
+          headers: *id586
           content:
             application/json:
               schema:
@@ -84690,7 +85607,7 @@ paths:
       responses:
         '200':
           description: List of checkpoints
-          headers: &id581
+          headers: &id587
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84704,9 +85621,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointList'
-        '401': &id582
+        '401': &id588
           description: Unauthorized - Authentication required or token invalid
-          headers: *id581
+          headers: *id587
           content:
             application/json:
               schema:
@@ -84758,14 +85675,14 @@ paths:
       responses:
         '201':
           description: Checkpoint created
-          headers: *id581
+          headers: *id587
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id581
+          headers: *id587
           content:
             application/json:
               schema:
@@ -84791,7 +85708,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id582
+        '401': *id588
         '409':
           description: Checkpoint with this name already exists
           content:
@@ -84853,7 +85770,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id583
+          headers: &id589
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84890,7 +85807,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id583
+          headers: *id589
           content:
             application/json:
               schema:
@@ -84910,7 +85827,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id583
+          headers: *id589
           content:
             application/json:
               schema:
@@ -84943,7 +85860,7 @@ paths:
       responses:
         '200':
           description: Checkpoint metadata
-          headers: &id584
+          headers: &id590
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -84957,9 +85874,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CheckpointMetadata'
-        '401': &id585
+        '401': &id591
           description: Unauthorized - Authentication required or token invalid
-          headers: *id584
+          headers: *id590
           content:
             application/json:
               schema:
@@ -84977,9 +85894,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id586
+        '404': &id592
           description: Not found - The requested resource does not exist
-          headers: *id584
+          headers: *id590
           content:
             application/json:
               schema:
@@ -85011,7 +85928,7 @@ paths:
       responses:
         '200':
           description: Checkpoint deleted
-          headers: *id584
+          headers: *id590
           content:
             application/json:
               schema:
@@ -85023,8 +85940,8 @@ paths:
                   name:
                     type: string
                     description: Name of deleted checkpoint
-        '401': *id585
-        '404': *id586
+        '401': *id591
+        '404': *id592
       x-aragora-stability: stable
   /api/v1/km/checkpoints/{checkpoint_name}/compare:
     get:
@@ -85065,7 +85982,7 @@ paths:
                     type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id587
+          headers: &id593
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85094,7 +86011,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id587
+          headers: *id593
           content:
             application/json:
               schema:
@@ -85134,7 +86051,7 @@ paths:
                 format: binary
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id588
+          headers: &id594
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85163,7 +86080,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id588
+          headers: *id594
           content:
             application/json:
               schema:
@@ -85214,7 +86131,7 @@ paths:
       responses:
         '200':
           description: Restore result
-          headers: &id589
+          headers: &id595
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85230,7 +86147,7 @@ paths:
                 $ref: '#/components/schemas/RestoreResult'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id589
+          headers: *id595
           content:
             application/json:
               schema:
@@ -85258,7 +86175,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id589
+          headers: *id595
           content:
             application/json:
               schema:
@@ -85278,7 +86195,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id589
+          headers: *id595
           content:
             application/json:
               schema:
@@ -85419,7 +86336,7 @@ paths:
       summary: List facts
       operationId: listKnowledgeFacts
       description: List knowledge facts with optional filtering.
-      security: &id591
+      security: &id597
       - bearerAuth: []
       parameters:
       - name: workspace_id
@@ -85455,7 +86372,7 @@ paths:
       responses:
         '200':
           description: Knowledge facts
-          headers: &id590
+          headers: &id596
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85469,9 +86386,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFactList'
-        '500': &id592
+        '500': &id598
           description: Internal server error - Unexpected error occurred
-          headers: *id590
+          headers: *id596
           content:
             application/json:
               schema:
@@ -85491,7 +86408,7 @@ paths:
       summary: Create fact
       operationId: createKnowledgeFact
       description: Create a new knowledge fact.
-      security: *id591
+      security: *id597
       requestBody:
         required: true
         content:
@@ -85524,14 +86441,14 @@ paths:
       responses:
         '201':
           description: Created fact
-          headers: *id590
+          headers: *id596
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id590
+          headers: *id596
           content:
             application/json:
               schema:
@@ -85557,7 +86474,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': *id592
+        '500': *id598
       x-aragora-stability: stable
   /api/v1/knowledge/facts/relations:
     post:
@@ -85608,7 +86525,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: &id593
+          headers: &id599
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85637,7 +86554,7 @@ paths:
                     description: Type of relation
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id593
+          headers: *id599
           content:
             application/json:
               schema:
@@ -85669,7 +86586,7 @@ paths:
 
         - Supersession history (if applicable)'
       operationId: getKnowledgeFact
-      security: &id595
+      security: &id601
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -85680,7 +86597,7 @@ paths:
       responses:
         '200':
           description: Knowledge fact
-          headers: &id594
+          headers: &id600
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85694,9 +86611,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': &id596
+        '404': &id602
           description: Not found - The requested resource does not exist
-          headers: *id594
+          headers: *id600
           content:
             application/json:
               schema:
@@ -85710,9 +86627,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id597
+        '500': &id603
           description: Internal server error - Unexpected error occurred
-          headers: *id594
+          headers: *id600
           content:
             application/json:
               schema:
@@ -85746,7 +86663,7 @@ paths:
 
         **Note:** Updates create an audit trail. Consider superseding instead of updating for significant changes.'
       operationId: updateKnowledgeFact
-      security: *id595
+      security: *id601
       parameters:
       - name: fact_id
         in: path
@@ -85777,13 +86694,13 @@ paths:
       responses:
         '200':
           description: Updated fact
-          headers: *id594
+          headers: *id600
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeFact'
-        '404': *id596
-        '500': *id597
+        '404': *id602
+        '500': *id603
       x-aragora-stability: experimental
     delete:
       tags:
@@ -85803,7 +86720,7 @@ paths:
 
         **Note:** Deleted facts can be restored by admin if needed.'
       operationId: deleteKnowledgeFact
-      security: *id595
+      security: *id601
       parameters:
       - name: fact_id
         in: path
@@ -85813,7 +86730,7 @@ paths:
       responses:
         '200':
           description: Deleted fact
-          headers: *id594
+          headers: *id600
           content:
             application/json:
               schema:
@@ -85825,8 +86742,8 @@ paths:
                   fact_id:
                     type: string
                     description: ID of deleted fact
-        '404': *id596
-        '500': *id597
+        '404': *id602
+        '500': *id603
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/contradictions:
     get:
@@ -85864,7 +86781,7 @@ paths:
       responses:
         '200':
           description: Contradicting facts
-          headers: &id598
+          headers: &id604
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85880,7 +86797,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeFactList'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id598
+          headers: *id604
           content:
             application/json:
               schema:
@@ -85912,7 +86829,7 @@ paths:
 
         - derived_from: Source facts used to derive this one'
       operationId: listKnowledgeRelations
-      security: &id600
+      security: &id606
       - bearerAuth: []
       parameters:
       - name: fact_id
@@ -85923,7 +86840,7 @@ paths:
       responses:
         '200':
           description: Fact relations
-          headers: &id599
+          headers: &id605
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -85937,9 +86854,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
-        '500': &id601
+        '500': &id607
           description: Internal server error - Unexpected error occurred
-          headers: *id599
+          headers: *id605
           content:
             application/json:
               schema:
@@ -85973,7 +86890,7 @@ paths:
 
         - evidence: Supporting evidence for the relation'
       operationId: addKnowledgeRelation
-      security: *id600
+      security: *id606
       parameters:
       - name: fact_id
         in: path
@@ -86010,7 +86927,7 @@ paths:
       responses:
         '200':
           description: Relation added
-          headers: *id599
+          headers: *id605
           content:
             application/json:
               schema:
@@ -86028,7 +86945,7 @@ paths:
                   relation_type:
                     type: string
                     description: Type of relation
-        '500': *id601
+        '500': *id607
       x-aragora-stability: experimental
   /api/v1/knowledge/facts/{fact_id}/verify:
     post:
@@ -86060,7 +86977,7 @@ paths:
       responses:
         '200':
           description: Fact verification started
-          headers: &id602
+          headers: &id608
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86089,7 +87006,7 @@ paths:
                     description: Verification status
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id602
+          headers: *id608
           content:
             application/json:
               schema:
@@ -86523,7 +87440,7 @@ paths:
       responses:
         '200':
           description: Culture patterns
-          headers: &id603
+          headers: &id609
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -86539,7 +87456,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id603
+          headers: *id609
           content:
             application/json:
               schema:
@@ -86555,7 +87472,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id603
+          headers: *id609
           content:
             application/json:
               schema:
@@ -87199,7 +88116,7 @@ paths:
       responses:
         '200':
           description: Audit trail
-          headers: &id604
+          headers: &id610
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87215,7 +88132,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id604
+          headers: *id610
           content:
             application/json:
               schema:
@@ -87268,7 +88185,7 @@ paths:
       responses:
         '200':
           description: User audit
-          headers: &id605
+          headers: &id611
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87284,7 +88201,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id605
+          headers: *id611
           content:
             application/json:
               schema:
@@ -87300,7 +88217,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id605
+          headers: *id611
           content:
             application/json:
               schema:
@@ -87366,7 +88283,7 @@ paths:
       responses:
         '200':
           description: Permission check
-          headers: &id606
+          headers: &id612
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87382,7 +88299,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id606
+          headers: *id612
           content:
             application/json:
               schema:
@@ -87410,7 +88327,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id606
+          headers: *id612
           content:
             application/json:
               schema:
@@ -87442,7 +88359,7 @@ paths:
       responses:
         '200':
           description: Permissions
-          headers: &id607
+          headers: &id613
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87458,7 +88375,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id607
+          headers: *id613
           content:
             application/json:
               schema:
@@ -87474,7 +88391,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id607
+          headers: *id613
           content:
             application/json:
               schema:
@@ -87521,7 +88438,7 @@ paths:
       responses:
         '200':
           description: Role created
-          headers: &id608
+          headers: &id614
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87537,7 +88454,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id608
+          headers: *id614
           content:
             application/json:
               schema:
@@ -87565,7 +88482,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id608
+          headers: *id614
           content:
             application/json:
               schema:
@@ -87617,7 +88534,7 @@ paths:
       responses:
         '200':
           description: Role assigned
-          headers: &id609
+          headers: &id615
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87633,7 +88550,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id609
+          headers: *id615
           content:
             application/json:
               schema:
@@ -87661,7 +88578,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id609
+          headers: *id615
           content:
             application/json:
               schema:
@@ -87706,7 +88623,7 @@ paths:
       responses:
         '200':
           description: Role revoked
-          headers: &id610
+          headers: &id616
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87722,7 +88639,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id610
+          headers: *id616
           content:
             application/json:
               schema:
@@ -87750,7 +88667,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id610
+          headers: *id616
           content:
             application/json:
               schema:
@@ -87776,7 +88693,7 @@ paths:
       responses:
         '200':
           description: Stats
-          headers: &id611
+          headers: &id617
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -87792,7 +88709,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id611
+          headers: *id617
           content:
             application/json:
               schema:
@@ -88237,7 +89154,7 @@ paths:
       responses:
         '200':
           description: Node revalidated
-          headers: &id612
+          headers: &id618
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88253,7 +89170,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id612
+          headers: *id618
           content:
             application/json:
               schema:
@@ -88281,7 +89198,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id612
+          headers: *id618
           content:
             application/json:
               schema:
@@ -88297,7 +89214,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id612
+          headers: *id618
           content:
             application/json:
               schema:
@@ -88455,7 +89372,7 @@ paths:
       responses:
         '200':
           description: Sync triggered
-          headers: &id613
+          headers: &id619
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88471,7 +89388,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id613
+          headers: *id619
           content:
             application/json:
               schema:
@@ -88499,7 +89416,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id613
+          headers: *id619
           content:
             application/json:
               schema:
@@ -88515,7 +89432,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id613
+          headers: *id619
           content:
             application/json:
               schema:
@@ -88556,7 +89473,7 @@ paths:
       responses:
         '200':
           description: Knowledge query response
-          headers: &id614
+          headers: &id620
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88572,7 +89489,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeQueryResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id614
+          headers: *id620
           content:
             application/json:
               schema:
@@ -88600,7 +89517,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id614
+          headers: *id620
           content:
             application/json:
               schema:
@@ -88682,7 +89599,7 @@ paths:
       responses:
         '200':
           description: Knowledge search response
-          headers: &id615
+          headers: &id621
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88698,7 +89615,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeSearchResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id615
+          headers: *id621
           content:
             application/json:
               schema:
@@ -88726,7 +89643,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id615
+          headers: *id621
           content:
             application/json:
               schema:
@@ -88757,7 +89674,7 @@ paths:
       responses:
         '200':
           description: Knowledge stats
-          headers: &id616
+          headers: &id622
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -88773,7 +89690,7 @@ paths:
                 $ref: '#/components/schemas/KnowledgeStats'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id616
+          headers: *id622
           content:
             application/json:
               schema:
@@ -89999,7 +90916,7 @@ paths:
       responses:
         '200':
           description: Matrix debate details
-          headers: &id617
+          headers: &id623
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -90028,7 +90945,7 @@ paths:
                     type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id617
+          headers: *id623
           content:
             application/json:
               schema:
@@ -93894,7 +94811,7 @@ paths:
                         format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id618
+          headers: &id624
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -93923,7 +94840,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id618
+          headers: *id624
           content:
             application/json:
               schema:
@@ -93945,7 +94862,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id618
+          headers: *id624
           content:
             application/json:
               schema:
@@ -94081,7 +94998,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id619
+          headers: &id625
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94118,7 +95035,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id619
+          headers: *id625
           content:
             application/json:
               schema:
@@ -94138,7 +95055,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id619
+          headers: *id625
           content:
             application/json:
               schema:
@@ -94279,9 +95196,9 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/StarterTemplate'
-        '401': &id621
+        '401': &id627
           description: Unauthorized - Authentication required or token invalid
-          headers: &id620
+          headers: &id626
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94308,9 +95225,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '500': &id622
+        '500': &id628
           description: Internal server error - Unexpected error occurred
-          headers: *id620
+          headers: *id626
           content:
             application/json:
               schema:
@@ -94400,7 +95317,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id620
+          headers: *id626
           content:
             application/json:
               schema:
@@ -94426,8 +95343,8 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id621
-        '500': *id622
+        '401': *id627
+        '500': *id628
       x-aragora-stability: stable
     put:
       summary: Autogenerated placeholder (spec pending)
@@ -94566,7 +95483,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id623
+          headers: &id629
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94603,7 +95520,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id623
+          headers: *id629
           content:
             application/json:
               schema:
@@ -94623,7 +95540,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id623
+          headers: *id629
           content:
             application/json:
               schema:
@@ -94749,7 +95666,7 @@ paths:
                         type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id624
+          headers: &id630
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94786,7 +95703,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id624
+          headers: *id630
           content:
             application/json:
               schema:
@@ -94806,7 +95723,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id624
+          headers: *id630
           content:
             application/json:
               schema:
@@ -94937,7 +95854,7 @@ paths:
                     - 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id625
+          headers: &id631
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -94966,7 +95883,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id625
+          headers: *id631
           content:
             application/json:
               schema:
@@ -95203,7 +96120,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id626
+          headers: &id632
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95240,7 +96157,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id626
+          headers: *id632
           content:
             application/json:
               schema:
@@ -95260,7 +96177,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id626
+          headers: *id632
           content:
             application/json:
               schema:
@@ -95282,7 +96199,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id626
+          headers: *id632
           content:
             application/json:
               schema:
@@ -95298,7 +96215,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id626
+          headers: *id632
           content:
             application/json:
               schema:
@@ -95390,7 +96307,7 @@ paths:
                         description: Action metadata
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id627
+          headers: &id633
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95419,7 +96336,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id627
+          headers: *id633
           content:
             application/json:
               schema:
@@ -95441,7 +96358,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id627
+          headers: *id633
           content:
             application/json:
               schema:
@@ -95457,7 +96374,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id627
+          headers: *id633
           content:
             application/json:
               schema:
@@ -95551,7 +96468,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id628
+          headers: &id634
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95588,7 +96505,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id628
+          headers: *id634
           content:
             application/json:
               schema:
@@ -95608,7 +96525,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id628
+          headers: *id634
           content:
             application/json:
               schema:
@@ -95630,7 +96547,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id628
+          headers: *id634
           content:
             application/json:
               schema:
@@ -95646,7 +96563,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id628
+          headers: *id634
           content:
             application/json:
               schema:
@@ -95739,7 +96656,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id629
+          headers: &id635
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95768,7 +96685,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id629
+          headers: *id635
           content:
             application/json:
               schema:
@@ -95790,7 +96707,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id629
+          headers: *id635
           content:
             application/json:
               schema:
@@ -95888,7 +96805,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id630
+          headers: &id636
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -95925,7 +96842,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id630
+          headers: *id636
           content:
             application/json:
               schema:
@@ -95945,7 +96862,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id630
+          headers: *id636
           content:
             application/json:
               schema:
@@ -95967,7 +96884,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id630
+          headers: *id636
           content:
             application/json:
               schema:
@@ -95983,7 +96900,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id630
+          headers: *id636
           content:
             application/json:
               schema:
@@ -96083,7 +97000,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id631
+          headers: &id637
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96120,7 +97037,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id631
+          headers: *id637
           content:
             application/json:
               schema:
@@ -96140,7 +97057,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id631
+          headers: *id637
           content:
             application/json:
               schema:
@@ -96162,7 +97079,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id631
+          headers: *id637
           content:
             application/json:
               schema:
@@ -96178,7 +97095,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id631
+          headers: *id637
           content:
             application/json:
               schema:
@@ -96277,7 +97194,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id632
+          headers: &id638
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96306,7 +97223,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id632
+          headers: *id638
           content:
             application/json:
               schema:
@@ -96328,7 +97245,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id632
+          headers: *id638
           content:
             application/json:
               schema:
@@ -96355,7 +97272,7 @@ paths:
         description: Filter by credential type
         schema:
           type: string
-          enum: &id633
+          enum: &id639
           - api_key
           - oauth_token
           - password
@@ -96372,7 +97289,7 @@ paths:
                 properties:
                   credentials:
                     type: array
-                    items: &id635
+                    items: &id641
                       type: object
                       description: Credential metadata (never includes actual secret values)
                       properties:
@@ -96384,7 +97301,7 @@ paths:
                           description: Human-readable credential name
                         credential_type:
                           type: string
-                          enum: *id633
+                          enum: *id639
                           description: Type of credential
                         user_id:
                           type: string
@@ -96419,9 +97336,9 @@ paths:
                           description: Credential metadata
                   total:
                     type: integer
-        '401': &id636
+        '401': &id642
           description: Unauthorized - Authentication required or token invalid
-          headers: &id634
+          headers: &id640
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96448,9 +97365,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id637
+        '403': &id643
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id634
+          headers: *id640
           content:
             application/json:
               schema:
@@ -96470,9 +97387,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id638
+        '500': &id644
           description: Internal server error - Unexpected error occurred
-          headers: *id634
+          headers: *id640
           content:
             application/json:
               schema:
@@ -96508,7 +97425,7 @@ paths:
                   description: Human-readable credential name
                 credential_type:
                   type: string
-                  enum: *id633
+                  enum: *id639
                   description: Type of credential
                 value:
                   type: string
@@ -96528,12 +97445,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  credential: *id635
+                  credential: *id641
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id634
+          headers: *id640
           content:
             application/json:
               schema:
@@ -96559,9 +97476,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id636
-        '403': *id637
-        '500': *id638
+        '401': *id642
+        '403': *id643
+        '500': *id644
       x-aragora-stability: stable
   /api/v1/openclaw/credentials/{credential_id}:
     delete:
@@ -96589,7 +97506,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id639
+          headers: &id645
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96618,7 +97535,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id639
+          headers: *id645
           content:
             application/json:
               schema:
@@ -96640,7 +97557,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id639
+          headers: *id645
           content:
             application/json:
               schema:
@@ -96656,7 +97573,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id639
+          headers: *id645
           content:
             application/json:
               schema:
@@ -96759,7 +97676,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id640
+          headers: &id646
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96796,7 +97713,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id640
+          headers: *id646
           content:
             application/json:
               schema:
@@ -96816,7 +97733,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id640
+          headers: *id646
           content:
             application/json:
               schema:
@@ -96838,7 +97755,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id640
+          headers: *id646
           content:
             application/json:
               schema:
@@ -96854,7 +97771,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id640
+          headers: *id646
           content:
             application/json:
               schema:
@@ -96965,7 +97882,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id641
+          headers: &id647
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -96994,7 +97911,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id641
+          headers: *id647
           content:
             application/json:
               schema:
@@ -97016,7 +97933,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id641
+          headers: *id647
           content:
             application/json:
               schema:
@@ -97053,7 +97970,7 @@ paths:
                 properties:
                   rules:
                     type: array
-                    items: &id643
+                    items: &id649
                       type: object
                       properties:
                         name:
@@ -97085,9 +98002,9 @@ paths:
                           description: Whether the rule is active
                   total:
                     type: integer
-        '401': &id644
+        '401': &id650
           description: Unauthorized - Authentication required or token invalid
-          headers: &id642
+          headers: &id648
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97114,9 +98031,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id645
+        '403': &id651
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id642
+          headers: *id648
           content:
             application/json:
               schema:
@@ -97136,9 +98053,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id646
+        '500': &id652
           description: Internal server error - Unexpected error occurred
-          headers: *id642
+          headers: *id648
           content:
             application/json:
               schema:
@@ -97205,12 +98122,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  rule: *id643
+                  rule: *id649
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id642
+          headers: *id648
           content:
             application/json:
               schema:
@@ -97236,9 +98153,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id644
-        '403': *id645
-        '500': *id646
+        '401': *id650
+        '403': *id651
+        '500': *id652
       x-aragora-stability: stable
   /api/v1/openclaw/policy/rules/{rule_name}:
     delete:
@@ -97266,7 +98183,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id647
+          headers: &id653
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97295,7 +98212,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id647
+          headers: *id653
           content:
             application/json:
               schema:
@@ -97317,7 +98234,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id647
+          headers: *id653
           content:
             application/json:
               schema:
@@ -97333,7 +98250,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id647
+          headers: *id653
           content:
             application/json:
               schema:
@@ -97360,7 +98277,7 @@ paths:
         description: Filter by session status
         schema:
           type: string
-          enum: &id648
+          enum: &id654
           - active
           - idle
           - closing
@@ -97389,7 +98306,7 @@ paths:
                 properties:
                   sessions:
                     type: array
-                    items: &id650
+                    items: &id656
                       type:
                       - object
                       - 'null'
@@ -97413,7 +98330,7 @@ paths:
                           type:
                           - string
                           - 'null'
-                          enum: *id648
+                          enum: *id654
                           description: Current session status
                         created_at:
                           type:
@@ -97441,9 +98358,9 @@ paths:
                           description: Session metadata
                   total:
                     type: integer
-        '401': &id651
+        '401': &id657
           description: Unauthorized - Authentication required or token invalid
-          headers: &id649
+          headers: &id655
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97470,9 +98387,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id652
+        '403': &id658
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id649
+          headers: *id655
           content:
             application/json:
               schema:
@@ -97492,9 +98409,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id653
+        '500': &id659
           description: Internal server error - Unexpected error occurred
-          headers: *id649
+          headers: *id655
           content:
             application/json:
               schema:
@@ -97535,12 +98452,12 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id650
+                  session: *id656
                   message:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id649
+          headers: *id655
           content:
             application/json:
               schema:
@@ -97566,9 +98483,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id651
-        '403': *id652
-        '500': *id653
+        '401': *id657
+        '403': *id658
+        '500': *id659
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}:
     get:
@@ -97578,7 +98495,7 @@ paths:
       description: Get details of a specific OpenClaw session.
       operationId: getOpenclawSession
       parameters:
-      - &id655
+      - &id661
         name: session_id
         in: path
         required: true
@@ -97593,7 +98510,7 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: &id656
+                  session: &id662
                     type:
                     - object
                     - 'null'
@@ -97648,9 +98565,9 @@ paths:
                       metadata:
                         type: object
                         description: Session metadata
-        '401': &id657
+        '401': &id663
           description: Unauthorized - Authentication required or token invalid
-          headers: &id654
+          headers: &id660
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97677,9 +98594,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id658
+        '403': &id664
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id654
+          headers: *id660
           content:
             application/json:
               schema:
@@ -97699,9 +98616,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id659
+        '404': &id665
           description: Not found - The requested resource does not exist
-          headers: *id654
+          headers: *id660
           content:
             application/json:
               schema:
@@ -97715,9 +98632,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id660
+        '500': &id666
           description: Internal server error - Unexpected error occurred
-          headers: *id654
+          headers: *id660
           content:
             application/json:
               schema:
@@ -97738,7 +98655,7 @@ paths:
       description: Close an OpenClaw session. Running actions will be cancelled.
       operationId: closeOpenclawSession
       parameters:
-      - *id655
+      - *id661
       responses:
         '200':
           description: Session closed
@@ -97747,13 +98664,13 @@ paths:
               schema:
                 type: object
                 properties:
-                  session: *id656
+                  session: *id662
                   message:
                     type: string
-        '401': *id657
-        '403': *id658
-        '404': *id659
-        '500': *id660
+        '401': *id663
+        '403': *id664
+        '404': *id665
+        '500': *id666
       x-aragora-stability: stable
   /api/v1/openclaw/sessions/{session_id}/end:
     post:
@@ -97836,7 +98753,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id661
+          headers: &id667
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97865,7 +98782,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id661
+          headers: *id667
           content:
             application/json:
               schema:
@@ -97887,7 +98804,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id661
+          headers: *id667
           content:
             application/json:
               schema:
@@ -97903,7 +98820,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id661
+          headers: *id667
           content:
             application/json:
               schema:
@@ -97953,7 +98870,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id662
+          headers: &id668
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -97982,7 +98899,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id662
+          headers: *id668
           content:
             application/json:
               schema:
@@ -98004,7 +98921,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id662
+          headers: *id668
           content:
             application/json:
               schema:
@@ -98333,7 +99250,7 @@ paths:
       responses:
         '200':
           description: Conversation
-          headers: &id663
+          headers: &id669
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98349,7 +99266,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id663
+          headers: *id669
           content:
             application/json:
               schema:
@@ -98369,7 +99286,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id663
+          headers: *id669
           content:
             application/json:
               schema:
@@ -98385,7 +99302,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id663
+          headers: *id669
           content:
             application/json:
               schema:
@@ -98416,7 +99333,7 @@ paths:
       responses:
         '200':
           description: Folders
-          headers: &id664
+          headers: &id670
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98432,7 +99349,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id664
+          headers: *id670
           content:
             application/json:
               schema:
@@ -98452,7 +99369,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id664
+          headers: *id670
           content:
             application/json:
               schema:
@@ -98499,7 +99416,7 @@ paths:
       responses:
         '200':
           description: Messages
-          headers: &id665
+          headers: &id671
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98515,7 +99432,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id665
+          headers: *id671
           content:
             application/json:
               schema:
@@ -98535,7 +99452,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id665
+          headers: *id671
           content:
             application/json:
               schema:
@@ -98619,7 +99536,7 @@ paths:
       summary: Get message
       operationId: getOutlookMessage
       description: Fetch Outlook message details.
-      security: &id667
+      security: &id673
       - {}
       parameters:
       - name: message_id
@@ -98634,7 +99551,7 @@ paths:
       responses:
         '200':
           description: Message
-          headers: &id666
+          headers: &id672
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98648,9 +99565,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': &id668
+        '401': &id674
           description: Unauthorized - Authentication required or token invalid
-          headers: *id666
+          headers: *id672
           content:
             application/json:
               schema:
@@ -98668,9 +99585,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id669
+        '404': &id675
           description: Not found - The requested resource does not exist
-          headers: *id666
+          headers: *id672
           content:
             application/json:
               schema:
@@ -98684,9 +99601,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id670
+        '500': &id676
           description: Internal server error - Unexpected error occurred
-          headers: *id666
+          headers: *id672
           content:
             application/json:
               schema:
@@ -98706,7 +99623,7 @@ paths:
       summary: Delete message
       operationId: deleteOutlookMessage
       description: Delete an Outlook message.
-      security: *id667
+      security: *id673
       parameters:
       - name: message_id
         in: path
@@ -98716,14 +99633,14 @@ paths:
       responses:
         '200':
           description: Message deleted
-          headers: *id666
+          headers: *id672
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/StandardSuccessResponse'
-        '401': *id668
-        '404': *id669
-        '500': *id670
+        '401': *id674
+        '404': *id675
+        '500': *id676
       x-aragora-stability: stable
   /api/v1/outlook/messages/{message_id}/move:
     post:
@@ -98758,7 +99675,7 @@ paths:
       responses:
         '200':
           description: Message moved
-          headers: &id671
+          headers: &id677
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98774,7 +99691,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id671
+          headers: *id677
           content:
             application/json:
               schema:
@@ -98794,7 +99711,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id671
+          headers: *id677
           content:
             application/json:
               schema:
@@ -98839,7 +99756,7 @@ paths:
       responses:
         '200':
           description: Message updated
-          headers: &id672
+          headers: &id678
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98855,7 +99772,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id672
+          headers: *id678
           content:
             application/json:
               schema:
@@ -98875,7 +99792,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id672
+          headers: *id678
           content:
             application/json:
               schema:
@@ -98917,7 +99834,7 @@ paths:
       responses:
         '200':
           description: OAuth complete
-          headers: &id673
+          headers: &id679
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -98933,7 +99850,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id673
+          headers: *id679
           content:
             application/json:
               schema:
@@ -98961,7 +99878,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id673
+          headers: *id679
           content:
             application/json:
               schema:
@@ -98997,7 +99914,7 @@ paths:
       responses:
         '200':
           description: OAuth URL
-          headers: &id674
+          headers: &id680
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99013,7 +99930,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id674
+          headers: *id680
           content:
             application/json:
               schema:
@@ -99041,7 +99958,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id674
+          headers: *id680
           content:
             application/json:
               schema:
@@ -99089,7 +100006,7 @@ paths:
       responses:
         '200':
           description: Reply sent
-          headers: &id675
+          headers: &id681
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99105,7 +100022,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id675
+          headers: *id681
           content:
             application/json:
               schema:
@@ -99133,7 +100050,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id675
+          headers: *id681
           content:
             application/json:
               schema:
@@ -99153,7 +100070,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id675
+          headers: *id681
           content:
             application/json:
               schema:
@@ -99188,7 +100105,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id676
+          headers: &id682
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99204,7 +100121,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id676
+          headers: *id682
           content:
             application/json:
               schema:
@@ -99224,7 +100141,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id676
+          headers: *id682
           content:
             application/json:
               schema:
@@ -99288,7 +100205,7 @@ paths:
       responses:
         '200':
           description: Message sent
-          headers: &id677
+          headers: &id683
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99304,7 +100221,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id677
+          headers: *id683
           content:
             application/json:
               schema:
@@ -99332,7 +100249,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id677
+          headers: *id683
           content:
             application/json:
               schema:
@@ -99352,7 +100269,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id677
+          headers: *id683
           content:
             application/json:
               schema:
@@ -99383,7 +100300,7 @@ paths:
       responses:
         '200':
           description: Status
-          headers: &id678
+          headers: &id684
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99399,7 +100316,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id678
+          headers: *id684
           content:
             application/json:
               schema:
@@ -99419,7 +100336,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id678
+          headers: *id684
           content:
             application/json:
               schema:
@@ -99638,7 +100555,7 @@ paths:
       responses:
         '201':
           description: Workflow created from Hive Mind pattern
-          headers: &id679
+          headers: &id685
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99654,7 +100571,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id679
+          headers: *id685
           content:
             application/json:
               schema:
@@ -99731,7 +100648,7 @@ paths:
       responses:
         '201':
           description: Workflow created from MapReduce pattern
-          headers: &id680
+          headers: &id686
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99747,7 +100664,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id680
+          headers: *id686
           content:
             application/json:
               schema:
@@ -99818,7 +100735,7 @@ paths:
       responses:
         '201':
           description: Workflow created from Review Cycle pattern
-          headers: &id681
+          headers: &id687
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99834,7 +100751,7 @@ paths:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id681
+          headers: *id687
           content:
             application/json:
               schema:
@@ -99877,7 +100794,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id682
+          headers: &id688
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -99893,7 +100810,7 @@ paths:
                 $ref: '#/components/schemas/PatternTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id682
+          headers: *id688
           content:
             application/json:
               schema:
@@ -100259,6 +101176,147 @@ paths:
       x-autogenerated: true
       x-method-inferred: true
       x-aragora-stability: experimental
+  /api/v1/pipeline/{id}/agents:
+    get:
+      tags:
+      - Pipeline
+      summary: List pipeline agents
+      operationId: listPipelineAgents
+      description: Return current agent assignments and statuses for a pipeline.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      responses:
+        '200':
+          description: Pipeline agent assignments
+          content:
+            application/json:
+              schema:
+                type: object
+      x-aragora-stability: experimental
+  /api/v1/pipeline/{id}/agents/{agent_id}/approve:
+    post:
+      tags:
+      - Pipeline
+      summary: Approve pipeline agent
+      operationId: approvePipelineAgent
+      description: Approve an assigned agent task for a pipeline.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent assignment ID
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                notes:
+                  type: string
+      responses:
+        '200':
+          description: Agent approval recorded
+          content:
+            application/json:
+              schema:
+                type: object
+      x-aragora-stability: experimental
+  /api/v1/pipeline/{id}/agents/{agent_id}/reject:
+    post:
+      tags:
+      - Pipeline
+      summary: Reject pipeline agent
+      operationId: rejectPipelineAgent
+      description: Reject an assigned agent task for a pipeline.
+      security:
+      - {}
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Pipeline ID
+      - name: agent_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Agent assignment ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - feedback
+              properties:
+                feedback:
+                  type: string
+      responses:
+        '200':
+          description: Agent rejection recorded
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers:
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+      x-aragora-stability: experimental
   /api/v1/plans:
     put:
       summary: Autogenerated placeholder (spec pending)
@@ -100339,7 +101397,7 @@ paths:
       responses:
         '200':
           description: List of playbooks
-          headers: &id683
+          headers: &id689
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100513,7 +101571,7 @@ paths:
                   count: 1
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id683
+          headers: *id689
           content:
             application/json:
               schema:
@@ -100570,7 +101628,7 @@ paths:
       responses:
         '200':
           description: Playbook details
-          headers: &id684
+          headers: &id690
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100734,7 +101792,7 @@ paths:
                   metadata: {}
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id684
+          headers: *id690
           content:
             application/json:
               schema:
@@ -100814,7 +101872,7 @@ paths:
       responses:
         '202':
           description: Playbook run queued
-          headers: &id685
+          headers: &id691
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -100915,7 +101973,7 @@ paths:
                     consensus_threshold: 0.75
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id685
+          headers: *id691
           content:
             application/json:
               schema:
@@ -100943,7 +102001,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id685
+          headers: *id691
           content:
             application/json:
               schema:
@@ -100959,7 +102017,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id685
+          headers: *id691
           content:
             application/json:
               schema:
@@ -100979,7 +102037,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id685
+          headers: *id691
           content:
             application/json:
               schema:
@@ -101425,7 +102483,7 @@ paths:
       operationId: installPlugin
       description: Install a plugin for the current user with optional configuration.
       parameters:
-      - &id686
+      - &id692
         name: name
         in: path
         required: true
@@ -101447,7 +102505,7 @@ paths:
       responses:
         '200':
           description: Installation result
-          headers: &id687
+          headers: &id693
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101476,11 +102534,11 @@ paths:
       operationId: uninstallPlugin
       description: Uninstall a plugin and remove its configuration for the current user.
       parameters:
-      - *id686
+      - *id692
       responses:
         '200':
           description: Uninstallation result
-          headers: *id687
+          headers: *id693
           content:
             application/json:
               schema:
@@ -101754,7 +102812,7 @@ paths:
       summary: Get policy by ID
       operationId: getPolicy
       description: Retrieve a specific governance policy by its unique identifier.
-      security: &id689
+      security: &id695
       - bearerAuth: []
       parameters:
       - name: policy_id
@@ -101766,7 +102824,7 @@ paths:
       responses:
         '200':
           description: Policy details
-          headers: &id688
+          headers: &id694
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -101780,9 +102838,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
-        '401': &id690
+        '401': &id696
           description: Unauthorized - Authentication required or token invalid
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101800,9 +102858,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id691
+        '403': &id697
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101822,9 +102880,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id692
+        '404': &id698
           description: Not found - The requested resource does not exist
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101838,9 +102896,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id693
+        '500': &id699
           description: Internal server error - Unexpected error occurred
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101861,7 +102919,7 @@ paths:
       summary: Update policy
       operationId: updatePolicy
       description: Update an existing governance policy. Validates for conflicts with other active policies.
-      security: *id689
+      security: *id695
       parameters:
       - name: policy_id
         in: path
@@ -101896,14 +102954,14 @@ paths:
       responses:
         '200':
           description: Policy updated
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Policy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101929,16 +102987,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id690
-        '403': *id691
-        '404': *id692
+        '401': *id696
+        '403': *id697
+        '404': *id698
         '409':
           description: Policy conflict detected with existing policies
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id693
+        '500': *id699
       x-aragora-stability: experimental
     delete:
       tags:
@@ -101947,7 +103005,7 @@ paths:
       summary: Delete policy
       operationId: deletePolicy
       description: Delete a governance policy by ID. Active policies must be disabled before deletion.
-      security: *id689
+      security: *id695
       parameters:
       - name: policy_id
         in: path
@@ -101958,7 +103016,7 @@ paths:
       responses:
         '200':
           description: Policy deleted
-          headers: *id688
+          headers: *id694
           content:
             application/json:
               schema:
@@ -101968,16 +103026,16 @@ paths:
                     type: string
                   deleted:
                     type: boolean
-        '401': *id690
-        '403': *id691
-        '404': *id692
+        '401': *id696
+        '403': *id697
+        '404': *id698
         '409':
           description: Cannot delete an active policy - disable it first
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id693
+        '500': *id699
       x-aragora-stability: stable
   /api/v1/postman.json:
     get:
@@ -102028,7 +103086,7 @@ paths:
       responses:
         '200':
           description: Account deletion scheduled
-          headers: &id694
+          headers: &id700
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102055,7 +103113,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id694
+          headers: *id700
           content:
             application/json:
               schema:
@@ -102083,7 +103141,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id694
+          headers: *id700
           content:
             application/json:
               schema:
@@ -102103,7 +103161,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id694
+          headers: *id700
           content:
             application/json:
               schema:
@@ -102136,7 +103194,7 @@ paths:
       responses:
         '200':
           description: Privacy data inventory
-          headers: &id695
+          headers: &id701
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102174,7 +103232,7 @@ paths:
                     type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id695
+          headers: *id701
           content:
             application/json:
               schema:
@@ -102216,7 +103274,7 @@ paths:
       responses:
         '200':
           description: User data export
-          headers: &id696
+          headers: &id702
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102268,7 +103326,7 @@ paths:
                         type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id696
+          headers: *id702
           content:
             application/json:
               schema:
@@ -102299,7 +103357,7 @@ paths:
       responses:
         '200':
           description: Privacy preferences
-          headers: &id697
+          headers: &id703
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -102311,10 +103369,10 @@ paths:
                 type: integer
           content:
             application/json:
-              schema: &id699
+              schema: &id705
                 type: object
                 properties:
-                  preferences: &id698
+                  preferences: &id704
                     type: object
                     properties:
                       do_not_sell:
@@ -102325,9 +103383,9 @@ paths:
                         type: boolean
                       third_party_sharing:
                         type: boolean
-        '401': &id700
+        '401': &id706
           description: Unauthorized - Authentication required or token invalid
-          headers: *id697
+          headers: *id703
           content:
             application/json:
               schema:
@@ -102358,17 +103416,17 @@ paths:
         required: true
         content:
           application/json:
-            schema: *id698
+            schema: *id704
       responses:
         '200':
           description: Privacy preferences updated
-          headers: *id697
+          headers: *id703
           content:
             application/json:
-              schema: *id699
+              schema: *id705
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id697
+          headers: *id703
           content:
             application/json:
               schema:
@@ -102394,7 +103452,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id700
+        '401': *id706
       x-aragora-stability: experimental
   /api/v1/probes/capability:
     post:
@@ -103248,7 +104306,7 @@ paths:
       responses:
         '200':
           description: List of jobs
-          headers: &id701
+          headers: &id707
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103285,9 +104343,9 @@ paths:
                           format: date-time
                   total:
                     type: integer
-        '401': &id702
+        '401': &id708
           description: Unauthorized - Authentication required or token invalid
-          headers: *id701
+          headers: *id707
           content:
             application/json:
               schema:
@@ -103350,7 +104408,7 @@ paths:
       responses:
         '201':
           description: Job created
-          headers: *id701
+          headers: *id707
           content:
             application/json:
               schema:
@@ -103362,7 +104420,7 @@ paths:
                     type: string
                   position:
                     type: integer
-        '401': *id702
+        '401': *id708
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -103382,7 +104440,7 @@ paths:
       responses:
         '200':
           description: Job details
-          headers: &id703
+          headers: &id709
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103414,9 +104472,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id704
+        '404': &id710
           description: Not found - The requested resource does not exist
-          headers: *id703
+          headers: *id709
           content:
             application/json:
               schema:
@@ -103448,7 +104506,7 @@ paths:
       responses:
         '200':
           description: Job cancelled
-          headers: *id703
+          headers: *id709
           content:
             application/json:
               schema:
@@ -103456,7 +104514,7 @@ paths:
                 properties:
                   cancelled:
                     type: boolean
-        '404': *id704
+        '404': *id710
         '409':
           description: Job cannot be cancelled (already running or completed)
           content:
@@ -103487,7 +104545,7 @@ paths:
       responses:
         '200':
           description: Job re-queued
-          headers: &id705
+          headers: &id711
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -103508,7 +104566,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id705
+          headers: *id711
           content:
             application/json:
               schema:
@@ -103994,7 +105052,7 @@ paths:
       responses:
         '200':
           description: Readiness report
-          headers: &id706
+          headers: &id712
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104115,7 +105173,7 @@ paths:
                   timestamp: '2026-02-21T12:00:00Z'
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id706
+          headers: *id712
           content:
             application/json:
               schema:
@@ -104278,7 +105336,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id707
+          headers: &id713
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104315,7 +105373,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id707
+          headers: *id713
           content:
             application/json:
               schema:
@@ -104335,7 +105393,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id707
+          headers: *id713
           content:
             application/json:
               schema:
@@ -104351,7 +105409,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id707
+          headers: *id713
           content:
             application/json:
               schema:
@@ -104444,7 +105502,7 @@ paths:
       responses:
         '200':
           description: Bulk resolution results
-          headers: &id708
+          headers: &id714
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104460,7 +105518,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id708
+          headers: *id714
           content:
             application/json:
               schema:
@@ -104488,7 +105546,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id708
+          headers: *id714
           content:
             application/json:
               schema:
@@ -104558,7 +105616,7 @@ paths:
       responses:
         '200':
           description: Reconciliation job started
-          headers: &id709
+          headers: &id715
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104574,7 +105632,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id709
+          headers: *id715
           content:
             application/json:
               schema:
@@ -104602,7 +105660,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id709
+          headers: *id715
           content:
             application/json:
               schema:
@@ -104694,7 +105752,7 @@ paths:
       responses:
         '200':
           description: Approval confirmation
-          headers: &id710
+          headers: &id716
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104710,7 +105768,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id710
+          headers: *id716
           content:
             application/json:
               schema:
@@ -104726,7 +105784,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id710
+          headers: *id716
           content:
             application/json:
               schema:
@@ -104807,7 +105865,7 @@ paths:
       responses:
         '200':
           description: Resolution confirmation
-          headers: &id711
+          headers: &id717
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -104823,7 +105881,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id711
+          headers: *id717
           content:
             application/json:
               schema:
@@ -104851,7 +105909,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id711
+          headers: *id717
           content:
             application/json:
               schema:
@@ -104867,7 +105925,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id711
+          headers: *id717
           content:
             application/json:
               schema:
@@ -105656,7 +106714,7 @@ paths:
       responses:
         '200':
           description: List of expiring items
-          headers: &id712
+          headers: &id718
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105679,7 +106737,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id712
+          headers: *id718
           content:
             application/json:
               schema:
@@ -105710,7 +106768,7 @@ paths:
       responses:
         '200':
           description: List of retention policies
-          headers: &id713
+          headers: &id719
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105724,9 +106782,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicyList'
-        '401': &id714
+        '401': &id720
           description: Unauthorized - Authentication required or token invalid
-          headers: *id713
+          headers: *id719
           content:
             application/json:
               schema:
@@ -105784,14 +106842,14 @@ paths:
       responses:
         '201':
           description: Policy created
-          headers: *id713
+          headers: *id719
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RetentionPolicy'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id713
+          headers: *id719
           content:
             application/json:
               schema:
@@ -105817,10 +106875,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id714
+        '401': *id720
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id713
+          headers: *id719
           content:
             application/json:
               schema:
@@ -105931,7 +106989,7 @@ paths:
       responses:
         '200':
           description: Execution result with affected items count
-          headers: &id715
+          headers: &id721
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -105954,7 +107012,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id715
+          headers: *id721
           content:
             application/json:
               schema:
@@ -105974,7 +107032,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id715
+          headers: *id721
           content:
             application/json:
               schema:
@@ -105996,7 +107054,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id715
+          headers: *id721
           content:
             application/json:
               schema:
@@ -106049,7 +107107,7 @@ paths:
       responses:
         '200':
           description: Review details
-          headers: &id716
+          headers: &id722
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -106077,9 +107135,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '400': &id717
+        '400': &id723
           description: Bad request - Invalid input or malformed JSON
-          headers: *id716
+          headers: *id722
           content:
             application/json:
               schema:
@@ -106105,9 +107163,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': &id718
+        '404': &id724
           description: Not found - The requested resource does not exist
-          headers: *id716
+          headers: *id722
           content:
             application/json:
               schema:
@@ -106121,9 +107179,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id719
+        '500': &id725
           description: Internal server error - Unexpected error occurred
-          headers: *id716
+          headers: *id722
           content:
             application/json:
               schema:
@@ -106172,7 +107230,7 @@ paths:
       responses:
         '200':
           description: Review updated
-          headers: *id716
+          headers: *id722
           content:
             application/json:
               schema:
@@ -106182,9 +107240,9 @@ paths:
                     type: boolean
                   review_id:
                     type: string
-        '400': *id717
-        '404': *id718
-        '500': *id719
+        '400': *id723
+        '404': *id724
+        '500': *id725
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -106204,7 +107262,7 @@ paths:
       responses:
         '200':
           description: Review deleted
-          headers: *id716
+          headers: *id722
           content:
             application/json:
               schema:
@@ -106214,8 +107272,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id718
-        '500': *id719
+        '404': *id724
+        '500': *id725
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -109720,13 +110778,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id720
+        schema: &id726
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id720
+        schema: *id726
       responses:
         '200':
           description: Ticket updated
@@ -109757,13 +110815,13 @@ paths:
         in: path
         required: true
         description: Unique support integration identifier.
-        schema: &id721
+        schema: &id727
           type: string
       - name: ticket_id
         in: path
         required: true
         description: Unique ticket identifier within the support system.
-        schema: *id721
+        schema: *id727
       responses:
         '200':
           description: Reply sent
@@ -110093,7 +111151,7 @@ paths:
       responses:
         '200':
           description: Template registry listing
-          headers: &id722
+          headers: &id728
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110148,7 +111206,7 @@ paths:
                     - 'null'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id722
+          headers: *id728
           content:
             application/json:
               schema:
@@ -110225,523 +111283,6 @@ paths:
       responses:
         '200':
           description: Email scan
-          headers: &id723
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id723
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id723
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id723
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/hash/{hash_value}:
-    get:
-      tags:
-      - Threat Intel
-      summary: File hash lookup
-      operationId: getThreatHash
-      description: Check a file hash for malware.
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: hash_value
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: Hash result
-          headers: &id724
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id724
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id724
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/hashes:
-    post:
-      tags:
-      - Threat Intel
-      summary: Batch hash lookup
-      operationId: createThreatHashes
-      description: Check multiple hashes for malware.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                hashes:
-                  type: array
-                  items:
-                    type: string
-                  description: File hashes to check (MD5, SHA1, or SHA256)
-                hash_type:
-                  type: string
-                  enum:
-                  - md5
-                  - sha1
-                  - sha256
-                  description: Type of hash provided
-              required:
-              - hashes
-      responses:
-        '200':
-          description: Hash results
-          headers: &id725
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id725
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id725
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id725
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/ip/{ip_address}:
-    get:
-      tags:
-      - Threat Intel
-      summary: IP reputation
-      operationId: getThreatIp
-      description: Check IP reputation.
-      security:
-      - bearerAuth: []
-      parameters:
-      - name: ip_address
-        in: path
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: IP result
-          headers: &id726
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id726
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id726
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/ips:
-    post:
-      tags:
-      - Threat Intel
-      summary: Batch IP reputation
-      operationId: createThreatIps
-      description: Check multiple IPs for reputation.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                ip_addresses:
-                  type: array
-                  items:
-                    type: string
-                    format: ipv4
-                  description: IP addresses to check reputation
-              required:
-              - ip_addresses
-      responses:
-        '200':
-          description: IP results
-          headers: &id727
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id727
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id727
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id727
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/status:
-    get:
-      tags:
-      - Threat Intel
-      summary: Service status
-      operationId: listThreatStatus
-      description: Get threat intel service status.
-      security:
-      - bearerAuth: []
-      responses:
-        '200':
-          description: Status
-          headers: &id728
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/StandardSuccessResponse'
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id728
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id728
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v1/threat/url:
-    post:
-      tags:
-      - Threat Intel
-      summary: Scan URL
-      operationId: createThreatUrl
-      description: Check a URL against threat intel feeds.
-      security:
-      - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                url:
-                  type: string
-                  format: uri
-                  description: URL to scan for threats
-              required:
-              - url
-      responses:
-        '200':
-          description: Threat result
           headers: &id729
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
@@ -110820,13 +111361,81 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
-  /api/v1/threat/urls:
+  /api/v1/threat/hash/{hash_value}:
+    get:
+      tags:
+      - Threat Intel
+      summary: File hash lookup
+      operationId: getThreatHash
+      description: Check a file hash for malware.
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: hash_value
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Hash result
+          headers: &id730
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id730
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id730
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/hashes:
     post:
       tags:
       - Threat Intel
-      summary: Batch scan URLs
-      operationId: createThreatUrls
-      description: Check multiple URLs for threats.
+      summary: Batch hash lookup
+      operationId: createThreatHashes
+      description: Check multiple hashes for malware.
       security:
       - bearerAuth: []
       requestBody:
@@ -110836,18 +111445,24 @@ paths:
             schema:
               type: object
               properties:
-                urls:
+                hashes:
                   type: array
                   items:
                     type: string
-                    format: uri
-                  description: URLs to scan for threats
+                  description: File hashes to check (MD5, SHA1, or SHA256)
+                hash_type:
+                  type: string
+                  enum:
+                  - md5
+                  - sha1
+                  - sha256
+                  description: Type of hash provided
               required:
-              - urls
+              - hashes
       responses:
         '200':
-          description: Threat results
-          headers: &id730
+          description: Hash results
+          headers: &id731
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -110863,7 +111478,7 @@ paths:
                 $ref: '#/components/schemas/StandardSuccessResponse'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id730
+          headers: *id731
           content:
             application/json:
               schema:
@@ -110891,7 +111506,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id730
+          headers: *id731
           content:
             application/json:
               schema:
@@ -110911,7 +111526,450 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id730
+          headers: *id731
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/ip/{ip_address}:
+    get:
+      tags:
+      - Threat Intel
+      summary: IP reputation
+      operationId: getThreatIp
+      description: Check IP reputation.
+      security:
+      - bearerAuth: []
+      parameters:
+      - name: ip_address
+        in: path
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: IP result
+          headers: &id732
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id732
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id732
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/ips:
+    post:
+      tags:
+      - Threat Intel
+      summary: Batch IP reputation
+      operationId: createThreatIps
+      description: Check multiple IPs for reputation.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ip_addresses:
+                  type: array
+                  items:
+                    type: string
+                    format: ipv4
+                  description: IP addresses to check reputation
+              required:
+              - ip_addresses
+      responses:
+        '200':
+          description: IP results
+          headers: &id733
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id733
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id733
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id733
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/status:
+    get:
+      tags:
+      - Threat Intel
+      summary: Service status
+      operationId: listThreatStatus
+      description: Get threat intel service status.
+      security:
+      - bearerAuth: []
+      responses:
+        '200':
+          description: Status
+          headers: &id734
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id734
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id734
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/url:
+    post:
+      tags:
+      - Threat Intel
+      summary: Scan URL
+      operationId: createThreatUrl
+      description: Check a URL against threat intel feeds.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                url:
+                  type: string
+                  format: uri
+                  description: URL to scan for threats
+              required:
+              - url
+      responses:
+        '200':
+          description: Threat result
+          headers: &id735
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id735
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id735
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id735
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v1/threat/urls:
+    post:
+      tags:
+      - Threat Intel
+      summary: Batch scan URLs
+      operationId: createThreatUrls
+      description: Check multiple URLs for threats.
+      security:
+      - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                urls:
+                  type: array
+                  items:
+                    type: string
+                    format: uri
+                  description: URLs to scan for threats
+              required:
+              - urls
+      responses:
+        '200':
+          description: Threat results
+          headers: &id736
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardSuccessResponse'
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id736
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id736
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id736
           content:
             application/json:
               schema:
@@ -111153,7 +112211,7 @@ paths:
       responses:
         '200':
           description: Tournament details
-          headers: &id731
+          headers: &id737
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -111183,9 +112241,9 @@ paths:
                   created_at:
                     type: string
                     format: date-time
-        '404': &id732
+        '404': &id738
           description: Not found - The requested resource does not exist
-          headers: *id731
+          headers: *id737
           content:
             application/json:
               schema:
@@ -111199,9 +112257,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id733
+        '500': &id739
           description: Internal server error - Unexpected error occurred
-          headers: *id731
+          headers: *id737
           content:
             application/json:
               schema:
@@ -111231,7 +112289,7 @@ paths:
       responses:
         '200':
           description: Tournament deleted
-          headers: *id731
+          headers: *id737
           content:
             application/json:
               schema:
@@ -111241,8 +112299,8 @@ paths:
                     type: boolean
                   deleted_id:
                     type: string
-        '404': *id732
-        '500': *id733
+        '404': *id738
+        '500': *id739
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -112146,7 +113204,7 @@ paths:
       responses:
         '200':
           description: List of linked providers
-          headers: &id734
+          headers: &id740
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112173,7 +113231,7 @@ paths:
                           format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id734
+          headers: *id740
           content:
             application/json:
               schema:
@@ -112790,9 +113848,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id736
+        '404': &id742
           description: Not found - The requested resource does not exist
-          headers: &id735
+          headers: &id741
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -112853,7 +113911,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id735
+          headers: *id741
           content:
             application/json:
               schema:
@@ -112865,7 +113923,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id735
+          headers: *id741
           content:
             application/json:
               schema:
@@ -112891,7 +113949,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id736
+        '404': *id742
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -113406,7 +114464,7 @@ paths:
                     format: date-time
         '404':
           description: Delivery not found
-          headers: &id737
+          headers: &id743
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -113436,7 +114494,7 @@ paths:
           description: Delivery deleted
         '404':
           description: Delivery not found
-          headers: *id737
+          headers: *id743
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -114060,7 +115118,7 @@ paths:
       operationId: getWebhook
       description: Get details of a specific webhook.
       parameters:
-      - &id738
+      - &id744
         name: id
         in: path
         required: true
@@ -114112,7 +115170,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: &id739
+          headers: &id745
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114132,7 +115190,7 @@ paths:
       operationId: patchWebhook
       description: Update webhook configuration.
       parameters:
-      - *id738
+      - *id744
       requestBody:
         required: true
         content:
@@ -114195,7 +115253,7 @@ paths:
                 - enabled
         '404':
           description: Webhook not found
-          headers: *id739
+          headers: *id745
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -114206,13 +115264,13 @@ paths:
       operationId: deleteWebhook
       description: Delete a webhook subscription.
       parameters:
-      - *id738
+      - *id744
       responses:
         '204':
           description: Webhook deleted
         '404':
           description: Webhook not found
-          headers: *id739
+          headers: *id745
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -114284,7 +115342,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id740
+          headers: &id746
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114307,7 +115365,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id740
+          headers: *id746
           content:
             application/json:
               schema:
@@ -114360,7 +115418,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id741
+          headers: &id747
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114383,7 +115441,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id741
+          headers: *id747
           content:
             application/json:
               schema:
@@ -114411,7 +115469,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id741
+          headers: *id747
           content:
             application/json:
               schema:
@@ -114431,7 +115489,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id741
+          headers: *id747
           content:
             application/json:
               schema:
@@ -114537,7 +115595,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id742
+          headers: &id748
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114564,9 +115622,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id743
+        '404': &id749
           description: Not found - The requested resource does not exist
-          headers: *id742
+          headers: *id748
           content:
             application/json:
               schema:
@@ -114596,7 +115654,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id742
+          headers: *id748
           content:
             application/json:
               schema:
@@ -114608,7 +115666,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id742
+          headers: *id748
           content:
             application/json:
               schema:
@@ -114634,7 +115692,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id743
+        '404': *id749
       x-aragora-stability: stable
   /api/v1/workflow-templates:
     get:
@@ -114683,7 +115741,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id744
+          headers: &id750
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114699,7 +115757,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id744
+          headers: *id750
           content:
             application/json:
               schema:
@@ -114783,7 +115841,7 @@ paths:
       responses:
         '200':
           description: Pattern template details
-          headers: &id745
+          headers: &id751
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114820,7 +115878,7 @@ paths:
                       type: string
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id745
+          headers: *id751
           content:
             application/json:
               schema:
@@ -114866,7 +115924,7 @@ paths:
       responses:
         '201':
           description: Workflow instantiated
-          headers: &id746
+          headers: &id752
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -114887,7 +115945,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id746
+          headers: *id752
           content:
             application/json:
               schema:
@@ -114915,7 +115973,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id746
+          headers: *id752
           content:
             application/json:
               schema:
@@ -114931,7 +115989,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id746
+          headers: *id752
           content:
             application/json:
               schema:
@@ -115018,7 +116076,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id747
+          headers: &id753
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115034,7 +116092,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id747
+          headers: *id753
           content:
             application/json:
               schema:
@@ -115062,7 +116120,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id747
+          headers: *id753
           content:
             application/json:
               schema:
@@ -115158,7 +116216,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id748
+          headers: &id754
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115174,7 +116232,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id748
+          headers: *id754
           content:
             application/json:
               schema:
@@ -115356,7 +116414,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id749
+          headers: &id755
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115393,7 +116451,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id749
+          headers: *id755
           content:
             application/json:
               schema:
@@ -115450,7 +116508,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id750
+          headers: &id756
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115511,14 +116569,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id750
+          headers: *id756
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id750
+          headers: *id756
           content:
             application/json:
               schema:
@@ -115655,7 +116713,7 @@ paths:
       responses:
         '200':
           description: Workflow execution details
-          headers: &id751
+          headers: &id757
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115678,9 +116736,9 @@ paths:
                     type: string
                   result:
                     type: object
-        '404': &id752
+        '404': &id758
           description: Not found - The requested resource does not exist
-          headers: *id751
+          headers: *id757
           content:
             application/json:
               schema:
@@ -115713,7 +116771,7 @@ paths:
       responses:
         '200':
           description: Workflow execution deleted
-          headers: *id751
+          headers: *id757
           content:
             application/json:
               schema:
@@ -115725,7 +116783,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id751
+          headers: *id757
           content:
             application/json:
               schema:
@@ -115751,7 +116809,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id752
+        '404': *id758
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -115907,7 +116965,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id753
+          headers: &id759
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -115921,9 +116979,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '404': &id754
+        '404': &id760
           description: Not found - The requested resource does not exist
-          headers: *id753
+          headers: *id759
           content:
             application/json:
               schema:
@@ -115985,14 +117043,14 @@ paths:
       responses:
         '200':
           description: Workflow template updated
-          headers: *id753
+          headers: *id759
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkflowTemplate'
-        '400': &id755
+        '400': &id761
           description: Bad request - Invalid input or malformed JSON
-          headers: *id753
+          headers: *id759
           content:
             application/json:
               schema:
@@ -116018,7 +117076,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id754
+        '404': *id760
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -116038,7 +117096,7 @@ paths:
       responses:
         '200':
           description: Workflow template deleted
-          headers: *id753
+          headers: *id759
           content:
             application/json:
               schema:
@@ -116048,8 +117106,8 @@ paths:
                     type: boolean
                   template_id:
                     type: string
-        '400': *id755
-        '404': *id754
+        '400': *id761
+        '404': *id760
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -116118,7 +117176,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id756
+          headers: &id762
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116132,9 +117190,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id757
+        '404': &id763
           description: Not found - The requested resource does not exist
-          headers: *id756
+          headers: *id762
           content:
             application/json:
               schema:
@@ -116170,14 +117228,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id756
+          headers: *id762
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id756
+          headers: *id762
           content:
             application/json:
               schema:
@@ -116203,7 +117261,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id757
+        '404': *id763
       x-aragora-stability: stable
     delete:
       tags:
@@ -116220,7 +117278,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id756
+          headers: *id762
           content:
             application/json:
               schema:
@@ -116230,7 +117288,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id757
+        '404': *id763
       x-aragora-stability: stable
     patch:
       summary: Update a workflow
@@ -116289,7 +117347,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id758
+          headers: &id764
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116312,7 +117370,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id758
+          headers: *id764
           content:
             application/json:
               schema:
@@ -116340,7 +117398,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id758
+          headers: *id764
           content:
             application/json:
               schema:
@@ -116356,7 +117414,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id758
+          headers: *id764
           content:
             application/json:
               schema:
@@ -116442,7 +117500,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id759
+          headers: &id765
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116465,7 +117523,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id759
+          headers: *id765
           content:
             application/json:
               schema:
@@ -116543,7 +117601,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id760
+          headers: &id766
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116557,9 +117615,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id761
+        '401': &id767
           description: Unauthorized - Authentication required or token invalid
-          headers: *id760
+          headers: *id766
           content:
             application/json:
               schema:
@@ -116614,14 +117672,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id760
+          headers: *id766
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id760
+          headers: *id766
           content:
             application/json:
               schema:
@@ -116647,10 +117705,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id761
+        '401': *id767
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id760
+          headers: *id766
           content:
             application/json:
               schema:
@@ -116695,7 +117753,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id762
+          headers: &id768
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116723,7 +117781,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id762
+          headers: *id768
           content:
             application/json:
               schema:
@@ -116760,7 +117818,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id763
+          headers: &id769
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -116774,9 +117832,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id764
+        '401': &id770
           description: Unauthorized - Authentication required or token invalid
-          headers: *id763
+          headers: *id769
           content:
             application/json:
               schema:
@@ -116794,9 +117852,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id765
+        '403': &id771
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id763
+          headers: *id769
           content:
             application/json:
               schema:
@@ -116816,9 +117874,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id766
+        '404': &id772
           description: Not found - The requested resource does not exist
-          headers: *id763
+          headers: *id769
           content:
             application/json:
               schema:
@@ -116850,7 +117908,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id763
+          headers: *id769
           content:
             application/json:
               schema:
@@ -116860,9 +117918,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id764
-        '403': *id765
-        '404': *id766
+        '401': *id770
+        '403': *id771
+        '404': *id772
       x-aragora-stability: stable
   /api/v1/workspaces/{workspace_id}/activity:
     get:
@@ -117075,7 +118133,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id767
+          headers: &id773
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117098,7 +118156,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id767
+          headers: *id773
           content:
             application/json:
               schema:
@@ -117126,7 +118184,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id767
+          headers: *id773
           content:
             application/json:
               schema:
@@ -117146,7 +118204,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id767
+          headers: *id773
           content:
             application/json:
               schema:
@@ -117282,7 +118340,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id768
+          headers: &id774
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117305,7 +118363,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id768
+          headers: *id774
           content:
             application/json:
               schema:
@@ -117333,7 +118391,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id768
+          headers: *id774
           content:
             application/json:
               schema:
@@ -117353,7 +118411,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id768
+          headers: *id774
           content:
             application/json:
               schema:
@@ -117375,7 +118433,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id768
+          headers: *id774
           content:
             application/json:
               schema:
@@ -117427,7 +118485,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id769
+          headers: &id775
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117454,7 +118512,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id769
+          headers: *id775
           content:
             application/json:
               schema:
@@ -117474,7 +118532,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id769
+          headers: *id775
           content:
             application/json:
               schema:
@@ -117496,7 +118554,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id769
+          headers: *id775
           content:
             application/json:
               schema:
@@ -117682,9 +118740,9 @@ paths:
                           type: integer
                   total:
                     type: integer
-        '401': &id771
+        '401': &id777
           description: Unauthorized - Authentication required or token invalid
-          headers: &id770
+          headers: &id776
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117711,9 +118769,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id772
+        '403': &id778
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id770
+          headers: *id776
           content:
             application/json:
               schema:
@@ -117733,9 +118791,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': &id773
+        '500': &id779
           description: Internal server error - Unexpected error occurred
-          headers: *id770
+          headers: *id776
           content:
             application/json:
               schema:
@@ -117808,7 +118866,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id770
+          headers: *id776
           content:
             application/json:
               schema:
@@ -117834,15 +118892,15 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id771
-        '403': *id772
+        '401': *id777
+        '403': *id778
         '409':
           description: Another backup is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id773
+        '500': *id779
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -117909,9 +118967,9 @@ paths:
                   expires_at:
                     type: string
                     format: date-time
-        '401': &id775
+        '401': &id781
           description: Unauthorized - Authentication required or token invalid
-          headers: &id774
+          headers: &id780
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -117938,9 +118996,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id776
+        '403': &id782
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id774
+          headers: *id780
           content:
             application/json:
               schema:
@@ -117960,9 +119018,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id777
+        '404': &id783
           description: Not found - The requested resource does not exist
-          headers: *id774
+          headers: *id780
           content:
             application/json:
               schema:
@@ -117976,9 +119034,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id778
+        '500': &id784
           description: Internal server error - Unexpected error occurred
-          headers: *id774
+          headers: *id780
           content:
             application/json:
               schema:
@@ -118020,16 +119078,16 @@ paths:
                     type: boolean
                   backup_id:
                     type: string
-        '401': *id775
-        '403': *id776
-        '404': *id777
+        '401': *id781
+        '403': *id782
+        '404': *id783
         '409':
           description: Cannot delete an in-progress backup
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id778
+        '500': *id784
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -118098,7 +119156,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id779
+          headers: &id785
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118127,7 +119185,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id779
+          headers: *id785
           content:
             application/json:
               schema:
@@ -118149,7 +119207,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id779
+          headers: *id785
           content:
             application/json:
               schema:
@@ -118228,7 +119286,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id780
+          headers: &id786
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118257,7 +119315,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id780
+          headers: *id786
           content:
             application/json:
               schema:
@@ -118279,7 +119337,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id780
+          headers: *id786
           content:
             application/json:
               schema:
@@ -118295,7 +119353,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id780
+          headers: *id786
           content:
             application/json:
               schema:
@@ -118380,7 +119438,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id781
+          headers: &id787
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118409,7 +119467,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id781
+          headers: *id787
           content:
             application/json:
               schema:
@@ -118431,7 +119489,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id781
+          headers: *id787
           content:
             application/json:
               schema:
@@ -118524,9 +119582,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '401': &id783
+        '401': &id789
           description: Unauthorized - Authentication required or token invalid
-          headers: &id782
+          headers: &id788
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118553,9 +119611,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id784
+        '403': &id790
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id782
+          headers: *id788
           content:
             application/json:
               schema:
@@ -118575,9 +119633,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id785
+        '404': &id791
           description: Not found - The requested resource does not exist
-          headers: *id782
+          headers: *id788
           content:
             application/json:
               schema:
@@ -118591,9 +119649,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id786
+        '500': &id792
           description: Internal server error - Unexpected error occurred
-          headers: *id782
+          headers: *id788
           content:
             application/json:
               schema:
@@ -118673,7 +119731,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id782
+          headers: *id788
           content:
             application/json:
               schema:
@@ -118699,16 +119757,16 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id783
-        '403': *id784
-        '404': *id785
+        '401': *id789
+        '403': *id790
+        '404': *id791
         '409':
           description: Another DR execution is already in progress
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-        '500': *id786
+        '500': *id792
       security:
       - bearerAuth: []
       x-aragora-stability: experimental
@@ -118792,7 +119850,7 @@ paths:
                         type: boolean
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id787
+          headers: &id793
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118821,7 +119879,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id787
+          headers: *id793
           content:
             application/json:
               schema:
@@ -118874,7 +119932,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id788
+          headers: &id794
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118903,7 +119961,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id788
+          headers: *id794
           content:
             application/json:
               schema:
@@ -118940,7 +119998,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id789
+          headers: &id795
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -118969,7 +120027,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id789
+          headers: *id795
           content:
             application/json:
               schema:
@@ -119021,7 +120079,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id790
+          headers: &id796
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119050,7 +120108,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id790
+          headers: *id796
           content:
             application/json:
               schema:
@@ -119091,7 +120149,7 @@ paths:
                     format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: &id791
+          headers: &id797
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119120,7 +120178,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id791
+          headers: *id797
           content:
             application/json:
               schema:
@@ -119177,7 +120235,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id792
+          headers: &id798
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119214,7 +120272,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id792
+          headers: *id798
           content:
             application/json:
               schema:
@@ -119234,7 +120292,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id792
+          headers: *id798
           content:
             application/json:
               schema:
@@ -119290,9 +120348,9 @@ paths:
                       type: object
                   health:
                     type: object
-        '400': &id794
+        '400': &id800
           description: Bad request - Invalid input or malformed JSON
-          headers: &id793
+          headers: &id799
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119327,9 +120385,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': &id795
+        '401': &id801
           description: Unauthorized - Authentication required or token invalid
-          headers: *id793
+          headers: *id799
           content:
             application/json:
               schema:
@@ -119347,9 +120405,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id796
+        '404': &id802
           description: Not found - The requested resource does not exist
-          headers: *id793
+          headers: *id799
           content:
             application/json:
               schema:
@@ -119363,9 +120421,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id797
+        '500': &id803
           description: Internal server error - Unexpected error occurred
-          headers: *id793
+          headers: *id799
           content:
             application/json:
               schema:
@@ -119423,10 +120481,10 @@ paths:
                     type: string
                   workspace_id:
                     type: string
-        '400': *id794
-        '401': *id795
-        '404': *id796
-        '500': *id797
+        '400': *id800
+        '401': *id801
+        '404': *id802
+        '500': *id803
       x-aragora-stability: stable
   /api/v2/integrations/{type}/health:
     get:
@@ -119498,7 +120556,7 @@ paths:
                 - healthy
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id798
+          headers: &id804
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119535,7 +120593,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id798
+          headers: *id804
           content:
             application/json:
               schema:
@@ -119555,7 +120613,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id798
+          headers: *id804
           content:
             application/json:
               schema:
@@ -119571,7 +120629,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id798
+          headers: *id804
           content:
             application/json:
               schema:
@@ -119639,7 +120697,7 @@ paths:
                     format: date-time
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id799
+          headers: &id805
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119676,7 +120734,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id799
+          headers: *id805
           content:
             application/json:
               schema:
@@ -119696,7 +120754,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id799
+          headers: *id805
           content:
             application/json:
               schema:
@@ -119712,7 +120770,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id799
+          headers: *id805
           content:
             application/json:
               schema:
@@ -119905,7 +120963,7 @@ paths:
       responses:
         '200':
           description: Marketplace categories.
-          headers: &id800
+          headers: &id806
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -119926,7 +120984,7 @@ paths:
                       type: string
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id800
+          headers: *id806
           content:
             application/json:
               schema:
@@ -120021,7 +121079,7 @@ paths:
       responses:
         '200':
           description: Marketplace templates.
-          headers: &id801
+          headers: &id807
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120046,9 +121104,9 @@ paths:
                     type: integer
                   offset:
                     type: integer
-        '400': &id802
+        '400': &id808
           description: Bad request - Invalid input or malformed JSON
-          headers: *id801
+          headers: *id807
           content:
             application/json:
               schema:
@@ -120074,9 +121132,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '500': &id803
+        '500': &id809
           description: Internal server error - Unexpected error occurred
-          headers: *id801
+          headers: *id807
           content:
             application/json:
               schema:
@@ -120130,7 +121188,7 @@ paths:
       responses:
         '201':
           description: Template created.
-          headers: *id801
+          headers: *id807
           content:
             application/json:
               schema:
@@ -120140,10 +121198,10 @@ paths:
                     type: string
                   success:
                     type: boolean
-        '400': *id802
+        '400': *id808
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id801
+          headers: *id807
           content:
             application/json:
               schema:
@@ -120163,7 +121221,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id801
+          headers: *id807
           content:
             application/json:
               schema:
@@ -120183,7 +121241,7 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '500': *id803
+        '500': *id809
       x-aragora-stability: experimental
   /api/v2/marketplace/templates/import:
     post:
@@ -120226,7 +121284,7 @@ paths:
       responses:
         '201':
           description: Template imported.
-          headers: &id804
+          headers: &id810
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120247,7 +121305,7 @@ paths:
                     type: boolean
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id804
+          headers: *id810
           content:
             application/json:
               schema:
@@ -120275,7 +121333,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id804
+          headers: *id810
           content:
             application/json:
               schema:
@@ -120295,7 +121353,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id804
+          headers: *id810
           content:
             application/json:
               schema:
@@ -120317,7 +121375,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id804
+          headers: *id810
           content:
             application/json:
               schema:
@@ -120340,7 +121398,7 @@ paths:
       description: Get template details by ID.
       security: []
       parameters:
-      - &id806
+      - &id812
         name: template_id
         in: path
         required: true
@@ -120350,7 +121408,7 @@ paths:
       responses:
         '200':
           description: Template details.
-          headers: &id805
+          headers: &id811
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120385,278 +121443,6 @@ paths:
                     type: integer
                   average_rating:
                     type: number
-        '400': &id807
-          description: Bad request - Invalid input or malformed JSON
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '404': &id808
-          description: Not found - The requested resource does not exist
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500': &id809
-          description: Internal server error - Unexpected error occurred
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-    delete:
-      tags:
-      - Marketplace
-      summary: Delete template
-      operationId: deleteMarketplaceTemplateV2
-      description: Delete a marketplace template. Requires `marketplace:delete`.
-      security:
-      - bearerAuth: []
-      parameters:
-      - *id806
-      responses:
-        '200':
-          description: Template deleted.
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  deleted:
-                    type: string
-        '400': *id807
-        '401':
-          description: Unauthorized - Authentication required or token invalid
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                missing_token:
-                  summary: No authentication token
-                  value:
-                    error: Authentication required
-                    code: AUTH_REQUIRED
-                    trace_id: req_abc123xyz
-                invalid_token:
-                  summary: Invalid or expired token
-                  value:
-                    error: Invalid or expired authentication token
-                    code: INVALID_TOKEN
-                    trace_id: req_abc123xyz
-        '403':
-          description: Forbidden - Insufficient permissions for this operation
-          headers: *id805
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                insufficient_permissions:
-                  summary: Insufficient permissions
-                  value:
-                    error: You do not have permission to access this resource
-                    code: FORBIDDEN
-                    required_role: admin
-                    trace_id: req_abc123xyz
-                resource_owner:
-                  summary: Not resource owner
-                  value:
-                    error: You do not have permission to modify this debate
-                    code: NOT_OWNER
-                    resource_type: debate
-                    trace_id: req_abc123xyz
-        '404': *id808
-        '500': *id809
-      x-aragora-stability: experimental
-  /api/v2/marketplace/templates/{template_id}/export:
-    get:
-      tags:
-      - Marketplace
-      summary: Export template
-      operationId: exportMarketplaceTemplateV2
-      description: Export a marketplace template as JSON.
-      security: []
-      parameters:
-      - name: template_id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Marketplace template ID.
-      responses:
-        '200':
-          description: Template JSON export.
-          content:
-            application/json:
-              schema:
-                type: object
-        '400':
-          description: Bad request - Invalid input or malformed JSON
-          headers: &id810
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                invalid_json:
-                  summary: Invalid JSON body
-                  value:
-                    error: Invalid JSON in request body
-                    code: INVALID_JSON
-                    trace_id: req_abc123xyz
-                missing_field:
-                  summary: Missing required field
-                  value:
-                    error: 'Missing required field: task'
-                    code: MISSING_FIELD
-                    field: task
-                    trace_id: req_abc123xyz
-                invalid_value:
-                  summary: Invalid field value
-                  value:
-                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
-                    code: INVALID_VALUE
-                    field: rounds
-                    trace_id: req_abc123xyz
-        '404':
-          description: Not found - The requested resource does not exist
-          headers: *id810
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                not_found:
-                  summary: Resource not found
-                  value:
-                    error: Debate not found
-                    code: NOT_FOUND
-                    resource_type: debate
-                    resource_id: deb_abc123
-                    trace_id: req_abc123xyz
-        '500':
-          description: Internal server error - Unexpected error occurred
-          headers: *id810
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              examples:
-                internal_error:
-                  summary: Internal server error
-                  value:
-                    error: An unexpected error occurred
-                    code: INTERNAL_ERROR
-                    trace_id: req_abc123xyz
-                    support_url: https://github.com/synaptent/aragora/issues
-      x-aragora-stability: experimental
-  /api/v2/marketplace/templates/{template_id}/ratings:
-    get:
-      tags:
-      - Marketplace
-      summary: Get template ratings
-      operationId: getMarketplaceTemplateRatingsV2
-      description: Get ratings and average score for a marketplace template.
-      security: []
-      parameters:
-      - &id812
-        name: template_id
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Marketplace template ID.
-      responses:
-        '200':
-          description: Template ratings.
-          headers: &id811
-            X-Request-ID:
-              description: Unique request identifier for tracing and debugging
-              schema:
-                type: string
-                format: uuid
-            X-Response-Time:
-              description: Server processing time in milliseconds
-              schema:
-                type: integer
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  ratings:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        user_id:
-                          type: string
-                        score:
-                          type: integer
-                        review:
-                          type: string
-                        created_at:
-                          type: string
-                          format: date-time
-                  average:
-                    type: number
-                  count:
-                    type: integer
         '400': &id813
           description: Bad request - Invalid input or malformed JSON
           headers: *id811
@@ -120717,35 +121503,19 @@ paths:
                     trace_id: req_abc123xyz
                     support_url: https://github.com/synaptent/aragora/issues
       x-aragora-stability: experimental
-    post:
+    delete:
       tags:
       - Marketplace
-      summary: Rate template
-      operationId: rateMarketplaceTemplateV2
-      description: Add a template rating. Requires `marketplace:write`.
+      summary: Delete template
+      operationId: deleteMarketplaceTemplateV2
+      description: Delete a marketplace template. Requires `marketplace:delete`.
       security:
       - bearerAuth: []
       parameters:
       - *id812
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-              - score
-              properties:
-                score:
-                  type: integer
-                  minimum: 1
-                  maximum: 5
-                review:
-                  type: string
-                  maxLength: 2000
       responses:
         '200':
-          description: Template rating saved.
+          description: Template deleted.
           headers: *id811
           content:
             application/json:
@@ -120754,8 +121524,8 @@ paths:
                 properties:
                   success:
                     type: boolean
-                  average_rating:
-                    type: number
+                  deleted:
+                    type: string
         '400': *id813
         '401':
           description: Unauthorized - Authentication required or token invalid
@@ -120802,6 +121572,294 @@ paths:
         '404': *id814
         '500': *id815
       x-aragora-stability: experimental
+  /api/v2/marketplace/templates/{template_id}/export:
+    get:
+      tags:
+      - Marketplace
+      summary: Export template
+      operationId: exportMarketplaceTemplateV2
+      description: Export a marketplace template as JSON.
+      security: []
+      parameters:
+      - name: template_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Marketplace template ID.
+      responses:
+        '200':
+          description: Template JSON export.
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Bad request - Invalid input or malformed JSON
+          headers: &id816
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '404':
+          description: Not found - The requested resource does not exist
+          headers: *id816
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500':
+          description: Internal server error - Unexpected error occurred
+          headers: *id816
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+  /api/v2/marketplace/templates/{template_id}/ratings:
+    get:
+      tags:
+      - Marketplace
+      summary: Get template ratings
+      operationId: getMarketplaceTemplateRatingsV2
+      description: Get ratings and average score for a marketplace template.
+      security: []
+      parameters:
+      - &id818
+        name: template_id
+        in: path
+        required: true
+        schema:
+          type: string
+        description: Marketplace template ID.
+      responses:
+        '200':
+          description: Template ratings.
+          headers: &id817
+            X-Request-ID:
+              description: Unique request identifier for tracing and debugging
+              schema:
+                type: string
+                format: uuid
+            X-Response-Time:
+              description: Server processing time in milliseconds
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ratings:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        user_id:
+                          type: string
+                        score:
+                          type: integer
+                        review:
+                          type: string
+                        created_at:
+                          type: string
+                          format: date-time
+                  average:
+                    type: number
+                  count:
+                    type: integer
+        '400': &id819
+          description: Bad request - Invalid input or malformed JSON
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                invalid_json:
+                  summary: Invalid JSON body
+                  value:
+                    error: Invalid JSON in request body
+                    code: INVALID_JSON
+                    trace_id: req_abc123xyz
+                missing_field:
+                  summary: Missing required field
+                  value:
+                    error: 'Missing required field: task'
+                    code: MISSING_FIELD
+                    field: task
+                    trace_id: req_abc123xyz
+                invalid_value:
+                  summary: Invalid field value
+                  value:
+                    error: 'Invalid value for ''rounds'': must be between 1 and 12'
+                    code: INVALID_VALUE
+                    field: rounds
+                    trace_id: req_abc123xyz
+        '404': &id820
+          description: Not found - The requested resource does not exist
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                not_found:
+                  summary: Resource not found
+                  value:
+                    error: Debate not found
+                    code: NOT_FOUND
+                    resource_type: debate
+                    resource_id: deb_abc123
+                    trace_id: req_abc123xyz
+        '500': &id821
+          description: Internal server error - Unexpected error occurred
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                internal_error:
+                  summary: Internal server error
+                  value:
+                    error: An unexpected error occurred
+                    code: INTERNAL_ERROR
+                    trace_id: req_abc123xyz
+                    support_url: https://github.com/synaptent/aragora/issues
+      x-aragora-stability: experimental
+    post:
+      tags:
+      - Marketplace
+      summary: Rate template
+      operationId: rateMarketplaceTemplateV2
+      description: Add a template rating. Requires `marketplace:write`.
+      security:
+      - bearerAuth: []
+      parameters:
+      - *id818
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - score
+              properties:
+                score:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                review:
+                  type: string
+                  maxLength: 2000
+      responses:
+        '200':
+          description: Template rating saved.
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  average_rating:
+                    type: number
+        '400': *id819
+        '401':
+          description: Unauthorized - Authentication required or token invalid
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                missing_token:
+                  summary: No authentication token
+                  value:
+                    error: Authentication required
+                    code: AUTH_REQUIRED
+                    trace_id: req_abc123xyz
+                invalid_token:
+                  summary: Invalid or expired token
+                  value:
+                    error: Invalid or expired authentication token
+                    code: INVALID_TOKEN
+                    trace_id: req_abc123xyz
+        '403':
+          description: Forbidden - Insufficient permissions for this operation
+          headers: *id817
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                insufficient_permissions:
+                  summary: Insufficient permissions
+                  value:
+                    error: You do not have permission to access this resource
+                    code: FORBIDDEN
+                    required_role: admin
+                    trace_id: req_abc123xyz
+                resource_owner:
+                  summary: Not resource owner
+                  value:
+                    error: You do not have permission to modify this debate
+                    code: NOT_OWNER
+                    resource_type: debate
+                    trace_id: req_abc123xyz
+        '404': *id820
+        '500': *id821
+      x-aragora-stability: experimental
   /api/v2/marketplace/templates/{template_id}/star:
     post:
       tags:
@@ -120821,7 +121879,7 @@ paths:
       responses:
         '200':
           description: Template starred.
-          headers: &id816
+          headers: &id822
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -120842,7 +121900,7 @@ paths:
                     type: integer
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id816
+          headers: *id822
           content:
             application/json:
               schema:
@@ -120870,7 +121928,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id816
+          headers: *id822
           content:
             application/json:
               schema:
@@ -120890,7 +121948,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id816
+          headers: *id822
           content:
             application/json:
               schema:
@@ -120912,7 +121970,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id816
+          headers: *id822
           content:
             application/json:
               schema:
@@ -120928,7 +121986,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id816
+          headers: *id822
           content:
             application/json:
               schema:
@@ -121096,7 +122154,7 @@ paths:
                       type: number
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id817
+          headers: &id823
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121133,7 +122191,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id817
+          headers: *id823
           content:
             application/json:
               schema:
@@ -121153,7 +122211,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id817
+          headers: *id823
           content:
             application/json:
               schema:
@@ -121175,7 +122233,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id817
+          headers: *id823
           content:
             application/json:
               schema:
@@ -121333,7 +122391,7 @@ paths:
                       type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id818
+          headers: &id824
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121370,7 +122428,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id818
+          headers: *id824
           content:
             application/json:
               schema:
@@ -121390,7 +122448,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id818
+          headers: *id824
           content:
             application/json:
               schema:
@@ -121412,7 +122470,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id818
+          headers: *id824
           content:
             application/json:
               schema:
@@ -121445,7 +122503,7 @@ paths:
       responses:
         '200':
           description: Deliberation status.
-          headers: &id819
+          headers: &id825
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121504,7 +122562,7 @@ paths:
                         type: number
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id819
+          headers: *id825
           content:
             application/json:
               schema:
@@ -121524,7 +122582,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id819
+          headers: *id825
           content:
             application/json:
               schema:
@@ -121546,7 +122604,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id819
+          headers: *id825
           content:
             application/json:
               schema:
@@ -121562,7 +122620,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id819
+          headers: *id825
           content:
             application/json:
               schema:
@@ -121619,7 +122677,7 @@ paths:
       responses:
         '200':
           description: Orchestration template list.
-          headers: &id820
+          headers: &id826
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121665,7 +122723,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id820
+          headers: *id826
           content:
             application/json:
               schema:
@@ -121685,7 +122743,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id820
+          headers: *id826
           content:
             application/json:
               schema:
@@ -121707,7 +122765,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id820
+          headers: *id826
           content:
             application/json:
               schema:
@@ -121733,7 +122791,7 @@ paths:
       responses:
         '200':
           description: Receipt list
-          headers: &id821
+          headers: &id827
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121768,7 +122826,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id821
+          headers: *id827
           content:
             application/json:
               schema:
@@ -121788,7 +122846,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id821
+          headers: *id827
           content:
             application/json:
               schema:
@@ -121815,7 +122873,7 @@ paths:
       responses:
         '200':
           description: Search results
-          headers: &id822
+          headers: &id828
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121840,7 +122898,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id822
+          headers: *id828
           content:
             application/json:
               schema:
@@ -121860,7 +122918,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id822
+          headers: *id828
           content:
             application/json:
               schema:
@@ -121899,7 +122957,7 @@ paths:
       responses:
         '200':
           description: Shared receipt payload
-          headers: &id823
+          headers: &id829
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121922,7 +122980,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id823
+          headers: *id829
           content:
             application/json:
               schema:
@@ -121940,7 +122998,7 @@ paths:
           description: Share link expired or access limit reached
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id823
+          headers: *id829
           content:
             application/json:
               schema:
@@ -121967,7 +123025,7 @@ paths:
       responses:
         '200':
           description: Receipt stats
-          headers: &id824
+          headers: &id830
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -121990,7 +123048,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id824
+          headers: *id830
           content:
             application/json:
               schema:
@@ -122010,7 +123068,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id824
+          headers: *id830
           content:
             application/json:
               schema:
@@ -122042,7 +123100,7 @@ paths:
       responses:
         '200':
           description: Receipt details
-          headers: &id825
+          headers: &id831
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122072,7 +123130,7 @@ paths:
                     type: object
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id825
+          headers: *id831
           content:
             application/json:
               schema:
@@ -122092,7 +123150,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id825
+          headers: *id831
           content:
             application/json:
               schema:
@@ -122108,7 +123166,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id825
+          headers: *id831
           content:
             application/json:
               schema:
@@ -122141,7 +123199,7 @@ paths:
       responses:
         '200':
           description: Exported receipt
-          headers: &id826
+          headers: &id832
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122164,7 +123222,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id826
+          headers: *id832
           content:
             application/json:
               schema:
@@ -122184,7 +123242,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id826
+          headers: *id832
           content:
             application/json:
               schema:
@@ -122200,7 +123258,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id826
+          headers: *id832
           content:
             application/json:
               schema:
@@ -122263,7 +123321,7 @@ paths:
                     description: Channel-specific formatted content
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id827
+          headers: &id833
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122300,7 +123358,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id827
+          headers: *id833
           content:
             application/json:
               schema:
@@ -122320,7 +123378,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id827
+          headers: *id833
           content:
             application/json:
               schema:
@@ -122336,7 +123394,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id827
+          headers: *id833
           content:
             application/json:
               schema:
@@ -122418,7 +123476,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id828
+          headers: &id834
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122455,7 +123513,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id828
+          headers: *id834
           content:
             application/json:
               schema:
@@ -122475,7 +123533,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id828
+          headers: *id834
           content:
             application/json:
               schema:
@@ -122491,7 +123549,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id828
+          headers: *id834
           content:
             application/json:
               schema:
@@ -122530,7 +123588,7 @@ paths:
       responses:
         '200':
           description: Receipt shared
-          headers: &id829
+          headers: &id835
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122562,7 +123620,7 @@ paths:
                     - type: 'null'
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id829
+          headers: *id835
           content:
             application/json:
               schema:
@@ -122582,7 +123640,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id829
+          headers: *id835
           content:
             application/json:
               schema:
@@ -122604,7 +123662,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id829
+          headers: *id835
           content:
             application/json:
               schema:
@@ -122620,7 +123678,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id829
+          headers: *id835
           content:
             application/json:
               schema:
@@ -122642,7 +123700,7 @@ paths:
       summary: Verify receipt
       operationId: verifyReceiptById
       description: Verify receipt integrity.
-      security: &id831
+      security: &id837
       - bearerAuth: []
       parameters:
       - name: receipt_id
@@ -122653,7 +123711,7 @@ paths:
       responses:
         '200':
           description: Verification result
-          headers: &id830
+          headers: &id836
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122677,9 +123735,9 @@ paths:
                   verified_at:
                     type: string
                     format: date-time
-        '401': &id832
+        '401': &id838
           description: Unauthorized - Authentication required or token invalid
-          headers: *id830
+          headers: *id836
           content:
             application/json:
               schema:
@@ -122697,9 +123755,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '404': &id833
+        '404': &id839
           description: Not found - The requested resource does not exist
-          headers: *id830
+          headers: *id836
           content:
             application/json:
               schema:
@@ -122713,9 +123771,9 @@ paths:
                     resource_type: debate
                     resource_id: deb_abc123
                     trace_id: req_abc123xyz
-        '500': &id834
+        '500': &id840
           description: Internal server error - Unexpected error occurred
-          headers: *id830
+          headers: *id836
           content:
             application/json:
               schema:
@@ -122736,7 +123794,7 @@ paths:
       summary: Verify receipt integrity
       operationId: verifyReceiptIntegrity
       description: Verify receipt integrity with payload.
-      security: *id831
+      security: *id837
       parameters:
       - name: receipt_id
         in: path
@@ -122746,7 +123804,7 @@ paths:
       responses:
         '200':
           description: Integrity verification result
-          headers: *id830
+          headers: *id836
           content:
             application/json:
               schema:
@@ -122758,9 +123816,9 @@ paths:
                     type: boolean
                   integrity_verified:
                     type: boolean
-        '401': *id832
-        '404': *id833
-        '500': *id834
+        '401': *id838
+        '404': *id839
+        '500': *id840
       x-aragora-stability: experimental
   /api/v2/receipts/{receipt_id}/verify-signature:
     post:
@@ -122781,7 +123839,7 @@ paths:
       responses:
         '200':
           description: Signature verification result
-          headers: &id835
+          headers: &id841
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -122806,7 +123864,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id835
+          headers: *id841
           content:
             application/json:
               schema:
@@ -122826,7 +123884,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id835
+          headers: *id841
           content:
             application/json:
               schema:
@@ -122842,7 +123900,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id835
+          headers: *id841
           content:
             application/json:
               schema:
@@ -123443,9 +124501,9 @@ paths:
                   updated_at:
                     type: string
                     format: date-time
-        '404': &id837
+        '404': &id843
           description: Not found - The requested resource does not exist
-          headers: &id836
+          headers: &id842
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123506,7 +124564,7 @@ paths:
       responses:
         '200':
           description: Vertical configuration updated
-          headers: *id836
+          headers: *id842
           content:
             application/json:
               schema:
@@ -123518,7 +124576,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id836
+          headers: *id842
           content:
             application/json:
               schema:
@@ -123544,7 +124602,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id837
+        '404': *id843
       security:
       - bearerAuth: []
       deprecated: true
@@ -123648,7 +124706,7 @@ paths:
       responses:
         '200':
           description: List of pending approvals
-          headers: &id838
+          headers: &id844
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123671,7 +124729,7 @@ paths:
                     type: integer
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id838
+          headers: *id844
           content:
             application/json:
               schema:
@@ -123724,7 +124782,7 @@ paths:
       responses:
         '200':
           description: Approval submitted
-          headers: &id839
+          headers: &id845
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123747,7 +124805,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id839
+          headers: *id845
           content:
             application/json:
               schema:
@@ -123775,7 +124833,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id839
+          headers: *id845
           content:
             application/json:
               schema:
@@ -123795,7 +124853,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id839
+          headers: *id845
           content:
             application/json:
               schema:
@@ -123873,7 +124931,7 @@ paths:
       responses:
         '200':
           description: Execution details with step progress
-          headers: &id840
+          headers: &id846
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -123900,9 +124958,9 @@ paths:
                     type: array
                     items:
                       type: object
-        '404': &id841
+        '404': &id847
           description: Not found - The requested resource does not exist
-          headers: *id840
+          headers: *id846
           content:
             application/json:
               schema:
@@ -123932,7 +124990,7 @@ paths:
       responses:
         '200':
           description: Execution cancelled
-          headers: *id840
+          headers: *id846
           content:
             application/json:
               schema:
@@ -123944,7 +125002,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id840
+          headers: *id846
           content:
             application/json:
               schema:
@@ -123970,7 +125028,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id841
+        '404': *id847
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflow-templates:
@@ -124019,7 +125077,7 @@ paths:
       responses:
         '200':
           description: Workflow template
-          headers: &id842
+          headers: &id848
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124035,7 +125093,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id842
+          headers: *id848
           content:
             application/json:
               schema:
@@ -124154,7 +125212,7 @@ paths:
       responses:
         '201':
           description: Created template instance
-          headers: &id843
+          headers: &id849
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124170,7 +125228,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id843
+          headers: *id849
           content:
             application/json:
               schema:
@@ -124198,7 +125256,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id843
+          headers: *id849
           content:
             application/json:
               schema:
@@ -124294,7 +125352,7 @@ paths:
       responses:
         '200':
           description: Workflow template details
-          headers: &id844
+          headers: &id850
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124310,7 +125368,7 @@ paths:
                 $ref: '#/components/schemas/WorkflowTemplate'
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id844
+          headers: *id850
           content:
             application/json:
               schema:
@@ -124492,7 +125550,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: &id845
+          headers: &id851
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124529,7 +125587,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id845
+          headers: *id851
           content:
             application/json:
               schema:
@@ -124586,7 +125644,7 @@ paths:
       responses:
         '200':
           description: List of workflows with pagination
-          headers: &id846
+          headers: &id852
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124647,14 +125705,14 @@ paths:
       responses:
         '201':
           description: Workflow created
-          headers: *id846
+          headers: *id852
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id846
+          headers: *id852
           content:
             application/json:
               schema:
@@ -124697,7 +125755,7 @@ paths:
       responses:
         '200':
           description: Workflow definition
-          headers: &id847
+          headers: &id853
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124711,9 +125769,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-        '404': &id848
+        '404': &id854
           description: Not found - The requested resource does not exist
-          headers: *id847
+          headers: *id853
           content:
             application/json:
               schema:
@@ -124749,14 +125807,14 @@ paths:
       responses:
         '200':
           description: Workflow updated
-          headers: *id847
+          headers: *id853
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id847
+          headers: *id853
           content:
             application/json:
               schema:
@@ -124782,7 +125840,7 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '404': *id848
+        '404': *id854
       deprecated: true
       x-aragora-stability: deprecated
     delete:
@@ -124799,7 +125857,7 @@ paths:
       responses:
         '200':
           description: Workflow deleted
-          headers: *id847
+          headers: *id853
           content:
             application/json:
               schema:
@@ -124809,7 +125867,7 @@ paths:
                     type: boolean
                   workflow_id:
                     type: string
-        '404': *id848
+        '404': *id854
       deprecated: true
       x-aragora-stability: deprecated
   /api/workflows/{workflow_id}/execute:
@@ -124841,7 +125899,7 @@ paths:
       responses:
         '200':
           description: Workflow execution result or execution ID
-          headers: &id849
+          headers: &id855
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124864,7 +125922,7 @@ paths:
                     type: object
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id849
+          headers: *id855
           content:
             application/json:
               schema:
@@ -124892,7 +125950,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id849
+          headers: *id855
           content:
             application/json:
               schema:
@@ -124908,7 +125966,7 @@ paths:
                     trace_id: req_abc123xyz
         '500':
           description: Internal server error - Unexpected error occurred
-          headers: *id849
+          headers: *id855
           content:
             application/json:
               schema:
@@ -124943,7 +126001,7 @@ paths:
       responses:
         '200':
           description: List of workflow versions
-          headers: &id850
+          headers: &id856
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -124966,7 +126024,7 @@ paths:
                     type: integer
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id850
+          headers: *id856
           content:
             application/json:
               schema:
@@ -125005,7 +126063,7 @@ paths:
       responses:
         '200':
           description: List of workspaces
-          headers: &id851
+          headers: &id857
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125019,9 +126077,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/WorkspaceList'
-        '401': &id852
+        '401': &id858
           description: Unauthorized - Authentication required or token invalid
-          headers: *id851
+          headers: *id857
           content:
             application/json:
               schema:
@@ -125076,14 +126134,14 @@ paths:
       responses:
         '201':
           description: Workspace created
-          headers: *id851
+          headers: *id857
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id851
+          headers: *id857
           content:
             application/json:
               schema:
@@ -125109,10 +126167,10 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id852
+        '401': *id858
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id851
+          headers: *id857
           content:
             application/json:
               schema:
@@ -125157,7 +126215,7 @@ paths:
       responses:
         '200':
           description: Available RBAC profiles with role details
-          headers: &id853
+          headers: &id859
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125185,7 +126243,7 @@ paths:
                             type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id853
+          headers: *id859
           content:
             application/json:
               schema:
@@ -125222,7 +126280,7 @@ paths:
       responses:
         '200':
           description: Workspace details
-          headers: &id854
+          headers: &id860
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125236,9 +126294,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workspace'
-        '401': &id855
+        '401': &id861
           description: Unauthorized - Authentication required or token invalid
-          headers: *id854
+          headers: *id860
           content:
             application/json:
               schema:
@@ -125256,9 +126314,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id856
+        '403': &id862
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id854
+          headers: *id860
           content:
             application/json:
               schema:
@@ -125278,9 +126336,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id857
+        '404': &id863
           description: Not found - The requested resource does not exist
-          headers: *id854
+          headers: *id860
           content:
             application/json:
               schema:
@@ -125312,7 +126370,7 @@ paths:
       responses:
         '200':
           description: Workspace deleted
-          headers: *id854
+          headers: *id860
           content:
             application/json:
               schema:
@@ -125322,9 +126380,9 @@ paths:
                     type: boolean
                   workspace_id:
                     type: string
-        '401': *id855
-        '403': *id856
-        '404': *id857
+        '401': *id861
+        '403': *id862
+        '404': *id863
       deprecated: true
       x-aragora-stability: deprecated
   /api/workspaces/{workspace_id}/members:
@@ -125362,7 +126420,7 @@ paths:
       responses:
         '200':
           description: Member added
-          headers: &id858
+          headers: &id864
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125385,7 +126443,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id858
+          headers: *id864
           content:
             application/json:
               schema:
@@ -125413,7 +126471,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id858
+          headers: *id864
           content:
             application/json:
               schema:
@@ -125433,7 +126491,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id858
+          headers: *id864
           content:
             application/json:
               schema:
@@ -125518,7 +126576,7 @@ paths:
       responses:
         '200':
           description: Role updated successfully
-          headers: &id859
+          headers: &id865
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125541,7 +126599,7 @@ paths:
                     type: string
         '400':
           description: Bad request - Invalid input or malformed JSON
-          headers: *id859
+          headers: *id865
           content:
             application/json:
               schema:
@@ -125569,7 +126627,7 @@ paths:
                     trace_id: req_abc123xyz
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id859
+          headers: *id865
           content:
             application/json:
               schema:
@@ -125589,7 +126647,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id859
+          headers: *id865
           content:
             application/json:
               schema:
@@ -125611,7 +126669,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id859
+          headers: *id865
           content:
             application/json:
               schema:
@@ -125663,7 +126721,7 @@ paths:
       responses:
         '200':
           description: Workspace roles with assignment permissions
-          headers: &id860
+          headers: &id866
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -125690,7 +126748,7 @@ paths:
                     type: string
         '401':
           description: Unauthorized - Authentication required or token invalid
-          headers: *id860
+          headers: *id866
           content:
             application/json:
               schema:
@@ -125710,7 +126768,7 @@ paths:
                     trace_id: req_abc123xyz
         '403':
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id860
+          headers: *id866
           content:
             application/json:
               schema:
@@ -125732,7 +126790,7 @@ paths:
                     trace_id: req_abc123xyz
         '404':
           description: Not found - The requested resource does not exist
-          headers: *id860
+          headers: *id866
           content:
             application/json:
               schema:
@@ -126227,9 +127285,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id862
+        '401': &id868
           description: Unauthorized - Authentication required or token invalid
-          headers: &id861
+          headers: &id867
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126256,9 +127314,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id863
+        '403': &id869
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id861
+          headers: *id867
           content:
             application/json:
               schema:
@@ -126278,9 +127336,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id864
+        '404': &id870
           description: Not found - The requested resource does not exist
-          headers: *id861
+          headers: *id867
           content:
             application/json:
               schema:
@@ -126351,9 +127409,9 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': &id865
+        '400': &id871
           description: Bad request - Invalid input or malformed JSON
-          headers: *id861
+          headers: *id867
           content:
             application/json:
               schema:
@@ -126379,9 +127437,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id862
-        '403': *id863
-        '404': *id864
+        '401': *id868
+        '403': *id869
+        '404': *id870
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -126444,10 +127502,10 @@ paths:
                     type: string
                   displayName:
                     type: string
-        '400': *id865
-        '401': *id862
-        '403': *id863
-        '404': *id864
+        '400': *id871
+        '401': *id868
+        '403': *id869
+        '404': *id870
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -126467,9 +127525,9 @@ paths:
       responses:
         '204':
           description: Group deleted successfully
-        '401': *id862
-        '403': *id863
-        '404': *id864
+        '401': *id868
+        '403': *id869
+        '404': *id870
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -126622,9 +127680,9 @@ paths:
                         format: date-time
                       location:
                         type: string
-        '401': &id867
+        '401': &id873
           description: Unauthorized - Authentication required or token invalid
-          headers: &id866
+          headers: &id872
             X-Request-ID:
               description: Unique request identifier for tracing and debugging
               schema:
@@ -126651,9 +127709,9 @@ paths:
                     error: Invalid or expired authentication token
                     code: INVALID_TOKEN
                     trace_id: req_abc123xyz
-        '403': &id868
+        '403': &id874
           description: Forbidden - Insufficient permissions for this operation
-          headers: *id866
+          headers: *id872
           content:
             application/json:
               schema:
@@ -126673,9 +127731,9 @@ paths:
                     code: NOT_OWNER
                     resource_type: debate
                     trace_id: req_abc123xyz
-        '404': &id869
+        '404': &id875
           description: Not found - The requested resource does not exist
-          headers: *id866
+          headers: *id872
           content:
             application/json:
               schema:
@@ -126760,9 +127818,9 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': &id870
+        '400': &id876
           description: Bad request - Invalid input or malformed JSON
-          headers: *id866
+          headers: *id872
           content:
             application/json:
               schema:
@@ -126788,9 +127846,9 @@ paths:
                     code: INVALID_VALUE
                     field: rounds
                     trace_id: req_abc123xyz
-        '401': *id867
-        '403': *id868
-        '404': *id869
+        '401': *id873
+        '403': *id874
+        '404': *id875
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -126855,10 +127913,10 @@ paths:
                     type: string
                   active:
                     type: boolean
-        '400': *id870
-        '401': *id867
-        '403': *id868
-        '404': *id869
+        '400': *id876
+        '401': *id873
+        '403': *id874
+        '404': *id875
       security:
       - bearerAuth: []
       x-aragora-stability: stable
@@ -126878,9 +127936,9 @@ paths:
       responses:
         '204':
           description: User deleted successfully
-        '401': *id867
-        '403': *id868
-        '404': *id869
+        '401': *id873
+        '403': *id874
+        '404': *id875
       security:
       - bearerAuth: []
       x-aragora-stability: stable

--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -22276,6 +22276,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/canvas/pipeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get latest pipeline or list pipelines
+         * @description Return the latest canvas pipeline by default. Pass `list=true` to return pipeline summaries instead.
+         */
+        get: operations["listOrLatestPipeline"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/canvas/pipeline/advance": {
         parameters: {
             query?: never;
@@ -22296,6 +22316,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/canvas/pipeline/approve-transition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve stage transition by body
+         * @description Approve or reject a pending stage transition when the pipeline ID is sent in the request body.
+         */
+        post: operations["approvePipelineTransitionByBody"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/auto-run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Auto-run pipeline from freeform text
+         * @description Start an asynchronous pipeline from freeform text and return a pipeline identifier immediately.
+         */
+        post: operations["autoRunPipeline"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/demo": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create demo pipeline
+         * @description Create a pre-populated demo pipeline with all stages completed.
+         */
+        post: operations["createDemoPipeline"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/canvas/pipeline/extract-goals": {
         parameters: {
             query?: never;
@@ -22310,6 +22390,46 @@ export interface paths {
          * @description Use AI to extract structured goals from an ideas canvas.
          */
         post: operations["extractGoals"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/extract-principles": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Extract principles from ideas canvas
+         * @description Extract principles and themes from an ideas canvas.
+         */
+        post: operations["extractPipelinePrinciples"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/from-braindump": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create pipeline from brain dump
+         * @description Parse unstructured text into ideas and immediately create a pipeline from the extracted ideas.
+         */
+        post: operations["createPipelineFromBrainDump"];
         delete?: never;
         options?: never;
         head?: never;
@@ -22350,6 +22470,26 @@ export interface paths {
          * @description Create a full 4-stage pipeline from a list of raw idea strings.
          */
         post: operations["createPipelineFromIdeas"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/from-system-metrics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create pipeline from system metrics
+         * @description Auto-generate a pipeline from system health analysis.
+         */
+        post: operations["createPipelineFromSystemMetrics"];
         delete?: never;
         options?: never;
         head?: never;
@@ -22460,6 +22600,66 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/canvas/pipeline/{id}/beliefs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pipeline beliefs
+         * @description Return belief-network-style confidence data for pipeline nodes.
+         */
+        get: operations["getPipelineBeliefs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/{id}/execute": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Execute completed pipeline
+         * @description Queue execution for a completed pipeline or return a dry-run summary of the planned work.
+         */
+        post: operations["executeCanvasPipeline"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/{id}/explanations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pipeline explanations
+         * @description Return explainability factors for pipeline nodes.
+         */
+        get: operations["getPipelineExplanations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/canvas/pipeline/{id}/graph": {
         parameters: {
             query?: never;
@@ -22472,6 +22672,46 @@ export interface paths {
          * @description Get the React Flow compatible graph JSON for a pipeline.
          */
         get: operations["getPipelineGraph"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/{id}/intelligence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pipeline intelligence rollup
+         * @description Return beliefs, explanations, and precedents for nodes in the pipeline.
+         */
+        get: operations["getPipelineIntelligence"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/{id}/precedents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pipeline precedents
+         * @description Return similar goals or precedents linked to the pipeline.
+         */
+        get: operations["getPipelinePrecedents"];
         put?: never;
         post?: never;
         delete?: never;
@@ -22494,6 +22734,26 @@ export interface paths {
         get: operations["getPipelineReceipt"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/canvas/pipeline/{id}/self-improve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Feed pipeline into self-improvement
+         * @description Trigger the self-improvement system using a pipeline as the source task definition.
+         */
+        post: operations["selfImprovePipeline"];
         delete?: never;
         options?: never;
         head?: never;
@@ -30746,6 +31006,26 @@ export interface paths {
          * @description Submit a suggestion or argument to be considered by debate agents in the next round.
          */
         post: operations["submitDebateSuggestionV1"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/debates/{id}/to-pipeline": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Convert debate to pipeline
+         * @description Load a completed debate's argument graph and create a pipeline from it.
+         */
+        post: operations["convertDebateToPipeline"];
         delete?: never;
         options?: never;
         head?: never;
@@ -46194,6 +46474,66 @@ export interface paths {
          * @description Autogenerated placeholder (spec pending)
          */
         post: operations["createPipelineTransitions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline/{id}/agents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List pipeline agents
+         * @description Return current agent assignments and statuses for a pipeline.
+         */
+        get: operations["listPipelineAgents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline/{id}/agents/{agent_id}/approve": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Approve pipeline agent
+         * @description Approve an assigned agent task for a pipeline.
+         */
+        post: operations["approvePipelineAgent"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/pipeline/{id}/agents/{agent_id}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reject pipeline agent
+         * @description Reject an assigned agent task for a pipeline.
+         */
+        post: operations["rejectPipelineAgent"];
         delete?: never;
         options?: never;
         head?: never;
@@ -98435,6 +98775,33 @@ export interface operations {
             };
         };
     };
+    listOrLatestPipeline: {
+        parameters: {
+            query?: {
+                /** @description Return pipeline summaries instead of the latest pipeline. */
+                list?: boolean;
+                /** @description Optional status filter when list mode is enabled. */
+                status?: string;
+                /** @description Maximum number of pipeline summaries to return in list mode. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Latest pipeline payload or pipeline list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
     advancePipelineStage: {
         parameters: {
             query?: never;
@@ -98489,6 +98856,156 @@ export interface operations {
             };
         };
     };
+    approvePipelineTransitionByBody: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    from_stage: string;
+                    to_stage: string;
+                    /** @description Defaults to true when omitted; set to false to reject. */
+                    approved?: boolean;
+                    comment?: string;
+                    pipeline_id: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Transition result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    autoRunPipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    text: string;
+                    /** @enum {string} */
+                    automation_level?: "full" | "guided" | "manual";
+                };
+            };
+        };
+        responses: {
+            /** @description Auto-run pipeline start status */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createDemoPipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    ideas?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Demo pipeline created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     extractGoals: {
         parameters: {
             query?: never;
@@ -98516,6 +99033,114 @@ export interface operations {
         responses: {
             /** @description Extracted goals */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    extractPipelinePrinciples: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    ideas_canvas: Record<string, never>;
+                    themes?: string[];
+                };
+            };
+        };
+        responses: {
+            /** @description Principles canvas */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createPipelineFromBrainDump: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    text: string;
+                    context?: string;
+                    auto_advance?: boolean;
+                    use_unified_orchestrator?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Pipeline created from a parsed brain dump */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -98649,6 +99274,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    createPipelineFromSystemMetrics: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            /** @description Pipeline created from system metrics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
                 };
             };
             /** @description Internal server error - Unexpected error occurred */
@@ -98883,9 +99545,11 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
-                    transition_id: string;
-                    approved: boolean;
-                    reason?: string;
+                    from_stage: string;
+                    to_stage: string;
+                    /** @description Defaults to true when omitted; set to false to reject. */
+                    approved?: boolean;
+                    comment?: string;
                 };
             };
         };
@@ -98927,6 +99591,142 @@ export interface operations {
             };
         };
     };
+    getPipelineBeliefs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pipeline beliefs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    executeCanvasPipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    dry_run?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Dry-run execution summary */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Pipeline execution queued */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getPipelineExplanations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pipeline explanations */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getPipelineGraph: {
         parameters: {
             query?: {
@@ -98943,6 +99743,78 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description React Flow graph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getPipelineIntelligence: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pipeline intelligence */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getPipelinePrecedents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pipeline precedents */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -99002,6 +99874,59 @@ export interface operations {
             };
         };
     };
+    selfImprovePipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    budget_limit?: number;
+                    require_approval?: boolean;
+                    dry_run?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Self-improvement preview */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Self-improvement run started */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
     getPipelineStage: {
         parameters: {
             query?: never;
@@ -99010,7 +99935,7 @@ export interface operations {
                 /** @description Pipeline ID */
                 id: string;
                 /** @description Pipeline stage name */
-                stage: "ideas" | "goals" | "actions" | "orchestration";
+                stage: "ideas" | "principles" | "goals" | "actions" | "orchestration";
             };
             cookie?: never;
         };
@@ -117500,6 +118425,62 @@ export interface operations {
             };
             /** @description Not found - The requested resource does not exist */
             404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    convertDebateToPipeline: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Debate ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    use_universal?: boolean;
+                    auto_advance?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Pipeline created from debate */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Not found - The requested resource does not exist */
+            404: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+            /** @description Internal server error - Unexpected error occurred */
+            500: {
                 headers: {
                     /** @description Unique request identifier for tracing and debugging */
                     "X-Request-ID"?: string;
@@ -149638,6 +150619,104 @@ export interface operations {
                         id?: string;
                         success?: boolean;
                     };
+                };
+            };
+        };
+    };
+    listPipelineAgents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pipeline agent assignments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    approvePipelineAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+                /** @description Agent assignment ID */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    notes?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Agent approval recorded */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+        };
+    };
+    rejectPipelineAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Pipeline ID */
+                id: string;
+                /** @description Agent assignment ID */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    feedback: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Agent rejection recorded */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
+            /** @description Bad request - Invalid input or malformed JSON */
+            400: {
+                headers: {
+                    /** @description Unique request identifier for tracing and debugging */
+                    "X-Request-ID"?: string;
+                    /** @description Server processing time in milliseconds */
+                    "X-Response-Time"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
                 };
             };
         };


### PR DESCRIPTION
## Summary
- refresh generated OpenAPI artifacts on current main
- regenerate TypeScript SDK types from the refreshed spec
- unblock shared Version Alignment failures hitting open PRs

## Testing
- python3 scripts/check_version_alignment.py
- python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check
- python3 scripts/generate_python_sdk_types.py --openapi docs/api/openapi_generated.json --check
- python3 scripts/check_capability_matrix_sync.py
- python3 scripts/check_legacy_entrypoints.py
- python3 scripts/check_legacy_collab_flags.py
- python3 scripts/generate_cli_reference.py --check
- cd sdk/typescript && npm run typecheck