### PR TITLE
fix(rbac): block self-approval in workflows

### DIFF
--- a/aragora/rbac/approvals.py
+++ b/aragora/rbac/approvals.py
@@ -249,6 +249,9 @@ class ApprovalWorkflow:
                 permission, resource_type, org_id, workspace_id
             )
 
+        # A requester must never be able to approve their own access request.
+        approvers = list(dict.fromkeys(a for a in approvers if a != requester_id))
+
         # Validate we have approvers
         if not approvers:
             raise ValueError("No approvers available for this request")
@@ -327,6 +330,9 @@ class ApprovalWorkflow:
         if not request:
             raise ValueError(f"Request not found: {request_id}")
 
+        if approver_id == request.requester_id:
+            raise ValueError("Requester cannot approve their own request")
+
         # Validate approver
         if approver_id not in request.approvers:
             raise ValueError(f"User {approver_id} is not an approver for this request")
@@ -397,6 +403,9 @@ class ApprovalWorkflow:
         request = self._requests.get(request_id)
         if not request:
             raise ValueError(f"Request not found: {request_id}")
+
+        if approver_id == request.requester_id:
+            raise ValueError("Requester cannot reject their own request")
 
         # Validate approver
         if approver_id not in request.approvers:

--- a/tests/rbac/test_approvals.py
+++ b/tests/rbac/test_approvals.py
@@ -365,6 +365,33 @@ class TestApprovalWorkflowRequestAccess:
         # Should be capped to 1
         assert request.required_approvals == 1
 
+    @pytest.mark.asyncio
+    async def test_request_access_filters_requester_from_approvers(self, workflow):
+        """Requester should never remain in the approver set."""
+        request = await workflow.request_access(
+            requester_id="user-1",
+            permission="debates:delete",
+            resource_type="debates",
+            justification="Test",
+            approvers=["user-1", "admin-1", "admin-1"],
+            required_approvals=2,
+        )
+
+        assert request.approvers == ["admin-1"]
+        assert request.required_approvals == 1
+
+    @pytest.mark.asyncio
+    async def test_request_access_rejects_when_only_requester_can_approve(self, workflow):
+        """A request should fail if self-approval is the only approver option."""
+        with pytest.raises(ValueError, match="No approvers available"):
+            await workflow.request_access(
+                requester_id="user-1",
+                permission="debates:delete",
+                resource_type="debates",
+                justification="Test",
+                approvers=["user-1"],
+            )
+
 
 class TestApprovalWorkflowApprove:
     """Tests for ApprovalWorkflow.approve()."""
@@ -462,6 +489,24 @@ class TestApprovalWorkflowApprove:
         with pytest.raises(ValueError, match="not an approver"):
             await workflow.approve(
                 approver_id="other-user",
+                request_id=request.id,
+            )
+
+    @pytest.mark.asyncio
+    async def test_approve_requester_self_approval_error(self, workflow):
+        """Requester cannot approve even if older data includes them as an approver."""
+        request = await workflow.request_access(
+            requester_id="user-1",
+            permission="debates:delete",
+            resource_type="debates",
+            justification="Test",
+            approvers=["admin-1"],
+        )
+        request.approvers.append("user-1")
+
+        with pytest.raises(ValueError, match="cannot approve their own request"):
+            await workflow.approve(
+                approver_id="user-1",
                 request_id=request.id,
             )
 
@@ -587,6 +632,25 @@ class TestApprovalWorkflowReject:
         with pytest.raises(ValueError, match="not an approver"):
             await workflow.reject(
                 approver_id="other-user",
+                request_id=request.id,
+                reason="No",
+            )
+
+    @pytest.mark.asyncio
+    async def test_reject_requester_self_rejection_error(self, workflow):
+        """Requester cannot reject even if older data includes them as an approver."""
+        request = await workflow.request_access(
+            requester_id="user-1",
+            permission="debates:delete",
+            resource_type="debates",
+            justification="Test",
+            approvers=["admin-1"],
+        )
+        request.approvers.append("user-1")
+
+        with pytest.raises(ValueError, match="cannot reject their own request"):
+            await workflow.reject(
+                approver_id="user-1",
                 request_id=request.id,
                 reason="No",
             )


### PR DESCRIPTION
## Summary
- remove the requester from the approver set when creating approval requests
- reject legacy or malformed approval records where the requester attempts to approve or reject their own request
- add regression coverage for self-approval and self-rejection paths

## Testing
- python -m ruff check aragora/rbac/approvals.py tests/rbac/test_approvals.py
- python -m pytest tests/rbac/test_approvals.py -q -k 'self_approval or self_rejection or filters_requester_from_approvers or only_requester_can_approve'
- python -m pytest tests/rbac/test_approvals.py -q