### PR TITLE
Fix decision-integrity receipt contract wiring

### DIFF
--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -213489,14 +213489,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "total_receipts": {
+                    "total": {
                       "type": "integer"
                     },
-                    "verified_count": {
+                    "verified": {
                       "type": "integer"
                     },
-                    "by_status": {
+                    "by_verdict": {
                       "type": "object"
+                    },
+                    "by_risk_level": {
+                      "type": "object"
+                    },
+                    "by_framework": {
+                      "type": "object"
+                    },
+                    "generated_at": {
+                      "type": "string",
+                      "format": "date-time"
                     }
                   }
                 }

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -122026,12 +122026,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  total_receipts:
+                  total:
                     type: integer
-                  verified_count:
+                  verified:
                     type: integer
-                  by_status:
+                  by_verdict:
                     type: object
+                  by_risk_level:
+                    type: object
+                  by_framework:
+                    type: object
+                  generated_at:
+                    type: string
+                    format: date-time
         '401':
           description: Unauthorized - Authentication required or token invalid
           headers: *id811


### PR DESCRIPTION
Supersedes #1858. GitHub did not attach the latest branch tip to #1858 even though the remote ref moved, so this PR republishes the current fixed tip on a fresh branch.