### PR TITLE
fix(server): publish initialized postgres stores into singletons

### DIFF
--- a/aragora/server/initialization.py
+++ b/aragora/server/initialization.py
@@ -8,6 +8,7 @@ like InsightStore, EloSystem, PersonaManager, etc.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 import sqlite3
 from concurrent.futures import ThreadPoolExecutor
@@ -1161,53 +1162,77 @@ async def init_postgres_stores() -> dict[str, bool]:
             return {"_connection": False}
 
     # List of PostgreSQL stores to initialize
-    stores_to_init: list[tuple[str, str, str]] = [
-        ("webhook_configs", "aragora.storage.webhook_config_store", "PostgresWebhookConfigStore"),
-        ("integrations", "aragora.storage.integration_store", "PostgresIntegrationStore"),
-        ("gmail_tokens", "aragora.storage.gmail_token_store", "PostgresGmailTokenStore"),
+    stores_to_init: list[tuple[str, str, str, str | None]] = [
+        (
+            "webhook_configs",
+            "aragora.storage.webhook_config_store",
+            "PostgresWebhookConfigStore",
+            "set_webhook_config_store",
+        ),
+        (
+            "integrations",
+            "aragora.storage.integration_store",
+            "PostgresIntegrationStore",
+            "set_integration_store",
+        ),
+        ("gmail_tokens", "aragora.storage.gmail_token_store", "PostgresGmailTokenStore", None),
         (
             "finding_workflows",
             "aragora.storage.finding_workflow_store",
             "PostgresFindingWorkflowStore",
+            None,
         ),
-        ("gauntlet_runs", "aragora.storage.gauntlet_run_store", "PostgresGauntletRunStore"),
-        ("job_queue", "aragora.storage.job_queue_store", "PostgresJobQueueStore"),
-        ("governance", "aragora.storage.governance_store", "PostgresGovernanceStore"),
-        ("marketplace", "aragora.storage.marketplace_store", "PostgresMarketplaceStore"),
+        ("gauntlet_runs", "aragora.storage.gauntlet_run_store", "PostgresGauntletRunStore", None),
+        ("job_queue", "aragora.storage.job_queue_store", "PostgresJobQueueStore", None),
+        ("governance", "aragora.storage.governance_store", "PostgresGovernanceStore", None),
+        ("marketplace", "aragora.storage.marketplace_store", "PostgresMarketplaceStore", None),
         (
             "federation_registry",
             "aragora.storage.federation_registry_store",
             "PostgresFederationRegistryStore",
+            None,
         ),
         (
             "approval_requests",
             "aragora.storage.approval_request_store",
             "PostgresApprovalRequestStore",
+            None,
         ),
-        ("token_blacklist", "aragora.storage.token_blacklist_store", "PostgresBlacklist"),
-        ("users", "aragora.storage.user_store", "PostgresUserStore"),
-        ("webhooks", "aragora.storage.webhook_store", "PostgresWebhookStore"),
+        ("token_blacklist", "aragora.storage.token_blacklist_store", "PostgresBlacklist", None),
+        ("users", "aragora.storage.user_store", "PostgresUserStore", None),
+        (
+            "webhooks",
+            "aragora.storage.webhook_store",
+            "PostgresWebhookStore",
+            "set_webhook_store",
+        ),
         # Phase 2 migration stores (facts handled by KnowledgeMound postgres_store)
-        ("insights", "aragora.insights.postgres_store", "PostgresInsightStore"),
-        ("debates", "aragora.server.postgres_storage", "PostgresDebateStorage"),
+        ("insights", "aragora.insights.postgres_store", "PostgresInsightStore", None),
+        ("debates", "aragora.server.postgres_storage", "PostgresDebateStorage", None),
         (
             "scheduled_debates",
             "aragora.pulse.postgres_store",
             "PostgresScheduledDebateStore",
+            None,
         ),
         (
             "cycle_learning",
             "aragora.nomic.postgres_cycle_store",
             "PostgresCycleLearningStore",
+            None,
         ),
     ]
 
-    for name, module_path, class_name in stores_to_init:
+    for name, module_path, class_name, setter_name in stores_to_init:
         try:
-            module = __import__(module_path, fromlist=[class_name])
+            module = importlib.import_module(module_path)
             store_class = getattr(module, class_name)
             store = store_class(pool)
             await store.initialize()
+            if setter_name:
+                setter = getattr(module, setter_name, None)
+                if callable(setter):
+                    setter(store)
             results[name] = True
             logger.info("[init] PostgreSQL store initialized: %s", name)
         except ImportError as e:

--- a/tests/server/test_initialization.py
+++ b/tests/server/test_initialization.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from aragora.server import initialization as init_mod
+
+
+@pytest.mark.asyncio
+async def test_init_postgres_stores_sets_global_store_singletons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from aragora.storage.factory import StorageBackend
+
+    shared_pool = object()
+    setter_calls: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        "aragora.storage.factory.get_storage_backend", lambda: StorageBackend.POSTGRES
+    )
+    monkeypatch.setattr("aragora.storage.pool_manager.is_pool_initialized", lambda: True)
+    monkeypatch.setattr("aragora.storage.pool_manager.get_shared_pool", lambda: shared_pool)
+
+    def make_module(module_path: str, class_name: str, setter_name: str | None) -> object:
+        class FakeStore:
+            def __init__(self, pool):
+                self.pool = pool
+                self.initialized = False
+
+            async def initialize(self) -> None:
+                self.initialized = True
+
+        module = SimpleNamespace(**{class_name: FakeStore})
+        if setter_name:
+            setattr(
+                module,
+                setter_name,
+                lambda store, key=module_path: setter_calls.setdefault(key, store),
+            )
+        return module
+
+    stores_to_setters = {
+        "aragora.storage.webhook_config_store": (
+            "PostgresWebhookConfigStore",
+            "set_webhook_config_store",
+        ),
+        "aragora.storage.integration_store": ("PostgresIntegrationStore", "set_integration_store"),
+        "aragora.storage.gmail_token_store": ("PostgresGmailTokenStore", None),
+        "aragora.storage.finding_workflow_store": ("PostgresFindingWorkflowStore", None),
+        "aragora.storage.gauntlet_run_store": ("PostgresGauntletRunStore", None),
+        "aragora.storage.job_queue_store": ("PostgresJobQueueStore", None),
+        "aragora.storage.governance_store": ("PostgresGovernanceStore", None),
+        "aragora.storage.marketplace_store": ("PostgresMarketplaceStore", None),
+        "aragora.storage.federation_registry_store": ("PostgresFederationRegistryStore", None),
+        "aragora.storage.approval_request_store": ("PostgresApprovalRequestStore", None),
+        "aragora.storage.token_blacklist_store": ("PostgresBlacklist", None),
+        "aragora.storage.user_store": ("PostgresUserStore", None),
+        "aragora.storage.webhook_store": ("PostgresWebhookStore", "set_webhook_store"),
+        "aragora.insights.postgres_store": ("PostgresInsightStore", None),
+        "aragora.server.postgres_storage": ("PostgresDebateStorage", None),
+        "aragora.pulse.postgres_store": ("PostgresScheduledDebateStore", None),
+        "aragora.nomic.postgres_cycle_store": ("PostgresCycleLearningStore", None),
+    }
+
+    modules = {
+        path: make_module(path, class_name, setter_name)
+        for path, (class_name, setter_name) in stores_to_setters.items()
+    }
+    monkeypatch.setattr(init_mod.importlib, "import_module", lambda path: modules[path])
+
+    results = await init_mod.init_postgres_stores()
+
+    assert results["webhook_configs"] is True
+    assert results["integrations"] is True
+    assert results["webhooks"] is True
+    assert setter_calls["aragora.storage.webhook_config_store"].pool is shared_pool
+    assert setter_calls["aragora.storage.integration_store"].pool is shared_pool
+    assert setter_calls["aragora.storage.webhook_store"].pool is shared_pool


### PR DESCRIPTION
## Summary
- publish selected PostgreSQL stores into their module-level singleton setters during startup initialization
- ensure webhook config, webhook delivery, and integration stores do not lazily recreate fallback stores later in async request paths
- add a startup test proving the initialized stores are handed to the expected setters

## Validation
- `python -m pytest tests/server/test_initialization.py tests/cli/commands/test_codebase_audit.py -q`
- `python -m ruff check aragora/server/initialization.py tests/server/test_initialization.py aragora/cli/parser.py aragora/cli/commands/codebase_audit.py tests/cli/commands/test_codebase_audit.py`