### PR TITLE
fix(live): harden admin health overview

### DIFF
--- a/aragora/live/e2e/admin.spec.ts
+++ b/aragora/live/e2e/admin.spec.ts
@@ -1,429 +1,102 @@
 import { test, expect, mockApiResponse } from './fixtures';
+import type { Page } from '@playwright/test';
 
-// Mock health data for consistent testing
 const mockHealthData = {
   status: 'healthy',
   uptime_seconds: 3600,
   version: '1.0.0',
   components: {
     database: { status: 'ok', latency_ms: 5 },
-    agents: { status: 'ok', available: 6 },
+    agents: { status: 'ok', available: 6, total: 6 },
     memory: { status: 'ok', usage_mb: 256 },
-    websocket: { status: 'ok', connections: 10 }
-  }
+    websocket: { status: 'ok', connections: 10 },
+  },
 };
 
-/**
- * E2E tests for Admin page.
- *
- * Tests system health, agent status, errors, and metrics tabs.
- */
+async function openAdmin(
+  page: Page,
+  aragoraPage: { dismissAllOverlays: () => Promise<void> },
+) {
+  await mockApiResponse(page, '**/api/health*', mockHealthData);
+  await page.goto('/admin');
+  await aragoraPage.dismissAllOverlays();
+  await page.waitForLoadState('domcontentloaded');
+}
 
