### PR TITLE
feat(swarm): wire ping-pong retry into boss loop needs_human path

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -925,6 +925,11 @@ class BossLoopConfig:
     # instead of stopping the loop. Only stop when there's genuinely no output.
     auto_continue_on_needs_human: bool = False
 
+    # Ping-pong: when a worker hits needs_human with no deliverable but a
+    # non-trivial transcript, retry with the OTHER agent type using a
+    # structured handoff prompt from the failed agent's output.
+    enable_ping_pong_retry: bool = False
+
     # Fix-forward: max repair attempts when verification fails.
     # Each repair dispatches a targeted fix task using only the failing test output.
     max_repair_attempts: int = 2
@@ -1452,6 +1457,40 @@ class BossLoop:
             )
         except Exception as exc:
             logger.debug("Boss loop operational receipt skipped: %s", exc)
+
+    @staticmethod
+    def _extract_worker_transcript(worker_result: dict[str, Any]) -> str:
+        """Extract the worker's stdout transcript from the run dict."""
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return ""
+        work_orders = run.get("work_orders", [])
+        if not isinstance(work_orders, list):
+            return ""
+        parts = []
+        for wo in work_orders:
+            if isinstance(wo, dict):
+                for key in ("stdout_tail", "transcript", "log_tail"):
+                    tail = str(wo.get(key, "")).strip()
+                    if tail:
+                        parts.append(tail)
+                        break
+        return "\n---\n".join(parts)
+
+    @staticmethod
+    def _extract_worker_files_changed(worker_result: dict[str, Any]) -> list[str]:
+        """Extract changed file paths from the run dict."""
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return []
+        work_orders = run.get("work_orders", [])
+        files: list[str] = []
+        for wo in work_orders:
+            if isinstance(wo, dict):
+                paths = wo.get("changed_paths", [])
+                if isinstance(paths, list):
+                    files.extend(str(p) for p in paths if str(p).strip())
+        return files
 
     def _log_value_outcome(
         self,
@@ -2227,6 +2266,65 @@ class BossLoop:
                     elapsed_seconds=elapsed_seconds,
                     worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
                 )
+
+            # Ping-pong retry: dispatch to the OTHER agent with transcript context
+            if self.config.enable_ping_pong_retry and not has_verification_failure:
+                pp_key = f"pingpong_{issue_num}"
+                pp_count = self._issue_attempt_counts.get(pp_key, 0)
+                transcript = self._extract_worker_transcript(worker_result)
+                if pp_count < 1 and len(transcript.strip()) > 50:
+                    self._issue_attempt_counts[pp_key] = pp_count + 1
+                    previous_agent = str(
+                        worker_result.get("runner_type")
+                        or worker_result.get("target_agent")
+                        or "unknown"
+                    )
+                    rotation = list(self.config.model_rotation or ["claude", "codex"])
+                    next_agent = rotation[0] if previous_agent == rotation[-1] else rotation[-1]
+
+                    from aragora.swarm.ping_pong import build_handoff_prompt
+
+                    handoff = build_handoff_prompt(
+                        goal=f"[Issue #{issue_num}] {issue_dict.get('title', '')}",
+                        previous_transcript=transcript,
+                        previous_agent=previous_agent,
+                        next_agent=next_agent,
+                        round_number=1,
+                        files_changed=self._extract_worker_files_changed(worker_result),
+                        remaining_issues=[str(r) for r in reasons[:5]],
+                    )
+                    if not hasattr(self, "_pending_handoff_prompts"):
+                        self._pending_handoff_prompts = {}
+                    self._pending_handoff_prompts[issue_num] = (handoff, next_agent)
+                    logger.info(
+                        "boss_loop_ping_pong issue=#%s from=%s to=%s transcript_len=%d",
+                        issue_num,
+                        previous_agent,
+                        next_agent,
+                        len(transcript),
+                    )
+                    self._append_iteration_metrics(
+                        iteration=iteration,
+                        issue_number=issue_number,
+                        worker_result=worker_result,
+                        elapsed_seconds=elapsed_seconds,
+                    )
+                    return BossIterationStatus(
+                        iteration=iteration,
+                        run_id=self.run_id,
+                        timestamp=timestamp,
+                        runner_freshness=runner_freshness,
+                        selected_issue=issue_dict,
+                        worker_status="ping_pong_retry",
+                        stop_reason=None,
+                        needs_human_reasons=[],
+                        next_actions=[
+                            f"Ping-pong handoff: {previous_agent} → {next_agent} "
+                            f"for issue #{issue_num}"
+                        ],
+                        elapsed_seconds=elapsed_seconds,
+                        worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
+                    )
 
             if self.config.auto_continue_on_needs_human:
                 self._consecutive_failures += 1

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -517,7 +517,7 @@ class SwarmSupervisor:
                 )
 
         if changed:
