### PR TITLE
fix(test): allocate dynamic canvas port in server smoke fixture

### DIFF
--- a/tests/e2e/server_fixture.py
+++ b/tests/e2e/server_fixture.py
@@ -43,6 +43,7 @@ class LiveServerInfo:
     ws_port: int
     control_plane_port: int
     nomic_loop_port: int
+    canvas_port: int
     host: str = "127.0.0.1"
 
     @property
@@ -161,6 +162,7 @@ async def live_server(
     ws_port = find_free_port()
     control_plane_port = find_free_port()
     nomic_loop_port = find_free_port()
+    canvas_port = find_free_port()
 
     # Create isolated nomic directory
     nomic_dir = tmp_path / ".nomic"
@@ -171,6 +173,7 @@ async def live_server(
         ws_port=ws_port,
         control_plane_port=control_plane_port,
         nomic_loop_port=nomic_loop_port,
+        canvas_port=canvas_port,
     )
 
     # Import server module
@@ -182,6 +185,7 @@ async def live_server(
         ws_port=ws_port,
         control_plane_port=control_plane_port,
         nomic_loop_port=nomic_loop_port,
+        canvas_port=canvas_port,
         http_host="127.0.0.1",
         ws_host="127.0.0.1",
         nomic_dir=nomic_dir,


### PR DESCRIPTION
## Summary
- allocate a dynamic `canvas_port` in the live server smoke fixture instead of inheriting UnifiedServer's fixed `8768` default
- pass the dynamic canvas port into `UnifiedServer` along with the existing dynamic HTTP/WebSocket/control-plane ports
- keep the smoke fixture isolated so repeated live-server startups don't collide on the canvas stream port

## Repro
- `Server Smoke Tests` on PR `#1713` failed in CI with `OSError: [Errno 98] ... ('127.0.0.1', 8768): address already in use`
- the smoke fixture already allocated dynamic ports for HTTP, WS, control-plane, and nomic-loop, but not for the canvas stream server

## Validation
- `python3 -m pytest tests/e2e/test_server_smoke.py -q -x`
- `python3 -m ruff check tests/e2e/server_fixture.py`
