### PR TITLE
fix(cli): surface truthful inbox receipt metadata

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -217,6 +217,69 @@ def _receipt_findings_count(meta: Any) -> int:
     return 0
 
 
+def _receipt_payload_dict(meta: Any) -> dict[str, Any]:
+    """Return the richest receipt payload available for display normalization."""
+    data = getattr(meta, "data", None)
+    if isinstance(data, dict):
+        return data
+    if isinstance(meta, dict):
+        return meta
+    return {}
+
+
+def _normalize_receipt_verdict_and_confidence(
+    data: dict[str, Any],
+    *,
+    verdict: str | None,
+    confidence: float | None,
+) -> tuple[str, float]:
+    """Fill missing verdict/confidence for trust-wedge receipts from nested metadata."""
+    normalized_verdict = str(verdict or "").strip()
+    normalized_confidence = float(confidence or 0.0)
+
+    triage = data.get("triage_decision")
+    if not isinstance(triage, dict):
+        return normalized_verdict or "UNKNOWN", normalized_confidence
+
+    triage_confidence = triage.get("confidence")
+    if triage_confidence is not None:
+        try:
+            triage_confidence_value = float(triage_confidence)
+        except (TypeError, ValueError):
+            triage_confidence_value = None
+        else:
+            if normalized_confidence == 0.0 and triage_confidence_value != 0.0:
+                normalized_confidence = triage_confidence_value
+
+    verdict_missing = not normalized_verdict or normalized_verdict.upper() == "UNKNOWN"
+    if verdict_missing:
+        if bool(triage.get("blocked_by_policy")):
+            normalized_verdict = "BLOCKED"
+        else:
+            state = str(data.get("state") or triage.get("receipt_state") or "").strip().lower()
+            if state in {"approved", "executed"}:
+                normalized_verdict = "PASS"
+            elif state == "expired":
+                normalized_verdict = "FAIL"
+            elif state:
+                normalized_verdict = "CONDITIONAL"
+
+    return normalized_verdict or "UNKNOWN", normalized_confidence
+
+
+def _normalize_receipt_payload_for_display(data: dict[str, Any]) -> dict[str, Any]:
+    """Overlay inferred verdict/confidence for legacy trust-wedge receipts."""
+    normalized = dict(data)
+    verdict, confidence = _normalize_receipt_verdict_and_confidence(
+        normalized,
+        verdict=normalized.get("verdict"),
+        confidence=normalized.get("confidence"),
+    )
+    normalized["verdict"] = verdict
+    normalized["confidence"] = confidence
+    return normalized
+
+
 def _load_storage_receipt_list(limit: int, verdict: str | None) -> list[Any]:
     """Read receipt rows from the durable receipt store."""
     from aragora.storage.receipt_store import get_receipt_store
@@ -673,12 +736,16 @@ def cmd_receipt_list(args: argparse.Namespace) -> None:
     print(f"{'ID':<14} {'VERDICT':<12} {'CONF':>6} {'FINDINGS':>8} {'CREATED':<20}")
     print("-" * 64)
     for meta in results:
+        payload = _receipt_payload_dict(meta)
         row_id = _receipt_row_id(meta)
         short_id = row_id[:12] + ".." if len(row_id) > 14 else row_id
         created = _format_receipt_created_at(getattr(meta, "created_at", None))
         findings = _receipt_findings_count(meta)
-        confidence = float(getattr(meta, "confidence", 0.0) or 0.0)
-        verdict_value = str(getattr(meta, "verdict", "UNKNOWN") or "UNKNOWN")
+        verdict_value, confidence = _normalize_receipt_verdict_and_confidence(
+            payload,
+            verdict=getattr(meta, "verdict", None),
+            confidence=getattr(meta, "confidence", None),
+        )
         print(f"{short_id:<14} {verdict_value:<12} {confidence:>5.0%} {findings:>8} {created:<20}")
     print(f"\n{len(results)} receipt(s) shown.")
 
@@ -724,6 +791,7 @@ def cmd_receipt_show(args: argparse.Namespace) -> None:
     if data is None:
         print(f"Error: Receipt not found: {receipt_id}", file=sys.stderr)
         sys.exit(1)
+    data = _normalize_receipt_payload_for_display(data)
     if output_format == "json":
         print(json.dumps(data, indent=2, default=str))
     elif output_format == "md":

--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -518,6 +518,15 @@ def _print_decisions(decisions: list) -> None:
 
     print(f"{'─' * 60}")
     print(f"Total: {len(decisions)} decisions")
+    receipt_ids = []
+    for decision in decisions:
+        receipt_id = getattr(decision, "receipt_id", None)
+        if receipt_id and receipt_id not in receipt_ids:
+            receipt_ids.append(receipt_id)
+    if receipt_ids:
+        print("Inspect receipts:")
+        for receipt_id in receipt_ids:
+            print(f"  aragora receipt show {receipt_id}")
 
     from aragora.inbox.trust_wedge import ReceiptState
 

--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -511,11 +511,23 @@ class InboxTrustWedgeStore:
         created_at: datetime,
         expires_at: datetime | None,
     ) -> dict[str, Any]:
