### PR TITLE
fix(cli): repair receipt tests and normalize local timestamps

### DIFF
--- a/aragora/cli/commands/inbox_wedge.py
+++ b/aragora/cli/commands/inbox_wedge.py
@@ -29,6 +29,21 @@ from aragora.inbox.trust_wedge import (
 )
 
 
+def _coerce_local_datetime(value: Any) -> datetime | None:
+    """Convert stored wedge timestamps into the operator's local time."""
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone() if value.tzinfo is not None else value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed.astimezone() if parsed.tzinfo is not None else parsed
+    return None
+
+
 def add_inbox_wedge_parser(subparsers: Any) -> None:
     parser = subparsers.add_parser(
         "inbox-wedge",
@@ -173,16 +188,11 @@ def _prompt(prompt: str) -> str:
 
 
 def _format_timestamp(value: Any) -> str:
+    parsed = _coerce_local_datetime(value)
+    if parsed is not None:
+        return parsed.strftime("%Y-%m-%d %H:%M")
     if value in (None, ""):
         return "N/A"
-    if isinstance(value, datetime):
-        return value.strftime("%Y-%m-%d %H:%M")
-    if isinstance(value, str):
-        try:
-            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            return parsed.strftime("%Y-%m-%d %H:%M")
-        except ValueError:
-            return value
     return str(value)
 
 

--- a/aragora/cli/commands/receipt.py
+++ b/aragora/cli/commands/receipt.py
@@ -24,6 +24,26 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _coerce_local_datetime(value: Any) -> datetime | None:
+    """Convert storage and ISO timestamps into the operator's local time."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.astimezone() if value.tzinfo is not None else value
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value))
+        except (OverflowError, OSError, TypeError, ValueError):
+            return None
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        return parsed.astimezone() if parsed.tzinfo is not None else parsed
+    return None
+
+
 def add_receipt_parser(subparsers: Any) -> None:
     """Register the 'receipt' subcommand with view/verify/inspect/export actions."""
     receipt_parser = subparsers.add_parser(
@@ -166,21 +186,11 @@ def _load_receipt_json(path: Path) -> dict[str, Any] | None:
 
 def _format_receipt_created_at(value: Any) -> str:
     """Format storage/legacy receipt timestamps for CLI display."""
-    if value is None:
-        return "N/A"
-    if isinstance(value, datetime):
-        return value.strftime("%Y-%m-%d %H:%M")
-    if isinstance(value, (int, float)):
-        try:
-            return datetime.fromtimestamp(float(value)).strftime("%Y-%m-%d %H:%M")
-        except (OverflowError, OSError, TypeError, ValueError):
-            return "N/A"
+    parsed = _coerce_local_datetime(value)
+    if parsed is not None:
+        return parsed.strftime("%Y-%m-%d %H:%M")
     if isinstance(value, str):
-        try:
-            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            return parsed.strftime("%Y-%m-%d %H:%M")
-        except ValueError:
-            return value[:16]
+        return value[:16]
     return "N/A"
 
 

--- a/tests/cli/test_inbox_wedge_command.py
+++ b/tests/cli/test_inbox_wedge_command.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+from datetime import datetime
 
 from aragora.cli.commands.inbox_wedge import (
+    _format_timestamp,
     cmd_inbox_wedge_create,
     cmd_inbox_wedge_list,
     cmd_inbox_wedge_export,
@@ -11,6 +13,7 @@ from aragora.cli.commands.inbox_wedge import (
     cmd_inbox_wedge_review,
     cmd_inbox_wedge_show,
 )
+from aragora.cli.commands.receipt import _format_receipt_created_at
 from aragora.cli.parser import build_parser
 from aragora.gauntlet.signing import HMACSigner, ReceiptSigner
 from aragora.inbox.trust_wedge import (
@@ -213,6 +216,13 @@ def test_list_command_renders_terminal_summary_by_default(monkeypatch, tmp_path,
     assert "archive" in output
     assert "direct" in output
     assert "1 receipt(s) shown." in output
+
+
+def test_inbox_wedge_timestamp_matches_receipt_list_localization() -> None:
+    iso_timestamp = "2026-03-30T18:47:29.647269+00:00"
+    epoch_timestamp = datetime.fromisoformat(iso_timestamp).timestamp()
+
+    assert _format_timestamp(iso_timestamp) == _format_receipt_created_at(epoch_timestamp)
 
 
 def test_show_command_renders_terminal_summary_by_default(monkeypatch, tmp_path, capsys):

--- a/tests/cli/test_receipt_command.py
+++ b/tests/cli/test_receipt_command.py
@@ -11,7 +11,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aragora.cli.commands.receipt import cmd_receipt_list, cmd_receipt_show
+from aragora.cli.commands.receipt import (
+    _format_receipt_created_at,
+    cmd_receipt_list,
+    cmd_receipt_show,
+)
 
 
 @dataclass
@@ -136,6 +140,13 @@ def test_receipt_list_filters_by_kind(capsys: pytest.CaptureFixture[str]) -> Non
     assert "rcpt-inbox-123" in output
     assert "inbox" in output
     assert "rcpt-decisio.." not in output
+
+
+def test_receipt_created_at_formats_epoch_and_iso_consistently() -> None:
+    iso_timestamp = "2026-03-30T18:47:29.647269+00:00"
+    epoch_timestamp = datetime.fromisoformat(iso_timestamp).timestamp()
+
+    assert _format_receipt_created_at(epoch_timestamp) == _format_receipt_created_at(iso_timestamp)
 
 
 def test_receipt_show_reads_durable_store_by_receipt_id(


### PR DESCRIPTION
## Summary
- remove unresolved merge markers from tests/cli/test_receipt_command.py and restore the inbox receipt detail coverage
- normalize ISO-backed inbox wedge timestamps through the same local-time path used for epoch-backed receipt rows
- keep receipt and inbox wedge CLI displays consistent for the same stored instant

## Validation
- python3 -m pytest tests/cli/test_receipt_command.py tests/cli/test_inbox_wedge_command.py -q
- python3 -m ruff check aragora/cli/commands/receipt.py aragora/cli/commands/inbox_wedge.py tests/cli/test_receipt_command.py tests/cli/test_inbox_wedge_command.py
- python3 -m aragora.cli.main inbox-wedge list --limit 3
- python3 -m aragora.cli.main receipt list --limit 3 --kind inbox
