### PR TITLE
test(usage-metering): align enterprise tier cap expectation

### DIFF
--- a/tests/services/test_usage_metering.py
+++ b/tests/services/test_usage_metering.py
@@ -1330,7 +1330,7 @@ class TestGetUsageLimits:
         """Test limits reflect enterprise tier caps."""
         limits = await meter.get_usage_limits(org_id="org_1", tier="enterprise")
 
-        assert limits.max_tokens == 100_000_000
+        assert limits.max_tokens == 999_999_999
         assert limits.max_debates == 999_999
         assert limits.max_api_calls == 999_999
 


### PR DESCRIPTION
## Summary
- align the stale enterprise-tier usage-limit expectation with the configured cap
- keep the test suite internally consistent with `metering_models.py`

## Verification
- `python3 -m pytest tests/services/test_usage_metering.py -k "limits_for_enterprise_tier or enterprise_effectively_unlimited" -q`
- `python3 -m pytest tests/services/test_usage_metering.py tests/billing/test_usage_metering_integration.py tests/server/fastapi/test_analytics_routes.py tests/client/test_cost_management_api.py -q`
- `python3 -m ruff check tests/services/test_usage_metering.py`