### PR TITLE
fix(slack): resolve oauth config from secrets at runtime

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -28,6 +28,7 @@ from urllib.parse import urlencode
 
 logger = logging.getLogger(__name__)
 
+from aragora.config.secrets import get_secret
 from aragora.server.oauth_state_store import OAUTH_STATE_TTL_SECONDS
 
 from ..base import (
@@ -54,6 +55,7 @@ SLACK_CLIENT_ID = os.environ.get("SLACK_CLIENT_ID")
 SLACK_CLIENT_SECRET = os.environ.get("SLACK_CLIENT_SECRET")
 SLACK_REDIRECT_URI = os.environ.get("SLACK_REDIRECT_URI")
 ARAGORA_ENV = os.environ.get("ARAGORA_ENV", "production")
+SLACK_SIGNING_SECRET = os.environ.get("SLACK_SIGNING_SECRET")
 
 # Log at debug level for unconfigured optional integrations
 if not SLACK_CLIENT_ID:
@@ -114,6 +116,36 @@ _slack_oauth_audit: Any = None
 
 # Legacy in-memory fallback for tests/compatibility
 _oauth_states_fallback: dict[str, dict[str, Any]] = {}
+
+
+def _get_aragora_env() -> str:
+    """Resolve environment mode from Secrets Manager or env."""
+    return get_secret("ARAGORA_ENV", ARAGORA_ENV, strict=False) or "production"
+
+
+def _get_slack_client_id() -> str:
+    """Resolve Slack client ID from Secrets Manager or env."""
+    return get_secret("SLACK_CLIENT_ID", SLACK_CLIENT_ID, strict=False) or ""
+
+
+def _get_slack_client_secret() -> str:
+    """Resolve Slack client secret from Secrets Manager or env."""
+    return get_secret("SLACK_CLIENT_SECRET", SLACK_CLIENT_SECRET, strict=False) or ""
+
+
+def _get_slack_redirect_uri() -> str:
+    """Resolve Slack redirect URI from Secrets Manager or env."""
+    return get_secret("SLACK_REDIRECT_URI", SLACK_REDIRECT_URI, strict=False) or ""
+
+
+def _get_slack_scopes() -> str:
+    """Resolve Slack scopes from Secrets Manager or env."""
+    return get_secret("SLACK_SCOPES", SLACK_SCOPES, strict=False) or DEFAULT_SCOPES
+
+
+def _get_slack_signing_secret() -> str:
+    """Resolve Slack signing secret from Secrets Manager or env."""
+    return get_secret("SLACK_SIGNING_SECRET", SLACK_SIGNING_SECRET, strict=False) or ""
 
 
 def _cleanup_oauth_states_fallback(now: float | None = None) -> None:
@@ -361,7 +393,7 @@ class SlackOAuthHandler(SecureHandler):
 
         # Allow unauthenticated install flow in non-production for developer convenience
         if path == "/api/integrations/slack/install" and method == "GET":
-            if ARAGORA_ENV.lower() in {"development", "dev", "test", "local"}:
+            if _get_aragora_env().lower() in {"development", "dev", "test", "local"}:
                 return await self._handle_install(query_params)
 
         # All other routes require authentication
@@ -468,7 +500,8 @@ class SlackOAuthHandler(SecureHandler):
         Optional query params:
             tenant_id: Aragora tenant to link workspace to
         """
-        if not SLACK_CLIENT_ID:
+        client_id = _get_slack_client_id()
+        if not client_id:
             return error_response(
                 "Slack OAuth not configured. Set SLACK_CLIENT_ID environment variable.",
                 503,
@@ -485,10 +518,10 @@ class SlackOAuthHandler(SecureHandler):
             return error_response("Failed to initialize OAuth flow", 503)
 
         # Build OAuth URL
-        redirect_uri = SLACK_REDIRECT_URI
+        redirect_uri = _get_slack_redirect_uri()
         if not redirect_uri:
             # SLACK_REDIRECT_URI is required in production to prevent open redirect attacks
-            if ARAGORA_ENV == "production":
+            if _get_aragora_env().lower() == "production":
                 return error_response(
                     "SLACK_REDIRECT_URI must be configured in production",
                     500,
@@ -502,8 +535,8 @@ class SlackOAuthHandler(SecureHandler):
             logger.warning("Using fallback redirect_uri in development: %s", redirect_uri)
 
         oauth_params = {
-            "client_id": SLACK_CLIENT_ID,
-            "scope": SLACK_SCOPES,
+            "client_id": client_id,
+            "scope": _get_slack_scopes(),
             "redirect_uri": redirect_uri,
             "state": state,
         }
@@ -540,7 +573,8 @@ class SlackOAuthHandler(SecureHandler):
         Query params:
             tenant_id: Optional tenant to link workspace to
         """
-        if not SLACK_CLIENT_ID:
+        client_id = _get_slack_client_id()
+        if not client_id:
             return error_response(
                 "Slack OAuth not configured. Set SLACK_CLIENT_ID environment variable.",
                 503,
@@ -549,7 +583,7 @@ class SlackOAuthHandler(SecureHandler):
         tenant_id = query_params.get("tenant_id", "")
 
         # Build scope information for display
-        current_scopes = SLACK_SCOPES.split(",")
+        current_scopes = _get_slack_scopes().split(",")
         required_scopes = []
         optional_scopes = []
 
@@ -825,7 +859,10 @@ class SlackOAuthHandler(SecureHandler):
             metadata = getattr(state_data, "metadata", None)
             tenant_id = metadata.get("tenant_id") if isinstance(metadata, dict) else None
 
-        if not SLACK_CLIENT_ID or not SLACK_CLIENT_SECRET:
+        client_id = _get_slack_client_id()
+        client_secret = _get_slack_client_secret()
+        redirect_uri = _get_slack_redirect_uri()
+        if not client_id or not client_secret:
             return error_response("Slack OAuth not configured", 503)
 
         # Exchange code for access token with retry logic
@@ -847,10 +884,10 @@ class SlackOAuthHandler(SecureHandler):
                         response = await client.post(
                             SLACK_OAUTH_TOKEN_URL,
                             data={
-                                "client_id": SLACK_CLIENT_ID,
-                                "client_secret": SLACK_CLIENT_SECRET,
+                                "client_id": client_id,
+                                "client_secret": client_secret,
                                 "code": code,
-                                "redirect_uri": SLACK_REDIRECT_URI,
+                                "redirect_uri": redirect_uri,
                             },
                         )
 
@@ -1082,8 +1119,8 @@ class SlackOAuthHandler(SecureHandler):
         Verifies the request signature using the Slack signing secret.
         """
         # Verify signature - REQUIRED in production
-        signing_secret = os.environ.get("SLACK_SIGNING_SECRET", "")
-        env = os.environ.get("ARAGORA_ENV", "production").lower()
+        signing_secret = _get_slack_signing_secret()
+        env = _get_aragora_env().lower()
         is_production = env not in ("development", "dev", "local", "test")
 
         if not signing_secret:
@@ -1340,8 +1377,8 @@ class SlackOAuthHandler(SecureHandler):
                     response = await client.post(
                         SLACK_OAUTH_TOKEN_URL,
                         data={
-                            "client_id": SLACK_CLIENT_ID,
-                            "client_secret": SLACK_CLIENT_SECRET,
+                            "client_id": _get_slack_client_id(),
+                            "client_secret": _get_slack_client_secret(),
                             "grant_type": "refresh_token",
                             "refresh_token": workspace.refresh_token,
                         },

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import os
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -100,6 +101,47 @@ def _patch_env(monkeypatch, handler_module):
     monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", "https://example.com/callback")
     monkeypatch.setattr(handler_module, "ARAGORA_ENV", "test")
     monkeypatch.setattr(handler_module, "SLACK_SCOPES", "channels:history,chat:write")
+    monkeypatch.setattr(handler_module, "SLACK_SIGNING_SECRET", "")
+    monkeypatch.setenv("SLACK_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("SLACK_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.setenv("SLACK_REDIRECT_URI", "https://example.com/callback")
+    monkeypatch.setenv("ARAGORA_ENV", "test")
+    monkeypatch.setenv("SLACK_SCOPES", "channels:history,chat:write")
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "")
+
+
+@pytest.fixture(autouse=True)
+def _patch_secret_lookup(monkeypatch, handler_module):
+    """Keep unit tests isolated from live Secrets Manager values."""
+
+    baselines = {
+        "SLACK_CLIENT_ID": "test-client-id",
+        "SLACK_CLIENT_SECRET": "test-client-secret",
+        "SLACK_REDIRECT_URI": "https://example.com/callback",
+        "ARAGORA_ENV": "test",
+        "SLACK_SCOPES": "channels:history,chat:write",
+        "SLACK_SIGNING_SECRET": "",
+    }
+
+    def fake_get_secret(name: str, default: str | None = None, strict: bool | None = None):
+        baseline = baselines.get(name)
+        module_value = getattr(handler_module, name, None)
+        env_value = os.environ.get(name)
+
+        if name in baselines and module_value != baseline:
+            return module_value if module_value not in (None, "") else default
+
+        if name in baselines and env_value != baseline:
+            return env_value if env_value not in (None, "") else default
+
+        env_value = os.environ.get(name)
+        if module_value not in (None, ""):
+            return module_value
+        if env_value not in (None, ""):
+            return env_value
+        return default
+
+    monkeypatch.setattr(handler_module, "get_secret", fake_get_secret)
 
 
 @pytest.fixture

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import json
 import os
 import time
+import hmac
+import hashlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -66,6 +68,22 @@ def reset_oauth_state_store(oauth_state_store):
     oauth_state_store._states.clear()
     yield
     oauth_state_store._states.clear()
+
+
+@pytest.fixture(autouse=True)
+def patch_secret_lookup(monkeypatch):
+    """Keep unit tests isolated from live Secrets Manager values."""
+
+    def fake_get_secret(name: str, default: str | None = None, strict: bool | None = None):
+        module_value = globals().get(name)
+        if module_value not in (None, ""):
+            return module_value
+        return default
+
+    monkeypatch.setattr(
+        "aragora.server.handlers.social.slack_oauth.get_secret",
+        fake_get_secret,
+    )
 
 
 def parse_handler_response(result) -> dict[str, Any]:
@@ -144,6 +162,28 @@ class TestSlackOAuthInstall:
         assert "Location" in result.headers
         assert "slack.com/oauth" in result.headers["Location"]
         assert "client_id=test-client-id" in result.headers["Location"]
+
+    @pytest.mark.asyncio
+    async def test_install_uses_secret_backed_client_id(self, oauth_handler, oauth_state_store):
+        """Install should use Secrets Manager values when module env snapshot is empty."""
+
+        def fake_get_secret(name: str, default: str | None = None, strict: bool | None = None):
+            values = {
+                "SLACK_CLIENT_ID": "secret-client-id",
+                "ARAGORA_ENV": "test",
+            }
+            return values.get(name, default)
+
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", ""),
+            patch(
+                "aragora.server.handlers.social.slack_oauth.get_secret", side_effect=fake_get_secret
+            ),
+        ):
+            result = await oauth_handler.handle("GET", "/api/integrations/slack/install")
+
+        assert result.status_code == 302
+        assert "client_id=secret-client-id" in result.headers["Location"]
 
     @pytest.mark.asyncio
     async def test_install_generates_state(self, oauth_handler, oauth_state_store):
@@ -411,7 +451,7 @@ class TestSlackOAuthUninstall:
     @pytest.fixture(autouse=True)
     def _set_test_env(self):
         """Set ARAGORA_ENV=test so uninstall handler skips signing secret checks."""
-        with patch.dict(os.environ, {"ARAGORA_ENV": "test"}):
+        with patch("aragora.server.handlers.social.slack_oauth.ARAGORA_ENV", "test"):
             yield
 
     @pytest.mark.asyncio
@@ -455,6 +495,58 @@ class TestSlackOAuthUninstall:
                         "type": "tokens_revoked",
                         "tokens": {"bot": ["xoxb-token"]},
                     },
+                },
+            )
+
+        assert result.status_code == 200
+        mock_store.deactivate.assert_called_once_with("T12345678")
+
+    @pytest.mark.asyncio
+    async def test_uninstall_uses_secret_backed_signing_secret(self, oauth_handler):
+        """Uninstall should verify signatures with secret-backed config in production."""
+        body = {
+            "type": "event_callback",
+            "team_id": "T12345678",
+            "event": {"type": "app_uninstalled", "team_id": "T12345678"},
+        }
+        raw_body = json.dumps(body, separators=(",", ":"))
+        timestamp = str(int(time.time()))
+        signing_secret = "secret-signing-key"
+        signature = (
+            "v0="
+            + hmac.new(
+                signing_secret.encode(),
+                f"v0:{timestamp}:{raw_body}".encode(),
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+        def fake_get_secret(name: str, default: str | None = None, strict: bool | None = None):
+            values = {
+                "SLACK_SIGNING_SECRET": signing_secret,
+                "ARAGORA_ENV": "production",
+            }
+            return values.get(name, default)
+
+        mock_store = MagicMock()
+
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_SIGNING_SECRET", ""),
+            patch(
+                "aragora.server.handlers.social.slack_oauth.get_secret", side_effect=fake_get_secret
+            ),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_store,
+            ),
+        ):
+            result = await oauth_handler.handle(
+                "POST",
+                "/api/integrations/slack/uninstall",
+                body=body,
+                headers={
+                    "x-slack-request-timestamp": timestamp,
+                    "x-slack-signature": signature,
                 },
             )
 


### PR DESCRIPTION
## Summary
- resolve Slack OAuth credentials and signing secret through the secrets accessor at use time
- stop relying on import-time environment snapshots for install, callback, refresh, and uninstall paths
- add regression coverage for secret-backed install and uninstall behavior while keeping Slack unit tests isolated from live host secrets

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'install or uninstall or callback or workspace_status_requires_auth'