-test.describe('Admin Page', () => {
-  test.beforeEach(async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-  });
+test.describe('Admin Overview', () => {
+  test('loads the overview shell', async ({ page, aragoraPage }) => {
+    await openAdmin(page, aragoraPage);
 
-  test('should load admin page', async ({ page }) => {
     await expect(page).toHaveTitle(/Admin|Aragora/i);
-    await expect(page.getByText(/system administration/i).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: /admin overview/i })).toBeVisible();
+    await expect(
+      page.getByText(/system health, usage metrics, and recent activity at a glance/i),
+    ).toBeVisible();
   });
 
-  test('should display read-only warning for non-admin users', async ({ page }) => {
-    // Non-authenticated users should see read-only warning
-    await expect(page.getByText(/read-only mode/i)).toBeVisible({ timeout: 10000 });
+  test('shows quick actions and refresh control', async ({ page, aragoraPage }) => {
+    await openAdmin(page, aragoraPage);
+
+    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /invite user/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /create organization/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /view audit logs/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /check billing/i })).toBeVisible();
   });
 
-  test('should display all tabs', async ({ page }) => {
-    const tabs = ['HEALTH', 'AGENTS', 'ERRORS', 'METRICS'];
+  test('renders the system health card without crashing', async ({ page, aragoraPage }) => {
+    await openAdmin(page, aragoraPage);
 
-    for (const tab of tabs) {
-      // Tabs can be buttons, text, or role="tab"
-      const tabElement = page.getByRole('button', { name: new RegExp(tab, 'i') })
-        .or(page.locator('[role="tab"]').filter({ hasText: new RegExp(tab, 'i') }))
-        .or(page.locator('button, span, div').filter({ hasText: new RegExp(`^${tab}$`, 'i') }));
-      await expect(tabElement.first()).toBeVisible({ timeout: 5000 });
-    }
+    await expect(page.getByRole('heading', { name: /system health/i })).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(/cannot read properties|runtime error/i);
   });
 
-  test('should have refresh button', async ({ page }) => {
-    await expect(page.getByRole('button', { name: /refresh/i })).toBeVisible({ timeout: 5000 });
-  });
-
-  test('should navigate back to dashboard', async ({ page, aragoraPage }) => {
-    const dashboardLink = page.getByText(/dashboard/i).first();
-    await dashboardLink.click();
-    await aragoraPage.dismissAllOverlays();
-    await expect(page).toHaveURL('/');
-  });
-
-  test('should navigate to settings', async ({ page, aragoraPage }) => {
-    const settingsLink = page.getByText(/settings/i).first();
-    await settingsLink.click();
-    await aragoraPage.dismissAllOverlays();
-    await expect(page).toHaveURL(/settings/);
-  });
-});
-
-test.describe('Admin - Health Tab', () => {
-  test.beforeEach(async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
+  test('tolerates minimal public health payloads', async ({ page, aragoraPage }) => {
+    await mockApiResponse(page, '**/api/health*', {
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+    });
     await page.goto('/admin');
     await aragoraPage.dismissAllOverlays();
     await page.waitForLoadState('domcontentloaded');
-    // Health tab should be default, but click it to be sure
-    const healthTab = page.getByRole('button', { name: /health/i });
-    if (await healthTab.isVisible()) {
-      await healthTab.click();
-    }
-  });
 
-  test('should display system health section', async ({ page }) => {
-    await expect(page.getByText(/system health/i)).toBeVisible();
-  });
-
-  test('should show health status badge', async ({ page }) => {
-    // Should show one of: HEALTHY, DEGRADED, UNHEALTHY
-    const statusBadge = page.locator('span').filter({ hasText: /^(HEALTHY|DEGRADED|UNHEALTHY)$/i });
-    await expect(statusBadge.first()).toBeVisible();
-  });
-
-  test('should display uptime information', async ({ page }) => {
-    await expect(page.getByText(/uptime/i)).toBeVisible();
-  });
-
-  test('should display version information', async ({ page }) => {
-    await expect(page.getByText(/version/i)).toBeVisible();
-  });
-
-  test('should display component status section', async ({ page }) => {
-    await expect(page.getByText(/component status/i)).toBeVisible();
-  });
-
-  test('should show database component', async ({ page }) => {
-    await expect(page.getByText(/database/i)).toBeVisible();
-  });
-
-  test('should show agents component', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: /admin overview/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /system health/i })).toBeVisible();
     await expect(page.getByText(/agents/i).first()).toBeVisible();
+    await expect(page.locator('body')).not.toContainText(/cannot read properties|runtime error/i);
   });
 
-  test('should show websocket component', async ({ page }) => {
-    // Websocket may be shown as "websocket", "ws", or "connections"
-    const wsComponent = page.getByText(/websocket|ws|connections/i).first();
-    await expect(wsComponent).toBeVisible({ timeout: 10000 });
-  });
-});
-
-test.describe('Admin - Agents Tab', () => {
-  test.beforeEach(async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-    // Click agents tab (may be button or role="tab")
-    const agentsTab = page.getByRole('button', { name: /agents/i })
-      .or(page.locator('[role="tab"]').filter({ hasText: /agents/i }));
-    await agentsTab.first().click();
-  });
-
-  test('should display circuit breaker states section', async ({ page }) => {
-    // Circuit breaker section or agent status should be visible
-    const cbSection = page.getByText(/circuit breaker|agent status|agent.*state/i).first();
-    await expect(cbSection).toBeVisible({ timeout: 10000 });
-  });
-
-  test('should display agent configuration section', async ({ page }) => {
-    await expect(page.getByText(/agent configuration/i)).toBeVisible();
-  });
-
-  test('should show available agents', async ({ page }) => {
-    // Check for common agent names
-    const agents = ['claude', 'gpt4', 'gemini', 'grok', 'deepseek', 'mistral'];
-
-    for (const agent of agents) {
-      await expect(page.getByText(new RegExp(agent, 'i')).first()).toBeVisible();
-    }
-  });
-
-  test('should show circuit breaker status badge', async ({ page }) => {
-    // May show CLOSED, OPEN, or HALF_OPEN
-    // Or may show "No circuit breaker data available"
-    const hasData = await page.getByText(/closed|open|half_open/i).isVisible().catch(() => false);
-    const hasNoData = await page.getByText(/no circuit breaker data/i).isVisible().catch(() => false);
-
-    expect(hasData || hasNoData).toBeTruthy();
-  });
-});
-
-test.describe('Admin - Errors Tab', () => {
-  test.beforeEach(async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-    // Click errors tab (may be button or role="tab")
-    const errorsTab = page.getByRole('button', { name: /errors/i })
-      .or(page.locator('[role="tab"]').filter({ hasText: /errors/i }));
-    await errorsTab.first().click();
-  });
-
-  test('should display recent errors section', async ({ page }) => {
-    // Errors section may show "recent errors", "no errors", or error list
-    const errorsSection = page.getByText(/recent errors|no.*errors|error log/i).first();
-    await expect(errorsSection).toBeVisible({ timeout: 10000 });
-  });
-
-  test('should show errors or no-errors message', async ({ page }) => {
-    // Either shows error entries or "No recent errors recorded"
-    const hasErrors = await page.locator('.border-l-2.border-acid-red').first().isVisible().catch(() => false);
-    const hasNoErrors = await page.getByText(/no recent errors/i).isVisible().catch(() => false);
-
-    expect(hasErrors || hasNoErrors).toBeTruthy();
-  });
-
-  test('should show error level badges if errors exist', async ({ page }) => {
-    const errorEntry = page.locator('.border-l-2.border-acid-red').first();
-
-    if (await errorEntry.isVisible().catch(() => false)) {
-      // Error entries should have level badge (ERROR, WARNING, INFO)
-      const levelBadge = errorEntry.locator('span').filter({ hasText: /^(ERROR|WARNING|INFO)$/i });
-      await expect(levelBadge).toBeVisible();
-    }
-  });
-});
-
-test.describe('Admin - Metrics Tab', () => {
-  test.beforeEach(async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-    await page.getByRole('button', { name: /metrics/i }).click();
-  });
-
-  test('should display metrics panel', async ({ page }) => {
-    // Wait for metrics panel to load (it's dynamically imported)
-    await page.waitForTimeout(1000);
-
-    // Should show MetricsPanel content or loading state
-    const metricsContent = page.locator('[class*="card"]');
-    await expect(metricsContent.first()).toBeVisible();
-  });
-
-  test('should handle metrics panel error gracefully', async ({ page }) => {
-    // If metrics fail to load, error boundary should catch it
-    await page.waitForTimeout(2000);
-
-    // Should not show uncaught error
-    const pageContent = await page.content();
-    expect(pageContent).not.toContain('Uncaught');
-  });
-});
-
-test.describe('Admin - Refresh Functionality', () => {
-  test('should refresh data when clicking refresh button', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
+  test('refreshes without crashing', async ({ page, aragoraPage }) => {
+    await openAdmin(page, aragoraPage);
 
     const refreshButton = page.getByRole('button', { name: /refresh/i });
-
-    // Click refresh
     await refreshButton.click();
-
-    // Button should show "Refreshing..." state
     await expect(refreshButton).toContainText(/refreshing/i);
-
-    // Wait for refresh to complete
-    await expect(refreshButton).toContainText(/refresh/i, { timeout: 10000 });
+    await expect(refreshButton).toContainText(/^refresh$/i, { timeout: 10000 });
   });
 
-  test('should auto-refresh data periodically', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
+  test('shows recent activity section', async ({ page, aragoraPage }) => {
+    await openAdmin(page, aragoraPage);
 
-    // Page should load without errors
-    const mainContent = page.locator('main').first();
-    await expect(mainContent).toBeVisible({ timeout: 10000 });
-
-    // Auto-refresh is tested implicitly - page loads and shows health data
-    // Test passes if page renders the mocked health data
-    const healthText = page.getByText(/healthy|system|admin/i).first();
-    await expect(healthText).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: /recent activity/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /view all activity/i })).toBeVisible();
   });
 });
 
