### PR TITLE
fix(knowledge): make mound search optional in handler mixin

### DIFF
--- a/aragora/server/handlers/knowledge_base/search.py
+++ b/aragora/server/handlers/knowledge_base/search.py
@@ -233,7 +233,8 @@ class SearchOperationsMixin:
         )
         domain = get_bounded_string_param(query_params, "domain", None, max_length=100)
 
-        mound = self._get_knowledge_mound()
+        mound_getter = getattr(self, "_get_knowledge_mound", None)
+        mound = mound_getter() if callable(mound_getter) else None
         if mound and KnowledgeMoundRetriever is not None:
             retriever = KnowledgeMoundRetriever(
                 mound,


### PR DESCRIPTION
## Summary
- treat `_get_knowledge_mound()` as optional in `SearchOperationsMixin`
- fall back to the query-engine path when a handler doesn't implement Knowledge Mound access
- restore the existing search response contract for handlers that only provide `_get_query_engine()`

## Repro
- `Integration Smoke` on PR `#1711` failed in `tests/handlers/knowledge_base/test_search.py::TestHandleSearchBasic::test_search_returns_default_workspace`
- `_handle_search()` now called `self._get_knowledge_mound()` unconditionally, but the concrete test handler only implements `_get_query_engine()` and `_get_fact_store()`

## Validation
- `python3 -m pytest tests/handlers/knowledge_base/test_search.py::TestHandleSearchBasic::test_search_returns_default_workspace tests/handlers/knowledge_base/test_search.py -q`
- `python3 -m ruff check aragora/server/handlers/knowledge_base/search.py tests/handlers/knowledge_base/test_search.py`
