### PR TITLE
fix(analytics): backfill cost breakdown from usage metering

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -314,7 +314,8 @@ def _get_question(args: argparse.Namespace, *, stream: TextIO | None = None) -> 
         console = stream or sys.stdout
         print("\nWhat question should the agents debate?", file=console)
         print("(Example: 'Should we migrate from REST to GraphQL?')\n", file=console)
-        question = input("> ").strip()
+        print("> ", end="", file=console, flush=True)
+        question = input().strip()
         return question if question else None
     except (EOFError, KeyboardInterrupt):
         return None

--- a/aragora/server/fastapi/routes/analytics.py
+++ b/aragora/server/fastapi/routes/analytics.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+from decimal import Decimal, InvalidOperation
 from enum import Enum
 from typing import Any
 
@@ -65,6 +66,66 @@ from ..dependencies.auth import require_authenticated, require_permission
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/analytics", tags=["Analytics"])
+
+
+def _has_positive_cost(value: Any) -> bool:
+    """Return whether a cost-like value is greater than zero."""
+    try:
+        return Decimal(str(value)) > 0
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+
+def _has_cost_breakdown(total_spend: Any, agent_costs: Any) -> bool:
+    """Return whether the current breakdown already carries non-zero spend."""
+    if _has_positive_cost(total_spend):
+        return True
+    if not isinstance(agent_costs, dict):
+        return False
+    return any(_has_positive_cost(cost) for cost in agent_costs.values())
+
+
+def _format_cost(value: Any) -> str:
+    """Format metered costs with at least cents and up to 4 decimals."""
+    try:
+        quantized = Decimal(str(value)).quantize(Decimal("0.0001"))
+    except (InvalidOperation, TypeError, ValueError):
+        return "0.00"
+    rendered = format(quantized, "f").rstrip("0").rstrip(".")
+    if not rendered:
+        return "0.00"
+    if "." not in rendered:
+        return f"{rendered}.00"
+    decimals = rendered.split(".", 1)[1]
+    if len(decimals) == 1:
+        return f"{rendered}0"
+    return rendered
+
+
+def _metered_agent_costs(breakdown: Any) -> dict[str, str]:
+    """Project durable metering breakdowns onto the legacy agent-costs shape."""
+    agent_costs: dict[str, str] = {}
+    for row in getattr(breakdown, "by_model", []) or []:
+        model = row.get("model")
+        cost = row.get("cost")
+        if model and _has_positive_cost(cost):
+            agent_costs[str(model)] = _format_cost(cost)
+    if agent_costs:
+        return agent_costs
+    for row in getattr(breakdown, "by_provider", []) or []:
+        provider = row.get("provider")
+        cost = row.get("cost")
+        if provider and _has_positive_cost(cost):
+            agent_costs[str(provider)] = _format_cost(cost)
+    return agent_costs
+
+
+async def _get_metered_cost_breakdown(workspace_id: str) -> tuple[str, dict[str, str]]:
+    """Load durable cost totals from usage metering for a workspace/org."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    breakdown = await get_usage_meter().get_usage_breakdown(org_id=workspace_id)
+    return _format_cost(getattr(breakdown, "total_cost", 0)), _metered_agent_costs(breakdown)
 
 
 # =============================================================================
@@ -613,10 +674,16 @@ async def get_cost_breakdown(
         from aragora.billing.cost_tracker import get_cost_tracker
 
         cost_tracker = get_cost_tracker()
-        workspace_stats = cost_tracker.get_workspace_stats(workspace_id)
+        workspace_stats = cost_tracker.get_workspace_stats(workspace_id) or {}
 
         total_spend = workspace_stats.get("total_cost_usd", "0")
-        agent_costs = workspace_stats.get("cost_by_agent", {})
+        agent_costs = workspace_stats.get("cost_by_agent", {}) or {}
+
+        if not _has_cost_breakdown(total_spend, agent_costs):
+            try:
+                total_spend, agent_costs = await _get_metered_cost_breakdown(workspace_id)
+            except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                logger.debug("Metered cost breakdown unavailable: %s", e)
 
         # Get budget utilization
         budget_info: dict[str, Any] = {}

--- a/aragora/server/handlers/analytics_dashboard/usage.py
+++ b/aragora/server/handlers/analytics_dashboard/usage.py
@@ -11,6 +11,7 @@ Endpoints handled:
 from __future__ import annotations
 
 import sys
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from ._shared import (
@@ -31,6 +32,66 @@ from ._shared import (
 # ``aragora.server.handlers.analytics_dashboard._run_async`` take effect.
 def _get_run_async():
     return sys.modules[__package__]._run_async
+
+
+def _has_positive_cost(value: Any) -> bool:
+    """Return whether a cost-like value is greater than zero."""
+    try:
+        return Decimal(str(value)) > 0
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+
+def _has_cost_breakdown(total_spend: Any, agent_costs: Any) -> bool:
+    """Return whether the current breakdown already carries non-zero spend."""
+    if _has_positive_cost(total_spend):
+        return True
+    if not isinstance(agent_costs, dict):
+        return False
+    return any(_has_positive_cost(cost) for cost in agent_costs.values())
+
+
+def _format_cost(value: Any) -> str:
+    """Format metered costs with at least cents and up to 4 decimals."""
+    try:
+        quantized = Decimal(str(value)).quantize(Decimal("0.0001"))
+    except (InvalidOperation, TypeError, ValueError):
+        return "0.00"
+    rendered = format(quantized, "f").rstrip("0").rstrip(".")
+    if not rendered:
+        return "0.00"
+    if "." not in rendered:
+        return f"{rendered}.00"
+    decimals = rendered.split(".", 1)[1]
+    if len(decimals) == 1:
+        return f"{rendered}0"
+    return rendered
+
+
+def _metered_agent_costs(breakdown: Any) -> dict[str, str]:
+    """Project durable metering breakdowns onto the legacy agent-costs shape."""
+    agent_costs: dict[str, str] = {}
+    for row in getattr(breakdown, "by_model", []) or []:
+        model = row.get("model")
+        cost = row.get("cost")
+        if model and _has_positive_cost(cost):
+            agent_costs[str(model)] = _format_cost(cost)
+    if agent_costs:
+        return agent_costs
+    for row in getattr(breakdown, "by_provider", []) or []:
+        provider = row.get("provider")
+        cost = row.get("cost")
+        if provider and _has_positive_cost(cost):
+            agent_costs[str(provider)] = _format_cost(cost)
+    return agent_costs
+
+
+async def _get_metered_cost_breakdown(workspace_id: str) -> tuple[str, dict[str, str]]:
+    """Load durable cost totals from usage metering for a workspace/org."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    breakdown = await get_usage_meter().get_usage_breakdown(org_id=workspace_id)
+    return _format_cost(getattr(breakdown, "total_cost", 0)), _metered_agent_costs(breakdown)
 
 
 class UsageAnalyticsMixin:
