### PR TITLE
fix(analytics): backfill spend summary from usage metering

### DIFF
--- a/aragora/server/handlers/spend_analytics_dashboard.py
+++ b/aragora/server/handlers/spend_analytics_dashboard.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from aragora.server.versioning.compat import strip_version_prefix
+from aragora.utils.async_utils import run_async
 
 from .base import (
     HandlerResult,
@@ -57,6 +59,44 @@ def _get_budget_manager() -> Any:
     except (ImportError, RuntimeError, OSError) as e:
         logger.debug("BudgetManager not available: %s", e)
         return None
+
+
+def _has_positive_cost(value: Any) -> bool:
+    """Return whether a cost-like value is greater than zero."""
+    try:
+        return Decimal(str(value)) > 0
+    except (InvalidOperation, TypeError, ValueError):
+        return False
+
+
+def _format_cost(value: Any) -> str:
+    """Format costs with at least cents and up to 4 decimals."""
+    try:
+        quantized = Decimal(str(value)).quantize(Decimal("0.0001"))
+    except (InvalidOperation, TypeError, ValueError):
+        return "0.00"
+    rendered = format(quantized, "f").rstrip("0").rstrip(".")
+    if not rendered:
+        return "0.00"
+    if "." not in rendered:
+        return f"{rendered}.00"
+    decimals = rendered.split(".", 1)[1]
+    if len(decimals) == 1:
+        return f"{rendered}0"
+    return rendered
+
+
+def _summary_has_usage(total_spend_usd: Any, total_api_calls: Any, total_tokens: Any) -> bool:
+    """Return whether the current summary already carries meaningful usage."""
+    return _has_positive_cost(total_spend_usd) or bool(total_api_calls) or bool(total_tokens)
+
+
+def _get_metered_summary(scope_id: str) -> tuple[str, int, int]:
+    """Load durable spend summary data from usage metering."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    summary = run_async(get_usage_meter().get_usage_summary(org_id=scope_id))
+    return _format_cost(summary.token_cost), summary.api_call_count, summary.total_tokens
 
 
 class SpendAnalyticsDashboardHandler(SecureHandler):
@@ -185,6 +225,13 @@ class SpendAnalyticsDashboardHandler(SecureHandler):
             total_spend_usd = stats.get("total_cost_usd", "0")
             total_api_calls = stats.get("total_api_calls", 0)
             total_tokens = stats.get("total_tokens_in", 0) + stats.get("total_tokens_out", 0)
+
+        if not _summary_has_usage(total_spend_usd, total_api_calls, total_tokens):
+            try:
+                scope_id = org_id if org_id and org_id != "default" else workspace_id
+                total_spend_usd, total_api_calls, total_tokens = _get_metered_summary(scope_id)
+            except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                logger.debug("Metered spend summary unavailable: %s", e)
 
         # Budget utilization
         budget_limit_usd = 0.0

--- a/tests/handlers/test_spend_analytics_dashboard.py
+++ b/tests/handlers/test_spend_analytics_dashboard.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -202,11 +202,50 @@ class TestSummaryEndpoint:
         mock_tracker_fn.return_value = None
         mock_budget_fn.return_value = None
 
-        result = handler.handle("/api/v1/analytics/spend/summary", {}, mock_http)
+        with patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_summary",
+            return_value=("0.00", 0, 0),
+        ):
+            result = handler.handle("/api/v1/analytics/spend/summary", {}, mock_http)
         body = _parse_body(result)
         assert body["total_spend_usd"] == "0.00"
         assert body["total_api_calls"] == 0
         assert body["total_tokens"] == 0
+
+    @patch("aragora.server.handlers.spend_analytics_dashboard._get_budget_manager")
+    @patch("aragora.server.handlers.spend_analytics_dashboard._get_cost_tracker")
+    def test_summary_falls_back_to_usage_meter_when_tracker_empty(
+        self, mock_tracker_fn, mock_budget_fn, handler, mock_http
+    ):
+        tracker = MagicMock()
+        tracker.get_workspace_stats.return_value = {
+            "workspace_id": "ws_123",
+            "total_cost_usd": "0.00",
+            "total_api_calls": 0,
+            "total_tokens_in": 0,
+            "total_tokens_out": 0,
+            "cost_by_agent": {},
+            "cost_by_model": {},
+        }
+        tracker.get_dashboard_summary.return_value = {}
+        mock_tracker_fn.return_value = tracker
+        mock_budget_fn.return_value = None
+
+        with patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_summary",
+            return_value=("12.34", 17, 9000),
+        ) as mock_metered:
+            result = handler.handle(
+                "/api/v1/analytics/spend/summary",
+                {"workspace_id": "ws_123", "org_id": "org_123"},
+                mock_http,
+            )
+
+        body = _parse_body(result)
+        assert body["total_spend_usd"] == "12.34"
+        assert body["total_api_calls"] == 17
+        assert body["total_tokens"] == 9000
+        mock_metered.assert_called_once_with("org_123")
 
     @patch("aragora.server.handlers.spend_analytics_dashboard._get_budget_manager")
     @patch("aragora.server.handlers.spend_analytics_dashboard._get_cost_tracker")


### PR DESCRIPTION
## Summary
- backfill /api/v1/analytics/spend/summary from durable usage metering when CostTracker has no spend data
- keep existing tracker-driven trend logic and budget manager behavior intact
- add focused regression coverage for the empty-tracker fallback path

## Repro
- the spend dashboard summary cards read `/api/v1/analytics/spend/summary`, but the handler only consulted the in-memory CostTracker state, so spend reset to zero after restart even when usage metering had persisted token cost/call data

## Validation
- python3 -m pytest tests/handlers/test_spend_analytics_dashboard.py -q
- python3 -m ruff check aragora/server/handlers/spend_analytics_dashboard.py tests/handlers/test_spend_analytics_dashboard.py