### PR TITLE
fix(swarm): reconcile supervisor stale-lane outcomes

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -73,6 +73,7 @@ _QUEUEABLE_DEVELOPER_TASK_STATUSES = {
 }
 _REAPED_NO_RECEIPT_ARCHIVE_GRACE_HOURS = 6.0
 _REAPED_NO_RECEIPT_BLOCKERS = {"stale_lease_reaped", "expired_lease_reaped"}
+_INACTIVE_LEASE_RELEASED_ARCHIVE_GRACE_HOURS = 6.0
 
 
 def _get_lane_telemetry() -> LaneTelemetryCollector:
@@ -884,6 +885,33 @@ class DevCoordinationStore:
             conn.close()
         return updated
 
+    def rehabilitate_reaped_deliverable_work_orders(self) -> int:
+        """Normalize historical reaped lanes that already have better terminal truth."""
+        now = _utcnow().isoformat()
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT * FROM supervisor_runs ORDER BY updated_at DESC").fetchall()
+            updated = 0
+            for row in rows:
+                record = self._supervisor_run_from_row(row)
+                changed = False
+                for item in record["work_orders"]:
+                    if not isinstance(item, dict):
+                        continue
+                    if not _rehabilitate_reaped_deliverable_work_order(item):
+                        continue
+                    changed = True
+                    updated += 1
+                if not changed:
+                    continue
+                record["status"] = self._derive_supervisor_run_status(record["work_orders"])
+                record["updated_at"] = now
+                self._persist_supervisor_run(conn, record)
+            conn.commit()
+        finally:
+            conn.close()
+        return updated
+
     def archive_reaped_no_receipt_work_orders(
         self,
         *,
@@ -933,6 +961,63 @@ class DevCoordinationStore:
                     item["status"] = "discarded"
                     if not _optional_text(item.get("failure_reason")):
                         item["failure_reason"] = archive_reason
+                    changed = True
+                    archived += 1
+                if not changed:
+                    continue
+                record["status"] = self._derive_supervisor_run_status(record["work_orders"])
+                record["updated_at"] = now.isoformat()
+                self._persist_supervisor_run(conn, record)
+            conn.commit()
+        finally:
+            conn.close()
+        return archived
+
+    def archive_inactive_lease_released_work_orders(
+        self,
+        *,
+        grace_period_hours: float = _INACTIVE_LEASE_RELEASED_ARCHIVE_GRACE_HOURS,
+    ) -> int:
+        """Archive old released-without-terminal-result lanes with no deliverable."""
+        now = _utcnow()
+        grace_period = timedelta(hours=max(0.0, float(grace_period_hours)))
+        cutoff = now - grace_period
+        conn = self._connect()
+        try:
+            rows = conn.execute("SELECT * FROM supervisor_runs ORDER BY updated_at DESC").fetchall()
+            lease_status_by_id = {
+                str(row["lease_id"]).strip(): str(row["status"]).strip()
+                for row in conn.execute("SELECT lease_id, status FROM leases").fetchall()
+                if str(row["lease_id"]).strip()
+            }
+            archived = 0
+            for row in rows:
+                record = self._supervisor_run_from_row(row)
+                changed = False
+                for item in record["work_orders"]:
+                    if not isinstance(item, dict):
+                        continue
+                    lease_status = lease_status_by_id.get(_optional_text(item.get("lease_id")))
+                    if not _work_order_should_archive_inactive_lease_released(
+                        item,
+                        run=record,
+                        cutoff=cutoff,
+                        lease_status=lease_status,
+                    ):
+                        continue
+                    metadata = dict(item.get("metadata") or {})
+                    metadata.update(
+                        {
+                            "archived_due_to": "inactive_lease_released",
+                            "archived_at": now.isoformat(),
+                            "archive_reason": "inactive_lease_released",
+                            "previous_status": _optional_text(item.get("status")) or "needs_human",
+                        }
+                    )
+                    item["metadata"] = metadata
+                    item["status"] = "discarded"
+                    if not _optional_text(item.get("failure_reason")):
+                        item["failure_reason"] = "inactive_lease_released"
                     changed = True
                     archived += 1
                 if not changed:
@@ -1515,7 +1600,9 @@ class DevCoordinationStore:
             )
         self.backfill_missing_completion_receipts()
         self.backfill_missing_blocker_metadata()
