### PR TITLE
feat(swarm): add calibration timestamp_iso

### DIFF
--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -340,7 +340,9 @@ class CalibrationSnapshot:
     recommendations: list[str]
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        data["timestamp_iso"] = self.timestamp
+        return data
 
 
 def compute_calibration(

--- a/tests/swarm/test_outcome_signals.py
+++ b/tests/swarm/test_outcome_signals.py
@@ -216,3 +216,10 @@ class TestCalibration:
         assert snap.loop_merge_rates["boss"] == 0.5
         assert snap.loop_merge_rates["nomic"] == 1.0
         assert snap.loop_merge_rates["ralph"] == 0.0
+
+    def test_calibration_to_dict_includes_timestamp_iso(self):
+        signals = self._make_signals(10)
+        snap = compute_calibration(signals)
+        assert snap is not None
+        data = snap.to_dict()
+        assert data["timestamp_iso"] == snap.timestamp


### PR DESCRIPTION
## Summary
- add timestamp_iso alongside the existing timestamp field in CalibrationSnapshot serialization
- keep the fix limited to outcome_signals and its focused tests
- cover the serialization alias in the calibration test slice

## Testing
- python3 -m pytest tests/swarm/test_outcome_signals.py -x -q -k calibration
- python3 -m ruff check aragora/swarm/outcome_signals.py tests/swarm/test_outcome_signals.py

Closes #1752