### PR TITLE
fix(chat): use canonical public receipt links

### DIFF
--- a/aragora/channels/teams_formatter.py
+++ b/aragora/channels/teams_formatter.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
+from aragora.utils.public_urls import public_receipt_url
+
 from .formatter import ReceiptFormatter, register_formatter
 
 if TYPE_CHECKING:
@@ -224,7 +226,7 @@ class TeamsReceiptFormatter(ReceiptFormatter):
                 {
                     "type": "Action.OpenUrl",
                     "title": "View Full Receipt",
-                    "url": f"https://aragora.ai/receipts/{receipt_id}",
+                    "url": public_receipt_url(receipt_id),
                 },
             ],
         }

--- a/aragora/connectors/chat/teams_adaptive_cards.py
+++ b/aragora/connectors/chat/teams_adaptive_cards.py
@@ -34,6 +34,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from aragora.utils.public_urls import public_receipt_url
+
 
 @dataclass
 class AgentContribution:
@@ -621,7 +623,7 @@ class TeamsAdaptiveCards:
                 {
                     "type": "Action.OpenUrl",
                     "title": "View Full Receipt",
-                    "url": f"/api/v1/receipts/{receipt_id}",
+                    "url": public_receipt_url(receipt_id),
                 }
             )
         if debate_id:
@@ -792,7 +794,7 @@ class TeamsAdaptiveCards:
             {
                 "type": "Action.OpenUrl",
                 "title": "View Full Receipt",
-                "url": f"/api/v1/receipts/{receipt_id}",
+                "url": public_receipt_url(receipt_id),
             }
         ]
         if verification_url:

--- a/aragora/integrations/slack_debate.py
+++ b/aragora/integrations/slack_debate.py
@@ -41,6 +41,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from aragora.utils.public_urls import public_receipt_url
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -759,14 +761,11 @@ class SlackDebateLifecycle:
         if receipt_url:
             return receipt_url
 
-        import os as _os
-
         receipt_id = getattr(receipt, "receipt_id", "")
         if not receipt_id:
             return ""
 
