### PR TITLE
feat(cli): add --json output flag to aragora quickstart

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -143,6 +143,7 @@ Examples:
     qs_parser.add_argument(
         "--question",
         "-q",
+        "--topic",
         help="The question to debate (uses a default if omitted with --demo)",
     )
     qs_parser.add_argument(
@@ -189,6 +190,12 @@ Examples:
         "--no-browser",
         action="store_true",
         help="Don't open receipt in browser (for CI/headless environments)",
+    )
+    qs_parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Print structured JSON result to stdout (receipt_id, consensus, confidence, agent votes)",
     )
     qs_parser.set_defaults(func=cmd_quickstart)
 
@@ -861,23 +868,25 @@ async def _filter_reachable_live_agents(
 
 def cmd_quickstart(args: argparse.Namespace) -> None:
     """Handle the 'quickstart' command."""
-    print("\n" + "=" * 60)
-    print("  ARAGORA QUICKSTART")
-    print("  Zero-to-receipt adversarial debate")
-    print("=" * 60)
+    json_output = getattr(args, "json_output", False)
+    _print = (lambda *a, **kw: print(*a, file=sys.stderr, **kw)) if json_output else print
+    _print("\n" + "=" * 60)
+    _print("  ARAGORA QUICKSTART")
+    _print("  Zero-to-receipt adversarial debate")
+    _print("=" * 60)
 
     # Step 1: Load .env
     loaded = _load_dotenv()
     if loaded:
-        print("\n[+] Loaded .env configuration")
+        _print("\n[+] Loaded .env configuration")
 
     # Step 2: Get question
     question = _get_question(args)
     if not question:
-        print("\nNo question provided. Exiting.")
+        _print("\nNo question provided. Exiting.")
         sys.exit(1)
 
-    print(f"\nQuestion: {question}")
+    _print(f"\nQuestion: {question}")
 
     # Step 3: Detect agents
     use_demo = getattr(args, "demo", False)
@@ -891,29 +900,29 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
             save_key=getattr(args, "save_key", False),
         )
     except (RuntimeError, ValueError) as exc:
-        print(f"\n[!] Quickstart configuration failed: {exc}")
+        _print(f"\n[!] Quickstart configuration failed: {exc}")
         sys.exit(1)
 
     if saved_key:
