### PR TITLE
feat(debate): skip empty sidecars for simple tasks

### DIFF
--- a/aragora/debate/arena_phases.py
+++ b/aragora/debate/arena_phases.py
@@ -266,6 +266,7 @@ def init_phases(arena: Arena) -> None:
         knowledge_mound=getattr(arena, "knowledge_mound", None),
         knowledge_workspace_id=getattr(arena, "loop_id", None) or "debate",
         enable_trending_context=getattr(arena.protocol, "enable_trending_injection", True),
+        skip_empty_sidecars=getattr(arena.protocol, "skip_empty_sidecars", False),
         enable_rlm_compression=getattr(arena, "enable_rlm", True)
         and getattr(arena, "use_rlm_limiter", True),
         document_store=getattr(arena, "document_store", None),

--- a/aragora/debate/context_gatherer/gatherer.py
+++ b/aragora/debate/context_gatherer/gatherer.py
@@ -96,6 +96,7 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
         max_document_context_items: int = 5,
         max_evidence_context_items: int = 5,
         auth_context: Any | None = None,
+        skip_empty_sidecars: bool = False,
     ):
         """
         Initialize the context gatherer.
@@ -123,6 +124,7 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
             enable_evidence_store_context: Whether to include EvidenceStore context.
             max_document_context_items: Max documents to include.
             max_evidence_context_items: Max evidence snippets to include.
+            skip_empty_sidecars: Skip optional research/KM sidecars for simple questions.
         """
         self._evidence_store_callback = evidence_store_callback
         self._prompt_builder = prompt_builder
@@ -149,6 +151,7 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
         self._max_document_context_items = max_document_context_items
         self._max_evidence_context_items = max_evidence_context_items
         self._auth_context = auth_context
+        self._skip_empty_sidecars = skip_empty_sidecars
 
         trending_disabled = is_trending_disabled()
         self._enable_trending_context = enable_trending_context and not trending_disabled
@@ -332,6 +335,64 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
             oldest_key = next(iter(cache))
             del cache[oldest_key]
 
