### PR TITLE
fix(receipts): preserve cost summaries in legacy exports

### DIFF
--- a/aragora/export/decision_receipt.py
+++ b/aragora/export/decision_receipt.py
@@ -70,6 +70,146 @@ class ReceiptVerification:
     proof_hash: str | None = None
 
 
+def _coerce_float(value: Any, default: float = 0.0) -> float:
+    """Best-effort float coercion for legacy receipt fields."""
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort int coercion for legacy receipt fields."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _render_cost_summary_markdown(cost_summary: dict[str, Any] | None) -> list[str]:
+    """Render a legacy cost summary section for Markdown exports."""
+    if not cost_summary:
+        return []
+
+    lines = [
+        "---",
+        "",
+        "## Cost Breakdown",
+        "",
+        f"- **Total Cost:** ${cost_summary.get('total_cost_usd', '0')}",
+        f"- **Tokens In:** {cost_summary.get('total_tokens_in', 0)}",
+        f"- **Tokens Out:** {cost_summary.get('total_tokens_out', 0)}",
+        f"- **Total Calls:** {cost_summary.get('total_calls', 0)}",
+        "",
+    ]
+
+    per_agent = cost_summary.get("per_agent") or {}
+    if per_agent:
+        lines.extend(
+            [
+                "### Per-Agent Costs",
+                "",
+                "| Agent | Cost (USD) | Tokens In | Tokens Out | Calls |",
+                "|-------|------------|-----------|------------|-------|",
+            ]
+        )
+        for agent_name, payload in per_agent.items():
+            if not isinstance(payload, dict):
+                continue
+            lines.append(
+                f"| {agent_name} | ${payload.get('total_cost_usd', '0')} | "
+                f"{payload.get('total_tokens_in', 0)} | {payload.get('total_tokens_out', 0)} | "
+                f"{payload.get('call_count', 0)} |"
+            )
+        lines.append("")
+
+    model_usage = cost_summary.get("model_usage") or {}
+    if model_usage:
+        lines.extend(
+            [
+                "### Model Usage",
+                "",
+                "| Model | Cost (USD) | Calls |",
+                "|-------|------------|-------|",
+            ]
+        )
+        for model_name, payload in model_usage.items():
+            if not isinstance(payload, dict):
+                continue
+            lines.append(
+                f"| {model_name} | ${payload.get('total_cost_usd', '0')} | "
+                f"{payload.get('call_count', 0)} |"
+            )
+        lines.append("")
+
+    return lines
+
+
+def _render_cost_summary_html(cost_summary: dict[str, Any] | None) -> str:
+    """Render a legacy cost summary section for HTML exports."""
+    if not cost_summary:
+        return ""
+
+    esc = html_mod.escape
+    per_agent_rows = ""
+    for agent_name, payload in (cost_summary.get("per_agent") or {}).items():
+        if not isinstance(payload, dict):
+            continue
+        per_agent_rows += (
+            "<tr>"
+            f"<td>{esc(str(agent_name))}</td>"
+            f"<td>${esc(str(payload.get('total_cost_usd', '0')))}</td>"
+            f"<td>{esc(str(payload.get('total_tokens_in', 0)))}</td>"
+            f"<td>{esc(str(payload.get('total_tokens_out', 0)))}</td>"
+            f"<td>{esc(str(payload.get('call_count', 0)))}</td>"
+            "</tr>"
+        )
+
+    model_usage_rows = ""
+    for model_name, payload in (cost_summary.get("model_usage") or {}).items():
+        if not isinstance(payload, dict):
+            continue
+        model_usage_rows += (
+            "<tr>"
+            f"<td>{esc(str(model_name))}</td>"
+            f"<td>${esc(str(payload.get('total_cost_usd', '0')))}</td>"
+            f"<td>{esc(str(payload.get('call_count', 0)))}</td>"
+            "</tr>"
+        )
+
+    per_agent_html = ""
+    if per_agent_rows:
+        per_agent_html = f"""
+        <h3>Per-Agent Costs</h3>
+        <table>
+            <tr><th>Agent</th><th>Cost (USD)</th><th>Tokens In</th><th>Tokens Out</th><th>Calls</th></tr>
+            {per_agent_rows}
+        </table>
+        """
+
+    model_usage_html = ""
+    if model_usage_rows:
+        model_usage_html = f"""
+        <h3>Model Usage</h3>
+        <table>
+            <tr><th>Model</th><th>Cost (USD)</th><th>Calls</th></tr>
+            {model_usage_rows}
+        </table>
+        """
+
+    return f"""
+    <div class="section">
+        <h2>Cost Breakdown</h2>
+        <p><strong>Total Cost:</strong> ${esc(str(cost_summary.get("total_cost_usd", "0")))}</p>
+        <p><strong>Tokens In:</strong> {esc(str(cost_summary.get("total_tokens_in", 0)))}</p>
+        <p><strong>Tokens Out:</strong> {esc(str(cost_summary.get("total_tokens_out", 0)))}</p>
+        <p><strong>Total Calls:</strong> {esc(str(cost_summary.get("total_calls", 0)))}</p>
+        {per_agent_html}
+        {model_usage_html}
+    </div>
+    """
+
+
 @dataclass
 class DecisionReceipt:
     """
@@ -156,6 +296,7 @@ class DecisionReceipt:
     cost_usd: float = 0.0
     tokens_used: int = 0
     budget_limit_usd: float | None = None
+    cost_summary: dict[str, Any] | None = None
 
     def __post_init__(self):
         if not self.checksum:
@@ -215,6 +356,7 @@ class DecisionReceipt:
             "cost_usd": self.cost_usd,
             "tokens_used": self.tokens_used,
             "budget_limit_usd": self.budget_limit_usd,
+            "cost_summary": self.cost_summary,
         }
 
     def to_json(self, indent: int = 2) -> str:
@@ -328,6 +470,8 @@ class DecisionReceipt:
             for m in self.mitigations:
                 lines.append(f"- {m}")
             lines.append("")
+
+        lines.extend(_render_cost_summary_markdown(self.cost_summary))
 
         # Dissenting views
         if self.dissenting_views:
@@ -451,6 +595,7 @@ class DecisionReceipt:
             </div>
             """
 
