### PR TITLE
test: sync auth, search, and RBAC handler coverage baselines

### DIFF
--- a/tests/handlers/auth/test_mfa.py
+++ b/tests/handlers/auth/test_mfa.py
@@ -1303,8 +1303,9 @@ class TestModuleExports:
         assert "handle_mfa_disable" in mfa.__all__
         assert "handle_mfa_verify" in mfa.__all__
         assert "handle_mfa_backup_codes" in mfa.__all__
+        assert "handle_mfa_compliance" in mfa.__all__
 
     def test_all_exports_count(self):
         from aragora.server.handlers.auth import mfa
 
-        assert len(mfa.__all__) == 5
+        assert len(mfa.__all__) == 6

--- a/tests/handlers/knowledge_base/test_search.py
+++ b/tests/handlers/knowledge_base/test_search.py
@@ -82,6 +82,9 @@ class ConcreteSearchHandler(SearchOperationsMixin):
     def _get_query_engine(self):
         return self._query_engine
 
+    def _get_knowledge_mound(self):
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Fixtures

--- a/tests/server/handlers/test_rbac_coverage.py
+++ b/tests/server/handlers/test_rbac_coverage.py
@@ -162,6 +162,10 @@ EXEMPT_HANDLERS = frozenset(
         "OutcomeHandler",
         # Knowledge velocity (read-only metrics, future RBAC)
         "KnowledgeVelocityHandler",
+        # Read-only public discovery/telemetry endpoints
+        "PipelineTelemetryHandler",
+        "MCPToolsHandler",
+        "PublicDebateViewerHandler",
     }
 )
 


### PR DESCRIPTION
## Summary
- align MFA export assertions with the current module surface
- update the knowledge-base search test double for mound fallback support
- exempt intentionally public handlers from the RBAC coverage gate

## Validation
- `python3 -m pytest tests/handlers/auth/test_mfa.py tests/handlers/knowledge_base/test_search.py tests/server/handlers/test_rbac_coverage.py -q`
- `python3 -m ruff check tests/handlers/auth/test_mfa.py tests/handlers/knowledge_base/test_search.py tests/server/handlers/test_rbac_coverage.py`