### PR TITLE
fix(slack): use current loop for tracked tasks

### DIFF
--- a/aragora/server/handlers/social/_slack_impl/config.py
+++ b/aragora/server/handlers/social/_slack_impl/config.py
@@ -162,6 +162,11 @@ def create_tracked_task(coro_or_factory: TrackedTaskInput, name: str) -> asyncio
     """
     coro = _resolve_tracked_task_coro(coro_or_factory)
 
+    try:
+        current = asyncio.get_running_loop()
+    except RuntimeError:
+        current = None
+
     # 1. Find the persistent main server loop
     main_loop = None
     try:
@@ -180,11 +185,6 @@ def create_tracked_task(coro_or_factory: TrackedTaskInput, name: str) -> asyncio
 
     # 2. Dispatch to the main loop if available
     if main_loop is not None and main_loop.is_running():
-        try:
-            current = asyncio.get_running_loop()
-        except RuntimeError:
-            current = None
-
         if current is main_loop:
             # Already on the main loop — create_task is safe
             task = main_loop.create_task(coro, name=name)
@@ -207,7 +207,13 @@ def create_tracked_task(coro_or_factory: TrackedTaskInput, name: str) -> asyncio
 
         return _ThreadsafeTask()  # type: ignore[return-value]
 
-    # 3. Final fallback: thread with isolated event loop
+    # 3. If we're already on a live loop, prefer it over a background thread.
+    if current is not None:
+        task = current.create_task(coro, name=name)
+        task.add_done_callback(lambda t: _handle_task_exception(t, name))
+        return task
+
+    # 4. Final fallback: thread with isolated event loop
     def _run_in_thread() -> None:
         try:
             asyncio.run(coro)


### PR DESCRIPTION
## Summary
- use the current running loop when no persistent main Slack loop is registered
- keep the thread fallback only for truly loopless contexts

## Validation
- python3 -m pytest tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_with_running_loop_creates_task tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_task_has_done_callback tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_task_name_set tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_without_loop_returns_background_task tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_background_task_add_done_callback_returns_none tests/handlers/social/_slack_impl/test_config.py::TestCreateTrackedTask::test_thread_name_contains_task_name -q
- python3 -m ruff check aragora/server/handlers/social/_slack_impl/config.py tests/handlers/social/_slack_impl/test_config.py