### PR TITLE
fix(inbox): share trust wedge state across linked worktrees

### DIFF
--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -41,12 +41,68 @@ from aragora.services.email_actions import (
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_DB_PATH = resolve_db_path(os.getenv("ARAGORA_INBOX_TRUST_WEDGE_DB", "inbox_trust_wedge.db"))
-DEFAULT_SIGNING_KEY_PATH = Path(
-    resolve_db_path(
-        os.getenv("ARAGORA_INBOX_TRUST_WEDGE_KEY_FILE", "inbox_trust_wedge_signing.key")
-    )
-)
+
+def _linked_worktree_shared_inbox_wedge_dir() -> Path | None:
+    """Return a repo-shared data dir for inbox trust wedge artifacts.
+
+    Inbox trust wedge state is an operator-facing approval surface. Like the
+    canonical receipt store, it should remain visible across linked worktrees so
+    review/execute flows do not lose sight of receipts when the current checkout
+    changes.
+    """
+
+    current = Path.cwd().resolve()
+    for candidate in (current, *current.parents):
+        git_marker = candidate / ".git"
+        if not git_marker.is_file():
+            if git_marker.is_dir():
+                return None
+            continue
+        try:
+            raw = git_marker.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        prefix = "gitdir:"
+        if not raw.startswith(prefix):
+            return None
+        gitdir = Path(raw[len(prefix) :].strip())
+        if not gitdir.is_absolute():
+            gitdir = (candidate / gitdir).resolve()
+        if gitdir.parent.name != "worktrees":
+            return None
+        common_git_dir = gitdir.parent.parent
+        repo_root = common_git_dir.parent
+        shared_data_dir = repo_root / ".nomic"
+        if not shared_data_dir.exists() and (repo_root / "data").exists():
+            shared_data_dir = repo_root / "data"
+        return shared_data_dir
+    return None
+
+
+def _default_inbox_wedge_db_path() -> Path:
+    explicit_path = os.environ.get("ARAGORA_INBOX_TRUST_WEDGE_DB")
+    if explicit_path:
+        return Path(explicit_path)
+    if not (os.environ.get("ARAGORA_DATA_DIR") or os.environ.get("ARAGORA_NOMIC_DIR")):
+        shared_dir = _linked_worktree_shared_inbox_wedge_dir()
+        if shared_dir is not None:
+            return shared_dir / "inbox_trust_wedge.db"
+    return Path(resolve_db_path("inbox_trust_wedge.db"))
+
+
+def _default_inbox_wedge_signing_key_path() -> Path:
+    explicit_path = os.environ.get("ARAGORA_INBOX_TRUST_WEDGE_KEY_FILE")
+    if explicit_path:
+        return Path(explicit_path)
+    if not (os.environ.get("ARAGORA_DATA_DIR") or os.environ.get("ARAGORA_NOMIC_DIR")):
+        shared_dir = _linked_worktree_shared_inbox_wedge_dir()
+        if shared_dir is not None:
+            return shared_dir / "inbox_trust_wedge_signing.key"
+    return Path(resolve_db_path("inbox_trust_wedge_signing.key"))
+
+
+DEFAULT_DB_PATH = _default_inbox_wedge_db_path()
+DEFAULT_SIGNING_KEY_PATH = _default_inbox_wedge_signing_key_path()
 SIGNING_KEY_ENV_VAR = "ARAGORA_INBOX_TRUST_WEDGE_SIGNING_KEY"
 AUTO_APPROVAL_THRESHOLD = float(
     os.getenv("ARAGORA_INBOX_TRUST_WEDGE_AUTO_APPROVAL_THRESHOLD", "0.85")

--- a/tests/inbox/test_trust_wedge_paths.py
+++ b/tests/inbox/test_trust_wedge_paths.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(args),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return _run(cwd, "git", *args)
+
+
+def _make_git_repo_with_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    (repo / ".nomic").mkdir()
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+
+    linked = tmp_path / "linked-worktree"
+    _git(repo, "worktree", "add", "-b", "feature/test", str(linked), "main")
+    return repo, linked
+
+
+def test_default_inbox_wedge_paths_use_repo_shared_nomic_for_linked_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, linked = _make_git_repo_with_linked_worktree(tmp_path)
+    monkeypatch.delenv("ARAGORA_INBOX_TRUST_WEDGE_DB", raising=False)
+    monkeypatch.delenv("ARAGORA_INBOX_TRUST_WEDGE_KEY_FILE", raising=False)
+    monkeypatch.delenv("ARAGORA_DATA_DIR", raising=False)
+    monkeypatch.delenv("ARAGORA_NOMIC_DIR", raising=False)
+    monkeypatch.chdir(linked)
+
+    import aragora.inbox.trust_wedge as trust_wedge_module
+
+    trust_wedge_module = importlib.reload(trust_wedge_module)
+    assert trust_wedge_module.DEFAULT_DB_PATH == repo / ".nomic" / "inbox_trust_wedge.db"
+    assert trust_wedge_module.DEFAULT_SIGNING_KEY_PATH == (
+        repo / ".nomic" / "inbox_trust_wedge_signing.key"
+    )
+
+
+def test_default_inbox_wedge_paths_respect_explicit_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    custom_dir = tmp_path / "custom-data"
+    monkeypatch.setenv("ARAGORA_DATA_DIR", str(custom_dir))
+    monkeypatch.delenv("ARAGORA_INBOX_TRUST_WEDGE_DB", raising=False)
+    monkeypatch.delenv("ARAGORA_INBOX_TRUST_WEDGE_KEY_FILE", raising=False)
+
+    import aragora.inbox.trust_wedge as trust_wedge_module
+
+    trust_wedge_module = importlib.reload(trust_wedge_module)
+    assert trust_wedge_module.DEFAULT_DB_PATH == custom_dir / "inbox_trust_wedge.db"
+    assert trust_wedge_module.DEFAULT_SIGNING_KEY_PATH == (
+        custom_dir / "inbox_trust_wedge_signing.key"
+    )
+
+
+def test_default_inbox_wedge_paths_respect_explicit_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    db_path = tmp_path / "explicit-wedge.db"
+    key_path = tmp_path / "explicit-wedge.key"
+    monkeypatch.setenv("ARAGORA_INBOX_TRUST_WEDGE_DB", str(db_path))
+    monkeypatch.setenv("ARAGORA_INBOX_TRUST_WEDGE_KEY_FILE", str(key_path))
+    monkeypatch.delenv("ARAGORA_DATA_DIR", raising=False)
+    monkeypatch.delenv("ARAGORA_NOMIC_DIR", raising=False)
+
+    import aragora.inbox.trust_wedge as trust_wedge_module
+
+    trust_wedge_module = importlib.reload(trust_wedge_module)
+    assert trust_wedge_module.DEFAULT_DB_PATH == db_path
+    assert trust_wedge_module.DEFAULT_SIGNING_KEY_PATH == key_path


### PR DESCRIPTION
## Summary
- route inbox trust wedge DB and signing key to repo-shared .nomic paths in linked worktrees
- preserve explicit data-dir and per-file overrides
- add linked-worktree path regressions for wedge DB and signing key defaults

## Validation
- python3 -m pytest tests/inbox/test_trust_wedge.py tests/inbox/test_trust_wedge_paths.py tests/cli/test_inbox_wedge_command.py -q
- python3 -m ruff check aragora/inbox/trust_wedge.py tests/inbox/test_trust_wedge_paths.py
- live: python3 -m aragora.cli.main inbox-wedge list --limit 3
- live: python3 -m aragora.cli.main inbox-wedge report --limit 20