+        cost_summary_html = _render_cost_summary_html(self.cost_summary)
         esc = html_mod.escape
         return f"""<!DOCTYPE html>
 <html>
@@ -519,6 +664,8 @@ class DecisionReceipt:
         <h2>All Findings</h2>
         {findings_html if findings_html else "<p>No findings.</p>"}
     </div>
+
+    {cost_summary_html}
 
     <div class="section">
         <h2>Audit Trail</h2>
@@ -955,6 +1102,7 @@ class DecisionReceipt:
         result: DebateResult,
         include_cost: bool = True,
         cost_data: dict[str, Any] | None = None,
+        cost_summary: dict[str, Any] | None = None,
     ) -> DecisionReceipt:
         """
         Generate a DecisionReceipt from a standard DebateResult.
@@ -966,6 +1114,7 @@ class DecisionReceipt:
             result: The DebateResult from a completed debate
             include_cost: Whether to include cost data in the receipt
             cost_data: Optional dict with cost_usd, tokens_used, budget_limit_usd
+            cost_summary: Optional rich breakdown dict with per-agent/model totals
 
         Returns:
             DecisionReceipt suitable for audit trail
@@ -1005,16 +1154,34 @@ class DecisionReceipt:
         cost_usd = 0.0
         tokens_used = 0
         budget_limit_usd = None
+        normalized_cost_summary: dict[str, Any] | None = None
 
         if include_cost:
-            if cost_data:
-                cost_usd = cost_data.get("cost_usd", 0.0)
-                tokens_used = cost_data.get("tokens_used", 0)
+            if isinstance(cost_summary, dict):
+                normalized_cost_summary = cost_summary
+            elif isinstance(cost_data, dict) and (
+                "per_agent" in cost_data
+                or "per_round" in cost_data
+                or "model_usage" in cost_data
+                or "total_cost_usd" in cost_data
+            ):
+                normalized_cost_summary = cost_data
+            elif isinstance(getattr(result, "cost_summary", None), dict):
+                normalized_cost_summary = result.cost_summary
+
+            if normalized_cost_summary:
+                cost_usd = _coerce_float(normalized_cost_summary.get("total_cost_usd"), 0.0)
+                tokens_used = _coerce_int(
+                    normalized_cost_summary.get("total_tokens_in")
+                ) + _coerce_int(normalized_cost_summary.get("total_tokens_out"))
+            elif cost_data:
+                cost_usd = _coerce_float(cost_data.get("cost_usd"), 0.0)
+                tokens_used = _coerce_int(cost_data.get("tokens_used"), 0)
                 budget_limit_usd = cost_data.get("budget_limit_usd")
             elif hasattr(result, "total_cost_usd"):
