### PR TITLE
feat(cli): classify and filter receipt kinds

### DIFF
--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -852,9 +852,40 @@ def _inspect_receipt_data(data: dict[str, Any]) -> None:
     print("=" * 60)
     print(f"\nReceipt ID:    {data.get('receipt_id', 'N/A')}")
     print(f"Gauntlet ID:   {data.get('gauntlet_id', 'N/A')}")
+    print(f"Type:          {_receipt_kind(data)}")
     print(f"Verdict:       {data.get('verdict', 'UNKNOWN')}")
     confidence = data.get("confidence", 0)
     print(f"Confidence:    {confidence:.1%}")
+    state = data.get("state")
+    if state:
+        print(f"State:         {state}")
+
+    action_intent = data.get("action_intent")
+    triage_decision = data.get("triage_decision")
+    if isinstance(action_intent, dict) or isinstance(triage_decision, dict):
+        action_intent = action_intent if isinstance(action_intent, dict) else {}
+        triage_decision = triage_decision if isinstance(triage_decision, dict) else {}
+        print("\n--- Inbox Trust Wedge ---")
+        print(
+            f"Action:        {triage_decision.get('final_action') or action_intent.get('action') or 'N/A'}"
+        )
+        print(f"Provider:      {action_intent.get('provider', 'N/A')}")
+        print(f"Message ID:    {action_intent.get('message_id', 'N/A')}")
+        print(
+            f"Route:         {triage_decision.get('provider_route') or action_intent.get('provider_route') or 'N/A'}"
+        )
+        print(
+            f"Receipt State: {triage_decision.get('receipt_state') or data.get('state') or 'N/A'}"
+        )
+        print(f"Blocked:       {'yes' if triage_decision.get('blocked_by_policy') else 'no'}")
+        if action_intent.get("label_id") or triage_decision.get("label_id"):
+            print(
+                f"Label ID:      {triage_decision.get('label_id') or action_intent.get('label_id')}"
+            )
+        rationale = str(action_intent.get("synthesized_rationale") or "").strip()
+        if rationale:
+            print(f"Rationale:     {rationale[:280]}")
+
     risk_summary = data.get("risk_summary", {})
     if risk_summary:
         print(

--- a/tests/cli/test_receipt_command.py
+++ b/tests/cli/test_receipt_command.py
@@ -175,6 +175,29 @@ def test_receipt_show_normalizes_trust_wedge_receipts_for_json(
         "triage_decision": {
             "confidence": 0.61,
             "blocked_by_policy": True,
+=======
+def test_receipt_show_renders_inbox_receipt_details(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stored = {
+        "receipt_id": "rcpt-inbox-789",
+        "gauntlet_id": "rcpt-inbox-789",
+        "verdict": "CONDITIONAL",
+        "confidence": 0.95,
+        "state": "created",
+        "action_intent": {
+            "provider": "gmail",
+            "message_id": "msg-123",
+            "action": "archive",
+            "provider_route": "direct",
+            "synthesized_rationale": "Archive the newsletter.",
+        },
+        "triage_decision": {
+            "final_action": "archive",
+            "provider_route": "direct",
+            "receipt_state": "created",
+            "blocked_by_policy": False,
+>>>>>>> eb63fb1ac (feat(cli): show inbox receipt details in inspect view)
         },
     }
 
@@ -184,6 +207,47 @@ def test_receipt_show_normalizes_trust_wedge_receipts_for_json(
     payload = json.loads(capsys.readouterr().out)
     assert payload["verdict"] == "BLOCKED"
     assert payload["confidence"] == pytest.approx(0.61)
+        cmd_receipt_show(argparse.Namespace(id="rcpt-triage-456", format="json", org_id=None))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["verdict"] == "BLOCKED"
+    assert payload["confidence"] == pytest.approx(0.61)
+
+
+def test_receipt_show_renders_inbox_receipt_details(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    stored = {
+        "receipt_id": "rcpt-inbox-789",
+        "gauntlet_id": "rcpt-inbox-789",
+        "verdict": "CONDITIONAL",
+        "confidence": 0.95,
+        "state": "created",
+        "action_intent": {
+            "provider": "gmail",
+            "message_id": "msg-123",
+            "action": "archive",
+            "provider_route": "direct",
+            "synthesized_rationale": "Archive the newsletter.",
+        },
+        "triage_decision": {
+            "final_action": "archive",
+            "provider_route": "direct",
+            "receipt_state": "created",
+            "blocked_by_policy": False,
+        },
+    }
+
+    with patch("aragora.cli.commands.receipt._load_storage_receipt", return_value=stored):
+        cmd_receipt_show(argparse.Namespace(id="rcpt-inbox-789", format=None, org_id=None))
+
+    output = capsys.readouterr().out
+    assert "Type:          inbox" in output
+    assert "Action:        archive" in output
+    assert "Provider:      gmail" in output
+    assert "Message ID:    msg-123" in output
+    assert "Receipt State: created" in output
+    assert "Rationale:     Archive the newsletter." in output
 
 
 def test_receipt_show_falls_back_to_legacy_when_durable_missing(


### PR DESCRIPTION
## Summary
- add a receipt kind classifier for inbox, decision, and other receipts
- show a TYPE column in `aragora receipt list` output
- add `aragora receipt list --kind ...` so inbox operators can isolate trust-wedge receipts

## Validation
- `python3 -m pytest tests/cli/test_receipt_command.py -q`
- `python3 -m ruff check aragora/cli/commands/receipt.py tests/cli/test_receipt_command.py`
- live: `python3 -m aragora.cli.main receipt list --limit 10 --kind inbox`

## Live result
A mixed receipt store that previously showed inbox and quickstart rows together can now be filtered cleanly to just inbox trust-wedge receipts.