-        base_url = _os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
-        return f"{base_url}/receipts/{receipt_id}"
+        return public_receipt_url(receipt_id)
 
     async def _post_to_thread(
         self,

--- a/aragora/integrations/teams_debate.py
+++ b/aragora/integrations/teams_debate.py
@@ -46,6 +46,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from aragora.utils.public_urls import public_receipt_url
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1830,8 +1832,6 @@ class TeamsDebateLifecycle:
         Returns:
             True if the receipt was delivered successfully.
         """
-        import os as _os
-
         # Load receipt if not provided
         if receipt is None:
             receipt = self._load_receipt(debate_id)
@@ -1841,10 +1841,9 @@ class TeamsDebateLifecycle:
 
         # Build receipt URL if not provided
         if not receipt_url:
-            base_url = _os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
             receipt_id = getattr(receipt, "receipt_id", "")
             if receipt_id:
-                receipt_url = f"{base_url}/receipts/{receipt_id}"
+                receipt_url = public_receipt_url(receipt_id)
 
         card = _build_receipt_with_approval_card(
             receipt, debate_id=debate_id, receipt_url=receipt_url

--- a/aragora/server/handlers/social/_slack_impl/commands.py
+++ b/aragora/server/handlers/social/_slack_impl/commands.py
@@ -10,12 +10,12 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 import time
 from typing import Any
 from urllib.parse import parse_qs
 
 from aragora.config import DEFAULT_ROUNDS
+from aragora.utils.public_urls import public_receipt_url
 
 try:
     from aragora.server.storage import get_debates_db
@@ -1371,8 +1371,7 @@ Reply in thread to add suggestions to ongoing debates
                 receipt_id = receipt.receipt_id
 
                 # Build receipt URL
-                base_url = os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
-                receipt_url = f"{base_url}/receipts/{receipt_id}"
+                receipt_url = public_receipt_url(receipt_id)
 
                 # Persist receipt
                 try:

--- a/aragora/server/handlers/social/teams.py
+++ b/aragora/server/handlers/social/teams.py
@@ -27,6 +27,7 @@ from typing import Any
 from collections.abc import Callable, Coroutine
 
 from aragora.config import DEFAULT_CONSENSUS, DEFAULT_ROUNDS
+from aragora.utils.public_urls import public_receipt_url
 
 logger = logging.getLogger(__name__)
 
@@ -1372,8 +1373,7 @@ class TeamsIntegrationHandler(BaseHandler):
     @staticmethod
     def _public_receipt_url(receipt_id: str) -> str:
         """Build an absolute receipt URL for external chat clients."""
-        base_url = os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai").rstrip("/")
-        return f"{base_url}/api/v1/receipts/{receipt_id}"
+        return public_receipt_url(receipt_id)
 
     def _read_json_body(self, handler: Any) -> dict[str, Any] | None:
         """Read and parse JSON body from request."""

--- a/aragora/utils/public_urls.py
+++ b/aragora/utils/public_urls.py
@@ -1,0 +1,17 @@
+"""Helpers for building public Aragora web URLs."""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlencode
+
+
+def public_receipt_url(receipt_id: str, *, base_url: str | None = None) -> str:
+    """Build the canonical public receipt URL for external clients."""
+    if not receipt_id:
+        return ""
+
+    resolved_base_url = (
+        base_url or os.environ.get("ARAGORA_PUBLIC_URL", "https://aragora.ai")
+    ).rstrip("/")
+    return f"{resolved_base_url}/receipts?{urlencode({'id': receipt_id})}"

--- a/tests/channels/test_formatters.py
+++ b/tests/channels/test_formatters.py
@@ -317,7 +317,7 @@ class TestTeamsFormatter:
 
         assert len(actions) == 1
         assert actions[0]["type"] == "Action.OpenUrl"
-        assert "my-receipt-id" in actions[0]["url"]
+        assert actions[0]["url"] == "https://aragora.ai/receipts?id=my-receipt-id"
 
     def test_channel_type(self):
         """Test channel type property."""

--- a/tests/connectors/chat/test_teams_adaptive_cards.py
+++ b/tests/connectors/chat/test_teams_adaptive_cards.py
@@ -925,7 +925,7 @@ class TestReceiptCard:
         actions = card["actions"]
         view_action = next((a for a in actions if "Receipt" in a.get("title", "")), None)
         assert view_action is not None
-        assert "rec_xyz789" in view_action["url"]
+        assert view_action["url"] == "https://aragora.ai/receipts?id=rec_xyz789"
 
     def test_receipt_card_with_verification_url(self):
         """Test receipt card has Verify Integrity action when URL provided."""

--- a/tests/handlers/social/test_slack_commands.py
+++ b/tests/handlers/social/test_slack_commands.py
@@ -1635,7 +1635,7 @@ class TestCreateDebateAsync:
 
         assert any(
             action.get("text", {}).get("text") == "View Receipt"
-            and action.get("url") == "https://app.example.ai/receipts/rcpt-slack-123"
+            and action.get("url") == "https://app.example.ai/receipts?id=rcpt-slack-123"
             for action in final_actions
         )
         fake_receipt_store.save.assert_called_once_with({"receipt_id": "rcpt-slack-123"})

--- a/tests/handlers/social/test_teams.py
+++ b/tests/handlers/social/test_teams.py
@@ -1458,8 +1458,7 @@ class TestBlockBuilders:
             action_blocks = [b for b in blocks if b.get("type") == "ActionSet"]
             assert len(action_blocks) == 1
             assert (
-                action_blocks[0]["actions"][0]["url"]
-                == "https://aragora.ai/api/v1/receipts/rcpt_abc"
+                action_blocks[0]["actions"][0]["url"] == "https://aragora.ai/receipts?id=rcpt_abc"
             )
 
     def test_build_result_blocks_with_receipt_uses_public_base_url(self, handler, monkeypatch):
@@ -1482,7 +1481,7 @@ class TestBlockBuilders:
         assert len(action_blocks) == 1
         assert (
             action_blocks[0]["actions"][0]["url"]
-            == "https://app.example.com/api/v1/receipts/rcpt_custom"
+            == "https://app.example.com/receipts?id=rcpt_custom"
         )
 
     def test_build_leaderboard_blocks(self, handler):

--- a/tests/integrations/test_slack_debate.py
+++ b/tests/integrations/test_slack_debate.py
@@ -876,7 +876,10 @@ class TestPostReceipt:
         _, _, _, blocks = mock_post.call_args.args
         assert any("View Full Receipt" in str(block) for block in blocks)
         assert any(
-            "https://app.aragora.ai/receipts/rcpt-slack-123" in str(block) for block in blocks
+            "https://app.aragora.ai/receipts?id=rcpt-slack-123" in str(block) for block in blocks
+        )
+        assert SlackDebateLifecycle._build_receipt_url(receipt) == (
+            "https://aragora.ai/receipts?id=rcpt-slack-123"
         )
 
 

--- a/tests/integrations/test_teams_debate.py
+++ b/tests/integrations/test_teams_debate.py
@@ -2022,7 +2022,7 @@ class TestDeliverReceiptToThread:
                 )
                 card = mock_send.call_args[0][2]
                 card_text = str(card)
-                assert "https://my.app/receipts/rcpt-xyz" in card_text
+                assert "https://my.app/receipts?id=rcpt-xyz" in card_text
 
 
 # =============================================================================


### PR DESCRIPTION
Revives the closed-but-unsuperseded diff from #1805 on a fresh branch after the original PR was closed.

This republishes the existing reviewed commit onto current main so CI can rerun against the live base without changing the patch content.