-                cost_usd = result.total_cost_usd
-                tokens_used = result.total_tokens
-                budget_limit_usd = result.budget_limit_usd
+                cost_usd = _coerce_float(getattr(result, "total_cost_usd", 0.0), 0.0)
+                tokens_used = _coerce_int(getattr(result, "total_tokens", 0), 0)
+                budget_limit_usd = getattr(result, "budget_limit_usd", None)
 
         # Convert critiques to findings (high severity by default)
         findings = []
@@ -1089,6 +1256,7 @@ class DecisionReceipt:
             cost_usd=cost_usd,
             tokens_used=tokens_used,
             budget_limit_usd=budget_limit_usd,
+            cost_summary=normalized_cost_summary,
         )
 
 

--- a/tests/export/test_decision_receipt.py
+++ b/tests/export/test_decision_receipt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -260,6 +261,21 @@ class TestDecisionReceipt:
         assert len(result["dissenting_views"]) == 1
         assert len(result["verified_claims"]) == 1
 
+    def test_to_dict_includes_cost_summary(self, basic_receipt: DecisionReceipt):
+        """Legacy receipts preserve rich cost breakdowns in JSON payloads."""
+        basic_receipt.cost_summary = {
+            "total_cost_usd": "0.0234",
+            "total_tokens_in": 3000,
+            "total_tokens_out": 1000,
+            "total_calls": 6,
+            "per_agent": {"claude": {"total_cost_usd": "0.015", "call_count": 3}},
+        }
+
+        result = basic_receipt.to_dict()
+
+        assert result["cost_summary"] is not None
+        assert result["cost_summary"]["total_cost_usd"] == "0.0234"
+
     def test_to_json(self, basic_receipt: DecisionReceipt):
         """Test JSON serialization."""
         json_str = basic_receipt.to_json()
@@ -288,6 +304,26 @@ class TestDecisionReceipt:
         assert "SQL Injection" in md  # Critical finding
         assert "N+1 Query" in md  # High finding
 
+    def test_to_markdown_includes_cost_summary(self, basic_receipt: DecisionReceipt):
+        """Markdown export renders the cost breakdown section when present."""
+        basic_receipt.cost_summary = {
+            "total_cost_usd": "0.0234",
+            "total_tokens_in": 3000,
+            "total_tokens_out": 1000,
+            "total_calls": 6,
+            "per_agent": {"claude": {"total_cost_usd": "0.015", "call_count": 3}},
+            "model_usage": {
+                "anthropic/claude-sonnet-4": {"total_cost_usd": "0.015", "call_count": 3}
+            },
+        }
+
+        md = basic_receipt.to_markdown()
+
+        assert "## Cost Breakdown" in md
+        assert "$0.0234" in md
+        assert "### Per-Agent Costs" in md
+        assert "### Model Usage" in md
+
     def test_to_markdown_with_dissent(self, detailed_receipt: DecisionReceipt):
         """Test Markdown includes dissenting views."""
         md = detailed_receipt.to_markdown()
@@ -312,6 +348,22 @@ class TestDecisionReceipt:
         assert "<title>Decision Receipt" in html
         assert "test-receipt-123" in html
         assert "APPROVED" in html
+
+    def test_to_html_includes_cost_summary(self, basic_receipt: DecisionReceipt):
+        """HTML export renders the cost breakdown section when present."""
+        basic_receipt.cost_summary = {
+            "total_cost_usd": "0.0234",
+            "total_tokens_in": 3000,
+            "total_tokens_out": 1000,
+            "total_calls": 6,
+            "per_agent": {"claude": {"total_cost_usd": "0.015", "call_count": 3}},
+        }
+
+        html = basic_receipt.to_html()
+
+        assert "Cost Breakdown" in html
+        assert "$0.0234" in html
+        assert "Per-Agent Costs" in html
 
     def test_to_html_verdict_colors(self):
         """Test HTML uses correct colors for different verdicts."""
