### PR TITLE
feat(swarm): add debate_id to outcome signals

### DIFF
--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -42,6 +42,7 @@ class OutcomeSignal:
     signal_type: str  # completed | failed | escalated | repaired | blocked
     entity_id: str  # issue number, cycle ID, campaign ID, etc.
     entity_title: str = ""
+    debate_id: str = ""
 
     # Quality
     quality_delta: float = 0.0  # Net quality change (-1.0 to 1.0)

--- a/tests/swarm/test_outcome_signals.py
+++ b/tests/swarm/test_outcome_signals.py
@@ -45,9 +45,10 @@ class TestOutcomeSignal:
         assert "T" in s.timestamp  # ISO format
 
     def test_to_dict_roundtrip(self):
-        s = _make_signal(entity_title="Fix bug", tokens_used=50000)
+        s = _make_signal(entity_title="Fix bug", debate_id="debate-123", tokens_used=50000)
         d = s.to_dict()
         assert d["entity_title"] == "Fix bug"
+        assert d["debate_id"] == "debate-123"
         assert d["tokens_used"] == 50000
         # Should be JSON-serializable
         json.dumps(d)
@@ -57,6 +58,10 @@ class TestOutcomeSignal:
         d = s.to_dict()
         assert "elapsed_seconds" in d
         assert d["elapsed_seconds"] == 12.5
+
+    def test_debate_id_defaults_to_empty_string(self):
+        s = _make_signal()
+        assert s.debate_id == ""
 
 
 class TestOutcomeSignalBus:


### PR DESCRIPTION
## Summary
- add `debate_id` to `OutcomeSignal` serialization with an empty-string default
- extend the outcome signal tests to cover round-trip serialization and the default value

## Validation
- `python3 -m pytest tests/swarm/test_outcome_signals.py -x -q`
- `python3 -m ruff check aragora/swarm/outcome_signals.py tests/swarm/test_outcome_signals.py`

Closes #1750.