### PR TITLE
fix(analytics): backfill spend by agent from usage metering

### DIFF
--- a/aragora/server/handlers/spend_analytics_dashboard.py
+++ b/aragora/server/handlers/spend_analytics_dashboard.py
@@ -69,6 +69,7 @@ def _has_positive_cost(value: Any) -> bool:
     except (InvalidOperation, TypeError, ValueError):
         return False
 
+
 def _format_cost(value: Any) -> str:
     """Format costs with at least cents and up to 4 decimals."""
     try:

--- a/aragora/server/handlers/spend_analytics_dashboard.py
+++ b/aragora/server/handlers/spend_analytics_dashboard.py
@@ -16,6 +16,7 @@ These endpoints aggregate data from:
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
@@ -68,7 +69,6 @@ def _has_positive_cost(value: Any) -> bool:
     except (InvalidOperation, TypeError, ValueError):
         return False
 
-
 def _format_cost(value: Any) -> str:
     """Format costs with at least cents and up to 4 decimals."""
     try:
@@ -97,6 +97,64 @@ def _get_metered_summary(scope_id: str) -> tuple[str, int, int]:
 
     summary = run_async(get_usage_meter().get_usage_summary(org_id=scope_id))
     return _format_cost(summary.token_cost), summary.api_call_count, summary.total_tokens
+
+
+def _get_metered_agents(org_id: str) -> tuple[str, list[dict[str, Any]]]:
+    """Load durable per-agent spend from usage metering token usage rows."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    meter = get_usage_meter()
+    run_async(meter.initialize())
+    if meter._conn is None:
+        return "0.00", []
+
+    cursor = meter._conn.cursor()
+    rows = cursor.execute(
+        """
+        SELECT metadata, total_cost
+        FROM token_usage
+        WHERE org_id = ?
+        """,
+        (org_id,),
+    ).fetchall()
+
+    by_agent: dict[str, Decimal] = {}
+    total_cost = Decimal("0")
+    for row in rows:
+        raw_cost = row["total_cost"] or "0"
+        try:
+            cost = Decimal(str(raw_cost))
+        except (InvalidOperation, TypeError, ValueError):
+            cost = Decimal("0")
+        total_cost += cost
+
+        metadata_raw = row["metadata"]
+        metadata: dict[str, Any] = {}
+        if isinstance(metadata_raw, str) and metadata_raw.strip():
+            try:
+                parsed = json.loads(metadata_raw)
+                if isinstance(parsed, dict):
+                    metadata = parsed
+            except json.JSONDecodeError:
+                metadata = {}
+
+        agent_name = (
+            str(metadata.get("agent_name") or metadata.get("agent") or "unknown").strip()
+            or "unknown"
+        )
+        by_agent[agent_name] = by_agent.get(agent_name, Decimal("0")) + cost
+
+    rendered_total = _format_cost(total_cost)
+    total_float = float(total_cost) if total_cost > 0 else 0.0
+    agents = [
+        {
+            "agent_name": agent_name,
+            "cost_usd": _format_cost(cost),
+            "percentage": round((float(cost) / total_float) * 100, 1) if total_float > 0 else 0.0,
+        }
+        for agent_name, cost in sorted(by_agent.items(), key=lambda item: item[1], reverse=True)
+    ]
+    return rendered_total, agents
 
 
 class SpendAnalyticsDashboardHandler(SecureHandler):
@@ -368,6 +426,12 @@ class SpendAnalyticsDashboardHandler(SecureHandler):
 
             # Sort by cost descending
             agents.sort(key=lambda x: float(x.get("cost_usd", "0")), reverse=True)
+
+        if not agents:
+            try:
+                total_usd, agents = _get_metered_agents(workspace_id)
+            except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                logger.debug("Metered agent spend unavailable: %s", e)
 
         return json_response(
             {

--- a/tests/handlers/test_spend_analytics_dashboard.py
+++ b/tests/handlers/test_spend_analytics_dashboard.py
@@ -81,6 +81,15 @@ def mock_http():
     return h
 
 
+@pytest.fixture(autouse=True)
+def _patch_metered_agents():
+    with patch(
+        "aragora.server.handlers.spend_analytics_dashboard._get_metered_agents",
+        return_value=("0.00", []),
+    ):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Routing tests
 # ---------------------------------------------------------------------------
@@ -377,7 +386,39 @@ class TestByAgentEndpoint:
         result = handler.handle("/api/v1/analytics/spend/by-agent", {}, mock_http)
         body = _parse_body(result)
         assert body["agents"] == []
-        assert body["total_usd"] == "0"
+        assert body["total_usd"] == "0.00"
+
+    @patch("aragora.server.handlers.spend_analytics_dashboard._get_cost_tracker")
+    def test_by_agent_falls_back_to_usage_meter(self, mock_tracker_fn, handler, mock_http):
+        tracker = MagicMock()
+        tracker.get_workspace_stats.return_value = _make_workspace_stats(
+            total_cost="0.00",
+            agent_costs={},
+        )
+        mock_tracker_fn.return_value = tracker
+
+        with patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_agents",
+            return_value=(
+                "9.75",
+                [
+                    {"agent_name": "claude", "cost_usd": "6.50", "percentage": 66.7},
+                    {"agent_name": "codex", "cost_usd": "3.25", "percentage": 33.3},
+                ],
+            ),
+        ) as mock_metered:
+            result = handler.handle(
+                "/api/v1/analytics/spend/by-agent",
+                {"workspace_id": "ws_123"},
+                mock_http,
+            )
+
+        body = _parse_body(result)
+        assert body["total_usd"] == "9.75"
+        assert body["agents"][0]["agent_name"] == "claude"
+        assert body["agents"][0]["cost_usd"] == "6.50"
+        assert body["agents"][1]["agent_name"] == "codex"
+        mock_metered.assert_called_once_with("ws_123")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backfill `/api/v1/analytics/spend/by-agent` from durable usage metering when the in-memory tracker has no agent spend data
- keep the existing tracker path when live per-agent spend is already available
- add focused regression coverage for the empty-tracker fallback path

## Repro
- the spend dashboard agent-cost table read `/api/v1/analytics/spend/by-agent`, but the handler only consulted `CostTracker.cost_by_agent`, so it returned an empty list after restart even when usage metering had persisted token usage rows with `agent_name` metadata

## Validation
- `python3 -m pytest tests/handlers/test_spend_analytics_dashboard.py -q`
- `python3 -m ruff check aragora/server/handlers/spend_analytics_dashboard.py tests/handlers/test_spend_analytics_dashboard.py`
