### PR TITLE
feat(swarm): pass prompt-refiner hints via worker env

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -890,6 +890,7 @@ async def dispatch_bounded_spec(
     default_reviewer_agent: str | None = None,
     use_managed_session_script: bool = True,
     selected_runner: dict[str, Any] | None = None,
+    worker_env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     # Auto-detect Claude profile from environment if no runner specified
     if selected_runner is None:
@@ -943,6 +944,7 @@ async def dispatch_bounded_spec(
             default_reviewer_agent=default_reviewer_agent,
             use_managed_session_script=use_managed_session_script,
             default_target_runner=selected_runner,
+            worker_env=worker_env,
         )
         run_dict = run.to_dict()
         run_status = str(run_dict.get("status", "")).strip().lower()
@@ -2169,13 +2171,17 @@ class BossLoop:
         )
 
         try:
-            from aragora.swarm.prompt_refiner import refine_worker_prompt
+            from aragora.swarm.prompt_refiner import (
+                build_refinement_worker_env,
+                refine_worker_prompt,
+            )
 
             refinement = await refine_worker_prompt(
                 issue.title,
                 issue.body or "",
                 repo_path=Path.cwd(),
             )
+            refinement_worker_env = build_refinement_worker_env(refinement)
             if refinement.get("context_gathered"):
                 goal = refinement["refined_prompt"]
                 logger.info(
@@ -2186,6 +2192,7 @@ class BossLoop:
                 )
         except Exception as exc:
             logger.debug("Prompt refinement skipped: %s", exc)
+            refinement_worker_env = {}
 
         spec = SwarmSpec.from_direct_goal(
             goal,
@@ -2270,6 +2277,7 @@ class BossLoop:
                 # default) due to ${VAR,,} syntax.  Matches tranche_queue.py.
                 use_managed_session_script=False,
                 selected_runner=selected_runner,
+                worker_env=refinement_worker_env or None,
             )
         finally:
             if claimed_runner_id:

--- a/aragora/swarm/commander.py
+++ b/aragora/swarm/commander.py
@@ -241,6 +241,7 @@ class SwarmCommander:
         default_reviewer_agent: str | None = None,
         use_managed_session_script: bool = True,
         default_target_runner: dict[str, Any] | None = None,
