### PR TITLE
fix(supervisor): narrow broad scopes to explicit file hints

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -77,6 +77,65 @@ def _path_in_scope(path: str, scope_pattern: str) -> bool:
     return _path_matches_glob(clean_path, clean_scope)
 
 
+def _is_concrete_repo_path(path: str) -> bool:
+    clean = path.strip().removeprefix("./").rstrip("/")
+    if not clean or any(token in clean for token in ("*", "?", "[", "]", "{", "}")):
+        return False
+    name = clean.rsplit("/", 1)[-1]
+    return "." in name
+
+
+def _narrow_scope_to_explicit_paths(
+    item: BoundedWorkOrder,
+    spec: SwarmSpec,
+) -> BoundedWorkOrder:
+    """Replace broad container scopes with explicit file paths named in task text."""
+    if not item.file_scope:
+        return item
+    inference_text = " ".join(
+        filter(
+            None,
+            [
+                spec.refined_goal or "",
+                spec.raw_goal or "",
+                item.title or "",
+                item.description or "",
+            ],
+        )
+    )
+    explicit_paths = [
+        path
+        for path in SwarmSpec.infer_file_scope_hints(inference_text)
+        if _is_concrete_repo_path(path)
+    ]
+    if not explicit_paths:
+        return item
+
+    original_scope = [str(path).strip() for path in item.file_scope if str(path).strip()]
+    if not original_scope:
+        return item
+
+    narrowed_scope: list[str] = []
+    replaced = False
+    for scope in original_scope:
+        contains_explicit = any(_path_in_scope(path, scope) for path in explicit_paths)
+        if contains_explicit and scope not in explicit_paths and not _is_concrete_repo_path(scope):
+            replaced = True
+            continue
+        narrowed_scope.append(scope)
+    if not replaced:
+        return item
+
+    item.file_scope = list(dict.fromkeys(narrowed_scope + explicit_paths))
+    logger.info(
+        "Narrowed broad file_scope on work order %s using explicit path hints: %s -> %s",
+        item.work_order_id,
+        original_scope,
+        item.file_scope,
+    )
+    return item
+
+
 def _ensure_work_order_scope(
     item: BoundedWorkOrder,
     spec: SwarmSpec,
@@ -136,7 +195,7 @@ def _ensure_work_order_scope(
                 item.work_order_id,
             )
 
-    return item
+    return _narrow_scope_to_explicit_paths(item, spec)
 
 
 class SupervisorRunStatus(str, Enum):
@@ -1871,6 +1930,7 @@ class SwarmSupervisor:
                             merged,
                         )
                     item.file_scope = merged
+            _narrow_scope_to_explicit_paths(item, spec)
             item.expected_tests = self._default_tests(item, spec)
             item.risk_level = str(item.risk_level).strip() or self._risk_level_for_scope(
                 item.file_scope

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -1247,6 +1247,110 @@ def test_explicit_work_orders_merge_spec_file_scope_hints(
     )
 
 
+def test_start_run_narrows_broad_scope_when_goal_names_specific_doc_path(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    lifecycle = MagicMock()
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="subtask_1",
+                title="Write governance ADR",
+                description="Write docs/governance/duplicate-subsystem-resolution.md.",
+                file_scope=["docs/governance/"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal="Write docs/governance/duplicate-subsystem-resolution.md with the resolution plan.",
+            refined_goal="Write docs/governance/duplicate-subsystem-resolution.md with the resolution plan.",
+        ),
+        refresh_scaling=False,
+    )
+
+    assert run.work_orders[0]["file_scope"] == ["docs/governance/duplicate-subsystem-resolution.md"]
+
+
+def test_start_run_narrows_explicit_spec_broad_scope_when_description_names_specific_path(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+
+    spec = SwarmSpec(
+        raw_goal="Write docs/plans/phase0b_campaign_manifest.yaml from the bootstrap plan.",
+        refined_goal="Write docs/plans/phase0b_campaign_manifest.yaml from the bootstrap plan.",
+        work_orders=[
+            {
+                "work_order_id": "manifest-lane",
+                "title": "Manifest lane",
+                "description": "Write docs/plans/phase0b_campaign_manifest.yaml from the bootstrap plan.",
+                "file_scope": ["docs/"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+            }
+        ],
+    )
+
+    run = supervisor.start_run(spec=spec, refresh_scaling=False)
+
+    assert run.work_orders[0]["file_scope"] == ["docs/plans/phase0b_campaign_manifest.yaml"]
+
+
+def test_start_run_preserves_broad_scope_without_explicit_path_hints(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    lifecycle = MagicMock()
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="subtask_1",
+                title="Write governance ADR",
+                description="Write the governance ADR.",
+                file_scope=["docs/governance/"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal="Write the governance ADR.",
+            refined_goal="Write the governance ADR.",
+        ),
+        refresh_scaling=False,
+    )
+
+    assert run.work_orders[0]["file_scope"] == ["docs/governance/"]
+
+
 def test_start_run_fails_closed_when_work_order_scope_remains_empty(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- replace broad container scopes with explicit repo paths mentioned in the goal or work order text
- keep existing specific paths and only narrow when a concrete file hint is available
- add supervisor coverage for explicit work orders and scope narrowing behavior

## Validation
- `python3 -m pytest tests/swarm/test_supervisor.py -q`
- `python3 -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py`