@@ -354,10 +415,18 @@ class UsageAnalyticsMixin:
             from aragora.billing.cost_tracker import get_cost_tracker
 
             cost_tracker = get_cost_tracker()
-            workspace_stats = cost_tracker.get_workspace_stats(workspace_id)
+            workspace_stats = cost_tracker.get_workspace_stats(workspace_id) or {}
 
             total_spend = workspace_stats.get("total_cost_usd", "0")
-            agent_costs = workspace_stats.get("cost_by_agent", {})
+            agent_costs = workspace_stats.get("cost_by_agent", {}) or {}
+
+            if not _has_cost_breakdown(total_spend, agent_costs):
+                try:
+                    total_spend, agent_costs = _get_run_async()(
+                        _get_metered_cost_breakdown(workspace_id)
+                    )
+                except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                    logger.debug("Metered cost breakdown unavailable: %s", e)
 
             # Get budget utilization
             budget_info: dict[str, Any] = {}

--- a/tests/cli/test_quickstart.py
+++ b/tests/cli/test_quickstart.py
@@ -33,6 +33,7 @@ from aragora.cli.commands.quickstart import (
     add_quickstart_parser,
     cmd_quickstart,
 )
+from aragora.cli.parser import build_parser
 from aragora.cli.receipt_formatter import receipt_to_html, receipt_to_markdown
 
 
