### PR TITLE
fix(cli): honor dry-run for tranche harvest queue

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -651,6 +651,10 @@ def _render_tranche_queue_harvest_table(payload: dict[str, object]) -> None:
     print(title)
     if status:
         print(f"status={status}")
+    if bool(payload.get("dry_run", False)):
+        print("dry_run=true")
+        if bool(payload.get("requested_execute_merge", False)):
+            print("requested_execute_merge=true")
     print()
     print(f"{'metric':<{metric_width}}  {'count':>{count_width}}")
     print(f"{'-' * metric_width}  {'-' * count_width}")
@@ -1925,12 +1929,16 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     )
                 )
             elif subaction == "harvest-queue":
+                requested_execute_merge = bool(getattr(args, "execute_merge", False))
+                dry_run = bool(getattr(args, "dry_run", False))
                 payload = harvest_tranche_queue(
                     queue_path=queue_path,
                     repo_root=repo_root,
-                    execute_merge=bool(getattr(args, "execute_merge", False)),
+                    execute_merge=requested_execute_merge and not dry_run,
                     allow_admin=bool(getattr(args, "allow_admin", False)),
                 )
+                payload["dry_run"] = dry_run
+                payload["requested_execute_merge"] = requested_execute_merge
             else:
                 payload = reconcile_tranche_queue(
                     queue_path=queue_path,

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -550,6 +550,7 @@ class TestSwarmParser:
                 "harvest-queue",
                 "--queue",
                 "docs/examples/overnight-queue.yaml",
+                "--dry-run",
                 "--execute-merge",
                 "--allow-admin",
                 "--json",
@@ -559,6 +560,7 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "tranche"
         assert args.swarm_goal == "harvest-queue"
         assert args.queue == "docs/examples/overnight-queue.yaml"
+        assert args.dry_run is True
         assert args.execute_merge is True
         assert args.allow_admin is True
         assert args.json is True
@@ -1144,6 +1146,40 @@ class TestSwarmCommand:
             queue_path=Path("/tmp/overnight-queue.yaml").resolve(),
             repo_root=Path("/tmp/repo"),
             execute_merge=True,
+            allow_admin=True,
+        )
+
+    def test_cmd_swarm_tranche_harvest_queue_dry_run_forces_non_mutating_json(self, capsys):
+        args = _swarm_args(
+            swarm_action_or_goal="tranche",
+            swarm_goal="harvest-queue",
+            queue="/tmp/overnight-queue.yaml",
+            dry_run=True,
+            execute_merge=True,
+            allow_admin=True,
+            json=True,
+        )
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.swarm.tranche_queue.harvest_tranche_queue") as mock_harvest_queue,
+        ):
+            mock_harvest_queue.return_value = {
+                "mode": "tranche-queue-harvest",
+                "queue_id": "overnight",
+                "status": "completed",
+                "pr_counts": {"merge_now": 1},
+                "executed_merges": [],
+            }
+            cmd_swarm(args)
+
+        out = capsys.readouterr().out
+        assert '"dry_run": true' in out
+        assert '"requested_execute_merge": true' in out
+        mock_harvest_queue.assert_called_once_with(
+            queue_path=Path("/tmp/overnight-queue.yaml").resolve(),
+            repo_root=Path("/tmp/repo"),
+            execute_merge=False,
             allow_admin=True,
         )
 


### PR DESCRIPTION
## Summary
- make the harvest-queue path stay non-mutating during dry runs even when execute-merge is requested
- surface dry_run and requested_execute_merge in the harvest payload and rendered summary
- add focused parser and command tests for the harvest dry-run path

## Testing
- python3 -m pytest tests/cli/test_swarm_command.py -x -q -k harvest
- python3 -m ruff check aragora/cli/commands/swarm.py tests/cli/test_swarm_command.py

Closes #1751