+        worker_env: dict[str, str] | None = None,
     ) -> SupervisorRun:
         """Dispatch a spec through the supervisor-backed Codex/Claude worker pool.
 
@@ -284,6 +285,7 @@ class SwarmCommander:
             approval_policy=approval_policy,
             default_target_agent=default_target_agent,
             default_reviewer_agent=default_reviewer_agent,
+            worker_env=worker_env,
         )
         if dispatch:
             launched = await supervisor.dispatch_workers(run.run_id)

--- a/aragora/swarm/prompt_refiner.py
+++ b/aragora/swarm/prompt_refiner.py
@@ -14,10 +14,29 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def build_refinement_worker_env(refinement: dict[str, Any] | None) -> dict[str, str]:
+    """Serialize prompt-refinement hints for worker subprocesses."""
+    payload = dict(refinement or {})
+    relevant_files = [
+        str(item).strip() for item in payload.get("files_to_change", []) if str(item).strip()
+    ]
+    test_patterns = [
+        str(item).strip() for item in payload.get("test_patterns", []) if str(item).strip()
+    ]
+
+    env: dict[str, str] = {}
+    if relevant_files:
+        env["ARAGORA_RELEVANT_FILES"] = os.pathsep.join(relevant_files)
+    if test_patterns:
+        env["ARAGORA_TEST_PATTERNS"] = os.pathsep.join(test_patterns)
+    return env
 
 
 async def refine_worker_prompt(

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -284,6 +284,7 @@ class SwarmSupervisor:
         refresh_scaling: bool = True,
         default_target_agent: str | None = None,
         default_reviewer_agent: str | None = None,
+        worker_env: dict[str, str] | None = None,
     ) -> SupervisorRun:
         goal = spec.refined_goal or spec.raw_goal
         policy = approval_policy or SwarmApprovalPolicy()
@@ -299,11 +300,20 @@ class SwarmSupervisor:
         if default_reviewer_agent:
             for item in work_orders:
                 item["reviewer_agent"] = default_reviewer_agent
+        normalized_worker_env = {
+            str(key).strip(): str(value)
+            for key, value in dict(worker_env or {}).items()
+            if str(key).strip()
+        }
         for item in work_orders:
             item.setdefault("status", "queued")
             item.setdefault("lease_id", None)
             item.setdefault("receipt_id", None)
             item.setdefault("review_status", "pending")
+            if normalized_worker_env:
+                metadata = dict(item.get("metadata") or {})
+                metadata["worker_env"] = normalized_worker_env
+                item["metadata"] = metadata
 
         record = self.store.create_supervisor_run(
             goal=goal,

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -167,6 +167,14 @@ class WorkerLauncher:
             worktree_path,
         )
 
+        metadata = work_order.get("metadata", {})
+        raw_worker_env = metadata.get("worker_env", {}) if isinstance(metadata, dict) else {}
+        worker_env_overrides = {
+            str(key).strip(): str(value)
+            for key, value in dict(raw_worker_env or {}).items()
+            if str(key).strip()
+        }
+
         # Codex CLI multi-agent mode creates isolated config dirs that lack
         # auth credentials.  Pin CODEX_HOME to the user's main config so
         # workers can authenticate.  Claude Code doesn't use this var.
@@ -175,6 +183,8 @@ class WorkerLauncher:
             codex_home = Path.home() / ".codex"
             if (codex_home / "auth.json").exists():
                 worker_env = {**os.environ, "CODEX_HOME": str(codex_home)}
+        if worker_env_overrides:
+            worker_env = {**(worker_env or dict(os.environ)), **worker_env_overrides}
 
         # Codex uses "-" as prompt arg and reads from stdin to avoid OS
         # ARG_MAX limits on long prompts with issue bodies + file lists.

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
@@ -1540,6 +1541,63 @@ async def test_dispatch_bounded_spec_wait_false_returns_running_after_launch() -
     assert result["status"] == "running"
     assert result["outcome"] == "dispatched"
     assert result["run_id"] == "run-873"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_refine_exports_worker_env_to_commander() -> None:
+    issue = _make_issue(
+        1641,
+        "Wire prompt refiner env",
+        body=(
+            "Pass prompt-refiner file and test hints as worker env vars.\n\n"
+            "Acceptance Criteria:\n"
+            "- pytest -q tests/swarm/test_boss_loop.py -k refine\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "status": "completed",
+        "run_id": "run-1641",
+        "work_orders": [
+            {
+                "status": "completed",
+                "branch": "codex/refine-env",
+                "commit_shas": ["abc123"],
+            }
+        ],
+    }
+
+    refinement = {
+        "refined_prompt": "Refined goal",
+        "files_to_change": ["aragora/swarm/boss_loop.py", "aragora/swarm/prompt_refiner.py"],
+        "test_patterns": ["tests/swarm/test_boss_loop.py"],
+        "constraints": [],
+        "context_gathered": True,
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(return_value=refinement),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(return_value=fake_run)
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    kwargs = mock_commander_cls.return_value.run_supervised_from_spec.await_args.kwargs
+    assert result["status"] == "completed"
+    assert kwargs["worker_env"] == {
+        "ARAGORA_RELEVANT_FILES": os.pathsep.join(refinement["files_to_change"]),
+        "ARAGORA_TEST_PATTERNS": os.pathsep.join(refinement["test_patterns"]),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -402,6 +402,41 @@ class TestLaunch:
             with pytest.raises(FileNotFoundError, match="CLI not found"):
                 await launcher.launch(wo, worktree_path="/tmp/wt")
 
+    @pytest.mark.asyncio
+    async def test_launch_merges_metadata_worker_env(self, tmp_path: Path):
+        launcher = WorkerLauncher(LaunchConfig(detach=False))
+        mock_proc = AsyncMock()
+        mock_proc.pid = 103
+        worktree = tmp_path / "wt"
+        (worktree / "scripts").mkdir(parents=True)
+        (worktree / "scripts" / "codex_session.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+
+        wo = {
+            "work_order_id": "wo-env",
+            "target_agent": "claude",
+            "title": "Env propagation test",
+            "metadata": {
+                "worker_env": {
+                    "ARAGORA_RELEVANT_FILES": "aragora/swarm/boss_loop.py",
+                    "ARAGORA_TEST_PATTERNS": "tests/swarm/test_boss_loop.py",
+                }
+            },
+        }
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch.object(WorkerLauncher, "_git_output", return_value=""),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc) as mock_exec,
+        ):
+            await launcher.launch(wo, worktree_path=str(worktree), branch="feat")
+
+        env = mock_exec.call_args.kwargs.get("env")
+        assert isinstance(env, dict)
+        assert env["ARAGORA_RELEVANT_FILES"] == "aragora/swarm/boss_loop.py"
+        assert env["ARAGORA_TEST_PATTERNS"] == "tests/swarm/test_boss_loop.py"
+
 
 class TestWait:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- serialize prompt-refiner file and test hints into worker env vars
- pass those env overrides through commander and supervisor into worker launch metadata
- verify both the boss-loop handoff and launcher env merge with focused regressions

## Testing
- python3 -m pytest tests/swarm/test_boss_loop.py -x -q -k refine
- python3 -m pytest tests/swarm/test_worker_launcher.py -x -q -k worker_env
- python3 -m pytest tests/swarm/test_boss_loop.py -q
- python3 -m ruff check aragora/swarm/boss_loop.py aragora/swarm/prompt_refiner.py aragora/swarm/commander.py aragora/swarm/supervisor.py aragora/swarm/worker_launcher.py tests/swarm/test_boss_loop.py tests/swarm/test_worker_launcher.py

Closes #1641