### PR TITLE
feat(security): harden execution and chain boundaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
         exclude: ^(docs/|\.json$|\.lock$)
       - id: check-yaml
         args: [--unsafe]  # Allow custom tags
-        exclude: ^deploy/(helm|multi-region/helm)/.*templates/  # Helm templates use Go templating
+        exclude: ^(deploy/(helm|multi-region/helm)|aragora-operator/helm)/.*templates/  # Helm templates use Go templating
       - id: check-json
         exclude: ^(package-lock\.json$|node_modules/)
       - id: check-added-large-files

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Why teams adopt Aragora:
 
 - **Disagreement becomes useful evidence.** Models challenge each other before work advances.
 - **Every consequential action has a receipt.** Review, provenance, confidence, and next steps stay inspectable.
-- **Execution is bounded and truthful.** Approval gates and blocker handling are explicit.
+- **Execution is bounded and truthful.** Consequential actions are denied by default unless an admin-scoped approval artifact exists.
+- **Sandboxed effectors are mandatory.** Browser automation and similar effectors require an approved sandbox backend instead of host-side execution.
 - **It fits above existing tools.** Use Aragora when review and governance matter; keep direct runtimes when raw speed is enough.
 
 ## Product Boundary
@@ -150,6 +151,12 @@ Each subtask gets an isolated git worktree, cross-agent review, sandbox
 validation, and a receipt trail before merge or truthful escalation. This is a
 governed execution path, not a claim that Aragora is a generic autonomous-agent
 runtime.
+
+Current default boundary:
+
+- public and issue-driven paths can draft plans and receipts, but cannot execute code, drive browsers, mutate git, emit consequential webhooks, or write on-chain without an explicit approval record
+- browser execution requires a sandbox backend; host-side browser automation is disabled by default
+- blockchain write requests queue durable chain actions for an admin signer lane instead of signing in the request path
 
 ### Add to Your CI Pipeline (1 minute)
 
