### PR TITLE
test(live): wrap runtime backend test in theme provider

### DIFF
--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import PublicDemoPage from '../(standalone)/demo/page';
 import TryPage from '../try/page';
+import { ThemeProvider } from '@/context/ThemeContext';
 
 const mockFetch = jest.fn();
 
@@ -55,6 +56,10 @@ function jsonResponse(data: unknown): Response {
   } as Response;
 }
 
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
 describe('runtime backend selection for public debate surfaces', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -72,7 +77,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<TryPage />);
+    renderWithTheme(<TryPage />);
     fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
       target: {
         value: 'Should we use the production backend for public try flows?',
@@ -106,7 +111,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<PublicDemoPage />);
+    renderWithTheme(<PublicDemoPage />);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |


### PR DESCRIPTION
## Summary
- wrap the runtime backend selection test render path in ThemeProvider
- keep the test exercising the real public page composition instead of mocking ThemeSelector away
- fix the shared Frontend E2E unit-test failure hitting unrelated PRs

## Validation
- cd aragora/live && npx jest src/app/__tests__/runtimeBackendSelection.test.tsx --runInBand
- cd aragora/live && npx eslint src/app/__tests__/runtimeBackendSelection.test.tsx
