### PR TITLE
test(live): stabilize shared frontend test baselines

### DIFF
--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, renderWithProviders, screen, waitFor } from '@/test-utils';
 
 import PublicDemoPage from '../(standalone)/demo/page';
 import TryPage from '../try/page';
@@ -72,7 +72,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<TryPage />);
+    renderWithProviders(<TryPage />);
     fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
       target: {
         value: 'Should we use the production backend for public try flows?',
@@ -106,7 +106,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<PublicDemoPage />);
+    renderWithProviders(<PublicDemoPage />);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(

--- a/aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx
+++ b/aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx
@@ -2,9 +2,6 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { AgentNetworkPanel } from '../AgentNetworkPanel';
 
-// Enable React 18 act() support in tests
-(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
-
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -22,7 +19,6 @@ describe('AgentNetworkPanel', () => {
     const user = userEvent.setup();
     await act(async () => {
       render(<AgentNetworkPanel />);
-      await Promise.resolve();
     });
 
     await act(async () => {


### PR DESCRIPTION
Shared CI unblocker for the frontend test lane.

Root causes addressed:
- `AgentNetworkPanel.test.tsx` allowed the mount-time leaderboard fetch to resolve outside a clean `act(...)` boundary and carried redundant local act-environment mutation already provided by `jest.setup.js`.
- `runtimeBackendSelection.test.tsx` rendered standalone pages without the provider-aware test wrapper, which broke when `PublicDemoPage` started requiring `ThemeProvider`.

Fixes:
- keep the async mount inside `act(...)` without the redundant `Promise.resolve()`
- remove the per-file `IS_REACT_ACT_ENVIRONMENT` mutation and rely on the existing global Jest setup
- use `renderWithProviders(...)` for the runtime backend selection coverage

Local verification:
- `NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules node /Users/armand/Development/aragora/aragora/live/node_modules/jest/bin/jest.js --config /Users/armand/Development/aragora/.worktrees/codex-auto/frontend-act-env-fix/aragora/live/jest.config.js --runInBand /Users/armand/Development/aragora/.worktrees/codex-auto/frontend-act-env-fix/aragora/live/src/components/__tests__/AgentNetworkPanel.test.tsx /Users/armand/Development/aragora/.worktrees/codex-auto/frontend-act-env-fix/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx`
- `cd /Users/armand/Development/aragora/.worktrees/codex-auto/frontend-act-env-fix/aragora/live && ln -s /Users/armand/Development/aragora/aragora/live/node_modules node_modules && node node_modules/eslint/bin/eslint.js src/components/__tests__/AgentNetworkPanel.test.tsx src/app/__tests__/runtimeBackendSelection.test.tsx && rm node_modules`