### PR TITLE
test(cli): use real cmd_ask cleanup in grounding gate smoke

### DIFF
--- a/tests/cli/test_offline_golden_path.py
+++ b/tests/cli/test_offline_golden_path.py
@@ -24,6 +24,9 @@ def _stub_cmd_ask_global_side_effects(request):
         "test_cmd_ask_demo_forces_local_offline",
         "test_cmd_ask_cleans_shared_resources_on_debate_loop",
         "test_cmd_ask_compare_mode_reuses_single_loop_for_cleanup",
+        # CI on Python 3.11 surfaces loop/socket leaks in this path unless the
+        # real cmd_ask cleanup coroutine runs on the active event loop.
+        "test_cmd_ask_grounding_fail_closed_rejects_ungrounded_output",
     }
 
     receipt_patch = patch.object(debate_cmd, "_persist_debate_receipt", return_value=None)


### PR DESCRIPTION
## Summary
- let the grounding fail-closed rejection test run the real `cmd_ask` cleanup coroutine
- avoid stubbing cleanup in the one CI path that surfaces loop/socket teardown warnings on Python 3.11

## Validation
- `python3 -m pytest tests/cli/test_offline_golden_path.py -v --timeout=60 --tb=short -W error::ResourceWarning -W error::pytest.PytestUnraisableExceptionWarning`
- `python3 -m ruff check tests/cli/test_offline_golden_path.py`

## Why
`#1848` is carrying a shared Offline Demo Smoke failure in this exact test path; this keeps the fix scoped instead of broadening the replay PR.