### PR TITLE
fix(playground): avoid secrets hydration on import

### DIFF
--- a/aragora/billing/auth/config.py
+++ b/aragora/billing/auth/config.py
@@ -92,7 +92,13 @@ def is_production() -> bool:
 def validate_security_config() -> None:
     """Validate security configuration at module load.
 
-    Enforces strict requirements in production and logs warnings in non-prod.
+    Keeps import-time validation side-effect free.
+
+    This function intentionally avoids Secrets Manager-backed lookups. Several
+    unrelated product paths import billing auth helpers transitively, and
+    hitting AWS during module import can stall handler imports by seconds when
+    the network is unavailable. Runtime secret enforcement still happens in
+    `get_secret()`, which is only called when JWT operations are actually used.
     """
     if "pytest" in sys.modules:
         return
@@ -114,7 +120,7 @@ def validate_security_config() -> None:
             MAX_REFRESH_TOKEN_DAYS,
         )
 
-    jwt_secret_prev = _get_jwt_secret_previous()
+    jwt_secret_prev = os.environ.get("ARAGORA_JWT_SECRET_PREVIOUS", "")
     if jwt_secret_prev and len(jwt_secret_prev) < MIN_SECRET_LENGTH:
         logger.warning(
             "jwt_previous_secret_too_short length=%s min=%s",
@@ -125,20 +131,19 @@ def validate_security_config() -> None:
     if jwt_secret_prev and not JWT_SECRET_ROTATED_AT:
         logger.warning("jwt_previous_secret_without_rotation_timestamp")
 
-    if is_production():
-        jwt_secret = _get_jwt_secret()
-        if not jwt_secret:
-            raise ConfigurationError(
-                component="JWT Authentication",
-                reason="ARAGORA_JWT_SECRET must be set in production. "
-                'Generate with: python -c "import secrets; print(secrets.token_urlsafe(32))"',
-            )
-        if len(jwt_secret) < MIN_SECRET_LENGTH:
-            raise ConfigurationError(
-                component="JWT Authentication",
-                reason=f"ARAGORA_JWT_SECRET must be at least {MIN_SECRET_LENGTH} characters in production. "
-                f"Current length: {len(jwt_secret)}",
-            )
+    jwt_secret = os.environ.get("ARAGORA_JWT_SECRET", "")
+    if is_production() and jwt_secret and len(jwt_secret) < MIN_SECRET_LENGTH:
+        raise ConfigurationError(
+            component="JWT Authentication",
+            reason=f"ARAGORA_JWT_SECRET must be at least {MIN_SECRET_LENGTH} characters in production. "
+            f"Current length: {len(jwt_secret)}",
+        )
+    if not is_production() and jwt_secret and len(jwt_secret) < MIN_SECRET_LENGTH:
+        logger.warning(
+            "jwt_secret_too_short_non_production length=%s min=%s",
+            len(jwt_secret),
+            MIN_SECRET_LENGTH,
+        )
 
 
 def validate_secret_strength(secret: str) -> bool:

--- a/aragora/core/decision_types.py
+++ b/aragora/core/decision_types.py
@@ -6,20 +6,32 @@ Extracted from decision.py for modularity.
 
 from __future__ import annotations
 
+import os
 from enum import Enum
 
-from aragora.config.settings import get_settings
+_FALLBACK_DEFAULT_AGENTS = "grok,anthropic-api,openai-api,deepseek,mistral,gemini,qwen,kimi"
 
-# Resolve defaults once per import (environment-driven)
-_DEFAULT_SETTINGS = get_settings()
-_DEFAULT_DECISION_ROUNDS = _DEFAULT_SETTINGS.debate.default_rounds
-_DEFAULT_DECISION_CONSENSUS = _DEFAULT_SETTINGS.debate.default_consensus
-_DEFAULT_DECISION_MAX_AGENTS = _DEFAULT_SETTINGS.debate.max_agents_per_debate
+
+def _get_int_env(name: str, default: int) -> int:
+    """Read import-safe integer defaults without triggering settings hydration."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+_DEFAULT_DECISION_ROUNDS = _get_int_env("ARAGORA_DEFAULT_ROUNDS", 9)
+_DEFAULT_DECISION_CONSENSUS = os.environ.get("ARAGORA_DEFAULT_CONSENSUS", "judge").lower()
+_DEFAULT_DECISION_MAX_AGENTS = _get_int_env("ARAGORA_MAX_AGENTS_PER_DEBATE", 20)
 
 
 def _default_decision_agents() -> list[str]:
-    """Get default agents from settings or fallback."""
-    agents = _DEFAULT_SETTINGS.agent.default_agent_list
+    """Get default agents from env without hydrating the full settings stack."""
+    raw_agents = os.environ.get("ARAGORA_DEFAULT_AGENTS", _FALLBACK_DEFAULT_AGENTS)
+    agents = [agent.strip() for agent in raw_agents.split(",") if agent.strip()]
     return agents if agents else ["anthropic-api", "openai-api"]
 
 

--- a/tests/server/handlers/test_playground_import.py
+++ b/tests/server/handlers/test_playground_import.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_playground_import_does_not_initialize_secrets_manager() -> None:
+    """Importing the public playground handler should stay side-effect free."""
+    script = """
+import os
+import aragora.config.secrets as secrets
+
+os.environ.pop("ARAGORA_JWT_SECRET", None)
+os.environ.pop("ARAGORA_JWT_SECRET_PREVIOUS", None)
+os.environ["ARAGORA_USE_SECRETS_MANAGER"] = "true"
+
+def fail(self):
+    raise RuntimeError("aws_called_during_import")
+
+secrets.SecretManager._load_from_aws = fail
+
+import aragora.server.handlers.playground  # noqa: F401
+print("ok")
+"""
+
+    env = os.environ.copy()
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=20,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip().endswith("ok")


### PR DESCRIPTION
Importing the playground handler was hydrating secrets via AWS before request handling. This keeps JWT auth and decision defaults import-safe, adds a regression test, and brings local import time back to about 1s instead of multi-region AWS retries.