+        self.rehabilitate_reaped_deliverable_work_orders()
         self.archive_reaped_no_receipt_work_orders()
+        self.archive_inactive_lease_released_work_orders()
         self.archive_scope_violation_no_deliverable_work_orders()
         self.archive_failed_no_deliverable_work_orders()
         self.archive_clean_exit_no_deliverable_work_orders()
@@ -1605,7 +1692,9 @@ class DevCoordinationStore:
 
         self.backfill_missing_completion_receipts()
         self.backfill_missing_blocker_metadata()
+        self.rehabilitate_reaped_deliverable_work_orders()
         self.archive_reaped_no_receipt_work_orders()
+        self.archive_inactive_lease_released_work_orders()
         self.archive_scope_violation_no_deliverable_work_orders()
         self.archive_failed_no_deliverable_work_orders()
         self.archive_clean_exit_no_deliverable_work_orders()
@@ -2596,7 +2685,9 @@ class DevCoordinationStore:
         """Project open developer tasks into the global work queue."""
         self.backfill_missing_completion_receipts()
         self.backfill_missing_blocker_metadata()
+        self.rehabilitate_reaped_deliverable_work_orders()
         self.archive_reaped_no_receipt_work_orders()
+        self.archive_inactive_lease_released_work_orders()
         self.archive_scope_violation_no_deliverable_work_orders()
         self.archive_failed_no_deliverable_work_orders()
         self.archive_clean_exit_no_deliverable_work_orders()
@@ -3294,6 +3385,13 @@ def _optional_text(*values: Any) -> str:
     return ""
 
 
+def _text_list(value: Any) -> list[str]:
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value or "").strip()
+    return [text] if text else []
+
+
 def _work_order_has_concrete_deliverable(work_order: dict[str, Any]) -> bool:
     receipt_id = _optional_text(work_order.get("receipt_id"))
     pr_url = _optional_text(work_order.get("pr_url"))
@@ -3448,6 +3546,8 @@ def _infer_missing_failure_reason_for_work_order(work_order: dict[str, Any]) -> 
         return "clean_exit_no_deliverable"
     if "dispatch blocked" in lowered:
         return "worker_type_blocked"
+    if "released without a synchronized terminal result" in lowered:
+        return "inactive_lease_released"
     if "autopilot ensure failed" in lowered or "lease" in lowered or "worktree" in lowered:
         return "work_order_leasing_failed"
 
@@ -3499,6 +3599,101 @@ def _backfill_work_order_blocker_metadata(work_order: dict[str, Any]) -> bool:
     return changed
 
 
