### PR TITLE
fix(live): route audit trail verify actions through selected backend

### DIFF
--- a/aragora/live/src/app/(app)/agent/[[...name]]/page.tsx
+++ b/aragora/live/src/app/(app)/agent/[[...name]]/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import { AgentProfileWrapper } from './AgentProfileWrapper';
 
-// For static export with optional catch-all
-export const dynamicParams = false;
+// Allow runtime agent names while still providing a fallback static export path.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   // Only generate the base route - client handles the rest

--- a/aragora/live/src/app/(app)/audit-trail/page.tsx
+++ b/aragora/live/src/app/(app)/audit-trail/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react';
 import Link from 'next/link';
+import { useBackend } from '@/components/BackendSelector';
 import { Scanlines, CRTVignette } from '@/components/MatrixRain';
 import { PanelErrorBoundary } from '@/components/PanelErrorBoundary';
 import { useSWRFetch } from '@/hooks/useSWRFetch';
@@ -136,6 +137,7 @@ function formatTimestamp(ts: string | null): string {
 type ActiveTab = 'trails' | 'receipts';
 
 export default function AuditTrailPage() {
+  const { config: backendConfig } = useBackend();
   const [activeTab, setActiveTab] = useState<ActiveTab>('trails');
   const [trailOffset, setTrailOffset] = useState(0);
   const [receiptOffset, setReceiptOffset] = useState(0);
@@ -155,7 +157,7 @@ export default function AuditTrailPage() {
   const { data: trailsData, isLoading: trailsLoading, error: trailsError } =
     useSWRFetch<AuditTrailsResponse>(
       activeTab === 'trails' ? `/api/v1/audit-trails?${trailParams}` : null,
-      { refreshInterval: 30000 },
+      { refreshInterval: 30000, baseUrl: backendConfig.api },
     );
 
   // Fetch receipts
@@ -167,7 +169,7 @@ export default function AuditTrailPage() {
   const { data: receiptsData, isLoading: receiptsLoading, error: receiptsError } =
     useSWRFetch<ReceiptsResponse>(
       activeTab === 'receipts' ? `/api/v1/receipts?${receiptParams}` : null,
-      { refreshInterval: 30000 },
+      { refreshInterval: 30000, baseUrl: backendConfig.api },
     );
 
   const trails = trailsData?.trails ?? [];
@@ -181,8 +183,8 @@ export default function AuditTrailPage() {
     setVerifyResult(null);
     try {
       const endpoint = type === 'trail'
-        ? `/api/v1/audit-trails/${id}/verify`
-        : `/api/v1/receipts/${id}/verify`;
+        ? `${backendConfig.api}/api/v1/audit-trails/${id}/verify`
+        : `${backendConfig.api}/api/v1/receipts/${id}/verify`;
       const response = await fetch(endpoint, { method: 'POST' });
       if (response.ok) {
         const data = await response.json();
@@ -193,7 +195,7 @@ export default function AuditTrailPage() {
     } finally {
       setVerifying(null);
     }
-  }, []);
+  }, [backendConfig.api]);
 
   const isLoading = activeTab === 'trails' ? trailsLoading : receiptsLoading;
   const error = activeTab === 'trails' ? trailsError : receiptsError;

--- a/aragora/live/src/app/(app)/gauntlet/[[...id]]/page.tsx
+++ b/aragora/live/src/app/(app)/gauntlet/[[...id]]/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import { GauntletLiveWrapper } from './GauntletLiveWrapper';
 
-// For static export with optional catch-all
-export const dynamicParams = false;
+// Allow runtime gauntlet IDs while still providing a fallback static export path.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   // Only generate the base route - client handles specific IDs

--- a/aragora/live/src/app/(app)/spectate/[debateId]/page.tsx
+++ b/aragora/live/src/app/(app)/spectate/[debateId]/page.tsx
@@ -1,7 +1,7 @@
 import SpectateClient from './SpectateClient';
 
-// For static export - no pages pre-rendered, client-side navigation only
-export const dynamicParams = false;
+// Allow runtime debate IDs while still providing a fallback static export path.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
   // Return a placeholder so static export has at least one path

--- a/aragora/live/src/app/__tests__/auditTrailBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/auditTrailBackendSelection.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import AuditTrailPage from '../(app)/audit-trail/page';
+import { useSWRFetch } from '@/hooks/useSWRFetch';
+
+const mockFetch = jest.fn();
+
+global.fetch = mockFetch as typeof fetch;
+
+jest.mock('next/link', () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock('@/components/BackendSelector', () => ({
+  useBackend: () => ({
+    config: {
+      api: 'https://api.aragora.ai',
+    },
+  }),
+}));
+
+jest.mock('@/components/MatrixRain', () => ({
+  Scanlines: () => <div data-testid="scanlines" />,
+  CRTVignette: () => <div data-testid="crt-vignette" />,
+}));
+
+jest.mock('@/components/PanelErrorBoundary', () => ({
+  PanelErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/hooks/useSWRFetch', () => ({
+  useSWRFetch: jest.fn(),
+}));
+
+const mockUseSWRFetch = useSWRFetch as jest.MockedFunction<typeof useSWRFetch>;
+
+function jsonResponse(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+  } as Response;
+}
+
+describe('runtime backend selection for audit trail integrity actions', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockUseSWRFetch.mockImplementation((endpoint) => {
+      if (endpoint?.startsWith('/api/v1/audit-trails?')) {
+        return {
+          data: {
+            trails: [
+              {
+                trail_id: 'trail-123',
+                gauntlet_id: 'gauntlet-123',
+                created_at: '2026-03-31T00:00:00Z',
+                verdict: 'approved',
+                confidence: 0.91,
+                total_findings: 2,
+                duration_seconds: 12.4,
+                checksum: 'sha256-trail',
+              },
+            ],
+            total: 1,
+            limit: 20,
+            offset: 0,
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      if (endpoint?.startsWith('/api/v1/receipts?')) {
+        return {
+          data: {
+            receipts: [
+              {
+                receipt_id: 'receipt-123',
+                gauntlet_id: 'gauntlet-123',
+                timestamp: '2026-03-31T00:00:00Z',
+                verdict: 'approved',
+                confidence: 0.95,
+                risk_level: 'low',
+                findings_count: 1,
+                checksum: 'sha256-receipt',
+              },
+            ],
+            total: 1,
+            limit: 20,
+            offset: 0,
+          },
+          error: null,
+          isLoading: false,
+        };
+      }
+
+      return {
+        data: null,
+        error: null,
+        isLoading: false,
+      };
+    });
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        valid: true,
+        stored_checksum: 'sha256-stored',
+        computed_checksum: 'sha256-computed',
+        match: true,
+      }),
+    );
+  });
+
+  it('uses the selected backend when verifying audit trails', async () => {
+    const user = userEvent.setup();
+
+    render(<AuditTrailPage />);
+
+    await user.click(await screen.findByRole('button', { name: 'VERIFY' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/v1/audit-trails/trail-123/verify',
+        { method: 'POST' },
+      );
+    });
+  });
+
+  it('uses the selected backend when verifying decision receipts', async () => {
+    const user = userEvent.setup();
+
+    render(<AuditTrailPage />);
+
+    await user.click(screen.getByRole('button', { name: '[DECISION RECEIPTS]' }));
+    await user.click(await screen.findByRole('button', { name: 'VERIFY' }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.aragora.ai/api/v1/receipts/receipt-123/verify',
+        { method: 'POST' },
+      );
+    });
+  });
+});

