### PR TITLE
fix(worktree): evict mismatched managed sessions

### DIFF
--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -525,6 +525,7 @@ def _choose_reusable_session(
     agent: str,
     session_id: str | None,
     active_paths: set[str],
+    active_branches_by_path: dict[str, str | None] | None = None,
 ) -> dict[str, Any] | None:
     sessions = state.get("sessions", [])
     candidates: list[dict[str, Any]] = []
@@ -536,6 +537,10 @@ def _choose_reusable_session(
         path = str(s.get("path", ""))
         if not path or path not in active_paths:
             continue
+        expected_branch = str(s.get("branch", "")).strip() or None
+        actual_branch = (active_branches_by_path or {}).get(path)
+        if expected_branch and actual_branch and actual_branch != expected_branch:
+            continue
         candidates.append(s)
 
     if not candidates:
@@ -546,6 +551,51 @@ def _choose_reusable_session(
 
     candidates.sort(key=sort_key, reverse=True)
     return candidates[0]
+
+
+def _evict_branch_mismatched_session(
+    repo_root: Path,
+    state: dict[str, Any],
+    *,
+    agent: str,
+    session_id: str | None,
+    active_branches_by_path: dict[str, str | None],
+) -> bool:
+    if not session_id:
+        return False
+
+    sessions = state.get("sessions", [])
+    if not isinstance(sessions, list):
+        return False
+
+    kept: list[dict[str, Any]] = []
+    evicted = False
+    for session in sessions:
+        if session.get("agent") != agent or session.get("session_id") != session_id:
+            kept.append(session)
+            continue
+
+        path = str(session.get("path", "")).strip()
+        expected_branch = str(session.get("branch", "")).strip() or None
+        actual_branch = active_branches_by_path.get(path)
+        if not path or not expected_branch or not actual_branch or actual_branch == expected_branch:
+            kept.append(session)
+            continue
+
+        worktree_path = Path(path)
+        if _has_active_session(worktree_path) or _has_active_lease(repo_root, worktree_path):
+            kept.append(session)
+            continue
+
+        removed = _remove_worktree(repo_root, worktree_path)
+        if not removed and worktree_path.exists():
+            kept.append(session)
+            continue
+        evicted = True
+
+    if evicted:
+        state["sessions"] = kept
+    return evicted
 
 
 def _create_managed_worktree(
@@ -617,6 +667,7 @@ def cmd_ensure(args: argparse.Namespace) -> int:
 
     entries = _get_worktree_entries(repo_root)
     active_paths = _active_path_set(entries)
+    active_branches_by_path = {str(entry.path): entry.branch for entry in entries}
     state = _load_state(state_file)
     state, _ = _prune_stale_state(state, active_paths)
 
@@ -627,7 +678,18 @@ def cmd_ensure(args: argparse.Namespace) -> int:
             agent=args.agent,
             session_id=args.session_id,
             active_paths=active_paths,
+            active_branches_by_path=active_branches_by_path,
         )
+        if session is None and _evict_branch_mismatched_session(
+            repo_root,
+            state,
+            agent=args.agent,
+            session_id=args.session_id,
+            active_branches_by_path=active_branches_by_path,
+        ):
+            entries = _get_worktree_entries(repo_root)
+            active_paths = _active_path_set(entries)
+            active_branches_by_path = {str(entry.path): entry.branch for entry in entries}
 
     ttl = timedelta(hours=DEFAULT_TTL_HOURS)
     created = False

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -121,6 +121,29 @@ def test_choose_reusable_session_honors_session_id_filter():
     assert chosen["session_id"] == "a"
 
 
+def test_choose_reusable_session_skips_branch_mismatches():
+    import codex_worktree_autopilot as mod
+
+    state = {
+        "sessions": [
+            {
+                "agent": "codex",
+                "session_id": "s1",
+                "branch": "codex/s1",
+                "path": "/repo/.worktrees/codex-auto/s1",
+            }
+        ]
+    }
+    chosen = mod._choose_reusable_session(
+        state,
+        agent="codex",
+        session_id="s1",
+        active_paths={"/repo/.worktrees/codex-auto/s1"},
+        active_branches_by_path={"/repo/.worktrees/codex-auto/s1": "codex/unrelated"},
+    )
+    assert chosen is None
+
+
 def test_cleanup_parser_defaults_to_delete_branches():
     import codex_worktree_autopilot as mod
 
@@ -574,6 +597,113 @@ def test_cmd_ensure_refreshes_active_paths_for_new_worktree(
     assert payload["session"]["lifecycle_state"] == "grace"
     assert saved_state["sessions"][0]["tracked_worktree"] is True
     assert saved_state["sessions"][0]["lifecycle_state"] == "grace"
+
+
+def test_cmd_ensure_evicts_branch_mismatch_before_recreate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    now = datetime(2026, 3, 30, 7, 50, tzinfo=timezone.utc)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    mismatched_path = tmp_path / "stale-session"
+    mismatched_path.mkdir()
+    state = {
+        "sessions": [
+            {
+                "session_id": "swarm-run-subtask_1",
+                "agent": "codex",
+                "branch": "codex/swarm-run-subtask_1",
+                "path": str(mismatched_path),
+                "created_at": now.isoformat(),
+                "last_seen_at": now.isoformat(),
+            }
+        ]
+    }
+    saved_state: dict[str, object] = {}
+    removed_paths: list[str] = []
+    create_calls: list[dict[str, object]] = []
+
+    entries_iter = iter(
+        [
+            [mod.WorktreeEntry(path=mismatched_path, branch="codex/unrelated")],
+            [],
+            [],
+        ]
+    )
+
+    def _create(*_args: object, **kwargs: object) -> dict[str, object]:
+        create_calls.append(dict(kwargs))
+        return {
+            "session_id": "swarm-run-subtask_1",
+            "agent": "codex",
+            "branch": "codex/swarm-run-subtask_1",
+            "path": str(mismatched_path),
+            "base_branch": "main",
+            "created_at": now.isoformat(),
+            "last_seen_at": now.isoformat(),
+        }
+
+    monkeypatch.setattr(mod, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(mod, "_get_worktree_entries", lambda _repo: next(entries_iter))
+    monkeypatch.setattr(mod, "_load_state", lambda _state_file: state)
+    monkeypatch.setattr(mod, "_create_managed_worktree", _create)
+    monkeypatch.setattr(mod, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_has_active_lease", lambda _repo, _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_remove_worktree",
+        lambda _repo, path: removed_paths.append(str(path)) or True,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_lease_snapshot",
+        lambda _repo_root, _path: {
+            "lease_id": None,
+            "lease_status": None,
+            "last_heartbeat_at": None,
+            "lease_expires_at": None,
+            "owner_agent": None,
+            "owner_session_id": None,
+            "branch": None,
+            "title": None,
+            "has_live_lease": False,
+            "lookup_failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "_worktree_status",
+        lambda *_args, **_kwargs: {"dirty": False, "ahead": 0, "behind": 0},
+    )
+    monkeypatch.setattr(mod, "_branch_ahead_count", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(
+        mod, "_save_state", lambda _state_file, payload: saved_state.update(payload)
+    )
+
+    args = argparse.Namespace(
+        repo=".",
+        managed_dir=".worktrees/codex-auto",
+        agent="codex",
+        base="main",
+        session_id="swarm-run-subtask_1",
+        force_new=False,
+        reconcile=True,
+        strategy="ff-only",
+        print_path=False,
+        json=True,
+    )
+    rc = mod.cmd_ensure(args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["created"] is True
+    assert removed_paths == [str(mismatched_path)]
+    assert create_calls and create_calls[0]["session_id"] == "swarm-run-subtask_1"
+    assert saved_state["sessions"][0]["branch"] == "codex/swarm-run-subtask_1"
 
 
 def test_cmd_cleanup_skips_worktree_with_active_lease(


### PR DESCRIPTION
## Summary
- refuse reusable managed worktree sessions whose actual checked-out branch no longer matches stored session metadata
- evict safe stale mismatched worktrees before recreating the requested managed session
- add regression coverage for branch mismatch reuse and auto-heal behavior

## Testing
- python3 -m pytest tests/scripts/test_codex_worktree_autopilot.py -q
- python3 -m ruff check scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py