### PR TITLE
fix(analytics): backfill spend decisions from usage metering

### DIFF
--- a/aragora/server/handlers/spend_analytics_dashboard.py
+++ b/aragora/server/handlers/spend_analytics_dashboard.py
@@ -18,9 +18,11 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from aragora.server.versioning.compat import strip_version_prefix
+from aragora.utils.async_utils import run_async
 
 from .base import (
     HandlerResult,
@@ -57,6 +59,55 @@ def _get_budget_manager() -> Any:
     except (ImportError, RuntimeError, OSError) as e:
         logger.debug("BudgetManager not available: %s", e)
         return None
+
+
+def _format_cost(value: Any) -> str:
+    """Format costs with at least cents and up to 4 decimals."""
+    try:
+        quantized = Decimal(str(value)).quantize(Decimal("0.0001"))
+    except (InvalidOperation, TypeError, ValueError):
+        return "0.00"
+    rendered = format(quantized, "f").rstrip("0").rstrip(".")
+    if not rendered:
+        return "0.00"
+    if "." not in rendered:
+        return f"{rendered}.00"
+    decimals = rendered.split(".", 1)[1]
+    if len(decimals) == 1:
+        return f"{rendered}0"
+    return rendered
+
+
+def _get_metered_decisions(org_id: str, limit: int) -> list[dict[str, str]]:
+    """Load per-debate costs from durable usage metering."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    meter = get_usage_meter()
+    run_async(meter.initialize())
+    if meter._conn is None:
+        return []
+
+    cursor = meter._conn.cursor()
+    rows = cursor.execute(
+        """
+        SELECT debate_id, SUM(CAST(total_cost AS REAL)) as cost
+        FROM debate_usage
+        WHERE org_id = ?
+        GROUP BY debate_id
+        ORDER BY cost DESC
+        LIMIT ?
+        """,
+        (org_id, limit),
+    ).fetchall()
+
+    return [
+        {
+            "debate_id": row["debate_id"],
+            "cost_usd": _format_cost(row["cost"]),
+        }
+        for row in rows
+        if row["debate_id"]
+    ]
 
 
 class SpendAnalyticsDashboardHandler(SecureHandler):
@@ -371,6 +422,12 @@ class SpendAnalyticsDashboardHandler(SecureHandler):
                         "cost_usd": str(cost),
                     }
                 )
+
+        if not decisions:
+            try:
+                decisions = _get_metered_decisions(workspace_id, limit)
+            except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                logger.debug("Metered decision spend unavailable: %s", e)
 
         return json_response(
             {

--- a/tests/handlers/test_spend_analytics_dashboard.py
+++ b/tests/handlers/test_spend_analytics_dashboard.py
@@ -81,6 +81,15 @@ def mock_http():
     return h
 
 
+@pytest.fixture(autouse=True)
+def _patch_metered_decisions():
+    with patch(
+        "aragora.server.handlers.spend_analytics_dashboard._get_metered_decisions",
+        return_value=[],
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Routing tests
 # ---------------------------------------------------------------------------
@@ -396,6 +405,31 @@ class TestByDecisionEndpoint:
         body = _parse_body(result)
         assert body["decisions"] == []
         assert body["count"] == 0
+
+    @patch("aragora.server.handlers.spend_analytics_dashboard._get_cost_tracker")
+    def test_by_decision_falls_back_to_usage_meter(self, mock_tracker_fn, handler, mock_http):
+        tracker = MagicMock()
+        tracker._debate_costs = {}
+        mock_tracker_fn.return_value = tracker
+
+        with patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_decisions",
+            return_value=[
+                {"debate_id": "debate_x", "cost_usd": "7.50"},
+                {"debate_id": "debate_y", "cost_usd": "3.25"},
+            ],
+        ) as mock_metered:
+            result = handler.handle(
+                "/api/v1/analytics/spend/by-decision",
+                {"workspace_id": "ws_123", "limit": "2"},
+                mock_http,
+            )
+
+        body = _parse_body(result)
+        assert body["count"] == 2
+        assert body["decisions"][0]["debate_id"] == "debate_x"
+        assert body["decisions"][0]["cost_usd"] == "7.50"
+        mock_metered.assert_called_once_with("ws_123", 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backfill /api/v1/analytics/spend/by-decision from durable usage metering when the in-memory tracker has no debate costs
- keep the existing tracker path when live in-memory debate costs are present
- add focused regression coverage for the empty-tracker fallback path

## Repro
- the spend dashboard decision-cost table read `/api/v1/analytics/spend/by-decision`, but the handler only consulted `CostTracker._debate_costs`, so it returned an empty list after restart even when usage metering had persisted debate cost rows

## Validation
- python3 -m pytest tests/handlers/test_spend_analytics_dashboard.py -q
- python3 -m ruff check aragora/server/handlers/spend_analytics_dashboard.py tests/handlers/test_spend_analytics_dashboard.py