### PR TITLE
fix(webhooks): fail closed on auth and workspace scope

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -224,6 +224,10 @@ class WebhookHandler(SecureHandler):
 
         Returns None if allowed, or an error response if denied.
         """
+        _user, auth_error = self.require_auth_or_error(handler)
+        if auth_error:
+            return auth_error
+
         if not RBAC_AVAILABLE:
             if rbac_fail_closed():
                 return error_response("Service unavailable: access control module not loaded", 503)
@@ -231,8 +235,7 @@ class WebhookHandler(SecureHandler):
 
         rbac_ctx = self._get_auth_context(handler)
         if not rbac_ctx:
-            # No auth context - rely on existing auth checks
-            return None
+            return error_response("Authentication required", 401)
 
         decision = check_permission(rbac_ctx, permission_key)
         if not decision.allowed:
@@ -248,6 +251,19 @@ class WebhookHandler(SecureHandler):
             )
 
         return None
+
+    @staticmethod
+    def _is_webhook_access_denied(webhook: WebhookConfig, user: Any | None) -> bool:
+        """Check whether the authenticated requester may access this webhook."""
+        if user is None:
+            return True
+        user_id = str(getattr(user, "user_id", "") or "").strip()
+        org_id = str(getattr(user, "org_id", "") or "").strip()
+        if webhook.user_id and webhook.user_id != user_id:
+            return True
+        if webhook.workspace_id and org_id and webhook.workspace_id != org_id:
+            return True
+        return False
 
     @api_endpoint(
         path="/api/v1/webhooks",
@@ -606,7 +622,7 @@ The webhook secret is only returned once on creation - save it securely.""",
 
         # Check ownership
         user = self.get_current_user(handler)
-        if user and webhook.user_id and webhook.user_id != user.user_id:
+        if self._is_webhook_access_denied(webhook, user):
             return error_response("Access denied", 403)
 
         return json_response({"webhook": webhook.to_dict(include_secret=False)})
@@ -657,6 +673,7 @@ The webhook secret is only returned once on creation - save it securely.""",
             name=body.get("name"),
             description=body.get("description"),
             user_id=user_id,
+            workspace_id=getattr(user, "org_id", None),
         )
 
         # Audit log: webhook created
@@ -693,7 +710,7 @@ The webhook secret is only returned once on creation - save it securely.""",
 
         # Check ownership
         user = self.get_current_user(handler)
-        if user and webhook.user_id and webhook.user_id != user.user_id:
+        if self._is_webhook_access_denied(webhook, user):
             return error_response("Access denied", 403)
 
         store.delete(webhook_id)
@@ -729,7 +746,7 @@ The webhook secret is only returned once on creation - save it securely.""",
 
         # Check ownership
         user = self.get_current_user(handler)
-        if user and webhook.user_id and webhook.user_id != user.user_id:
+        if self._is_webhook_access_denied(webhook, user):
             return error_response("Access denied", 403)
 
         # Validate URL if provided (SSRF check)
@@ -787,7 +804,7 @@ The webhook secret is only returned once on creation - save it securely.""",
 
         # Check ownership
         user = self.get_current_user(handler)
-        if user and webhook.user_id and webhook.user_id != user.user_id:
+        if self._is_webhook_access_denied(webhook, user):
             return error_response("Access denied", 403)
 
         # Import here to avoid circular dependency

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import time
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
@@ -73,7 +74,15 @@ def webhook_handler(server_context):
     """Create webhook handler instance."""
     from aragora.server.handlers.webhooks import WebhookHandler
 
-    return WebhookHandler(server_context)
+    handler = WebhookHandler(server_context)
+    handler.get_current_user = MagicMock(
+        return_value=SimpleNamespace(
+            user_id="test-user-001",
+            role="admin",
+            org_id="org-001",
+        )
+    )
+    return handler
 
 
 # ===========================================================================
@@ -241,6 +250,17 @@ class TestWebhookStore:
 
         result = webhook_store.list(active_only=True)
         assert len(result) == 1
