### PR TITLE
feat(live): OpenRouter OAuth PKCE one-click API key setup

### DIFF
--- a/aragora/live/src/app/(standalone)/openrouter/callback/page.tsx
+++ b/aragora/live/src/app/(standalone)/openrouter/callback/page.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useEffect, useState, Suspense } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+import { exchangeCodeForKey, SESSION_RETURN_KEY } from '@/lib/openrouter-pkce';
+import { getStoredProviderKeys, storeProviderKeys } from '@/lib/provider-keys';
+
+type Status = 'processing' | 'success' | 'error';
+
+function CallbackContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const [status, setStatus] = useState<Status>('processing');
+  const [message, setMessage] = useState('Connecting to OpenRouter...');
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    if (!code) {
+      setStatus('error');
+      setMessage('No authorization code received. Please try connecting again.');
+      return;
+    }
+
+    let cancelled = false;
+
+    async function exchange() {
+      try {
+        const { key } = await exchangeCodeForKey(code!);
+
+        if (cancelled) return;
+
+        // Store the key in the same slot as manual paste
+        const keys = getStoredProviderKeys();
+        keys.openrouter = key;
+        storeProviderKeys(keys);
+
+        // Notify other components / tabs
+        window.dispatchEvent(new Event('openrouter:updated'));
+
+        setStatus('success');
+        setMessage('Connected! Redirecting...');
+
+        // Redirect to where the user came from
+        const returnPath = sessionStorage.getItem(SESSION_RETURN_KEY) || '/landing/';
+        sessionStorage.removeItem(SESSION_RETURN_KEY);
+
+        setTimeout(() => {
+          if (!cancelled) router.replace(returnPath);
+        }, 1200);
+      } catch (err) {
+        if (cancelled) return;
+        setStatus('error');
+        setMessage(err instanceof Error ? err.message : 'Failed to connect. Please try again.');
+      }
+    }
+
+    exchange();
+    return () => { cancelled = true; };
+  }, [searchParams, router]);
+
+  const statusIcon = status === 'processing' ? '...' : status === 'success' ? '\u2713' : '\u2717';
+  const statusColor = status === 'processing'
+    ? 'var(--accent)'
+    : status === 'success'
+    ? 'var(--accent)'
+    : 'var(--crimson, #ff0040)';
+
+  return (
+    <div
+      className="min-h-screen flex items-center justify-center px-4"
+      style={{ backgroundColor: 'var(--bg)', color: 'var(--text)' }}
+    >
+      <div className="text-center max-w-md w-full">
+        <div
+          className="text-5xl font-mono mb-6"
+          style={{ color: statusColor }}
+        >
+          {statusIcon}
+        </div>
+        <h1 className="font-mono text-lg mb-2" style={{ color: 'var(--text)' }}>
+          {status === 'processing' && 'Connecting OpenRouter'}
+          {status === 'success' && 'Connected'}
+          {status === 'error' && 'Connection Failed'}
+        </h1>
+        <p className="font-mono text-sm" style={{ color: 'var(--text-muted)' }}>
+          {message}
+        </p>
+
+        {status === 'processing' && (
+          <div className="mt-6 flex justify-center">
+            <div
+              className="w-6 h-6 border-2 rounded-full animate-spin"
+              style={{
+                borderColor: 'color-mix(in srgb, var(--accent) 20%, transparent)',
+                borderTopColor: 'var(--accent)',
+              }}
+            />
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="mt-6 flex gap-3 justify-center">
+            <button
+              onClick={() => router.replace('/landing/')}
+              className="px-4 py-2 font-mono text-xs rounded transition-colors cursor-pointer"
+              style={{
+                color: 'var(--accent)',
+                border: '1px solid color-mix(in srgb, var(--accent) 40%, transparent)',
+              }}
+            >
+              Back to home
+            </button>
+            <button
+              onClick={() => router.replace('/settings/')}
+              className="px-4 py-2 font-mono text-xs rounded transition-colors cursor-pointer"
+              style={{
+                color: 'var(--text-muted)',
+                border: '1px solid var(--border)',
+              }}
+            >
+              Paste key manually
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function OpenRouterCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div
+        className="min-h-screen flex items-center justify-center"
+        style={{ backgroundColor: 'var(--bg)', color: 'var(--text-muted)' }}
+      >
+        <span className="font-mono text-sm">Loading...</span>
+      </div>
+    }>
+      <CallbackContent />
+    </Suspense>
+  );
+}