+def _is_reaped_failure_reason(reason: str) -> bool:
+    return reason in {"stale_lease_reaped", "expired_lease_reaped"}
+
+
+def _clear_reaped_blocker_metadata(work_order: dict[str, Any]) -> None:
+    if _is_reaped_failure_reason(_optional_text(work_order.get("failure_reason"))):
+        work_order.pop("failure_reason", None)
+    if _is_reaped_failure_reason(_optional_text(work_order.get("dispatch_error"))):
+        work_order.pop("dispatch_error", None)
+    blocker = work_order.get("blocker")
+    if isinstance(blocker, dict) and _is_reaped_failure_reason(
+        _optional_text(blocker.get("reason"))
+    ):
+        work_order.pop("blocker", None)
+    blocking_question = _optional_text(work_order.get("blocking_question"))
+    if blocking_question in {
+        _default_blocking_question_for_reason("stale_lease_reaped"),
+        _default_blocking_question_for_reason("expired_lease_reaped"),
+    }:
+        work_order.pop("blocking_question", None)
+    blockers = [
+        text
+        for text in _text_list(work_order.get("blockers"))
+        if text.lower() not in {"stale_lease_reaped", "expired_lease_reaped"}
+    ]
+    if blockers:
+        work_order["blockers"] = blockers
+    else:
+        work_order.pop("blockers", None)
+
+
+def _rehabilitate_reaped_deliverable_work_order(work_order: dict[str, Any]) -> bool:
+    if not isinstance(work_order, dict):
+        return False
+    status = _optional_text(work_order.get("status")).lower()
+    failure_reason = _optional_text(work_order.get("failure_reason")).lower()
+    if status != "needs_human" or not _is_reaped_failure_reason(failure_reason):
+        return False
+    if not _work_order_has_concrete_deliverable(work_order):
+        return False
+
+    changed = False
+    worker_outcome = _optional_text(work_order.get("worker_outcome")).lower()
+    dispatch_error = _optional_text(work_order.get("dispatch_error")).lower()
+
+    if worker_outcome in {"", "completed"}:
+        work_order["status"] = "completed"
+        if _optional_text(work_order.get("review_status")).lower() in {
+            "",
+            "pending",
+            "changes_requested",
+        }:
+            work_order["review_status"] = "pending_heterogeneous_review"
+        _clear_reaped_blocker_metadata(work_order)
+        work_order.pop("blocking_question", None)
+        work_order.pop("blocker", None)
+        changed = True
+    elif worker_outcome == "merge_gate_failed":
+        normalized_reason = (
+            "missing_verification_plan"
+            if "missing verification plan" in dispatch_error
+            else "merge_gate_failed"
+        )
+        if _optional_text(work_order.get("failure_reason")) != normalized_reason:
+            work_order["failure_reason"] = normalized_reason
+            changed = True
+        blocking_question = _default_blocking_question_for_reason(normalized_reason)
+        if _optional_text(work_order.get("blocking_question")) != blocking_question:
+            work_order["blocking_question"] = blocking_question
+            changed = True
+        blocker = {
+            "reason": normalized_reason,
+            "question": blocking_question,
+        }
+        if work_order.get("blocker") != blocker:
+            work_order["blocker"] = blocker
+            changed = True
+        blockers = [
+            text
+            for text in _text_list(work_order.get("blockers"))
+            if text.lower() not in {"stale_lease_reaped", "expired_lease_reaped"}
+        ]
+        if _optional_text(work_order.get("dispatch_error")):
+            if _optional_text(work_order.get("dispatch_error")) not in blockers:
+                blockers.append(_optional_text(work_order.get("dispatch_error")))
+        if blockers != work_order.get("blockers"):
+            if blockers:
+                work_order["blockers"] = blockers
+            else:
+                work_order.pop("blockers", None)
+            changed = True
+
+    return changed
+
+
 def _work_order_reap_failure_reason(
     work_order: dict[str, Any],
     *,
@@ -3545,6 +3740,41 @@ def _work_order_should_archive_reaped_no_receipt(
     ):
         return False
     if not _work_order_reap_failure_reason(work_order, lease_status=lease_status):
+        return False
+    updated_at = _parse_dt(_developer_task_updated_at(work_order, run))
+    return updated_at <= cutoff
+
+
+def _work_order_inactive_lease_released_reason(work_order: dict[str, Any]) -> str:
+    for blocker in _developer_task_blockers(work_order):
+        normalized = blocker.strip().lower()
+        if normalized == "inactive_lease_released":
+            return "inactive_lease_released"
+        if "released without a synchronized terminal result" in normalized:
+            return "inactive_lease_released"
+    return ""
+
+
+def _work_order_should_archive_inactive_lease_released(
+    work_order: dict[str, Any],
+    *,
+    run: dict[str, Any],
+    cutoff: datetime,
+    lease_status: str | None,
+) -> bool:
+    status = _optional_text(work_order.get("status")).lower()
+    if status not in _OPEN_DEVELOPER_TASK_STATUSES:
+        return False
+    if _optional_text(lease_status).lower() == LeaseStatus.ACTIVE.value:
+        return False
+    metadata = work_order.get("metadata")
+    if isinstance(metadata, dict) and _optional_text(metadata.get("archived_due_to")):
+        return False
+    if _optional_text(work_order.get("receipt_id")) or _work_order_has_concrete_deliverable(
+        work_order
+    ):
+        return False
+    if not _work_order_inactive_lease_released_reason(work_order):
         return False
     updated_at = _parse_dt(_developer_task_updated_at(work_order, run))
     return updated_at <= cutoff

--- a/aragora/nomic/task_decomposer.py
+++ b/aragora/nomic/task_decomposer.py
@@ -394,6 +394,8 @@ class TaskDecomposer:
         depth: int = 0,
         *,
         file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
     ) -> TaskDecomposition:
         """Analyze a task and determine if decomposition is needed.
 
@@ -446,7 +448,12 @@ class TaskDecomposer:
         ):
             llm_subtasks = self._finalize_generated_subtasks(
                 task_description,
-                self._llm_extract_subtasks(task_description, file_scope_hints=file_scope_hints),
+                self._llm_extract_subtasks(
+                    task_description,
+                    file_scope_hints=file_scope_hints,
+                    acceptance_criteria=acceptance_criteria,
+                    constraints=constraints,
+                ),
                 file_scope_hints=file_scope_hints,
             )
             if llm_subtasks and (len(llm_subtasks) >= 2 or file_scope_hints):
@@ -524,7 +531,11 @@ class TaskDecomposer:
             result.subtasks = self._finalize_generated_subtasks(
                 task_description,
                 self._generate_subtasks(
-                    task_description, debate_result, file_scope_hints=file_scope_hints
+                    task_description,
+                    debate_result,
+                    file_scope_hints=file_scope_hints,
+                    acceptance_criteria=acceptance_criteria,
+                    constraints=constraints,
                 ),
                 file_scope_hints=file_scope_hints,
             )
@@ -1220,6 +1231,8 @@ class TaskDecomposer:
         debate_result: DebateResult | None = None,
         *,
         file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
     ) -> list[SubTask]:
         """Generate subtasks for a complex task.
 
