### PR TITLE
fix(swarm): use unique temp files for runner registry saves

### DIFF
--- a/aragora/swarm/runner_registry.py
+++ b/aragora/swarm/runner_registry.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import platform
 import shutil
 import subprocess
+import tempfile
 from typing import Any
 
 from aragora.rbac.models import AuthorizationContext
@@ -1780,9 +1781,23 @@ class LocalRunnerRegistry:
 
     def _save(self, data: dict[str, Any]) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        temp_path = self.path.with_suffix(self.path.suffix + ".tmp")
-        temp_path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-        temp_path.replace(self.path)
+        payload = json.dumps(data, indent=2, sort_keys=True)
+        temp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                "w",
+                encoding="utf-8",
+                dir=self.path.parent,
+                prefix=f"{self.path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                handle.write(payload)
+                temp_path = Path(handle.name)
+            temp_path.replace(self.path)
+        finally:
+            if temp_path is not None and temp_path.exists():
+                temp_path.unlink(missing_ok=True)
 
 
 def authorization_context_from_env(

--- a/tests/swarm/test_runner_registry.py
+++ b/tests/swarm/test_runner_registry.py
@@ -944,6 +944,18 @@ class TestLocalRunnerRegistry:
         assert decision.is_blocked is False
         assert decision.selected_runner_ids == ["claude-runner-1"]
 
+    def test_save_ignores_preexisting_fixed_temp_file(self, tmp_path: Path) -> None:
+        registry_path = tmp_path / "swarm-runners.json"
+        registry = LocalRunnerRegistry(path=registry_path)
+        stale_temp = registry_path.with_suffix(registry_path.suffix + ".tmp")
+        stale_temp.write_text("stale-temp", encoding="utf-8")
+
+        registry._save({"registrations": [{"runner_id": "claude-runner-1"}]})
+
+        payload = json.loads(registry_path.read_text(encoding="utf-8"))
+        assert payload["registrations"][0]["runner_id"] == "claude-runner-1"
+        assert stale_temp.read_text(encoding="utf-8") == "stale-temp"
+
     def test_requested_runner_capacity_is_not_masked_by_other_type_staleness(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary\n- isolate the atomic runner registry save fix from #1728\n- write registry updates through unique temp files before replace\n- keep the larger worktree/queue audit stack in #1728 until it is split further\n\n## Verification\n- python3 -m pytest tests/swarm/test_runner_registry.py -q\n- python3 -m ruff check aragora/swarm/runner_registry.py tests/swarm/test_runner_registry.py\n- python3 -m ruff format --check aragora/swarm/runner_registry.py tests/swarm/test_runner_registry.py