@@ -493,7 +500,7 @@ python scripts/run_nomic_with_stream.py run --cycles 3
 python scripts/self_develop.py --goal "Improve test coverage" --require-approval
 ```
 
-Safety: automatic backups, protected file checksums, rollback on failure, human approval gates.
+Safety: automatic backups, protected file checksums, rollback on failure, explicit approval gates for consequential actions, sandbox-required browser execution, and asynchronous chain settlement.
 
 ---
 

--- a/aragora-operator/helm/aragora-operator/templates/deployment.yaml
+++ b/aragora-operator/helm/aragora-operator/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             {{- if .Values.aragoraAPI.endpoint }}
             - --aragora-api-endpoint={{ .Values.aragoraAPI.endpoint }}
             {{- end }}
+            {{- if .Values.aragoraAPI.allowInsecure }}
+            - --allow-insecure-control-plane
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           ports:

--- a/aragora-operator/helm/aragora-operator/values.yaml
+++ b/aragora-operator/helm/aragora-operator/values.yaml
@@ -66,6 +66,7 @@ leaderElection:
 # Aragora control plane API settings
 aragoraAPI:
   endpoint: ""
+  allowInsecure: false
   tokenSecretName: ""
   tokenSecretKey: "token"
 

--- a/aragora-operator/main.go
+++ b/aragora-operator/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"flag"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -49,22 +50,30 @@ func main() {
 	var probeAddr string
 	var aragoraAPIEndpoint string
 	var aragoraAPIToken string
+	var allowInsecureControlPlane bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.StringVar(&aragoraAPIEndpoint, "aragora-api-endpoint", "http://aragora-control-plane:8080",
+	flag.StringVar(&aragoraAPIEndpoint, "aragora-api-endpoint", "https://aragora-control-plane:8443",
 		"The Aragora control plane API endpoint.")
 	flag.StringVar(&aragoraAPIToken, "aragora-api-token", "",
 		"The Aragora API token for authentication.")
+	flag.BoolVar(&allowInsecureControlPlane, "allow-insecure-control-plane", false,
+		"Allow http:// Aragora control plane endpoints. Disabled by default.")
 
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(aragoraAPIEndpoint)), "http://") && !allowInsecureControlPlane {
+		setupLog.Error(nil, "refusing insecure Aragora API endpoint without explicit opt-in", "endpoint", aragoraAPIEndpoint)
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
@@ -88,11 +97,11 @@ func main() {
 
 	// Setup AragoraCluster controller
 	if err = (&controllers.AragoraClusterReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("aragoracluster-controller"),
-		APIEndpoint:     aragoraAPIEndpoint,
-		APIToken:        aragoraAPIToken,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("aragoracluster-controller"),
+		APIEndpoint:      aragoraAPIEndpoint,
+		APIToken:         aragoraAPIToken,
 		MetricsCollector: metricsCollector,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AragoraCluster")
@@ -101,9 +110,9 @@ func main() {
 
 	// Setup AragoraInstance controller
 	if err = (&controllers.AragoraInstanceReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("aragorainstance-controller"),
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("aragorainstance-controller"),
 		MetricsCollector: metricsCollector,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AragoraInstance")
@@ -112,11 +121,11 @@ func main() {
 
 	// Setup AragoraPolicy controller
 	if err = (&controllers.AragoraPolicyReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("aragorapolicy-controller"),
-		APIEndpoint:     aragoraAPIEndpoint,
-		APIToken:        aragoraAPIToken,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Recorder:         mgr.GetEventRecorderFor("aragorapolicy-controller"),
+		APIEndpoint:      aragoraAPIEndpoint,
+		APIToken:         aragoraAPIToken,
 		MetricsCollector: metricsCollector,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "AragoraPolicy")

--- a/aragora/blockchain/action_store.py
+++ b/aragora/blockchain/action_store.py
@@ -1,0 +1,324 @@
+"""
+Durable queue and processor for consequential blockchain actions.
+
+Request-serving paths enqueue actions here instead of signing and sending
+transactions inline. Processing requires an explicit chain-write approval.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from aragora.security.capability_gate import (
+    Capability,
+    authorize_capability_dispatch,
+)
+from aragora.storage.backends import DatabaseBackend, get_database_backend
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+
+class ChainActionType(str, Enum):
+    REGISTER_AGENT = "register_agent"
+
+
+class ChainActionStatus(str, Enum):
+    QUEUED = "queued"
+    SUBMITTED = "submitted"
+    MINED = "mined"
+    CONFIRMED = "confirmed"
+    FAILED = "failed"
+
+
+@dataclass(slots=True)
+class ChainActionRecord:
+    action_id: str
+    action_type: ChainActionType
+    requested_by: str
+    approval_id: str = ""
+    receipt_id: str = ""
+    status: ChainActionStatus = ChainActionStatus.QUEUED
+    payload: dict[str, Any] = field(default_factory=dict)
+    result: dict[str, Any] = field(default_factory=dict)
+    error: str = ""
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+
+
+def _parse_json(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+class ChainActionStore:
+    def __init__(self, backend: DatabaseBackend | None = None) -> None:
+        self._backend = backend or get_database_backend()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._backend.execute_write(
+            """
+            CREATE TABLE IF NOT EXISTS blockchain_chain_actions (
+                action_id TEXT PRIMARY KEY,
+                action_type TEXT NOT NULL,
+                requested_by TEXT NOT NULL,
+                approval_id TEXT DEFAULT '',
+                receipt_id TEXT DEFAULT '',
+                status TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                result_json TEXT DEFAULT '{}',
+                error TEXT DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        self._backend.execute_write(
+            """
+            CREATE INDEX IF NOT EXISTS idx_blockchain_chain_actions_status
+            ON blockchain_chain_actions(status, action_type)
+            """
+        )
+
+    def create_action(
+        self,
+        *,
+        action_type: ChainActionType,
+        requested_by: str,
+        approval_id: str = "",
+        receipt_id: str = "",
+        payload: dict[str, Any],
+    ) -> ChainActionRecord:
+        now = datetime.now(UTC).isoformat()
+        record = ChainActionRecord(
+            action_id=f"chain-{uuid.uuid4().hex[:12]}",
+            action_type=action_type,
+            requested_by=requested_by,
+            approval_id=approval_id,
+            receipt_id=receipt_id,
+            status=ChainActionStatus.QUEUED,
+            payload=dict(payload),
+            created_at=now,
+            updated_at=now,
+        )
+        self._backend.execute_write(
+            """
+            INSERT INTO blockchain_chain_actions (
+                action_id, action_type, requested_by, approval_id, receipt_id,
+                status, payload_json, result_json, error, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.action_id,
+                record.action_type.value,
+                record.requested_by,
+                record.approval_id,
+                record.receipt_id,
+                record.status.value,
+                json.dumps(record.payload, sort_keys=True, default=str),
+                json.dumps(record.result, sort_keys=True, default=str),
+                record.error,
+                record.created_at,
+                record.updated_at,
+            ),
+        )
+        return record
+
+    def get_action(self, action_id: str) -> ChainActionRecord | None:
+        row = self._backend.fetch_one(
+            """
+            SELECT action_id, action_type, requested_by, approval_id, receipt_id,
+                   status, payload_json, result_json, error, created_at, updated_at
+            FROM blockchain_chain_actions
+            WHERE action_id = ?
+            """,
+            (action_id,),
+        )
+        if row is None:
+            return None
+        return ChainActionRecord(
+            action_id=str(row[0]),
+            action_type=ChainActionType(str(row[1])),
+            requested_by=str(row[2]),
+            approval_id=str(row[3] or ""),
+            receipt_id=str(row[4] or ""),
+            status=ChainActionStatus(str(row[5])),
+            payload=_parse_json(row[6]),
+            result=_parse_json(row[7]),
+            error=str(row[8] or ""),
+            created_at=str(row[9]),
+            updated_at=str(row[10]),
+        )
+
+    def update_action(
+        self,
+        action_id: str,
+        *,
+        status: ChainActionStatus,
+        result: dict[str, Any] | None = None,
+        error: str | None = None,
+        approval_id: str | None = None,
+    ) -> ChainActionRecord | None:
+        current = self.get_action(action_id)
+        if current is None:
+            return None
+        merged_result = dict(current.result)
+        if result:
+            merged_result.update(result)
+        self._backend.execute_write(
+            """
+            UPDATE blockchain_chain_actions
+            SET status = ?, result_json = ?, error = ?, approval_id = ?, updated_at = ?
+            WHERE action_id = ?
+            """,
+            (
+                status.value,
+                json.dumps(merged_result, sort_keys=True, default=str),
+                error if error is not None else current.error,
+                approval_id if approval_id is not None else current.approval_id,
+                datetime.now(UTC).isoformat(),
+                action_id,
+            ),
+        )
+        return self.get_action(action_id)
+
+    def list_pending(self) -> list[ChainActionRecord]:
+        rows = self._backend.fetch_all(
+            """
+            SELECT action_id
+            FROM blockchain_chain_actions
+            WHERE status IN (?, ?, ?)
+            ORDER BY created_at ASC
+            """,
+            (
+                ChainActionStatus.QUEUED.value,
+                ChainActionStatus.SUBMITTED.value,
+                ChainActionStatus.MINED.value,
+            ),
+        )
+        return [record for row in rows if (record := self.get_action(str(row[0])))]
+
+
+_store: ChainActionStore | None = None
+
+
+def get_chain_action_store() -> ChainActionStore:
+    global _store
+    if _store is None:
+        _store = ChainActionStore()
+    return _store
+
+
+def enqueue_register_agent_action(
+    *,
+    agent_uri: str,
+    metadata: dict[str, Any] | None = None,
+    requested_by: str = "",
+    approval_id: str = "",
+    receipt_id: str = "",
+) -> ChainActionRecord:
+    payload = {
+        "agent_uri": agent_uri,
+        "metadata": dict(metadata or {}),
+    }
+    return get_chain_action_store().create_action(
+        action_type=ChainActionType.REGISTER_AGENT,
+        requested_by=requested_by or "system",
+        approval_id=approval_id,
+        receipt_id=receipt_id,
+        payload=payload,
+    )
+
+
+def process_chain_action(action_id: str, *, approval_id: str = "") -> ChainActionRecord:
+    record = get_chain_action_store().get_action(action_id)
+    if record is None:
+        raise KeyError(f"Unknown chain action: {action_id}")
+    if record.action_type != ChainActionType.REGISTER_AGENT:
+        raise ValueError(f"Unsupported chain action type: {record.action_type.value}")
+
+    payload = dict(record.payload)
+    effective_approval_id = str(approval_id or record.approval_id or "").strip()
+    capability_action = authorize_capability_dispatch(
+        capability=Capability.CHAIN_WRITE,
+        actor_id=record.requested_by or "system",
+        target_resource=f"erc8004:{record.action_type.value}",
+        input_payload=payload,
+        approval_id=effective_approval_id,
+        receipt_id=record.receipt_id,
+        metadata={"chain_action_id": record.action_id},
+    )
+    get_chain_action_store().update_action(
+        action_id,
+        status=ChainActionStatus.SUBMITTED,
+        approval_id=effective_approval_id,
+        result={"capability_action_id": capability_action.action_id},
+    )
+
+    try:
+        from aragora.blockchain.contracts.identity import IdentityRegistryContract
+        from aragora.blockchain.models import MetadataEntry
+        from aragora.blockchain.provider import Web3Provider
+        from aragora.blockchain.wallet import WalletSigner
+    except ImportError as exc:
+        get_chain_action_store().update_action(
+            action_id,
+            status=ChainActionStatus.FAILED,
+            error=f"Blockchain dependencies unavailable: {exc}",
+        )
+        raise
+
+    provider = Web3Provider.from_env()
+    signer = WalletSigner.from_env()
+    contract = IdentityRegistryContract(provider)
+    metadata_entries = [
+        MetadataEntry(key=str(key), value=str(value).encode("utf-8"))
+        for key, value in dict(payload.get("metadata") or {}).items()
+    ]
+    try:
+        token_id = contract.register_agent(
+            str(payload.get("agent_uri") or ""), signer, metadata_entries
+        )
+        get_chain_action_store().update_action(
+            action_id,
+            status=ChainActionStatus.MINED,
+            result={"token_id": token_id, "owner": signer.address},
+        )
+        confirmed = get_chain_action_store().update_action(
+            action_id,
+            status=ChainActionStatus.CONFIRMED,
+            result={"token_id": token_id, "owner": signer.address},
+        )
+        return confirmed or record
+    except Exception as exc:
+        logger.error("Chain action %s failed: %s", action_id, exc)
+        get_chain_action_store().update_action(
+            action_id,
+            status=ChainActionStatus.FAILED,
+            error=str(exc),
+        )
+        raise
+
+
+__all__ = [
+    "ChainActionRecord",
+    "ChainActionStatus",
+    "ChainActionStore",
+    "ChainActionType",
+    "enqueue_register_agent_action",
+    "get_chain_action_store",
+    "process_chain_action",
+]

--- a/aragora/blockchain/receipt_anchor.py
+++ b/aragora/blockchain/receipt_anchor.py
@@ -78,6 +78,7 @@ class ReceiptAnchor:
         receipt_hash: str,
         metadata: dict[str, Any] | None = None,
         signer: Any | None = None,
+        agent_id: int | None = None,
     ) -> str:
         """Write a receipt hash to the blockchain.
 
@@ -93,16 +94,29 @@ class ReceiptAnchor:
         """
         meta = metadata or {}
 
-        if self._provider is not None and signer is not None:
-            return await self._anchor_on_chain(receipt_hash, meta, signer)
+        resolved_agent_id = self._resolve_agent_id(agent_id, meta)
+        if self._provider is not None and signer is not None and resolved_agent_id is not None:
+            return await self._anchor_on_chain(receipt_hash, meta, signer, resolved_agent_id)
 
         return self._anchor_locally(receipt_hash, meta)
+
+    @staticmethod
+    def _resolve_agent_id(agent_id: int | None, metadata: dict[str, Any]) -> int | None:
+        if isinstance(agent_id, int) and agent_id >= 0:
+            return agent_id
+        candidate = metadata.get("on_chain_agent_id")
+        try:
+            resolved = int(candidate)
+        except (TypeError, ValueError):
+            return None
+        return resolved if resolved >= 0 else None
 
     async def _anchor_on_chain(
         self,
         receipt_hash: str,
         metadata: dict[str, Any],
         signer: Any,
+        agent_id: int,
     ) -> str:
         """Submit receipt hash to the Validation Registry on-chain."""
         from aragora.blockchain.contracts.validation import ValidationRegistryContract
@@ -125,7 +139,7 @@ class ReceiptAnchor:
         try:
             tx_hash = contract.request_validation(
                 validator_address=signer.address,
-                agent_id=0,  # Receipt anchor, not an agent validation
+                agent_id=agent_id,
                 request_uri=metadata_uri,
                 request_hash=receipt_hash_bytes,
                 signer=signer,

--- a/aragora/blockchain/wallet.py
+++ b/aragora/blockchain/wallet.py
@@ -23,6 +23,21 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+_LOCAL_ENVIRONMENTS = {"dev", "development", "local", "test", "testing"}
+
+
+def _raw_private_key_allowed_by_default() -> bool:
+    env = (
+        str(
+            os.getenv("ARAGORA_ENV")
+            or os.getenv("ARAGORA_ENVIRONMENT")
+            or os.getenv("NODE_ENV")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    return env in _LOCAL_ENVIRONMENTS
 
 
 class SignerType(Enum):
@@ -56,7 +71,7 @@ class WalletSigner:
     _account: Any = field(default=None, repr=False)
 
     @classmethod
-    def from_env(cls) -> WalletSigner:
+    def from_env(cls, allow_private_key: bool | None = None) -> WalletSigner:
         """Create a signer from environment variables.
 
         Checks in order:
@@ -69,8 +84,15 @@ class WalletSigner:
         Raises:
             ValueError: If no wallet credentials are configured.
         """
+        if allow_private_key is None:
+            allow_private_key = _raw_private_key_allowed_by_default()
         private_key = os.getenv("ERC8004_WALLET_KEY")
         if private_key:
+            if not allow_private_key:
+                raise ValueError(
+                    "Raw ERC8004_WALLET_KEY is disabled in production-like environments. "
+                    "Use ERC8004_KEYSTORE_PATH or an external signer."
+                )
             return cls.from_private_key(private_key)
 
         keystore_path = os.getenv("ERC8004_KEYSTORE_PATH")

--- a/aragora/computer_use/orchestrator.py
+++ b/aragora/computer_use/orchestrator.py
@@ -595,6 +595,7 @@ class ComputerUseOrchestrator:
                 session_id=self._current_task.task_id if self._current_task else "",
                 tenant_id=metadata.get("tenant_id"),
                 roles=metadata.get("roles", []),
+                approval_id=metadata.get("approval_id"),
             )
 
             decision = await self._approval_enforcer.enforce(request)

--- a/aragora/knowledge/mound/adapters/erc8004_adapter.py
+++ b/aragora/knowledge/mound/adapters/erc8004_adapter.py
@@ -840,16 +840,26 @@ class ERC8004Adapter(KnowledgeMoundAdapter):
             "metadata": metadata or {},
             "status": "recorded",
         }
+        resolved_agent_id: int | None = None
+        if isinstance(agent_id, int):
+            resolved_agent_id = agent_id if agent_id >= 0 else None
+        elif isinstance(metadata, dict):
+            try:
+                candidate = int(metadata.get("on_chain_agent_id"))
+            except (TypeError, ValueError):
+                candidate = None
+            if candidate is not None and candidate >= 0:
+                resolved_agent_id = candidate
 
         # If we have signer + reverse sync, push on-chain
-        if self._signer is not None and self._enable_reverse_sync:
+        if self._signer is not None and self._enable_reverse_sync and resolved_agent_id is not None:
             try:
                 reputation_contract = self._get_reputation_contract()
                 feedback_data = f"{agent_id}:{domain}:{score}"
                 feedback_hash = hashlib.sha256(feedback_data.encode()).digest()
 
                 tx_hash = reputation_contract.give_feedback(
-                    agent_id=0,  # Resolved by contract from agent name
+                    agent_id=resolved_agent_id,
                     value=score,
                     signer=self._signer,
                     value_decimals=0,
@@ -864,6 +874,9 @@ class ERC8004Adapter(KnowledgeMoundAdapter):
             except (OSError, ConnectionError, RuntimeError, ValueError) as e:
                 record["status"] = "local_only"
                 logger.debug("On-chain reputation push failed for %s: %s", agent_id, e)
+        elif self._signer is not None and self._enable_reverse_sync:
+            record["status"] = "local_only"
+            record["error"] = "on_chain_agent_id is required for reverse sync"
 
         self._emit_event("reputation_pushed", record)
         return True

--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -43,6 +43,12 @@ from aragora.pipeline.decision_plan import (
     PlanStatus,
     record_plan_outcome,
 )
+from aragora.security.capability_gate import (
+    Capability,
+    CapabilityApprovalEnforcer,
+    CapabilityApprovalRequiredError,
+    ensure_capability_approval_id,
+)
 
 if TYPE_CHECKING:
     from aragora.rbac.models import AuthorizationContext
@@ -173,6 +179,56 @@ class PlanExecutor:
         self._max_parallel = max_parallel
         self._execution_mode: ExecutionMode = execution_mode or DEFAULT_EXECUTION_MODE
         self._repo_path = repo_path or Path.cwd()
+
+    @staticmethod
+    def _resolve_browser_execution_approval(
+        plan: DecisionPlan,
+        *,
+        goal: str,
+    ) -> tuple[str, str, str, dict[str, Any]]:
+        metadata = dict(getattr(plan, "metadata", {}) or {})
+        actor_id = (
+            str(
+                metadata.get("requested_by")
+                or metadata.get("user_id")
+                or metadata.get("approved_by")
+                or "system"
+            ).strip()
+            or "system"
+        )
+        target_resource = str(
+            metadata.get("execution_target_resource")
+            or metadata.get("target_resource")
+            or f"plan:{plan.id}"
+        ).strip()
+        payload = {
+            "plan_id": plan.id,
+            "debate_id": plan.debate_id,
+            "goal": goal,
+            "tasks": [
+                str(getattr(task, "description", "")).strip()
+                for task in (getattr(plan.implement_plan, "tasks", None) or [])
+                if str(getattr(task, "description", "")).strip()
+            ],
+        }
+        approval_id = ensure_capability_approval_id(
+            capability=Capability.BROWSER_EXEC,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=payload,
+            approval_id=str(metadata.get("approval_id") or "").strip(),
+            receipt_id=str(
+                metadata.get("decision_receipt_id") or metadata.get("receipt_id") or ""
+            ).strip(),
+            admin_approved=bool(metadata.get("admin_approved")),
+            approved_by=str(metadata.get("approved_by") or actor_id or "system").strip(),
+            metadata={
+                "plan_id": plan.id,
+                "debate_id": plan.debate_id,
+                "approval_request_id": str(metadata.get("approval_request_id", "")).strip(),
+            },
+        )
+        return approval_id, actor_id, target_resource, payload
 
     @staticmethod
     def _emit_plan_event(event_type: str, data: dict[str, Any]) -> None:
@@ -940,11 +996,33 @@ class PlanExecutor:
             goal = f"{plan.task}\n\nTasks:\n" + "\n".join(f"- {d}" for d in task_descriptions)
 
         # Configure computer use
+        if self._sandbox_executor is None:
+            raise PermissionError(
+                "Computer use execution requires an approved sandbox backend; "
+                "host-side browser automation is disabled by default."
+            )
+
+        approval_id, actor_id, target_resource, approval_payload = (
+            self._resolve_browser_execution_approval(plan, goal=goal)
+        )
         config = ComputerUseConfig(
             max_steps=50,  # Reasonable limit for automated tasks
             screenshot_delay_ms=500,
+            enforce_sensitive_approvals=True,
         )
         policy = create_default_computer_policy()
+        approval_enforcer = CapabilityApprovalEnforcer(
+            capability=Capability.BROWSER_EXEC,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=approval_payload,
+            receipt_id=str(
+                (getattr(plan, "metadata", {}) or {}).get("decision_receipt_id")
+                or (getattr(plan, "metadata", {}) or {}).get("receipt_id")
+                or ""
+            ).strip(),
+            metadata={"plan_id": plan.id, "debate_id": plan.debate_id},
+        )
 
         tasks_total = len(plan.implement_plan.tasks) if plan.implement_plan else 1
         lessons: list[str] = []
@@ -962,6 +1040,7 @@ class PlanExecutor:
                     executor=executor,
                     policy=policy,
                     config=config,
+                    approval_enforcer=approval_enforcer,
                 )
 
                 # Run the computer use task
@@ -969,7 +1048,12 @@ class PlanExecutor:
                     goal=goal,
                     max_steps=config.max_steps,
                     initial_context=f"Debate ID: {plan.debate_id}\nPlan ID: {plan.id}",
-                    metadata={"debate_id": plan.debate_id, "plan_id": plan.id},
+                    metadata={
+                        "debate_id": plan.debate_id,
+                        "plan_id": plan.id,
+                        "approval_id": approval_id,
+                        "user_id": actor_id,
+                    },
                 )
 
             duration = time.time() - start_time
@@ -1030,7 +1114,15 @@ class PlanExecutor:
                 tasks_total=tasks_total,
             )
 
-        except (OSError, ConnectionError, RuntimeError, TimeoutError, ValueError) as e:
+        except (
+            OSError,
+            ConnectionError,
+            RuntimeError,
+            TimeoutError,
+            ValueError,
+            PermissionError,
+            CapabilityApprovalRequiredError,
+        ) as e:
             duration = time.time() - start_time
             logger.error("Computer use execution failed: %s", e)
             plan.status = PlanStatus.FAILED

--- a/aragora/security/capability_gate.py
+++ b/aragora/security/capability_gate.py
@@ -1,0 +1,667 @@
+"""
+Durable capability approvals and dispatch audit records.
+
+This module provides a small persistent gate for consequential capabilities
+such as code execution, browser automation, git push, and chain writes.
+It is intentionally storage-backed so approval and dispatch state survives
+process restarts in production.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+from aragora.storage.backends import DatabaseBackend, get_database_backend
+
+logger = logging.getLogger(__name__)
+
+UTC = timezone.utc
+
+
+class Capability(str, Enum):
+    """Consequential capabilities that require explicit approval."""
+
+    CODE_EXEC = "code_exec"
+    BROWSER_EXEC = "browser_exec"
+    GIT_WRITE = "git_write"
+    GIT_PUSH = "git_push"
+    WEBHOOK_EMIT = "webhook_emit"
+    CHAIN_WRITE = "chain_write"
+
+
+class ApprovalStatus(str, Enum):
+    """Lifecycle state for a capability approval."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+    EXPIRED = "expired"
+
+
+class ActionStatus(str, Enum):
+    """Lifecycle state for a gated action dispatch."""
+
+    PENDING = "pending"
+    ALLOWED = "allowed"
+    DENIED = "denied"
+    FAILED = "failed"
+    COMPLETED = "completed"
+
+
+@dataclass(slots=True)
+class CapabilityApprovalRecord:
+    """Durable approval record for a consequential capability."""
+
+    approval_id: str
+    capability: Capability
+    actor_id: str
+    target_resource: str
+    normalized_input_hash: str
+    receipt_id: str = ""
+    status: ApprovalStatus = ApprovalStatus.PENDING
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    expires_at: str = field(
+        default_factory=lambda: (datetime.now(UTC) + timedelta(hours=1)).isoformat()
+    )
+    approved_by: str = ""
+    approved_at: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class CapabilityActionRecord:
+    """Durable dispatch record for a capability invocation."""
+
+    action_id: str
+    capability: Capability
+    actor_id: str
+    target_resource: str
+    normalized_input_hash: str
+    receipt_id: str = ""
+    approval_id: str = ""
+    status: ActionStatus = ActionStatus.PENDING
+    created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    updated_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
+    error: str = ""
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class CapabilityApprovalRequiredError(PermissionError):
+    """Raised when a consequential capability lacks a valid approval record."""
+
+    def __init__(self, capability: Capability, reason: str, action_id: str = "") -> None:
+        self.capability = capability
+        self.reason = reason
+        self.action_id = action_id
+        super().__init__(f"{capability.value} requires explicit approval: {reason}")
+
+
+def _is_dev_mode() -> bool:
+    env = (
+        str(
+            os.getenv("ARAGORA_ENV")
+            or os.getenv("ARAGORA_ENVIRONMENT")
+            or os.getenv("NODE_ENV")
+            or ""
+        )
+        .strip()
+        .lower()
+    )
+    if not env:
+        return False
+    return env in {"dev", "development", "local", "test", "testing"}
+
+
+def normalize_input_hash(payload: Any) -> str:
+    """Compute a stable SHA-256 hash for an approval-sensitive input payload."""
+
+    try:
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        encoded = str(payload).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _parse_json(value: str | None) -> dict[str, Any]:
+    if not value:
+        return {}
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _parse_capability(row_value: Any) -> Capability:
+    return row_value if isinstance(row_value, Capability) else Capability(str(row_value))
+
+
+def _parse_approval_status(row_value: Any) -> ApprovalStatus:
+    return row_value if isinstance(row_value, ApprovalStatus) else ApprovalStatus(str(row_value))
+
+
+def _parse_action_status(row_value: Any) -> ActionStatus:
+    return row_value if isinstance(row_value, ActionStatus) else ActionStatus(str(row_value))
+
+
+class CapabilityGateStore:
+    """Storage-backed approvals and action audit records."""
+
+    def __init__(self, backend: DatabaseBackend | None = None) -> None:
+        self._backend = backend or get_database_backend()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self._backend.execute_write(
+            """
+            CREATE TABLE IF NOT EXISTS capability_approvals (
+                approval_id TEXT PRIMARY KEY,
+                capability TEXT NOT NULL,
+                actor_id TEXT NOT NULL,
+                target_resource TEXT NOT NULL,
+                normalized_input_hash TEXT NOT NULL,
+                receipt_id TEXT DEFAULT '',
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                expires_at TEXT NOT NULL,
+                approved_by TEXT DEFAULT '',
+                approved_at TEXT DEFAULT '',
+                metadata_json TEXT DEFAULT '{}'
+            )
+            """
+        )
+        self._backend.execute_write(
+            """
+            CREATE INDEX IF NOT EXISTS idx_capability_approvals_status
+            ON capability_approvals(status)
+            """
+        )
+        self._backend.execute_write(
+            """
+            CREATE INDEX IF NOT EXISTS idx_capability_approvals_capability
+            ON capability_approvals(capability, actor_id)
+            """
+        )
+        self._backend.execute_write(
+            """
+            CREATE TABLE IF NOT EXISTS capability_actions (
+                action_id TEXT PRIMARY KEY,
+                capability TEXT NOT NULL,
+                actor_id TEXT NOT NULL,
+                target_resource TEXT NOT NULL,
+                normalized_input_hash TEXT NOT NULL,
+                receipt_id TEXT DEFAULT '',
+                approval_id TEXT DEFAULT '',
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                error TEXT DEFAULT '',
+                metadata_json TEXT DEFAULT '{}'
+            )
+            """
+        )
+        self._backend.execute_write(
+            """
+            CREATE INDEX IF NOT EXISTS idx_capability_actions_capability
+            ON capability_actions(capability, actor_id, status)
+            """
+        )
+
+    def create_approval(
+        self,
+        *,
+        capability: Capability,
+        actor_id: str,
+        target_resource: str,
+        input_payload: Any,
+        receipt_id: str = "",
+        expires_in_seconds: int = 3600,
+        approved: bool = False,
+        approved_by: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> CapabilityApprovalRecord:
+        now = datetime.now(UTC)
+        approval = CapabilityApprovalRecord(
+            approval_id=f"cap-{uuid.uuid4().hex[:12]}",
+            capability=capability,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            normalized_input_hash=normalize_input_hash(input_payload),
+            receipt_id=receipt_id,
+            status=ApprovalStatus.APPROVED if approved else ApprovalStatus.PENDING,
+            created_at=now.isoformat(),
+            expires_at=(now + timedelta(seconds=expires_in_seconds)).isoformat(),
+            approved_by=approved_by if approved else "",
+            approved_at=now.isoformat() if approved else "",
+            metadata=metadata or {},
+        )
+        self._backend.execute_write(
+            """
+            INSERT INTO capability_approvals (
+                approval_id, capability, actor_id, target_resource,
+                normalized_input_hash, receipt_id, status, created_at,
+                expires_at, approved_by, approved_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                approval.approval_id,
+                approval.capability.value,
+                approval.actor_id,
+                approval.target_resource,
+                approval.normalized_input_hash,
+                approval.receipt_id,
+                approval.status.value,
+                approval.created_at,
+                approval.expires_at,
+                approval.approved_by,
+                approval.approved_at,
+                json.dumps(approval.metadata, sort_keys=True, default=str),
+            ),
+        )
+        return approval
+
+    def approve(self, approval_id: str, approved_by: str) -> CapabilityApprovalRecord | None:
+        approval = self.get_approval(approval_id)
+        if approval is None:
+            return None
+        now = datetime.now(UTC).isoformat()
+        self._backend.execute_write(
+            """
+            UPDATE capability_approvals
+            SET status = ?, approved_by = ?, approved_at = ?
+            WHERE approval_id = ?
+            """,
+            (
+                ApprovalStatus.APPROVED.value,
+                approved_by,
+                now,
+                approval_id,
+            ),
+        )
+        return self.get_approval(approval_id)
+
+    def get_approval(self, approval_id: str) -> CapabilityApprovalRecord | None:
+        row = self._backend.fetch_one(
+            """
+            SELECT approval_id, capability, actor_id, target_resource,
+                   normalized_input_hash, receipt_id, status, created_at,
+                   expires_at, approved_by, approved_at, metadata_json
+            FROM capability_approvals
+            WHERE approval_id = ?
+            """,
+            (approval_id,),
+        )
+        if row is None:
+            return None
+        return CapabilityApprovalRecord(
+            approval_id=str(row[0]),
+            capability=_parse_capability(row[1]),
+            actor_id=str(row[2]),
+            target_resource=str(row[3]),
+            normalized_input_hash=str(row[4]),
+            receipt_id=str(row[5] or ""),
+            status=_parse_approval_status(row[6]),
+            created_at=str(row[7]),
+            expires_at=str(row[8]),
+            approved_by=str(row[9] or ""),
+            approved_at=str(row[10] or ""),
+            metadata=_parse_json(row[11]),
+        )
+
+    def create_action(
+        self,
+        *,
+        capability: Capability,
+        actor_id: str,
+        target_resource: str,
+        input_payload: Any,
+        receipt_id: str = "",
+        approval_id: str = "",
+        status: ActionStatus = ActionStatus.PENDING,
+        error: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> CapabilityActionRecord:
+        now = datetime.now(UTC).isoformat()
+        action = CapabilityActionRecord(
+            action_id=f"act-{uuid.uuid4().hex[:12]}",
+            capability=capability,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            normalized_input_hash=normalize_input_hash(input_payload),
+            receipt_id=receipt_id,
+            approval_id=approval_id,
+            status=status,
+            created_at=now,
+            updated_at=now,
+            error=error,
+            metadata=metadata or {},
+        )
+        self._backend.execute_write(
+            """
+            INSERT INTO capability_actions (
+                action_id, capability, actor_id, target_resource,
+                normalized_input_hash, receipt_id, approval_id, status,
+                created_at, updated_at, error, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                action.action_id,
+                action.capability.value,
+                action.actor_id,
+                action.target_resource,
+                action.normalized_input_hash,
+                action.receipt_id,
+                action.approval_id,
+                action.status.value,
+                action.created_at,
+                action.updated_at,
+                action.error,
+                json.dumps(action.metadata, sort_keys=True, default=str),
+            ),
+        )
+        return action
+
+    def update_action(
+        self,
+        action_id: str,
+        *,
+        status: ActionStatus,
+        error: str = "",
+        approval_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> CapabilityActionRecord | None:
+        current = self.get_action(action_id)
+        if current is None:
+            return None
+        next_metadata = dict(current.metadata)
+        if metadata:
+            next_metadata.update(metadata)
+        self._backend.execute_write(
+            """
+            UPDATE capability_actions
+            SET status = ?, updated_at = ?, error = ?, approval_id = ?, metadata_json = ?
+            WHERE action_id = ?
+            """,
+            (
+                status.value,
+                datetime.now(UTC).isoformat(),
+                error,
+                approval_id if approval_id is not None else current.approval_id,
+                json.dumps(next_metadata, sort_keys=True, default=str),
+                action_id,
+            ),
+        )
+        return self.get_action(action_id)
+
+    def get_action(self, action_id: str) -> CapabilityActionRecord | None:
+        row = self._backend.fetch_one(
+            """
+            SELECT action_id, capability, actor_id, target_resource,
+                   normalized_input_hash, receipt_id, approval_id, status,
+                   created_at, updated_at, error, metadata_json
+            FROM capability_actions
+            WHERE action_id = ?
+            """,
+            (action_id,),
+        )
+        if row is None:
+            return None
+        return CapabilityActionRecord(
+            action_id=str(row[0]),
+            capability=_parse_capability(row[1]),
+            actor_id=str(row[2]),
+            target_resource=str(row[3]),
+            normalized_input_hash=str(row[4]),
+            receipt_id=str(row[5] or ""),
+            approval_id=str(row[6] or ""),
+            status=_parse_action_status(row[7]),
+            created_at=str(row[8]),
+            updated_at=str(row[9]),
+            error=str(row[10] or ""),
+            metadata=_parse_json(row[11]),
+        )
+
+
+_store: CapabilityGateStore | None = None
+
+
+def get_capability_gate_store() -> CapabilityGateStore:
+    global _store
+    if _store is None:
+        _store = CapabilityGateStore()
+    return _store
+
+
+def ensure_approved_capability_approval(
+    *,
+    capability: Capability,
+    actor_id: str,
+    target_resource: str,
+    input_payload: Any,
+    receipt_id: str = "",
+    approved_by: str,
+    metadata: dict[str, Any] | None = None,
+    expires_in_seconds: int = 3600,
+) -> CapabilityApprovalRecord:
+    """Create an already-approved capability record for an admin or trusted lane."""
+
+    return get_capability_gate_store().create_approval(
+        capability=capability,
+        actor_id=actor_id,
+        target_resource=target_resource,
+        input_payload=input_payload,
+        receipt_id=receipt_id,
+        expires_in_seconds=expires_in_seconds,
+        approved=True,
+        approved_by=approved_by,
+        metadata=metadata,
+    )
+
+
+def ensure_capability_approval_id(
+    *,
+    capability: Capability,
+    actor_id: str,
+    target_resource: str,
+    input_payload: Any,
+    approval_id: str = "",
+    receipt_id: str = "",
+    admin_approved: bool = False,
+    approved_by: str = "",
+    metadata: dict[str, Any] | None = None,
+    expires_in_seconds: int = 3600,
+) -> str:
+    """Return an approval id, creating one only for explicit admin-approved flows."""
+
+    normalized_approval_id = str(approval_id or "").strip()
+    if normalized_approval_id:
+        return normalized_approval_id
+    if not admin_approved:
+        return ""
+    approval = ensure_approved_capability_approval(
+        capability=capability,
+        actor_id=actor_id,
+        target_resource=target_resource,
+        input_payload=input_payload,
+        receipt_id=receipt_id,
+        approved_by=approved_by or actor_id or "system",
+        metadata=metadata,
+        expires_in_seconds=expires_in_seconds,
+    )
+    return approval.approval_id
+
+
+def _approval_validation_error(
+    approval: CapabilityApprovalRecord | None,
+    *,
+    capability: Capability,
+    actor_id: str,
+    target_resource: str,
+    input_hash: str,
+    receipt_id: str,
+) -> str:
+    if approval is None:
+        return "missing approval record"
+    if approval.capability != capability:
+        return "capability mismatch"
+    if approval.status != ApprovalStatus.APPROVED:
+        return f"approval is {approval.status.value}"
+    if approval.expires_at and datetime.fromisoformat(approval.expires_at) <= datetime.now(UTC):
+        return "approval expired"
+    if approval.actor_id and approval.actor_id != actor_id:
+        return "actor mismatch"
+    if approval.target_resource and approval.target_resource != target_resource:
+        return "target resource mismatch"
+    if approval.normalized_input_hash and approval.normalized_input_hash != input_hash:
+        return "input hash mismatch"
+    if receipt_id and approval.receipt_id and approval.receipt_id != receipt_id:
+        return "receipt mismatch"
+    return ""
+
+
+def authorize_capability_dispatch(
+    *,
+    capability: Capability,
+    actor_id: str,
+    target_resource: str,
+    input_payload: Any,
+    approval_id: str = "",
+    receipt_id: str = "",
+    metadata: dict[str, Any] | None = None,
+) -> CapabilityActionRecord:
+    """Validate approval and create a durable dispatch audit record."""
+
+    store = get_capability_gate_store()
+    input_hash = normalize_input_hash(input_payload)
+    approval = store.get_approval(approval_id) if approval_id else None
+    reason = _approval_validation_error(
+        approval,
+        capability=capability,
+        actor_id=actor_id,
+        target_resource=target_resource,
+        input_hash=input_hash,
+        receipt_id=receipt_id,
+    )
+    status = ActionStatus.ALLOWED if not reason else ActionStatus.DENIED
+    action = store.create_action(
+        capability=capability,
+        actor_id=actor_id,
+        target_resource=target_resource,
+        input_payload=input_payload,
+        receipt_id=receipt_id,
+        approval_id=approval_id,
+        status=status,
+        error=reason,
+        metadata=metadata,
+    )
+    if reason:
+        raise CapabilityApprovalRequiredError(capability, reason, action_id=action.action_id)
+    return action
+
+
+class CapabilityApprovalEnforcer:
+    """Minimal approval enforcer backed by the durable capability gate."""
+
+    def __init__(
+        self,
+        *,
+        capability: Capability,
+        actor_id: str,
+        target_resource: str,
+        input_payload: Any,
+        receipt_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        self._capability = capability
+        self._actor_id = actor_id
+        self._target_resource = target_resource
+        self._input_payload = input_payload
+        self._receipt_id = receipt_id
+        self._metadata = metadata or {}
+
+    async def enforce(self, request: Any) -> Any:
+        try:
+            from aragora.security.approval_enforcer import (
+                EnforcementDecision,
+                EnforcementResult,
+            )
+        except ImportError as exc:  # pragma: no cover - defensive fallback
+            raise RuntimeError("Unified approval enforcer types unavailable") from exc
+
+        approval_id = str(getattr(request, "approval_id", "") or "").strip()
+        try:
+            action = authorize_capability_dispatch(
+                capability=self._capability,
+                actor_id=self._actor_id,
+                target_resource=self._target_resource,
+                input_payload=self._input_payload,
+                approval_id=approval_id,
+                receipt_id=self._receipt_id,
+                metadata={
+                    **self._metadata,
+                    "enforcement_source": getattr(request, "source", ""),
+                    "enforcement_action_type": getattr(request, "action_type", ""),
+                },
+            )
+            return EnforcementDecision(
+                id=action.action_id,
+                result=EnforcementResult.ALLOWED,
+                reason=f"Capability gate approved via {approval_id}",
+                request=request,
+                approval_request_id=approval_id or None,
+                metadata={"capability": self._capability.value},
+            )
+        except CapabilityApprovalRequiredError as exc:
+            return EnforcementDecision(
+                id=exc.action_id or f"cap-deny-{uuid.uuid4().hex[:12]}",
+                result=EnforcementResult.DENIED,
+                reason=exc.reason,
+                request=request,
+                approval_request_id=approval_id or None,
+                metadata={"capability": self._capability.value},
+            )
+
+    async def wait_for_approval(
+        self,
+        approval_id: str,
+        timeout: float | None = None,
+    ) -> bool:
+        del timeout
+        approval = get_capability_gate_store().get_approval(approval_id)
+        if approval is None:
+            return False
+        if approval.status != ApprovalStatus.APPROVED:
+            return False
+        if approval.expires_at and datetime.fromisoformat(approval.expires_at) <= datetime.now(UTC):
+            return False
+        return True
+
+
+__all__ = [
+    "ActionStatus",
+    "Capability",
+    "CapabilityActionRecord",
+    "CapabilityApprovalEnforcer",
+    "CapabilityApprovalRecord",
+    "CapabilityApprovalRequiredError",
+    "CapabilityGateStore",
+    "ApprovalStatus",
+    "authorize_capability_dispatch",
+    "ensure_capability_approval_id",
+    "ensure_approved_capability_approval",
+    "get_capability_gate_store",
+    "normalize_input_hash",
+]

--- a/aragora/server/debate_controller.py
+++ b/aragora/server/debate_controller.py
@@ -142,6 +142,20 @@ def _normalize_documents(value: Any, max_items: int = 50) -> list[str]:
     return normalized
 
 
+def _normalize_question_payload(data: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(data)
+    question = normalized.get("question")
+    task = normalized.get("task")
+    question_text = str(question).strip() if question is not None else ""
+    task_text = str(task).strip() if task is not None else ""
+    if question_text and task_text and question_text != task_text:
+        raise ValueError("question and deprecated task fields must match when both are provided")
+    if not question_text and task is not None:
+        normalized["question"] = task
+    normalized.pop("task", None)
+    return normalized
+
+
 def _normalize_agent_names(agents_value: Any) -> list[str]:
     """Normalize agent specs into a list of display names/providers."""
     if not agents_value:
@@ -534,10 +548,11 @@ class DebateRequest:
         Raises:
             ValueError: If required fields are missing or invalid
         """
-        question = data.get("question") or data.get("task") or ""
+        data = _normalize_question_payload(data)
+        question = data.get("question") or ""
         question = str(question).strip()
         if not question:
-            raise ValueError("question or task field is required")
+            raise ValueError("question field is required")
         if len(question) > 10000:
             raise ValueError("question must be under 10,000 characters")
 

--- a/aragora/server/debate_factory.py
+++ b/aragora/server/debate_factory.py
@@ -595,6 +595,9 @@ class DebateFactory:
             round_timeout_seconds=base_protocol.round_timeout_seconds,
             debate_rounds_timeout_seconds=base_protocol.debate_rounds_timeout_seconds,
             enable_breakpoints=base_protocol.enable_breakpoints,
+            enable_content_moderation=True,
+            enable_context_trust_tiering=True,
+            detect_context_taint=True,
         )
 
         # Enable epistemic hygiene flags when mode is set

--- a/aragora/server/handlers/debates/create.py
+++ b/aragora/server/handlers/debates/create.py
@@ -43,6 +43,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _allows_admin_override(body: dict[str, Any]) -> bool:
+    metadata = body.get("metadata")
+    if isinstance(metadata, dict):
+        candidate = metadata.get("admin_override")
+        if isinstance(candidate, bool):
+            return candidate
+        if str(candidate or "").strip().lower() in {"1", "true", "yes", "on"}:
+            return True
+    candidate = body.get("admin_override")
+    if isinstance(candidate, bool):
+        return candidate
+    return str(candidate or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _normalize_debate_body(body: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(body)
+    question = normalized.get("question")
+    task = normalized.get("task")
+    question_text = str(question).strip() if question is not None else ""
+    task_text = str(task).strip() if task is not None else ""
+    if question_text and task_text and question_text != task_text:
+        raise ValueError("question and deprecated task fields must match when both are provided")
+    if not question_text and task is not None:
+        normalized["question"] = task
+    normalized.pop("task", None)
+    return normalized
+
+
 def _get_validate_against_schema():
     handler_module = sys.modules.get("aragora.server.handlers.debates.handler")
     if handler_module is not None:
@@ -172,18 +200,20 @@ class CreateOperationsMixin:
         if not body:
             return error_response("No content provided", 400)
 
+        try:
+            body = _normalize_debate_body(body)
+        except ValueError as exc:
+            return error_response(str(exc), 422)
+
         # Schema validation for input sanitization
         validation_result = _get_validate_against_schema()(body, DEBATE_START_SCHEMA)
         if not validation_result.is_valid:
             return error_response(validation_result.error, 400)
 
         # Pydantic v2 strict validation (question length, rounds bounds, agents limit)
-        # Only applies when the body contains a 'question' field (the primary field);
-        # requests using the legacy 'task' field bypass this layer to preserve compatibility.
-        if "question" in body:
-            _pydantic_req, _pydantic_err = validate_debate_request(body)
-            if _pydantic_err is not None:
-                return error_response(_pydantic_err, 422)
+        _pydantic_req, _pydantic_err = validate_debate_request(body)
+        if _pydantic_err is not None:
+            return error_response(_pydantic_err, 422)
 
         # Spam check for debate content
         spam_result = self._check_spam_content(body)
@@ -494,7 +524,7 @@ class CreateOperationsMixin:
             from aragora.moderation import check_debate_content, ContentModerationError
 
             # Extract content to check
-            proposal = body.get("task") or body.get("question", "")
+            proposal = body.get("question", "")
             context = body.get("context", "")
 
             if not proposal:
@@ -524,16 +554,26 @@ class CreateOperationsMixin:
             return None  # Content passed
 
         except ImportError:
-            # Moderation module not available - allow content through
-            logger.debug("Spam moderation not available, skipping check")
-            return None
+            if _allows_admin_override(body):
+                logger.warning("Spam moderation unavailable; admin override allowed request")
+                return None
+            return error_response(
+                "Content moderation is required for public debate creation and is currently unavailable.",
+                503,
+            )
         except ContentModerationError as e:
             # Moderation explicitly rejected content
             logger.warning("Content moderation error: %s", e)
             return error_response("Invalid request", 400)
         except (ValueError, KeyError, TypeError, RuntimeError, OSError) as e:
             logger.error("Spam check failed unexpectedly: %s", e, exc_info=True)
-            return None
+            if _allows_admin_override(body):
+                logger.warning("Spam moderation failed; admin override allowed request")
+                return None
+            return error_response(
+                "Content moderation check failed; request requires admin override to continue.",
+                503,
+            )
 
 
 __all__ = ["CreateOperationsMixin"]

--- a/aragora/server/handlers/debates/implementation.py
+++ b/aragora/server/handlers/debates/implementation.py
@@ -820,6 +820,16 @@ class ImplementationOperationsMixin:
                 approver_id=approval_request.approved_by or requested_by or "system",
                 reason="Approved",
             )
+            plan_metadata = dict(getattr(computer_use_plan, "metadata", {}) or {})
+            plan_metadata["admin_approved"] = True
+            plan_metadata["approved_by"] = approval_request.approved_by or requested_by or "system"
+            plan_metadata["requested_by"] = requested_by or "system"
+            plan_metadata["approval_request_id"] = getattr(approval_request, "id", "")
+            receipt_id = str(response_payload.get("receipt_id") or "").strip()
+            if receipt_id:
+                plan_metadata["decision_receipt_id"] = receipt_id
+            plan_metadata.setdefault("execution_target_resource", f"plan:{computer_use_plan.id}")
+            computer_use_plan.metadata = plan_metadata
             store_plan(computer_use_plan)
             plan_executor = PlanExecutor(
                 continuum_memory=self.ctx.get("continuum_memory"),
@@ -827,6 +837,7 @@ class ImplementationOperationsMixin:
                 parallel_execution=rc.parallel_execution,
                 execution_mode="computer_use",
                 repo_path=rc.repo_path or Path.cwd(),
+                sandbox_config=self.ctx.get("sandbox_config"),
             )
             outcome = run_async(
                 plan_executor.execute(

--- a/aragora/server/handlers/erc8004.py
+++ b/aragora/server/handlers/erc8004.py
@@ -18,6 +18,7 @@ import logging
 from typing import Any
 from collections.abc import Awaitable
 
+from aragora.blockchain.action_store import enqueue_register_agent_action
 from aragora.server.handlers.base import (
     BaseHandler,
     HandlerResult,
@@ -543,10 +544,10 @@ async def handle_list_agents(skip: int = 0, limit: int = 100) -> HandlerResult:
     method="POST",
     path="/api/v1/blockchain/agents",
     summary="Register new agent on-chain",
-    description="Registers a new agent on the ERC-8004 Identity Registry.",
+    description="Queues a new agent registration for the ERC-8004 Identity Registry.",
     tags=["Blockchain", "Agents"],
     responses={
-        "201": {"description": "Agent registered"},
+        "202": {"description": "Agent registration queued"},
         "400": {"description": "Invalid request"},
         "500": {"description": "Registration error"},
         "503": {"description": "Blockchain dependencies not installed or circuit breaker open"},
@@ -558,8 +559,11 @@ async def handle_list_agents(skip: int = 0, limit: int = 100) -> HandlerResult:
 async def handle_register_agent(
     agent_uri: str = "",
     metadata: dict[str, Any] | None = None,
+    requested_by: str = "",
+    approval_id: str = "",
+    receipt_id: str = "",
 ) -> HandlerResult:
-    """Register a new agent on the Identity Registry."""
+    """Queue a new agent registration on the Identity Registry."""
     if not agent_uri:
         return error_response("agent_uri is required", status=400)
 
@@ -569,8 +573,6 @@ async def handle_register_agent(
             return error_response("Blockchain service temporarily unavailable", status=503)
 
         from aragora.blockchain.contracts.identity import IdentityRegistryContract
-        from aragora.blockchain.models import MetadataEntry
-        from aragora.blockchain.wallet import WalletSigner
 
         provider = _get_provider()
         config = provider.get_config()
@@ -580,33 +582,28 @@ async def handle_register_agent(
                 status=503,
             )
 
-        try:
-            signer = WalletSigner.from_env()
-        except ValueError as e:
-            logger.warning("Handler error: %s", e)
-            return error_response("Invalid request", status=400)
+        # Validate metadata values up front, but do not sign inside the request path.
+        for value in (metadata or {}).values():
+            _coerce_metadata_value(value)
 
-        contract = IdentityRegistryContract(provider)
-
-        metadata_entries: list[MetadataEntry] = []
-        for key, value in (metadata or {}).items():
-            metadata_entries.append(
-                MetadataEntry(
-                    key=str(key),
-                    value=_coerce_metadata_value(value),
-                )
-            )
-
-        token_id = contract.register_agent(agent_uri, signer, metadata_entries)
+        IdentityRegistryContract(provider)
+        action = enqueue_register_agent_action(
+            agent_uri=agent_uri,
+            metadata=metadata,
+            requested_by=requested_by or "system",
+            approval_id=approval_id,
+            receipt_id=receipt_id,
+        )
 
         return json_response(
             {
-                "token_id": token_id,
+                "action_id": action.action_id,
+                "status": action.status.value,
                 "agent_uri": agent_uri,
-                "owner": signer.address,
                 "chain_id": config.chain_id,
+                "requires_approval": True,
             },
-            status=201,
+            status=202,
         )
     except ValueError as e:
         logger.warning("Handler error: %s", e)
@@ -722,7 +719,13 @@ class ERC8004Handler(BaseHandler):
                 metadata = body.get("metadata")
                 if metadata is not None and not isinstance(metadata, dict):
                     return error_response("metadata must be an object", status=400)
-                return handle_register_agent(agent_uri=agent_uri, metadata=metadata)
+                return handle_register_agent(
+                    agent_uri=agent_uri,
+                    metadata=metadata,
+                    requested_by=str(body.get("requested_by", "")).strip(),
+                    approval_id=str(body.get("approval_id", "")).strip(),
+                    receipt_id=str(body.get("receipt_id", "")).strip(),
+                )
             return error_response(f"Method {method} not allowed", status=405)
 
         if path.startswith("/api/v1/blockchain/agents/"):

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -21,6 +21,13 @@ import sys
 import time
 from typing import Any
 
+from aragora.security.capability_gate import (
+    Capability,
+    CapabilityApprovalRequiredError,
+    authorize_capability_dispatch,
+    ensure_capability_approval_id,
+)
+
 logger = logging.getLogger(__name__)
 
 UTC = timezone.utc
@@ -88,6 +95,10 @@ class WorkerProcess:
     pid: int | None = None
     session_id: str = ""
     lease_id: str = ""
+    receipt_id: str = ""
+    approval_id: str = ""
+    git_write_approval_id: str = ""
+    push_approval_id: str = ""
     started_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     completed_at: str | None = None
     exit_code: int | None = None
@@ -102,6 +113,9 @@ class WorkerProcess:
     tests_run: list[str] = field(default_factory=list)
     verification_results: list[dict[str, Any]] = field(default_factory=list)
     command: list[str] = field(default_factory=list)
+    dispatch_action_id: str = ""
+    push_action_id: str = ""
+    admin_approved: bool = False
 
     @property
     def is_running(self) -> bool:
@@ -116,6 +130,10 @@ class WorkerProcess:
             "pid": self.pid,
             "session_id": self.session_id,
             "lease_id": self.lease_id,
+            "receipt_id": self.receipt_id,
+            "approval_id": self.approval_id,
+            "git_write_approval_id": self.git_write_approval_id,
+            "push_approval_id": self.push_approval_id,
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "exit_code": self.exit_code,
@@ -125,6 +143,9 @@ class WorkerProcess:
             "expected_tests": list(self.expected_tests),
             "tests_run": list(self.tests_run),
             "verification_results": [dict(item) for item in self.verification_results],
+            "dispatch_action_id": self.dispatch_action_id,
+            "push_action_id": self.push_action_id,
+            "admin_approved": self.admin_approved,
         }
 
 
@@ -144,6 +165,7 @@ class LaunchConfig:
     use_managed_session_script: bool = True
     base_branch: str = "main"
     detach: bool = False
+    require_explicit_approval: bool = True
 
 
 class WorkerLauncher:
@@ -174,12 +196,27 @@ class WorkerLauncher:
         prompt = self._build_prompt(work_order)
         session_id = str(work_order.get("owner_session_id", "")).strip()
         lease_id = str(work_order.get("lease_id", "")).strip()
+        metadata = self._metadata_dict(work_order)
+        admin_approved = self._is_admin_approved(work_order, metadata)
+        actor_id = self._actor_id_for_work_order(work_order, metadata)
+        receipt_id = self._receipt_id_for_work_order(work_order, metadata)
+        approval_id, dispatch_action_id = self._authorize_worker_launch(
+            work_order=work_order,
+            worktree_path=worktree_path,
+            agent=agent,
+            actor_id=actor_id,
+            receipt_id=receipt_id,
+            admin_approved=admin_approved,
+            metadata=metadata,
+            prompt=prompt,
+        )
 
         cmd = self._build_command(
             agent,
             prompt,
             worktree_path,
             session_id=session_id,
+            admin_approved=admin_approved,
         )
         if not cmd:
             raise RuntimeError(f"Cannot build launch command for agent={agent}")
@@ -193,8 +230,6 @@ class WorkerLauncher:
             work_order_id,
             worktree_path,
         )
-
-        metadata = work_order.get("metadata", {})
         raw_worker_env = metadata.get("worker_env", {}) if isinstance(metadata, dict) else {}
         worker_env_overrides = {
             str(key).strip(): str(value)
@@ -263,11 +298,15 @@ class WorkerLauncher:
             pid=proc.pid,
             session_id=session_id,
             lease_id=lease_id,
+            receipt_id=receipt_id,
+            approval_id=approval_id,
             initial_head=initial_head,
             expected_tests=[
                 str(item) for item in work_order.get("expected_tests", []) if str(item).strip()
             ],
             command=list(cmd),
+            dispatch_action_id=dispatch_action_id,
+            admin_approved=admin_approved,
         )
         self._workers[work_order_id] = worker
         self._processes[work_order_id] = proc
@@ -517,9 +556,15 @@ class WorkerLauncher:
         worktree_path: str,
         *,
         session_id: str = "",
+        admin_approved: bool = False,
     ) -> list[str]:
         """Build the launch command for the given agent type."""
-        inner = self._build_agent_command(agent, prompt, worktree_path=worktree_path)
+        inner = self._build_agent_command(
+            agent,
+            prompt,
+            worktree_path=worktree_path,
+            admin_approved=admin_approved,
+        )
         if not self.config.use_managed_session_script:
             return inner
 
@@ -544,11 +589,16 @@ class WorkerLauncher:
         return cmd
 
     def _build_agent_command(
-        self, agent: str, prompt: str, *, worktree_path: str = ""
+        self,
+        agent: str,
+        prompt: str,
+        *,
+        worktree_path: str = "",
+        admin_approved: bool = False,
     ) -> list[str]:
         if agent == "claude":
             cmd = [self.config.claude_path, "-p", prompt]
-            if self._should_skip_claude_permissions():
+            if admin_approved and self._should_skip_claude_permissions():
                 cmd.append("--dangerously-skip-permissions")
             if self.config.claude_model:
                 cmd.extend(["--model", self.config.claude_model])
@@ -562,17 +612,19 @@ class WorkerLauncher:
         if agent == "codex":
             # Use stdin ("-") for prompts to avoid OS arg length limits.
             # Long prompts with issue bodies + file lists can exceed ARG_MAX.
-            cmd = [self.config.codex_path, "exec", "-", "--full-auto"]
+            cmd = [self.config.codex_path, "exec", "-"]
+            if admin_approved:
+                cmd.append("--full-auto")
             if self.config.codex_model:
                 cmd.extend(["--model", self.config.codex_model])
-            git_dir = self._resolve_worktree_gitdir(worktree_path)
+            git_dir = self._resolve_worktree_gitdir(worktree_path) if admin_approved else ""
             if git_dir:
                 cmd.extend(["--add-dir", git_dir])
             return cmd
 
         logger.warning("Unknown agent %r, falling back to claude", agent)
         cmd = [self.config.claude_path, "-p", prompt]
-        if self._should_skip_claude_permissions():
+        if admin_approved and self._should_skip_claude_permissions():
             cmd.append("--dangerously-skip-permissions")
         if self.config.claude_profile:
             profile_script = self.config.claude_profile_script or str(
@@ -580,6 +632,100 @@ class WorkerLauncher:
             )
             return [profile_script, "exec", self.config.claude_profile, "--", *cmd]
         return cmd
+
+    @staticmethod
+    def _metadata_dict(work_order: dict[str, Any]) -> dict[str, Any]:
+        metadata = work_order.get("metadata")
+        return dict(metadata) if isinstance(metadata, dict) else {}
+
+    @staticmethod
+    def _truthy(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+    @classmethod
+    def _is_admin_approved(cls, work_order: dict[str, Any], metadata: dict[str, Any]) -> bool:
+        return cls._truthy(work_order.get("admin_approved")) or cls._truthy(
+            metadata.get("admin_approved")
+        )
+
+    @staticmethod
+    def _actor_id_for_work_order(work_order: dict[str, Any], metadata: dict[str, Any]) -> str:
+        for candidate in (
+            metadata.get("requested_by"),
+            metadata.get("user_id"),
+            work_order.get("owner_session_id"),
+            work_order.get("lease_id"),
+            work_order.get("work_order_id"),
+            "system",
+        ):
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return "system"
+
+    @staticmethod
+    def _receipt_id_for_work_order(work_order: dict[str, Any], metadata: dict[str, Any]) -> str:
+        return str(
+            work_order.get("receipt_id")
+            or metadata.get("receipt_id")
+            or metadata.get("decision_receipt_id")
+            or ""
+        ).strip()
+
+    def _authorize_worker_launch(
+        self,
+        *,
+        work_order: dict[str, Any],
+        worktree_path: str,
+        agent: str,
+        actor_id: str,
+        receipt_id: str,
+        admin_approved: bool,
+        metadata: dict[str, Any],
+        prompt: str,
+    ) -> tuple[str, str]:
+        if self.config.require_explicit_approval and not self.config.use_managed_session_script:
+            raise CapabilityApprovalRequiredError(
+                Capability.CODE_EXEC,
+                "managed session wrapper is required for code execution lanes",
+            )
+
+        target_resource = str(Path(worktree_path).resolve())
+        payload = {
+            "work_order_id": str(work_order.get("work_order_id", "")).strip(),
+            "agent": agent,
+            "prompt_hash": hash(prompt),
+            "expected_tests": list(work_order.get("expected_tests") or []),
+            "file_scope": list(work_order.get("file_scope") or []),
+        }
+        approval_id = ensure_capability_approval_id(
+            capability=Capability.CODE_EXEC,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=payload,
+            approval_id=str(
+                metadata.get("approval_id") or work_order.get("approval_id") or ""
+            ).strip(),
+            receipt_id=receipt_id,
+            admin_approved=admin_approved,
+            approved_by=str(metadata.get("approved_by") or actor_id or "system").strip(),
+            metadata={
+                "work_order_id": str(work_order.get("work_order_id", "")).strip(),
+                "approval_request_id": str(metadata.get("approval_request_id", "")).strip(),
+            },
+        )
+        action = authorize_capability_dispatch(
+            capability=Capability.CODE_EXEC,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=payload,
+            approval_id=approval_id,
+            receipt_id=receipt_id,
+            metadata={"agent": agent},
+        )
+        return approval_id, action.action_id
 
     @staticmethod
     def _should_skip_claude_permissions() -> bool:
@@ -740,7 +886,7 @@ class WorkerLauncher:
             "  - Stage only the files you intentionally changed with `git add <file> ...`.\n"
             "  - Do NOT use `git add -A` or `git add .` — session metadata files must not be committed.\n"
             '  - Commit with a descriptive message using `git commit -m "..."` before exiting.\n'
-            "  - After committing, push your branch: `git push origin HEAD`.\n"
+            "  - Push only when the lane has explicit remote-mutation approval; otherwise leave the local commit intact.\n"
             "  - If `git push` fails (e.g. no remote, permission error), that is acceptable — "
             "the harness will attempt to push for you.\n"
             "  - Exit with a truthful final state; do not claim integration or approval work is done unless it happened in this lane."
@@ -1542,9 +1688,63 @@ class WorkerLauncher:
         return text[-max_chars:]
 
     @staticmethod
+    def _worker_actor_id(worker: WorkerProcess) -> str:
+        for candidate in (worker.session_id, worker.lease_id, worker.work_order_id, "system"):
+            text = str(candidate or "").strip()
+            if text:
+                return text
+        return "system"
+
+    @classmethod
+    def _authorize_worker_capability(
+        cls,
+        worker: WorkerProcess,
+        *,
+        capability: Capability,
+        input_payload: Any,
+        approval_id: str = "",
+        metadata: dict[str, Any] | None = None,
+    ) -> tuple[str, str]:
+        actor_id = cls._worker_actor_id(worker)
+        target_resource = str(Path(worker.worktree_path).resolve())
+        effective_approval_id = ensure_capability_approval_id(
+            capability=capability,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=input_payload,
+            approval_id=approval_id,
+            receipt_id=worker.receipt_id,
+            admin_approved=worker.admin_approved,
+            approved_by=actor_id,
+            metadata=metadata,
+        )
+        action = authorize_capability_dispatch(
+            capability=capability,
+            actor_id=actor_id,
+            target_resource=target_resource,
+            input_payload=input_payload,
+            approval_id=effective_approval_id,
+            receipt_id=worker.receipt_id,
+            metadata=metadata,
+        )
+        return effective_approval_id, action.action_id
+
+    @staticmethod
     async def _auto_commit(worker: WorkerProcess) -> None:
         """Auto-commit changes in the worktree, excluding session artifacts."""
         try:
+            approval_id, _ = WorkerLauncher._authorize_worker_capability(
+                worker,
+                capability=Capability.GIT_WRITE,
+                input_payload={
+                    "agent": worker.agent,
+                    "work_order_id": worker.work_order_id,
+                    "branch": worker.branch,
+                },
+                approval_id=worker.git_write_approval_id,
+                metadata={"work_order_id": worker.work_order_id},
+            )
+            worker.git_write_approval_id = approval_id
             # Stage everything, then unstage session artifacts so they are
             # never committed by the harness.
             add_proc = await asyncio.create_subprocess_exec(
@@ -1629,6 +1829,12 @@ class WorkerLauncher:
             # Best-effort: if push fails (no remote, auth, etc.) the local
             # commit is still collected by _collect_commit_shas.
             await WorkerLauncher._auto_push(worker)
+        except CapabilityApprovalRequiredError as exc:
+            logger.info(
+                "Auto-commit skipped for %s: %s — working tree left intact",
+                worker.work_order_id,
+                exc.reason,
+            )
         except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
             logger.warning("Auto-commit failed for %s: %s", worker.work_order_id, exc)
 
@@ -1636,6 +1842,18 @@ class WorkerLauncher:
     def _auto_commit_sync(worker: WorkerProcess) -> None:
         """Sync auto-commit used by pre-reap refresh paths."""
         try:
+            approval_id, _ = WorkerLauncher._authorize_worker_capability(
+                worker,
+                capability=Capability.GIT_WRITE,
+                input_payload={
+                    "agent": worker.agent,
+                    "work_order_id": worker.work_order_id,
+                    "branch": worker.branch,
+                },
+                approval_id=worker.git_write_approval_id,
+                metadata={"work_order_id": worker.work_order_id},
+            )
+            worker.git_write_approval_id = approval_id
             add_proc = subprocess.run(
                 ["git", "add", "-A"],
                 cwd=worker.worktree_path,
@@ -1703,6 +1921,12 @@ class WorkerLauncher:
                 return
 
             WorkerLauncher._auto_push_sync(worker)
+        except CapabilityApprovalRequiredError as exc:
+            logger.info(
+                "Sync auto-commit skipped for %s: %s — working tree left intact",
+                worker.work_order_id,
+                exc.reason,
+            )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
             logger.warning("Sync auto-commit failed for %s: %s", worker.work_order_id, exc)
 
@@ -1716,6 +1940,20 @@ class WorkerLauncher:
         the local worktree.
         """
         try:
+            approval_id, action_id = WorkerLauncher._authorize_worker_capability(
+                worker,
+                capability=Capability.GIT_PUSH,
+                input_payload={
+                    "agent": worker.agent,
+                    "work_order_id": worker.work_order_id,
+                    "branch": worker.branch,
+                    "commit_shas": list(worker.commit_shas),
+                },
+                approval_id=worker.push_approval_id,
+                metadata={"work_order_id": worker.work_order_id},
+            )
+            worker.push_approval_id = approval_id
+            worker.push_action_id = action_id
             push_proc = await asyncio.create_subprocess_exec(
                 "git",
                 "push",
@@ -1735,6 +1973,12 @@ class WorkerLauncher:
                 )
             else:
                 logger.info("Auto-pushed branch for %s", worker.work_order_id)
+        except CapabilityApprovalRequiredError as exc:
+            logger.info(
+                "Auto-push skipped for %s: %s — local commit preserved",
+                worker.work_order_id,
+                exc.reason,
+            )
         except (asyncio.TimeoutError, FileNotFoundError, OSError) as exc:
             logger.info(
                 "Auto-push skipped for %s: %s — local commit preserved",
@@ -1745,6 +1989,20 @@ class WorkerLauncher:
     @staticmethod
     def _auto_push_sync(worker: WorkerProcess) -> None:
         try:
+            approval_id, action_id = WorkerLauncher._authorize_worker_capability(
+                worker,
+                capability=Capability.GIT_PUSH,
+                input_payload={
+                    "agent": worker.agent,
+                    "work_order_id": worker.work_order_id,
+                    "branch": worker.branch,
+                    "commit_shas": list(worker.commit_shas),
+                },
+                approval_id=worker.push_approval_id,
+                metadata={"work_order_id": worker.work_order_id},
+            )
+            worker.push_approval_id = approval_id
+            worker.push_action_id = action_id
             push_proc = subprocess.run(
                 ["git", "push", "origin", "HEAD"],
                 cwd=worker.worktree_path,
@@ -1762,6 +2020,12 @@ class WorkerLauncher:
                 )
             else:
                 logger.info("Sync auto-pushed branch for %s", worker.work_order_id)
+        except CapabilityApprovalRequiredError as exc:
+            logger.info(
+                "Sync auto-push skipped for %s: %s — local commit preserved",
+                worker.work_order_id,
+                exc.reason,
+            )
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as exc:
             logger.info(
                 "Sync auto-push skipped for %s: %s — local commit preserved",

--- a/contracts/erc8004/contracts/ReputationRegistry.sol
+++ b/contracts/erc8004/contracts/ReputationRegistry.sol
@@ -12,6 +12,10 @@ pragma solidity ^0.8.24;
  *
  * Linked to AgentIdentityRegistry — only registered agents can receive feedback.
  */
+interface IReputationIdentityRegistry {
+    function ownerOf(uint256 tokenId) external view returns (address);
+}
+
 contract ReputationRegistry {
 
     // ── Types ──
@@ -80,6 +84,10 @@ contract ReputationRegistry {
         identityRegistry = _identityRegistry;
     }
 
+    function _requireRegisteredAgent(uint256 agentId) internal view returns (address) {
+        return IReputationIdentityRegistry(identityRegistry).ownerOf(agentId);
+    }
+
     // ── Feedback ──
 
     /**
@@ -103,6 +111,7 @@ contract ReputationRegistry {
         string calldata feedbackURI,
         bytes32 feedbackHash
     ) external {
+        _requireRegisteredAgent(agentId);
         uint64 idx = _nextIndex[agentId][msg.sender]++;
 
         _feedback[agentId][msg.sender][idx] = Feedback({
@@ -153,8 +162,13 @@ contract ReputationRegistry {
         string calldata responseURI,
         bytes32 responseHash
     ) external {
+        address agentOwner = _requireRegisteredAgent(agentId);
         Feedback storage fb = _feedback[agentId][clientAddress][feedbackIndex];
         require(fb.timestamp > 0, "Feedback not found");
+        require(
+            msg.sender == clientAddress || msg.sender == agentOwner,
+            "Not feedback participant"
+        );
 
         emit ResponseAppended(
             agentId, clientAddress, feedbackIndex,

--- a/contracts/erc8004/contracts/ValidationRegistry.sol
+++ b/contracts/erc8004/contracts/ValidationRegistry.sol
@@ -11,6 +11,10 @@ pragma solidity ^0.8.24;
  *
  * Linked to AgentIdentityRegistry — only registered agents can be validated.
  */
+interface IValidationIdentityRegistry {
+    function ownerOf(uint256 tokenId) external view returns (address);
+}
+
 contract ValidationRegistry {
 
     // ── Types ──
@@ -75,6 +79,10 @@ contract ValidationRegistry {
         identityRegistry = _identityRegistry;
     }
 
+    function _requireRegisteredAgent(uint256 agentId) internal view {
+        IValidationIdentityRegistry(identityRegistry).ownerOf(agentId);
+    }
+
     // ── Validation Request ──
 
     /**
@@ -92,6 +100,7 @@ contract ValidationRegistry {
     ) external {
         require(validatorAddress != address(0), "Zero validator address");
         require(_records[requestHash].lastUpdate == 0, "Request hash already used");
+        _requireRegisteredAgent(agentId);
 
         _records[requestHash] = ValidationRecord({
             validatorAddress: validatorAddress,

--- a/contracts/erc8004/test/ERC8004.test.ts
+++ b/contracts/erc8004/test/ERC8004.test.ts
@@ -20,6 +20,12 @@ describe("ERC-8004 Contracts", function () {
     return { identity, reputation, validation, owner, client, validator, other };
   }
 
+  async function registerAgents(identity: any, count: number): Promise<void> {
+    for (let i = 0; i < count; i += 1) {
+      await identity.register(`ipfs://agent-${i}`, []);
+    }
+  }
+
   // ── AgentIdentityRegistry ──
 
   describe("AgentIdentityRegistry", function () {
@@ -129,7 +135,8 @@ describe("ERC-8004 Contracts", function () {
 
   describe("ReputationRegistry", function () {
     it("should accept feedback from any address", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0,        // agentId
@@ -152,7 +159,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should track multiple feedback entries", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 900, 3, "medical", "", "/api/v1/diagnose", "", ethers.ZeroHash
@@ -165,7 +173,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should revoke feedback", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 500, 3, "test", "", "", "", ethers.ZeroHash
@@ -177,7 +186,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should reject revocation from non-submitter", async function () {
-      const { reputation, client, other } = await loadFixture(deployFixture);
+      const { identity, reputation, client, other } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 500, 3, "test", "", "", "", ethers.ZeroHash
@@ -190,7 +200,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should compute summary across clients", async function () {
-      const { reputation, client, validator } = await loadFixture(deployFixture);
+      const { identity, reputation, client, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       // Two clients give feedback
       await reputation.connect(client).giveFeedback(
@@ -206,7 +217,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should filter summary by tag", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 800, 3, "financial", "", "", "", ethers.ZeroHash
@@ -220,7 +232,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should exclude revoked feedback from summary", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 800, 3, "test", "", "", "", ethers.ZeroHash
@@ -236,7 +249,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should track client list", async function () {
-      const { reputation, client, validator } = await loadFixture(deployFixture);
+      const { identity, reputation, client, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await reputation.connect(client).giveFeedback(
         0, 100, 0, "", "", "", "", ethers.ZeroHash
@@ -252,7 +266,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should emit NewFeedback event", async function () {
-      const { reputation, client } = await loadFixture(deployFixture);
+      const { identity, reputation, client } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       await expect(
         reputation.connect(client).giveFeedback(
@@ -271,7 +286,8 @@ describe("ERC-8004 Contracts", function () {
 
   describe("ValidationRegistry", function () {
     it("should submit a validation request", async function () {
-      const { validation, validator, owner } = await loadFixture(deployFixture);
+      const { identity, validation, validator, owner } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const requestHash = ethers.id("validation-request-1");
       await validation.validationRequest(
@@ -287,7 +303,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should reject duplicate request hash", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const requestHash = ethers.id("duplicate");
       await validation.validationRequest(validator.address, 0, "", requestHash);
@@ -298,7 +315,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should accept response from designated validator", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const requestHash = ethers.id("val-req");
       await validation.validationRequest(validator.address, 0, "", requestHash);
@@ -318,7 +336,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should reject response from non-validator", async function () {
-      const { validation, validator, other } = await loadFixture(deployFixture);
+      const { identity, validation, validator, other } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const requestHash = ethers.id("val-req-2");
       await validation.validationRequest(validator.address, 0, "", requestHash);
@@ -331,7 +350,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should reject invalid response codes", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const requestHash = ethers.id("val-req-3");
       await validation.validationRequest(validator.address, 0, "", requestHash);
@@ -350,7 +370,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should compute summary with tag filtering", async function () {
-      const { validation, validator, other } = await loadFixture(deployFixture);
+      const { identity, validation, validator, other } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       // Two validation requests for the same agent
       const h1 = ethers.id("req-1");
@@ -375,7 +396,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should track agent validations", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
 
       const h1 = ethers.id("a-1");
       const h2 = ethers.id("a-2");
@@ -387,7 +409,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should track validator requests", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 2);
 
       const h1 = ethers.id("v-1");
       const h2 = ethers.id("v-2");
@@ -399,7 +422,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should emit ValidationRequested event", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
       const requestHash = ethers.id("ev-1");
 
       await expect(
@@ -409,7 +433,8 @@ describe("ERC-8004 Contracts", function () {
     });
 
     it("should emit ValidationResponded event", async function () {
-      const { validation, validator } = await loadFixture(deployFixture);
+      const { identity, validation, validator } = await loadFixture(deployFixture);
+      await registerAgents(identity, 1);
       const requestHash = ethers.id("ev-2");
 
       await validation.validationRequest(validator.address, 0, "", requestHash);

--- a/docs-site/docs/api/cli.md
+++ b/docs-site/docs/api/cli.md
@@ -1,6 +1,6 @@
 ---
 title: Aragora CLI Reference
-description: Aragora CLI Reference
+description: Generated Aragora CLI command catalog from live parser
 ---
 
 # Aragora CLI Reference
@@ -11,8 +11,8 @@ description: Aragora CLI Reference
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **89**
-- Total top-level invocations (including aliases): **90**
+- Canonical top-level commands: **87**
+- Total top-level invocations (including aliases): **88**
 
 ## Installation
 
@@ -54,7 +54,6 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `bench` | - | Benchmark agents | - |
 | `billing` | - | Manage billing, usage, and subscriptions | `invoices`, `portal`, `status`, `subscribe`, `usage` |
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
-| `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
@@ -72,7 +71,6 @@ For full runtime configuration, see [ENVIRONMENT](../getting-started/environment
 | `document-audit` | - | Audit documents using multi-agent analysis | `report`, `scan`, `status`, `upload` |
 | `documents` | - | Document management (upload, list, show) | `list`, `show`, `upload` |
 | `elo` | - | View ELO ratings, leaderboards, and match history | - |
-| `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |

--- a/docs/TRUST_PORTABILITY.md
+++ b/docs/TRUST_PORTABILITY.md
@@ -23,24 +23,22 @@ Each agent is represented as an ERC-721 NFT on the Identity Registry.
 **Registration** (`aragora/blockchain/contracts/identity.py`):
 
 ```python
-# Register with metadata
-token_id = identity_registry.register(
+# Request registration with metadata
+action = client.blockchain.register_agent(
     agent_uri="https://org-a.com/agents/analyst-1.json",
-    metadata=[
-        {"key": "aragora_agent_id", "value": "analyst-1"},
-        {"key": "capabilities", "value": "security,compliance"},
-    ],
+    metadata={"aragora_agent_id": "analyst-1", "capabilities": "security,compliance"},
+    approval_id="cap-approval-123",
 )
 ```
 
-Returns a `token_id` (the portable identity) and records the `owner` address.
+The public API now queues a durable chain action and returns an `action_id`. An admin-approved signer lane submits the transaction asynchronously, and the portable `token_id` only exists after the queued action is mined and confirmed.
 
 **Wallet binding**: Agents can bind to wallet addresses via EIP-191 signed messages using `setAgentWallet()`. Supports private key, encrypted keystore, or external (hardware wallet) signers.
 
 **SDK surface** (`sdk/python/aragora_sdk/namespaces/blockchain.py`):
 
 ```python
-# Register
+# Queue registration
 result = client.blockchain.register_agent(
     agent_uri="https://org-a.com/agents/analyst-1.json",
     metadata={"aragora_agent_id": "analyst-1"},
@@ -49,6 +47,8 @@ result = client.blockchain.register_agent(
 # List all agents (paginated)
 agents = client.blockchain.list_agents(skip=0, limit=50)
 ```
+
+The registration request returns queue metadata such as `action_id`, `status="queued"`, and `requires_approval=True`. Consequential chain writes are not performed inline in the request-serving path.
 
 ## Reputation Scoring
 

--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -67174,7 +67174,7 @@
           "Blockchain",
           "Agents"
         ],
-        "description": "Registers a new agent on the ERC-8004 Identity Registry.",
+        "description": "Queues a new agent registration for the ERC-8004 Identity Registry.",
         "operationId": "handle_register_agent",
         "requestBody": {
           "content": {
@@ -67186,8 +67186,8 @@
           }
         },
         "responses": {
-          "201": {
-            "description": "Agent registered"
+          "202": {
+            "description": "Agent registration queued"
           },
           "400": {
             "description": "Invalid request"

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -40459,7 +40459,7 @@ paths:
       tags:
       - Blockchain
       - Agents
-      description: Registers a new agent on the ERC-8004 Identity Registry.
+      description: Queues a new agent registration for the ERC-8004 Identity Registry.
       operationId: handle_register_agent
       requestBody:
         content:
@@ -40467,8 +40467,8 @@ paths:
             schema:
               type: object
       responses:
-        '201':
-          description: Agent registered
+        '202':
+          description: Agent registration queued
         '400':
           description: Invalid request
         '500':

--- a/docs/reference/CLI_REFERENCE.md
+++ b/docs/reference/CLI_REFERENCE.md
@@ -6,8 +6,8 @@
 
 This reference documents the command surface as implemented in code. It includes all top-level commands and known aliases.
 
-- Canonical top-level commands: **89**
-- Total top-level invocations (including aliases): **90**
+- Canonical top-level commands: **87**
+- Total top-level invocations (including aliases): **88**
 
 ## Installation
 
@@ -49,7 +49,6 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `bench` | - | Benchmark agents | - |
 | `billing` | - | Manage billing, usage, and subscriptions | `invoices`, `portal`, `status`, `subscribe`, `usage` |
 | `build` | - | Turn a vague idea into executed, reviewed, merged code | - |
-| `codebase-audit` | - | Run a staged repo audit with triage, threat-surface ranking, and deep audit | - |
 | `compliance` | - | Compliance framework and EU AI Act tools | `audit`, `check`, `classify`, `eu-ai-act`, `evidence`, `export`, `report`, `status` |
 | `computer-use` | - | Computer use task management | `list`, `run`, `status` |
 | `config` | - | Manage configuration | - |
@@ -67,7 +66,6 @@ For full runtime configuration, see [ENVIRONMENT](ENVIRONMENT.md).
 | `document-audit` | - | Audit documents using multi-agent analysis | `report`, `scan`, `status`, `upload` |
 | `documents` | - | Document management (upload, list, show) | `list`, `show`, `upload` |
 | `elo` | - | View ELO ratings, leaderboards, and match history | - |
-| `essay` | - | Refine raw ideas into a polished essay or score an existing draft | `refine`, `score` |
 | `explain` | - | Explain a debate decision (evidence chains, vote pivots, counterfactuals) | - |
 | `export` | - | Export debate artifacts | - |
 | `gauntlet` | - | Adversarial stress-test a specification, architecture, or policy | - |

--- a/scripts/claude-wt
+++ b/scripts/claude-wt
@@ -68,4 +68,8 @@ echo "▸ Worktree: $WORKTREE_PATH"
 echo "▸ Agent: $AGENT | Base: $BASE"
 
 cd "$WORKTREE_PATH"
-exec claude --dangerously-skip-permissions "${CLAUDE_ARGS[@]}"
+CLAUDE_CMD=(claude)
+if [[ "${ARAGORA_ADMIN_APPROVED:-0}" == "1" ]]; then
+  CLAUDE_CMD+=(--dangerously-skip-permissions)
+fi
+exec "${CLAUDE_CMD[@]}" "${CLAUDE_ARGS[@]}"

--- a/scripts/sprint_coordinator.py
+++ b/scripts/sprint_coordinator.py
@@ -335,8 +335,13 @@ def cmd_execute(args: argparse.Namespace) -> None:
         log_file = wt_path / ".sprint-agent.log"
         log_handle = open(log_file, "w")
 
+        cmd = [claude_bin, "--print"]
+        if os.environ.get("ARAGORA_ADMIN_APPROVED", "").strip() == "1":
+            cmd.append("--dangerously-skip-permissions")
+        cmd.extend(["-p", prompt])
+
         proc = subprocess.Popen(
-            [claude_bin, "--print", "--dangerously-skip-permissions", "-p", prompt],
+            cmd,
             cwd=str(wt_path),
             stdout=log_handle,
             stderr=subprocess.STDOUT,

--- a/tests/blockchain/test_wallet.py
+++ b/tests/blockchain/test_wallet.py
@@ -94,11 +94,17 @@ class TestWalletSigner:
         mock_acct.address = "0xABCD1234567890ABCD1234567890ABCD12345678"
         mock_account_cls.from_key.return_value = mock_acct
 
-        env = {"ERC8004_WALLET_KEY": "0x" + "b" * 64}
+        env = {"ERC8004_WALLET_KEY": "0x" + "b" * 64, "ARAGORA_ENV": "development"}
         with patch.dict(os.environ, env, clear=False):
             with patch.dict(sys.modules, {"eth_account": mock_mod}):
                 signer = WalletSigner.from_env()
         assert signer.address == "0xABCD1234567890ABCD1234567890ABCD12345678"
+
+    def test_from_env_rejects_private_key_in_production_like_env(self):
+        env = {"ERC8004_WALLET_KEY": "0x" + "d" * 64, "ARAGORA_ENV": "production"}
+        with patch.dict(os.environ, env, clear=False):
+            with pytest.raises(ValueError, match="disabled in production-like environments"):
+                WalletSigner.from_env()
 
     def test_from_env_with_keystore(self, tmp_path):
         mock_mod, mock_messages, mock_account_cls = _make_mock_eth_account()

--- a/tests/handlers/debates/test_create.py
+++ b/tests/handlers/debates/test_create.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -273,7 +274,7 @@ class TestCreateDebate:
     @patch("aragora.server.handlers.debates.create._get_validate_against_schema")
     @patch("aragora.server.handlers.debates.create.importlib.import_module")
     def test_create_debate_schema_validation_failure(self, mock_import, mock_get_schema):
-        """Invalid schema returns 400 with validation error."""
+        """Invalid request returns validation error."""
         mock_get_schema.return_value = lambda body, schema: _MockValidationResult(
             is_valid=False, error="question field is required"
         )
@@ -282,8 +283,7 @@ class TestCreateDebate:
         h = _make_handler(json_body=body)
         handler = _mock_http_handler()
         result = h._create_debate(handler)
-        assert _status(result) == 400
-        # Error comes from schema validation
+        assert _status(result) == 422
         error_text = _body(result).get("error", "").lower()
         assert "question" in error_text or "invalid" in error_text
 
@@ -780,7 +780,11 @@ class TestCancelDebate:
         h = _make_handler()
         handler = _mock_http_handler()
 
-        result = h._cancel_debate(handler, "debate-emit-1")
+        with patch(
+            "aragora.server.stream.StreamEvent",
+            side_effect=lambda **kwargs: SimpleNamespace(**kwargs),
+        ):
+            result = h._cancel_debate(handler, "debate-emit-1")
 
         assert _status(result) == 200
         handler.stream_emitter.emit.assert_called_once()
@@ -1106,13 +1110,12 @@ class TestCheckSpamContent:
         assert result is None
 
     def test_moderation_import_error(self):
-        """If moderation module is not available, content passes."""
+        """If moderation module is not available, public creation fails closed."""
         handler = _make_spam_handler()
 
         with patch.dict("sys.modules", {"aragora.moderation": None}):
             result = handler._check_spam_content({"question": "Buy stuff!"})
-        # ImportError path => returns None (allowed)
-        assert result is None
+        assert _status(result) == 503
 
     @patch("aragora.server.handlers.debates.create.run_async")
     def test_spam_blocked(self, mock_run_async):
@@ -1159,7 +1162,7 @@ class TestCheckSpamContent:
         assert result is None
 
     def test_spam_check_runtime_error(self):
-        """Runtime error during spam check allows content through."""
+        """Runtime error during spam check blocks unless explicitly overridden."""
         handler = _make_spam_handler()
 
         mock_mod = MagicMock()
@@ -1173,11 +1176,12 @@ class TestCheckSpamContent:
             ):
                 result = handler._check_spam_content({"question": "Normal question"})
 
-        assert result is None
+        assert _status(result) == 503
 
     def test_spam_check_uses_task_or_question(self):
-        """Spam check extracts from 'task' field if 'question' is absent."""
+        """Legacy task alias is normalized to question before spam checking."""
         handler = _make_spam_handler()
+        from aragora.server.handlers.debates.create import _normalize_debate_body
 
         mock_result = MagicMock()
         mock_result.should_block = False
@@ -1192,7 +1196,7 @@ class TestCheckSpamContent:
                 "aragora.server.handlers.debates.create.run_async",
                 return_value=mock_result,
             ):
-                handler._check_spam_content({"task": "Design a system"})
+                handler._check_spam_content(_normalize_debate_body({"task": "Design a system"}))
 
         mock_mod.check_debate_content.assert_called_once()
         call_args = mock_mod.check_debate_content.call_args

--- a/tests/handlers/test_erc8004.py
+++ b/tests/handlers/test_erc8004.py
@@ -70,6 +70,23 @@ def _status(result: HandlerResult) -> int:
     return 200
 
 
+def _assert_register_queued(
+    result: HandlerResult,
+    *,
+    agent_uri: str,
+    chain_id: int,
+) -> dict[str, Any]:
+    """Assert the request path queues a chain action instead of signing inline."""
+    assert _status(result) == 202
+    body = _body(result)
+    assert body["agent_uri"] == agent_uri
+    assert body["chain_id"] == chain_id
+    assert body["status"] == "queued"
+    assert body["requires_approval"] is True
+    assert body["action_id"].startswith("chain-")
+    return body
+
+
 class MockHTTPHandler:
     """Mock HTTP handler for testing (simulates BaseHTTPRequestHandler)."""
 
@@ -1482,12 +1499,12 @@ class TestRegisterAgent:
                 metadata={"role": "verifier"},
             )
 
-        assert _status(result) == 201
-        body = _body(result)
-        assert body["token_id"] == 42
-        assert body["agent_uri"] == "https://agent.example.com"
-        assert body["owner"] == "0xsigner_addr"
-        assert body["chain_id"] == 137
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=137,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -1515,7 +1532,11 @@ class TestRegisterAgent:
         ):
             result = await handle_register_agent(agent_uri="https://agent.example.com")
 
-        assert _status(result) == 400
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -1591,7 +1612,12 @@ class TestRegisterAgent:
         ):
             result = await handle_register_agent(agent_uri="https://agent.example.com")
 
-        assert _status(result) == 500
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -1651,9 +1677,12 @@ class TestRegisterAgent:
                 metadata=None,
             )
 
-        assert _status(result) == 201
-        # register_agent should have been called with empty metadata list
-        contract_inst.register_agent.assert_called_once()
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
+        contract_inst.register_agent.assert_not_called()
 
 
 # ============================================================================
@@ -2990,7 +3019,12 @@ class TestRegisterAgentEdgeCases:
         ):
             result = await handle_register_agent(agent_uri="https://agent.example.com")
 
-        assert _status(result) == 500
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -3027,7 +3061,12 @@ class TestRegisterAgentEdgeCases:
         ):
             result = await handle_register_agent(agent_uri="https://agent.example.com")
 
-        assert _status(result) == 500
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -3064,7 +3103,12 @@ class TestRegisterAgentEdgeCases:
         ):
             result = await handle_register_agent(agent_uri="https://agent.example.com")
 
-        assert _status(result) == 500
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -3105,9 +3149,12 @@ class TestRegisterAgentEdgeCases:
                 metadata={"role": "verifier", "level": 42, "active": True},
             )
 
-        assert _status(result) == 201
-        body = _body(result)
-        assert body["token_id"] == 100
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=42,
+        )
+        contract_inst.register_agent.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -3148,7 +3195,11 @@ class TestRegisterAgentEdgeCases:
                 metadata={},
             )
 
-        assert _status(result) == 201
+        _assert_register_queued(
+            result,
+            agent_uri="https://agent.example.com",
+            chain_id=1,
+        )
 
     @pytest.mark.asyncio
     @patch("aragora.server.handlers.erc8004._get_circuit_breaker")
@@ -3187,10 +3238,18 @@ class TestRegisterAgentEdgeCases:
             result = await handle_register_agent(agent_uri="https://a.com")
 
         body = _body(result)
-        expected_keys = {"token_id", "agent_uri", "owner", "chain_id"}
+        expected_keys = {
+            "action_id",
+            "agent_uri",
+            "chain_id",
+            "requires_approval",
+            "status",
+        }
         assert set(body.keys()) == expected_keys
         assert body["chain_id"] == 5
-        assert body["owner"] == "0xaddr"
+        assert body["status"] == "queued"
+        assert body["requires_approval"] is True
+        assert body["action_id"].startswith("chain-")
 
 
 # ============================================================================
@@ -3253,6 +3312,9 @@ class TestHandlerRoutingAdditional:
         mock_fn.assert_called_once_with(
             agent_uri="https://test.com",
             metadata={"role": "verifier"},
+            requested_by="",
+            approval_id="",
+            receipt_id="",
         )
 
     @patch("aragora.server.handlers.erc8004.handle_register_agent")
@@ -3261,7 +3323,13 @@ class TestHandlerRoutingAdditional:
         mock_fn.return_value = MagicMock()
         h = _make_handler(body={}, method="POST")
         handler.handle("/api/v1/blockchain/agents", {}, h)
-        mock_fn.assert_called_once_with(agent_uri="", metadata=None)
+        mock_fn.assert_called_once_with(
+            agent_uri="",
+            metadata=None,
+            requested_by="",
+            approval_id="",
+            receipt_id="",
+        )
 
     def test_metadata_as_list_rejected(self, handler):
         h = _make_handler(body={"agent_uri": "https://test.com", "metadata": [1, 2]}, method="POST")

--- a/tests/pipeline/test_gold_path.py
+++ b/tests/pipeline/test_gold_path.py
@@ -784,8 +784,14 @@ class TestHybridExecutorBridge:
         result = _make_debate_result()
         plan = DecisionPlanFactory.from_debate_result(result, approval_mode=ApprovalMode.NEVER)
         plan.status = PlanStatus.APPROVED
+        plan.metadata = {
+            "admin_approved": True,
+            "approved_by": "test-admin",
+            "requested_by": "test-admin",
+        }
 
         executor = PlanExecutor(execution_mode="computer_use")
+        executor._sandbox_executor = object()
 
         # Create a mock task result
         mock_task_result = MagicMock()
@@ -827,8 +833,14 @@ class TestHybridExecutorBridge:
         result = _make_debate_result()
         plan = DecisionPlanFactory.from_debate_result(result, approval_mode=ApprovalMode.NEVER)
         plan.status = PlanStatus.APPROVED
+        plan.metadata = {
+            "admin_approved": True,
+            "approved_by": "test-admin",
+            "requested_by": "test-admin",
+        }
 
         executor = PlanExecutor(execution_mode="computer_use")
+        executor._sandbox_executor = object()
         progress_events: list[tuple[str, object]] = []
 
         def _on_task_complete(task_id: str, result: object) -> None:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -145,7 +145,7 @@ class TestBuildCommand:
     def test_claude_command(self, monkeypatch):
         monkeypatch.setattr("aragora.swarm.worker_launcher.os.geteuid", lambda: 501)
         launcher = WorkerLauncher(LaunchConfig(claude_model="claude-opus-4-6"))
-        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt")
+        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt", admin_approved=True)
         assert cmd[0] == "bash"
         assert "scripts/codex_session.sh" in cmd[1]
         # session-id is derived from worktree basename when not provided
@@ -161,18 +161,18 @@ class TestBuildCommand:
     def test_claude_command_omits_dangerous_flag_as_root(self, monkeypatch):
         monkeypatch.setattr("aragora.swarm.worker_launcher.os.geteuid", lambda: 0)
         launcher = WorkerLauncher(LaunchConfig(claude_model="claude-opus-4-6"))
-        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt")
+        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt", admin_approved=True)
         assert "--dangerously-skip-permissions" not in cmd
 
     def test_claude_command_fails_closed_when_geteuid_is_unavailable(self, monkeypatch):
         monkeypatch.delattr("aragora.swarm.worker_launcher.os.geteuid", raising=False)
         launcher = WorkerLauncher(LaunchConfig(claude_model="claude-opus-4-6"))
-        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt")
+        cmd = launcher._build_command("claude", "fix bug", "/tmp/wt", admin_approved=True)
         assert "--dangerously-skip-permissions" not in cmd
 
     def test_codex_command(self):
         launcher = WorkerLauncher(LaunchConfig(codex_model="o3"))
-        cmd = launcher._build_command("codex", "fix bug", "/tmp/wt")
+        cmd = launcher._build_command("codex", "fix bug", "/tmp/wt", admin_approved=True)
         assert cmd[0] == "bash"
         assert "exec" in cmd
         # Prompt is piped via stdin using "-" to avoid ARG_MAX limits
@@ -184,7 +184,7 @@ class TestBuildCommand:
     def test_unknown_agent_falls_back_to_claude(self, monkeypatch):
         monkeypatch.setattr("aragora.swarm.worker_launcher.os.geteuid", lambda: 501)
         launcher = WorkerLauncher()
-        cmd = launcher._build_command("gpt5", "do thing", "/tmp/wt")
+        cmd = launcher._build_command("gpt5", "do thing", "/tmp/wt", admin_approved=True)
         assert cmd[0] == "bash"
         assert "--dangerously-skip-permissions" in cmd
 
@@ -236,7 +236,7 @@ class TestBuildCommand:
         (real_gitdir / "commondir").write_text("../..\n")
         (wt / ".git").write_text(f"gitdir: {real_gitdir}\n")
         launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
-        cmd = launcher._build_command("codex", "task", str(wt))
+        cmd = launcher._build_command("codex", "task", str(wt), admin_approved=True)
         assert "--add-dir" in cmd
         idx = cmd.index("--add-dir")
         assert cmd[idx + 1] == str(parent_git.resolve())
@@ -248,7 +248,7 @@ class TestBuildCommand:
         wt.mkdir()
         (wt / ".git").mkdir()
         launcher = WorkerLauncher(LaunchConfig(use_managed_session_script=False))
-        cmd = launcher._build_command("codex", "task", str(wt))
+        cmd = launcher._build_command("codex", "task", str(wt), admin_approved=True)
         assert "--add-dir" not in cmd
         assert "--full-auto" in cmd
 
@@ -301,6 +301,7 @@ class TestLaunch:
             "target_agent": "claude",
             "title": "Test",
             "expected_tests": ["python -m pytest tests/auth/ -q"],
+            "metadata": {"admin_approved": True},
         }
 
         with (
@@ -333,6 +334,7 @@ class TestLaunch:
             "work_order_id": "wo-stdin",
             "target_agent": "claude",
             "title": "Stdin guard test",
+            "metadata": {"admin_approved": True},
         }
 
         with (
@@ -362,6 +364,7 @@ class TestLaunch:
             "work_order_id": "wo-stdin-detach",
             "target_agent": "codex",
             "title": "Stdin guard detached",
+            "metadata": {"admin_approved": True},
         }
 
         with (
@@ -389,6 +392,7 @@ class TestLaunch:
             "work_order_id": "wo-detach-handles",
             "target_agent": "codex",
             "title": "Detached handle cleanup",
+            "metadata": {"admin_approved": True},
         }
 
         with (
@@ -408,7 +412,11 @@ class TestLaunch:
     @pytest.mark.asyncio
     async def test_launch_raises_on_missing_cli(self):
         launcher = WorkerLauncher()
-        wo = {"work_order_id": "wo-1", "target_agent": "claude"}
+        wo = {
+            "work_order_id": "wo-1",
+            "target_agent": "claude",
+            "metadata": {"admin_approved": True},
+        }
 
         with patch("shutil.which", return_value=None):
             with pytest.raises(FileNotFoundError, match="CLI not found"):
@@ -433,7 +441,8 @@ class TestLaunch:
                 "worker_env": {
                     "ARAGORA_RELEVANT_FILES": "aragora/swarm/boss_loop.py",
                     "ARAGORA_TEST_PATTERNS": "tests/swarm/test_boss_loop.py",
-                }
+                },
+                "admin_approved": True,
             },
         }
 
@@ -686,7 +695,12 @@ class TestLaunchAndWait:
     @pytest.mark.asyncio
     async def test_launch_and_wait_combined(self, tmp_path: Path):
         launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
-        wo = {"work_order_id": "wo-combo", "target_agent": "claude", "title": "Test"}
+        wo = {
+            "work_order_id": "wo-combo",
+            "target_agent": "claude",
+            "title": "Test",
+            "metadata": {"admin_approved": True},
+        }
         worktree = tmp_path / "wt"
         (worktree / "scripts").mkdir(parents=True)
         (worktree / "scripts" / "codex_session.sh").write_text(


### PR DESCRIPTION
## Summary
- deny dangerous execution by default unless an admin-scoped capability approval exists
- require sandbox-backed browser execution, queue ERC-8004 writes instead of signing inline, and tighten chain identity invariants
- normalize debate input onto `question`, fail closed on moderation outages for public entrypoints, and refresh generated docs required by the version-alignment gate

## Verification
- `pytest -q tests/swarm/test_worker_launcher.py tests/handlers/debates/test_create.py tests/handlers/test_erc8004.py tests/blockchain/test_wallet.py tests/pipeline/test_gold_path.py tests/computer_use/test_orchestrator.py`
- `go test ./...`
- `python3 scripts/check_version_alignment.py && python3 scripts/guard_repo_clean.py --check-working-tree && python3 scripts/check_capability_matrix_sync.py && python3 scripts/check_legacy_entrypoints.py && python3 scripts/check_legacy_collab_flags.py && python3 scripts/generate_cli_reference.py --check`
- `npx hardhat test` (validated in clean worktree with the repo's local contract lockfile)