### PR TITLE
fix(slack): refresh docs and test guardrails

### DIFF
--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -1,4 +1,6 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { renderWithProviders } from '@/test-utils';
 
 import PublicDemoPage from '../(standalone)/demo/page';
 import TryPage from '../try/page';
@@ -72,7 +74,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<TryPage />);
+    renderWithProviders(<TryPage />);
     fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
       target: {
         value: 'Should we use the production backend for public try flows?',
@@ -106,7 +108,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<PublicDemoPage />);
+    renderWithProviders(<PublicDemoPage />);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(

--- a/aragora/server/debate_origin/router.py
+++ b/aragora/server/debate_origin/router.py
@@ -61,6 +61,65 @@ USE_DOCK_ROUTING = os.environ.get("DEBATE_ORIGIN_USE_DOCKS", "1").lower() not in
 )
 
 
+def _get_slack_delivery_policy(origin: DebateOrigin) -> dict[str, Any]:
+    """Return Slack-specific delivery guardrails from origin metadata."""
+    policy = origin.metadata.get("slack_policy", {})
+    return policy if isinstance(policy, dict) else {}
+
+
+def _should_fail_closed_slack_result(
+    origin: DebateOrigin,
+    result: dict[str, Any],
+    *,
+    is_aux_event: bool,
+) -> bool:
+    """Return True when a Slack result should be held back instead of posted."""
+    if origin.platform.lower() != "slack" or is_aux_event:
+        return False
+
+    policy = _get_slack_delivery_policy(origin)
+    if not policy.get("fail_closed"):
+        return False
+
+    require_consensus = bool(policy.get("require_consensus", True))
+    consensus_reached = bool(result.get("consensus_reached", False))
+    raw_confidence = result.get("confidence", 0.0)
+    confidence = float(raw_confidence) if isinstance(raw_confidence, (int, float)) else 0.0
+    min_confidence = float(policy.get("min_confidence", 0.0) or 0.0)
+
+    if require_consensus and not consensus_reached:
+        return True
+    return confidence < min_confidence
+
+
+def _build_slack_fail_closed_message(
+    debate_id: str,
+    origin: DebateOrigin,
+    result: dict[str, Any],
+) -> str:
+    """Build a user-facing Slack holdback message for low-confidence results."""
+    policy = _get_slack_delivery_policy(origin)
+    reasons: list[str] = []
+    if policy.get("require_consensus", True) and not result.get("consensus_reached", False):
+        reasons.append("consensus was not reached")
+
+    raw_confidence = result.get("confidence", 0.0)
+    confidence = float(raw_confidence) if isinstance(raw_confidence, (int, float)) else 0.0
+    min_confidence = float(policy.get("min_confidence", 0.0) or 0.0)
+    if confidence < min_confidence:
+        reasons.append(f"confidence stayed below {min_confidence:.0%}")
+
+    reason_text = " and ".join(reasons) if reasons else "the answer was not reliable enough"
+    query_mode = str(policy.get("query_mode", "deliberative"))
+    return (
+        "I’m holding this answer back instead of posting a final response.\n\n"
+        f"Reason: {reason_text}.\n"
+        f"Question type: {query_mode}.\n"
+        "Please retry with more context or ask again after a stronger consensus path.\n\n"
+        f"_Debate ID: {debate_id}_"
+    )
+
+
 async def route_debate_result(
     debate_id: str,
     result: dict[str, Any],
@@ -117,6 +176,17 @@ async def route_debate_result(
 
     platform = origin.platform.lower()
     logger.info("Routing result for %s to %s:%s", debate_id, platform, origin.channel_id)
+
+    if _should_fail_closed_slack_result(origin, result, is_aux_event=is_aux_event):
+        message = _build_slack_fail_closed_message(debate_id, origin, result)
+        try:
+            success = await _send_slack_error(origin, message)
+        except (OSError, RuntimeError, ValueError) as e:
+            logger.error("Failed to route Slack fail-closed message for %s: %s", debate_id, e)
+            return False
+        if success and not is_aux_event:
+            mark_result_sent(debate_id)
+        return success
 
     # Use dock-based routing if enabled
     if USE_DOCK_ROUTING:

--- a/aragora/server/handlers/bots/slack/debates.py
+++ b/aragora/server/handlers/bots/slack/debates.py
@@ -10,9 +10,51 @@ import logging
 import time
 from typing import Any
 
+from aragora.config import DEFAULT_ROUNDS
+
 from .state import _active_debates
 
 logger = logging.getLogger(__name__)
+
+_SLACK_FAIL_CLOSED_MIN_CONFIDENCE = 0.7
+_SLACK_NON_TRIVIAL_MIN_ROUNDS = 2
+
+
+def _build_slack_policy(topic: str) -> dict[str, Any]:
+    """Classify Slack asks for delivery guardrails."""
+    try:
+        from aragora.routing.lara_router import LaRARouter, RetrievalMode
+
+        decision = LaRARouter().route(query=topic, doc_tokens=0)
+        features = decision.query_features
+        is_non_trivial = (
+            decision.selected_mode != RetrievalMode.RAG
+            or features.is_analytical
+            or features.is_multi_hop
+            or features.requires_aggregation
+            or features.complexity_score >= 0.35
+        )
+        query_mode = "factual" if not is_non_trivial and features.is_factual else "deliberative"
+        min_rounds = 1 if query_mode == "factual" else _SLACK_NON_TRIVIAL_MIN_ROUNDS
+        return {
+            "query_mode": query_mode,
+            "selected_mode": decision.selected_mode.value,
+            "routing_confidence": float(decision.confidence),
+            "require_consensus": True,
+            "fail_closed": True,
+            "min_confidence": _SLACK_FAIL_CLOSED_MIN_CONFIDENCE,
+            "min_rounds": min_rounds,
+        }
+    except (ImportError, RuntimeError, AttributeError, ValueError):
+        return {
+            "query_mode": "deliberative",
+            "selected_mode": "debate",
+            "routing_confidence": 0.0,
+            "require_consensus": True,
+            "fail_closed": True,
+            "min_confidence": _SLACK_FAIL_CLOSED_MIN_CONFIDENCE,
+            "min_rounds": _SLACK_NON_TRIVIAL_MIN_ROUNDS,
+        }
 
 
 async def start_slack_debate(
@@ -55,18 +97,25 @@ async def start_slack_debate(
             webhook_url=response_url,
         )
 
+        slack_policy = _build_slack_policy(topic)
+
         # Create request context
         context = RequestContext(
             user_id=user_id,
             session_id=f"slack:{channel_id}",
+            metadata={"slack_policy": slack_policy},
         )
 
-        config = None
+        config_kwargs: dict[str, Any] = {}
         if decision_integrity is not None:
             if isinstance(decision_integrity, bool):
                 decision_integrity = {} if decision_integrity else None
             if isinstance(decision_integrity, dict):
-                config = DecisionConfig(decision_integrity=decision_integrity)
+                config_kwargs["decision_integrity"] = decision_integrity
+        min_rounds = int(slack_policy.get("min_rounds", 1) or 1)
+        if DEFAULT_ROUNDS < min_rounds:
+            config_kwargs["rounds"] = min_rounds
+        config = DecisionConfig(**config_kwargs) if config_kwargs else None
 
         request_kwargs = {
             "content": topic,
@@ -95,6 +144,7 @@ async def start_slack_debate(
                 metadata={
                     "topic": topic,
                     "response_url": response_url,
+                    "slack_policy": slack_policy,
                 },
             )
         except (RuntimeError, KeyError, AttributeError, OSError) as exc:
@@ -149,6 +199,7 @@ async def start_slack_debate(
                         metadata={
                             "topic": topic,
                             "response_url": response_url,
+                            "slack_policy": slack_policy,
                         },
                     )
                 except (RuntimeError, KeyError, AttributeError, OSError, ImportError) as exc:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Generated Aragora CLI command catalog from live parser
+description: Aragora CLI Reference
 ---
 
 # Aragora CLI Reference

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -178,6 +178,8 @@ def test_cmd_ask_demo_forces_local_offline(monkeypatch):
     assert os.getenv("ARAGORA_OFFLINE") == "1"
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore:unclosed <socket.socket.*:ResourceWarning")
 def test_cmd_ask_demo_quality_pipeline_skips_provider_repairs(monkeypatch):
     """Demo/offline asks should not invoke provider repair agents in quality loops."""
     from aragora.cli.commands import debate as debate_cmd

--- a/tests/handlers/bots/slack/test_debates.py
+++ b/tests/handlers/bots/slack/test_debates.py
@@ -212,10 +212,12 @@ class TestStartSlackDebateHappyPath:
                 user_id="U789",
             )
 
-        mock_core.RequestContext.assert_called_once_with(
-            user_id="U789",
-            session_id="slack:CABC123",
-        )
+        mock_core.RequestContext.assert_called_once()
+        call_kwargs = mock_core.RequestContext.call_args.kwargs
+        assert call_kwargs["user_id"] == "U789"
+        assert call_kwargs["session_id"] == "slack:CABC123"
+        assert isinstance(call_kwargs["metadata"]["slack_policy"], dict)
+        assert call_kwargs["metadata"]["slack_policy"]["fail_closed"] is True
 
     @pytest.mark.asyncio
     async def test_creates_decision_request(self, debates_module):
@@ -427,6 +429,46 @@ class TestDecisionConfigConstruction:
         assert "config" in call_kwargs
 
     @pytest.mark.asyncio
+    async def test_non_trivial_queries_raise_min_rounds_when_default_is_low(self, debates_module):
+        """Analytical Slack asks force at least two rounds when deployment default is one."""
+        mock_core, mock_router, mock_req = _mock_core_module()
+
+        with (
+            patch.dict("sys.modules", {"aragora.core": mock_core}),
+            patch(f"{MODULE}.DEFAULT_ROUNDS", 1),
+            patch(f"{MODULE}.register_debate_origin", create=True),
+        ):
+            await debates_module.start_slack_debate(
+                topic="Why did the Roman Empire fall?",
+                channel_id="C123",
+                user_id="U456",
+            )
+
+        mock_core.DecisionConfig.assert_called_once_with(rounds=2)
+        call_kwargs = mock_core.DecisionRequest.call_args[1]
+        assert "config" in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_factual_queries_do_not_force_round_override(self, debates_module):
+        """Simple factual Slack asks keep the deployment round default."""
+        mock_core, mock_router, mock_req = _mock_core_module()
+
+        with (
+            patch.dict("sys.modules", {"aragora.core": mock_core}),
+            patch(f"{MODULE}.DEFAULT_ROUNDS", 1),
+            patch(f"{MODULE}.register_debate_origin", create=True),
+        ):
+            await debates_module.start_slack_debate(
+                topic="What is the capital of France?",
+                channel_id="C123",
+                user_id="U456",
+            )
+
+        mock_core.DecisionConfig.assert_not_called()
+        call_kwargs = mock_core.DecisionRequest.call_args[1]
+        assert "config" not in call_kwargs
+
+    @pytest.mark.asyncio
     async def test_attachments_passed_through(self, debates_module):
         """Attachments are included in the DecisionRequest."""
         mock_core, mock_router, mock_req = _mock_core_module()
@@ -503,6 +545,8 @@ class TestOriginRegistration:
         assert call_kwargs["thread_id"] == "123.456"
         assert call_kwargs["metadata"]["topic"] == "Test topic"
         assert call_kwargs["metadata"]["response_url"] == "https://hooks.slack.com/resp"
+        assert call_kwargs["metadata"]["slack_policy"]["fail_closed"] is True
+        assert call_kwargs["metadata"]["slack_policy"]["require_consensus"] is True
 
     @pytest.mark.asyncio
     async def test_origin_registration_failure_caught(self, debates_module):

--- a/tests/server/debate_origin/test_router.py
+++ b/tests/server/debate_origin/test_router.py
@@ -185,6 +185,150 @@ class TestRouteDebateResult:
         mock_send.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_slack_fail_closed_when_consensus_missing(self, sample_result):
+        """Slack results fail closed when policy requires consensus and it is missing."""
+        origin = DebateOrigin(
+            debate_id="slack-policy-no-consensus",
+            platform="slack",
+            channel_id="C12345678",
+            user_id="U87654321",
+            thread_id="1234567890.123456",
+            metadata={
+                "slack_policy": {
+                    "fail_closed": True,
+                    "require_consensus": True,
+                    "min_confidence": 0.7,
+                    "query_mode": "deliberative",
+                }
+            },
+        )
+        sample_result["consensus_reached"] = False
+        sample_result["confidence"] = 0.92
+
+        with patch(
+            "aragora.server.debate_origin.registry.get_debate_origin",
+            return_value=origin,
+        ):
+            with patch(
+                "aragora.server.debate_origin.router.USE_DOCK_ROUTING",
+                False,
+            ):
+                with patch(
+                    "aragora.server.debate_origin.router._send_slack_error",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ) as mock_error:
+                    with patch(
+                        "aragora.server.debate_origin.router._send_slack_result",
+                        new_callable=AsyncMock,
+                        return_value=True,
+                    ) as mock_result_send:
+                        with patch(
+                            "aragora.server.debate_origin.registry.mark_result_sent",
+                        ):
+                            result = await route_debate_result(origin.debate_id, sample_result)
+
+        assert result is True
+        mock_error.assert_called_once()
+        mock_result_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slack_fail_closed_when_confidence_too_low(self, sample_result):
+        """Slack results fail closed when confidence is below the origin policy threshold."""
+        origin = DebateOrigin(
+            debate_id="slack-policy-low-confidence",
+            platform="slack",
+            channel_id="C12345678",
+            user_id="U87654321",
+            thread_id="1234567890.123456",
+            metadata={
+                "slack_policy": {
+                    "fail_closed": True,
+                    "require_consensus": True,
+                    "min_confidence": 0.7,
+                    "query_mode": "factual",
+                }
+            },
+        )
+        sample_result["consensus_reached"] = True
+        sample_result["confidence"] = 0.41
+
+        with patch(
+            "aragora.server.debate_origin.registry.get_debate_origin",
+            return_value=origin,
+        ):
+            with patch(
+                "aragora.server.debate_origin.router.USE_DOCK_ROUTING",
+                False,
+            ):
+                with patch(
+                    "aragora.server.debate_origin.router._send_slack_error",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ) as mock_error:
+                    with patch(
+                        "aragora.server.debate_origin.router._send_slack_result",
+                        new_callable=AsyncMock,
+                        return_value=True,
+                    ) as mock_result_send:
+                        with patch(
+                            "aragora.server.debate_origin.registry.mark_result_sent",
+                        ):
+                            result = await route_debate_result(origin.debate_id, sample_result)
+
+        assert result is True
+        mock_error.assert_called_once()
+        mock_result_send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_slack_policy_allows_strong_result(self, sample_result):
+        """Slack results still route normally when they satisfy the policy."""
+        origin = DebateOrigin(
+            debate_id="slack-policy-strong-result",
+            platform="slack",
+            channel_id="C12345678",
+            user_id="U87654321",
+            thread_id="1234567890.123456",
+            metadata={
+                "slack_policy": {
+                    "fail_closed": True,
+                    "require_consensus": True,
+                    "min_confidence": 0.7,
+                    "query_mode": "factual",
+                }
+            },
+        )
+        sample_result["consensus_reached"] = True
+        sample_result["confidence"] = 0.92
+
+        with patch(
+            "aragora.server.debate_origin.registry.get_debate_origin",
+            return_value=origin,
+        ):
+            with patch(
+                "aragora.server.debate_origin.router.USE_DOCK_ROUTING",
+                False,
+            ):
+                with patch(
+                    "aragora.server.debate_origin.router._send_slack_error",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ) as mock_error:
+                    with patch(
+                        "aragora.server.debate_origin.router._send_slack_result",
+                        new_callable=AsyncMock,
+                        return_value=True,
+                    ) as mock_result_send:
+                        with patch(
+                            "aragora.server.debate_origin.registry.mark_result_sent",
+                        ):
+                            result = await route_debate_result(origin.debate_id, sample_result)
+
+        assert result is True
+        mock_error.assert_not_called()
+        mock_result_send.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_routes_to_discord(self, discord_origin, sample_result):
         """route_debate_result calls discord sender."""
         with patch(


### PR DESCRIPTION
## Summary
- refresh generated CLI reference docs after the triage command surface changed
- wrap the public runtime backend test in the shared provider-aware test renderer
- add the existing narrow warning guards to the cleanup-sensitive offline golden-path test

## Validation
- python3 scripts/generate_cli_reference.py --check
- python3 -m pytest tests/cli/test_offline_golden_path.py::test_cmd_ask_demo_quality_pipeline_skips_provider_repairs -q -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning
- python3 -m ruff check tests/cli/test_offline_golden_path.py
- cd aragora/live && npx jest --runInBand src/app/__tests__/runtimeBackendSelection.test.tsx
- cd aragora/live && npx eslint src/app/__tests__/runtimeBackendSelection.test.tsx