### PR TITLE
fix(swarm): prefer Claude for boss-loop defaults

### DIFF
--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2515,13 +2515,13 @@ def _add_swarm_parser(subparsers) -> None:
     )
     swarm_parser.add_argument(
         "--worker-model",
-        default="codex",
-        help="Worker model for campaign or boss-loop execution (default: codex)",
+        default="claude",
+        help="Worker model for campaign or boss-loop execution (default: claude)",
     )
     swarm_parser.add_argument(
         "--review-model",
-        default="claude",
-        help="Review model for campaign or boss-loop cross-check/review (default: claude)",
+        default="codex",
+        help="Review model for campaign or boss-loop cross-check/review (default: codex)",
     )
     swarm_parser.add_argument(
         "--runner-type",

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -198,6 +198,14 @@ class TestSwarmParser:
         assert args.boss_issue_list == "101,102"
         assert args.worker_model == "claude"
 
+    def test_swarm_boss_parser_defaults_to_claude_worker_and_codex_review(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["swarm", "boss-loop"])
+        assert args.worker_model == "claude"
+        assert args.review_model == "codex"
+
     def test_swarm_boss_parser_accepts_claude_profile_pool(self):
         from aragora.cli.parser import build_parser
 


### PR DESCRIPTION
## Summary
- default swarm boss-loop execution to Claude workers and Codex review
- keep the CLI help text aligned with the new default pair
- add a parser regression test for the default boss-loop routing pair

## Testing
- python3 -m pytest tests/cli/test_swarm_command.py -q
- python3 -m ruff check aragora/cli/parser.py tests/cli/test_swarm_command.py
- ARAGORA_USER_ID=armand ARAGORA_WORKSPACE_ID=aragora python3 -m aragora.cli.main swarm boss-loop --boss-repo synaptent/aragora --boss-issue-number 1639 --autonomy full-auto --max-ticks 1 --no-dispatch --json