@@ -1252,7 +1265,12 @@ class TaskDecomposer:
 
         # 2. Try LLM-based subtask extraction (frontier model).
         #    Returns [] when no API key is configured — falls through silently.
-        llm_subtasks = self._llm_extract_subtasks(task, file_scope_hints=file_scope_hints)
+        llm_subtasks = self._llm_extract_subtasks(
+            task,
+            file_scope_hints=file_scope_hints,
+            acceptance_criteria=acceptance_criteria,
+            constraints=constraints,
+        )
         if llm_subtasks:
             return llm_subtasks[: self.config.max_subtasks]
 
@@ -1260,7 +1278,12 @@ class TaskDecomposer:
         return self._heuristic_decomposition(task, debate_result)
 
     def _llm_extract_subtasks(
-        self, task: str, *, file_scope_hints: list[str] | None = None
+        self,
+        task: str,
+        *,
+        file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
     ) -> list[SubTask]:
         """Extract subtasks using a frontier LLM.
 
@@ -1271,7 +1294,12 @@ class TaskDecomposer:
         Returns an empty list if no provider is available or both fail,
         allowing the caller to fall back to heuristic decomposition.
         """
-        prompt = self._build_decomposition_prompt(task, file_scope_hints)
+        prompt = self._build_decomposition_prompt(
+            task,
+            file_scope_hints=file_scope_hints,
+            acceptance_criteria=acceptance_criteria,
+            constraints=constraints,
+        )
 
         # Try Anthropic first
         text = self._call_anthropic(prompt)
