### PR TITLE
fix(slack): restore ask command self-call path

### DIFF
--- a/aragora/server/handlers/social/_slack_impl/commands.py
+++ b/aragora/server/handlers/social/_slack_impl/commands.py
@@ -480,66 +480,90 @@ Reply in thread to add suggestions to ongoing debates
         """Answer a question asynchronously using a single agent."""
 
         try:
-            # Call the debate engine directly instead of HTTP self-call.
-            # Self-calls hit auth middleware which rejects the API token format.
-            from aragora import Arena, DebateProtocol, Environment
-            from aragora.agents.api_agents import create_api_agents
+            from aragora.server.http_client_pool import get_http_pool
 
-            env = Environment(task=question)
-            protocol = DebateProtocol(rounds=1, consensus="majority")
-            agents = create_api_agents(count=2)
-            if not agents:
-                # Fallback: create minimal agent list
-                from aragora.agents.api_agents.anthropic import AnthropicAgent
-
-                agents = [AnthropicAgent(role="proposer"), AnthropicAgent(role="critic")]
-            arena = Arena(env, agents=agents, protocol=protocol)
-            result = await arena.run()
-            answer = str(
-                getattr(result, "final_answer", None)
-                or getattr(result, "summary", None)
-                or "Debate completed but no clear answer emerged."
-            )
-
-            # Build response blocks
-            blocks = [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"*Question:*\n_{question[:200]}{'...' if len(question) > 200 else ''}_",
-                    },
-                },
-                {
-                    "type": "divider",
-                },
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": f"*Answer:*\n{answer[:2000] if answer else 'No answer available'}",
-                    },
-                },
-                {
-                    "type": "context",
-                    "elements": [
-                        {
-                            "type": "mrkdwn",
-                            "text": f"Asked by <@{user_id}>",
+            pool = get_http_pool()
+            # Internal self-calls need the API token to bypass auth
+            api_token = os.environ.get("ARAGORA_API_TOKEN", "")
+            headers = {"Authorization": f"Bearer {api_token}"} if api_token else {}
+            async with pool.get_session("slack") as client:
+                resp = await client.post(
+                    f"{ARAGORA_API_BASE_URL}/api/quick-answer",
+                    json={
+                        "question": question,
+                        "metadata": {
+                            "source": "slack",
+                            "channel_id": channel_id,
+                            "user_id": user_id,
                         },
-                    ],
-                },
-            ]
+                    },
+                    headers=headers,
+                    timeout=60,
+                )
+                if resp.status_code != 200:
+                    # Fallback to debate API if quick-answer not available
+                    data = {"answer": None, "error": "Quick answer service unavailable"}
+                else:
+                    data = resp.json()
 
-            await self._post_to_response_url(
-                response_url,
-                {
-                    "response_type": "in_channel",
-                    "text": f"Answer: {answer[:100] if answer else 'No answer'}...",
-                    "blocks": blocks,
-                    "replace_original": False,
-                },
-            )
+                answer = data.get("answer")
+                if not answer:
+                    # Fallback: use single-round debate
+                    debate_resp = await client.post(
+                        f"{ARAGORA_API_BASE_URL}/api/debates",
+                        json={
+                            "task": question,
+                            "rounds": 1,
+                            "agents": ["anthropic-api"],
+                        },
+                        headers=headers,
+                        timeout=60,
+                    )
+                    if debate_resp.status_code == 200 or debate_resp.status_code == 201:
+                        debate_data = debate_resp.json()
+                        answer = debate_data.get("final_answer", "Unable to generate answer.")
+                    else:
+                        answer = "Unable to generate answer at this time."
+
+                # Build response blocks
+                blocks = [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*Question:*\n_{question[:200]}{'...' if len(question) > 200 else ''}_",
+                        },
+                    },
+                    {
+                        "type": "divider",
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": f"*Answer:*\n{answer[:2000] if answer else 'No answer available'}",
+                        },
+                    },
+                    {
+                        "type": "context",
+                        "elements": [
+                            {
+                                "type": "mrkdwn",
+                                "text": f"Asked by <@{user_id}>",
+                            },
+                        ],
+                    },
+                ]
+
+                await self._post_to_response_url(
+                    response_url,
+                    {
+                        "response_type": "in_channel",
+                        "text": f"Answer: {answer[:100] if answer else 'No answer'}...",
+                        "blocks": blocks,
+                        "replace_original": False,
+                    },
+                )
 
         except (
             OSError,


### PR DESCRIPTION
## Summary
- restore Slack `/aragora ask` async answering to the existing internal HTTP self-call flow
- use `/api/quick-answer` first and fall back to a one-round `/api/debates` request when needed
- keep bearer-token auth and Slack response block rendering intact

## Repro
On the latest `origin/main`, the Slack handler suite failed because `CommandsMixin._answer_question_async()` tried to import and call `create_api_agents` from `aragora.agents.api_agents`, but that helper does not exist in the actual codebase.

## Fix
Revert that path to the already-supported server self-call flow via `get_http_pool()`, `POST /api/quick-answer`, and fallback `POST /api/debates`.

## Validation
- `python3 -m pytest tests/handlers/social/_slack_impl/test_commands.py tests/handlers/social/_slack_impl/test_handler.py -q`
- `python3 -m ruff check aragora/server/handlers/social/_slack_impl/commands.py`

## Notes
- The focused Slack suites passed: `242 passed`.
- Broader founder-loop smoke reruns were attempted earlier in this environment but did not finish cleanly, so this PR stays scoped to the directly reproduced Slack regression.