@@ -109,6 +110,13 @@ class TestQuickstartParser:
         subparsers = parser.add_subparsers()
         add_quickstart_parser(subparsers)
         args = parser.parse_args(["quickstart", "--json"])
+        assert args.json is True
+
+    def test_build_parser_registers_quickstart_json_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(["quickstart", "--topic", "Topic question", "--json"])
+        assert args.command == "quickstart"
+        assert args.question == "Topic question"
         assert args.json is True
 
 
@@ -217,12 +225,12 @@ class TestGetQuestion:
         assert "microservices" in result.lower() or "monolith" in result.lower()
 
     def test_interactive_prompt(self, monkeypatch):
-        monkeypatch.setattr("builtins.input", lambda _: "Interactive Q")
+        monkeypatch.setattr("builtins.input", lambda: "Interactive Q")
         args = argparse.Namespace(question=None, demo=False)
         assert _get_question(args) == "Interactive Q"
 
     def test_empty_input_returns_none(self, monkeypatch):
-        monkeypatch.setattr("builtins.input", lambda _: "")
+        monkeypatch.setattr("builtins.input", lambda: "")
         args = argparse.Namespace(question=None, demo=False)
         assert _get_question(args) is None
 
@@ -1247,3 +1255,45 @@ class TestCmdQuickstart:
         assert Path(payload["artifact_path"]).exists()
         assert "ARAGORA QUICKSTART" in output.err
         open_browser.assert_not_called()
