### PR TITLE
fix(knowledge): default search handler to query engine

### DIFF
--- a/aragora/server/handlers/knowledge_base/handler.py
+++ b/aragora/server/handlers/knowledge_base/handler.py
@@ -140,20 +140,10 @@ class KnowledgeHandler(
         return self._query_engine
 
     def _get_knowledge_mound(self) -> Any | None:
-        """Get a shared Knowledge Mound instance when available."""
+        """Get an explicitly configured Knowledge Mound instance when available."""
         mound = self.ctx.get("knowledge_mound")
         if mound is not None:
             return mound
-        if self._knowledge_mound is not None:
-            return self._knowledge_mound
-
-        try:
-            from aragora.knowledge.mound import get_knowledge_mound
-
-            self._knowledge_mound = get_knowledge_mound()
-        except (ImportError, RuntimeError, OSError, ValueError) as e:
-            logger.debug("Knowledge Mound unavailable for search: %s", e)
-            self._knowledge_mound = None
         return self._knowledge_mound
 
     def can_handle(self, path: str) -> bool:

--- a/aragora/server/handlers/knowledge_base/search.py
+++ b/aragora/server/handlers/knowledge_base/search.py
@@ -264,7 +264,8 @@ class SearchOperationsMixin:
 
                 normalized = []
                 if retrieved is not None:
-                    normalized = [_normalize_search_result(item) for item in retrieved.items]
+                    items = getattr(retrieved, "items", retrieved)
+                    normalized = [_normalize_search_result(item) for item in items]
                 normalized = _filter_normalized_results(
                     normalized,
                     min_confidence=min_confidence,


### PR DESCRIPTION
## Summary
- stop knowledge search from auto-bootstrapping a global Knowledge Mound in the base handler
- keep Knowledge Mound search opt-in via explicit context/injection
- accept both KM retrieval result objects and plain item lists when normalizing search results

## Validation
- python3 -m pytest tests/handlers/knowledge_base/test_handler.py tests/handlers/knowledge_base/test_search.py -q
- python3 -m ruff check aragora/server/handlers/knowledge_base/handler.py aragora/server/handlers/knowledge_base/search.py tests/handlers/knowledge_base/test_handler.py tests/handlers/knowledge_base/test_search.py