### PR TITLE
fix(boss-loop): preserve ping-pong handoff on dispatch failure

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -2828,8 +2828,6 @@ class BossLoop:
             if pending_handoff is not None and str(pending_handoff[1]).strip()
             else self._requested_target_agent_for_issue(issue.number)
         )
-        if pending_handoff is not None:
-            self._pending_handoff_prompts.pop(issue.number, None)
 
         claimed_runner_id: str | None = None
         selected_runner, claimed_runner_id = self._claim_runner_for_dispatch(
@@ -2860,6 +2858,10 @@ class BossLoop:
         finally:
             if claimed_runner_id:
                 self._release_runner_claim(claimed_runner_id)
+        if pending_handoff is not None:
+            dispatch_started = bool(result.get("run") or result.get("run_id"))
+            if result.get("status") != "failed" or dispatch_started:
+                self._pending_handoff_prompts.pop(issue.number, None)
         result["receipt_metadata"] = self._receipt_metadata_for_result(
             result,
             issue=issue,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2032,6 +2032,41 @@ async def test_dispatch_issue_consumes_pending_handoff_prompt_and_target_agent()
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_preserves_pending_handoff_on_pre_run_failure() -> None:
+    issue = _make_issue(1703, "Retry handoff should survive dispatch crash")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="claude"))
+    loop._pending_handoff_prompts[issue.number] = (
+        "## Goal\nRetry with preserved context\n\n## Context (from claude, round 1)\nStill relevant.",
+        "codex",
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": requested_target_agent or "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "failed", "outcome": "crash", "error": "boom"}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    dispatch_kwargs = dispatch_mock.await_args.kwargs
+    assert result["status"] == "failed"
+    assert dispatch_kwargs["default_target_agent"] == "codex"
+    assert loop._pending_handoff_prompts[issue.number] == (
+        "## Goal\nRetry with preserved context\n\n## Context (from claude, round 1)\nStill relevant.",
+        "codex",
+    )
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_preserves_issue_header_with_refined_prompt() -> None:
     issue = _make_issue(
         1641,


### PR DESCRIPTION
## Summary
- keep pending ping-pong handoff prompts when bounded dispatch fails before a run starts
- still consume the handoff once dispatch actually starts or finishes
- add a boss-loop regression for the pre-run dispatch failure case

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k 'dispatch_issue_consumes_pending_handoff_prompt_and_target_agent or preserves_pending_handoff_on_pre_run_failure or ping_pong_retry_prioritizes_same_issue_and_uses_handoff_prompt or run_iteration_prioritizes_pending_handoff_issue'
- python -m pytest tests/swarm/test_boss_loop.py tests/swarm/test_ping_pong.py tests/swarm/test_ping_pong_integration.py -q