@@ -381,6 +433,51 @@ class TestDecisionReceipt:
         assert loaded.verdict == detailed_receipt.verdict
         assert len(loaded.findings) == len(detailed_receipt.findings)
         assert len(loaded.dissenting_views) == len(detailed_receipt.dissenting_views)
+
+    def test_from_dict_preserves_cost_summary(self, basic_receipt: DecisionReceipt):
+        """Legacy receipts round-trip stored cost summaries without crashing."""
+        basic_receipt.cost_summary = {
+            "total_cost_usd": "0.0234",
+            "total_tokens_in": 3000,
+            "total_tokens_out": 1000,
+            "total_calls": 6,
+            "per_agent": {"claude": {"total_cost_usd": "0.015", "call_count": 3}},
+        }
+
+        loaded = DecisionReceipt.from_dict(basic_receipt.to_dict())
+
+        assert loaded.cost_summary is not None
+        assert loaded.cost_summary["total_cost_usd"] == "0.0234"
+
+    def test_from_debate_result_accepts_cost_summary(self):
+        """from_debate_result stays compatible with rich cost_summary callers."""
+        result = SimpleNamespace(
+            confidence=0.8,
+            critiques=[],
+            dissenting_views=[],
+            debate_id="d-1",
+            id="d-1",
+            task="Design a rate limiter",
+            consensus_reached=True,
+            participants=["claude", "codex"],
+            rounds_completed=2,
+            duration_seconds=12.5,
+        )
+
+        receipt = DecisionReceipt.from_debate_result(
+            result,
+            cost_summary={
+                "total_cost_usd": "0.0234",
+                "total_tokens_in": 3000,
+                "total_tokens_out": 1000,
+                "total_calls": 6,
+            },
+        )
+
+        assert receipt.cost_summary is not None
+        assert receipt.cost_summary["total_cost_usd"] == "0.0234"
+        assert receipt.cost_usd == pytest.approx(0.0234)
+        assert receipt.tokens_used == 4000
 
     def test_load_from_file(self, basic_receipt: DecisionReceipt):
         """Test loading from saved file."""

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -396,6 +396,30 @@ class TestExportReceipt:
         assert exported["agents_involved"] == ["claude", "codex"]
         assert data["format"] == "json"
 
+    def test_export_receipt_from_stored_receipt_preserves_cost_summary(
+        self, client, mock_receipt_store, sample_stored_receipt
+    ):
+        """Stored rich receipt payloads export even when cost_summary is present."""
+        sample_stored_receipt.data = dict(sample_stored_receipt.data)
+        sample_stored_receipt.data["cost_summary"] = {
+            "total_cost_usd": "0.0234",
+            "total_tokens_in": 3000,
+            "total_tokens_out": 1000,
+            "total_calls": 6,
+            "per_agent": {"claude": {"total_cost_usd": "0.015", "call_count": 3}},
+        }
+        mock_receipt_store.get.return_value = sample_stored_receipt
+
+        response = client.get("/api/v2/receipts/rcpt_test123/export?format=json")
+
+        assert response.status_code == 200
+        data = response.json()
+        import json
+
+        exported = json.loads(data["content"])
+        assert exported["cost_summary"]["total_cost_usd"] == "0.0234"
+        assert exported["cost_summary"]["per_agent"]["claude"]["call_count"] == 3
+
     def test_export_receipt_default_format_is_json(
         self, client, mock_receipt_store, sample_receipt_dict
     ):


### PR DESCRIPTION
## Summary
- preserve `cost_summary` on legacy export-layer `DecisionReceipt` roundtrips
- accept rich `cost_summary` payloads in `from_debate_result` and render them in markdown/html exports
- add regressions for the export model and `/api/v2/receipts/{id}/export` with stored cost breakdown payloads

## Validation
- `python3 -m pytest tests/export/test_decision_receipt.py -k 'cost_summary or not TestDecisionReceiptPDF' tests/server/fastapi/test_receipts_routes.py tests/test_receipt_contract.py -q`
- `python3 -m ruff check aragora/export/decision_receipt.py tests/export/test_decision_receipt.py tests/server/fastapi/test_receipts_routes.py`

## Notes
- local PDF-specific receipt tests still depend on WeasyPrint system libraries (`libgobject-2.0`) and were intentionally excluded from the focused pytest slice because that environment issue is unrelated to this patch
