### PR TITLE
feat(cli): allow codebase audit without research

### DIFF
--- a/aragora/cli/commands/codebase_audit.py
+++ b/aragora/cli/commands/codebase_audit.py
@@ -14,6 +14,7 @@ import argparse
 import asyncio
 import json
 from collections import Counter, defaultdict
+from dataclasses import replace
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -540,6 +541,7 @@ async def _run_interrogate_stage(
     top_files: int,
     max_file_chars: int,
     dry_run: bool,
+    disable_research: bool,
 ) -> dict[str, Any]:
     from aragora.modes.deep_audit import CODE_ARCHITECTURE_AUDIT, run_deep_audit
 
@@ -561,11 +563,17 @@ async def _run_interrogate_stage(
         result["errors"] = errors
         return result
 
+    audit_config = (
+        replace(CODE_ARCHITECTURE_AUDIT, enable_research=False)
+        if disable_research
+        else CODE_ARCHITECTURE_AUDIT
+    )
+
     verdict = await run_deep_audit(
         task=task,
         agents=agents,
         context=context,
-        config=CODE_ARCHITECTURE_AUDIT,
+        config=audit_config,
     )
     result["status"] = "completed"
     result["errors"] = errors
@@ -609,6 +617,7 @@ def cmd_codebase_audit(args: argparse.Namespace) -> int:
                 top_files=getattr(args, "top_files", 12),
                 max_file_chars=getattr(args, "max_file_chars", 12000),
                 dry_run=getattr(args, "dry_run", False),
+                disable_research=bool(getattr(args, "disable_research", False)),
             )
         )
     except Exception as exc:  # noqa: BLE001

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -1321,6 +1321,11 @@ def _add_codebase_audit_parser(subparsers) -> None:
         help="Skip the LLM deep-audit stage and only emit staged artifacts",
     )
     parser.add_argument(
+        "--disable-research",
+        action="store_true",
+        help="Disable Deep Audit web research and use only the selected audit agents",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print the final run summary as JSON",

--- a/tests/cli/commands/test_codebase_audit.py
+++ b/tests/cli/commands/test_codebase_audit.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from aragora.cli.commands import codebase_audit
 from aragora.cli.parser import build_parser
 
@@ -20,6 +22,7 @@ def test_codebase_audit_parser_accepts_flags() -> None:
             "codebase-audit",
             "/tmp/repo",
             "--dry-run",
+            "--disable-research",
             "--json",
             "--top-files",
             "5",
@@ -31,6 +34,7 @@ def test_codebase_audit_parser_accepts_flags() -> None:
     assert args.command == "codebase-audit"
     assert args.repo == "/tmp/repo"
     assert args.dry_run is True
+    assert args.disable_research is True
     assert args.json is True
     assert args.top_files == 5
     assert args.artifact_dir == "/tmp/artifacts"
@@ -176,3 +180,51 @@ def test_cmd_codebase_audit_persists_partial_artifacts_when_interrogate_fails(
     interrogate = json.loads((artifact_dir / "interrogate.json").read_text())
     assert interrogate["status"] == "failed"
     assert interrogate["errors"] == ["interrogate exploded"]
+
+
+@pytest.mark.asyncio
+async def test_run_interrogate_stage_can_disable_research(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write(
+        tmp_path / "aragora" / "swarm" / "boss_loop.py",
+        "create_agent('codex')\nworker = 'dispatch worker'\n",
+    )
+    triage = codebase_audit.collect_repo_triage(tmp_path)
+    surface = codebase_audit.identify_threat_surface(tmp_path, top_files=4)
+
+    monkeypatch.setattr(codebase_audit, "_build_agents", lambda _: ([object()], []))
+    observed: dict[str, object] = {}
+
+    async def _fake_run_deep_audit(*, task, agents, context, config):
+        observed["task"] = task
+        observed["agents"] = agents
+        observed["context"] = context
+        observed["enable_research"] = config.enable_research
+        return SimpleNamespace(
+            recommendation="focus supervisor and webhook paths",
+            confidence=0.72,
+            findings=[],
+            unanimous_issues=[],
+            split_opinions=[],
+            risk_areas=[],
+            citations=[],
+            cross_examination_notes="",
+        )
+
+    monkeypatch.setattr("aragora.modes.deep_audit.run_deep_audit", _fake_run_deep_audit)
+
+    result = await codebase_audit._run_interrogate_stage(
+        repo_root=tmp_path,
+        triage=triage,
+        surface=surface,
+        agents_str="openai-api,gemini",
+        top_files=4,
+        max_file_chars=1000,
+        dry_run=False,
+        disable_research=True,
+    )
+
+    assert result["status"] == "completed"
+    assert observed["enable_research"] is False


### PR DESCRIPTION
## Summary
- add `--disable-research` to `codebase-audit` so the deep-audit stage can stay inside the chosen agent set
- pass the flag through to `DeepAuditConfig` by disabling research on the architecture-audit preset
- add regression coverage for the parser flag and the config handoff into the interrogate stage

## Validation
- `python -m pytest tests/cli/commands/test_codebase_audit.py -q`
- `python -m ruff check aragora/cli/parser.py aragora/cli/commands/codebase_audit.py tests/cli/commands/test_codebase_audit.py`