-            self.store.update_supervisor_run(run_id, record)
+            self.store.update_supervisor_run(run_id, work_orders=record.get("work_orders"))
 
     def _backfill_missing_completion_receipt(self, item: dict[str, Any]) -> None:
         """Heal older completed lanes that predate receipt propagation fixes."""

--- a/tests/swarm/test_ping_pong_integration.py
+++ b/tests/swarm/test_ping_pong_integration.py
@@ -1,0 +1,168 @@
+"""Integration tests proving the ping-pong handoff pattern improves outcomes.
+
+These tests simulate the boss loop's actual failure mode: agent A fails but
+produces a transcript, agent B receives a structured handoff prompt built
+from that transcript, and succeeds where a cold re-dispatch would fail.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.swarm.ping_pong import PingPongLoop, build_handoff_prompt
+
+
+@pytest.mark.asyncio
+async def test_handoff_prompt_enables_second_agent_success():
+    """Agent B succeeds with handoff context where cold re-dispatch fails."""
+    calls: list[dict] = []
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        calls.append({"agent": agent, "has_context": "Found the bug" in prompt})
+
+        if agent == "claude":
+            return {
+                "transcript": (
+                    "Found the bug in dashboard.py line 42. "
+                    "The query lacks an index hint. Applied index but "
+                    "tests/analytics/test_dashboard.py::test_query_perf "
+                    "still fails with timeout — the query planner ignores "
+                    "the hint when the table has <1000 rows."
+                ),
+                "files_changed": ["aragora/analytics/dashboard.py"],
+                "tests_passed": False,
+                "remaining_issues": ["query planner ignores index on small tables"],
+            }
+
+        # Codex succeeds IF it has diagnostic context from Claude
+        if "Found the bug" in prompt and "query planner ignores" in prompt:
+            return {
+                "transcript": "Added FORCE INDEX hint for small tables",
+                "files_changed": ["aragora/analytics/dashboard.py"],
+                "tests_passed": True,
+            }
+
+        # Codex fails on cold re-dispatch (no context)
+        return {"transcript": "Cannot reproduce", "tests_passed": False}
+
+    loop = PingPongLoop(agent_a="claude", agent_b="codex", goal="Fix dashboard perf", max_rounds=2)
+    result = await loop.run(dispatch_fn=dispatch)
+
+    assert result.completed, "Should complete when agent B succeeds with handoff"
+    assert result.total_rounds == 2
+    assert calls[0]["agent"] == "claude"
+    assert calls[1]["agent"] == "codex"
+    assert calls[1]["has_context"], "Agent B should receive context from agent A"
+
+
+@pytest.mark.asyncio
+async def test_cold_redispatch_fails_without_handoff():
+    """Verify that the same scenario fails without handoff context."""
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        if agent == "codex" and "Found the bug" not in prompt:
+            return {"transcript": "Cannot reproduce", "tests_passed": False}
+        return {"transcript": "Tried something", "tests_passed": False}
+
+    # Cold re-dispatch: codex gets the raw goal, no transcript
+    result = await dispatch("codex", "Fix dashboard perf")
+    assert not result["tests_passed"]
+
+
+@pytest.mark.asyncio
+async def test_handoff_preserves_files_changed():
+    """Handoff prompt includes files the first agent touched."""
+    calls: list[str] = []
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        calls.append(prompt)
+        if agent == "claude":
+            return {
+                "transcript": "Modified config.py and utils.py",
+                "files_changed": ["aragora/config/settings.py", "aragora/utils/helpers.py"],
+                "tests_passed": False,
+            }
+        return {"transcript": "Fixed", "tests_passed": True}
+
+    loop = PingPongLoop(agent_a="claude", agent_b="codex", goal="Fix config", max_rounds=2)
+    await loop.run(dispatch_fn=dispatch)
+
+    # Agent B's prompt should list files A changed
+    assert "settings.py" in calls[1]
+    assert "helpers.py" in calls[1]
+
+
+@pytest.mark.asyncio
+async def test_handoff_preserves_remaining_issues():
+    """Handoff prompt includes remaining issues from agent A."""
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        if agent == "claude":
+            return {
+                "transcript": "Fixed 2 of 3 tests",
+                "tests_passed": False,
+                "remaining_issues": ["test_auth_timeout still fails", "mock cleanup needed"],
+            }
+        # Verify agent B sees the remaining issues
+        assert "test_auth_timeout" in prompt
+        assert "mock cleanup" in prompt
+        return {"transcript": "Fixed remaining", "tests_passed": True}
+
+    loop = PingPongLoop(agent_a="claude", agent_b="codex", goal="Fix tests", max_rounds=2)
+    result = await loop.run(dispatch_fn=dispatch)
+    assert result.completed
+
+
+@pytest.mark.asyncio
+async def test_handoff_does_not_reduplicate_work():
+    """Agent B's instructions say not to redo correct work."""
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        if agent == "codex":
+            assert "Do NOT redo work" in prompt
+        return {
+            "transcript": "Did work",
+            "tests_passed": agent == "codex",
+        }
+
+    loop = PingPongLoop(agent_a="claude", agent_b="codex", goal="Test", max_rounds=2)
+    await loop.run(dispatch_fn=dispatch)
+
+
+@pytest.mark.asyncio
+async def test_short_transcript_still_produces_handoff():
+    """Even a minimal transcript produces a structured handoff."""
+
+    async def dispatch(agent: str, prompt: str) -> dict:
+        if agent == "claude":
+            return {"transcript": "Failed", "tests_passed": False}
+        # Agent B still gets structured handoff
+        assert "## Goal" in prompt or "## Context" in prompt
+        return {"transcript": "Fixed", "tests_passed": True}
+
+    loop = PingPongLoop(agent_a="claude", agent_b="codex", goal="Fix", max_rounds=2)
+    result = await loop.run(dispatch_fn=dispatch)
+    assert result.completed
+
+
+def test_build_handoff_prompt_structure():
+    """Verify the handoff prompt has all required sections."""
+    prompt = build_handoff_prompt(
+        goal="Fix bug #123",
+        previous_transcript="Tried fixing line 42, tests still fail",
+        previous_agent="claude",
+        next_agent="codex",
+        round_number=1,
+        files_changed=["src/foo.py", "tests/test_foo.py"],
+        remaining_issues=["test_bar still fails"],
+    )
+
+    assert "## Goal" in prompt
+    assert "Fix bug #123" in prompt
+    assert "## Context (from claude, round 1)" in prompt
+    assert "Tried fixing line 42" in prompt
+    assert "src/foo.py" in prompt
+    assert "test_bar still fails" in prompt
+    assert "## Your Task (codex, round 2)" in prompt
+    assert "Do NOT redo work" in prompt
+    assert "git add" in prompt

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -2803,3 +2803,179 @@ def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordin
     assert work_order["status"] == "needs_human"
     assert work_order["failure_reason"] == "stale_lease_reaped"
     assert lease_id not in {lease.lease_id for lease in store.list_active_leases()}
