### PR TITLE
fix(cli): drain ask cleanup callbacks before loop shutdown

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -344,10 +344,10 @@ async def _shutdown_cmd_ask_resources() -> None:
     except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
         logger.debug("Ask dispatcher shutdown skipped: %s", exc)
 
-    # Give async transport/connector close callbacks one loop turn before
-    # asyncio.run() tears the loop down. This avoids intermittent unclosed
-    # socket warnings in CLI proof-path tests.
-    await asyncio.sleep(0)
+    # Give async transport/connector close callbacks a brief chance to finish
+    # before asyncio.run() tears the loop down. A single yield is not always
+    # enough on Linux runners and can leave socket/event-loop warnings behind.
+    await asyncio.sleep(0.05)
 
 
 async def _run_coro_with_cmd_ask_cleanup(coro: Any) -> Any:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -22,6 +22,7 @@ def _stub_cmd_ask_global_side_effects(request):
 
     cleanup_sensitive_tests = {
         "test_cmd_ask_demo_forces_local_offline",
+        "test_shutdown_cmd_ask_resources_drains_transport_callbacks",
         "test_cmd_ask_cleans_shared_resources_on_debate_loop",
         "test_cmd_ask_compare_mode_reuses_single_loop_for_cleanup",
     }
@@ -243,6 +244,36 @@ def test_cmd_ask_demo_quality_pipeline_skips_provider_repairs(monkeypatch):
         ),
     ):
         debate_cmd.cmd_ask(args)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cmd_ask_resources_drains_transport_callbacks() -> None:
+    """CLI ask shutdown should leave a small drain window for async closes."""
+    from aragora.cli.commands import debate as debate_cmd
+
+    with (
+        patch(
+            "aragora.server.startup.database.close_postgres_pool",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.server.http_client_pool.close_http_pool",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.agents.api_agents.common.close_shared_connector",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.storage.connection_factory.close_all_pools",
+            new=AsyncMock(),
+        ),
+        patch("aragora.events.dispatcher.shutdown_dispatcher"),
+        patch("aragora.cli.commands.debate.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+    ):
+        await debate_cmd._shutdown_cmd_ask_resources()
+
+    mock_sleep.assert_awaited_once_with(0.05)
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")


### PR DESCRIPTION
## Summary
- give `cmd_ask` shutdown a short drain window for async transport close callbacks
- align the debate CLI cleanup behavior with the existing triage CLI shutdown pattern
- add a regression covering the cleanup drain path in the offline golden-path test module

## Why
- `Hetzner Offline Golden Path Shadow` is failing on multiple PRs with unclosed socket and event-loop warnings in `tests/cli/test_offline_golden_path.py`
- the current ask cleanup only yields one loop turn, which is not enough on Linux runners for some async close callbacks

## Validation
- python3 -m pytest tests/cli/test_offline_golden_path.py -k "shutdown_cmd_ask_resources_drains_transport_callbacks or demo_quality_pipeline_skips_provider_repairs or cleans_shared_resources_on_debate_loop" -q
- python3 -m ruff check aragora/cli/commands/debate.py tests/cli/test_offline_golden_path.py