### PR TITLE
fix(agents): honor YAML fallback chain order

### DIFF
--- a/aragora/agents/config_loader.py
+++ b/aragora/agents/config_loader.py
@@ -373,9 +373,10 @@ class AgentConfigLoader:
         if hasattr(agent, "stance"):
             agent.stance = config.stance
 
-        # Store config reference for later access
-        if hasattr(agent, "_config"):
-            agent._config = config
+        # Store config reference for later access. Some registry-created agents do
+        # not predefine ``_config``, but they still need access to YAML fallback
+        # metadata at runtime.
+        agent._config = config
 
         logger.debug("Created agent from config: %s", config.name)
         return agent

--- a/aragora/agents/fallback.py
+++ b/aragora/agents/fallback.py
@@ -380,13 +380,53 @@ class QuotaFallbackMixin:
         ("MISTRAL_API_KEY", "mistral"),
         ("XAI_API_KEY", "grok"),
     ]
+    _PROVIDER_ENV_BY_KEY = {provider_key: env_var for env_var, provider_key in _PROVIDER_ENV_KEYS}
+    _PROVIDER_ALIASES = {
+        "anthropic": "anthropic",
+        "anthropic-api": "anthropic",
+        "claude": "anthropic",
+        "gemini": "gemini",
+        "gemini-cli": "gemini",
+        "grok": "grok",
+        "grok-cli": "grok",
+        "mistral": "mistral",
+        "mistral-api": "mistral",
+        "codestral": "mistral",
+        "openai": "openai",
+        "openai-api": "openai",
+        "openrouter": "openrouter",
+        "xai": "grok",
+    }
+
+    def _normalize_fallback_provider_key(self, provider_name: str) -> str | None:
+        """Map config/provider aliases onto the runtime fallback provider keys."""
+        normalized = provider_name.strip().lower()
+        if not normalized:
+            return None
+        return self._PROVIDER_ALIASES.get(normalized, normalized)
+
+    def _get_configured_fallback_order(self) -> list[str]:
+        """Return normalized providers requested by agent config, preserving order."""
+        configured_chain = getattr(getattr(self, "_config", None), "fallback_chain", None)
+        if configured_chain is None:
+            configured_chain = getattr(self, "fallback_chain", None)
+
+        ordered: list[str] = []
+        for provider_name in configured_chain or []:
+            provider_key = self._normalize_fallback_provider_key(str(provider_name))
+            if provider_key not in self._PROVIDER_ENV_BY_KEY or provider_key in ordered:
+                continue
+            ordered.append(provider_key)
+        return ordered
 
     def _get_available_fallback_providers(self) -> list[tuple[str, Any]]:
         """Build an ordered list of ``(provider_name, agent)`` pairs for fallback.
 
         Skips the provider that ``self`` belongs to (no point falling back to
-        itself). OpenRouter is always tried first when available.
-        Returns only providers whose API keys are set in the environment.
+        itself). When the agent was created from YAML config, its declared
+        ``fallback_chain`` is preferred first and any remaining default providers
+        are appended afterwards. Returns only providers whose API keys are set in
+        the environment.
         """
         own_provider = self._derive_provider_name()
         name = getattr(self, "name", "fallback")
@@ -395,12 +435,19 @@ class QuotaFallbackMixin:
         system_prompt = getattr(self, "system_prompt", None)
 
         providers: list[tuple[str, Any]] = []
+        configured_order = self._get_configured_fallback_order()
+        ordered_provider_keys = configured_order + [
+            provider_key
+            for _, provider_key in self._PROVIDER_ENV_KEYS
+            if provider_key not in configured_order
+        ]
 
-        for env_var, provider_key in self._PROVIDER_ENV_KEYS:
+        for provider_key in ordered_provider_keys:
             # Skip self
             if provider_key == own_provider:
                 continue
 
+            env_var = self._PROVIDER_ENV_BY_KEY[provider_key]
             api_key = os.environ.get(env_var)
             if not api_key:
                 continue

--- a/tests/agents/test_config_loader.py
+++ b/tests/agents/test_config_loader.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -882,6 +883,24 @@ class TestAgentConfigLoaderAgentCreation:
         agent = loader.create_agent(config)
 
         agent.set_system_prompt.assert_called_once_with("You are helpful.")
+
+    def test_create_agent_attaches_config_even_without_existing_attr(self, mock_registry):
+        """create_agent preserves YAML config metadata on plain agent objects."""
+        from aragora.agents.config_loader import AgentConfig, AgentConfigLoader
+
+        bare_agent = SimpleNamespace(name="test")
+        mock_registry.create.return_value = bare_agent
+
+        loader = AgentConfigLoader(registry=mock_registry)
+        config = AgentConfig(
+            name="test",
+            model_type="anthropic-api",
+            fallback_chain=["openai-api", "gemini"],
+        )
+
+        agent = loader.create_agent(config)
+
+        assert agent._config is config
 
     def test_create_agents_all(self, temp_config_dir, mock_registry):
         """create_agents creates all loaded agents when no list provided."""

--- a/tests/test_fallback_chain.py
+++ b/tests/test_fallback_chain.py
@@ -524,6 +524,50 @@ class TestQuotaFallbackMixin:
                 # Both should be the same instance
                 assert result1 is result2
 
+    def test_configured_fallback_chain_reorders_available_providers(self):
+        """Configured fallback_chain should be preferred before default providers."""
+        from aragora.agents.config_loader import AgentConfig
+        from aragora.agents.fallback import QuotaFallbackMixin
+        from unittest.mock import patch
+
+        class TestAgent(QuotaFallbackMixin):
+            name = "primary"
+            role = "proposer"
+            timeout = 60
+
+            def __init__(self):
+                self._config = AgentConfig(
+                    name="configured-agent",
+                    model_type="anthropic-api",
+                    fallback_chain=["gemini", "openai-api"],
+                )
+
+        agent = TestAgent()
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "OPENROUTER_API_KEY": "router-key",
+                    "OPENAI_API_KEY": "openai-key",
+                    "GEMINI_API_KEY": "gemini-key",
+                },
+                clear=True,
+            ),
+            patch.object(
+                TestAgent,
+                "_create_fallback_agent",
+                side_effect=lambda provider_key, *args: provider_key,
+            ),
+        ):
+            providers = agent._get_available_fallback_providers()
+
+        assert [provider_name for provider_name, _ in providers] == [
+            "gemini",
+            "openai",
+            "openrouter",
+        ]
+
 
 class TestBuildFallbackChainWithLocal:
     """Tests for build_fallback_chain_with_local function."""


### PR DESCRIPTION
## Summary
- preserve YAML-loaded agent configs on registry-created agents so fallback metadata survives construction
- normalize configured provider aliases and prefer the declared fallback_chain order before appending remaining available providers
- add regressions for config attachment and fallback ordering

## Validation
- ARAGORA_USE_SECRETS_MANAGER=0 python3 -m pytest tests/agents/test_config_loader.py tests/test_fallback_chain.py -q
- python3 -m ruff check aragora/agents/config_loader.py aragora/agents/fallback.py tests/agents/test_config_loader.py tests/test_fallback_chain.py