-test.describe('Admin - Tab Navigation', () => {
-  test('should switch between all tabs', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Helper to click tab
-    const clickTab = async (name: string) => {
-      const tab = page.getByRole('button', { name: new RegExp(name, 'i') })
-        .or(page.locator('[role="tab"]').filter({ hasText: new RegExp(name, 'i') }));
-      await tab.first().click();
-    };
-
-    // Start at health tab
-    await clickTab('health');
-    await expect(page.getByText(/system health|health.*status/i).first()).toBeVisible({ timeout: 10000 });
-
-    // Switch to agents tab
-    await clickTab('agents');
-    await expect(page.getByText(/circuit breaker|agent/i).first()).toBeVisible({ timeout: 10000 });
-
-    // Switch to errors tab
-    await clickTab('errors');
-    await expect(page.getByText(/recent errors|no.*errors|error/i).first()).toBeVisible({ timeout: 10000 });
-
-    // Switch to metrics tab
-    await clickTab('metrics');
-    await page.waitForTimeout(500); // Wait for dynamic import
-
-    // Metrics panel should be visible (even if loading)
-    const metricsArea = page.locator('[class*="card"], main').first();
-    await expect(metricsArea).toBeVisible({ timeout: 10000 });
-  });
-
-  test('should maintain tab selection on page focus', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Select agents tab
-    const agentsTab = page.getByRole('button', { name: /agents/i })
-      .or(page.locator('[role="tab"]').filter({ hasText: /agents/i }));
-    await agentsTab.first().click();
-    await expect(page.getByText(/circuit breaker|agent/i).first()).toBeVisible({ timeout: 10000 });
-
-    // Blur and refocus page (simulate tab switch)
-    await page.evaluate(() => {
-      window.dispatchEvent(new Event('blur'));
-      window.dispatchEvent(new Event('focus'));
-    });
-
-    // Tab should still show agents content
-    await expect(page.getByText(/circuit breaker|agent/i).first()).toBeVisible({ timeout: 10000 });
-  });
-});
-
-test.describe('Admin - Header Navigation', () => {
-  test('should have header link to home', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Click the banner/logo area or any header link to home
-    const bannerLink = page.locator('header a[href="/"]').first();
-    if (await bannerLink.isVisible().catch(() => false)) {
-      await bannerLink.click();
-      await aragoraPage.dismissAllOverlays();
-      await expect(page).toHaveURL('/');
-    } else {
-      // Test passes if header exists
-      await expect(page.locator('header').first()).toBeVisible();
-    }
-  });
-
-  test('should have backend selector or environment indicator', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Backend selector or environment indicator should be visible
-    const backendSelector = page.locator('header').getByRole('button').filter({ hasText: /local|production|staging/i });
-    const envIndicator = page.locator('text=/local|production|staging|backend/i').first();
-    const hasBackend = await backendSelector.first().isVisible().catch(() => false);
-    const hasEnv = await envIndicator.isVisible().catch(() => false);
-
-    // Either backend selector or environment indicator should exist, or test passes
-    expect(hasBackend || hasEnv || true).toBeTruthy();
-  });
-
-  test('should have theme toggle in header or page', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Theme toggle can be button with text, icon button, or in settings
-    const header = page.locator('header');
-    const themeButton = header.getByRole('button').filter({ hasText: /theme|dark|light/i });
-    const iconButton = header.locator('button[aria-label*="theme" i], button[title*="theme" i], button svg');
-
-    const hasText = await themeButton.first().isVisible().catch(() => false);
-    const hasIcon = await iconButton.first().isVisible().catch(() => false);
-
-    // Theme toggle should exist somewhere
-    expect(hasText || hasIcon || true).toBeTruthy();
-  });
-});
-
-test.describe('Admin - Responsive Layout', () => {
-  test('should display correctly on mobile', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
+test.describe('Admin Overview Layout', () => {
+  test('renders on mobile', async ({ page, aragoraPage }) => {
     await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
+    await openAdmin(page, aragoraPage);
 
-    // Page body should be visible
-    await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('heading', { name: /admin overview/i })).toBeVisible();
+    await expect(page.locator('body')).toBeVisible();
   });
 
-  test('should display correctly on tablet', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.setViewportSize({ width: 768, height: 1024 });
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
+  test('renders grid content on desktop', async ({ page, aragoraPage }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await openAdmin(page, aragoraPage);
 
-    // Page body should be visible
-    await expect(page.locator('body')).toBeVisible({ timeout: 10000 });
-  });
-
-  test('should display grid layout on desktop', async ({ page, aragoraPage }) => {
-    // Mock health endpoint for reliable testing
-    await mockApiResponse(page, '**/api/health', mockHealthData);
-    await page.setViewportSize({ width: 1920, height: 1080 });
-    await page.goto('/admin');
-    await aragoraPage.dismissAllOverlays();
-    await page.waitForLoadState('domcontentloaded');
-
-    // Health tab should show grid layout
-    const healthTab = page.getByRole('button', { name: /health/i })
-      .or(page.locator('[role="tab"]').filter({ hasText: /health/i }));
-    await healthTab.first().click();
-
-    // Should have grid layout (various possible classes)
-    const gridContainer = page.locator('[class*="grid"]').first();
-    await expect(gridContainer).toBeVisible();
+    await expect(page.locator('[class*="grid"]').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /system health/i })).toBeVisible();
   });
 });

--- a/aragora/live/src/app/(app)/admin/page.tsx
+++ b/aragora/live/src/app/(app)/admin/page.tsx
@@ -14,11 +14,80 @@ interface HealthStatus {
   version: string;
   components: {
     database: { status: string; latency_ms?: number };
-    agents: { status: string; available: number; total: number };
+    agents: { status: string; available?: number; total?: number };
     memory: { status: string; usage_mb?: number };
-    websocket: { status: string; connections: number };
+    websocket: { status: string; connections?: number };
   };
   timestamp: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function readStatus(primary: unknown, fallbackHealthy: unknown): string {
+  if (typeof primary === 'string' && primary) return primary;
+  if (fallbackHealthy === true) return 'healthy';
+  if (fallbackHealthy === false) return 'unhealthy';
+  return 'unknown';
+}
+
+function readVersion(value: unknown): string {
+  if (typeof value === 'string' && value) return value;
+  const version = asRecord(value);
+  const api = typeof version.api === 'string' ? version.api : '';
+  const server = typeof version.server === 'string' ? version.server : '';
+  return [api, server].filter(Boolean).join(' / ') || 'restricted';
+}
+
+function normalizeHealthStatus(value: unknown): HealthStatus {
+  const raw = asRecord(value);
+  const components = asRecord(raw.components);
+  const checks = asRecord(raw.checks);
+  const database = asRecord(components.database);
+  const agents = asRecord(components.agents);
+  const memory = asRecord(components.memory);
+  const websocket = asRecord(components.websocket);
+  const databaseCheck = asRecord(checks.database);
+  const websocketCheck = asRecord(checks.websocket);
+
+  return {
+    status: raw.status === 'healthy' || raw.status === 'degraded' || raw.status === 'unhealthy'
+      ? raw.status
+      : 'degraded',
+    uptime_seconds: readNumber(raw.uptime_seconds) ?? 0,
+    version: readVersion(raw.version),
+    components: {
+      database: {
+        status: readStatus(database.status, databaseCheck.healthy),
+        latency_ms: readNumber(database.latency_ms) ?? readNumber(databaseCheck.latency_ms),
+      },
+      agents: {
+        status: readStatus(agents.status, undefined),
+        available: readNumber(agents.available),
+        total: readNumber(agents.total),
+      },
+      memory: {
+        status: readStatus(memory.status, undefined),
+        usage_mb: readNumber(memory.usage_mb),
+      },
+      websocket: {
+        status: readStatus(websocket.status, websocketCheck.healthy),
+        connections: readNumber(websocket.connections) ?? readNumber(websocketCheck.active_clients),
+      },
+    },
+    timestamp: typeof raw.timestamp === 'string' ? raw.timestamp : new Date().toISOString(),
+  };
+}
+
+function formatAgentSummary(agents: HealthStatus['components']['agents']): string {
+  if (typeof agents.available !== 'number') return '--';
+  if (typeof agents.total !== 'number') return `${agents.available}/--`;
+  return `${agents.available}/${agents.total}`;
 }
 
 interface AdminStats {
@@ -109,7 +178,7 @@ export default function AdminOverviewPage() {
       const healthRes = await fetch(buildHealthCheckUrl(backendConfig.api));
       if (healthRes.ok) {
         const healthData = await healthRes.json();
-        setHealth(healthData);
+        setHealth(normalizeHealthStatus(healthData));
         // Detect demo mode from health response or environment flag
         if (healthData.demo_mode || healthData.mode === 'demo') {
           setIsDemoMode(true);
@@ -319,12 +388,16 @@ export default function AdminOverviewPage() {
               <div className="flex justify-between items-center">
                 <span className="font-mono text-sm text-text-muted">Agents</span>
                 <span className="font-mono text-sm text-acid-green">
-                  {health.components.agents.available}/{health.components.agents.total}
+                  {formatAgentSummary(health.components.agents)}
                 </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="font-mono text-sm text-text-muted">WebSocket</span>
-                <span className="font-mono text-sm text-text">{health.components.websocket.connections} conn</span>
+                <span className="font-mono text-sm text-text">
+                  {typeof health.components.websocket.connections === 'number'
+                    ? `${health.components.websocket.connections} conn`
+                    : '--'}
+                </span>
               </div>
               <div className="flex justify-between items-center">
                 <span className="font-mono text-sm text-text-muted">Database</span>


### PR DESCRIPTION
## Summary
- harden the admin overview against minimal public `/api/health` payloads and older detailed variants
- replace the stale admin Playwright coverage with tests that match the current page and real health endpoint shape

## Why
Current `main` assumes `health.components.agents.available/total` and `health.components.websocket.connections` always exist. The real unauthenticated health endpoint only returns a minimal payload, which crashes the admin page during Frontend E2E.

This is a shared baseline fix for branches like #1819 and #1820, not a branch-local behavior change.

## Validation
- `cd aragora/live && NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules /Users/armand/Development/aragora/aragora/live/node_modules/.bin/playwright test e2e/admin.spec.ts --project=chromium`
- `8 passed`