### PR TITLE
fix(swarm): harden ping-pong retry and dead-worker salvage

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1274,6 +1274,7 @@ class BossLoop:
         self._iteration_statuses: list[BossIterationStatus] = []
         self._consecutive_failures = 0
         self._issue_attempt_counts: dict[int, int] = {}
+        self._pending_handoff_prompts: dict[int, tuple[str, str | None]] = {}
         self._stop_reason: str | None = None
 
     def _extract_iteration_metrics(self, worker_result: dict[str, Any]) -> tuple[int, int, int]:
@@ -1437,6 +1438,55 @@ class BossLoop:
         if default_target:
             return rotation[(attempt_count - 2) % len(rotation)]
         return rotation[(attempt_count - 2) % len(rotation)]
+
+    def _extract_worker_agent(self, worker_result: dict[str, Any]) -> str | None:
+        for key in ("target_agent", "runner_type"):
+            value = str(worker_result.get(key, "")).strip().lower()
+            if value:
+                return value
+
+        receipt_metadata = worker_result.get("receipt_metadata")
+        if isinstance(receipt_metadata, dict):
+            for key in ("actual_target_agent", "requested_target_agent", "runner_type"):
+                value = str(receipt_metadata.get(key, "")).strip().lower()
+                if value:
+                    return value
+
+        run = worker_result.get("run")
+        if not isinstance(run, dict):
+            return None
+        work_orders = run.get("work_orders", [])
+        if not isinstance(work_orders, list):
+            return None
+        for work_order in work_orders:
+            if not isinstance(work_order, dict):
+                continue
+            value = str(work_order.get("target_agent", "")).strip().lower()
+            if value:
+                return value
+        return None
+
+    def _pending_handoff_candidates(self, issues: list[GitHubIssue]) -> list[GitHubIssue]:
+        if not self._pending_handoff_prompts:
+            return []
+
+        issue_by_number = {int(issue.number): issue for issue in issues}
+        candidates: list[GitHubIssue] = []
+        stale_issue_numbers: list[int] = []
+
+        for issue_number in list(self._pending_handoff_prompts):
+            issue = issue_by_number.get(issue_number)
+            if issue is None:
+                stale_issue_numbers.append(issue_number)
+                continue
+            if self.config.issue_number is not None and issue_number != self.config.issue_number:
+                continue
+            candidates.append(issue)
+
+        for issue_number in stale_issue_numbers:
+            self._pending_handoff_prompts.pop(issue_number, None)
+
+        return candidates
 
     def _target_issue_miss_guidance(self, issue_number: int) -> tuple[list[str], list[str]]:
         reasons = [
@@ -1880,7 +1930,10 @@ class BossLoop:
             if count >= self.config.max_retries_per_issue
         }
         candidate_issues = [i for i in issues if i.number not in already_maxed]
-        if self.config.issue_number is not None:
+        pending_handoffs = self._pending_handoff_candidates(candidate_issues)
+        if pending_handoffs:
+            selected = pending_handoffs[0]
+        elif self.config.issue_number is not None:
             target_issue = next(
                 (issue for issue in candidate_issues if issue.number == self.config.issue_number),
                 None,
@@ -2010,8 +2063,13 @@ class BossLoop:
             if count >= self.config.max_retries_per_issue
         }
         candidate_issues = [i for i in issues if i.number not in already_maxed]
+        pending_handoffs = self._pending_handoff_candidates(candidate_issues)
+        pending_issue_numbers = {issue.number for issue in pending_handoffs}
+        ordered_candidates = pending_handoffs + [
+            issue for issue in candidate_issues if issue.number not in pending_issue_numbers
+        ]
         selected_issues = self._select_issues_for_iteration(
-            candidate_issues,
+            ordered_candidates,
             limit=None,
         )
 
@@ -2370,11 +2428,7 @@ class BossLoop:
                 transcript = self._extract_worker_transcript(worker_result)
                 if pp_count < 1 and len(transcript.strip()) > 50:
                     self._issue_attempt_counts[pp_key] = pp_count + 1
