### PR TITLE
feat(swarm): harden worktree branch guards and queue audits

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -140,8 +140,8 @@ def _classify_issue_validation_status(
         and ("unrecognized arguments" in combined_output or "usage: main.py" in combined_output)
     ):
         return (
-            "invalid_cli_contract",
-            "Update the issue's CLI validation command to match the current Aragora parser.",
+            "cli_usage_failure",
+            "The current Aragora parser rejects this queued CLI command. Refresh the contract if the flags were renamed, or keep the issue queued if it is meant to add that CLI surface.",
         )
     if returncode == 5 and (
         command.startswith("pytest ")
@@ -149,8 +149,8 @@ def _classify_issue_validation_status(
         or command.startswith("python3 -m pytest ")
     ):
         return (
-            "stale_test_selector",
-            "Update the issue's pytest selector or test path; the current contract does not collect any matching tests.",
+            "no_matching_tests_collected",
+            "The queued pytest selector collects no tests on the current branch. Refresh the selector if tests moved, or keep the issue queued if the expected coverage has not been added yet.",
         )
     if any(
         cmd.startswith(prefix)

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 from uuid import uuid4
 
 
@@ -239,6 +241,51 @@ def _audit_issue_validation_contract(
         "status": status,
         "next_action": next_action,
     }
+
+
+@contextmanager
+def _open_audit_checkout(repo_root: Path, *, git_ref: str | None):
+    if not git_ref:
+        yield repo_root
+        return
+
+    with tempfile.TemporaryDirectory(prefix="aragora-audit-") as temp_dir:
+        checkout_root = Path(temp_dir) / "checkout"
+        add_proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "add",
+                "--detach",
+                str(checkout_root),
+                git_ref,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if add_proc.returncode != 0:
+            stderr = _trim_command_output(add_proc.stderr or "") or "git worktree add failed"
+            raise RuntimeError(f"Failed to open audit checkout for {git_ref}: {stderr}")
+        try:
+            yield checkout_root
+        finally:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(checkout_root),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
 
 def _build_runner_report_payload(
@@ -1151,6 +1198,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         from aragora.swarm.boss_loop import GitHubIssueFeed
 
         cli_labels: list[str] = list(getattr(args, "labels", None) or [])
+        audit_ref = _optional_text(getattr(args, "audit_ref", None))
         legacy_label = getattr(args, "boss_label_filter", None)
         if legacy_label and legacy_label not in cli_labels:
             cli_labels.insert(0, legacy_label)
@@ -1180,7 +1228,10 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 )
             ]
 
-        audits = [_audit_issue_validation_contract(issue, repo_root=Path.cwd()) for issue in issues]
+        with _open_audit_checkout(Path.cwd(), git_ref=audit_ref) as audit_root:
+            audits = [
+                _audit_issue_validation_contract(issue, repo_root=audit_root) for issue in issues
+            ]
         summary: dict[str, int] = {}
         for item in audits:
             status = str(item.get("status", "unknown") or "unknown")
@@ -1189,6 +1240,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             "mode": "swarm-issue-audit",
             "action": "audit-issues",
             "repo": getattr(args, "boss_repo", None),
+            "audit_ref": audit_ref,
             "labels": cli_labels,
             "issue_count": len(audits),
             "summary": summary,
@@ -1199,6 +1251,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         else:
             print(
                 f"audited={len(audits)} "
+                + (f"ref={audit_ref} " if audit_ref else "")
                 + " ".join(f"{key}={value}" for key, value in sorted(summary.items()))
             )
             rows = [

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 from uuid import uuid4
 
@@ -32,6 +33,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "run",
         "boss",
         "boss-loop",
+        "audit-issues",
         "runner",
         "status",
         "reconcile",
@@ -88,6 +90,155 @@ def _print_table(
     print("  ".join("-" * widths[key] for key, _label in headers))
     for row in rows:
         print("  ".join(str(row.get(key, "") or "").ljust(widths[key]) for key, _label in headers))
+
+
+def _trim_command_output(text: str, *, limit: int = 240) -> str | None:
+    normalized = " ".join(str(text or "").strip().split())
+    if not normalized:
+        return None
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3] + "..."
+
+
+def _classify_issue_validation_status(
+    *,
+    validation_contract: list[str],
+    commands: list[str],
+    probe_results: list[dict[str, object]],
+) -> tuple[str, str]:
+    if not validation_contract:
+        return (
+            "missing_validation_contract",
+            "Add an Acceptance Criteria, Validation, or Test section with at least one concrete command.",
+        )
+    if not commands:
+        return (
+            "non_runnable_validation_contract",
+            "Rewrite the validation contract so it contains runnable commands instead of prose.",
+        )
+    if probe_results and all(str(item.get("status")) == "passed" for item in probe_results):
+        return (
+            "passes_now",
+            "Issue validations already pass on the current branch; close, relabel, or rewrite the stale queue item.",
+        )
+    first_failure = next(
+        (item for item in probe_results if str(item.get("status")) != "passed"),
+        None,
+    )
+    command = str(first_failure.get("command") if isinstance(first_failure, dict) else "")
+    returncode = (
+        int(first_failure.get("returncode"))
+        if isinstance(first_failure, dict) and isinstance(first_failure.get("returncode"), int)
+        else None
+    )
+    stdout_text = str(first_failure.get("stdout") if isinstance(first_failure, dict) else "" or "")
+    stderr_text = str(first_failure.get("stderr") if isinstance(first_failure, dict) else "" or "")
+    combined_output = f"{stdout_text}\n{stderr_text}".lower()
+    if command.startswith("python3 -m aragora.cli.main ") and (
+        returncode in {1, 2}
+        and ("unrecognized arguments" in combined_output or "usage: main.py" in combined_output)
+    ):
+        return (
+            "invalid_cli_contract",
+            "Update the issue's CLI validation command to match the current Aragora parser.",
+        )
+    if returncode == 5 and (
+        command.startswith("pytest ")
+        or command.startswith("python -m pytest ")
+        or command.startswith("python3 -m pytest ")
+    ):
+        return (
+            "stale_test_selector",
+            "Update the issue's pytest selector or test path; the current contract does not collect any matching tests.",
+        )
+    if any(
+        cmd.startswith(prefix)
+        for cmd in commands
+        for prefix in (
+            "pytest tests/ -q",
+            "python -m pytest tests/ -q",
+            "python3 -m pytest tests/ -q",
+        )
+    ):
+        return (
+            "broad_validation_contract",
+            "Replace the broad test-suite command with focused validation tied to the intended file scope.",
+        )
+    return (
+        "validation_fails_now",
+        "Validation still fails on the current branch; confirm whether the issue remains real or the contract is stale.",
+    )
+
+
+def _audit_issue_validation_contract(
+    issue: object,
+    *,
+    repo_root: Path,
+    timeout_seconds: float = 45.0,
+) -> dict[str, object]:
+    from aragora.swarm.boss_loop import (
+        extract_issue_validation_contract,
+        extract_pre_dispatch_validation_commands,
+    )
+
+    body = str(getattr(issue, "body", "") or "")
+    validation_contract = extract_issue_validation_contract(body)
+    commands = extract_pre_dispatch_validation_commands(body)
+    probe_results: list[dict[str, object]] = []
+
+    for command in commands:
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                executable="/bin/bash",
+                cwd=str(repo_root),
+                text=True,
+                capture_output=True,
+                timeout=max(1, int(timeout_seconds)),
+                check=False,
+            )
+            result = {
+                "command": command,
+                "status": "passed" if proc.returncode == 0 else "failed",
+                "returncode": proc.returncode,
+                "stdout": _trim_command_output(proc.stdout),
+                "stderr": _trim_command_output(proc.stderr),
+            }
+        except subprocess.TimeoutExpired as exc:
+            result = {
+                "command": command,
+                "status": "timeout",
+                "stdout": _trim_command_output(getattr(exc, "stdout", "") or ""),
+                "stderr": _trim_command_output(getattr(exc, "stderr", "") or ""),
+            }
+        except (FileNotFoundError, OSError) as exc:
+            result = {
+                "command": command,
+                "status": "error",
+                "stderr": _trim_command_output(str(exc)),
+            }
+        probe_results.append(result)
+        if result["status"] != "passed":
+            break
+
+    status, next_action = _classify_issue_validation_status(
+        validation_contract=validation_contract,
+        commands=commands,
+        probe_results=probe_results,
+    )
+    return {
+        "number": int(getattr(issue, "number", 0) or 0),
+        "title": str(getattr(issue, "title", "") or "").strip(),
+        "url": str(getattr(issue, "url", "") or "").strip(),
+        "labels": list(getattr(issue, "labels", []) or []),
+        "validation_contract": validation_contract,
+        "commands": commands,
+        "probe_results": probe_results,
+        "status": status,
+        "next_action": next_action,
+    }
 
 
 def _build_runner_report_payload(
@@ -994,6 +1145,80 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     print()
             else:
                 print(render_runner_registration_text(payload))
+        return
+
+    if action == "audit-issues":
+        from aragora.swarm.boss_loop import GitHubIssueFeed
+
+        cli_labels: list[str] = list(getattr(args, "labels", None) or [])
+        legacy_label = getattr(args, "boss_label_filter", None)
+        if legacy_label and legacy_label not in cli_labels:
+            cli_labels.insert(0, legacy_label)
+        label_filter = cli_labels[0] if cli_labels else None
+        required_labels = set(cli_labels)
+        issue_list = [
+            int(item.strip())
+            for item in str(getattr(args, "boss_issue_list", "") or "").split(",")
+            if item.strip()
+        ]
+        if getattr(args, "boss_issue_number", None):
+            issue_list.append(int(getattr(args, "boss_issue_number")))
+
+        feed = GitHubIssueFeed(
+            repo=getattr(args, "boss_repo", None),
+            label_filter=label_filter,
+            issue_numbers=issue_list or None,
+            limit=25,
+        )
+        issues = feed.fetch()
+        if required_labels:
+            issues = [
+                issue
+                for issue in issues
+                if required_labels.issubset(
+                    {str(label).strip() for label in getattr(issue, "labels", [])}
+                )
+            ]
+
+        audits = [_audit_issue_validation_contract(issue, repo_root=Path.cwd()) for issue in issues]
+        summary: dict[str, int] = {}
+        for item in audits:
+            status = str(item.get("status", "unknown") or "unknown")
+            summary[status] = summary.get(status, 0) + 1
+        payload = {
+            "mode": "swarm-issue-audit",
+            "action": "audit-issues",
+            "repo": getattr(args, "boss_repo", None),
+            "labels": cli_labels,
+            "issue_count": len(audits),
+            "summary": summary,
+            "issues": audits,
+        }
+        if as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(
+                f"audited={len(audits)} "
+                + " ".join(f"{key}={value}" for key, value in sorted(summary.items()))
+            )
+            rows = [
+                {
+                    "number": item["number"],
+                    "status": item["status"],
+                    "title": item["title"][:64],
+                    "next_action": str(item["next_action"])[:80],
+                }
+                for item in audits
+            ]
+            _print_table(
+                [
+                    ("number", "Issue"),
+                    ("status", "Status"),
+                    ("title", "Title"),
+                    ("next_action", "Next Action"),
+                ],
+                rows,
+            )
         return
 
     if action == "integrator":

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2474,6 +2474,11 @@ def _add_swarm_parser(subparsers) -> None:
         help="Comma-separated GitHub issue numbers for boss-loop scoped dispatch",
     )
     swarm_parser.add_argument(
+        "--audit-ref",
+        default=None,
+        help="For 'swarm audit-issues', run validations from a temporary detached worktree at this git ref (for example: origin/main)",
+    )
+    swarm_parser.add_argument(
         "--max-consecutive-failures",
         type=int,
         default=3,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -318,6 +318,16 @@ _VALIDATION_INLINE_PREFIXES = (
 )
 _VALIDATION_BULLET_RE = re.compile(r"^\s*(?:[-*]|\d+\.)\s*(?:\[(?: |x|X)\]\s*)?(?P<text>.+?)\s*$")
 _MARKDOWN_BOLD_RE = re.compile(r"\*\*(?P<text>.+?)\*\*")
+_PRE_DISPATCH_SAFE_COMMAND_PREFIXES = (
+    "pytest ",
+    "python -m pytest",
+    "python3 -m pytest",
+    "uv run pytest",
+    "uv run python -m pytest",
+    "aragora ",
+    "python -m aragora",
+    "python3 -m aragora",
+)
 
 
 def _ordered_unique_strings(items: list[str]) -> list[str]:
@@ -397,6 +407,69 @@ def extract_issue_validation_contract(issue_body: str) -> list[str]:
         criteria.append(stripped)
 
     return _ordered_unique_strings(criteria)
+
+
+def extract_pre_dispatch_validation_commands(issue_body: str) -> list[str]:
+    """Return explicit validation commands that are safe to probe before dispatch."""
+    commands: list[str] = []
+    for item in extract_issue_validation_contract(issue_body):
+        normalized = str(item).strip().strip("`").strip()
+        if not normalized:
+            continue
+        if any(normalized.startswith(prefix) for prefix in _PRE_DISPATCH_SAFE_COMMAND_PREFIXES):
+            commands.append(normalized)
+    return _ordered_unique_strings(commands)
+
+
+def run_pre_dispatch_validation_commands(
+    commands: list[str],
+    *,
+    cwd: Path,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Execute bounded validation commands locally before spawning a worker lane."""
+    results: list[dict[str, Any]] = []
+    timeout = max(1, int(timeout_seconds))
+    for command in commands:
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                executable="/bin/bash",
+                cwd=str(cwd),
+                text=True,
+                capture_output=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            results.append(
+                {
+                    "command": command,
+                    "status": "timeout",
+                }
+            )
+            return {"satisfied": False, "results": results}
+        except (FileNotFoundError, OSError) as exc:
+            results.append(
+                {
+                    "command": command,
+                    "status": "error",
+                    "detail": str(exc),
+                }
+            )
+            return {"satisfied": False, "results": results}
+
+        results.append(
+            {
+                "command": command,
+                "status": "passed" if proc.returncode == 0 else "failed",
+                "returncode": proc.returncode,
+            }
+        )
+        if proc.returncode != 0:
+            return {"satisfied": False, "results": results}
+    return {"satisfied": True, "results": results}
 
 
 # ---------------------------------------------------------------------------
@@ -818,6 +891,8 @@ class BossLoopConfig:
     skip_labels: set[str] = field(default_factory=lambda: {"wontfix", "duplicate", "invalid"})
     require_labels: set[str] | None = None
     require_validation_contract: bool = True
+    enable_pre_dispatch_satisfaction_check: bool = True
+    pre_dispatch_validation_timeout_seconds: float = 45.0
 
     # Retry / self-correction
     max_consecutive_failures: int = 3
@@ -1830,6 +1905,11 @@ class BossLoop:
             self._consecutive_failures = 0
             self._emit_lane_receipt(worker_result, issue_dict, elapsed_seconds)
             self._log_value_outcome(issue_dict, "completed", elapsed_seconds)
+            next_actions = [
+                str(item).strip()
+                for item in worker_result.get("next_actions", [])
+                if str(item).strip()
+            ] or ["Proceeding to next issue."]
             return BossIterationStatus(
                 iteration=iteration,
                 run_id=self.run_id,
@@ -1839,8 +1919,9 @@ class BossLoop:
                 worker_status="completed",
                 stop_reason=None,
                 needs_human_reasons=[],
-                next_actions=["Proceeding to next issue."],
+                next_actions=next_actions,
                 elapsed_seconds=elapsed_seconds,
+                worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
             )
 
         if worker_result.get("status") == "needs_human":
@@ -2050,6 +2131,27 @@ class BossLoop:
             user_expertise="developer",
         )
         validation_contract = extract_issue_validation_contract(issue.body)
+        if self.config.enable_pre_dispatch_satisfaction_check:
+            pre_dispatch_commands = extract_pre_dispatch_validation_commands(issue.body)
+            if pre_dispatch_commands:
+                probe = run_pre_dispatch_validation_commands(
+                    pre_dispatch_commands,
+                    cwd=Path.cwd(),
+                    timeout_seconds=self.config.pre_dispatch_validation_timeout_seconds,
+                )
+                if probe.get("satisfied"):
+                    return {
+                        "status": "completed",
+                        "outcome": "already_satisfied",
+                        "validations_run": pre_dispatch_commands,
+                        "next_actions": [
+                            (
+                                f"Issue #{issue.number} already satisfies its explicit validation "
+                                "contract on the current branch."
+                            ),
+                            "Close, relabel, or remove the stale boss-ready issue before the next tick.",
+                        ],
+                    }
         if validation_contract and self.config.use_focused_verification:
             # Replace broad test suite commands with focused verification
             # that only tests files related to the worker's changes

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1523,41 +1523,8 @@ class BossLoop:
         """Execute a single Boss loop iteration."""
         now = datetime.now(UTC).isoformat()
         iter_start = time.monotonic()
-
-        # Step 1: Check runner freshness
-        freshness = self._freshness_checker(
-            freshness_ttl_seconds=self.config.freshness_ttl_seconds,
-            registry_path=self.config.registry_path,
-            env=self._env,
-            requested_runner_type=self.config.default_target_agent,
-            allowed_profiles=self.config.allowed_runner_profiles,
-            rotation_interval_seconds=self.config.runner_rotation_interval_seconds,
-        )
-        freshness_dict = freshness.to_dict() if hasattr(freshness, "to_dict") else dict(freshness)
-
-        if not (freshness.fresh if hasattr(freshness, "fresh") else freshness_dict.get("fresh")):
-            blocked_reason = (
-                freshness.blocked_reason
-                if hasattr(freshness, "blocked_reason")
-                else freshness_dict.get("blocked_reason", "runner_not_fresh")
-            )
-            return BossIterationStatus(
-                iteration=iteration,
-                run_id=self.run_id,
-                timestamp=now,
-                runner_freshness=freshness_dict,
-                selected_issue=None,
-                worker_status="blocked",
-                stop_reason=BossStopReason.NO_FRESH_RUNNER.value,
-                needs_human_reasons=[f"No fresh runner: {blocked_reason}"],
-                next_actions=[
-                    "Re-register or refresh the Codex runner before resuming the Boss loop.",
-                    f"Blocked reason: {blocked_reason}",
-                ],
-                elapsed_seconds=time.monotonic() - iter_start,
-            )
-
-        # Step 2: Fetch issues from GitHub
+        freshness_dict: dict[str, Any] = {}
+        # Step 1: Fetch issues from GitHub
         try:
             issues = self._feed.fetch()
         except Exception as exc:
@@ -1576,7 +1543,7 @@ class BossLoop:
                 error="issue_feed_error",
             )
 
-        # Step 3: Select eligible issue
+        # Step 2: Select eligible issue
         # Skip issues that have exceeded retry limits
         already_maxed = {
             num
@@ -1630,6 +1597,39 @@ class BossLoop:
                 elapsed_seconds=time.monotonic() - iter_start,
             )
 
+        # Step 3: Check runner freshness only when there is eligible work to dispatch
+        freshness = self._freshness_checker(
+            freshness_ttl_seconds=self.config.freshness_ttl_seconds,
+            registry_path=self.config.registry_path,
+            env=self._env,
+            requested_runner_type=self.config.default_target_agent,
+            allowed_profiles=self.config.allowed_runner_profiles,
+            rotation_interval_seconds=self.config.runner_rotation_interval_seconds,
+        )
+        freshness_dict = freshness.to_dict() if hasattr(freshness, "to_dict") else dict(freshness)
+
+        if not (freshness.fresh if hasattr(freshness, "fresh") else freshness_dict.get("fresh")):
+            blocked_reason = (
+                freshness.blocked_reason
+                if hasattr(freshness, "blocked_reason")
+                else freshness_dict.get("blocked_reason", "runner_not_fresh")
+            )
+            return BossIterationStatus(
+                iteration=iteration,
+                run_id=self.run_id,
+                timestamp=now,
+                runner_freshness=freshness_dict,
+                selected_issue=None,
+                worker_status="blocked",
+                stop_reason=BossStopReason.NO_FRESH_RUNNER.value,
+                needs_human_reasons=[f"No fresh runner: {blocked_reason}"],
+                next_actions=[
+                    "Re-register or refresh the Codex runner before resuming the Boss loop.",
+                    f"Blocked reason: {blocked_reason}",
+                ],
+                elapsed_seconds=time.monotonic() - iter_start,
+            )
+
         # Step 4: Dispatch supervised work for this issue
         issue_dict = selected.to_dict()
         self._attempted_issues.append(issue_dict)
@@ -1653,6 +1653,64 @@ class BossLoop:
 
         now = datetime.now(UTC).isoformat()
         iter_start = time.monotonic()
+        freshness_dict: dict[str, Any] = {}
+
+        try:
+            issues = self._feed.fetch()
+        except Exception as exc:
+            logger.warning("Issue feed error: %s", exc)
+            return [
+                BossIterationStatus(
+                    iteration=iteration,
+                    run_id=self.run_id,
+                    timestamp=now,
+                    runner_freshness=freshness_dict,
+                    selected_issue=None,
+                    worker_status="blocked",
+                    stop_reason=BossStopReason.ISSUE_FEED_ERROR.value,
+                    needs_human_reasons=["GitHub issue feed is unreachable."],
+                    next_actions=["Check GitHub CLI authentication and network."],
+                    elapsed_seconds=time.monotonic() - iter_start,
+                    error="issue_feed_error",
+                )
+            ]
+
+        already_maxed = {
+            num
+            for num, count in self._issue_attempt_counts.items()
+            if count >= self.config.max_retries_per_issue
+        }
+        candidate_issues = [i for i in issues if i.number not in already_maxed]
+        selected_issues = self._select_issues_for_iteration(
+            candidate_issues,
+            limit=None,
+        )
+
+        if not selected_issues:
+            if self.config.issue_number is not None:
+                needs_human_reasons, next_actions = self._target_issue_miss_guidance(
+                    self.config.issue_number
+                )
+            else:
+                needs_human_reasons = ["No suitable open issue found in the GitHub feed."]
+                next_actions = [
+                    "Create a new issue with actionable scope, or adjust label filters.",
+                    f"Issues checked: {len(issues)}, already maxed retries: {len(already_maxed)}",
+                ]
+            return [
+                BossIterationStatus(
+                    iteration=iteration,
+                    run_id=self.run_id,
+                    timestamp=now,
+                    runner_freshness=freshness_dict,
+                    selected_issue=None,
+                    worker_status="idle",
+                    stop_reason=BossStopReason.NO_SUITABLE_ISSUE.value,
+                    needs_human_reasons=needs_human_reasons,
+                    next_actions=next_actions,
+                    elapsed_seconds=time.monotonic() - iter_start,
+                )
+            ]
 
         freshness = self._freshness_checker(
             freshness_ttl_seconds=self.config.freshness_ttl_seconds,
@@ -1688,64 +1746,7 @@ class BossLoop:
                 )
             ]
 
-        try:
-            issues = self._feed.fetch()
-        except Exception as exc:
-            logger.warning("Issue feed error: %s", exc)
-            return [
-                BossIterationStatus(
-                    iteration=iteration,
-                    run_id=self.run_id,
-                    timestamp=now,
-                    runner_freshness=freshness_dict,
-                    selected_issue=None,
-                    worker_status="blocked",
-                    stop_reason=BossStopReason.ISSUE_FEED_ERROR.value,
-                    needs_human_reasons=["GitHub issue feed is unreachable."],
-                    next_actions=["Check GitHub CLI authentication and network."],
-                    elapsed_seconds=time.monotonic() - iter_start,
-                    error="issue_feed_error",
-                )
-            ]
-
-        already_maxed = {
-            num
-            for num, count in self._issue_attempt_counts.items()
-            if count >= self.config.max_retries_per_issue
-        }
-        candidate_issues = [i for i in issues if i.number not in already_maxed]
         parallel_limit = self._parallel_dispatch_limit(freshness)
-        selected_issues = self._select_issues_for_iteration(
-            candidate_issues,
-            limit=None,
-        )
-
-        if not selected_issues:
-            if self.config.issue_number is not None:
-                needs_human_reasons, next_actions = self._target_issue_miss_guidance(
-                    self.config.issue_number
-                )
-            else:
-                needs_human_reasons = ["No suitable open issue found in the GitHub feed."]
-                next_actions = [
-                    "Create a new issue with actionable scope, or adjust label filters.",
-                    f"Issues checked: {len(issues)}, already maxed retries: {len(already_maxed)}",
-                ]
-            return [
-                BossIterationStatus(
-                    iteration=iteration,
-                    run_id=self.run_id,
-                    timestamp=now,
-                    runner_freshness=freshness_dict,
-                    selected_issue=None,
-                    worker_status="idle",
-                    stop_reason=BossStopReason.NO_SUITABLE_ISSUE.value,
-                    needs_human_reasons=needs_human_reasons,
-                    next_actions=next_actions,
-                    elapsed_seconds=time.monotonic() - iter_start,
-                )
-            ]
-
         pending_issues = list(selected_issues)
         active_tasks: dict[
             asyncio.Task[dict[str, Any]], tuple[GitHubIssue, dict[str, Any], float]

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import time
 import uuid
@@ -328,6 +329,7 @@ _PRE_DISPATCH_SAFE_COMMAND_PREFIXES = (
     "python -m aragora",
     "python3 -m aragora",
 )
+_BACKTICK_COMMAND_RE = re.compile(r"`(?P<command>[^`]+)`")
 
 
 def _ordered_unique_strings(items: list[str]) -> list[str]:
@@ -409,11 +411,25 @@ def extract_issue_validation_contract(issue_body: str) -> list[str]:
     return _ordered_unique_strings(criteria)
 
 
+def _normalize_pre_dispatch_command(text: str) -> str:
+    normalized = str(text).strip()
+    if not normalized:
+        return ""
+    backtick_match = _BACKTICK_COMMAND_RE.search(normalized)
+    if backtick_match:
+        normalized = backtick_match.group("command").strip()
+    if normalized.endswith(" passes."):
+        normalized = normalized[: -len(" passes.")].strip()
+    if normalized.startswith("aragora ") and shutil.which("aragora") is None:
+        normalized = f"python3 -m aragora.cli.main {normalized[len('aragora ') :].strip()}"
+    return normalized
+
+
 def extract_pre_dispatch_validation_commands(issue_body: str) -> list[str]:
     """Return explicit validation commands that are safe to probe before dispatch."""
     commands: list[str] = []
     for item in extract_issue_validation_contract(issue_body):
-        normalized = str(item).strip().strip("`").strip()
+        normalized = _normalize_pre_dispatch_command(item)
         if not normalized:
             continue
         if any(normalized.startswith(prefix) for prefix in _PRE_DISPATCH_SAFE_COMMAND_PREFIXES):

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -604,6 +604,21 @@ def check_runner_freshness(
                     allowed_profiles=allowed_profile_set or None,
                     rotation_interval_seconds=rotation_interval_seconds,
                 )
+        selected_verified = len(
+            [
+                item
+                for item in routing.selected_runners
+                if isinstance(item, dict) and registry._probe_status(item) == "passed"
+            ]
+        )
+        if selected_verified == 0:
+            return RunnerFreshnessResult(
+                fresh=False,
+                runner_ids=routing.selected_runner_ids,
+                checked_at=checked_at,
+                blocked_reason="no_execution_verified_runner",
+                details={"routing": routing.to_dict(), "probe": probe_summary},
+            )
 
     if routing.is_blocked:
         return RunnerFreshnessResult(

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 import re
-import shutil
 import subprocess
 import time
 import uuid
@@ -420,7 +419,7 @@ def _normalize_pre_dispatch_command(text: str) -> str:
         normalized = backtick_match.group("command").strip()
     if normalized.endswith(" passes."):
         normalized = normalized[: -len(" passes.")].strip()
-    if normalized.startswith("aragora ") and shutil.which("aragora") is None:
+    if normalized.startswith("aragora "):
         normalized = f"python3 -m aragora.cli.main {normalized[len('aragora ') :].strip()}"
     return normalized
 

--- a/aragora/swarm/runner_registry.py
+++ b/aragora/swarm/runner_registry.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import platform
 import shutil
 import subprocess
+import tempfile
 from typing import Any
 
 from aragora.rbac.models import AuthorizationContext
@@ -1780,9 +1781,23 @@ class LocalRunnerRegistry:
 
     def _save(self, data: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = self.path.with_suffix(self.path.suffix + ".tmp")
-        temp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-        temp_path.replace(self.path)
+        payload = json.dumps(data, indent=2, sort_keys=True)
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f"{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                handle.write(payload)
+                temp_path = Path(handle.name)
+            temp_path.replace(self.path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
 
 
 def authorization_context_from_env(

--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -525,6 +525,7 @@ def _choose_reusable_session(
     agent: str,
     session_id: str | None,
     active_paths: set[str],
+    active_branches_by_path: dict[str, str | None] | None = None,
 ) -> dict[str, Any] | None:
     sessions = state.get("sessions", [])
     candidates: list[dict[str, Any]] = []
@@ -536,6 +537,10 @@ def _choose_reusable_session(
         path = str(s.get("path", ""))
         if not path or path not in active_paths:
             continue
+        expected_branch = str(s.get("branch", "")).strip() or None
+        actual_branch = (active_branches_by_path or {}).get(path)
+        if expected_branch and actual_branch and actual_branch != expected_branch:
+            continue
         candidates.append(s)
 
     if not candidates:
@@ -546,6 +551,51 @@ def _choose_reusable_session(
 
     candidates.sort(key=sort_key, reverse=True)
     return candidates[0]
+
+
+def _evict_branch_mismatched_session(
+    repo_root: Path,
+    state: dict[str, Any],
+    *,
+    agent: str,
+    session_id: str | None,
+    active_branches_by_path: dict[str, str | None],
+) -> bool:
+    if not session_id:
+        return False
+
+    sessions = state.get("sessions", [])
+    if not isinstance(sessions, list):
+        return False
+
+    kept: list[dict[str, Any]] = []
+    evicted = False
+    for session in sessions:
+        if session.get("agent") != agent or session.get("session_id") != session_id:
+            kept.append(session)
+            continue
+
+        path = str(session.get("path", "")).strip()
+        expected_branch = str(session.get("branch", "")).strip() or None
+        actual_branch = active_branches_by_path.get(path)
+        if not path or not expected_branch or not actual_branch or actual_branch == expected_branch:
+            kept.append(session)
+            continue
+
+        worktree_path = Path(path)
+        if _has_active_session(worktree_path) or _has_active_lease(repo_root, worktree_path):
+            kept.append(session)
+            continue
+
+        removed = _remove_worktree(repo_root, worktree_path)
+        if not removed and worktree_path.exists():
+            kept.append(session)
+            continue
+        evicted = True
+
+    if evicted:
+        state["sessions"] = kept
+    return evicted
 
 
 def _create_managed_worktree(
@@ -617,6 +667,7 @@ def cmd_ensure(args: argparse.Namespace) -> int:
 
     entries = _get_worktree_entries(repo_root)
     active_paths = _active_path_set(entries)
+    active_branches_by_path = {str(entry.path): entry.branch for entry in entries}
     state = _load_state(state_file)
     state, _ = _prune_stale_state(state, active_paths)
 
@@ -627,7 +678,18 @@ def cmd_ensure(args: argparse.Namespace) -> int:
             agent=args.agent,
             session_id=args.session_id,
             active_paths=active_paths,
+            active_branches_by_path=active_branches_by_path,
         )
+        if session is None and _evict_branch_mismatched_session(
+            repo_root,
+            state,
+            agent=args.agent,
+            session_id=args.session_id,
+            active_branches_by_path=active_branches_by_path,
+        ):
+            entries = _get_worktree_entries(repo_root)
+            active_paths = _active_path_set(entries)
+            active_branches_by_path = {str(entry.path): entry.branch for entry in entries}
 
     ttl = timedelta(hours=DEFAULT_TTL_HOURS)
     created = False

--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -611,36 +611,43 @@ def _create_managed_worktree(
     token = uuid4().hex[:8]
     sid = session_id or f"{agent}-{now.strftime('%Y%m%d-%H%M%S')}-{token}"
     branch = f"codex/{sid}"
-    while _branch_exists(repo_root, branch):
-        branch = f"{branch}-{uuid4().hex[:4]}"
     worktree_path = (managed_root / sid).resolve()
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path, ignore_errors=True)
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
-    source = f"origin/{base}"
-    add_proc = _run_git(
-        repo_root,
-        "worktree",
-        "add",
-        "-b",
-        branch,
-        str(worktree_path),
-        source,
-    )
-    if add_proc.returncode != 0:
-        add_proc = _run_git(
-            repo_root,
-            "worktree",
-            "add",
-            "-b",
-            branch,
-            str(worktree_path),
-            base,
-        )
-    if add_proc.returncode != 0:
-        raise RuntimeError(add_proc.stderr.strip() or "git worktree add failed")
+    while True:
+        while _branch_exists(repo_root, branch):
+            branch = f"codex/{sid}-{uuid4().hex[:4]}"
+
+        retry_branch = False
+        add_proc = None
+        for source in (f"origin/{base}", base):
+            add_proc = _run_git(
+                repo_root,
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                source,
+            )
+            if add_proc.returncode == 0:
+                retry_branch = False
+                break
+            stderr = add_proc.stderr.strip().lower()
+            if "branch named" in stderr and "already exists" in stderr:
+                branch = f"codex/{sid}-{uuid4().hex[:4]}"
+                retry_branch = True
+                break
+        if retry_branch:
+            continue
+        if add_proc is None or add_proc.returncode != 0:
+            raise RuntimeError(
+                add_proc.stderr.strip() if add_proc is not None else "git worktree add failed"
+            )
+        break
 
     return {
         "session_id": sid,

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from aragora.cli.commands.swarm import cmd_swarm
+from aragora.cli.commands.swarm import _classify_issue_validation_status, cmd_swarm
 from aragora.swarm.spec import SwarmSpec
 
 
@@ -184,6 +184,27 @@ class TestSwarmParser:
         assert args.swarm_goal == "probe"
         assert args.runner_type == "claude"
         assert args.probe_limit == 2
+        assert args.json is True
+
+    def test_swarm_audit_issues_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "audit-issues",
+                "--boss-repo",
+                "synaptent/aragora",
+                "--label",
+                "boss-ready",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "audit-issues"
+        assert args.boss_repo == "synaptent/aragora"
+        assert args.labels == ["boss-ready"]
         assert args.json is True
 
     def test_swarm_boss_parser_accepts_issue_list(self):
@@ -1488,6 +1509,90 @@ class TestSwarmCommand:
         assert '"failed": 1' in out
         assert '"selected_before": 1' in out
         assert '"selected_after": 0' in out
+
+    def test_cmd_swarm_audit_issues_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="audit-issues",
+            swarm_goal=None,
+            boss_repo="synaptent/aragora",
+            labels=["boss-ready"],
+            boss_label_filter=None,
+            boss_issue_number=None,
+            boss_issue_list=None,
+            json=True,
+        )
+        issue = SimpleNamespace(
+            number=1639,
+            title="Add --json output flag to aragora quickstart CLI",
+            body="Validation: pytest tests/cli/test_quickstart.py -x -q",
+            labels=["boss-ready"],
+            url="https://github.com/synaptent/aragora/issues/1639",
+        )
+
+        with (
+            patch("aragora.swarm.boss_loop.GitHubIssueFeed") as feed_cls,
+            patch(
+                "aragora.cli.commands.swarm._audit_issue_validation_contract",
+                return_value={
+                    "number": 1639,
+                    "title": "Add --json output flag to aragora quickstart CLI",
+                    "url": "https://github.com/synaptent/aragora/issues/1639",
+                    "labels": ["boss-ready"],
+                    "validation_contract": ["pytest tests/cli/test_quickstart.py -x -q"],
+                    "commands": ["pytest tests/cli/test_quickstart.py -x -q"],
+                    "probe_results": [
+                        {
+                            "command": "pytest tests/cli/test_quickstart.py -x -q",
+                            "status": "failed",
+                            "returncode": 1,
+                        }
+                    ],
+                    "status": "validation_fails_now",
+                    "next_action": "Validation still fails on the current branch.",
+                },
+            ) as audit_issue,
+        ):
+            feed_cls.return_value.fetch.return_value = [issue]
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"mode": "swarm-issue-audit"' in out
+        assert '"action": "audit-issues"' in out
+        assert '"issue_count": 1' in out
+        assert '"validation_fails_now": 1' in out
+        audit_issue.assert_called_once()
+
+    def test_classify_issue_validation_status_detects_invalid_cli_contract(self):
+        status, next_action = _classify_issue_validation_status(
+            validation_contract=["aragora quickstart --json"],
+            commands=["python3 -m aragora.cli.main quickstart --json"],
+            probe_results=[
+                {
+                    "command": "python3 -m aragora.cli.main quickstart --json",
+                    "status": "failed",
+                    "returncode": 1,
+                    "stderr": "usage: main.py ... error: unrecognized arguments: --json",
+                }
+            ],
+        )
+        assert status == "invalid_cli_contract"
+        assert "CLI validation command" in next_action
+
+    def test_classify_issue_validation_status_detects_stale_test_selector(self):
+        status, next_action = _classify_issue_validation_status(
+            validation_contract=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
+            commands=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
+            probe_results=[
+                {
+                    "command": "pytest tests/swarm/test_boss_loop.py -k refine -q",
+                    "status": "failed",
+                    "returncode": 5,
+                    "stdout": "82 deselected in 0.44s",
+                }
+            ],
+        )
+        assert status == "stale_test_selector"
+        assert "does not collect any matching tests" in next_action
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -81,6 +81,7 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "owner_session_id": None,
         "skip_review": False,
         "output": None,
+        "audit_ref": None,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -198,6 +199,8 @@ class TestSwarmParser:
                 "synaptent/aragora",
                 "--label",
                 "boss-ready",
+                "--audit-ref",
+                "origin/main",
                 "--json",
             ]
         )
@@ -205,6 +208,7 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "audit-issues"
         assert args.boss_repo == "synaptent/aragora"
         assert args.labels == ["boss-ready"]
+        assert args.audit_ref == "origin/main"
         assert args.json is True
 
     def test_swarm_boss_parser_accepts_issue_list(self):
@@ -1519,6 +1523,7 @@ class TestSwarmCommand:
             boss_label_filter=None,
             boss_issue_number=None,
             boss_issue_list=None,
+            audit_ref="origin/main",
             json=True,
         )
         issue = SimpleNamespace(
@@ -1531,6 +1536,13 @@ class TestSwarmCommand:
 
         with (
             patch("aragora.swarm.boss_loop.GitHubIssueFeed") as feed_cls,
+            patch(
+                "aragora.cli.commands.swarm._open_audit_checkout",
+                return_value=MagicMock(
+                    __enter__=MagicMock(return_value=Path("/tmp/audit-main")),
+                    __exit__=MagicMock(return_value=False),
+                ),
+            ) as open_checkout,
             patch(
                 "aragora.cli.commands.swarm._audit_issue_validation_contract",
                 return_value={
@@ -1558,9 +1570,15 @@ class TestSwarmCommand:
         out = capsys.readouterr().out
         assert '"mode": "swarm-issue-audit"' in out
         assert '"action": "audit-issues"' in out
+        assert '"audit_ref": "origin/main"' in out
         assert '"issue_count": 1' in out
         assert '"validation_fails_now": 1' in out
+        open_checkout.assert_called_once()
+        _, kwargs = open_checkout.call_args
+        assert kwargs["git_ref"] == "origin/main"
         audit_issue.assert_called_once()
+        _, kwargs = audit_issue.call_args
+        assert kwargs["repo_root"] == Path("/tmp/audit-main")
 
     def test_classify_issue_validation_status_detects_cli_usage_failure(self):
         status, next_action = _classify_issue_validation_status(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1562,7 +1562,7 @@ class TestSwarmCommand:
         assert '"validation_fails_now": 1' in out
         audit_issue.assert_called_once()
 
-    def test_classify_issue_validation_status_detects_invalid_cli_contract(self):
+    def test_classify_issue_validation_status_detects_cli_usage_failure(self):
         status, next_action = _classify_issue_validation_status(
             validation_contract=["aragora quickstart --json"],
             commands=["python3 -m aragora.cli.main quickstart --json"],
@@ -1575,10 +1575,10 @@ class TestSwarmCommand:
                 }
             ],
         )
-        assert status == "invalid_cli_contract"
-        assert "CLI validation command" in next_action
+        assert status == "cli_usage_failure"
+        assert "parser rejects this queued CLI command" in next_action
 
-    def test_classify_issue_validation_status_detects_stale_test_selector(self):
+    def test_classify_issue_validation_status_detects_no_matching_tests_collected(self):
         status, next_action = _classify_issue_validation_status(
             validation_contract=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
             commands=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
@@ -1591,8 +1591,8 @@ class TestSwarmCommand:
                 }
             ],
         )
-        assert status == "stale_test_selector"
-        assert "does not collect any matching tests" in next_action
+        assert status == "no_matching_tests_collected"
+        assert "collects no tests on the current branch" in next_action
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -121,6 +121,29 @@ def test_choose_reusable_session_honors_session_id_filter():
     assert chosen["session_id"] == "a"
 
 
+def test_choose_reusable_session_skips_branch_mismatches():
+    import codex_worktree_autopilot as mod
+
+    state = {
+        "sessions": [
+            {
+                "agent": "codex",
+                "session_id": "s1",
+                "branch": "codex/s1",
+                "path": "/repo/.worktrees/codex-auto/s1",
+            }
+        ]
+    }
+    chosen = mod._choose_reusable_session(
+        state,
+        agent="codex",
+        session_id="s1",
+        active_paths={"/repo/.worktrees/codex-auto/s1"},
+        active_branches_by_path={"/repo/.worktrees/codex-auto/s1": "codex/unrelated"},
+    )
+    assert chosen is None
+
+
 def test_cleanup_parser_defaults_to_delete_branches():
     import codex_worktree_autopilot as mod
 
@@ -574,6 +597,113 @@ def test_cmd_ensure_refreshes_active_paths_for_new_worktree(
     assert payload["session"]["lifecycle_state"] == "grace"
     assert saved_state["sessions"][0]["tracked_worktree"] is True
     assert saved_state["sessions"][0]["lifecycle_state"] == "grace"
+
+
+def test_cmd_ensure_evicts_branch_mismatch_before_recreate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    now = datetime(2026, 3, 30, 7, 50, tzinfo=timezone.utc)
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    mismatched_path = tmp_path / "stale-session"
+    mismatched_path.mkdir()
+    state = {
+        "sessions": [
+            {
+                "session_id": "swarm-run-subtask_1",
+                "agent": "codex",
+                "branch": "codex/swarm-run-subtask_1",
+                "path": str(mismatched_path),
+                "created_at": now.isoformat(),
+                "last_seen_at": now.isoformat(),
+            }
+        ]
+    }
+    saved_state: dict[str, object] = {}
+    removed_paths: list[str] = []
+    create_calls: list[dict[str, object]] = []
+
+    entries_iter = iter(
+        [
+            [mod.WorktreeEntry(path=mismatched_path, branch="codex/unrelated")],
+            [],
+            [],
+        ]
+    )
+
+    def _create(*_args: object, **kwargs: object) -> dict[str, object]:
+        create_calls.append(dict(kwargs))
+        return {
+            "session_id": "swarm-run-subtask_1",
+            "agent": "codex",
+            "branch": "codex/swarm-run-subtask_1",
+            "path": str(mismatched_path),
+            "base_branch": "main",
+            "created_at": now.isoformat(),
+            "last_seen_at": now.isoformat(),
+        }
+
+    monkeypatch.setattr(mod, "_repo_root_from", lambda _path: repo_root)
+    monkeypatch.setattr(mod, "_get_worktree_entries", lambda _repo: next(entries_iter))
+    monkeypatch.setattr(mod, "_load_state", lambda _state_file: state)
+    monkeypatch.setattr(mod, "_create_managed_worktree", _create)
+    monkeypatch.setattr(mod, "_has_active_session", lambda _path: False)
+    monkeypatch.setattr(mod, "_has_active_lease", lambda _repo, _path: False)
+    monkeypatch.setattr(
+        mod,
+        "_remove_worktree",
+        lambda _repo, path: removed_paths.append(str(path)) or True,
+    )
+    monkeypatch.setattr(
+        mod,
+        "_lease_snapshot",
+        lambda _repo_root, _path: {
+            "lease_id": None,
+            "lease_status": None,
+            "last_heartbeat_at": None,
+            "lease_expires_at": None,
+            "owner_agent": None,
+            "owner_session_id": None,
+            "branch": None,
+            "title": None,
+            "has_live_lease": False,
+            "lookup_failed": False,
+        },
+    )
+    monkeypatch.setattr(
+        mod,
+        "_worktree_status",
+        lambda *_args, **_kwargs: {"dirty": False, "ahead": 0, "behind": 0},
+    )
+    monkeypatch.setattr(mod, "_branch_ahead_count", lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(
+        mod, "_save_state", lambda _state_file, payload: saved_state.update(payload)
+    )
+
+    args = argparse.Namespace(
+        repo=".",
+        managed_dir=".worktrees/codex-auto",
+        agent="codex",
+        base="main",
+        session_id="swarm-run-subtask_1",
+        force_new=False,
+        reconcile=True,
+        strategy="ff-only",
+        print_path=False,
+        json=True,
+    )
+    rc = mod.cmd_ensure(args)
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["created"] is True
+    assert removed_paths == [str(mismatched_path)]
+    assert create_calls and create_calls[0]["session_id"] == "swarm-run-subtask_1"
+    assert saved_state["sessions"][0]["branch"] == "codex/swarm-run-subtask_1"
 
 
 def test_cmd_cleanup_skips_worktree_with_active_lease(

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -599,6 +599,63 @@ def test_cmd_ensure_refreshes_active_paths_for_new_worktree(
     assert saved_state["sessions"][0]["lifecycle_state"] == "grace"
 
 
+def test_create_managed_worktree_retries_when_branch_is_created_concurrently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    managed_root = tmp_path / "managed"
+    now = datetime(2026, 3, 30, 10, 0, tzinfo=timezone.utc)
+    branches_seen: list[str] = []
+
+    def _proc(returncode: int, stderr: str = "") -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+    def _run_git(_repo: Path, *args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:2] == ("worktree", "add"):
+            branch = args[3]
+            branches_seen.append(branch)
+            if len(branches_seen) == 1:
+                return _proc(
+                    128,
+                    f"fatal: a branch named '{branch}' already exists",
+                )
+            return _proc(0)
+        raise AssertionError(f"unexpected git args: {args}")
+
+    class _UUID:
+        def __init__(self, value: str) -> None:
+            self.hex = value
+
+    uuids = iter(
+        [
+            _UUID("sessiontokdeadbeef"),
+            _UUID("retryabcd12345678"),
+        ]
+    )
+
+    monkeypatch.setattr(mod, "_ensure_fetched", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "_branch_exists", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(mod, "_run_git", _run_git)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "uuid4", lambda: next(uuids))
+
+    session = mod._create_managed_worktree(
+        repo_root,
+        managed_root,
+        agent="codex",
+        base="main",
+        session_id="swarm-ec71e047-subtask_1",
+    )
+
+    assert branches_seen[0] == "codex/swarm-ec71e047-subtask_1"
+    assert session["branch"] == "codex/swarm-ec71e047-subtask_1-retr"
+    assert branches_seen[1] == session["branch"]
+
+
 def test_cmd_ensure_evicts_branch_mismatch_before_recreate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -224,7 +224,8 @@ class TestSelectEligibleIssue:
 
 
 class TestPreDispatchValidationCommands:
-    def test_extract_pre_dispatch_validation_commands_filters_non_commands(self):
+    def test_extract_pre_dispatch_validation_commands_filters_non_commands(self, monkeypatch):
+        monkeypatch.setattr("aragora.swarm.boss_loop.shutil.which", lambda _name: None)
         body = """
 Acceptance Criteria:
 - Dashboard query path remains bounded to aragora/analytics/dashboard.py
@@ -233,7 +234,21 @@ Acceptance Criteria:
 """
         assert extract_pre_dispatch_validation_commands(body) == [
             "python -m pytest tests/swarm/test_boss_loop.py -q",
-            'aragora quickstart --topic test --rounds 1 --json | python3 -c "import json,sys; json.load(sys.stdin)"',
+            'python3 -m aragora.cli.main quickstart --topic test --rounds 1 --json | python3 -c "import json,sys; json.load(sys.stdin)"',
+        ]
+
+    def test_extract_pre_dispatch_validation_commands_normalizes_inline_acceptance(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr("aragora.swarm.boss_loop.shutil.which", lambda _name: None)
+        body = """**Test:** `aragora quickstart --topic "test" --rounds 1 --json | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'receipt_id' in d"`
+
+**Acceptance:** `pytest tests/cli/test_quickstart.py -x -q` passes."""
+
+        assert extract_pre_dispatch_validation_commands(body) == [
+            'python3 -m aragora.cli.main quickstart --topic "test" --rounds 1 --json | '
+            "python3 -c \"import json,sys; d=json.load(sys.stdin); assert 'receipt_id' in d\"",
+            "pytest tests/cli/test_quickstart.py -x -q",
         ]
 
     def test_run_pre_dispatch_validation_commands_stops_on_failure(self, monkeypatch):

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -485,6 +485,9 @@ class TestRunnerFreshness:
                             "updated_at": now,
                             "heartbeat_at": now,
                             "freshness_status": "fresh",
+                            "probe_status": "passed",
+                            "probe_checked_at": now,
+                            "probe_ttl_seconds": 3600,
                         }
                     ]
                 }
@@ -624,6 +627,96 @@ class TestRunnerFreshness:
         assert result.fresh is True
         assert result.details["probe"]["auto_probe_triggered"] is True
         assert result.details["probe"]["passed"] == 1
+
+    def test_runner_freshness_blocks_when_no_selected_runner_is_execution_verified(
+        self, tmp_path, monkeypatch
+    ):
+        registry_path = tmp_path / "runners.json"
+        now = datetime.now(UTC).isoformat()
+        registry_path.write_text(
+            json.dumps(
+                {
+                    "registrations": [
+                        {
+                            "runner_id": "claude-runner-1",
+                            "runner_type": "claude",
+                            "profile": "max-01",
+                            "registered": True,
+                            "availability": "available",
+                            "available": True,
+                            "auth_mode": "subscription",
+                            "owner_binding": {"user_id": "user-1", "workspace_id": "ws-1"},
+                            "capabilities": {"max_parallel_lanes": 1},
+                            "updated_at": now,
+                            "heartbeat_at": now,
+                            "freshness_status": "fresh",
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("ARAGORA_BOSS_VERIFIED_RUNNER_TARGET", "1")
+        monkeypatch.setenv("ARAGORA_BOSS_RUNNER_PROBE_LIMIT", "1")
+        inspection = SimpleNamespace(runner_id="claude-runner-1", profile="max-01")
+        failed_probe = SimpleNamespace(
+            status="failed",
+            detail="Probe failed (exit 1): org access denied",
+            to_runner_fields=lambda: {
+                "probe_status": "failed",
+                "probe_checked_at": now,
+                "probe_detail": "Probe failed (exit 1): org access denied",
+                "probe_latency_seconds": 1.0,
+                "probe_ttl_seconds": 3600,
+            },
+            to_dict=lambda: {
+                "runner_id": "claude-runner-1",
+                "runner_type": "claude",
+                "probe_status": "failed",
+            },
+        )
+
+        class _Inspector:
+            def inspect(self) -> MagicMock:
+                inspected = MagicMock()
+                inspected.available = True
+                inspected.auth_mode = "subscription"
+                inspected.runner_id = "claude-runner-1"
+                inspected.to_dict.return_value = {
+                    "runner_id": "claude-runner-1",
+                    "available": True,
+                    "auth_mode": "subscription",
+                }
+                return inspected
+
+        with (
+            patch(
+                "aragora.swarm.runner_registry.refresh_discovered_runners",
+                return_value=[inspection],
+            ),
+            patch(
+                "aragora.swarm.runner_registry.prioritized_probe_candidates",
+                return_value=[inspection],
+            ),
+            patch(
+                "aragora.swarm.runner_registry.probe_runner_execution",
+                return_value=failed_probe,
+            ),
+            patch(
+                "aragora.swarm.runner_registry.make_runner_inspector",
+                return_value=_Inspector(),
+            ),
+        ):
+            result = check_runner_freshness(
+                freshness_ttl_seconds=3600.0,
+                registry_path=str(registry_path),
+                env={"ARAGORA_USER_ID": "user-1", "ARAGORA_WORKSPACE_ID": "ws-1"},
+                requested_runner_type="claude",
+            )
+
+        assert result.fresh is False
+        assert result.blocked_reason == "no_execution_verified_runner"
+        assert result.details["probe"]["failed"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -224,8 +224,7 @@ class TestSelectEligibleIssue:
 
 
 class TestPreDispatchValidationCommands:
-    def test_extract_pre_dispatch_validation_commands_filters_non_commands(self, monkeypatch):
-        monkeypatch.setattr("aragora.swarm.boss_loop.shutil.which", lambda _name: None)
+    def test_extract_pre_dispatch_validation_commands_filters_non_commands(self):
         body = """
 Acceptance Criteria:
 - Dashboard query path remains bounded to aragora/analytics/dashboard.py
@@ -237,10 +236,7 @@ Acceptance Criteria:
             'python3 -m aragora.cli.main quickstart --topic test --rounds 1 --json | python3 -c "import json,sys; json.load(sys.stdin)"',
         ]
 
-    def test_extract_pre_dispatch_validation_commands_normalizes_inline_acceptance(
-        self, monkeypatch
-    ):
-        monkeypatch.setattr("aragora.swarm.boss_loop.shutil.which", lambda _name: None)
+    def test_extract_pre_dispatch_validation_commands_normalizes_inline_acceptance(self):
         body = """**Test:** `aragora quickstart --topic "test" --rounds 1 --json | python3 -c "import json,sys; d=json.load(sys.stdin); assert 'receipt_id' in d"`
 
 **Acceptance:** `pytest tests/cli/test_quickstart.py -x -q` passes."""

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -17,6 +17,7 @@ import argparse
 import asyncio
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -36,6 +37,8 @@ from aragora.swarm.boss_loop import (
     discover_focused_tests,
     dispatch_bounded_spec,
     extract_issue_validation_contract,
+    extract_pre_dispatch_validation_commands,
+    run_pre_dispatch_validation_commands,
     select_eligible_issue,
 )
 
@@ -218,7 +221,42 @@ class TestSelectEligibleIssue:
         ]
         selected = select_eligible_issue(issues, skip_labels={"duplicate"})
         assert selected is not None
-        assert selected.number == 2
+
+
+class TestPreDispatchValidationCommands:
+    def test_extract_pre_dispatch_validation_commands_filters_non_commands(self):
+        body = """
+Acceptance Criteria:
+- Dashboard query path remains bounded to aragora/analytics/dashboard.py
+- python -m pytest tests/swarm/test_boss_loop.py -q
+- `aragora quickstart --topic test --rounds 1 --json | python3 -c "import json,sys; json.load(sys.stdin)"`
+"""
+        assert extract_pre_dispatch_validation_commands(body) == [
+            "python -m pytest tests/swarm/test_boss_loop.py -q",
+            'aragora quickstart --topic test --rounds 1 --json | python3 -c "import json,sys; json.load(sys.stdin)"',
+        ]
+
+    def test_run_pre_dispatch_validation_commands_stops_on_failure(self, monkeypatch):
+        calls: list[str] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(cmd)
+            result = MagicMock()
+            result.returncode = 1
+            result.stdout = ""
+            result.stderr = "failed"
+            return result
+
+        monkeypatch.setattr("aragora.swarm.boss_loop.subprocess.run", _run)
+        result = run_pre_dispatch_validation_commands(
+            ["python -m pytest tests/swarm/test_boss_loop.py -q"],
+            cwd=Path.cwd(),
+            timeout_seconds=15,
+        )
+
+        assert calls == ["python -m pytest tests/swarm/test_boss_loop.py -q"]
+        assert result["satisfied"] is False
+        assert result["results"][0]["status"] == "failed"
 
     def test_requires_labels_when_specified(self):
         issues = [
@@ -1045,6 +1083,37 @@ class TestBossLoop:
         assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
         assert result.iterations_completed == 1
         assert result.issues_completed[0]["number"] == 1639
+        assert result.iteration_statuses[0]["worker_outcome"] == "deliverable_created"
+
+    def test_completed_iteration_preserves_worker_next_actions(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(1641, "Already fixed queue item")]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=1),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        async def _already_satisfied_dispatch(issue, freshness):
+            return {
+                "status": "completed",
+                "outcome": "already_satisfied",
+                "next_actions": [
+                    "Close or relabel the stale boss-ready issue before dispatching again."
+                ],
+            }
+
+        loop._dispatch_issue = _already_satisfied_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert (
+            result.iteration_statuses[0]["next_actions"][0]
+            == "Close or relabel the stale boss-ready issue before dispatching again."
+        )
+        assert result.iteration_statuses[0]["worker_outcome"] == "already_satisfied"
 
     def test_no_dispatch_preview_stops_truthfully(self):
         feed = MagicMock(spec=GitHubIssueFeed)
@@ -1584,6 +1653,64 @@ async def test_dispatch_bounded_spec_wait_false_returns_running_after_launch() -
     assert result["status"] == "running"
     assert result["outcome"] == "dispatched"
     assert result["run_id"] == "run-873"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_completes_when_validation_already_passes(monkeypatch) -> None:
+    issue = _make_issue(
+        1639,
+        "Add --json output flag to aragora quickstart CLI",
+        body=("Acceptance Criteria:\n- python -m pytest tests/cli/test_quickstart.py -q\n"),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "ok"
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr("aragora.swarm.boss_loop.subprocess.run", _run)
+
+    with patch(
+        "aragora.swarm.boss_loop.dispatch_bounded_spec",
+        new=AsyncMock(return_value={"status": "running"}),
+    ) as dispatch_mock:
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    assert result["outcome"] == "already_satisfied"
+    assert result["validations_run"] == ["python -m pytest tests/cli/test_quickstart.py -q"]
+    dispatch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_continues_when_pre_dispatch_validation_fails(monkeypatch) -> None:
+    issue = _make_issue(
+        1640,
+        "Tighten quickstart JSON output",
+        body=("Acceptance Criteria:\n- python -m pytest tests/cli/test_quickstart.py -q\n"),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 1
+        result.stdout = ""
+        result.stderr = "failing validation"
+        return result
+
+    monkeypatch.setattr("aragora.swarm.boss_loop.subprocess.run", _run)
+
+    with patch(
+        "aragora.swarm.boss_loop.dispatch_bounded_spec",
+        new=AsyncMock(return_value={"status": "running", "outcome": "dispatched"}),
+    ) as dispatch_mock:
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "running"
+    dispatch_mock.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1428,6 +1428,22 @@ class TestBossLoopCLI:
         assert parsed["stop_reason"] == "no_suitable_issue"
         assert parsed["iterations_completed"] == 1
 
+    def test_boss_loop_no_issue_skips_runner_freshness_check(self, capsys):
+        from aragora.cli.commands.swarm import cmd_swarm
+
+        args = self._swarm_args(json=True, max_ticks=1)
+
+        with patch.object(GitHubIssueFeed, "fetch", return_value=[]):
+            with patch(
+                "aragora.swarm.boss_loop.check_runner_freshness",
+                side_effect=AssertionError("freshness should not be checked for an empty queue"),
+            ):
+                cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["stop_reason"] == "no_suitable_issue"
+
     def test_boss_loop_text_output(self, capsys):
         from aragora.cli.commands.swarm import cmd_swarm
 
@@ -1803,6 +1819,23 @@ class TestBossLoopFixtureInvocation:
         assert "run_id" in payload2
         assert isinstance(payload2["next_actions"], list)
         assert len(payload2["next_actions"]) > 0
+
+
+def test_boss_loop_batch_no_issue_skips_runner_freshness_check() -> None:
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = []
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_parallel_dispatches=2),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: (_ for _ in ()).throw(
+            AssertionError("freshness should not be checked for an empty queue")
+        ),
+    )
+
+    result = asyncio.run(loop.run())
+
+    assert result.stop_reason == "no_suitable_issue"
+    assert result.iterations_completed == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_runner_registry.py
+++ b/tests/swarm/test_runner_registry.py
@@ -944,6 +944,18 @@ class TestLocalRunnerRegistry:
         assert decision.is_blocked is False
         assert decision.selected_runner_ids == ["claude-runner-1"]
 
+    def test_save_ignores_preexisting_fixed_temp_file(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "swarm-runners.json"
+        registry = LocalRunnerRegistry(path=registry_path)
+        stale_temp = registry_path.with_suffix(registry_path.suffix + ".tmp")
+        stale_temp.write_text("stale-temp", encoding="utf-8")
+
+        registry._save({"registrations": [{"runner_id": "claude-runner-1"}]})
+
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert payload["registrations"][0]["runner_id"] == "claude-runner-1"
+        assert stale_temp.read_text(encoding="utf-8") == "stale-temp"
+
     def test_requested_runner_capacity_is_not_masked_by_other_type_staleness(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- preserve the remaining unmerged worktree/session guard and queue-audit lane
- includes codex worktree autopilot protections, runner-registry hardening, and boss-loop queue validation improvements
- opened as draft because several stacked swarm features already landed separately and this lane needs a deliberate split/rebase before final merge

## Current signal
- `python3 -m pytest tests/scripts/test_codex_worktree_autopilot.py tests/swarm/test_runner_registry.py -q`
  - `58 passed`