-        print(
+        _print(
             "\n[+] Saved "
             f"{saved_key['env_var']} to secure store ({saved_key['backend']}) as {saved_key['masked_value']}"
         )
 
     if use_demo:
-        print("\n[*] Run mode: demo (requested with --demo)")
-        print("    Agents: analyst (supportive), critic (critical), synthesizer (balanced)")
+        _print("\n[*] Run mode: demo (requested with --demo)")
+        _print("    Agents: analyst (supportive), critic (critical), synthesizer (balanced)")
     else:
         try:
             detected = _detect_agents(normalized_provider)
         except ValueError as exc:
-            print(f"\n[!] Quickstart configuration failed: {exc}")
+            _print(f"\n[!] Quickstart configuration failed: {exc}")
             sys.exit(1)
         if not detected:
-            print("\n[!] No supported API keys detected. Falling back to demo mode.")
-            print("    This run will use local mock agents, not live model calls.")
-            print("    Set ANTHROPIC_API_KEY or OPENAI_API_KEY for live debates.")
-            print("    Agents: analyst (supportive), critic (critical), synthesizer (balanced)")
+            _print("\n[!] No supported API keys detected. Falling back to demo mode.")
+            _print("    This run will use local mock agents, not live model calls.")
+            _print("    Set ANTHROPIC_API_KEY or OPENAI_API_KEY for live debates.")
+            _print("    Agents: analyst (supportive), critic (critical), synthesizer (balanced)")
             use_demo = True
         else:
             preview_team = _build_live_team(
@@ -922,10 +931,10 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
                 api_key=inline_api_key,
             )
             providers = list(dict.fromkeys(str(member["provider"]) for member in preview_team))
-            print("\n[+] Run mode: live")
-            print(f"    Agents: {', '.join(providers)}")
+            _print("\n[+] Run mode: live")
+            _print(f"    Agents: {', '.join(providers)}")
 
-    print(f"[*] Running {rounds}-round debate...\n")
+    _print(f"[*] Running {rounds}-round debate...\n")
 
     # Step 4: Run debate
     start_time = time.monotonic()
@@ -945,23 +954,42 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
     except (OSError, ConnectionError, RuntimeError, ValueError, TypeError) as e:
         logger.debug("Live debate failed, falling back to demo: %s", e)
         if _is_tls_verification_failure(e):
-            print("\n[!] Provider TLS check failed. Falling back to demo mode.")
-            print("    Check the local CA trust store for live debates.")
+            _print("\n[!] Provider TLS check failed. Falling back to demo mode.")
+            _print("    Check the local CA trust store for live debates.")
         elif "No live" in str(e) or "no live" in str(e):
-            print("\n[!] No live providers available. Falling back to demo mode.")
+            _print("\n[!] No live providers available. Falling back to demo mode.")
         else:
-            print(f"\n[!] Live debate failed: {e}")
-            print("    Falling back to demo mode.")
+            _print(f"\n[!] Live debate failed: {e}")
+            _print("    Falling back to demo mode.")
         # Fall back to demo — the user should always get a result
         try:
             result = _run_sync(_run_demo_debate(question, rounds))
         except (OSError, RuntimeError, ValueError) as demo_err:
             logger.debug("Demo debate also failed: %s", demo_err)
-            print(f"\n[!] Demo debate also failed: {demo_err}")
+            _print(f"\n[!] Demo debate also failed: {demo_err}")
             sys.exit(1)
 
     elapsed = time.monotonic() - start_time
     result["elapsed_seconds"] = elapsed
+
+    # --json: emit structured JSON to stdout and exit early
+    if json_output:
+        consensus_proof = result.get("consensus_proof", {})
+        consensus_reached = consensus_proof.get("reached") if consensus_proof else None
+        votes = result.get("votes", [])
+        json_payload: dict[str, Any] = {
+            "receipt_id": result.get("receipt_id", result.get("debate_id", "")),
+            "consensus": consensus_reached,
+            "confidence": result.get("confidence"),
+            "verdict": result.get("verdict"),
+            "agents": result.get("agents", []),
+            "votes": votes,
+            "rounds": result.get("rounds"),
+            "mode": result.get("mode", "demo"),
+            "elapsed_seconds": elapsed,
+        }
+        print(json.dumps(json_payload, indent=2, default=str))
+        return
 
     # Step 5: Display results
     print("=" * 60)
@@ -1058,3 +1086,4 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
     print("  aragora ask 'Your question' --agents anthropic-api,openai-api  # Full debate")
     print("  aragora decide 'Your question'                                  # Full pipeline")
     print("  aragora doctor                                                  # System health")
+    # System health")

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -1146,3 +1146,77 @@ class TestCmdQuickstart:
         output = capsys.readouterr().out
         assert "Live debate failed: Live debate timed out after 120s" in output
         assert "Mode:       Demo" in output
+
+    def test_json_flag_outputs_structured_json(self, capsys):
+        """Test --json flag prints structured JSON to stdout."""
+        args = argparse.Namespace(
+            question="Should we use JSON output?",
+            demo=True,
+            provider=None,
+            api_key=None,
+            save_key=False,
+            output=None,
+            format="json",
+            rounds=1,
+            no_browser=True,
+            json_output=True,
+        )
+        with patch(
+            "aragora.cli.commands.quickstart._run_demo_debate",
+            return_value={
+                "question": "Should we use JSON output?",
+                "verdict": "consensus",
+                "confidence": 0.85,
+                "rounds": 1,
+                "agents": ["analyst", "critic", "synthesizer"],
+                "summary": "JSON output is useful.",
+                "dissent": [],
+                "mode": "demo",
+                "receipt_id": "demo-receipt-json-1",
+                "consensus_proof": {"reached": True},
+                "votes": [
+                    {"agent": "analyst", "choice": "yes"},
+                    {"agent": "critic", "choice": "yes"},
+                ],
+            },
+        ):
+            cmd_quickstart(args)
+
+        output = capsys.readouterr().out
+        data = json.loads(output)
+        assert data["receipt_id"] == "demo-receipt-json-1"
+        assert data["consensus"] is True
+        assert data["confidence"] == 0.85
+        assert data["verdict"] == "consensus"
+        assert data["agents"] == ["analyst", "critic", "synthesizer"]
+        assert len(data["votes"]) == 2
+        assert data["rounds"] == 1
+        assert data["mode"] == "demo"
+        assert "elapsed_seconds" in data
+        # Should NOT contain human-readable banner
+        assert "QUICKSTART" not in output
+        assert "RESULT" not in output
+
+    def test_json_flag_parser_registration(self):
+        """Test --json flag is registered in quickstart parser."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        add_quickstart_parser(subparsers)
+        args = parser.parse_args(["quickstart", "--json"])
+        assert args.json_output is True
+
+    def test_json_flag_default_is_false(self):
+        """Test --json defaults to false."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        add_quickstart_parser(subparsers)
+        args = parser.parse_args(["quickstart", "--demo"])
+        assert args.json_output is False
+
+    def test_topic_alias_for_question(self):
+        """Test --topic works as alias for --question."""
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers()
+        add_quickstart_parser(subparsers)
+        args = parser.parse_args(["quickstart", "--topic", "Test topic"])
+        assert args.question == "Test topic"


### PR DESCRIPTION
Add --json flag that prints structured JSON (receipt_id, consensus,
confidence, verdict, agents, votes) to stdout. Human-readable output
is redirected to stderr when --json is active. Also adds --topic as
an alias for --question.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
