### PR TITLE
fix(triage): separate global diagnostics from message counts

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -549,14 +549,23 @@ def _print_run_footer(
     next_page_token: str | None = None,
 ) -> None:
     """Print a compact diagnostics-aware run footer."""
-    print(
-        "Run summary: "
-        f"processed={len(decisions)} "
-        f"fast={meta.get('fast_tier_count', 0)} "
-        f"escalated={meta.get('escalated_count', 0)} "
-        f"blocked={meta.get('blocked_count', 0)} "
-        f"suppressed={meta.get('suppressed_diagnostics_count', 0)}"
+    message_suppressed = int(
+        meta.get(
+            "message_suppressed_diagnostics_count",
+            meta.get("suppressed_diagnostics_count", 0),
+        )
     )
+    global_suppressed = int(meta.get("global_suppressed_diagnostics_count", 0))
+    summary_parts = [
+        f"processed={len(decisions)}",
+        f"fast={meta.get('fast_tier_count', 0)}",
+        f"escalated={meta.get('escalated_count', 0)}",
+        f"blocked={meta.get('blocked_count', 0)}",
+        f"suppressed={message_suppressed}",
+    ]
+    if global_suppressed:
+        summary_parts.append(f"global_diag={global_suppressed}")
+    print("Run summary: " + " ".join(summary_parts))
     if getattr(diagnostics, "has_degraded_or_blocking", lambda: False)():
         print(f"Diagnostics: {meta.get('artifact_dir')}")
     if next_page_token:

--- a/aragora/inbox/triage_diagnostics.py
+++ b/aragora/inbox/triage_diagnostics.py
@@ -370,6 +370,8 @@ class TriageRunDiagnostics:
         }
         for event in self._events:
             severity_counts[event.severity] += 1
+        message_suppressed_count = sum(1 for event in self._events if event.message_id)
+        global_suppressed_count = sum(1 for event in self._events if not event.message_id)
 
         meta = {
             "run_id": self.run_id,
@@ -393,6 +395,8 @@ class TriageRunDiagnostics:
                 1 for decision in decisions if getattr(decision, "blocked_by_policy", False)
             ),
             "suppressed_diagnostics_count": self._suppressed_count,
+            "message_suppressed_diagnostics_count": message_suppressed_count,
+            "global_suppressed_diagnostics_count": global_suppressed_count,
             "severity_counts": severity_counts,
             "artifact_dir": str(self.artifact_dir),
             "events_path": str(self.events_path),

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -234,6 +234,8 @@ async def test_run_triage_footer_shows_diagnostics_path(capsys, tmp_path, monkey
 
     out = capsys.readouterr().out
     assert "Run summary:" in out
+    assert "suppressed=0" in out
+    assert "global_diag=" in out
     assert "Diagnostics:" in out
     diag_root = tmp_path / "triage-runs"
     meta_files = list(diag_root.glob("*/meta.json"))

--- a/tests/inbox/test_triage_diagnostics.py
+++ b/tests/inbox/test_triage_diagnostics.py
@@ -138,3 +138,36 @@ def test_finalize_writes_meta_and_event_artifacts(tmp_path):
     assert written_meta["profile"] == "staged_v1"
     assert written_meta["artifact_dir"] == str(diagnostics.artifact_dir)
     assert meta["severity_counts"]["diagnostic"] == 1
+    assert meta["message_suppressed_diagnostics_count"] == 1
+    assert meta["global_suppressed_diagnostics_count"] == 0
+
+
+def test_finalize_separates_global_and_message_suppressed_counts(tmp_path):
+    diagnostics = TriageRunDiagnostics(
+        profile="staged_v1",
+        batch_size=1,
+        auto_approve=False,
+        dry_run=True,
+        verbose=False,
+        diagnostics_dir=tmp_path,
+    )
+    with diagnostics.activate():
+        diagnostics.record_event(
+            code="startup",
+            severity="diagnostic",
+            logger_name="aragora.storage.pool_manager",
+            summary="startup warning",
+        )
+        with diagnostics.message_scope("msg-7"):
+            diagnostics.record_event(
+                code="slow_round",
+                severity="diagnostic",
+                logger_name="aragora.debate.performance_monitor",
+                summary="slow round",
+            )
+
+    meta = diagnostics.finalize([])
+
+    assert meta["suppressed_diagnostics_count"] == 2
+    assert meta["message_suppressed_diagnostics_count"] == 1
+    assert meta["global_suppressed_diagnostics_count"] == 1


### PR DESCRIPTION
## Summary
- split triage diagnostics metadata into message-scoped and global suppressed counts
- render the CLI run footer with truthful per-message suppression plus global startup noise
- add regressions for diagnostics metadata and footer output

## Testing
- python3 -m pytest tests/inbox/test_triage_diagnostics.py tests/cli/test_triage_command.py -q
- python3 -m ruff check aragora/inbox/triage_diagnostics.py aragora/cli/commands/triage.py tests/inbox/test_triage_diagnostics.py tests/cli/test_triage_command.py
