### PR TITLE
fix(swarm): reject unsafe queue validation commands

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -22,7 +22,6 @@ from datetime import datetime, timezone
 import json
 import os
 from pathlib import Path
-import shlex
 import subprocess
 import sys
 import tempfile
@@ -104,26 +103,14 @@ def _trim_command_output(text: str, *, limit: int = 240) -> str | None:
     return normalized[: limit - 3] + "..."
 
 
-_UNSAFE_VALIDATION_SHELL_FRAGMENTS = (
-    "|",
-    "&&",
-    "||",
-    ";",
-    "<",
-    ">",
-    "$(",
-    "`",
-    "\n",
-    "\r",
-)
-
-
 def _probe_validation_command(
     command: str,
     *,
     repo_root: Path,
     timeout_seconds: float,
 ) -> dict[str, object]:
+    from aragora.swarm.boss_loop import split_pre_dispatch_validation_command
+
     normalized = str(command or "").strip()
     if not normalized:
         return {
@@ -131,29 +118,13 @@ def _probe_validation_command(
             "status": "unsafe",
             "detail": "empty validation command",
         }
-    for fragment in _UNSAFE_VALIDATION_SHELL_FRAGMENTS:
-        if fragment in normalized:
-            return {
-                "command": command,
-                "status": "unsafe",
-                "detail": (
-                    "shell operators are not allowed in auto-probed validation commands; "
-                    "use a single direct command instead"
-                ),
-            }
     try:
-        argv = shlex.split(normalized, posix=True)
+        argv = split_pre_dispatch_validation_command(normalized)
     except ValueError as exc:
         return {
             "command": command,
             "status": "unsafe",
-            "detail": f"invalid shell quoting: {exc}",
-        }
-    if not argv:
-        return {
-            "command": command,
-            "status": "unsafe",
-            "detail": "empty validation command",
+            "detail": str(exc),
         }
     try:
         proc = subprocess.run(

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import shlex
 import subprocess
 import time
 import uuid
@@ -330,6 +331,18 @@ _PRE_DISPATCH_SAFE_COMMAND_PREFIXES = (
     "python3 -m aragora",
 )
 _BACKTICK_COMMAND_RE = re.compile(r"`(?P<command>[^`]+)`")
+_UNSAFE_PRE_DISPATCH_SHELL_FRAGMENTS = (
+    "|",
+    "&&",
+    "||",
+    ";",
+    "<",
+    ">",
+    "$(",
+    "`",
+    "\n",
+    "\r",
+)
 
 
 def _ordered_unique_strings(items: list[str]) -> list[str]:
@@ -425,8 +438,28 @@ def _normalize_pre_dispatch_command(text: str) -> str:
     return normalized
 
 
+def split_pre_dispatch_validation_command(command: str) -> list[str]:
+    """Split a pre-dispatch validation command into argv after safety checks."""
+    normalized = str(command or "").strip()
+    if not normalized:
+        raise ValueError("empty validation command")
+    for fragment in _UNSAFE_PRE_DISPATCH_SHELL_FRAGMENTS:
+        if fragment in normalized:
+            raise ValueError(
+                "shell operators are not allowed in pre-dispatch validation commands; "
+                "use a single direct command instead"
+            )
+    try:
+        argv = shlex.split(normalized, posix=True)
+    except ValueError as exc:
+        raise ValueError(f"invalid shell quoting: {exc}") from exc
+    if not argv:
+        raise ValueError("empty validation command")
+    return argv
+
+
 def extract_pre_dispatch_validation_commands(issue_body: str) -> list[str]:
-    """Return explicit validation commands that are safe to probe before dispatch."""
+    """Return explicit validation commands declared in the issue body."""
     commands: list[str] = []
     for item in extract_issue_validation_contract(issue_body):
         normalized = _normalize_pre_dispatch_command(item)
@@ -448,8 +481,19 @@ def run_pre_dispatch_validation_commands(
     timeout = max(1, int(timeout_seconds))
     for command in commands:
         try:
+            argv = split_pre_dispatch_validation_command(command)
+        except ValueError as exc:
+            results.append(
+                {
+                    "command": command,
+                    "status": "unsafe",
+                    "detail": str(exc),
+                }
+            )
+            return {"satisfied": False, "results": results}
+        try:
             proc = subprocess.run(
-                ["/bin/bash", "-lc", command],
+                argv,
                 cwd=str(cwd),
                 text=True,
                 capture_output=True,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -267,9 +267,32 @@ Acceptance Criteria:
             timeout_seconds=15,
         )
 
-        assert calls == [["/bin/bash", "-lc", "python -m pytest tests/swarm/test_boss_loop.py -q"]]
+        assert calls == [["python", "-m", "pytest", "tests/swarm/test_boss_loop.py", "-q"]]
         assert result["satisfied"] is False
         assert result["results"][0]["status"] == "failed"
+
+    def test_run_pre_dispatch_validation_commands_rejects_shell_operators(
+        self, monkeypatch, tmp_path: Path
+    ):
+        calls: list[object] = []
+
+        def _run(cmd, **kwargs):
+            calls.append(cmd)
+            raise AssertionError("unsafe command should not be executed")
+
+        monkeypatch.setattr("aragora.swarm.boss_loop.subprocess.run", _run)
+        marker = tmp_path / "injected.txt"
+        result = run_pre_dispatch_validation_commands(
+            [f"python -m pytest tests/swarm/test_boss_loop.py -q; echo injected > {marker}"],
+            cwd=tmp_path,
+            timeout_seconds=15,
+        )
+
+        assert calls == []
+        assert result["satisfied"] is False
+        assert result["results"][0]["status"] == "unsafe"
+        assert "shell operators are not allowed" in result["results"][0]["detail"]
+        assert not marker.exists()
 
     def test_requires_labels_when_specified(self):
         issues = [


### PR DESCRIPTION
## Summary
- reject unsafe shell operators in pre-dispatch validation commands
- reuse one command-splitting safety path from boss loop and CLI probing
- add regression coverage so unsafe commands are marked unsafe instead of executed

## Test plan
- python3 -m pytest tests/swarm/test_boss_loop.py -q -k validation_command
- python3 -m ruff check aragora/cli/commands/swarm.py aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py