### PR TITLE
fix(storage): bridge webhook store sync wrappers safely

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from asyncpg import Pool
 
 from aragora.config import resolve_db_path
-from aragora.utils.async_utils import get_event_loop_safe
+from aragora.utils.async_utils import run_async
 
 # Pre-declare encryption names for optional import fallback
 EncryptionError: type[Exception]
@@ -985,9 +985,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
         workspace_id: str | None = None,
     ) -> WebhookConfig:
         """Register a new webhook (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(
-            self.register_async(url, events, name, description, user_id, workspace_id)
-        )
+        return run_async(self.register_async(url, events, name, description, user_id, workspace_id))
 
     async def register_async(
         self,
@@ -1046,7 +1044,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
 
     def get(self, webhook_id: str) -> WebhookConfig | None:
         """Get webhook by ID (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(self.get_async(webhook_id))
+        return run_async(self.get_async(webhook_id))
 
     async def get_async(self, webhook_id: str) -> WebhookConfig | None:
         """Get webhook by ID asynchronously."""
@@ -1093,9 +1091,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
         active_only: bool = False,
     ) -> _list[WebhookConfig]:
         """List webhooks (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(
-            self.list_async(user_id, workspace_id, active_only)
-        )
+        return run_async(self.list_async(user_id, workspace_id, active_only))
 
     async def list_async(
         self,
@@ -1134,7 +1130,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
 
     def delete(self, webhook_id: str) -> bool:
         """Delete webhook (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(self.delete_async(webhook_id))
+        return run_async(self.delete_async(webhook_id))
 
     async def delete_async(self, webhook_id: str) -> bool:
         """Delete webhook asynchronously."""
@@ -1155,9 +1151,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
         description: str | None = None,
     ) -> WebhookConfig | None:
         """Update webhook (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(
-            self.update_async(webhook_id, url, events, active, name, description)
-        )
+        return run_async(self.update_async(webhook_id, url, events, active, name, description))
 
     async def update_async(
         self,
@@ -1225,9 +1219,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
         success: bool = True,
     ) -> None:
         """Record delivery (sync wrapper for async)."""
-        get_event_loop_safe().run_until_complete(
-            self.record_delivery_async(webhook_id, status_code, success)
-        )
+        run_async(self.record_delivery_async(webhook_id, status_code, success))
 
     async def record_delivery_async(
         self,
@@ -1258,7 +1250,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
 
     def get_for_event(self, event_type: str) -> _list[WebhookConfig]:
         """Get webhooks for event (sync wrapper for async)."""
-        return get_event_loop_safe().run_until_complete(self.get_for_event_async(event_type))
+        return run_async(self.get_for_event_async(event_type))
 
     async def get_for_event_async(self, event_type: str) -> _list[WebhookConfig]:
         """Get webhooks for event asynchronously."""

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -24,6 +24,7 @@ from aragora.storage.webhook_config_store import (
     WebhookConfig,
     WebhookConfigStoreBackend,
     InMemoryWebhookConfigStore,
+    PostgresWebhookConfigStore,
     SQLiteWebhookConfigStore,
     RedisWebhookConfigStore,
     get_webhook_config_store,
@@ -1390,6 +1391,70 @@ class TestRedisWebhookConfigStore:
 
         store.close()
         mock_redis.close.assert_called_once()
+
+
+# =============================================================================
+# PostgresWebhookConfigStore Sync Wrapper Tests
+# =============================================================================
+
+
+class TestPostgresWebhookConfigStoreSyncWrappers:
+    """Tests for Postgres sync wrappers bridging through run_async()."""
+
+    @pytest.fixture
+    def postgres_store(self):
+        """Create a Postgres store with a mocked pool."""
+        return PostgresWebhookConfigStore(MagicMock())
+
+    @pytest.mark.parametrize(
+        ("method_name", "args", "kwargs"),
+        [
+            ("register", ("https://example.com/hook", ["debate_end"]), {}),
+            ("get", ("webhook-123",), {}),
+            ("list", (), {"user_id": "user-123", "workspace_id": "ws-123", "active_only": True}),
+            ("delete", ("webhook-123",), {}),
+            ("update", ("webhook-123",), {"url": "https://example.com/new"}),
+            ("get_for_event", ("debate_end",), {}),
+        ],
+    )
+    def test_sync_wrappers_delegate_via_run_async(
+        self,
+        postgres_store,
+        method_name: str,
+        args: tuple[object, ...],
+        kwargs: dict[str, object],
+    ) -> None:
+        """Sync wrappers should use the shared async bridge instead of run_until_complete()."""
+        sentinel = object()
+
+        def _capture(coro, timeout: float = 30.0):
+            assert timeout == 30.0
+            coro.close()
+            return sentinel
+
+        with patch(
+            "aragora.storage.webhook_config_store.run_async", side_effect=_capture
+        ) as mock_run:
+            result = getattr(postgres_store, method_name)(*args, **kwargs)
+
+        assert result is sentinel
+        mock_run.assert_called_once()
+
+    def test_record_delivery_delegates_via_run_async(self, postgres_store) -> None:
+        """record_delivery should also bridge via run_async()."""
+
+        def _capture(coro, timeout: float = 30.0):
+            assert timeout == 30.0
+            coro.close()
+            return object()
+
+        with patch(
+            "aragora.storage.webhook_config_store.run_async", side_effect=_capture
+        ) as mock_run:
+            result = postgres_store.record_delivery("webhook-123", 200, success=True)
+
+        assert result is None
+        mock_run.assert_called_once()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- replace raw run_until_complete sync wrappers in the Postgres webhook config store with the shared run_async bridge
- cover all sync wrappers so async request paths do not depend on calling run_until_complete on a running loop
- keep webhook handler and storage behavior unchanged while removing the unsafe bridge path

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'PostgresWebhookConfigStoreSyncWrappers or sync_wrappers_delegate_via_run_async or record_delivery_delegates_via_run_async'
- python -m pytest tests/storage/test_webhook_config_store.py tests/server/handlers/test_webhooks_handler.py -q