### PR TITLE
fix(cli): drain ask cleanup callbacks before loop shutdown

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -344,10 +344,10 @@ async def _shutdown_cmd_ask_resources() -> None:
     except Exception as exc:  # noqa: BLE001 - shutdown must never hide CLI result
         logger.debug("Ask dispatcher shutdown skipped: %s", exc)
 
-    # Give async transport/connector close callbacks one loop turn before
-    # asyncio.run() tears the loop down. This avoids intermittent unclosed
-    # socket warnings in CLI proof-path tests.
-    await asyncio.sleep(0)
+    # Give async transport/connector close callbacks a brief chance to finish
+    # before asyncio.run() tears the loop down. A single yield is not always
+    # enough on Linux runners and can leave socket/event-loop warnings behind.
+    await asyncio.sleep(0.05)
 
 
 async def _run_coro_with_cmd_ask_cleanup(coro: Any) -> Any:

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -120,7 +120,7 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -115,7 +115,7 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `templates` | - | List available debate templates | - |
 | `tenant` | - | Manage multi-tenant deployments | `activate`, `create`, `delete`, `export`, `list`, `quota-get`, `quota-set`, `suspend` |
 | `testfixer` | - | Run automated test-fix loop | - |
-| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `auth`, `run`, `status` |
+| `triage` | - | Inbox triage via adversarial debate with receipt-gated actions | `audit`, `auth`, `calibrate`, `digest`, `label`, `queue`, `run`, `status` |
 | `validate` | - | Validate API keys by making test calls | - |
 | `validate-env` | - | Validate environment configuration and backend connectivity | - |
 | `verify` | - | Verify a decision receipt's integrity | - |

--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -22,6 +22,7 @@ def _stub_cmd_ask_global_side_effects(request):
 
     cleanup_sensitive_tests = {
         "test_cmd_ask_demo_forces_local_offline",
+        "test_shutdown_cmd_ask_resources_drains_transport_callbacks",
         "test_cmd_ask_cleans_shared_resources_on_debate_loop",
         "test_cmd_ask_compare_mode_reuses_single_loop_for_cleanup",
     }
@@ -243,6 +244,36 @@ def test_cmd_ask_demo_quality_pipeline_skips_provider_repairs(monkeypatch):
         ),
     ):
         debate_cmd.cmd_ask(args)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_cmd_ask_resources_drains_transport_callbacks() -> None:
+    """CLI ask shutdown should leave a small drain window for async closes."""
+    from aragora.cli.commands import debate as debate_cmd
+
+    with (
+        patch(
+            "aragora.server.startup.database.close_postgres_pool",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.server.http_client_pool.close_http_pool",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.agents.api_agents.common.close_shared_connector",
+            new=AsyncMock(),
+        ),
+        patch(
+            "aragora.storage.connection_factory.close_all_pools",
+            new=AsyncMock(),
+        ),
+        patch("aragora.events.dispatcher.shutdown_dispatcher"),
+        patch("aragora.cli.commands.debate.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+    ):
+        await debate_cmd._shutdown_cmd_ask_resources()
+
+    mock_sleep.assert_awaited_once_with(0.05)
 
 
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")


### PR DESCRIPTION
Revives the closed-but-unsuperseded diff from #1797 on a fresh branch after the original PR was closed.

This republishes the reviewed cleanup-drain fix that addresses the offline golden path resource leak around `cmd_ask` loop shutdown, plus its regression coverage and regenerated CLI reference docs.