### PR TITLE
fix(review): filter malformed location artifacts

### DIFF
--- a/aragora/cli/review.py
+++ b/aragora/cli/review.py
@@ -382,7 +382,7 @@ def _looks_like_agent_target(target: Any) -> bool:
 def _is_meta_review_issue(issue: str, suggestions: list[str], raw_target: Any) -> bool:
     """Filter critique-of-review chatter out of blocking issue buckets."""
     normalized_issue = issue.strip().lower()
-    if normalized_issue.startswith(("location:**", "location:")):
+    if normalized_issue.startswith(("location**:", "location:**", "location:")):
         return True
     if normalized_issue.startswith(_META_REVIEW_PREFIXES):
         return True

--- a/tests/cli/test_review.py
+++ b/tests/cli/test_review.py
@@ -388,6 +388,35 @@ class TestExtractReviewFindings:
         assert len(findings["meta_issues"]) == 1
         assert findings["meta_issues"][0]["grounded"] is False
 
+    def test_filters_malformed_location_only_issue(self):
+        """Location-only artifacts from review formatting should not block PRs."""
+        result = MockDebateResult(
+            critiques=[
+                MockCritique(
+                    severity=0.95,
+                    target_agent="openai-api_performance_reviewer",
+                    issues=["Location**: aragora/live/src/app/(app)/admin/page.tsx"],
+                    suggestions=[],
+                )
+            ],
+            messages=[],
+        )
+
+        mock_report = MagicMock()
+        mock_report.unanimous_critiques = []
+        mock_report.split_opinions = []
+        mock_report.risk_areas = []
+        mock_report.agreement_score = 0.5
+        mock_report.agent_alignment = {}
+
+        with patch("aragora.cli.review.DisagreementReporter") as mock_reporter_class:
+            mock_reporter_class.return_value.generate_report.return_value = mock_report
+            findings = extract_review_findings(result)
+
+        assert findings["critical_issues"] == []
+        assert len(findings["meta_issues"]) == 1
+        assert findings["meta_issues"][0]["grounded"] is False
+
     def test_keeps_grounded_code_issue_and_extracts_location(self):
         """Concrete code findings should remain blocking even if aimed at another reviewer."""
         result = MockDebateResult(

--- a/tests/test_pr_review.py
+++ b/tests/test_pr_review.py
@@ -179,6 +179,35 @@ class TestExtractReviewFindings:
         assert findings["critical_issues"] == []
         assert len(findings["meta_issues"]) == 1
 
+    def test_extract_findings_drops_location_only_artifact(self):
+        """Malformed location-only review artifacts should stay non-blocking."""
+        mock_result = Mock()
+        mock_result.votes = []
+        mock_result.final_answer = ""
+        mock_result.messages = []
+
+        meta_critique = Mock()
+        meta_critique.severity = 0.95
+        meta_critique.agent = "agent1"
+        meta_critique.target_agent = "openai-api_performance_reviewer"
+        meta_critique.issues = ["Location**: aragora/live/e2e/admin.spec.ts"]
+        meta_critique.suggestions = []
+        mock_result.critiques = [meta_critique]
+
+        with patch("aragora.cli.review.DisagreementReporter") as MockReporter:
+            mock_report = Mock()
+            mock_report.unanimous_critiques = []
+            mock_report.split_opinions = []
+            mock_report.risk_areas = []
+            mock_report.agreement_score = 0.5
+            mock_report.agent_alignment = {}
+            MockReporter.return_value.generate_report.return_value = mock_report
+
+            findings = extract_review_findings(mock_result)
+
+        assert findings["critical_issues"] == []
+        assert len(findings["meta_issues"]) == 1
+
     def test_extract_findings_drops_meta_review_with_file_target(self):
         """Meta-review should not become blocking just because it names a file."""
         mock_result = Mock()


### PR DESCRIPTION
## Summary
- fix the malformed `Location**:` meta-review prefix check in `aragora.cli.review`
- treat location-only review artifacts as non-blocking meta issues instead of critical findings
- add focused regressions in both review parser test suites

## Why
The Aragora review gate on active PRs is failing on malformed review artifacts like `Location**: aragora/live/e2e/admin.spec.ts`. The parser intended to drop those as meta-review chatter, but the prefix matcher was misspelled, so they leaked into `critical_issues` and tripped the gate.

## Validation
- `python3 -m pytest tests/cli/test_review.py -q -k 'meta_review or location_only or malformed_location'`
- `python3 -m pytest tests/test_pr_review.py -q -k 'meta_review or location_only or malformed_location'`
- `python3 -m ruff check aragora/cli/review.py tests/cli/test_review.py tests/test_pr_review.py`
