### PR TITLE
feat(swarm): add calibration timestamp_iso

### DIFF
--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -339,7 +339,9 @@ class CalibrationSnapshot:
     recommendations: list[str]
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        data["timestamp_iso"] = self.timestamp
+        return data
 
 
 def compute_calibration(

--- a/tests/swarm/test_outcome_signals.py
+++ b/tests/swarm/test_outcome_signals.py
@@ -211,3 +211,10 @@ class TestCalibration:
         assert snap.loop_merge_rates["boss"] == 0.5
         assert snap.loop_merge_rates["nomic"] == 1.0
         assert snap.loop_merge_rates["ralph"] == 0.0
+
+    def test_calibration_to_dict_includes_timestamp_iso(self):
+        signals = self._make_signals(10)
+        snap = compute_calibration(signals)
+        assert snap is not None
+        data = snap.to_dict()
+        assert data["timestamp_iso"] == snap.timestamp


### PR DESCRIPTION
Closes #1752

## Summary
- add `timestamp_iso` to `CalibrationSnapshot` serialization as an alias of `timestamp`
- extend the calibration tests to cover the new serialized field

## Validation
- `python3 -m pytest tests/swarm/test_outcome_signals.py -x -q -k calibration`
- `python3 -m ruff check aragora/swarm/outcome_signals.py tests/swarm/test_outcome_signals.py`