### PR TITLE
feat(swarm): audit queued issue contracts

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -140,8 +140,8 @@ def _classify_issue_validation_status(
         and ("unrecognized arguments" in combined_output or "usage: main.py" in combined_output)
     ):
         return (
-            "invalid_cli_contract",
-            "Update the issue's CLI validation command to match the current Aragora parser.",
+            "cli_usage_failure",
+            "The current Aragora parser rejects this queued CLI command. Refresh the contract if the flags were renamed, or keep the issue queued if it is meant to add that CLI surface.",
         )
     if returncode == 5 and (
         command.startswith("pytest ")
@@ -149,8 +149,8 @@ def _classify_issue_validation_status(
         or command.startswith("python3 -m pytest ")
     ):
         return (
-            "stale_test_selector",
-            "Update the issue's pytest selector or test path; the current contract does not collect any matching tests.",
+            "no_matching_tests_collected",
+            "The queued pytest selector collects no tests on the current branch. Refresh the selector if tests moved, or keep the issue queued if the expected coverage has not been added yet.",
         )
     if any(
         cmd.startswith(prefix)

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 from uuid import uuid4
 
 
@@ -239,6 +241,51 @@ def _audit_issue_validation_contract(
         "status": status,
         "next_action": next_action,
     }
+
+
+@contextmanager
+def _open_audit_checkout(repo_root: Path, *, git_ref: str | None):
+    if not git_ref:
+        yield repo_root
+        return
+
+    with tempfile.TemporaryDirectory(prefix="aragora-audit-") as temp_dir:
+        checkout_root = Path(temp_dir) / "checkout"
+        add_proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "worktree",
+                "add",
+                "--detach",
+                str(checkout_root),
+                git_ref,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if add_proc.returncode != 0:
+            stderr = _trim_command_output(add_proc.stderr or "") or "git worktree add failed"
+            raise RuntimeError(f"Failed to open audit checkout for {git_ref}: {stderr}")
+        try:
+            yield checkout_root
+        finally:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(checkout_root),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
 
 
 def _build_runner_report_payload(
@@ -1151,6 +1198,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         from aragora.swarm.boss_loop import GitHubIssueFeed
 
         cli_labels: list[str] = list(getattr(args, "labels", None) or [])
+        audit_ref = _optional_text(getattr(args, "audit_ref", None))
         legacy_label = getattr(args, "boss_label_filter", None)
         if legacy_label and legacy_label not in cli_labels:
             cli_labels.insert(0, legacy_label)
@@ -1180,7 +1228,10 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 )
             ]
 
-        audits = [_audit_issue_validation_contract(issue, repo_root=Path.cwd()) for issue in issues]
+        with _open_audit_checkout(Path.cwd(), git_ref=audit_ref) as audit_root:
+            audits = [
+                _audit_issue_validation_contract(issue, repo_root=audit_root) for issue in issues
+            ]
         summary: dict[str, int] = {}
         for item in audits:
             status = str(item.get("status", "unknown") or "unknown")
@@ -1189,6 +1240,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             "mode": "swarm-issue-audit",
             "action": "audit-issues",
             "repo": getattr(args, "boss_repo", None),
+            "audit_ref": audit_ref,
             "labels": cli_labels,
             "issue_count": len(audits),
             "summary": summary,
@@ -1199,6 +1251,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         else:
             print(
                 f"audited={len(audits)} "
+                + (f"ref={audit_ref} " if audit_ref else "")
                 + " ".join(f"{key}={value}" for key, value in sorted(summary.items()))
             )
             rows = [

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 from uuid import uuid4
 
@@ -32,6 +33,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "run",
         "boss",
         "boss-loop",
+        "audit-issues",
         "runner",
         "status",
         "reconcile",
@@ -88,6 +90,155 @@ def _print_table(
     print("  ".join("-" * widths[key] for key, _label in headers))
     for row in rows:
         print("  ".join(str(row.get(key, "") or "").ljust(widths[key]) for key, _label in headers))
+
+
+def _trim_command_output(text: str, *, limit: int = 240) -> str | None:
+    normalized = " ".join(str(text or "").strip().split())
+    if not normalized:
+        return None
+    if len(normalized) <= limit:
+        return normalized
+    return normalized[: limit - 3] + "..."
+
+
+def _classify_issue_validation_status(
+    *,
+    validation_contract: list[str],
+    commands: list[str],
+    probe_results: list[dict[str, object]],
+) -> tuple[str, str]:
+    if not validation_contract:
+        return (
+            "missing_validation_contract",
+            "Add an Acceptance Criteria, Validation, or Test section with at least one concrete command.",
+        )
+    if not commands:
+        return (
+            "non_runnable_validation_contract",
+            "Rewrite the validation contract so it contains runnable commands instead of prose.",
+        )
+    if probe_results and all(str(item.get("status")) == "passed" for item in probe_results):
+        return (
+            "passes_now",
+            "Issue validations already pass on the current branch; close, relabel, or rewrite the stale queue item.",
+        )
+    first_failure = next(
+        (item for item in probe_results if str(item.get("status")) != "passed"),
+        None,
+    )
+    command = str(first_failure.get("command") if isinstance(first_failure, dict) else "")
+    returncode = (
+        int(first_failure.get("returncode"))
+        if isinstance(first_failure, dict) and isinstance(first_failure.get("returncode"), int)
+        else None
+    )
+    stdout_text = str(first_failure.get("stdout") if isinstance(first_failure, dict) else "" or "")
+    stderr_text = str(first_failure.get("stderr") if isinstance(first_failure, dict) else "" or "")
+    combined_output = f"{stdout_text}\n{stderr_text}".lower()
+    if command.startswith("python3 -m aragora.cli.main ") and (
+        returncode in {1, 2}
+        and ("unrecognized arguments" in combined_output or "usage: main.py" in combined_output)
+    ):
+        return (
+            "invalid_cli_contract",
+            "Update the issue's CLI validation command to match the current Aragora parser.",
+        )
+    if returncode == 5 and (
+        command.startswith("pytest ")
+        or command.startswith("python -m pytest ")
+        or command.startswith("python3 -m pytest ")
+    ):
+        return (
+            "stale_test_selector",
+            "Update the issue's pytest selector or test path; the current contract does not collect any matching tests.",
+        )
+    if any(
+        cmd.startswith(prefix)
+        for cmd in commands
+        for prefix in (
+            "pytest tests/ -q",
+            "python -m pytest tests/ -q",
+            "python3 -m pytest tests/ -q",
+        )
+    ):
+        return (
+            "broad_validation_contract",
+            "Replace the broad test-suite command with focused validation tied to the intended file scope.",
+        )
+    return (
+        "validation_fails_now",
+        "Validation still fails on the current branch; confirm whether the issue remains real or the contract is stale.",
+    )
+
+
+def _audit_issue_validation_contract(
+    issue: object,
+    *,
+    repo_root: Path,
+    timeout_seconds: float = 45.0,
+) -> dict[str, object]:
+    from aragora.swarm.boss_loop import (
+        extract_issue_validation_contract,
+        extract_pre_dispatch_validation_commands,
+    )
+
+    body = str(getattr(issue, "body", "") or "")
+    validation_contract = extract_issue_validation_contract(body)
+    commands = extract_pre_dispatch_validation_commands(body)
+    probe_results: list[dict[str, object]] = []
+
+    for command in commands:
+        try:
+            proc = subprocess.run(
+                command,
+                shell=True,
+                executable="/bin/bash",
+                cwd=str(repo_root),
+                text=True,
+                capture_output=True,
+                timeout=max(1, int(timeout_seconds)),
+                check=False,
+            )
+            result = {
+                "command": command,
+                "status": "passed" if proc.returncode == 0 else "failed",
+                "returncode": proc.returncode,
+                "stdout": _trim_command_output(proc.stdout),
+                "stderr": _trim_command_output(proc.stderr),
+            }
+        except subprocess.TimeoutExpired as exc:
+            result = {
+                "command": command,
+                "status": "timeout",
+                "stdout": _trim_command_output(getattr(exc, "stdout", "") or ""),
+                "stderr": _trim_command_output(getattr(exc, "stderr", "") or ""),
+            }
+        except (FileNotFoundError, OSError) as exc:
+            result = {
+                "command": command,
+                "status": "error",
+                "stderr": _trim_command_output(str(exc)),
+            }
+        probe_results.append(result)
+        if result["status"] != "passed":
+            break
+
+    status, next_action = _classify_issue_validation_status(
+        validation_contract=validation_contract,
+        commands=commands,
+        probe_results=probe_results,
+    )
+    return {
+        "number": int(getattr(issue, "number", 0) or 0),
+        "title": str(getattr(issue, "title", "") or "").strip(),
+        "url": str(getattr(issue, "url", "") or "").strip(),
+        "labels": list(getattr(issue, "labels", []) or []),
+        "validation_contract": validation_contract,
+        "commands": commands,
+        "probe_results": probe_results,
+        "status": status,
+        "next_action": next_action,
+    }
 
 
 def _build_runner_report_payload(
@@ -994,6 +1145,80 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     print()
             else:
                 print(render_runner_registration_text(payload))
+        return
+
+    if action == "audit-issues":
+        from aragora.swarm.boss_loop import GitHubIssueFeed
+
+        cli_labels: list[str] = list(getattr(args, "labels", None) or [])
+        legacy_label = getattr(args, "boss_label_filter", None)
+        if legacy_label and legacy_label not in cli_labels:
+            cli_labels.insert(0, legacy_label)
+        label_filter = cli_labels[0] if cli_labels else None
+        required_labels = set(cli_labels)
+        issue_list = [
+            int(item.strip())
+            for item in str(getattr(args, "boss_issue_list", "") or "").split(",")
+            if item.strip()
+        ]
+        if getattr(args, "boss_issue_number", None):
+            issue_list.append(int(getattr(args, "boss_issue_number")))
+
+        feed = GitHubIssueFeed(
+            repo=getattr(args, "boss_repo", None),
+            label_filter=label_filter,
+            issue_numbers=issue_list or None,
+            limit=25,
+        )
+        issues = feed.fetch()
+        if required_labels:
+            issues = [
+                issue
+                for issue in issues
+                if required_labels.issubset(
+                    {str(label).strip() for label in getattr(issue, "labels", [])}
+                )
+            ]
+
+        audits = [_audit_issue_validation_contract(issue, repo_root=Path.cwd()) for issue in issues]
+        summary: dict[str, int] = {}
+        for item in audits:
+            status = str(item.get("status", "unknown") or "unknown")
+            summary[status] = summary.get(status, 0) + 1
+        payload = {
+            "mode": "swarm-issue-audit",
+            "action": "audit-issues",
+            "repo": getattr(args, "boss_repo", None),
+            "labels": cli_labels,
+            "issue_count": len(audits),
+            "summary": summary,
+            "issues": audits,
+        }
+        if as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(
+                f"audited={len(audits)} "
+                + " ".join(f"{key}={value}" for key, value in sorted(summary.items()))
+            )
+            rows = [
+                {
+                    "number": item["number"],
+                    "status": item["status"],
+                    "title": item["title"][:64],
+                    "next_action": str(item["next_action"])[:80],
+                }
+                for item in audits
+            ]
+            _print_table(
+                [
+                    ("number", "Issue"),
+                    ("status", "Status"),
+                    ("title", "Title"),
+                    ("next_action", "Next Action"),
+                ],
+                rows,
+            )
         return
 
     if action == "integrator":

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -22,6 +22,7 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -103,6 +104,89 @@ def _trim_command_output(text: str, *, limit: int = 240) -> str | None:
     return normalized[: limit - 3] + "..."
 
 
+_UNSAFE_VALIDATION_SHELL_FRAGMENTS = (
+    "|",
+    "&&",
+    "||",
+    ";",
+    "<",
+    ">",
+    "$(",
+    "`",
+    "\n",
+    "\r",
+)
+
+
+def _probe_validation_command(
+    command: str,
+    *,
+    repo_root: Path,
+    timeout_seconds: float,
+) -> dict[str, object]:
+    normalized = str(command or "").strip()
+    if not normalized:
+        return {
+            "command": command,
+            "status": "unsafe",
+            "detail": "empty validation command",
+        }
+    for fragment in _UNSAFE_VALIDATION_SHELL_FRAGMENTS:
+        if fragment in normalized:
+            return {
+                "command": command,
+                "status": "unsafe",
+                "detail": (
+                    "shell operators are not allowed in auto-probed validation commands; "
+                    "use a single direct command instead"
+                ),
+            }
+    try:
+        argv = shlex.split(normalized, posix=True)
+    except ValueError as exc:
+        return {
+            "command": command,
+            "status": "unsafe",
+            "detail": f"invalid shell quoting: {exc}",
+        }
+    if not argv:
+        return {
+            "command": command,
+            "status": "unsafe",
+            "detail": "empty validation command",
+        }
+    try:
+        proc = subprocess.run(
+            argv,
+            cwd=str(repo_root),
+            text=True,
+            capture_output=True,
+            timeout=max(1, int(timeout_seconds)),
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "command": command,
+            "status": "timeout",
+            "stdout": _trim_command_output(getattr(exc, "stdout", "") or ""),
+            "stderr": _trim_command_output(getattr(exc, "stderr", "") or ""),
+        }
+    except (FileNotFoundError, OSError) as exc:
+        return {
+            "command": command,
+            "status": "error",
+            "stderr": _trim_command_output(str(exc)),
+        }
+
+    return {
+        "command": command,
+        "status": "passed" if proc.returncode == 0 else "failed",
+        "returncode": proc.returncode,
+        "stdout": _trim_command_output(proc.stdout),
+        "stderr": _trim_command_output(proc.stderr),
+    }
+
+
 def _classify_issue_validation_status(
     *,
     validation_contract: list[str],
@@ -137,6 +221,11 @@ def _classify_issue_validation_status(
     stdout_text = str(first_failure.get("stdout") if isinstance(first_failure, dict) else "" or "")
     stderr_text = str(first_failure.get("stderr") if isinstance(first_failure, dict) else "" or "")
     combined_output = f"{stdout_text}\n{stderr_text}".lower()
+    if isinstance(first_failure, dict) and str(first_failure.get("status")) == "unsafe":
+        return (
+            "unsafe_validation_contract",
+            "Rewrite the validation contract as a single direct command without shell pipelines, redirects, or chaining.",
+        )
     if command.startswith("python3 -m aragora.cli.main ") and (
         returncode in {1, 2}
         and ("unrecognized arguments" in combined_output or "usage: main.py" in combined_output)
@@ -190,37 +279,11 @@ def _audit_issue_validation_contract(
     probe_results: list[dict[str, object]] = []
 
     for command in commands:
-        try:
-            proc = subprocess.run(
-                command,
-                shell=True,
-                executable="/bin/bash",
-                cwd=str(repo_root),
-                text=True,
-                capture_output=True,
-                timeout=max(1, int(timeout_seconds)),
-                check=False,
-            )
-            result = {
-                "command": command,
-                "status": "passed" if proc.returncode == 0 else "failed",
-                "returncode": proc.returncode,
-                "stdout": _trim_command_output(proc.stdout),
-                "stderr": _trim_command_output(proc.stderr),
-            }
-        except subprocess.TimeoutExpired as exc:
-            result = {
-                "command": command,
-                "status": "timeout",
-                "stdout": _trim_command_output(getattr(exc, "stdout", "") or ""),
-                "stderr": _trim_command_output(getattr(exc, "stderr", "") or ""),
-            }
-        except (FileNotFoundError, OSError) as exc:
-            result = {
-                "command": command,
-                "status": "error",
-                "stderr": _trim_command_output(str(exc)),
-            }
+        result = _probe_validation_command(
+            command,
+            repo_root=repo_root,
+            timeout_seconds=timeout_seconds,
+        )
         probe_results.append(result)
         if result["status"] != "passed":
             break

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2474,6 +2474,11 @@ def _add_swarm_parser(subparsers) -> None:
         help="Comma-separated GitHub issue numbers for boss-loop scoped dispatch",
     )
     swarm_parser.add_argument(
+        "--audit-ref",
+        default=None,
+        help="For 'swarm audit-issues', run validations from a temporary detached worktree at this git ref (for example: origin/main)",
+    )
+    swarm_parser.add_argument(
         "--max-consecutive-failures",
         type=int,
         default=3,

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1570,7 +1570,7 @@ class TestSwarmCommand:
         assert '"validation_fails_now": 1' in out
         audit_issue.assert_called_once()
 
-    def test_classify_issue_validation_status_detects_invalid_cli_contract(self):
+    def test_classify_issue_validation_status_detects_cli_usage_failure(self):
         status, next_action = _classify_issue_validation_status(
             validation_contract=["aragora quickstart --json"],
             commands=["python3 -m aragora.cli.main quickstart --json"],
@@ -1583,10 +1583,10 @@ class TestSwarmCommand:
                 }
             ],
         )
-        assert status == "invalid_cli_contract"
-        assert "CLI validation command" in next_action
+        assert status == "cli_usage_failure"
+        assert "parser rejects this queued CLI command" in next_action
 
-    def test_classify_issue_validation_status_detects_stale_test_selector(self):
+    def test_classify_issue_validation_status_detects_no_matching_tests_collected(self):
         status, next_action = _classify_issue_validation_status(
             validation_contract=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
             commands=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
@@ -1599,8 +1599,8 @@ class TestSwarmCommand:
                 }
             ],
         )
-        assert status == "stale_test_selector"
-        assert "does not collect any matching tests" in next_action
+        assert status == "no_matching_tests_collected"
+        assert "collects no tests on the current branch" in next_action
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from aragora.cli.commands.swarm import cmd_swarm
+from aragora.cli.commands.swarm import _classify_issue_validation_status, cmd_swarm
 from aragora.swarm.spec import SwarmSpec
 
 
@@ -184,6 +184,27 @@ class TestSwarmParser:
         assert args.swarm_goal == "probe"
         assert args.runner_type == "claude"
         assert args.probe_limit == 2
+        assert args.json is True
+
+    def test_swarm_audit_issues_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "audit-issues",
+                "--boss-repo",
+                "synaptent/aragora",
+                "--label",
+                "boss-ready",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "audit-issues"
+        assert args.boss_repo == "synaptent/aragora"
+        assert args.labels == ["boss-ready"]
         assert args.json is True
 
     def test_swarm_boss_parser_accepts_issue_list(self):
@@ -1496,6 +1517,90 @@ class TestSwarmCommand:
         assert '"failed": 1' in out
         assert '"selected_before": 1' in out
         assert '"selected_after": 0' in out
+
+    def test_cmd_swarm_audit_issues_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="audit-issues",
+            swarm_goal=None,
+            boss_repo="synaptent/aragora",
+            labels=["boss-ready"],
+            boss_label_filter=None,
+            boss_issue_number=None,
+            boss_issue_list=None,
+            json=True,
+        )
+        issue = SimpleNamespace(
+            number=1639,
+            title="Add --json output flag to aragora quickstart CLI",
+            body="Validation: pytest tests/cli/test_quickstart.py -x -q",
+            labels=["boss-ready"],
+            url="https://github.com/synaptent/aragora/issues/1639",
+        )
+
+        with (
+            patch("aragora.swarm.boss_loop.GitHubIssueFeed") as feed_cls,
+            patch(
+                "aragora.cli.commands.swarm._audit_issue_validation_contract",
+                return_value={
+                    "number": 1639,
+                    "title": "Add --json output flag to aragora quickstart CLI",
+                    "url": "https://github.com/synaptent/aragora/issues/1639",
+                    "labels": ["boss-ready"],
+                    "validation_contract": ["pytest tests/cli/test_quickstart.py -x -q"],
+                    "commands": ["pytest tests/cli/test_quickstart.py -x -q"],
+                    "probe_results": [
+                        {
+                            "command": "pytest tests/cli/test_quickstart.py -x -q",
+                            "status": "failed",
+                            "returncode": 1,
+                        }
+                    ],
+                    "status": "validation_fails_now",
+                    "next_action": "Validation still fails on the current branch.",
+                },
+            ) as audit_issue,
+        ):
+            feed_cls.return_value.fetch.return_value = [issue]
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"mode": "swarm-issue-audit"' in out
+        assert '"action": "audit-issues"' in out
+        assert '"issue_count": 1' in out
+        assert '"validation_fails_now": 1' in out
+        audit_issue.assert_called_once()
+
+    def test_classify_issue_validation_status_detects_invalid_cli_contract(self):
+        status, next_action = _classify_issue_validation_status(
+            validation_contract=["aragora quickstart --json"],
+            commands=["python3 -m aragora.cli.main quickstart --json"],
+            probe_results=[
+                {
+                    "command": "python3 -m aragora.cli.main quickstart --json",
+                    "status": "failed",
+                    "returncode": 1,
+                    "stderr": "usage: main.py ... error: unrecognized arguments: --json",
+                }
+            ],
+        )
+        assert status == "invalid_cli_contract"
+        assert "CLI validation command" in next_action
+
+    def test_classify_issue_validation_status_detects_stale_test_selector(self):
+        status, next_action = _classify_issue_validation_status(
+            validation_contract=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
+            commands=["pytest tests/swarm/test_boss_loop.py -k refine -q"],
+            probe_results=[
+                {
+                    "command": "pytest tests/swarm/test_boss_loop.py -k refine -q",
+                    "status": "failed",
+                    "returncode": 5,
+                    "stdout": "82 deselected in 0.44s",
+                }
+            ],
+        )
+        assert status == "stale_test_selector"
+        assert "does not collect any matching tests" in next_action
 
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1620,6 +1620,27 @@ class TestSwarmCommand:
         assert status == "no_matching_tests_collected"
         assert "collects no tests on the current branch" in next_action
 
+    def test_classify_issue_validation_status_detects_unsafe_validation_contract(self):
+        status, next_action = _classify_issue_validation_status(
+            validation_contract=[
+                'aragora quickstart --topic test --rounds 1 --json | python3 -c "import json"'
+            ],
+            commands=[
+                "python3 -m aragora.cli.main quickstart --topic test --rounds 1 --json | "
+                'python3 -c "import json"'
+            ],
+            probe_results=[
+                {
+                    "command": "python3 -m aragora.cli.main quickstart --topic test --rounds 1 --json | "
+                    'python3 -c "import json"',
+                    "status": "unsafe",
+                    "detail": "shell operators are not allowed",
+                }
+            ],
+        )
+        assert status == "unsafe_validation_contract"
+        assert "single direct command" in next_action
+
     def test_cmd_swarm_requires_goal_or_spec(self, capsys):
         args = argparse.Namespace(
             swarm_action_or_goal="run",

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -1882,7 +1882,7 @@ class TestSwarmCommand:
         assert "runs=1 queued=0 leased=0 completed=1" in out
         assert "integrator ready=0 review=0 blocked=1" in out
         assert (
-            "next: Write operator guide: Review the validated lane and decide whether it should merge."
+            "next: Write operator guide: Inspect why the lane produced no concrete deliverable before rerunning it."
             in out
         )
 

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -81,6 +81,7 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "owner_session_id": None,
         "skip_review": False,
         "output": None,
+        "audit_ref": None,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -198,6 +199,8 @@ class TestSwarmParser:
                 "synaptent/aragora",
                 "--label",
                 "boss-ready",
+                "--audit-ref",
+                "origin/main",
                 "--json",
             ]
         )
@@ -205,6 +208,7 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "audit-issues"
         assert args.boss_repo == "synaptent/aragora"
         assert args.labels == ["boss-ready"]
+        assert args.audit_ref == "origin/main"
         assert args.json is True
 
     def test_swarm_boss_parser_accepts_issue_list(self):
@@ -1527,6 +1531,7 @@ class TestSwarmCommand:
             boss_label_filter=None,
             boss_issue_number=None,
             boss_issue_list=None,
+            audit_ref="origin/main",
             json=True,
         )
         issue = SimpleNamespace(
@@ -1539,6 +1544,13 @@ class TestSwarmCommand:
 
         with (
             patch("aragora.swarm.boss_loop.GitHubIssueFeed") as feed_cls,
+            patch(
+                "aragora.cli.commands.swarm._open_audit_checkout",
+                return_value=MagicMock(
+                    __enter__=MagicMock(return_value=Path("/tmp/audit-main")),
+                    __exit__=MagicMock(return_value=False),
+                ),
+            ) as open_checkout,
             patch(
                 "aragora.cli.commands.swarm._audit_issue_validation_contract",
                 return_value={
@@ -1566,9 +1578,15 @@ class TestSwarmCommand:
         out = capsys.readouterr().out
         assert '"mode": "swarm-issue-audit"' in out
         assert '"action": "audit-issues"' in out
+        assert '"audit_ref": "origin/main"' in out
         assert '"issue_count": 1' in out
         assert '"validation_fails_now": 1' in out
+        open_checkout.assert_called_once()
+        _, kwargs = open_checkout.call_args
+        assert kwargs["git_ref"] == "origin/main"
         audit_issue.assert_called_once()
+        _, kwargs = audit_issue.call_args
+        assert kwargs["repo_root"] == Path("/tmp/audit-main")
 
     def test_classify_issue_validation_status_detects_cli_usage_failure(self):
         status, next_action = _classify_issue_validation_status(


### PR DESCRIPTION
## Summary\n- add a  command that probes queued issue validation contracts\n- support auditing against a detached git ref\n- align the stale status-output test with current integrator messaging\n\n## Testing\n- python3 -m pytest tests/cli/test_swarm_command.py -q\n- python3 -m ruff check aragora/cli/commands/swarm.py aragora/cli/parser.py tests/cli/test_swarm_command.py