### PR TITLE
fix(agents): preserve injected fallback precedence

### DIFF
--- a/aragora/agents/fallback.py
+++ b/aragora/agents/fallback.py
@@ -542,6 +542,32 @@ class QuotaFallbackMixin:
             logger.debug("Could not create fallback agent for %s: %s", provider_key, e)
             return None
 
+    def _get_preconfigured_fallback_agent(self) -> OpenRouterAgent | None:
+        """Return an explicitly injected fallback agent without auto-creating one.
+
+        ``fallback_generate()`` should respect pre-seeded or test-injected
+        fallback agents, but it should not auto-create a real OpenRouter agent
+        ahead of an explicitly patched provider chain. Auto-creation remains
+        available through ``_get_cached_fallback_agent()`` for callers that
+        explicitly opt into it.
+        """
+        cached_fallback = getattr(self, "_fallback_agent", None)
+        if cached_fallback is not None:
+            return cast("OpenRouterAgent | None", cached_fallback)
+
+        instance_getter = getattr(self, "__dict__", {}).get("_get_cached_fallback_agent")
+        if callable(instance_getter):
+            return cast("OpenRouterAgent | None", instance_getter())
+
+        class_getter = type(self).__dict__.get("_get_cached_fallback_agent")
+        if (
+            class_getter is not None
+            and class_getter is not QuotaFallbackMixin._get_cached_fallback_agent
+        ):
+            return cast("OpenRouterAgent | None", self._get_cached_fallback_agent())
+
+        return None
+
     async def fallback_generate(
         self,
         prompt: str,
@@ -574,8 +600,19 @@ class QuotaFallbackMixin:
         status_info = f" (status {status_code})" if status_code else ""
         error_type = "rate_limit" if status_code == 429 else "quota"
 
-        # Build the list of fallback providers with valid API keys
-        fallback_providers = self._get_available_fallback_providers()
+        # Prefer the cached/injected OpenRouter fallback first, then the
+        # broader provider chain discovered from available API keys.
+        fallback_providers: list[tuple[str, Any]] = []
+        seen_provider_keys: set[str] = set()
+        cached_fallback = self._get_preconfigured_fallback_agent()
+        if cached_fallback is not None and self._derive_provider_name() != "openrouter":
+            fallback_providers.append(("openrouter", cached_fallback))
+            seen_provider_keys.add("openrouter")
+        for provider_key, agent in self._get_available_fallback_providers():
+            if provider_key in seen_provider_keys:
+                continue
+            fallback_providers.append((provider_key, agent))
+            seen_provider_keys.add(provider_key)
         if not fallback_providers:
             logger.debug(
                 "%s quota exceeded but no fallback provider API keys set - cannot fallback",
@@ -673,7 +710,17 @@ class QuotaFallbackMixin:
         name = getattr(self, "name", "unknown")
         error_type = "rate_limit" if status_code == 429 else "quota"
 
-        fallback_providers = self._get_available_fallback_providers()
+        fallback_providers: list[tuple[str, Any]] = []
+        seen_provider_keys: set[str] = set()
+        cached_fallback = self._get_preconfigured_fallback_agent()
+        if cached_fallback is not None and self._derive_provider_name() != "openrouter":
+            fallback_providers.append(("openrouter", cached_fallback))
+            seen_provider_keys.add("openrouter")
+        for provider_key, agent in self._get_available_fallback_providers():
+            if provider_key in seen_provider_keys:
+                continue
+            fallback_providers.append((provider_key, agent))
+            seen_provider_keys.add(provider_key)
         if not fallback_providers:
             logger.debug(
                 "%s quota exceeded but no fallback provider API keys set - cannot fallback",

--- a/aragora/agents/fallback.py
+++ b/aragora/agents/fallback.py
@@ -559,14 +559,25 @@ class QuotaFallbackMixin:
         if callable(instance_getter):
             return cast("OpenRouterAgent | None", instance_getter())
 
-        class_getter = type(self).__dict__.get("_get_cached_fallback_agent")
-        if (
-            class_getter is not None
-            and class_getter is not QuotaFallbackMixin._get_cached_fallback_agent
-        ):
-            return cast("OpenRouterAgent | None", self._get_cached_fallback_agent())
-
         return None
+
+    def _build_fallback_providers(self) -> list[tuple[str, Any]]:
+        """Build the fallback provider chain without auto-creating OpenRouter."""
+        fallback_providers: list[tuple[str, Any]] = []
+        seen_provider_keys: set[str] = set()
+
+        cached_fallback = self._get_preconfigured_fallback_agent()
+        if cached_fallback is not None and self._derive_provider_name() != "openrouter":
+            fallback_providers.append(("openrouter", cached_fallback))
+            seen_provider_keys.add("openrouter")
+
+        for provider_key, agent in self._get_available_fallback_providers():
+            if provider_key in seen_provider_keys:
+                continue
+            fallback_providers.append((provider_key, agent))
+            seen_provider_keys.add(provider_key)
+
+        return fallback_providers
 
     async def fallback_generate(
         self,
@@ -600,19 +611,7 @@ class QuotaFallbackMixin:
         status_info = f" (status {status_code})" if status_code else ""
         error_type = "rate_limit" if status_code == 429 else "quota"
 
-        # Prefer the cached/injected OpenRouter fallback first, then the
-        # broader provider chain discovered from available API keys.
-        fallback_providers: list[tuple[str, Any]] = []
-        seen_provider_keys: set[str] = set()
-        cached_fallback = self._get_preconfigured_fallback_agent()
-        if cached_fallback is not None and self._derive_provider_name() != "openrouter":
-            fallback_providers.append(("openrouter", cached_fallback))
-            seen_provider_keys.add("openrouter")
-        for provider_key, agent in self._get_available_fallback_providers():
-            if provider_key in seen_provider_keys:
-                continue
-            fallback_providers.append((provider_key, agent))
-            seen_provider_keys.add(provider_key)
+        fallback_providers = self._build_fallback_providers()
         if not fallback_providers:
             logger.debug(
                 "%s quota exceeded but no fallback provider API keys set - cannot fallback",
@@ -710,17 +709,7 @@ class QuotaFallbackMixin:
         name = getattr(self, "name", "unknown")
         error_type = "rate_limit" if status_code == 429 else "quota"
 
-        fallback_providers: list[tuple[str, Any]] = []
-        seen_provider_keys: set[str] = set()
-        cached_fallback = self._get_preconfigured_fallback_agent()
-        if cached_fallback is not None and self._derive_provider_name() != "openrouter":
-            fallback_providers.append(("openrouter", cached_fallback))
-            seen_provider_keys.add("openrouter")
-        for provider_key, agent in self._get_available_fallback_providers():
-            if provider_key in seen_provider_keys:
-                continue
-            fallback_providers.append((provider_key, agent))
-            seen_provider_keys.add(provider_key)
+        fallback_providers = self._build_fallback_providers()
         if not fallback_providers:
             logger.debug(
                 "%s quota exceeded but no fallback provider API keys set - cannot fallback",


### PR DESCRIPTION
## Summary
- preserve explicitly injected fallback agents ahead of discovered providers without auto-creating a real OpenRouter fallback
- keep environment-driven provider discovery semantics unchanged for fallback utility tests
- fix the live fallback regressions on current main in session circuit-breaker and OpenAI-compatible fallback paths

## Validation
- python3 -m pytest tests/agents/test_fallback.py tests/agents/test_session_circuit_breaker_integration.py tests/agents/api_agents/test_openai_compatible.py -q
- python3 -m ruff check aragora/agents/fallback.py tests/agents/test_fallback.py tests/agents/test_session_circuit_breaker_integration.py tests/agents/api_agents/test_openai_compatible.py