### PR TITLE
fix(inbox): preserve CLI review trust signals

### DIFF
--- a/aragora/inbox/cli_review.py
+++ b/aragora/inbox/cli_review.py
@@ -150,6 +150,17 @@ class CLIReviewLoop:
             self._print("  Status  : blocked pending human review")
         else:
             self._print(f"  Status  : {decision.receipt_state}")
+        if decision.provider_route:
+            self._print(f"  Route   : {decision.provider_route}")
+        self._print(f"  Tier    : {decision.execution_tier}")
+        if decision.escalation_reasons:
+            self._print(f"  Escal.  : {', '.join(decision.escalation_reasons)}")
+        if decision.suppressed_diagnostics_count:
+            self._print(f"  Suppres.: {decision.suppressed_diagnostics_count}")
+        if decision.cost_usd is not None:
+            self._print(f"  Cost    : ${decision.cost_usd:.4f}")
+        if decision.latency_seconds is not None:
+            self._print(f"  Latency : {decision.latency_seconds:.2f}s")
         if decision.dissent_summary:
             self._print(f"  Dissent : {decision.dissent_summary}")
         self._print(f"  Receipt : {decision.receipt_id}")
@@ -258,6 +269,11 @@ class CLIReviewLoop:
         decision.provider_route = updated.provider_route
         decision.label_id = updated.label_id
         decision.blocked_by_policy = updated.blocked_by_policy
+        decision.cost_usd = updated.cost_usd
+        decision.latency_seconds = updated.latency_seconds
+        decision.execution_tier = updated.execution_tier
+        decision.escalation_reasons = list(updated.escalation_reasons)
+        decision.suppressed_diagnostics_count = updated.suppressed_diagnostics_count
 
 
 __all__ = ["CLIReviewLoop"]

--- a/tests/inbox/test_cli_review.py
+++ b/tests/inbox/test_cli_review.py
@@ -15,6 +15,10 @@ def _make_decision() -> TriageDecision:
         confidence=0.4,
         dissent_summary="",
         receipt_id="receipt-1",
+        provider_route="gmail",
+        cost_usd=0.0125,
+        latency_seconds=1.25,
+        execution_tier="baseline",
     )
 
 
@@ -35,6 +39,11 @@ def _make_envelope(
         provider_route=decision.provider_route,
         label_id=decision.label_id,
         blocked_by_policy=decision.blocked_by_policy,
+        cost_usd=decision.cost_usd,
+        latency_seconds=decision.latency_seconds,
+        execution_tier=decision.execution_tier,
+        escalation_reasons=decision.escalation_reasons,
+        suppressed_diagnostics_count=decision.suppressed_diagnostics_count,
     )
     return SimpleNamespace(
         intent=decision.intent,
@@ -101,7 +110,11 @@ def test_review_batch_displays_manual_review_reason():
         confidence=0.0,
         dissent_summary="No consensus reached; manual review required.",
         receipt_id="receipt-2",
+        provider_route="gmail",
         blocked_by_policy=True,
+        execution_tier="escalated",
+        escalation_reasons=["policy:block", "confidence:low"],
+        suppressed_diagnostics_count=2,
     )
     printed: list[str] = []
 
@@ -114,3 +127,52 @@ def test_review_batch_displays_manual_review_reason():
 
     output = "\n".join(printed)
     assert "No consensus reached; manual review required." in output
+    assert "Route   : gmail" in output
+    assert "Tier    : escalated" in output
+    assert "Escal.  : policy:block, confidence:low" in output
+    assert "Suppres.: 2" in output
+
+
+def test_review_batch_copies_review_metadata_from_envelope():
+    decision = _make_decision()
+    updated = TriageDecision.create(
+        final_action="archive",
+        confidence=0.9,
+        dissent_summary="policy override",
+        receipt_id="receipt-1",
+        auto_approval_eligible=False,
+        receipt_state=ReceiptState.CREATED.value,
+        provider_route="gmail+policy",
+        blocked_by_policy=True,
+        cost_usd=0.0321,
+        latency_seconds=2.75,
+        execution_tier="escalated",
+        escalation_reasons=["policy:block"],
+        suppressed_diagnostics_count=3,
+    )
+    review_fn = MagicMock(
+        return_value=SimpleNamespace(
+            intent=decision.intent,
+            decision=updated,
+            receipt=SimpleNamespace(receipt_id="receipt-1", state=ReceiptState.CREATED),
+        )
+    )
+
+    loop = CLIReviewLoop(
+        input_fn=lambda _prompt: "a",
+        print_fn=lambda *_args, **_kwargs: None,
+        review_fn=review_fn,
+    )
+
+    loop.review_batch([decision])
+
+    assert decision.final_action == InboxWedgeAction.ARCHIVE
+    assert decision.confidence == 0.9
+    assert decision.dissent_summary == "policy override"
+    assert decision.provider_route == "gmail+policy"
+    assert decision.blocked_by_policy is True
+    assert decision.cost_usd == 0.0321
+    assert decision.latency_seconds == 2.75
+    assert decision.execution_tier == "escalated"
+    assert decision.escalation_reasons == ["policy:block"]
+    assert decision.suppressed_diagnostics_count == 3


### PR DESCRIPTION
## Summary
- surface truthful trust and escalation metadata in CLI inbox review summaries
- preserve reviewed execution metadata on the live decision after receipt-backed approve/edit actions
- add focused regressions for display and metadata propagation

## Testing
- python3 -m pytest tests/inbox/test_cli_review.py -q
- python3 -m ruff check aragora/inbox/cli_review.py tests/inbox/test_cli_review.py
