### PR TITLE
fix(webhooks): encrypt redis cache secrets

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -786,6 +786,24 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
     def _redis_key(self, webhook_id: str) -> str:
         return f"{self.REDIS_PREFIX}:{webhook_id}"
 
+    @staticmethod
+    def _serialize_for_cache(webhook: WebhookConfig) -> str:
+        """Serialize cache entries without storing decrypted secrets in Redis."""
+        payload = webhook.to_dict(include_secret=True)
+        secret = str(payload.get("secret") or "").strip()
+        if secret:
+            payload["secret"] = _encrypt_secret(secret)
+        return json.dumps(payload)
+
+    @staticmethod
+    def _deserialize_from_cache(payload: str) -> WebhookConfig:
+        """Deserialize cache entries, decrypting cached secrets when present."""
+        data = json.loads(payload)
+        secret = str(data.get("secret") or "").strip()
+        if secret:
+            data["secret"] = _decrypt_secret(secret)
+        return WebhookConfig(**data)
+
     def register(
         self,
         url: str,
@@ -809,7 +827,9 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         redis = self._get_redis()
         if redis:
             try:
-                redis.setex(self._redis_key(webhook.id), self.REDIS_TTL, webhook.to_json())
+                redis.setex(
+                    self._redis_key(webhook.id), self.REDIS_TTL, self._serialize_for_cache(webhook)
+                )
             except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
                 logger.debug("Redis cache update failed: %s", e)
 
@@ -823,7 +843,7 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
             try:
                 data = redis.get(self._redis_key(webhook_id))
                 if data:
-                    return WebhookConfig.from_json(data)
+                    return self._deserialize_from_cache(data)
             except (
                 _RedisError,
                 ConnectionError,
@@ -840,7 +860,9 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         # Populate Redis cache if found
         if webhook and redis:
             try:
-                redis.setex(self._redis_key(webhook_id), self.REDIS_TTL, webhook.to_json())
+                redis.setex(
+                    self._redis_key(webhook_id), self.REDIS_TTL, self._serialize_for_cache(webhook)
+                )
             except (_RedisError, ConnectionError, TimeoutError) as e:
                 logger.debug("Redis cache population failed (connection issue): %s", e)
             except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
@@ -894,7 +916,11 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
             redis = self._get_redis()
             if redis:
                 try:
-                    redis.setex(self._redis_key(webhook_id), self.REDIS_TTL, webhook.to_json())
+                    redis.setex(
+                        self._redis_key(webhook_id),
+                        self.REDIS_TTL,
+                        self._serialize_for_cache(webhook),
+                    )
                 except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
                     logger.debug("Redis cache update failed: %s", e)
 

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1218,6 +1218,28 @@ class TestRedisWebhookConfigStore:
         assert call_args[0][1] == 86400  # TTL
         store.close()
 
+    def test_with_mocked_redis_register_encrypts_cached_secret(self, tmp_path):
+        """Redis cache entries should not store decrypted webhook secrets."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        with patch(
+            "aragora.storage.webhook_config_store._encrypt_secret",
+            return_value="ENCRYPTED-SECRET",
+        ) as mock_encrypt:
+            webhook = store.register(url="https://example.com", events=["debate_end"])
+
+        payload = json.loads(mock_redis.setex.call_args[0][2])
+        assert payload["id"] == webhook.id
+        assert payload["secret"] == "ENCRYPTED-SECRET"
+        assert any(call.args == (webhook.secret,) for call in mock_encrypt.call_args_list)
+        store.close()
+
     def test_with_mocked_redis_get_cache_hit(self, tmp_path):
         """Test get returns from Redis cache when available."""
         db_path = tmp_path / "test.db"
@@ -1238,6 +1260,32 @@ class TestRedisWebhookConfigStore:
         assert retrieved is not None
         assert retrieved.url == "https://example.com"
         mock_redis.get.assert_called_once()
+        store.close()
+
+    def test_with_mocked_redis_get_cache_hit_decrypts_cached_secret(self, tmp_path):
+        """Redis cache hits should decrypt cached secrets before returning them."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store._sqlite.register(url="https://example.com", events=["debate_end"])
+        payload = webhook.to_dict(include_secret=True)
+        payload["secret"] = "ENCRYPTED-SECRET"
+        mock_redis.get.return_value = json.dumps(payload)
+
+        with patch(
+            "aragora.storage.webhook_config_store._decrypt_secret",
+            return_value=webhook.secret,
+        ) as mock_decrypt:
+            retrieved = store.get(webhook.id)
+
+        assert retrieved is not None
+        assert retrieved.secret == webhook.secret
+        mock_decrypt.assert_called_once_with("ENCRYPTED-SECRET")
         store.close()
 
     def test_with_mocked_redis_get_cache_miss(self, tmp_path):


### PR DESCRIPTION
## Summary
- stop caching decrypted webhook secrets in Redis JSON payloads
- encrypt secrets before Redis writes and decrypt them on cache hits
- add focused Redis cache regressions for encrypted write/decrypted read behavior

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'redis and (encrypts_cached_secret or decrypts_cached_secret or mocked_redis_register or mocked_redis_get_cache_hit or mocked_redis_get_cache_miss or mocked_redis_update_refreshes_cache)'
- python -m pytest tests/storage/test_webhook_config_store.py -q