-                    previous_agent = str(
-                        worker_result.get("runner_type")
-                        or worker_result.get("target_agent")
-                        or "unknown"
-                    )
+                    previous_agent = self._extract_worker_agent(worker_result) or "unknown"
                     rotation = list(self.config.model_rotation or ["claude", "codex"])
                     next_agent = rotation[0] if previous_agent == rotation[-1] else rotation[-1]
 
@@ -2389,8 +2443,6 @@ class BossLoop:
                         files_changed=self._extract_worker_files_changed(worker_result),
                         remaining_issues=[str(r) for r in reasons[:5]],
                     )
-                    if not hasattr(self, "_pending_handoff_prompts"):
-                        self._pending_handoff_prompts = {}
                     self._pending_handoff_prompts[issue_num] = (handoff, next_agent)
                     logger.info(
                         "boss_loop_ping_pong issue=#%s from=%s to=%s transcript_len=%d",
@@ -2542,6 +2594,9 @@ class BossLoop:
 
         refinement: dict[str, Any] = {}
         refined_prompt = ""
+        pending_handoff = self._pending_handoff_prompts.get(issue.number)
+        if pending_handoff is not None:
+            refined_prompt = str(pending_handoff[0]).strip()
 
         try:
             from aragora.swarm.prompt_refiner import (
@@ -2556,7 +2611,8 @@ class BossLoop:
             )
             refinement_worker_env = build_refinement_worker_env(refinement)
             if refinement.get("context_gathered"):
-                refined_prompt = str(refinement.get("refined_prompt", "")).strip()
+                if pending_handoff is None:
+                    refined_prompt = str(refinement.get("refined_prompt", "")).strip()
                 logger.info(
                     "Refined prompt for #%s: %d relevant files, %d test patterns",
                     issue.number,
@@ -2598,6 +2654,13 @@ class BossLoop:
             issue_body=issue.body or "",
             refined_prompt=refined_prompt,
         )
+        if "git add -A && git commit" not in goal:
+            goal += (
+                "\n\n## CRITICAL: You MUST commit your changes\n"
+                "After making changes, run:\n"
+                "```\ngit add -A && git commit -m 'fix: description of changes'\n```\n"
+                "If you do not commit, your work will be lost."
+            )
 
         spec = SwarmSpec(
             raw_goal=goal,
@@ -2668,7 +2731,13 @@ class BossLoop:
                 ],
             }
 
