### PR TITLE
test(costs): refresh route count expectations

### DIFF
--- a/tests/handlers/costs/test_routes.py
+++ b/tests/handlers/costs/test_routes.py
@@ -437,8 +437,8 @@ class TestRouteMethods:
     def test_get_route_count(self, app):
         """Correct number of GET routes are registered."""
         get_paths = _paths_for_method(app, "GET")
-        # 18 unique GET endpoints, each with v1 + legacy = 36
-        assert len(get_paths) == 36
+        # 21 unique GET endpoints, each with v1 + legacy = 42
+        assert len(get_paths) == 42
 
     def test_post_route_count(self, app):
         """Correct number of POST routes are registered."""
@@ -647,5 +647,5 @@ class TestEdgeCases:
     def test_total_route_count(self, app):
         """Total number of registered routes matches expectations."""
         routes = _registered_routes(app)
-        # 36 GET + 36 HEAD (auto) + 18 POST = 90
-        assert len(routes) == 90
+        # 42 GET + 42 HEAD (auto) + 18 POST = 102
+        assert len(routes) == 102


### PR DESCRIPTION
Shared CI unblocker for the costs route tests.

Root cause:
- the costs handler now registers 21 GET endpoints across v1 and legacy prefixes, but `tests/handlers/costs/test_routes.py` still asserted the older 18-endpoint totals.

Fix:
- update the GET route count from 36 to 42
- update the aggregate route count from 90 to 102

Local verification:
- `python3 -m pytest tests/handlers/costs/test_routes.py -q`