### PR TITLE
feat(cli): link triage dry-run to inbox wedge receipts

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -333,6 +333,7 @@ async def _run_triage(
                     diagnostics,
                     next_page_token=getattr(runner, "next_page_token", None),
                 )
+                _print_wedge_receipt_handoffs(decisions)
                 return
 
             _print_decisions(decisions)
@@ -551,6 +552,25 @@ def _print_run_footer(
         print(f"Diagnostics: {meta.get('artifact_dir')}")
     if next_page_token:
         print(f"Next page token: {next_page_token}")
+
+
+def _print_wedge_receipt_handoffs(decisions: list) -> None:
+    """Print inbox trust wedge inspect handles for created receipts."""
+    receipt_ids: list[str] = []
+    seen: set[str] = set()
+    for decision in decisions:
+        receipt_id = str(getattr(decision, "receipt_id", "") or "").strip()
+        if not receipt_id or receipt_id in seen:
+            continue
+        seen.add(receipt_id)
+        receipt_ids.append(receipt_id)
+
+    if not receipt_ids:
+        return
+
+    print("\nInspect inbox receipts:")
+    for receipt_id in receipt_ids:
+        print(f"  aragora inbox-wedge show {receipt_id}")
 
 
 def _show_status() -> None:

--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -571,6 +571,9 @@ def _print_wedge_receipt_handoffs(decisions: list) -> None:
     print("\nInspect inbox receipts:")
     for receipt_id in receipt_ids:
         print(f"  aragora inbox-wedge show {receipt_id}")
+    print("\nReview inbox receipts:")
+    for receipt_id in receipt_ids:
+        print(f"  aragora inbox-wedge review {receipt_id} --choice <approve|reject|edit|skip>")
 
 
 def _show_status() -> None:

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -123,6 +123,8 @@ async def test_run_triage_dry_run_disables_action_execution(capsys, tmp_path, mo
     assert "[DRY RUN] Proposed triage decisions" in out
     assert "archive" in out
     assert "Run summary:" in out
+    assert "Inspect inbox receipts:" in out
+    assert "aragora inbox-wedge show receipt-2" in out
     assert "Next page token: next-page-xyz" in out
 
 

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -125,6 +125,8 @@ async def test_run_triage_dry_run_disables_action_execution(capsys, tmp_path, mo
     assert "Run summary:" in out
     assert "Inspect inbox receipts:" in out
     assert "aragora inbox-wedge show receipt-2" in out
+    assert "Review inbox receipts:" in out
+    assert "aragora inbox-wedge review receipt-2 --choice <approve|reject|edit|skip>" in out
     assert "Next page token: next-page-xyz" in out
 
 


### PR DESCRIPTION
## Summary
- surface `aragora inbox-wedge show <id>` handles in `triage run --dry-run` output
- keep the dry-run footer compact while making the next operator step explicit
- add CLI regression coverage for the new handoff output

## Validation
- `python3 -m pytest tests/cli/test_triage_command.py -q`
- `python3 -m ruff check aragora/cli/commands/triage.py tests/cli/test_triage_command.py`
- live: `python3 -m aragora.cli.main triage run --dry-run --batch 1`
