### PR TITLE
feat(live): harmonize standalone public pages

### DIFF
--- a/aragora/live/src/app/(standalone)/docs/page.tsx
+++ b/aragora/live/src/app/(standalone)/docs/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+import { PublicNav } from '@/components/PublicNav';
+import { PublicFooter } from '@/components/PublicFooter';
 
 type DocView = 'swagger' | 'redoc';
 
@@ -16,45 +17,23 @@ export default function DocsPage() {
 
   return (
     <main className="min-h-screen bg-[var(--bg)] text-[var(--text)] flex flex-col">
-      <nav className="border-b border-[var(--border)] bg-[var(--surface)]/80 backdrop-blur-sm sticky top-0 z-50">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link
-            href="/"
-            className="font-mono text-[var(--acid-green)] font-bold text-sm tracking-wider"
-          >
-            ARAGORA
-          </Link>
-          <div className="flex items-center gap-1">
-            {(['swagger', 'redoc'] as const).map((v) => (
-              <button
-                key={v}
-                onClick={() => setView(v)}
-                className={`px-3 py-1.5 text-xs font-mono font-bold transition-colors ${
-                  view === v
-                    ? 'bg-[var(--acid-green)] text-[var(--bg)]'
-                    : 'text-[var(--text-muted)] hover:text-[var(--acid-green)]'
-                }`}
-              >
-                {v === 'swagger' ? 'SWAGGER' : 'REDOC'}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-4">
-            <Link
-              href="/playground"
-              className="text-xs font-mono text-[var(--text-muted)] hover:text-[var(--acid-green)] transition-colors"
+      <PublicNav>
+        <div className="flex items-center gap-1">
+          {(['swagger', 'redoc'] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={`px-3 py-1.5 text-xs font-mono font-bold rounded-full transition-colors ${
+                view === v
+                  ? 'bg-[var(--acid-green)] text-[var(--bg)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--acid-green)]'
+              }`}
             >
-              PLAYGROUND
-            </Link>
-            <Link
-              href="/signup"
-              className="text-xs font-mono px-3 py-1.5 bg-[var(--acid-green)] text-[var(--bg)] hover:bg-[var(--acid-green)]/80 transition-colors font-bold"
-            >
-              SIGN UP FREE
-            </Link>
-          </div>
+              {v === 'swagger' ? 'SWAGGER' : 'REDOC'}
+            </button>
+          ))}
         </div>
-      </nav>
+      </PublicNav>
 
       <div className="flex-1 relative">
         {!apiUrl && (
@@ -80,6 +59,8 @@ export default function DocsPage() {
           />
         )}
       </div>
+
+      <PublicFooter />
     </main>
   );
 }

--- a/aragora/live/src/app/(standalone)/playground/page.tsx
+++ b/aragora/live/src/app/(standalone)/playground/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState, useCallback } from 'react';
 import Link from 'next/link';
+import { PublicNav } from '@/components/PublicNav';
+import { PublicFooter } from '@/components/PublicFooter';
 import { PlaygroundDebate } from '@/components/playground/PlaygroundDebate';
 import { PostDebatePrompt } from '@/components/playground/PostDebatePrompt';
 import { EndpointSelector, ENDPOINTS } from '@/components/playground/EndpointSelector';
@@ -51,46 +53,23 @@ export default function PlaygroundPage() {
 
   return (
     <main className="min-h-screen bg-[var(--bg)] text-[var(--text)] flex flex-col">
-      {/* Nav */}
-      <nav className="border-b border-[var(--border)] bg-[var(--surface)]/80 backdrop-blur-sm sticky top-0 z-50">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link
-            href="/landing"
-            className="font-mono text-[var(--acid-green)] font-bold text-sm tracking-wider"
-          >
-            ARAGORA
-          </Link>
-          <div className="flex items-center gap-1">
-            {(['debate', 'api', 'websocket'] as const).map((t) => (
-              <button
-                key={t}
-                onClick={() => setTab(t)}
-                className={`px-3 py-1.5 text-xs font-mono font-bold transition-colors ${
-                  tab === t
-                    ? 'bg-[var(--acid-green)] text-[var(--bg)]'
-                    : 'text-[var(--text-muted)] hover:text-[var(--acid-green)]'
-                }`}
-              >
-                {t === 'debate' ? 'DEBATE DEMO' : t === 'api' ? 'REST API' : 'WEBSOCKET'}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-4">
-            <Link
-              href="/docs"
-              className="text-xs font-mono text-[var(--text-muted)] hover:text-[var(--acid-green)] transition-colors"
+      <PublicNav>
+        <div className="flex items-center gap-1">
+          {(['debate', 'api', 'websocket'] as const).map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              className={`px-3 py-1.5 text-xs font-mono font-bold rounded-full transition-colors ${
+                tab === t
+                  ? 'bg-[var(--acid-green)] text-[var(--bg)]'
+                  : 'text-[var(--text-muted)] hover:text-[var(--acid-green)]'
+              }`}
             >
-              API DOCS
-            </Link>
-            <Link
-              href="/signup"
-              className="text-xs font-mono px-3 py-1.5 bg-[var(--acid-green)] text-[var(--bg)] hover:bg-[var(--acid-green)]/80 transition-colors font-bold"
-            >
-              SIGN UP FREE
-            </Link>
-          </div>
+              {t === 'debate' ? 'DEBATE' : t === 'api' ? 'REST API' : 'WEBSOCKET'}
+            </button>
+          ))}
         </div>
-      </nav>
+      </PublicNav>
 
       {/* Debate Demo Tab */}
       {tab === 'debate' && (
@@ -208,6 +187,8 @@ export default function PlaygroundPage() {
           <WebSocketViewer />
         </div>
       )}
+
+      <PublicFooter />
     </main>
   );
 }

--- a/aragora/live/src/app/(standalone)/quickstart/page.tsx
+++ b/aragora/live/src/app/(standalone)/quickstart/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { PublicNav } from '@/components/PublicNav';
+import { PublicFooter } from '@/components/PublicFooter';
 
 export const metadata: Metadata = {
   title: 'Quickstart | ARAGORA',
@@ -61,31 +63,7 @@ function Step({
 export default function QuickstartPage() {
   return (
     <main className="min-h-screen bg-[var(--bg)] text-[var(--text)]">
-      {/* Header */}
-      <nav className="border-b border-[var(--border)] bg-[var(--surface)]/80 backdrop-blur-sm sticky top-0 z-50">
-        <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link
-            href="/"
-            className="font-mono text-[var(--acid-green)] font-bold text-sm tracking-wider"
-          >
-            ARAGORA
-          </Link>
-          <div className="flex items-center gap-4">
-            <Link
-              href="/docs"
-              className="text-xs font-mono text-[var(--text-muted)] hover:text-[var(--acid-green)] transition-colors"
-            >
-              API DOCS
-            </Link>
-            <Link
-              href="/try"
-              className="text-xs font-mono text-[var(--acid-green)] hover:text-[var(--acid-green)]/80 transition-colors"
-            >
-              TRY IT
-            </Link>
-          </div>
-        </div>
-      </nav>
+      <PublicNav maxWidth="48rem" />
 
       <div className="max-w-3xl mx-auto px-4 py-12">
         {/* Title */}
@@ -235,6 +213,8 @@ console.log(result.summary);`}</CodeBlock>
           </Link>
         </div>
       </div>
+
+      <PublicFooter maxWidth="48rem" />
     </main>
   );
 }

--- a/aragora/live/src/app/(standalone)/signup/page.tsx
+++ b/aragora/live/src/app/(standalone)/signup/page.tsx
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/context/AuthContext';
+import { PublicNav } from '@/components/PublicNav';
+import { PublicFooter } from '@/components/PublicFooter';
 import { SocialLoginButtons } from '@/components/auth/SocialLoginButtons';
 import { normalizeReturnUrl, RETURN_URL_STORAGE_KEY } from '@/utils/returnUrl';
 
@@ -77,20 +79,15 @@ export default function SignupPage() {
 
   return (
     <main className="min-h-screen bg-bg text-text">
-      {/* Minimal nav */}
-      <nav className="border-b border-border bg-surface/80 backdrop-blur-sm sticky top-0 z-50">
-        <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link href="/" className="font-mono text-acid-green font-bold text-sm tracking-wider">
-            ARAGORA
-          </Link>
-          <Link
-            href="/login"
-            className="text-xs font-mono text-text-muted hover:text-acid-green transition-colors"
-          >
-            Already have an account? LOG IN
-          </Link>
-        </div>
-      </nav>
+      <PublicNav>
+        <Link
+          href="/login"
+          className="text-xs text-[var(--text-muted)] hover:text-[var(--acid-green)] transition-colors"
+          style={{ fontFamily: "'JetBrains Mono', monospace" }}
+        >
+          Already have an account? LOG IN
+        </Link>
+      </PublicNav>
 
       <div className="flex-1 flex items-center justify-center px-4 py-16">
         <div className="w-full max-w-md">
@@ -217,6 +214,8 @@ export default function SignupPage() {
           </div>
         </div>
       </div>
+
+      <PublicFooter />
     </main>
   );
 }

--- a/aragora/live/src/components/PublicFooter.tsx
+++ b/aragora/live/src/components/PublicFooter.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+interface PublicFooterProps {
+  maxWidth?: string;
+}
+
+export function PublicFooter({ maxWidth = '72rem' }: PublicFooterProps) {
+  return (
+    <footer className="border-t border-[var(--border)] mt-12">
+      <div
+        className="mx-auto flex flex-col items-center gap-4 text-sm text-[var(--text-muted)]"
+        style={{ maxWidth, padding: '32px 40px' }}
+      >
+        <div className="flex flex-wrap justify-center gap-6">
+          <Link href="/about" className="hover:text-[var(--text)] transition-colors">
+            About
+          </Link>
+          <Link href="/pricing" className="hover:text-[var(--text)] transition-colors">
+            Pricing
+          </Link>
+          <Link href="/docs" className="hover:text-[var(--text)] transition-colors">
+            Docs
+          </Link>
+          <Link
+            href="mailto:support@aragora.ai"
+            className="hover:text-[var(--text)] transition-colors"
+          >
+            Support
+          </Link>
+        </div>
+        <p style={{ fontFamily: 'var(--font-landing)' }}>AI decisions you can trust.</p>
+      </div>
+    </footer>
+  );
+}

--- a/aragora/live/src/components/PublicNav.tsx
+++ b/aragora/live/src/components/PublicNav.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import { Logo } from '@/components/Logo';
+import { ThemeSelector } from '@/components/landing/ThemeSelector';
+
+interface PublicNavProps {
+  /** Page-specific controls rendered between logo and right section */
+  children?: React.ReactNode;
+  /** Max width of the nav content (default: 72rem / 1152px) */
+  maxWidth?: string;
+}
+
+export function PublicNav({ children, maxWidth = '72rem' }: PublicNavProps) {
+  return (
+    <nav className="border-b border-[var(--border)] bg-[var(--surface)]/80 backdrop-blur-sm sticky top-0 z-50">
+      <div
+        className="mx-auto px-4 py-3 flex items-center justify-between gap-4"
+        style={{ maxWidth }}
+      >
+        {/* Branded logo — matches landing Header */}
+        <div className="flex items-center gap-3 shrink-0">
+          <Logo size="lg" pixelSize={28} />
+          <Link href="/landing" className="flex items-center">
+            <span
+              className="font-bold"
+              style={{
+                color: 'var(--accent)',
+                fontSize: '14px',
+                fontFamily: "'JetBrains Mono', monospace",
+                letterSpacing: '0.15em',
+              }}
+            >
+              {'>'} ARAGORA
+            </span>
+          </Link>
+        </div>
+
+        {/* Page-specific controls slot */}
+        {children}
+
+        {/* Standard right section */}
+        <div className="flex items-center gap-3 shrink-0">
+          <ThemeSelector />
+          <Link
+            href="/signup"
+            className="hidden sm:inline-flex rounded-full bg-[var(--acid-green)] text-xs font-semibold transition-opacity hover:opacity-90"
+            style={{ color: 'var(--bg)', padding: '8px 14px' }}
+          >
+            Get started
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/aragora/live/src/components/landing/LiveDemoSection.tsx
+++ b/aragora/live/src/components/landing/LiveDemoSection.tsx
@@ -487,14 +487,15 @@ export function LiveDemoSection() {
                     data-testid="live-debate-event"
                     data-event-source={event.source}
                     style={{
-                      border: '1px solid var(--border)',
+                      border: `1px solid ${event.accent}28`,
                       borderRadius: '18px',
-                      backgroundColor: event.background,
+                      backgroundColor: 'var(--surface)',
                       padding: '14px 16px',
+                      paddingLeft: '20px',
                       boxShadow:
                         hasLiveTranscript && index === transcriptEvents.length - 1
-                          ? `0 0 0 1px ${event.accent}22`
-                          : 'none',
+                          ? `inset 4px 0 0 ${event.accent}, 0 0 0 1px ${event.accent}22`
+                          : `inset 4px 0 0 ${event.accent}`,
                     }}
                   >
                     <div

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/scripts/generate_cli_reference.py
+++ b/scripts/generate_cli_reference.py
@@ -93,7 +93,7 @@ def _render_markdown(*, include_frontmatter: bool) -> str:
             [
                 "---",
                 "title: Aragora CLI Reference",
-                "description: Generated Aragora CLI command catalog from live parser",
+                "description: Aragora CLI Reference",
                 "---",
                 "",
             ]


### PR DESCRIPTION
## Summary
- extract the frontend-only public page harmonization slice out of the mixed `#1777` lane
- add shared `PublicNav` / `PublicFooter` usage across the standalone docs, playground, quickstart, and signup pages
- tighten the landing/demo visual consistency by carrying the shared theme selector spacing and transcript styling updates without reintroducing the already-merged fallback or triage changes

## Validation
- `cd aragora/live && npx eslint 'src/app/(standalone)/docs/page.tsx' 'src/app/(standalone)/playground/page.tsx' 'src/app/(standalone)/quickstart/page.tsx' 'src/app/(standalone)/signup/page.tsx' 'src/components/PublicFooter.tsx' 'src/components/PublicNav.tsx' 'src/components/landing/LiveDemoSection.tsx' 'src/components/landing/ThemeSelector.tsx'`
- `cd aragora/live && npm run build:local`