-        requested_target_agent = self._requested_target_agent_for_issue(issue.number)
+        requested_target_agent = (
+            str(pending_handoff[1]).strip().lower()
+            if pending_handoff is not None and str(pending_handoff[1]).strip()
+            else self._requested_target_agent_for_issue(issue.number)
+        )
+        if pending_handoff is not None:
+            self._pending_handoff_prompts.pop(issue.number, None)
 
         claimed_runner_id: str | None = None
         selected_runner, claimed_runner_id = self._claim_runner_for_dispatch(

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import subprocess
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -450,11 +451,13 @@ class SwarmSupervisor:
         return SupervisorRun.from_record(refreshed)
 
     def _collect_finished_workers_sync(self, run_id: str) -> None:
-        """Mark dispatched workers with dead PIDs for deferred collection.
+        """Synchronously reconcile dead dispatched workers before lease reaping.
 
-        Does NOT call asyncio.run (unsafe in async contexts). Instead,
-        checks git state synchronously using subprocess and backfills
-        commit SHAs so the lease reaper doesn't discard real deliverables.
+        This path runs when ``refresh_run()`` is called from an async context
+        and the normal ``collect_finished_results()`` coroutine cannot be used
+        safely. For dead workers with real git commits, synthesize a minimal
+        worker result and flow it through the normal result-application path so
+        the lane becomes a truthful terminal salvage state before reaping.
         """
         import os
         import subprocess
@@ -462,7 +465,13 @@ class SwarmSupervisor:
         record = self.store.get_supervisor_run(run_id)
         if record is None:
             return
-        work_orders = record.get("work_orders", [])
+        work_orders = [
+            dict(item) for item in record.get("work_orders", []) if isinstance(item, dict)
+        ]
+        metadata = dict(record.get("metadata") or {})
+        worker_type_circuit_breaker_policy = self._worker_type_circuit_breaker_policy(metadata)
+        worker_type_circuit_breakers = self._worker_type_circuit_breakers(metadata)
+        self._expire_worker_type_circuit_breakers(worker_type_circuit_breakers)
         changed = False
         for item in work_orders:
             if str(item.get("status", "")) != "dispatched":
@@ -482,40 +491,29 @@ class SwarmSupervisor:
             if not worktree_path or not os.path.isdir(worktree_path):
                 continue
 
-            # Synchronous git check — no asyncio.run needed
             try:
-                head_result = subprocess.run(
-                    ["git", "rev-parse", "HEAD"],
-                    cwd=worktree_path,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
+                result = self._build_dead_worker_salvage_result(
+                    item,
+                    worktree_path=worktree_path,
+                    initial_head=initial_head,
                 )
-                if head_result.returncode != 0:
+                if result is None or not result.commit_shas:
                     continue
-                head_sha = head_result.stdout.strip()
 
-                # Check for commits ahead of initial_head or origin/main
-                base_ref = initial_head if initial_head else "origin/main"
-                rev_result = subprocess.run(
-                    ["git", "rev-list", "--reverse", f"{base_ref}..{head_sha}"],
-                    cwd=worktree_path,
-                    capture_output=True,
-                    text=True,
-                    timeout=10,
+                item["worker_outcome"] = WorkerOutcome.CRASH_WITH_SALVAGE.value
+                self._apply_worker_result(
+                    item,
+                    result,
+                    worker_type_circuit_breakers=worker_type_circuit_breakers,
+                    worker_type_circuit_breaker_policy=worker_type_circuit_breaker_policy,
                 )
-                commit_shas = [
-                    s.strip() for s in rev_result.stdout.strip().splitlines() if s.strip()
-                ]
-                if commit_shas:
-                    logger.info(
-                        "Pre-reap salvage: found %d commits from dead worker %s",
-                        len(commit_shas),
-                        item.get("work_order_id"),
-                    )
-                    item["commit_shas"] = commit_shas
-                    item["head_sha"] = head_sha
-                    changed = True
+                self._backfill_missing_completion_receipt(item)
+                logger.info(
+                    "Pre-reap salvage reconciled dead worker %s with %d commits",
+                    item.get("work_order_id"),
+                    len(result.commit_shas),
+                )
+                changed = True
             except (subprocess.TimeoutExpired, OSError) as exc:
                 logger.debug(
                     "Pre-reap git check failed for %s: %s",
@@ -524,7 +522,95 @@ class SwarmSupervisor:
                 )
 
         if changed:
-            self.store.update_supervisor_run(run_id, work_orders=work_orders)
+            self._record_terminal_work_order_telemetry(run_id, work_orders)
+            self.store.update_supervisor_run(
+                run_id,
+                status=self._derive_status(work_orders),
+                work_orders=work_orders,
+                metadata=self._campaign_metadata(
+                    self._worker_type_circuit_breaker_metadata(
+                        metadata,
+                        worker_type_circuit_breakers,
+                    ),
+                    work_orders,
+                ),
+            )
+
+    @staticmethod
+    def _run_git_capture_sync(
+        worktree_path: str,
+        *args: str,
+        timeout: float = 10.0,
+    ) -> subprocess.CompletedProcess[str]:
+        import subprocess
+
+        return subprocess.run(
+            ["git", *args],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+
+    def _build_dead_worker_salvage_result(
+        self,
+        item: dict[str, Any],
+        *,
+        worktree_path: str,
+        initial_head: str,
+    ) -> WorkerProcess | None:
+        head_result = self._run_git_capture_sync(worktree_path, "rev-parse", "HEAD")
+        if head_result.returncode != 0:
+            return None
+        head_sha = head_result.stdout.strip()
+        base_ref = initial_head or "origin/main"
+
+        rev_result = self._run_git_capture_sync(
+            worktree_path,
+            "rev-list",
+            "--reverse",
+            f"{base_ref}..{head_sha}",
+        )
+        if rev_result.returncode != 0:
+            return None
+        commit_shas = [line.strip() for line in rev_result.stdout.splitlines() if line.strip()]
+        if not commit_shas:
+            return None
+
+        paths_result = self._run_git_capture_sync(
+            worktree_path,
+            "diff",
+            "--name-only",
+            f"{base_ref}..{head_sha}",
+        )
+        diff_result = self._run_git_capture_sync(
+            worktree_path,
+            "diff",
+            f"{base_ref}..{head_sha}",
+        )
+        changed_paths = [line.strip() for line in paths_result.stdout.splitlines() if line.strip()]
+        return WorkerProcess(
+            work_order_id=str(item.get("work_order_id", "")).strip(),
+            agent=str(item.get("target_agent", "codex")).strip() or "codex",
+            worktree_path=worktree_path,
+            branch=str(item.get("branch", "main")).strip() or "main",
+            pid=item.get("pid"),
+            session_id=str(item.get("owner_session_id", "")).strip(),
+            lease_id=str(item.get("lease_id", "")).strip(),
+            completed_at=datetime.now(UTC).isoformat(),
+            exit_code=1,
+            stdout=str(item.get("stdout_tail", "")).strip(),
+            stderr=str(item.get("stderr_tail", "")).strip(),
+            diff=diff_result.stdout if diff_result.returncode == 0 else "",
+            initial_head=initial_head,
+            head_sha=head_sha,
+            commit_shas=commit_shas,
+            changed_paths=changed_paths,
+            expected_tests=[
+                str(test).strip() for test in item.get("expected_tests", []) if str(test).strip()
+            ],
+        )
 
     def _collect_finished_results_before_reap(
         self,
@@ -748,7 +834,27 @@ class SwarmSupervisor:
             return False
         if str(item.get("dispatch_error", "")).strip():
             return False
-        if str(item.get("failure_reason", "")).strip():
+        failure_reason = str(item.get("failure_reason", "")).strip()
+        if failure_reason and failure_reason != "needs_human":
+            return False
+        default_question = "What human input is required before rerunning this lane?"
+        blocking_question = str(item.get("blocking_question", "")).strip()
+        if blocking_question and blocking_question != default_question:
+            return False
+        blocker = item.get("blocker")
+        if isinstance(blocker, dict):
+            blocker_reason = str(blocker.get("reason", "")).strip()
+            blocker_question = str(blocker.get("question", "")).strip()
+            if blocker_reason and blocker_reason != "needs_human":
+                return False
+            if blocker_question and blocker_question != default_question:
+                return False
+        blockers = [
+            str(blocker_text).strip()
+            for blocker_text in item.get("blockers", [])
+            if str(blocker_text).strip()
+        ]
+        if blockers:
             return False
         return True
 
@@ -766,8 +872,11 @@ class SwarmSupervisor:
             "blocking_question",
             "failure_reason",
             "resource_error",
+            "blocker",
+            "conflicts",
         ):
             item.pop(key, None)
+        item.pop("blockers", None)
 
     def _backfill_missing_completion_receipt(self, item: dict[str, Any]) -> None:
         """Heal older completed lanes that predate receipt propagation fixes."""

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1972,6 +1972,45 @@ async def test_dispatch_issue_builds_clean_spec_from_issue_body() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_consumes_pending_handoff_prompt_and_target_agent() -> None:
+    issue = _make_issue(1701, "Retry same issue with handoff")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="claude"))
+    loop._pending_handoff_prompts[issue.number] = (
+        "## Goal\nRetry with prior context\n\n## Context (from claude, round 1)\nKnown bad edge case.",
+        "codex",
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": requested_target_agent or "codex",
+    }
+
+    fake_result = {
+        "status": "completed",
+        "run": {"work_orders": [{"status": "completed", "target_agent": "codex"}]},
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value=fake_result),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    dispatched_spec = dispatch_mock.await_args.args[0]
+    dispatch_kwargs = dispatch_mock.await_args.kwargs
+    assert result["status"] == "completed"
+    assert "Retry with prior context" in dispatched_spec.raw_goal
+    assert dispatch_kwargs["default_target_agent"] == "codex"
+    assert issue.number not in loop._pending_handoff_prompts
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_preserves_issue_header_with_refined_prompt() -> None:
     issue = _make_issue(
         1641,
@@ -2022,6 +2061,82 @@ async def test_dispatch_issue_preserves_issue_header_with_refined_prompt() -> No
 
 
 @pytest.mark.asyncio
+async def test_ping_pong_retry_prioritizes_same_issue_and_uses_handoff_prompt() -> None:
+    issue = _make_issue(1702, "Ping-pong retry")
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [issue]
+
+    loop = BossLoop(
+        config=_boss_config(
+            max_iterations=2,
+            default_target_agent="claude",
+            enable_ping_pong_retry=True,
+            model_rotation=["claude", "codex"],
+        ),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: _fresh_result(fresh=True),
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": f"{requested_target_agent or 'claude'}-runner-1",
+        "runner_type": requested_target_agent or "claude",
+    }
+
+    calls: list[dict[str, Any]] = []
+
+    async def _dispatch(spec, **kwargs):
+        calls.append(
+            {
+                "goal": spec.raw_goal,
+                "target_agent": kwargs.get("default_target_agent"),
+            }
+        )
+        if len(calls) == 1:
+            return {
+                "status": "needs_human",
+                "reasons": ["Need a second implementation pass"],
+                "run": {
+                    "work_orders": [
+                        {
+                            "stdout_tail": (
+                                "Found the failure in the boss loop retry path. "
+                                "The next agent needs the transcript to finish the fix cleanly."
+                            ),
+                            "changed_paths": ["aragora/swarm/boss_loop.py"],
+                            "target_agent": "claude",
+                        }
+                    ]
+                },
+            }
+        return {
+            "status": "completed",
+            "run": {"work_orders": [{"status": "completed", "target_agent": "codex"}]},
+        }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec", new=AsyncMock(side_effect=_dispatch)
+        ),
+    ):
+        result = await loop.run()
+
+    assert [status["worker_status"] for status in result.iteration_statuses] == [
+        "ping_pong_retry",
+        "completed",
+    ]
+    assert len(calls) == 2
+    assert calls[0]["target_agent"] == "claude"
+    assert calls[1]["target_agent"] == "codex"
+    assert "## Context (from claude, round 1)" in calls[1]["goal"]
+    assert "Need a second implementation pass" in calls[1]["goal"]
+    assert not loop._pending_handoff_prompts
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_keeps_explicit_validation_commands_when_focused_enabled() -> None:
     issue = _make_issue(
         1640,
@@ -2062,6 +2177,34 @@ async def test_dispatch_issue_keeps_explicit_validation_commands_when_focused_en
     assert spec.acceptance_criteria == [
         "python -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_spec.py -q"
     ]
+
+
+@pytest.mark.asyncio
+async def test_run_iteration_prioritizes_pending_handoff_issue() -> None:
+    issue_a = _make_issue(1801, "Regular issue")
+    issue_b = _make_issue(1802, "Pending handoff issue")
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [issue_a, issue_b]
+
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: _fresh_result(fresh=True),
+    )
+    loop._pending_handoff_prompts[issue_b.number] = ("handoff prompt", "codex")
+
+    seen: list[int] = []
+
+    async def _dispatch_issue(issue, freshness):
+        seen.append(issue.number)
+        return {"status": "completed"}
+
+    loop._dispatch_issue = _dispatch_issue
+
+    status = await loop._run_iteration(1)
+
+    assert seen == [issue_b.number]
+    assert status.selected_issue["number"] == issue_b.number
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3226,14 +3226,14 @@ def test_pre_reap_salvage_backfills_commit_shas_from_dead_worker(
                 id="wo-1",
                 title="Test salvage",
                 description="Test pre-reap salvage",
-                file_scope=["test.py"],
+                file_scope=["salvage_test.py"],
             )
         ],
     )
     supervisor = SwarmSupervisor(
         repo_root=repo, store=store, lifecycle=lifecycle, decomposer=decomposer
     )
-    spec = SwarmSpec(raw_goal="salvage test", file_scope_hints=["test.py"])
+    spec = SwarmSpec(raw_goal="salvage test", file_scope_hints=["salvage_test.py"])
     run = supervisor.start_run(spec=spec)
 
     # Simulate a dispatched work order with a dead PID
@@ -3268,12 +3268,16 @@ def test_pre_reap_salvage_backfills_commit_shas_from_dead_worker(
     # Run pre-reap salvage
     supervisor._collect_finished_workers_sync(run.run_id)
 
-    # Verify commit SHAs were salvaged
+    # Verify the dead worker was fully reconciled into a salvage completion
     updated = store.get_supervisor_run(run.run_id)
     wo_updated = updated["work_orders"][0]
+    assert wo_updated["status"] == "completed"
+    assert wo_updated["worker_outcome"] == "crash_with_salvage"
+    assert wo_updated["review_status"] == "pending_heterogeneous_review"
     assert wo_updated.get("commit_shas"), "Expected commit SHAs to be salvaged"
     assert len(wo_updated["commit_shas"]) >= 1
     assert wo_updated.get("head_sha"), "Expected head SHA to be set"
+    assert wo_updated.get("receipt_id"), "Expected salvage receipt to be backfilled"
 
     # Cleanup
     subprocess.run(
@@ -3366,3 +3370,91 @@ def test_pre_reap_salvage_handles_missing_worktree(repo: Path, store: DevCoordin
     # No SHAs salvaged from nonexistent path
     updated = store.get_supervisor_run(run.run_id)
     assert not updated["work_orders"][0].get("commit_shas")
+
+
+@pytest.mark.asyncio
+async def test_refresh_run_async_context_reconciles_dead_worker_salvage(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    session_path = repo / "wt-async-salvage"
+    session_path.mkdir()
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-async-salvage",
+        agent="codex",
+        branch="codex/swarm-async-salvage",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="async salvage",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=False,
+        subtasks=[
+            SubTask(
+                id="wo-1",
+                title="Async salvage lane",
+                description="Prove sync reconciliation in async refresh",
+                file_scope=["salvage_async.py"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo, store=store, lifecycle=lifecycle, decomposer=decomposer
+    )
+    run = supervisor.start_run(
+        spec=SwarmSpec(raw_goal="async salvage", file_scope_hints=["salvage_async.py"])
+    )
+
+    wt_path = repo / "async-salvage-wt"
+    subprocess.run(
+        ["git", "worktree", "add", str(wt_path), "-b", "async-salvage-branch"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )
+    test_file = wt_path / "salvage_async.py"
+    test_file.write_text("print('salvage')\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "add", "salvage_async.py"], cwd=wt_path, capture_output=True, check=False
+    )
+    subprocess.run(
+        ["git", "commit", "-m", "async salvage commit"],
+        cwd=wt_path,
+        capture_output=True,
+        check=False,
+    )
+    initial_head = subprocess.run(
+        ["git", "rev-parse", "HEAD~1"],
+        cwd=wt_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).stdout.strip()
+
+    record = store.get_supervisor_run(run.run_id)
+    assert record is not None
+    record["work_orders"][0]["status"] = "dispatched"
+    record["work_orders"][0]["pid"] = 99999
+    record["work_orders"][0]["worktree_path"] = str(wt_path)
+    record["work_orders"][0]["initial_head"] = initial_head
+    store.update_supervisor_run(run.run_id, work_orders=record["work_orders"])
+
+    refreshed = supervisor.refresh_run(run.run_id)
+
+    work_order = refreshed.work_orders[0]
+    assert work_order["status"] == "completed"
+    assert work_order["worker_outcome"] == "crash_with_salvage"
+    assert work_order["receipt_id"]
+    assert work_order["commit_shas"]
+
+    subprocess.run(
+        ["git", "worktree", "remove", str(wt_path), "--force"],
+        cwd=repo,
+        capture_output=True,
+        check=False,
+    )


### PR DESCRIPTION
## Summary
- harden boss-loop ping-pong handoff consumption and same-issue retry priority
- reconcile dead dispatched workers into truthful salvage results before lease reap
- add boss-loop and supervisor regression coverage for the new paths

## Validation
- python -m pytest tests/swarm/test_supervisor.py tests/swarm/test_boss_loop.py tests/swarm/test_ping_pong.py tests/swarm/test_ping_pong_integration.py -q