### PR TITLE
fix(docs): stabilize doc stats headline rounding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 212,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,600+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 210,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,600+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -415,7 +415,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 212,000+ tests across 5,000+ test files
+**Test Suite:** 210,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ aragora/
 └── workflow/       # DAG-based automation engine
 ```
 
-**Scale:** 3,000+ Python modules | 212,000+ tests across 5,000+ test files
+**Scale:** 3,000+ Python modules | 210,000+ tests across 5,000+ test files
 
 ### Performance and Costs
 

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -336,7 +336,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 212,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 210,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
 
 ---
 

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -24,7 +24,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | [Developer Tools](#8-developer-tools) | 35+ | Stable |
 | [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
 
-**Total**: 230+ features | 3,000+ Python modules | 212,000+ tests | 3,000+ API operations across 2,600+ paths
+**Total**: 230+ features | 3,000+ Python modules | 210,000+ tests | 3,000+ API operations across 2,600+ paths
 
 ---
 

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/scripts/doc_stats.py
+++ b/scripts/doc_stats.py
@@ -207,7 +207,8 @@ def _apply_patterns(
 
 def patch_docs(stats: Stats, write: bool) -> int:
     modules_approx = _approx(stats.python_modules, 1000)
-    tests_approx = _approx(stats.test_count, 1000)
+    # Keep the repo-wide headline coarse enough to avoid CI/local flapping.
+    tests_approx = _approx(stats.test_count, 10000)
     test_files_approx = _approx(stats.test_files, 1000)
     api_ops_approx = _approx(stats.api_operations, 1000)
     api_paths_approx = _approx(stats.api_paths, 100)

--- a/tests/scripts/test_doc_stats.py
+++ b/tests/scripts/test_doc_stats.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from scripts import doc_stats
+
+
+def test_patch_docs_uses_coarse_repo_test_rounding(monkeypatch, tmp_path) -> None:
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "**Scale:** 3,000+ Python modules | 212,000+ tests across 5,000+ test files\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(doc_stats, "ROOT", tmp_path)
+    changed = doc_stats.patch_docs(
+        doc_stats.Stats(
+            python_modules=3869,
+            test_count=212_650,
+            test_files=5219,
+            api_paths=2603,
+            api_operations=3084,
+            ws_event_types=272,
+            km_adapters_registered=0,
+            workflow_templates=62,
+            ts_namespaces=186,
+            agent_types_allowlisted=34,
+        ),
+        write=True,
+    )
+
+    assert changed == 1
+    assert "210,000+ tests" in readme.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- make repo-wide test-count headlines coarser so doc stats do not flap across CI environments
- add a regression for the rounded headline write path in `scripts/doc_stats.py`
- regenerate the affected root docs with the stabilized count

## Why
- `build` was failing on unrelated PRs because `python scripts/doc_stats.py --write` rewrote root docs from `212,000+ tests` to a nearby value in CI
- the failure pattern matched the four headline docs only, so this lands the generator fix independently and unblocks downstream PR reruns

## Validation
- python3 -m pytest tests/scripts/test_doc_stats.py -q
- python3 -m ruff check scripts/doc_stats.py tests/scripts/test_doc_stats.py
- python3 scripts/doc_stats.py --write
- node docs-site/scripts/sync-docs.js