+        if decision.blocked_by_policy:
+            verdict = "BLOCKED"
+        elif state in {ReceiptState.APPROVED, ReceiptState.EXECUTED}:
+            verdict = "PASS"
+        elif state == ReceiptState.EXPIRED:
+            verdict = "FAIL"
+        else:
+            verdict = "CONDITIONAL"
         return {
             "receipt_id": receipt_id,
+            "gauntlet_id": receipt_id,
             "intent_hash": intent.intent_hash(),
             "action_intent": intent.to_dict(),
             "triage_decision": decision.to_dict(),
+            "timestamp": created_at.isoformat(),
+            "verdict": verdict,
+            "confidence": float(decision.confidence),
             "state": state.value,
             "created_at": created_at.isoformat(),
             "expires_at": _isoformat(expires_at),

--- a/tests/cli/test_receipt_command.py
+++ b/tests/cli/test_receipt_command.py
@@ -79,6 +79,32 @@ def test_receipt_list_falls_back_to_legacy_when_durable_empty(
     assert "4" in output
 
 
+def test_receipt_list_normalizes_trust_wedge_receipts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stored = _StoredReceiptStub(
+        receipt_id="rcpt-triage-123",
+        gauntlet_id="rcpt-triage-123",
+        verdict="UNKNOWN",
+        confidence=0.0,
+        created_at=1711300000.0,
+        data={
+            "state": "CREATED",
+            "triage_decision": {
+                "confidence": 0.73,
+                "blocked_by_policy": True,
+            },
+        },
+    )
+
+    with patch("aragora.cli.commands.receipt._load_storage_receipt_list", return_value=[stored]):
+        cmd_receipt_list(argparse.Namespace(limit=5, verdict=None, org_id=None))
+
+    output = capsys.readouterr().out
+    assert "BLOCKED" in output
+    assert "73%" in output
+
+
 def test_receipt_show_reads_durable_store_by_receipt_id(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -102,6 +128,29 @@ def test_receipt_show_reads_durable_store_by_receipt_id(
     assert payload["receipt_id"] == "rcpt-live-123"
     assert payload["summary"] == "Stored in durable receipt store"
     legacy_loader.assert_not_called()
+
+
+def test_receipt_show_normalizes_trust_wedge_receipts_for_json(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stored = {
+        "receipt_id": "rcpt-triage-456",
+        "gauntlet_id": "rcpt-triage-456",
+        "verdict": "UNKNOWN",
+        "confidence": 0.0,
+        "state": "CREATED",
+        "triage_decision": {
+            "confidence": 0.61,
+            "blocked_by_policy": True,
+        },
+    }
+
+    with patch("aragora.cli.commands.receipt._load_storage_receipt", return_value=stored):
+        cmd_receipt_show(argparse.Namespace(id="rcpt-triage-456", format="json", org_id=None))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["confidence"] == pytest.approx(0.61)
 
 
 def test_receipt_show_falls_back_to_legacy_when_durable_missing(

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -275,6 +275,7 @@ def test_print_decisions_formats_enum_values(capsys):
     assert "ignore" in out
     assert "InboxWedgeAction" not in out
     assert "created" in out
+    assert "aragora receipt show receipt-1" in out
 
 
 def test_print_decisions_shows_blocked_status_for_truthful_stop(capsys):

--- a/tests/inbox/test_inbox_receipt_convergence.py
+++ b/tests/inbox/test_inbox_receipt_convergence.py
@@ -152,6 +152,8 @@ class TestReceiptCreationPersistsToFacade:
             mock_facade.persist_and_save.assert_called_once()
             call_args = mock_facade.persist_and_save.call_args
             assert call_args[0][0] == envelope.receipt.receipt_id
+            assert call_args[0][1]["verdict"] == "CONDITIONAL"
+            assert call_args[0][1]["confidence"] == pytest.approx(0.9)
             assert call_args[1]["signature"] == "test-sig"
             assert call_args[1]["state"] == "CREATED"
 


### PR DESCRIPTION
## Summary
- surface copyable `aragora receipt show <id>` handles in triage CLI output
- persist top-level verdict/confidence on inbox trust-wedge receipts for future list/show accuracy
- normalize legacy trust-wedge receipts in `receipt list` and `receipt show` so existing rows stop rendering as `UNKNOWN / 0%`

## Validation
- `python3 -m pytest tests/cli/test_triage_command.py tests/cli/test_receipt_command.py tests/inbox/test_inbox_receipt_convergence.py -q`
- `python3 -m pytest tests/inbox/test_trust_wedge.py -q`
- `python3 -m ruff check aragora/inbox/trust_wedge.py aragora/cli/commands/triage.py aragora/cli/commands/receipt.py tests/cli/test_triage_command.py tests/cli/test_receipt_command.py tests/inbox/test_inbox_receipt_convergence.py`
- live: `python3 -m aragora.cli.main triage run --dry-run --batch 1`
- live: `python3 -m aragora.cli.main receipt list --limit 5`

## Live result
A fresh dry-run now prints a copyable receipt handle and `receipt list` immediately 
## Sume new row as `CONDITIONAL 95%` instead of `UNKNOWN 0%`.
