### PR TITLE
test(live): wrap runtime backend selection in providers

### DIFF
--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, renderWithProviders, screen, waitFor } from '@/test-utils';
 
 import PublicDemoPage from '../(standalone)/demo/page';
 import TryPage from '../try/page';
@@ -72,7 +72,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<TryPage />);
+    renderWithProviders(<TryPage />);
     fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
       target: {
         value: 'Should we use the production backend for public try flows?',
@@ -106,7 +106,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<PublicDemoPage />);
+    renderWithProviders(<PublicDemoPage />);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- use the provider-aware test renderer for runtime backend selection coverage
- keep the existing assertions intact while restoring ThemeProvider context for the standalone demo page

## Validation
- NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules /Users/armand/Development/aragora/aragora/live/node_modules/.bin/jest --config /tmp/aragora-runtime-backend-theme/aragora/live/jest.config.js --runInBand /tmp/aragora-runtime-backend-theme/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
- git diff --check

## Note
- eslint from the disposable worktree is blocked by workspace-local module resolution because the worktree does not have its own installed frontend dependencies; the focused Jest file passes against the repo toolchain.