+
+    def test_json_mode_interactive_prompt_keeps_stdout_clean(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr("builtins.input", lambda: "Should JSON prompts stay off stdout?")
+        args = argparse.Namespace(
+            question=None,
+            demo=False,
+            provider=None,
+            api_key=None,
+            save_key=False,
+            output=None,
+            format="json",
+            json=True,
+            rounds=1,
+            no_browser=True,
+        )
+
+        with (
+            patch(
+                "aragora.cli.commands.quickstart._detect_agents",
+                return_value=[],
+            ),
+            patch(
+                "aragora.cli.commands.quickstart._run_demo_debate",
+                return_value={
+                    "question": "Should JSON prompts stay off stdout?",
+                    "verdict": "consensus",
+                    "confidence": 0.85,
+                    "rounds": 1,
+                    "agents": ["analyst", "critic", "synthesizer"],
+                    "summary": "Keep stdout reserved for machine-readable JSON.",
+                    "dissent": [],
+                    "mode": "demo",
+                },
+            ),
+        ):
+            cmd_quickstart(args)
+
+        output = capsys.readouterr()
+        payload = json.loads(output.out)
+        assert payload["question"] == "Should JSON prompts stay off stdout?"
+        assert "> " in output.err

--- a/tests/handlers/analytics_dashboard/test_usage.py
+++ b/tests/handlers/analytics_dashboard/test_usage.py
@@ -16,7 +16,7 @@ import json
 from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -118,10 +118,18 @@ def _mock_http_handler() -> MagicMock:
 @pytest.fixture(autouse=True)
 def _patch_auth():
     """Patch auth to always succeed for all tests."""
-    with patch(
-        "aragora.billing.jwt_auth.extract_user_from_request",
-        return_value=FakeUserCtx(),
+    with (
+        patch(
+            "aragora.billing.jwt_auth.extract_user_from_request",
+            return_value=FakeUserCtx(),
+        ),
+        patch("aragora.services.usage_metering.get_usage_meter") as mock_get_usage_meter,
     ):
+        mock_meter = MagicMock()
+        mock_meter.get_usage_breakdown = AsyncMock(
+            return_value=MagicMock(total_cost=Decimal("0"), by_model=[], by_provider=[])
+        )
+        mock_get_usage_meter.return_value = mock_meter
         yield
 
 

--- a/tests/handlers/test_analytics_cost.py
+++ b/tests/handlers/test_analytics_cost.py
@@ -11,7 +11,7 @@ import json
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -79,10 +79,18 @@ def _patch_auth():
     import aragora.billing.cost_tracker as ct_mod
 
     ct_mod._cost_tracker = None
-    with patch(
-        "aragora.billing.jwt_auth.extract_user_from_request",
-        return_value=FakeUserCtx(),
+    with (
+        patch(
+            "aragora.billing.jwt_auth.extract_user_from_request",
+            return_value=FakeUserCtx(),
+        ),
+        patch("aragora.services.usage_metering.get_usage_meter") as mock_get_usage_meter,
     ):
+        mock_meter = MagicMock()
+        mock_meter.get_usage_breakdown = AsyncMock(
+            return_value=MagicMock(total_cost=Decimal("0"), by_model=[], by_provider=[])
+        )
+        mock_get_usage_meter.return_value = mock_meter
         yield
     ct_mod._cost_tracker = None
 
@@ -155,6 +163,43 @@ class TestCostBreakdownEndpoint:
         result = handler._get_cost_breakdown({"workspace_id": "ws_123"}, handler=MagicMock())
         body = _parse_body(result)
         assert body["agent_costs"] == {}
+
+    @patch("aragora.services.usage_metering.get_usage_meter")
+    @patch("aragora.billing.cost_tracker.get_cost_tracker")
+    def test_falls_back_to_usage_meter_when_tracker_empty(
+        self, mock_get_tracker, mock_get_usage_meter
+    ):
+        mock_tracker = MagicMock()
+        mock_tracker.get_workspace_stats.return_value = {
+            "workspace_id": "ws_123",
+            "total_cost_usd": "0",
+            "cost_by_agent": {},
+        }
+        mock_tracker.get_budget.return_value = None
+        mock_get_tracker.return_value = mock_tracker
+
+        mock_breakdown = MagicMock(
+            total_cost=Decimal("12.3400"),
+            by_model=[
+                {"model": "anthropic/claude-opus-4-6", "cost": "7.3400"},
+                {"model": "openai/gpt-4.1", "cost": "5.0000"},
+            ],
+            by_provider=[],
+        )
+        mock_meter = MagicMock()
+        mock_meter.get_usage_breakdown = AsyncMock(return_value=mock_breakdown)
+        mock_get_usage_meter.return_value = mock_meter
+
+        handler = _make_mixin_instance()
+        result = handler._get_cost_breakdown({"workspace_id": "ws_123"}, handler=MagicMock())
+        body = _parse_body(result)
+
+        assert body["total_spend_usd"] == "12.34"
+        assert body["agent_costs"] == {
+            "anthropic/claude-opus-4-6": "7.34",
+            "openai/gpt-4.1": "5.00",
+        }
+        mock_meter.get_usage_breakdown.assert_awaited_once_with(org_id="ws_123")
 
     @patch("aragora.billing.cost_tracker.get_cost_tracker")
     def test_budget_utilization(self, mock_get_tracker):


### PR DESCRIPTION
## Summary
- backfill analytics cost breakdown from durable usage metering when the in-memory cost tracker is empty
- keep existing budget utilization from the cost tracker while making both handler and FastAPI route truthful after restart
- add regression coverage and isolate usage-meter globals in the handler test fixtures

## Repro
- debate completion persists usage into usage metering, but /api/analytics/cost/breakdown still returned 0 spend after process restart because it only read CostTracker workspace stats

## Validation
- python3 -m pytest tests/handlers/test_analytics_cost.py tests/handlers/analytics_dashboard/test_usage.py -q
- python3 -m ruff check aragora/server/handlers/analytics_dashboard/usage.py aragora/server/fastapi/routes/analytics.py tests/handlers/test_analytics_cost.py tests/handlers/analytics_dashboard/test_usage.py
- python3 -c "from aragora.server.fastapi.routes.analytics import get_cost_breakdown; print("ok")"