### PR TITLE
test(live): wrap runtime backend selection with providers

### DIFF
--- a/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
+++ b/aragora/live/src/app/__tests__/runtimeBackendSelection.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@/test-utils';
 
 import PublicDemoPage from '../(standalone)/demo/page';
 import TryPage from '../try/page';
-
 const mockFetch = jest.fn();
 
 global.fetch = mockFetch as typeof fetch;
@@ -72,7 +72,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<TryPage />);
+    renderWithProviders(<TryPage />);
     fireEvent.change(screen.getByPlaceholderText('Enter your decision question...'), {
       target: {
         value: 'Should we use the production backend for public try flows?',
@@ -106,7 +106,7 @@ describe('runtime backend selection for public debate surfaces', () => {
       }),
     );
 
-    render(<PublicDemoPage />);
+    renderWithProviders(<PublicDemoPage />);
 
     await waitFor(() => {
       expect(mockFetch).toHaveBeenCalledWith(


### PR DESCRIPTION
Fixes the shared frontend Jest failure in `runtimeBackendSelection.test.tsx` by using the existing provider-aware test wrapper.

## Validation
- `cd aragora/live && npx jest src/app/__tests__/runtimeBackendSelection.test.tsx --runInBand`
- `cd aragora/live && npx eslint src/app/__tests__/runtimeBackendSelection.test.tsx`