--- a/aragora/live/src/app/(standalone)/quickstart/page.tsx
+++ b/aragora/live/src/app/(standalone)/quickstart/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { ConnectOpenRouterButton } from '@/components/openrouter/ConnectOpenRouterButton';
 
 export const metadata: Metadata = {
   title: 'Quickstart | ARAGORA',
@@ -126,8 +127,9 @@ print(result.receipt.to_markdown())`}</CodeBlock>
 
         {/* Step 3 */}
         <Step number={3} title="Add Real AI Models">
-          <p className="text-sm font-mono text-[var(--text-muted)]">
-            Set at least one API key:
+          <ConnectOpenRouterButton />
+          <p className="text-sm font-mono text-[var(--text-muted)] mt-4">
+            Or set API keys manually:
           </p>
           <CodeBlock lang="bash">{`export ANTHROPIC_API_KEY="sk-ant-..."   # Claude
 # or

--- a/aragora/live/src/components/landing/HeroSection.tsx
+++ b/aragora/live/src/components/landing/HeroSection.tsx
@@ -7,6 +7,7 @@ import { DebateResultPreview, RETURN_URL_KEY, PENDING_DEBATE_KEY, type DebateRes
 import { getCurrentReturnUrl, normalizeReturnUrl } from '@/utils/returnUrl';
 import { useBackend, BACKENDS } from '../BackendSelector';
 import { DebateInput } from '../DebateInput';
+import { ConnectOpenRouterButton } from '../openrouter/ConnectOpenRouterButton';
 import type { HeroSectionProps } from './types';
 
 const ASCII_BANNER = `    \u2584\u2584\u2584       \u2588\u2588\u2580\u2588\u2588\u2588   \u2584\u2584\u2584        \u2584\u2588\u2588\u2588\u2588  \u2592\u2588\u2588\u2588\u2588\u2588   \u2588\u2588\u2580\u2588\u2588\u2588   \u2584\u2584\u2584
@@ -452,6 +453,11 @@ export function HeroSection(props: Partial<HeroSectionProps> & Record<string, un
           >
             No account needed -- watch AI agents debate a real question
           </p>
+        )}
+        {!isRunning && !result && (
+          <div className="text-center mt-4">
+            <ConnectOpenRouterButton compact />
+          </div>
         )}
 
         {/* Loading state — phased progress */}

--- a/aragora/live/src/components/openrouter/ConnectOpenRouterButton.tsx
+++ b/aragora/live/src/components/openrouter/ConnectOpenRouterButton.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useOpenRouterConnection } from '@/hooks/useOpenRouterConnection';
+
+function maskKey(key: string): string {
+  if (key.length <= 8) return '*'.repeat(key.length);
+  return key.slice(0, 6) + '****' + key.slice(-4);
+}
+
+function formatCredits(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function OpenRouterIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 2L2 7l10 5 10-5-10-5z" />
+      <path d="M2 17l10 5 10-5" />
+      <path d="M2 12l10 5 10-5" />
+    </svg>
+  );
+}
+
+interface ConnectOpenRouterButtonProps {
+  compact?: boolean;
+  className?: string;
+}
+
+export function ConnectOpenRouterButton({ compact = false, className = '' }: ConnectOpenRouterButtonProps) {
+  const { isConnected, keyInfo, connect, disconnect } = useOpenRouterConnection();
+
+  if (compact) {
+    if (isConnected) {
+      return (
+        <span
+          className={`inline-flex items-center gap-1.5 font-mono text-xs ${className}`}
+          style={{ color: 'var(--accent)' }}
+        >
+          <span style={{
+            width: 6,
+            height: 6,
+            borderRadius: '50%',
+            backgroundColor: 'var(--accent)',
+            display: 'inline-block',
+          }} />
+          OpenRouter connected
+          {keyInfo?.limitRemaining != null && (
+            <span style={{ color: 'var(--text-muted)' }}>
+              ({formatCredits(keyInfo.limitRemaining)} remaining)
+            </span>
+          )}
+        </span>
+      );
+    }
+
+    return (
+      <button
+        onClick={connect}
+        className={`inline-flex items-center gap-1.5 font-mono text-xs cursor-pointer transition-opacity hover:opacity-80 ${className}`}
+        style={{ color: 'var(--accent)', background: 'none', border: 'none', padding: 0 }}
+      >
+        <OpenRouterIcon />
+        Connect OpenRouter for instant setup
+      </button>
+    );
+  }
+
+  // Full card mode (settings page)
+  if (isConnected) {
+    const storedKeys = typeof window !== 'undefined'
+      ? JSON.parse(localStorage.getItem('aragora_provider_keys') || '{}')
+      : {};
+    const maskedKey = storedKeys.openrouter ? maskKey(storedKeys.openrouter) : '';
+
+    return (
+      <div
+        className={`p-4 rounded border ${className}`}
+        style={{
+          backgroundColor: 'var(--surface)',
+          borderColor: 'color-mix(in srgb, var(--accent) 30%, transparent)',
+        }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-mono text-sm font-medium" style={{ color: 'var(--text)' }}>
+                OpenRouter
+              </span>
+              <span
+                className="px-1.5 py-0.5 text-[10px] font-mono rounded"
+                style={{
+                  backgroundColor: 'color-mix(in srgb, var(--accent) 10%, transparent)',
+                  color: 'var(--accent)',
+                  border: '1px solid color-mix(in srgb, var(--accent) 30%, transparent)',
+                }}
+              >
+                CONNECTED
+              </span>
+            </div>
+            {maskedKey && (
+              <code
+                className="font-mono text-xs rounded px-1.5 py-0.5"
+                style={{ color: 'var(--text-muted)', backgroundColor: 'var(--bg)' }}
+              >
+                {maskedKey}
+              </code>
+            )}
+            {keyInfo?.limitRemaining != null && (
+              <div className="mt-2 font-mono text-xs" style={{ color: 'var(--text-muted)' }}>
+                {formatCredits(keyInfo.limitRemaining)} credit remaining
+                {keyInfo.limit != null && (
+                  <span> of {formatCredits(keyInfo.limit)} limit</span>
+                )}
+              </div>
+            )}
+          </div>
+          <button
+            onClick={disconnect}
+            className="px-2 py-1 text-[10px] font-mono rounded transition-colors cursor-pointer"
+            style={{ color: 'var(--crimson, #ff0040)' }}
+            onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--crimson, #ff0040) 10%, transparent)')}
+            onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'transparent')}
+          >
+            Disconnect
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`p-4 rounded border ${className}`}
+      style={{
+        backgroundColor: 'color-mix(in srgb, var(--accent) 5%, var(--surface))',
+        borderColor: 'color-mix(in srgb, var(--accent) 20%, transparent)',
+      }}
+    >
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <div className="min-w-0">
+          <div className="font-mono text-sm font-medium" style={{ color: 'var(--text)' }}>
+            One-click setup via OpenRouter
+          </div>
+          <div className="font-mono text-[10px] mt-0.5" style={{ color: 'var(--text-muted)' }}>
+            Connect your account and set a budget — no key pasting needed.
+          </div>
+        </div>
+        <button
+          onClick={connect}
+          className="inline-flex items-center gap-2 px-4 py-2 font-mono text-xs rounded transition-colors cursor-pointer shrink-0"
+          style={{
+            color: 'var(--accent)',
+            border: '1px solid color-mix(in srgb, var(--accent) 40%, transparent)',
+            backgroundColor: 'color-mix(in srgb, var(--accent) 10%, transparent)',
+          }}
+          onMouseEnter={e => (e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--accent) 20%, transparent)')}
+          onMouseLeave={e => (e.currentTarget.style.backgroundColor = 'color-mix(in srgb, var(--accent) 10%, transparent)')}
+        >
+          <OpenRouterIcon />
+          Connect OpenRouter
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/aragora/live/src/components/settings-panel/ApiKeysTab.tsx
+++ b/aragora/live/src/components/settings-panel/ApiKeysTab.tsx
@@ -2,6 +2,14 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import type { UserPreferences, ApiKey } from './types';
+import {
+  LLM_PROVIDERS,
+  getStoredProviderKeys,
+  storeProviderKeys,
+  type ProviderKeyConfig,
+} from '@/lib/provider-keys';
+import { ConnectOpenRouterButton } from '@/components/openrouter/ConnectOpenRouterButton';
+export { getProviderKeyHeaders } from '@/lib/provider-keys';
 
 export interface ApiKeysTabProps {
   preferences: UserPreferences;
@@ -167,90 +175,6 @@ function ApiKeyCard({
 // ---------------------------------------------------------------------------
 // Provider Keys — localStorage-backed LLM provider key management
 // ---------------------------------------------------------------------------
-
-const PROVIDER_KEYS_STORAGE_KEY = 'aragora_provider_keys';
-
-interface ProviderKeyConfig {
-  id: string;
-  label: string;
-  envVar: string;
-  placeholder: string;
-  docsUrl?: string;
-}
-
-const LLM_PROVIDERS: ProviderKeyConfig[] = [
-  {
-    id: 'anthropic',
-    label: 'Anthropic (Claude)',
-    envVar: 'ANTHROPIC_API_KEY',
-    placeholder: 'sk-ant-...',
-    docsUrl: 'https://console.anthropic.com/settings/keys',
-  },
-  {
-    id: 'openai',
-    label: 'OpenAI (GPT)',
-    envVar: 'OPENAI_API_KEY',
-    placeholder: 'sk-...',
-    docsUrl: 'https://platform.openai.com/api-keys',
-  },
-  {
-    id: 'openrouter',
-    label: 'OpenRouter (Fallback)',
-    envVar: 'OPENROUTER_API_KEY',
-    placeholder: 'sk-or-...',
-    docsUrl: 'https://openrouter.ai/keys',
-  },
-  {
-    id: 'mistral',
-    label: 'Mistral',
-    envVar: 'MISTRAL_API_KEY',
-    placeholder: '...',
-    docsUrl: 'https://console.mistral.ai/api-keys/',
-  },
-  {
-    id: 'gemini',
-    label: 'Google Gemini',
-    envVar: 'GEMINI_API_KEY',
-    placeholder: 'AIza...',
-    docsUrl: 'https://aistudio.google.com/app/apikey',
-  },
-  {
-    id: 'xai',
-    label: 'xAI (Grok)',
-    envVar: 'XAI_API_KEY',
-    placeholder: 'xai-...',
-    docsUrl: 'https://console.x.ai/',
-  },
-];
-
-function getStoredProviderKeys(): Record<string, string> {
-  if (typeof window === 'undefined') return {};
-  try {
-    const stored = localStorage.getItem(PROVIDER_KEYS_STORAGE_KEY);
-    return stored ? JSON.parse(stored) : {};
-  } catch {
-    return {};
-  }
-}
-
-function storeProviderKeys(keys: Record<string, string>): void {
-  localStorage.setItem(PROVIDER_KEYS_STORAGE_KEY, JSON.stringify(keys));
-}
-
-/** Exported for use by debate hooks — reads provider keys from localStorage. */
-export function getProviderKeyHeaders(): Record<string, string> {
-  const keys = getStoredProviderKeys();
-  const headers: Record<string, string> = {};
-  for (const [id, value] of Object.entries(keys)) {
-    if (value) {
-      const provider = LLM_PROVIDERS.find(p => p.id === id);
-      if (provider) {
-        headers[`X-Provider-Key-${provider.id}`] = value;
-      }
-    }
-  }
-  return headers;
-}
 
 function maskKey(key: string): string {
   if (key.length <= 8) return '*'.repeat(key.length);
@@ -431,6 +355,8 @@ function ProviderKeysSection() {
           limits.
         </p>
       </div>
+
+      <ConnectOpenRouterButton className="mb-4" />
 
       <div className="space-y-3">
         {LLM_PROVIDERS.map((provider) => (

--- a/aragora/live/src/hooks/useOpenRouterConnection.ts
+++ b/aragora/live/src/hooks/useOpenRouterConnection.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { getStoredProviderKeys, storeProviderKeys } from '@/lib/provider-keys';
+import { startOpenRouterAuth, fetchKeyInfo, type OpenRouterKeyInfo } from '@/lib/openrouter-pkce';
+
+export interface OpenRouterConnection {
+  isConnected: boolean;
+  keyInfo: OpenRouterKeyInfo | null;
+  connect: () => void;
+  disconnect: () => void;
+  refreshKeyInfo: () => void;
+}
+
+export function useOpenRouterConnection(): OpenRouterConnection {
+  const [isConnected, setIsConnected] = useState(false);
+  const [keyInfo, setKeyInfo] = useState<OpenRouterKeyInfo | null>(null);
+
+  const checkConnection = useCallback(() => {
+    const keys = getStoredProviderKeys();
+    setIsConnected(!!keys.openrouter);
+    return keys.openrouter;
+  }, []);
+
+  // Check initial state
+  useEffect(() => {
+    checkConnection();
+  }, [checkConnection]);
+
+  // Listen for cross-tab and same-page storage updates
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === 'aragora_provider_keys' || e.key === null) {
+        checkConnection();
+      }
+    };
+
+    // Custom event for same-tab updates (StorageEvent only fires cross-tab)
+    const onCustom = () => checkConnection();
+
+    window.addEventListener('storage', onStorage);
+    window.addEventListener('openrouter:updated', onCustom);
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener('openrouter:updated', onCustom);
+    };
+  }, [checkConnection]);
+
+  // Fetch key info when connected
+  useEffect(() => {
+    if (!isConnected) {
+      setKeyInfo(null);
+      return;
+    }
+    const key = getStoredProviderKeys().openrouter;
+    if (key) {
+      fetchKeyInfo(key).then(setKeyInfo);
+    }
+  }, [isConnected]);
+
+  const connect = useCallback(() => {
+    const callbackUrl = `${window.location.origin}/openrouter/callback/`;
+    startOpenRouterAuth(callbackUrl);
+  }, []);
+
+  const disconnect = useCallback(() => {
+    const keys = getStoredProviderKeys();
+    delete keys.openrouter;
+    storeProviderKeys(keys);
+    setIsConnected(false);
+    setKeyInfo(null);
+    window.dispatchEvent(new Event('openrouter:updated'));
+  }, []);
+
+  const refreshKeyInfo = useCallback(() => {
+    const key = getStoredProviderKeys().openrouter;
+    if (key) {
+      fetchKeyInfo(key).then(setKeyInfo);
+    }
+  }, []);
+
+  return { isConnected, keyInfo, connect, disconnect, refreshKeyInfo };
+}

--- a/aragora/live/src/lib/openrouter-pkce.ts
+++ b/aragora/live/src/lib/openrouter-pkce.ts
@@ -1,0 +1,154 @@
+/**
+ * OpenRouter OAuth PKCE utilities.
+ *
+ * Implements the client-side PKCE flow for obtaining an OpenRouter API key
+ * without requiring users to manually copy-paste keys. No app registration
+ * needed — OpenRouter accepts any callback URL.
+ *
+ * Flow:
+ *   1. generateCodeVerifier() + generateCodeChallenge()
+ *   2. Redirect to OpenRouter /auth with challenge
+ *   3. User authorises and sets budget cap
+ *   4. exchangeCodeForKey() with the returned code
+ *   5. Receive a permanent sk-or-v1-... API key
+ */
+
+const OPENROUTER_AUTH_URL = 'https://openrouter.ai/auth';
+const OPENROUTER_KEYS_API = 'https://openrouter.ai/api/v1/auth/keys';
+const OPENROUTER_KEY_INFO_API = 'https://openrouter.ai/api/v1/auth/key';
+
+export const SESSION_VERIFIER_KEY = 'openrouter_pkce_verifier';
+export const SESSION_RETURN_KEY = 'openrouter_return_path';
+
+// ---------------------------------------------------------------------------
+// PKCE helpers
+// ---------------------------------------------------------------------------
+
+function base64url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generateCodeVerifier(): string {
+  const bytes = new Uint8Array(64);
+  crypto.getRandomValues(bytes);
+  return base64url(bytes.buffer);
+}
+
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const digest = await crypto.subtle.digest('SHA-256', encoder.encode(verifier));
+  return base64url(digest);
+}
+
+// ---------------------------------------------------------------------------
+// Auth flow
+// ---------------------------------------------------------------------------
+
+/**
+ * Begin the OpenRouter OAuth PKCE flow.
+ * Stores the code verifier in sessionStorage, then redirects the browser.
+ */
+export async function startOpenRouterAuth(callbackUrl: string): Promise<void> {
+  const verifier = generateCodeVerifier();
+  const challenge = await generateCodeChallenge(verifier);
+
+  sessionStorage.setItem(SESSION_VERIFIER_KEY, verifier);
+  sessionStorage.setItem(SESSION_RETURN_KEY, window.location.pathname);
+
+  const params = new URLSearchParams({
+    callback_url: callbackUrl,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+
+  window.location.href = `${OPENROUTER_AUTH_URL}?${params.toString()}`;
+}
+
+export interface KeyExchangeResult {
+  key: string;
+  userId: string | null;
+}
+
+/**
+ * Exchange an authorization code for an OpenRouter API key.
+ * Reads the code verifier from sessionStorage (set by startOpenRouterAuth).
+ */
+export async function exchangeCodeForKey(code: string): Promise<KeyExchangeResult> {
+  const verifier = sessionStorage.getItem(SESSION_VERIFIER_KEY);
+  if (!verifier) {
+    throw new Error('Missing PKCE code verifier. Please restart the connection flow.');
+  }
+
+  const res = await fetch(OPENROUTER_KEYS_API, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      code,
+      code_verifier: verifier,
+      code_challenge_method: 'S256',
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`OpenRouter key exchange failed (${res.status}): ${body || res.statusText}`);
+  }
+
+  const data = await res.json();
+
+  // Clean up session storage
+  sessionStorage.removeItem(SESSION_VERIFIER_KEY);
+
+  return {
+    key: data.key,
+    userId: data.user_id ?? null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Key info
+// ---------------------------------------------------------------------------
+
+export interface OpenRouterKeyInfo {
+  label: string | null;
+  limit: number | null;
+  limitRemaining: number | null;
+  usage: number;
+  rateLimit: {
+    requests: number;
+    interval: string;
+  } | null;
+}
+
+/**
+ * Fetch usage and limit info for an OpenRouter API key.
+ * Returns null on any failure (best-effort).
+ */
+export async function fetchKeyInfo(apiKey: string): Promise<OpenRouterKeyInfo | null> {
+  try {
+    const res = await fetch(OPENROUTER_KEY_INFO_API, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    if (!res.ok) return null;
+
+    const data = await res.json();
+    return {
+      label: data.data?.label ?? null,
+      limit: data.data?.limit ?? null,
+      limitRemaining: data.data?.limit != null && data.data?.usage != null
+        ? data.data.limit - data.data.usage
+        : null,
+      usage: data.data?.usage ?? 0,
+      rateLimit: data.data?.rate_limit
+        ? { requests: data.data.rate_limit.requests, interval: data.data.rate_limit.interval }
+        : null,
+    };
+  } catch {
+    return null;
+  }
+}

--- a/aragora/live/src/lib/provider-keys.ts
+++ b/aragora/live/src/lib/provider-keys.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared provider key storage utilities.
+ *
+ * LLM provider API keys are stored in localStorage under `aragora_provider_keys`
+ * and passed to the backend per-request via `X-Provider-Key-{id}` headers.
+ */
+
+export const PROVIDER_KEYS_STORAGE_KEY = 'aragora_provider_keys';
+
+export interface ProviderKeyConfig {
+  id: string;
+  label: string;
+  envVar: string;
+  placeholder: string;
+  docsUrl?: string;
+}
+
+export const LLM_PROVIDERS: ProviderKeyConfig[] = [
+  {
+    id: 'anthropic',
+    label: 'Anthropic (Claude)',
+    envVar: 'ANTHROPIC_API_KEY',
+    placeholder: 'sk-ant-...',
+    docsUrl: 'https://console.anthropic.com/settings/keys',
+  },
+  {
+    id: 'openai',
+    label: 'OpenAI (GPT)',
+    envVar: 'OPENAI_API_KEY',
+    placeholder: 'sk-...',
+    docsUrl: 'https://platform.openai.com/api-keys',
+  },
+  {
+    id: 'openrouter',
+    label: 'OpenRouter (Fallback)',
+    envVar: 'OPENROUTER_API_KEY',
+    placeholder: 'sk-or-...',
+    docsUrl: 'https://openrouter.ai/keys',
+  },
+  {
+    id: 'mistral',
+    label: 'Mistral',
+    envVar: 'MISTRAL_API_KEY',
+    placeholder: '...',
+    docsUrl: 'https://console.mistral.ai/api-keys/',
+  },
+  {
+    id: 'gemini',
+    label: 'Google Gemini',
+    envVar: 'GEMINI_API_KEY',
+    placeholder: 'AIza...',
+    docsUrl: 'https://aistudio.google.com/app/apikey',
+  },
+  {
+    id: 'xai',
+    label: 'xAI (Grok)',
+    envVar: 'XAI_API_KEY',
+    placeholder: 'xai-...',
+    docsUrl: 'https://console.x.ai/',
+  },
+];
+
+export function getStoredProviderKeys(): Record<string, string> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const stored = localStorage.getItem(PROVIDER_KEYS_STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function storeProviderKeys(keys: Record<string, string>): void {
+  localStorage.setItem(PROVIDER_KEYS_STORAGE_KEY, JSON.stringify(keys));
+}
+
+/** Build X-Provider-Key-{id} headers from stored provider keys. */
+export function getProviderKeyHeaders(): Record<string, string> {
+  const keys = getStoredProviderKeys();
+  const headers: Record<string, string> = {};
+  for (const [id, value] of Object.entries(keys)) {
+    if (value) {
+      const provider = LLM_PROVIDERS.find(p => p.id === id);
+      if (provider) {
+        headers[`X-Provider-Key-${provider.id}`] = value;
+      }
+    }
+  }
+  return headers;
+}


### PR DESCRIPTION
## Summary

- Adds client-side OpenRouter OAuth PKCE flow so users can connect their OpenRouter account with one click instead of manually pasting API keys
- No backend changes needed — the PKCE flow runs entirely in the browser and stores the resulting `sk-or-v1-...` key in the existing `aragora_provider_keys` localStorage slot
- Users set their own budget cap during the OpenRouter consent screen, so Aragora never controls their spending

## Changes

**5 new files:**
- `src/lib/provider-keys.ts` — Extracted shared provider key storage utilities
- `src/lib/openrouter-pkce.ts` — PKCE crypto (code_verifier/challenge via Web Crypto API) + OpenRouter key exchange
- `src/hooks/useOpenRouterConnection.ts` — React hook for connection state with cross-tab sync
- `src/components/openrouter/ConnectOpenRouterButton.tsx` — Reusable connect/disconnect button (compact + card modes)
- `src/app/(standalone)/openrouter/callback/page.tsx` — OAuth callback handler page

**3 modified files:**
- `ApiKeysTab.tsx` — Imports from shared module, adds OAuth card above provider list
- `HeroSection.tsx` — Compact "Connect OpenRouter" link below hero CTAs
- `quickstart/page.tsx` — Full OAuth card as alternative to manual env var setup

## How it works

1. User clicks "Connect OpenRouter"
2. Browser generates PKCE verifier/challenge, redirects to `openrouter.ai/auth`
3. User logs in to OpenRouter, sets a budget cap
4. OpenRouter redirects back to `/openrouter/callback/?code=...`
5. Callback page exchanges code for API key via `POST /api/v1/auth/keys`
6. Key stored in localStorage, ready for debates

## Test plan

- [ ] Build passes with 0 TypeScript errors (verified: 222 pages generated)
- [ ] Landing page shows "Connect OpenRouter for instant setup" below CTAs (verified: warm + dark themes)
- [ ] Quickstart page shows OAuth card in Step 3 (verified)
- [ ] Callback page shows error state when visited without code (verified)
- [ ] Settings API keys tab shows OAuth card above provider list (requires auth to test)
- [ ] Full OAuth flow: click connect → OpenRouter consent → callback → key stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)