@@ -1284,7 +1312,11 @@ class TaskDecomposer:
         return self._parse_llm_subtasks(text)
 
     def _build_decomposition_prompt(
-        self, task: str, file_scope_hints: list[str] | None = None
+        self,
+        task: str,
+        file_scope_hints: list[str] | None = None,
+        acceptance_criteria: list[str] | None = None,
+        constraints: list[str] | None = None,
     ) -> str:
         """Build a structured prompt for LLM-based task decomposition."""
         scope_section = ""
@@ -1296,12 +1328,26 @@ class TaskDecomposer:
                 f"- ALL subtask file_scope values MUST reference paths within these directories.\n"
                 f"- Do NOT generate subtasks targeting other parts of the codebase.\n"
             )
+        acceptance_section = ""
+        if acceptance_criteria:
+            acceptance_list = "\n".join(
+                f"- {item}" for item in acceptance_criteria if str(item).strip()
+            )
+            if acceptance_list:
+                acceptance_section = f"\n## Acceptance Criteria\n{acceptance_list}\n"
+        constraints_section = ""
+        if constraints:
+            constraints_list = "\n".join(f"- {item}" for item in constraints if str(item).strip())
+            if constraints_list:
+                constraints_section = f"\n## Constraints\n{constraints_list}\n"
 
         return (
             "You are a precise task decomposition engine for a software project.\n\n"
             "## Task\n"
             f"{task}\n"
             f"{scope_section}\n"
+            f"{acceptance_section}"
+            f"{constraints_section}"
             "## Instructions\n"
             "Analyze the task above and decompose it into 1-5 concrete, actionable subtasks.\n\n"
             "### Classification Rules\n"

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1438,6 +1438,8 @@ class SwarmSupervisor:
         decomposition = self.decomposer.analyze(
             goal,
             file_scope_hints=spec_hints or None,
+            acceptance_criteria=list(spec.acceptance_criteria) or None,
+            constraints=list(spec.constraints) or None,
         )
         subtasks = list(decomposition.subtasks)
         if not subtasks:

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -878,6 +878,93 @@ def test_archive_reaped_no_receipt_work_orders_discards_old_backlog(
     assert store.list_developer_tasks(open_only=True) == []
 
 
+def test_archive_inactive_lease_released_work_orders_discards_old_backlog(
+    store: DevCoordinationStore,
+) -> None:
+    run = store.create_supervisor_run(
+        goal="Archive inactive released backlog",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={
+            "require_merge_approval": True,
+            "require_external_action_approval": True,
+        },
+        spec={
+            "raw_goal": "Archive inactive released backlog",
+            "refined_goal": "Archive inactive released backlog",
+        },
+        work_orders=[
+            {
+                "work_order_id": "wo-inactive-release",
+                "title": "Old inactive released lane",
+                "file_scope": ["aragora/swarm/reporter.py"],
+                "status": "needs_human",
+                "failure_reason": "inactive_lease_released",
+                "dispatch_error": (
+                    "Lease lease-inactive was released without a synchronized terminal result."
+                ),
+                "dispatched_at": "2000-01-01T00:00:00+00:00",
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+            }
+        ],
+    )
+
+    archived = store.archive_inactive_lease_released_work_orders(grace_period_hours=6.0)
+    refreshed = store.get_supervisor_run(run["run_id"])
+
+    assert archived == 1
+    assert refreshed is not None
+    work_order = refreshed["work_orders"][0]
+    assert work_order["status"] == "discarded"
+    assert work_order["failure_reason"] == "inactive_lease_released"
+    assert work_order["metadata"]["archived_due_to"] == "inactive_lease_released"
+    assert work_order["metadata"]["archive_reason"] == "inactive_lease_released"
+    assert work_order["metadata"]["previous_status"] == "needs_human"
+
+
+def test_archive_inactive_lease_released_work_orders_preserves_deliverable_lane(
+    store: DevCoordinationStore,
+) -> None:
+    run = store.create_supervisor_run(
+        goal="Keep inactive released deliverable reviewable",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={
+            "require_merge_approval": True,
+            "require_external_action_approval": True,
+        },
+        spec={
+            "raw_goal": "Keep inactive released deliverable reviewable",
+            "refined_goal": "Keep inactive released deliverable reviewable",
+        },
+        work_orders=[
+            {
+                "work_order_id": "wo-inactive-deliverable",
+                "title": "Inactive released deliverable lane",
+                "file_scope": ["aragora/swarm/reporter.py"],
+                "status": "needs_human",
+                "failure_reason": "inactive_lease_released",
+                "dispatch_error": (
+                    "Lease lease-inactive was released without a synchronized terminal result."
+                ),
+                "dispatched_at": "2000-01-01T00:00:00+00:00",
+                "branch": "codex/inactive-release-deliverable",
+                "commit_shas": ["abc12345"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+            }
+        ],
+    )
+
+    archived = store.archive_inactive_lease_released_work_orders(grace_period_hours=6.0)
+    refreshed = store.get_supervisor_run(run["run_id"])
+
+    assert archived == 0
+    assert refreshed is not None
+    assert refreshed["work_orders"][0]["status"] == "needs_human"
+
+
 def test_archive_reaped_no_receipt_work_orders_preserves_active_or_receipt_backed_lanes(
     store: DevCoordinationStore,
 ) -> None:
@@ -1714,6 +1801,43 @@ def test_backfill_missing_blocker_metadata_infers_clean_exit_no_deliverable(
     assert work_order["blocker"]["reason"] == "clean_exit_no_deliverable"
 
 
+def test_backfill_missing_blocker_metadata_infers_inactive_lease_released(
+    store: DevCoordinationStore,
+) -> None:
+    run = store.create_supervisor_run(
+        goal="Backfill inactive lease released blocker metadata",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={
+            "require_merge_approval": True,
+            "require_external_action_approval": True,
+        },
+        spec={
+            "raw_goal": "Backfill inactive lease released blocker metadata",
+            "refined_goal": "Backfill inactive lease released blocker metadata",
+        },
+        work_orders=[
+            {
+                "work_order_id": "subtask_1",
+                "title": "Historical inactive released lane",
+                "status": "needs_human",
+                "dispatch_error": (
+                    "Lease lease-inactive was released without a synchronized terminal result."
+                ),
+            }
+        ],
+    )
+
+    updated = store.backfill_missing_blocker_metadata()
+    refreshed = store.get_supervisor_run(run["run_id"])
+
+    assert updated == 1
+    assert refreshed is not None
+    work_order = refreshed["work_orders"][0]
+    assert work_order["failure_reason"] == "inactive_lease_released"
+    assert work_order["blocker"]["reason"] == "inactive_lease_released"
+
+
 def test_backfill_missing_blocker_metadata_preserves_blocked_deliverable_lane(
     store: DevCoordinationStore,
 ) -> None:
@@ -1821,6 +1945,118 @@ def test_backfill_missing_completion_receipts_for_historical_deliverable(
     assert receipt is not None
     assert receipt.outcome == "deliverable_created"
     assert receipt.metadata["backfilled_receipt"] is True
+
+
+def test_rehabilitate_reaped_deliverable_work_orders_recovers_completed_lane(
+    store: DevCoordinationStore,
+) -> None:
+    run = store.create_supervisor_run(
+        goal="Rehabilitate stale deliverable lane",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={
+            "require_merge_approval": True,
+            "require_external_action_approval": True,
+        },
+        spec={
+            "raw_goal": "Rehabilitate stale deliverable lane",
+            "refined_goal": "Rehabilitate stale deliverable lane",
+        },
+        work_orders=[
+            {
+                "work_order_id": "wo-rehab-completed",
+                "title": "Historical stale deliverable lane",
+                "status": "needs_human",
+                "failure_reason": "stale_lease_reaped",
+                "dispatch_error": "stale_lease_reaped",
+                "blocking_question": (
+                    "Should this stalled lane be rerun, split, or investigated before retrying?"
+                ),
+                "blocker": {
+                    "reason": "stale_lease_reaped",
+                    "question": (
+                        "Should this stalled lane be rerun, split, or investigated before retrying?"
+                    ),
+                },
+                "blockers": ["stale_lease_reaped", "historical-note"],
+                "worker_outcome": "completed",
+                "review_status": "pending",
+                "receipt_id": "receipt-rehab-completed",
+                "branch": "codex/rehab-completed",
+                "commit_shas": ["abc12345"],
+            }
+        ],
+    )
+
+    updated = store.rehabilitate_reaped_deliverable_work_orders()
+    refreshed = store.get_supervisor_run(run["run_id"])
+
+    assert updated == 1
+    assert refreshed is not None
+    work_order = refreshed["work_orders"][0]
+    assert work_order["status"] == "completed"
+    assert work_order["review_status"] == "pending_heterogeneous_review"
+    assert "failure_reason" not in work_order
+    assert "dispatch_error" not in work_order
+    assert "blocking_question" not in work_order
+    assert "blocker" not in work_order
+    assert work_order["blockers"] == ["historical-note"]
+
+
+def test_rehabilitate_reaped_deliverable_work_orders_rewrites_merge_gate_lane(
+    store: DevCoordinationStore,
+) -> None:
+    run = store.create_supervisor_run(
+        goal="Rehabilitate stale merge gate lane",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={
+            "require_merge_approval": True,
+            "require_external_action_approval": True,
+        },
+        spec={
+            "raw_goal": "Rehabilitate stale merge gate lane",
+            "refined_goal": "Rehabilitate stale merge gate lane",
+        },
+        work_orders=[
+            {
+                "work_order_id": "wo-rehab-merge-gate",
+                "title": "Historical stale merge gate lane",
+                "status": "needs_human",
+                "failure_reason": "stale_lease_reaped",
+                "dispatch_error": (
+                    "merge gate blocked: missing verification plan for code-change lane"
+                ),
+                "blocking_question": (
+                    "Should this stalled lane be rerun, split, or investigated before retrying?"
+                ),
+                "blocker": {
+                    "reason": "stale_lease_reaped",
+                    "question": (
+                        "Should this stalled lane be rerun, split, or investigated before retrying?"
+                    ),
+                },
+                "blockers": ["stale_lease_reaped"],
+                "worker_outcome": "merge_gate_failed",
+                "branch": "codex/rehab-merge-gate",
+                "commit_shas": ["def67890"],
+            }
+        ],
+    )
+
+    updated = store.rehabilitate_reaped_deliverable_work_orders()
+    refreshed = store.get_supervisor_run(run["run_id"])
+
+    assert updated == 1
+    assert refreshed is not None
+    work_order = refreshed["work_orders"][0]
+    assert work_order["status"] == "needs_human"
+    assert work_order["failure_reason"] == "missing_verification_plan"
+    assert "verification command" in work_order["blocking_question"]
+    assert work_order["blocker"]["reason"] == "missing_verification_plan"
+    assert work_order["blockers"] == [
+        "merge gate blocked: missing verification plan for code-change lane"
+    ]
 
 
 def test_list_developer_tasks_preserves_terminal_truth_metadata(

--- a/tests/nomic/test_task_decomposer.py
+++ b/tests/nomic/test_task_decomposer.py
@@ -225,6 +225,35 @@ class TestTaskDecomposer:
         assert "mirrored subtask" in result.rationale.lower()
 
     @patch.object(TaskDecomposer, "_llm_extract_subtasks", return_value=[])
+    def test_analyze_threads_acceptance_and_constraints_to_llm_extraction(
+        self,
+        mock_llm_extract: object,
+    ) -> None:
+        decomposer = TaskDecomposer()
+        task = (
+            "Refactor the entire database layer to support multi-tenancy. "
+            "This requires changes to models, migrations, API endpoints, "
+            "and security middleware. Update auth.py, db.py, handlers.py."
+        )
+        acceptance = ["python -m pytest tests/database/test_tenancy.py -q"]
+        constraints = ["Keep merge gate enabled", "Stay within the bounded scope"]
+        hints = ["aragora/database/**", "tests/database/**"]
+
+        decomposer.analyze(
+            task,
+            file_scope_hints=hints,
+            acceptance_criteria=acceptance,
+            constraints=constraints,
+        )
+
+        mock_llm_extract.assert_called_once_with(
+            task,
+            file_scope_hints=hints,
+            acceptance_criteria=acceptance,
+            constraints=constraints,
+        )
+
+    @patch.object(TaskDecomposer, "_llm_extract_subtasks", return_value=[])
     def test_same_scope_heuristic_subtasks_collapse_to_one_lane(self, _mock_llm_extract: object):
         decomposer = TaskDecomposer(DecomposerConfig(complexity_threshold=1))
         task = (

--- a/tests/nomic/test_task_decomposer.py
+++ b/tests/nomic/test_task_decomposer.py
@@ -54,8 +54,8 @@ class TestTaskDecomposer:
         assert result.should_decompose is True
         assert len(result.subtasks) >= 2
 
-    def test_file_mentions_increase_complexity(self):
-        """Tasks mentioning multiple files should score higher."""
+    def test_file_mentions_reduce_abstract_goal_bonus(self):
+        """Concrete file mentions should narrow a vague task's scope."""
         decomposer = TaskDecomposer()
 
         simple = decomposer.analyze("Update auth logic")
@@ -63,7 +63,8 @@ class TestTaskDecomposer:
             "Update auth logic in auth.py, handlers.py, middleware.py, tests.py"
         )
 
-        assert with_files.complexity_score > simple.complexity_score
+        assert with_files.complexity_score < simple.complexity_score
+        assert with_files.should_decompose is False
 
     def test_concept_extraction(self):
         """Should extract concept areas for subtask generation."""

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -118,6 +118,58 @@ def test_start_run_creates_leased_work_orders(repo: Path, store: DevCoordination
     assert store.status_summary()["counts"]["active_leases"] == 2
 
 
+def test_start_run_passes_acceptance_and_constraints_to_decomposer(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    session = ManagedWorktreeSession(
+        session_id="swarm-acceptance",
+        agent="codex",
+        branch="codex/swarm-acceptance",
+        path=repo / "wt-acceptance",
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    session.path.mkdir()
+
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = session
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="wo-1",
+                title="Server lane",
+                description="Implement server lane",
+                file_scope=["README.md"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+    spec = SwarmSpec(
+        raw_goal="Goal",
+        refined_goal="Goal",
+        acceptance_criteria=["python -m pytest tests/swarm/test_supervisor.py -q"],
+        constraints=["Keep merge gate enabled", "Human approval required"],
+    )
+
+    supervisor.start_run(spec=spec, max_concurrency=1)
+
+    decomposer.analyze.assert_called_once()
+    kwargs = decomposer.analyze.call_args.kwargs
+    assert kwargs["acceptance_criteria"] == ["python -m pytest tests/swarm/test_supervisor.py -q"]
+    assert kwargs["constraints"] == ["Keep merge gate enabled", "Human approval required"]
+
+
 def test_refresh_run_scales_queued_work_after_completion(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- rehabilitate stale reaped deliverables before archival so supervisor truth reflects actual outcomes
- archive inactive lease-released lanes without deliverables after a grace period
- extend task decomposer inputs/tests for acceptance criteria and constraints in reconciliation flows

## Validation
- python3 -m pytest tests/nomic/test_dev_coordination.py tests/nomic/test_task_decomposer.py tests/swarm/test_supervisor.py -q
- python3 -m ruff check aragora/nomic/dev_coordination.py aragora/nomic/task_decomposer.py aragora/swarm/supervisor.py tests/nomic/test_dev_coordination.py tests/nomic/test_task_decomposer.py tests/swarm/test_supervisor.py

## Stack
- base branch: codex/task-decomposer-concrete-scope (#1791)