### PR TITLE
fix(live): use real control-plane panels for verticals tab

### DIFF
--- a/aragora/live/src/app/(app)/control-plane/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(app)/control-plane/__tests__/page.test.tsx
@@ -89,8 +89,8 @@ jest.mock('@/components/control-plane', () => ({
   SystemHealthDashboard: () => <div data-testid="system-health-dashboard">System Health</div>,
 }));
 
-// Mock verticals components
-jest.mock('@/components/verticals', () => ({
+// Mock vertical selector
+jest.mock('@/components/VerticalSelector', () => ({
   VerticalSelector: ({
     apiBase: _apiBase,
     selectedVertical: _selectedVertical,
@@ -104,10 +104,6 @@ jest.mock('@/components/verticals', () => ({
   }) => (
     <div data-testid="vertical-selector">Vertical Selector</div>
   ),
-  KnowledgeExplorer: ({ selectedVertical: _selectedVertical }: { selectedVertical?: string }) => (
-    <div data-testid="vertical-knowledge-explorer">Vertical Knowledge Explorer</div>
-  ),
-  ExecutionMonitor: () => <div data-testid="vertical-execution-monitor">Vertical Execution Monitor</div>,
 }));
 
 // Mock fetch globally

--- a/aragora/live/src/app/(app)/control-plane/__tests__/page.test.tsx
+++ b/aragora/live/src/app/(app)/control-plane/__tests__/page.test.tsx
@@ -91,7 +91,17 @@ jest.mock('@/components/control-plane', () => ({
 
 // Mock verticals components
 jest.mock('@/components/verticals', () => ({
-  VerticalSelector: ({ selectedVertical: _selectedVertical, onSelect: _onSelect, verticals: _verticals }: { selectedVertical?: string; onSelect: () => void; verticals: unknown[] }) => (
+  VerticalSelector: ({
+    apiBase: _apiBase,
+    selectedVertical: _selectedVertical,
+    onVerticalChange: _onVerticalChange,
+    compact: _compact,
+  }: {
+    apiBase: string;
+    selectedVertical: string;
+    onVerticalChange: (verticalId: string) => void;
+    compact?: boolean;
+  }) => (
     <div data-testid="vertical-selector">Vertical Selector</div>
   ),
   KnowledgeExplorer: ({ selectedVertical: _selectedVertical }: { selectedVertical?: string }) => (
@@ -482,6 +492,10 @@ describe('ControlPlanePage', () => {
       });
 
       expect(screen.getByTestId('vertical-selector')).toBeInTheDocument();
+      expect(screen.getByTestId('knowledge-explorer')).toBeInTheDocument();
+      expect(screen.getByTestId('execution-monitor')).toBeInTheDocument();
+      expect(screen.queryByTestId('vertical-knowledge-explorer')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('vertical-execution-monitor')).not.toBeInTheDocument();
     });
 
     it('switches to policy tab', async () => {

--- a/aragora/live/src/app/(app)/control-plane/page.tsx
+++ b/aragora/live/src/app/(app)/control-plane/page.tsx
@@ -41,10 +41,7 @@ import {
   type Deliberation,
 } from '@/components/control-plane';
 
-// Verticals Components
-import {
-  VerticalSelector,
-} from '@/components/verticals';
+import { VerticalSelector } from '@/components/VerticalSelector';
 
 export default function ControlPlanePage() {
   const { config: backendConfig } = useBackend();

--- a/aragora/live/src/app/(app)/control-plane/page.tsx
+++ b/aragora/live/src/app/(app)/control-plane/page.tsx
@@ -44,8 +44,6 @@ import {
 // Verticals Components
 import {
   VerticalSelector,
-  KnowledgeExplorer as VerticalKnowledgeExplorer,
-  ExecutionMonitor as VerticalExecutionMonitor,
 } from '@/components/verticals';
 
 export default function ControlPlanePage() {
@@ -885,28 +883,42 @@ export default function ControlPlanePage() {
                 {activeTab === 'verticals' && (
                   <div className="space-y-6">
                     <VerticalSelector
-                      selectedVertical={selectedVertical || undefined}
-                      onSelect={(vertical) => setSelectedVertical(vertical.id)}
-                      verticals={verticalsData.map(v => ({
-                        id: v.vertical_id,
-                        displayName: v.display_name,
-                        description: v.description,
-                        expertiseAreas: v.expertise_areas || [],
-                        complianceFrameworks: v.compliance_frameworks || [],
-                        defaultModel: v.default_model || 'claude-sonnet-4',
-                        icon: v.vertical_id === 'software' ? '💻' :
-                              v.vertical_id === 'legal' ? '⚖️' :
-                              v.vertical_id === 'healthcare' ? '🏥' :
-                              v.vertical_id === 'accounting' ? '📊' :
-                              v.vertical_id === 'research' ? '🔬' : '📋',
-                      }))}
+                      apiBase={backendConfig.api}
+                      selectedVertical={selectedVertical || 'general'}
+                      onVerticalChange={setSelectedVertical}
+                      compact
                     />
+                    <div className="card p-3 flex flex-col gap-2 text-xs font-mono text-text-muted lg:flex-row lg:items-center lg:justify-between">
+                      <span>
+                        {verticalsData.length > 0
+                          ? `${verticalsData.length} live vertical profiles available from /api/verticals`
+                          : 'Using built-in vertical presets while backend vertical metadata is unavailable'}
+                      </span>
+                      <span>
+                        Focus:{' '}
+                        <span className="text-acid-green">
+                          {(selectedVertical || 'general').toUpperCase()}
+                        </span>
+                      </span>
+                    </div>
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                      <div className="h-[400px]">
-                        <VerticalKnowledgeExplorer selectedVertical={selectedVertical || undefined} />
+                      <div className="h-[500px]">
+                        <KnowledgeExplorer
+                          onSelectNode={(_node) => {
+                            // Vertical knowledge selection handler
+                          }}
+                          height={500}
+                          showStats={false}
+                          className="h-full"
+                        />
                       </div>
-                      <div className="h-[400px]">
-                        <VerticalExecutionMonitor />
+                      <div className="h-[500px]">
+                        <ExecutionMonitor
+                          onSelectExecution={(_execution) => {
+                            // Vertical execution selection handler
+                          }}
+                          className="h-full"
+                        />
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- use the real control-plane knowledge and execution panels on the verticals tab
- keep the vertical selector wired to the backend API contract instead of old mocked props
- tighten the page test to assert the real panels are rendered

## Test plan
- cd aragora/live && npx jest --ci --runTestsByPath "src/app/(app)/control-plane/__tests__/page.test.tsx"
- cd aragora/live && npx eslint "src/app/(app)/control-plane/page.tsx" "src/app/(app)/control-plane/__tests__/page.test.tsx"