--- a/tests/compat/test_live_route_dynamic_params.py
+++ b/tests/compat/test_live_route_dynamic_params.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.parametrize(
+    ("page_path", "wrapper_path"),
+    [
+        (
+            "aragora/live/src/app/(app)/spectate/[debateId]/page.tsx",
+            "aragora/live/src/app/(app)/spectate/[debateId]/SpectateClient.tsx",
+        ),
+        (
+            "aragora/live/src/app/(app)/gauntlet/[[...id]]/page.tsx",
+            "aragora/live/src/app/(app)/gauntlet/[[...id]]/GauntletLiveWrapper.tsx",
+        ),
+        (
+            "aragora/live/src/app/(app)/agent/[[...name]]/page.tsx",
+            "aragora/live/src/app/(app)/agent/[[...name]]/AgentProfileWrapper.tsx",
+        ),
+    ],
+)
+def test_client_side_dynamic_live_pages_allow_runtime_params(
+    page_path: str,
+    wrapper_path: str,
+) -> None:
+    """Client-side ID routes must not be locked to placeholder static params."""
+
+    page_source = (REPO_ROOT / page_path).read_text()
+    wrapper_source = (REPO_ROOT / wrapper_path).read_text()
+
+    assert "generateStaticParams" in page_source
+    assert "useParams(" in wrapper_source
+    assert "export const dynamicParams = true;" in page_source
+    assert "dynamicParams = false" not in page_source


### PR DESCRIPTION
Revives the closed-but-unsuperseded diff from #1800 after the original PR was closed when main moved.

Local validation:
- python3 -m pytest tests/compat/test_live_route_dynamic_params.py -q
- cd aragora/live && NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules node /Users/armand/Development/aragora/aragora/live/node_modules/jest/bin/jest.js --runInBand src/app/__tests__/auditTrailBackendSelection.test.tsx

This keeps runtime params flowing on client-routed pages and routes audit-trail verify actions through the currently selected backend.