+    def _should_skip_optional_sidecars(self, task: str) -> bool:
+        """Skip high-latency sidecars for short, generic questions when opted in."""
+        if not self._skip_empty_sidecars:
+            return False
+
+        normalized = " ".join(task.lower().split())
+        if not normalized:
+            return False
+
+        words = normalized.split()
+        is_short_question = normalized.endswith("?") and len(words) <= 8 and len(normalized) <= 80
+        if not is_short_question:
+            return False
+
+        domain_keywords = (
+            "api",
+            "architecture",
+            "auth",
+            "benchmark",
+            "bug",
+            "cache",
+            "compliance",
+            "database",
+            "debate",
+            "debug",
+            "design",
+            "encryption",
+            "fix",
+            "gdpr",
+            "implementation",
+            "jwt",
+            "knowledge mound",
+            "latency",
+            "migration",
+            "obsidian",
+            "oauth",
+            "openapi",
+            "performance",
+            "pii",
+            "postgres",
+            "privacy",
+            "python",
+            "redis",
+            "refactor",
+            "sdk",
+            "security",
+            "shard",
+            "sql",
+            "swarm",
+            "test",
+            "threat",
+            "typescript",
+            "vector",
+            "websocket",
+            "worker",
+        )
+        return not any(keyword in normalized for keyword in domain_keywords)
+
     async def gather_all(self, task: str, timeout: float | None = None) -> str:
         """
         Perform multi-source research and return formatted context.
@@ -362,9 +423,14 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
 
         async def _gather_with_timeout():
             nonlocal context_parts
+            skip_optional_sidecars = self._should_skip_optional_sidecars(task)
+            if skip_optional_sidecars:
+                logger.info("[context] Skipping optional sidecars for simple task: %s", task)
 
             # 1. Primary: Claude's web search (best quality research)
-            claude_ctx = await self._gather_claude_web_search(task)
+            claude_ctx = None
+            if not skip_optional_sidecars:
+                claude_ctx = await self._gather_claude_web_search(task)
             if claude_ctx:
                 context_parts.append(claude_ctx)
 
@@ -375,20 +441,30 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
 
             # 3. Gather trending context for real-time relevance (if enabled)
             trending_task = None
-            if self._enable_trending_context:
+            if not skip_optional_sidecars and self._enable_trending_context:
                 trending_task = asyncio.create_task(self._gather_trending_with_timeout())
 
             # 4. Gather knowledge mound context for institutional knowledge
-            knowledge_task = asyncio.create_task(self._gather_knowledge_mound_with_timeout(task))
+            tasks = []
+            if not skip_optional_sidecars:
+                knowledge_task = asyncio.create_task(
+                    self._gather_knowledge_mound_with_timeout(task)
+                )
+                tasks.append(knowledge_task)
 
-            # 5. Gather belief crux context for debate guidance (fast, cached)
-            belief_task = asyncio.create_task(self._gather_belief_with_timeout(task))
+                # 5. Gather belief crux context for debate guidance (fast, cached)
+                belief_task = asyncio.create_task(self._gather_belief_with_timeout(task))
+                tasks.append(belief_task)
 
-            # 6. Gather culture patterns for organizational learning
-            culture_task = asyncio.create_task(self._gather_culture_with_timeout(task))
+                # 6. Gather culture patterns for organizational learning
+                culture_task = asyncio.create_task(self._gather_culture_with_timeout(task))
+                tasks.append(culture_task)
 
-            # 7. Gather threat intelligence context for security topics
-            threat_intel_task = asyncio.create_task(self._gather_threat_intel_with_timeout(task))
+                # 7. Gather threat intelligence context for security topics
+                threat_intel_task = asyncio.create_task(
+                    self._gather_threat_intel_with_timeout(task)
+                )
+                tasks.append(threat_intel_task)
 
             # 8. Gather document/evidence store context (if available)
             document_task = None
@@ -401,7 +477,6 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
                 )
 
             # 9. Gather additional evidence in parallel (fallback if Claude search weak)
-            tasks = [knowledge_task, belief_task, culture_task, threat_intel_task]
             if trending_task is not None:
                 tasks.append(trending_task)
             if document_task is not None:
@@ -409,7 +484,7 @@ class ContextGatherer(SourceGatheringMixin, CompressionMixin, MemoryMixin):
             if evidence_store_task is not None:
                 tasks.append(evidence_store_task)
 
-            if not claude_ctx or len(claude_ctx) < 500:
+            if not skip_optional_sidecars and (not claude_ctx or len(claude_ctx) < 500):
                 evidence_task = asyncio.create_task(self._gather_evidence_with_timeout(task))
                 tasks.insert(0, evidence_task)
 

--- a/aragora/debate/protocol.py
+++ b/aragora/debate/protocol.py
@@ -412,6 +412,7 @@ class DebateProtocol:
     enable_trending_injection: bool = True  # Enable trending topic injection by default
     trending_injection_max_topics: int = 3  # Max trending topics to inject per prompt
     trending_relevance_filter: bool = True  # Only include topics relevant to debate task
+    skip_empty_sidecars: bool = False  # Skip optional research/KM sidecars for simple tasks
 
     # ThinkPRM: Process Reward Models for step-wise debate verification
     # When enabled, debate rounds are verified for logical consistency using

--- a/tests/debate/context_gatherer/test_gatherer.py
+++ b/tests/debate/context_gatherer/test_gatherer.py
@@ -611,6 +611,62 @@ class TestGatherAll:
         assert "trending_data" in result
 
     @pytest.mark.asyncio
+    async def test_skip_empty_sidecars_skips_optional_sidecars_for_simple_question(self):
+        """Opt-in sidecar skipping bypasses research/KM tasks for simple questions."""
+        g = _make_gatherer(skip_empty_sidecars=True, enable_trending_context=True)
+        g._gather_claude_web_search = AsyncMock(return_value="claude_ctx")
+        g.gather_aragora_context = AsyncMock(return_value=None)
+        g._gather_trending_with_timeout = AsyncMock(return_value="trending_data")
+        g._gather_knowledge_mound_with_timeout = AsyncMock(return_value="knowledge_ctx")
+        g._gather_belief_with_timeout = AsyncMock(return_value="belief_ctx")
+        g._gather_culture_with_timeout = AsyncMock(return_value="culture_ctx")
+        g._gather_threat_intel_with_timeout = AsyncMock(return_value="threat_ctx")
+        g._gather_evidence_with_timeout = AsyncMock(return_value="evidence_ctx")
+
+        result = await g.gather_all("What is 2 + 2?")
+
+        assert result == "No research context available."
+        g.gather_aragora_context.assert_called_once_with("What is 2 + 2?")
+        g._gather_claude_web_search.assert_not_called()
+        g._gather_trending_with_timeout.assert_not_called()
+        g._gather_knowledge_mound_with_timeout.assert_not_called()
+        g._gather_belief_with_timeout.assert_not_called()
+        g._gather_culture_with_timeout.assert_not_called()
+        g._gather_threat_intel_with_timeout.assert_not_called()
+        g._gather_evidence_with_timeout.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skip_empty_sidecars_preserves_sidecars_for_domain_question(self):
+        """Domain-specific questions still gather sidecars even when the flag is enabled."""
+        g = _make_gatherer(skip_empty_sidecars=True, enable_trending_context=True)
+        g._gather_claude_web_search = AsyncMock(return_value="claude_ctx")
+        g.gather_aragora_context = AsyncMock(return_value=None)
+        g._gather_trending_with_timeout = AsyncMock(return_value=None)
+        g._gather_knowledge_mound_with_timeout = AsyncMock(return_value=None)
+        g._gather_belief_with_timeout = AsyncMock(return_value=None)
+        g._gather_culture_with_timeout = AsyncMock(return_value=None)
+        g._gather_threat_intel_with_timeout = AsyncMock(return_value=None)
+        g._gather_evidence_with_timeout = AsyncMock(return_value=None)
+
+        result = await g.gather_all("How should we shard Postgres writes?")
+
+        assert "claude_ctx" in result
+        g._gather_claude_web_search.assert_called_once_with("How should we shard Postgres writes?")
+        g._gather_trending_with_timeout.assert_called_once()
+        g._gather_knowledge_mound_with_timeout.assert_called_once_with(
+            "How should we shard Postgres writes?"
+        )
+        g._gather_belief_with_timeout.assert_called_once_with(
+            "How should we shard Postgres writes?"
+        )
+        g._gather_culture_with_timeout.assert_called_once_with(
+            "How should we shard Postgres writes?"
+        )
+        g._gather_threat_intel_with_timeout.assert_called_once_with(
+            "How should we shard Postgres writes?"
+        )
+
+    @pytest.mark.asyncio
     async def test_document_store_task_created_when_configured(self):
         """When document_store is set, its gather task is created."""
         ds = MagicMock()

--- a/tests/debate/test_arena_phases.py
+++ b/tests/debate/test_arena_phases.py
@@ -165,6 +165,18 @@ class TestInitPhases:
         _, kwargs = mock_gatherer_cls.call_args
         assert kwargs["enable_rlm_compression"] is False
 
+    def test_init_phases_passes_skip_empty_sidecars_flag_to_context_gatherer(self):
+        """ContextGatherer should receive the protocol sidecar skip flag."""
+        mock_arena = self._create_mock_arena()
+        mock_arena.protocol.skip_empty_sidecars = True
+
+        with patch("aragora.debate.arena_phases.ContextGatherer") as mock_gatherer_cls:
+            init_phases(mock_arena)
+
+        assert mock_gatherer_cls.called
+        _, kwargs = mock_gatherer_cls.call_args
+        assert kwargs["skip_empty_sidecars"] is True
+
     def test_init_phases_sets_context_initializer(self):
         """init_phases sets context_initializer attribute."""
         mock_arena = self._create_mock_arena()

--- a/tests/debate/test_protocol.py
+++ b/tests/debate/test_protocol.py
@@ -133,6 +133,16 @@ class TestDebateProtocolDefaults:
         protocol = DebateProtocol()
         assert protocol.enable_breakpoints is True
 
+    def test_default_skip_empty_sidecars_disabled(self):
+        """Default keeps optional sidecars enabled."""
+        protocol = DebateProtocol()
+        assert protocol.skip_empty_sidecars is False
+
+    def test_skip_empty_sidecars_can_be_enabled(self):
+        """Protocol accepts the sidecar skip flag."""
+        protocol = DebateProtocol(skip_empty_sidecars=True)
+        assert protocol.skip_empty_sidecars is True
+
 
 class TestDebateProtocolConsensusTypes:
     """Tests for consensus type configurations."""


### PR DESCRIPTION
## Summary
- add a protocol flag to skip optional research and knowledge sidecars for short generic questions
- wire the protocol flag into ContextGatherer so Arena initialization actually respects it
- add focused protocol, gatherer, and arena wiring regressions for the sidecar skip path

## Testing
- python3 -m pytest tests/debate/test_protocol.py -x -q -k sidecar
- python3 -m pytest tests/debate/context_gatherer/test_gatherer.py -x -q -k sidecar
- python3 -m pytest tests/debate/test_arena_phases.py -x -q -k sidecar
- python3 -m ruff check aragora/debate/protocol.py aragora/debate/context_gatherer/gatherer.py aragora/debate/arena_phases.py tests/debate/test_protocol.py tests/debate/context_gatherer/test_gatherer.py tests/debate/test_arena_phases.py

Closes #1756