+
+    def test_register_persists_workspace_id(self, webhook_store):
+        """register should retain provided workspace ownership."""
+        webhook = webhook_store.register(
+            url="https://a.com",
+            events=["debate_start"],
+            user_id="user-1",
+            workspace_id="ws-1",
+        )
+
+        assert webhook.workspace_id == "ws-1"
 
     def test_delete_removes_webhook(self, webhook_store, sample_webhook):
         """delete should remove webhook."""
@@ -422,6 +442,9 @@ class TestWebhookHandlerRegister:
         assert body["webhook"]["url"] == "https://example.com/webhook"
         # Secret should be included on creation
         assert "secret" in body["webhook"]
+        created = webhook_handler._get_webhook_store().get(body["webhook"]["id"])
+        assert created is not None
+        assert created.workspace_id == "org-001"
 
     @pytest.mark.asyncio
     async def test_register_webhook_missing_url(self, webhook_handler):
@@ -494,6 +517,19 @@ class TestWebhookHandlerList:
     """Tests for GET /api/webhooks endpoint."""
 
     @pytest.mark.asyncio
+    @pytest.mark.no_auto_auth
+    async def test_list_webhooks_requires_authentication(self, server_context):
+        """Unauthenticated callers should not be able to enumerate webhooks."""
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        handler_obj = WebhookHandler(server_context)
+        handler = MockHandler(headers={})
+
+        result = await handler_obj.handle("/api/v1/webhooks", {}, handler)
+
+        assert result.status_code == 401
+
+    @pytest.mark.asyncio
     async def test_list_webhooks_empty(self, webhook_handler):
         """Should return empty list when no webhooks registered."""
         handler = MockHandler(headers={})
@@ -559,6 +595,31 @@ class TestWebhookHandlerGet:
         result = await webhook_handler.handle("/api/v1/webhooks/non-existent-id", {}, handler)
 
         assert result.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_webhook_denies_workspace_mismatch(self, server_context):
+        """Workspace-scoped records should not leak across orgs."""
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com",
+            events=["debate_start"],
+            workspace_id="org-locked",
+        )
+        handler_obj = WebhookHandler(server_context)
+        handler_obj.get_current_user = MagicMock(
+            return_value=SimpleNamespace(
+                user_id="test-user-001",
+                role="admin",
+                org_id="org-other",
+            )
+        )
+
+        handler = MockHandler(headers={})
+        result = await handler_obj.handle(f"/api/v1/webhooks/{webhook.id}", {}, handler)
+
+        assert result.status_code == 403
 
 
 class TestWebhookHandlerDelete:
@@ -774,7 +835,15 @@ class TestWebhookRBAC:
     def handler(self, server_context):
         from aragora.server.handlers.webhooks import WebhookHandler
 
-        return WebhookHandler(server_context)
+        handler = WebhookHandler(server_context)
+        handler.get_current_user = MagicMock(
+            return_value=SimpleNamespace(
+                user_id="test-user-001",
+                role="admin",
+                org_id="org-001",
+            )
+        )
+        return handler
 
     def test_rbac_helper_methods_exist(self, handler):
         """Handler should have RBAC helper methods."""
@@ -789,6 +858,19 @@ class TestWebhookRBAC:
         with patch.dict(module_globals, {"RBAC_AVAILABLE": False}):
             result = handler._check_rbac_permission(mock_http, "webhooks.create")
             assert result is None  # None means allowed
+
+    @pytest.mark.no_auto_auth
+    def test_permission_check_requires_authentication(self, server_context):
+        """Permission helper should fail closed when no user is attached."""
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        handler = WebhookHandler(server_context)
+        mock_http = MockHandler(headers={})
+
+        result = handler._check_rbac_permission(mock_http, "webhooks.create")
+
+        assert result is not None
+        assert result.status_code == 401
 
     def test_permission_check_allowed(self, handler):
         """Permission check should pass when RBAC allows."""


### PR DESCRIPTION
## Summary
- require authenticated user context before webhook RBAC checks proceed
- persist workspace ownership on webhook registration and enforce workspace ownership on read/update/delete/test paths
- add webhook handler regressions for unauthenticated enumeration and workspace mismatch access

## Testing
- python -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/test_webhooks_handler.py
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q