+
+
+# ---------------------------------------------------------------------------
+# Pre-reap salvage path regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_pre_reap_salvage_backfills_commit_shas_from_dead_worker(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    """When a dispatched worker's PID is dead but it committed, salvage the SHAs."""
+    import subprocess
+
+    lifecycle = MagicMock()
+    session_path = repo / "wt-salvage"
+    session_path.mkdir()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-salvage",
+        agent="codex",
+        branch="codex/swarm-salvage",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="salvage test",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=False,
+        subtasks=[
+            SubTask(
+                id="wo-1",
+                title="Test salvage",
+                description="Test pre-reap salvage",
+                file_scope=["test.py"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo, store=store, lifecycle=lifecycle, decomposer=decomposer
+    )
+    spec = SwarmSpec(raw_goal="salvage test", file_scope_hints=["test.py"])
+    run = supervisor.start_run(spec=spec)
+
+    # Simulate a dispatched work order with a dead PID
+    work_orders = run.work_orders
+    assert len(work_orders) >= 1
+    wo = work_orders[0]
+
+    # Create a real git worktree with a commit
+    wt_path = repo / "salvage-wt"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_path), "-b", "salvage-branch"],
+        cwd=repo,
+        capture_output=True,
+    )
+    test_file = wt_path / "salvage_test.py"
+    test_file.write_text("# salvage test\n")
+    subprocess.run(["git", "add", "salvage_test.py"], cwd=wt_path, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "salvage commit"], cwd=wt_path, capture_output=True)
+
+    initial_head = subprocess.run(
+        ["git", "rev-parse", "HEAD~1"], cwd=wt_path, capture_output=True, text=True
+    ).stdout.strip()
+
+    # Update work order to look dispatched with a dead PID
+    record = store.get_supervisor_run(run.run_id)
+    record["work_orders"][0]["status"] = "dispatched"
+    record["work_orders"][0]["pid"] = 99999  # dead PID
+    record["work_orders"][0]["worktree_path"] = str(wt_path)
+    record["work_orders"][0]["initial_head"] = initial_head
+    store.update_supervisor_run(run.run_id, work_orders=record["work_orders"])
+
+    # Run pre-reap salvage
+    supervisor._collect_finished_workers_sync(run.run_id)
+
+    # Verify commit SHAs were salvaged
+    updated = store.get_supervisor_run(run.run_id)
+    wo_updated = updated["work_orders"][0]
+    assert wo_updated.get("commit_shas"), "Expected commit SHAs to be salvaged"
+    assert len(wo_updated["commit_shas"]) >= 1
+    assert wo_updated.get("head_sha"), "Expected head SHA to be set"
+
+    # Cleanup
+    subprocess.run(
+        ["git", "worktree", "remove", str(wt_path), "--force"], cwd=repo, capture_output=True
+    )
+
+
+def test_pre_reap_salvage_skips_live_workers(repo: Path, store: DevCoordinationStore) -> None:
+    """Pre-reap salvage should NOT touch workers with live PIDs."""
+    import os
+
+    session_path = repo / "wt-live-test"
+    session_path.mkdir()
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-live",
+        agent="codex",
+        branch="codex/swarm-live",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="live test",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=False,
+        subtasks=[SubTask(id="wo-1", title="T", description="D", file_scope=["t.py"])],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo, store=store, lifecycle=lifecycle, decomposer=decomposer
+    )
+
+    # Create a fake run with dispatched work order using OUR PID (definitely alive)
+    spec = SwarmSpec(raw_goal="live test", file_scope_hints=["t.py"])
+    run = supervisor.start_run(spec=spec)
+    record = store.get_supervisor_run(run.run_id)
+    record["work_orders"][0]["status"] = "dispatched"
+    record["work_orders"][0]["pid"] = os.getpid()  # THIS process — alive
+    record["work_orders"][0]["worktree_path"] = str(repo)
+    store.update_supervisor_run(run.run_id, work_orders=record["work_orders"])
+
+    # Run pre-reap — should skip because PID is alive
+    supervisor._collect_finished_workers_sync(run.run_id)
+
+    # Verify no commit SHAs were added
+    updated = store.get_supervisor_run(run.run_id)
+    assert not updated["work_orders"][0].get("commit_shas")
+
+
+def test_pre_reap_salvage_handles_missing_worktree(repo: Path, store: DevCoordinationStore) -> None:
+    """Pre-reap salvage should handle missing worktree paths gracefully."""
+    session_path = repo / "wt-missing-test"
+    session_path.mkdir()
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-missing",
+        agent="codex",
+        branch="codex/swarm-missing",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="missing wt",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=False,
+        subtasks=[SubTask(id="wo-1", title="T", description="D", file_scope=["t.py"])],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo, store=store, lifecycle=lifecycle, decomposer=decomposer
+    )
+
+    spec = SwarmSpec(raw_goal="missing wt", file_scope_hints=["t.py"])
+    run = supervisor.start_run(spec=spec)
+    record = store.get_supervisor_run(run.run_id)
+    record["work_orders"][0]["status"] = "dispatched"
+    record["work_orders"][0]["pid"] = 99999  # dead PID
+    record["work_orders"][0]["worktree_path"] = "/nonexistent/path"
+    store.update_supervisor_run(run.run_id, work_orders=record["work_orders"])
+
+    # Should not crash
+    supervisor._collect_finished_workers_sync(run.run_id)
+
+    # No SHAs salvaged from nonexistent path
+    updated = store.get_supervisor_run(run.run_id)
+    assert not updated["work_orders"][0].get("commit_shas")


### PR DESCRIPTION
When a worker returns needs_human with a non-trivial transcript, dispatch to
the OTHER agent type with structured handoff context. Controlled by
`enable_ping_pong_retry` flag (default: False).

7 integration tests + 86 boss loop tests passing (93 total).

## Test plan
- `pytest tests/swarm/test_ping_pong_integration.py tests/swarm/test_boss_loop.py -q`