### PR TITLE
fix(slack): verify uninstall signatures against raw payloads

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -299,6 +299,7 @@ class SlackOAuthHandler(SecureHandler):
             body = (
                 args[2] if len(args) > 2 and isinstance(args[2], dict) else kwargs.get("body", {})
             )
+            raw_body = kwargs.get("raw_body")
             qp = (
                 args[3]
                 if len(args) > 3 and isinstance(args[3], dict)
@@ -315,6 +316,7 @@ class SlackOAuthHandler(SecureHandler):
             path = str(args[0]) if args else kwargs.get("path", "")
             raw_qp = args[1] if len(args) > 1 else kwargs.get("query_params", {})
             hndlr = args[2] if len(args) > 2 else kwargs.get("handler")
+            raw_body = b""
 
             # Extract method from handler's command attribute (HTTP method)
             method = getattr(hndlr, "command", "GET") if hndlr else "GET"
@@ -343,7 +345,7 @@ class SlackOAuthHandler(SecureHandler):
             # Extract headers from handler if available
             hdrs = dict(hndlr.headers) if hndlr and hasattr(hndlr, "headers") else {}
 
-        return await self._handle_oauth(method, path, body, qp, hdrs, hndlr)
+        return await self._handle_oauth(method, path, body, qp, hdrs, hndlr, raw_body)
 
     async def _handle_oauth(
         self,
@@ -353,6 +355,7 @@ class SlackOAuthHandler(SecureHandler):
         query_params: dict[str, str],
         headers: dict[str, str],
         handler: Any | None = None,
+        raw_body: bytes | str | None = None,
     ) -> HandlerResult:
         """Internal OAuth request handler.
 
@@ -388,7 +391,7 @@ class SlackOAuthHandler(SecureHandler):
         # Security: Request is verified using Slack signing secret (HMAC-SHA256)
         if path == "/api/integrations/slack/uninstall":
             if method == "POST":
-                return await self._handle_uninstall(body, headers or {})
+                return await self._handle_uninstall(body, headers or {}, raw_body=raw_body)
             return error_response("Method not allowed", 405)
 
         # Allow unauthenticated install flow in non-production for developer convenience
@@ -1110,7 +1113,11 @@ class SlackOAuthHandler(SecureHandler):
         )
 
     async def _handle_uninstall(
-        self, body: dict[str, Any], headers: dict[str, str]
+        self,
+        body: dict[str, Any],
+        headers: dict[str, str],
+        *,
+        raw_body: bytes | str | None = None,
     ) -> HandlerResult:
         """
         Handle app uninstallation webhook from Slack.
@@ -1156,12 +1163,22 @@ class SlackOAuthHandler(SecureHandler):
             import hmac
             import hashlib
 
-            sig_basestring = f"v0:{timestamp}:{json.dumps(body, separators=(',', ':'))}"
+            if isinstance(raw_body, str):
+                raw_body_bytes = raw_body.encode("utf-8")
+            elif isinstance(raw_body, bytes):
+                raw_body_bytes = raw_body
+            else:
+                # Compatibility fallback for tests/direct calls that only pass a
+                # parsed dict. Real webhook verification must prefer the exact
+                # raw body Slack signed, not a reserialized approximation.
+                raw_body_bytes = json.dumps(body, separators=(",", ":")).encode("utf-8")
+
+            sig_basestring = b"v0:" + timestamp.encode("utf-8") + b":" + raw_body_bytes
             computed_sig = (
                 "v0="
                 + hmac.new(
                     signing_secret.encode(),
-                    sig_basestring.encode(),
+                    sig_basestring,
                     hashlib.sha256,
                 ).hexdigest()
             )

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -554,6 +554,59 @@ class TestSlackOAuthUninstall:
         mock_store.deactivate.assert_called_once_with("T12345678")
 
     @pytest.mark.asyncio
+    async def test_uninstall_verifies_signature_against_raw_body(self, oauth_handler):
+        """Signature verification must use the exact raw Slack payload, not reserialized JSON."""
+        body = {
+            "type": "event_callback",
+            "team_id": "T12345678",
+            "event": {"type": "app_uninstalled", "team_id": "T12345678"},
+        }
+        raw_body = json.dumps(body, indent=2, sort_keys=True)
+        timestamp = str(int(time.time()))
+        signing_secret = "secret-signing-key"
+        signature = (
+            "v0="
+            + hmac.new(
+                signing_secret.encode(),
+                f"v0:{timestamp}:{raw_body}".encode(),
+                hashlib.sha256,
+            ).hexdigest()
+        )
+
+        def fake_get_secret(name: str, default: str | None = None, strict: bool | None = None):
+            values = {
+                "SLACK_SIGNING_SECRET": signing_secret,
+                "ARAGORA_ENV": "production",
+            }
+            return values.get(name, default)
+
+        mock_store = MagicMock()
+
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_SIGNING_SECRET", ""),
+            patch(
+                "aragora.server.handlers.social.slack_oauth.get_secret", side_effect=fake_get_secret
+            ),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_store,
+            ),
+        ):
+            result = await oauth_handler.handle(
+                "POST",
+                "/api/integrations/slack/uninstall",
+                body=body,
+                headers={
+                    "x-slack-request-timestamp": timestamp,
+                    "x-slack-signature": signature,
+                },
+                raw_body=raw_body.encode("utf-8"),
+            )
+
+        assert result.status_code == 200
+        mock_store.deactivate.assert_called_once_with("T12345678")
+
+    @pytest.mark.asyncio
     async def test_uninstall_unknown_event(self, oauth_handler):
         """Test uninstall handles unknown event type."""
         result = await oauth_handler.handle(


### PR DESCRIPTION
## Summary
- verify Slack uninstall webhook signatures against the exact raw request payload when available
- keep a compatibility fallback for direct-call tests that only pass parsed JSON
- add a regression covering a valid signature over pretty-printed raw JSON

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q -k 'uninstall_uses_secret_backed_signing_secret or uninstall_verifies_signature_against_raw_body or uninstall_unknown_event'
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py tests/handlers/social/test_slack_oauth.py -q