### PR TITLE
fix(cli): persist staged audit artifacts before deep audit

### DIFF
--- a/aragora/cli/commands/codebase_audit.py
+++ b/aragora/cli/commands/codebase_audit.py
@@ -593,18 +593,31 @@ def cmd_codebase_audit(args: argparse.Namespace) -> int:
         top_files=getattr(args, "top_files", 12),
         max_preview_chars=getattr(args, "max_preview_chars", 4000),
     )
-    deep_audit_result = asyncio.run(
-        _run_interrogate_stage(
-            repo_root=repo_root,
-            triage=triage,
-            surface=surface,
-            agents_str=getattr(args, "agents", ""),
-            top_files=getattr(args, "top_files", 12),
-            max_file_chars=getattr(args, "max_file_chars", 12000),
-            dry_run=getattr(args, "dry_run", False),
-        )
-    )
     blast_radius = build_blast_radius(surface)
+
+    _write_json(artifact_dir / "triage.json", triage)
+    _write_json(artifact_dir / "surface.json", surface)
+    _write_json(artifact_dir / "blast_radius.json", blast_radius)
+
+    try:
+        deep_audit_result = asyncio.run(
+            _run_interrogate_stage(
+                repo_root=repo_root,
+                triage=triage,
+                surface=surface,
+                agents_str=getattr(args, "agents", ""),
+                top_files=getattr(args, "top_files", 12),
+                max_file_chars=getattr(args, "max_file_chars", 12000),
+                dry_run=getattr(args, "dry_run", False),
+            )
+        )
+    except Exception as exc:  # noqa: BLE001
+        deep_audit_result = {
+            "status": "failed",
+            "errors": [str(exc)],
+            "task": None,
+            "context_preview": None,
+        }
 
     summary = {
         "repo_root": str(repo_root),
@@ -624,10 +637,7 @@ def cmd_codebase_audit(args: argparse.Namespace) -> int:
         },
     }
 
-    _write_json(artifact_dir / "triage.json", triage)
-    _write_json(artifact_dir / "surface.json", surface)
     _write_json(artifact_dir / "interrogate.json", deep_audit_result)
-    _write_json(artifact_dir / "blast_radius.json", blast_radius)
     _write_json(artifact_dir / "run.json", summary)
     (artifact_dir / "summary.md").write_text(
         _summary_markdown(
@@ -654,4 +664,4 @@ def cmd_codebase_audit(args: argparse.Namespace) -> int:
             print(
                 f"- {item['path']} [{item['dominant_boundary']}] score={item['score']} loc={item['loc']}"
             )
-    return 0
+    return 0 if deep_audit_result.get("status") != "failed" else 1

--- a/tests/cli/commands/test_codebase_audit.py
+++ b/tests/cli/commands/test_codebase_audit.py
@@ -131,3 +131,48 @@ def test_cmd_codebase_audit_dry_run_writes_staged_artifacts(
     interrogate = json.loads((artifact_dir / "interrogate.json").read_text())
     assert interrogate["status"] == "skipped_dry_run"
     assert "Highest-risk files:" in interrogate["task"]
+
+
+def test_cmd_codebase_audit_persists_partial_artifacts_when_interrogate_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write(
+        tmp_path / "aragora" / "swarm" / "boss_loop.py",
+        "create_agent('codex')\nworker = 'dispatch worker'\n",
+    )
+    artifact_dir = tmp_path / "artifacts"
+
+    async def _boom(**_: object) -> dict[str, object]:
+        raise RuntimeError("interrogate exploded")
+
+    monkeypatch.setattr(codebase_audit, "_run_interrogate_stage", _boom)
+
+    args = argparse.Namespace(
+        repo=str(tmp_path),
+        agents="claude,codex,openai",
+        top_files=4,
+        max_dirs=25,
+        max_preview_chars=500,
+        max_file_chars=1000,
+        artifact_dir=str(artifact_dir),
+        dry_run=False,
+        json=False,
+    )
+
+    exit_code = codebase_audit.cmd_codebase_audit(args)
+
+    assert exit_code == 1
+    for name in [
+        "triage.json",
+        "surface.json",
+        "blast_radius.json",
+        "interrogate.json",
+        "run.json",
+        "summary.md",
+    ]:
+        assert (artifact_dir / name).exists()
+
+    interrogate = json.loads((artifact_dir / "interrogate.json").read_text())
+    assert interrogate["status"] == "failed"
+    assert interrogate["errors"] == ["interrogate exploded"]


### PR DESCRIPTION
## Summary
- persist triage, surface, and blast-radius artifacts before the deep-audit stage starts
- convert interrogate-stage exceptions into a persisted failed artifact instead of losing the whole run
- add a regression test for partial artifact persistence when interrogate blows up

## Validation
- `python -m pytest tests/cli/commands/test_codebase_audit.py -q`
- `python -m ruff check aragora/cli/commands/codebase_audit.py tests/cli/commands/test_codebase_audit.py`