### PR TITLE
fix(stream): avoid draining suggestions on GET

### DIFF
--- a/aragora/server/stream/emitter.py
+++ b/aragora/server/stream/emitter.py
@@ -242,6 +242,27 @@ class AudienceInbox:
             self._messages.extend(remaining)
             return suggestions
 
+    def peek_suggestions(self, loop_id: str | None = None) -> list[dict]:
+        """
+        Return suggestion messages without removing them from the inbox.
+
+        Args:
+            loop_id: Optional loop ID to filter suggestions by
+
+        Returns:
+            List of suggestion payloads
+        """
+        with self._lock:
+            suggestions = []
+
+            for msg in self._messages:
+                if loop_id and msg.loop_id != loop_id:
+                    continue
+                if msg.type == "suggestion":
+                    suggestions.append(msg.payload)
+
+            return suggestions
+
 
 class SyncEventEmitter:
     """

--- a/aragora/server/stream/stream_handlers.py
+++ b/aragora/server/stream/stream_handlers.py
@@ -807,8 +807,9 @@ class StreamAPIHandlersMixin:
                     headers=self._cors_headers(origin),
                 )
 
-            # Get suggestions from audience inbox for this loop
-            suggestions = self.audience_inbox.drain_suggestions(loop_id=loop_id)
+            # GET must be non-destructive so dashboard refreshes do not erase
+            # pending audience input before the debate loop can consume it.
+            suggestions = self.audience_inbox.peek_suggestions(loop_id=loop_id)
 
             if not suggestions:
                 return web.json_response(

--- a/tests/server/stream/test_emitter.py
+++ b/tests/server/stream/test_emitter.py
@@ -481,6 +481,18 @@ class TestAudienceInbox:
         assert len(remaining) == 1
         assert remaining[0].loop_id == "loop-2"
 
+    def test_peek_suggestions_does_not_drain(self, audience_inbox, suggestion_message):
+        """peek_suggestions returns suggestions without removing them."""
+        audience_inbox.put(suggestion_message)
+
+        suggestions = audience_inbox.peek_suggestions()
+        assert len(suggestions) == 1
+        assert suggestions[0]["text"] == "Consider environmental impact"
+
+        remaining = audience_inbox.get_all()
+        assert len(remaining) == 1
+        assert remaining[0].type == "suggestion"
+
     def test_thread_safety_put(self, audience_inbox):
         """AudienceInbox.put() is thread-safe."""
 

--- a/tests/server/stream/test_stream_handlers.py
+++ b/tests/server/stream/test_stream_handlers.py
@@ -778,6 +778,31 @@ class TestAudienceClustersHandler:
             call_args = mock_response.call_args[0][0]
             assert "error" in call_args or call_args.get("clusters") == []
 
+    @pytest.mark.asyncio
+    async def test_does_not_drain_suggestions_when_reading_clusters(self, request_factory):
+        """GET audience clusters should not consume pending suggestions."""
+        from aragora.server.stream.emitter import AudienceInbox
+        from aragora.server.stream.events import AudienceMessage
+
+        inbox = AudienceInbox()
+        inbox.put(
+            AudienceMessage(
+                type="suggestion",
+                loop_id="test-loop",
+                payload={"text": "Add more benchmarks", "user_id": "user-1"},
+            )
+        )
+        handler = ConcreteStreamAPIHandlers(audience_inbox=inbox)
+        request = request_factory(match_info={"loop_id": "test-loop"})
+
+        with patch("aiohttp.web.json_response") as mock_response:
+            mock_response.return_value = MagicMock()
+            await handler._handle_audience_clusters(request)
+
+        remaining = inbox.drain_suggestions(loop_id="test-loop")
+        assert len(remaining) == 1
+        assert remaining[0]["text"] == "Add more benchmarks"
+
 
 # ===========================================================================
 # Test Replay Handlers


### PR DESCRIPTION
## Summary
- make audience suggestion reads non-destructive by adding a peek path in the inbox
- switch the GET audience cluster endpoint to read pending suggestions without consuming them
- add regressions for inbox peek semantics and the handler read path

## Testing
- python -m ruff check aragora/server/stream/emitter.py aragora/server/stream/stream_handlers.py tests/server/stream/test_emitter.py tests/server/stream/test_stream_handlers.py
- python -m pytest tests/server/stream/test_emitter.py tests/server/stream/test_stream_handlers.py -q -k 'peek_suggestions or does_not_drain_suggestions_when_reading_clusters or drain_suggestions or audience_clusters'
- python -m pytest tests/server/stream/test_emitter.py tests/server/stream/test_stream_handlers.py -q