### PR TITLE
fix(worker-launcher): strip nested session artifacts

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -156,6 +156,11 @@ class WorkerLauncher:
         self._live_log_tasks: dict[str, dict[str, asyncio.Task[bytes]]] = {}
         self._live_log_handles: dict[str, dict[str, Any]] = {}
 
+    @staticmethod
+    def _strip_session_artifacts(paths: set[str]) -> list[str]:
+        """Normalize changed paths by removing harness-owned artifacts by basename."""
+        return sorted(path for path in paths if Path(path).name not in SESSION_ARTIFACTS)
+
     async def launch(
         self,
         work_order: dict[str, Any],
@@ -951,8 +956,7 @@ class WorkerLauncher:
             if path:
                 changed.add(path)
         # Strip session artifacts — these are harness metadata, not deliverables
-        changed -= SESSION_ARTIFACTS
-        return sorted(changed)
+        return cls._strip_session_artifacts(changed)
 
     @classmethod
     def _collect_changed_paths_sync(
@@ -997,8 +1001,7 @@ class WorkerLauncher:
                 path = path.split(" -> ")[-1].strip()
             if path:
                 changed.add(path)
-        changed -= SESSION_ARTIFACTS
-        return sorted(changed)
+        return cls._strip_session_artifacts(changed)
 
     @classmethod
     async def collect_detached_result(

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -469,6 +469,26 @@ class TestCollectChangedPathsFiltering:
         assert ".swarm_worker_stdout.log" not in paths
         assert ".swarm_worker_stderr.log" not in paths
 
+    def test_collect_excludes_nested_session_artifacts(self, repo: Path) -> None:
+        """Nested harness artifacts must be stripped by basename, not exact path."""
+        initial = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+        nested = repo / "subdir"
+        nested.mkdir()
+        (nested / ".codex_session_meta.json").write_text("{}", encoding="utf-8")
+        (nested / ".swarm_worker_stdout.log").write_text("worker stdout\n", encoding="utf-8")
+        (repo / "real.py").write_text("x = 1\n", encoding="utf-8")
+        _run(repo, "git", "add", "-A")
+        _run(repo, "git", "commit", "-m", "test nested artifacts")
+        head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+        paths = asyncio.run(
+            WorkerLauncher._collect_changed_paths(str(repo), initial_head=initial, head_sha=head)
+        )
+        assert "real.py" in paths
+        assert "subdir/.codex_session_meta.json" not in paths
+        assert "subdir/.swarm_worker_stdout.log" not in paths
+
 
 # ---------------------------------------------------------------------------
 # End-to-end detached worker fail-closed path

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1149,6 +1149,27 @@ class TestCollectChangedPaths:
         assert changed == []
         assert ("diff", "--name-only", "origin/main..HEAD") not in calls
 
+    def test_collect_changed_paths_sync_strips_nested_session_artifacts(self):
+        calls: list[tuple[str, ...]] = []
+
+        def _git_output_sync(_worktree_path: str, *args: str) -> str:
+            calls.append(tuple(args))
+            if args[:2] == ("diff", "--name-only"):
+                return "subdir/.codex_session_meta.json\nreal.py\n"
+            if args[:2] == ("status", "--porcelain"):
+                return "?? subdir/.swarm_worker_stdout.log\n"
+            return ""
+
+        with patch.object(WorkerLauncher, "_git_output_sync", side_effect=_git_output_sync):
+            changed = WorkerLauncher._collect_changed_paths_sync(
+                "/tmp/wt",
+                initial_head="abc123",
+                head_sha="def456",
+            )
+
+        assert changed == ["real.py"]
+        assert ("diff", "--name-only", "abc123..def456") in calls
+
 
 class TestIsPidRunning:
     def test_current_process_is_running(self):


### PR DESCRIPTION
## Summary
- filter worker-changed paths by artifact basename instead of exact path
- prevent nested session artifacts from surfacing as deliverables in async and sync collection
- add nested artifact regressions for worker-launcher and session-artifact coverage

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_session_artifact_prevention.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_session_artifact_prevention.py tests/swarm/test_worker_launcher.py -q -k 'nested_session_artifacts or strips_nested_session_artifacts or session_artifact or collect_changed_paths'
- python -m pytest tests/swarm/test_worker_launcher.py tests/swarm/test_timeout_cleanup.py tests/swarm/test_pid_alive_fallback.py tests/swarm/test_shell_trap_artifact_race.py tests/swarm/test_session_artifact_cleanup_guaranteed.py tests/swarm/test_session_artifact_prevention.py -q