### PR TITLE
fix(analytics): backfill spend decisions from usage metering

### DIFF
--- a/aragora/server/handlers/spend_analytics_dashboard.py
+++ b/aragora/server/handlers/spend_analytics_dashboard.py
@@ -158,6 +158,38 @@ def _get_metered_agents(org_id: str) -> tuple[str, list[dict[str, Any]]]:
     return rendered_total, agents
 
 
+def _get_metered_decisions(org_id: str, limit: int) -> list[dict[str, str]]:
+    """Load per-debate costs from durable usage metering."""
+    from aragora.services.usage_metering import get_usage_meter
+
+    meter = get_usage_meter()
+    run_async(meter.initialize())
+    if meter._conn is None:
+        return []
+
+    cursor = meter._conn.cursor()
+    rows = cursor.execute(
+        """
+        SELECT debate_id, SUM(CAST(total_cost AS REAL)) AS cost
+        FROM debate_usage
+        WHERE org_id = ?
+        GROUP BY debate_id
+        ORDER BY cost DESC
+        LIMIT ?
+        """,
+        (org_id, limit),
+    ).fetchall()
+
+    return [
+        {
+            "debate_id": row["debate_id"],
+            "cost_usd": _format_cost(row["cost"]),
+        }
+        for row in rows
+        if row["debate_id"]
+    ]
+
+
 class SpendAnalyticsDashboardHandler(SecureHandler):
     """Handler for the spend analytics dashboard endpoints.
 
@@ -483,6 +515,12 @@ class SpendAnalyticsDashboardHandler(SecureHandler):
                         "cost_usd": str(cost),
                     }
                 )
+
+        if not decisions:
+            try:
+                decisions = _get_metered_decisions(workspace_id, limit)
+            except Exception as e:  # noqa: BLE001 - metering fallback must stay best-effort
+                logger.debug("Metered decision spend unavailable: %s", e)
 
         return json_response(
             {

--- a/tests/handlers/test_spend_analytics_dashboard.py
+++ b/tests/handlers/test_spend_analytics_dashboard.py
@@ -82,10 +82,16 @@ def mock_http():
 
 
 @pytest.fixture(autouse=True)
-def _patch_metered_agents():
-    with patch(
-        "aragora.server.handlers.spend_analytics_dashboard._get_metered_agents",
-        return_value=("0.00", []),
+def _patch_metered_fallbacks():
+    with (
+        patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_agents",
+            return_value=("0.00", []),
+        ),
+        patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_decisions",
+            return_value=[],
+        ),
     ):
         yield
 
@@ -476,6 +482,31 @@ class TestByDecisionEndpoint:
         body = _parse_body(result)
         assert body["decisions"] == []
         assert body["count"] == 0
+
+    @patch("aragora.server.handlers.spend_analytics_dashboard._get_cost_tracker")
+    def test_by_decision_falls_back_to_usage_meter(self, mock_tracker_fn, handler, mock_http):
+        tracker = MagicMock()
+        tracker._debate_costs = {}
+        mock_tracker_fn.return_value = tracker
+
+        with patch(
+            "aragora.server.handlers.spend_analytics_dashboard._get_metered_decisions",
+            return_value=[
+                {"debate_id": "debate_x", "cost_usd": "7.50"},
+                {"debate_id": "debate_y", "cost_usd": "3.25"},
+            ],
+        ) as mock_metered:
+            result = handler.handle(
+                "/api/v1/analytics/spend/by-decision",
+                {"workspace_id": "ws_123", "limit": "2"},
+                mock_http,
+            )
+
+        body = _parse_body(result)
+        assert body["count"] == 2
+        assert body["decisions"][0]["debate_id"] == "debate_x"
+        assert body["decisions"][0]["cost_usd"] == "7.50"
+        mock_metered.assert_called_once_with("ws_123", 2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backfill `/api/v1/analytics/spend/by-decision` from durable usage metering when the in-memory tracker has no debate costs
- keep the existing tracker path when live in-memory debate costs are present
- add focused regression coverage for the empty-tracker fallback path

## Repro
- the spend dashboard decision-cost table read `/api/v1/analytics/spend/by-decision`, but the handler only consulted `CostTracker._debate_costs`, so it returned an empty list after restart even when usage metering had persisted debate cost rows

## Validation
- `python3 -m pytest tests/handlers/test_spend_analytics_dashboard.py -q`
- `python3 -m ruff check aragora/server/handlers/spend_analytics_dashboard.py tests/handlers/test_spend_analytics_dashboard.py`
