### PR TITLE
fix(swarm): honor terminal session meta in sync collection

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -412,7 +412,12 @@ class WorkerLauncher:
         ids = work_order_ids or list(self._processes.keys())
         for work_order_id in ids:
             proc = self._processes.get(work_order_id)
-            if proc is None or proc.returncode is None:
+            worker = self._workers.get(work_order_id)
+            session_exit_code: int | None = None
+            if worker is not None:
+                session_meta = self._read_session_meta(worker.worktree_path)
+                session_exit_code, _ = self._terminal_session_result(session_meta)
+            if proc is None or (proc.returncode is None and session_exit_code is None):
                 continue
             completed.append(self._wait_sync(work_order_id))
         return completed
@@ -1748,11 +1753,17 @@ class WorkerLauncher:
         """Synchronously finalize a worker whose subprocess already exited."""
         worker = self._workers.get(work_order_id)
         proc = self._processes.get(work_order_id)
-        if worker is None or proc is None or proc.returncode is None:
+        if worker is None or proc is None:
+            raise KeyError(f"No finished worker for {work_order_id}")
+
+        session_meta = self._read_session_meta(worker.worktree_path)
+        session_exit_code, session_completed_at = self._terminal_session_result(session_meta)
+        exit_code = proc.returncode if proc.returncode is not None else session_exit_code
+        if exit_code is None:
             raise KeyError(f"No finished worker for {work_order_id}")
 
         live_capture_enabled = work_order_id in self._live_log_tasks
-        worker.exit_code = proc.returncode
+        worker.exit_code = exit_code
         if live_capture_enabled:
             live_logs = self._finish_live_log_capture_sync(
                 work_order_id,
@@ -1764,7 +1775,7 @@ class WorkerLauncher:
             worker.stdout = self._read_log_file(worker.worktree_path, "stdout")
             worker.stderr = self._read_log_file(worker.worktree_path, "stderr")
 
-        worker.completed_at = datetime.now(UTC).isoformat()
+        worker.completed_at = session_completed_at or datetime.now(UTC).isoformat()
         try:
             worker.diff = self._collect_diff_sync(worker.worktree_path)
 
@@ -1803,6 +1814,16 @@ class WorkerLauncher:
                     if str(item.get("command", "")).strip()
                 ]
         finally:
+            cleanup_pid = worker.pid
+            if cleanup_pid is None:
+                raw_pid = session_meta.get("pid")
+                if raw_pid is not None:
+                    try:
+                        cleanup_pid = int(raw_pid)
+                    except (TypeError, ValueError):
+                        pass
+            if cleanup_pid is not None:
+                self._wait_for_pid_exit_sync(cleanup_pid)
             self._cleanup_session_artifacts(worker.worktree_path)
 
         logger.info(

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -918,6 +918,70 @@ class TestCollectFinishedSync:
         mock_verify.assert_called_once_with("/tmp/wt", [expected_test])
         assert "wo-sync-finished" not in launcher._processes
 
+    def test_collects_in_memory_worker_when_session_meta_marks_complete(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        expected_test = "python -m pytest tests/swarm/test_supervisor.py -q"
+        verification_results = [
+            {
+                "command": expected_test,
+                "exit_code": 0,
+                "passed": True,
+                "stdout": "1 passed",
+                "stderr": "",
+                "duration_seconds": 0.1,
+            }
+        ]
+
+        worker = WorkerProcess(
+            work_order_id="wo-sync-meta-finished",
+            agent="codex",
+            worktree_path="/tmp/wt-meta",
+            branch="main",
+            pid=333,
+            initial_head="def456",
+            expected_tests=[expected_test],
+        )
+        launcher._workers["wo-sync-meta-finished"] = worker
+        proc = MagicMock()
+        proc.returncode = None
+        launcher._processes["wo-sync-meta-finished"] = proc
+
+        session_meta = {
+            "pid": 333,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(
+                WorkerLauncher,
+                "_run_verification_commands_sync",
+                return_value=verification_results,
+            ) as mock_verify,
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync") as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=["wo-sync-meta-finished"])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 143
+        assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        assert result.head_sha == "abc123"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == [expected_test]
+        assert result.verification_results == verification_results
+        mock_verify.assert_called_once_with("/tmp/wt-meta", [expected_test])
+        mock_wait_pid.assert_called_once_with(333)
+        assert "wo-sync-meta-finished" not in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- let sync finished-worker collection trust terminal session metadata when subprocess returncode has not propagated yet
- preserve session completion timestamps and wait for the worker pid to fully exit before cleaning session artifacts
- add regression coverage for async-refresh-style sync collection of in-memory workers

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q -k 'refresh_run_async_context_collects_finished_in_memory_worker or collect_finished_results_uses_terminal_session_meta_even_when_pid_looks_alive'
