### PR TITLE
fix(agents): degrade optional api imports gracefully

### DIFF
--- a/aragora/agents/__init__.py
+++ b/aragora/agents/__init__.py
@@ -12,6 +12,23 @@ from __future__ import annotations
 import importlib
 from typing import Any
 
+_OPTIONAL_MODULE_EXPORTS = {
+    "aragora.agents.api_agents": {
+        "AnthropicAPIAgent",
+        "DeepSeekAgent",
+        "DeepSeekReasonerAgent",
+        "DeepSeekV3Agent",
+        "GeminiAgent",
+        "GrokAgent",
+        "LlamaAgent",
+        "LMStudioAgent",
+        "MistralAgent",
+        "OllamaAgent",
+        "OpenAIAPIAgent",
+        "OpenRouterAgent",
+    },
+}
+
 _EXPORT_MAP = {
     "AirlockConfig": ("aragora.agents.airlock", "AirlockConfig"),
     "AirlockMetrics": ("aragora.agents.airlock", "AirlockMetrics"),
@@ -138,7 +155,15 @@ def __getattr__(name: str) -> Any:
     except KeyError as exc:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
 
-    module = importlib.import_module(module_name)
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError:
+        if attr_name not in _OPTIONAL_MODULE_EXPORTS.get(module_name, set()):
+            raise
+        value = None
+        globals()[name] = value
+        return value
+
     value = getattr(module, attr_name)
     globals()[name] = value
     return value


### PR DESCRIPTION
## Summary
- restore graceful degradation for `aragora.agents` when optional API-agent dependencies are missing
- treat lazy exports from `aragora.agents.api_agents` as optional in `__getattr__`
- keep the package import usable for CLI agents even if `aiohttp` is unavailable

## Repro
- `python3 -m pytest tests/agents/test_package_imports.py::test_aragora_agents_import_survives_missing_api_agent_deps -q`
- before this change, accessing `agents.OpenAIAPIAgent` raised `ImportError: aiohttp unavailable`

## Validation
- `python3 -m pytest tests/agents/test_package_imports.py::test_aragora_agents_import_survives_missing_api_agent_deps -q`
- `python3 -m ruff check aragora/agents/__init__.py tests/agents/test_package_imports.py`
