### PR TITLE
test(auth): align MFA export baseline

### DIFF
--- a/tests/handlers/auth/test_mfa.py
+++ b/tests/handlers/auth/test_mfa.py
@@ -1303,8 +1303,9 @@ class TestModuleExports:
         assert "handle_mfa_disable" in mfa.__all__
         assert "handle_mfa_verify" in mfa.__all__
         assert "handle_mfa_backup_codes" in mfa.__all__
+        assert "handle_mfa_compliance" in mfa.__all__
 
     def test_all_exports_count(self):
         from aragora.server.handlers.auth import mfa
 
-        assert len(mfa.__all__) == 5
+        assert len(mfa.__all__) == 6


### PR DESCRIPTION
## Summary
- update MFA module export assertions for the new compliance handler
- align the exported symbol count with the actual module surface

## Testing
- python3 -m pytest tests/handlers/auth/test_mfa.py -q
- python3 -m ruff check tests/handlers/auth/test_mfa.py