### PR TITLE
fix(nomic): group superseded conflicts by tranche lane

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -1918,9 +1918,6 @@ class DevCoordinationStore:
 
             grouped_waiting_by_goal: dict[str, list[tuple[dict[str, Any], dict[str, Any]]]] = {}
             for record in records:
-                goal_key = _canonical_goal_key(record.get("goal"))
-                if not goal_key:
-                    continue
                 for item in record["work_orders"]:
                     if not isinstance(item, dict):
                         continue
@@ -1931,7 +1928,10 @@ class DevCoordinationStore:
                         lease_status=lease_status_by_id.get(_optional_text(item.get("lease_id"))),
                     ):
                         continue
-                    grouped_waiting_by_goal.setdefault(goal_key, []).append((record, item))
+                    group_key = _superseded_waiting_conflict_group_key(item, run=record)
+                    if not group_key:
+                        continue
+                    grouped_waiting_by_goal.setdefault(group_key, []).append((record, item))
 
             changed_run_ids: set[str] = set()
             for siblings in grouped_waiting_by_goal.values():
@@ -6372,6 +6372,22 @@ def _duplicate_waiting_conflict_group_key(
     if not goal_key:
         return None
     return ("goal", goal_key, scope_key)
+
+
+def _superseded_waiting_conflict_group_key(
+    work_order: dict[str, Any],
+    *,
+    run: dict[str, Any],
+) -> str | None:
+    metadata = work_order.get("metadata")
+    if isinstance(metadata, dict):
+        tranche_lane_id = _optional_text(metadata.get("tranche_lane_id"))
+        if tranche_lane_id:
+            return f"lane:{tranche_lane_id}"
+    goal_key = _canonical_goal_key(run.get("goal"))
+    if not goal_key:
+        return None
+    return f"goal:{goal_key}"
 
 
 def _duplicate_work_order_leasing_failed_priority(

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -1974,6 +1974,79 @@ def test_archive_superseded_waiting_conflict_work_orders_discards_cross_run_cont
     assert newer_refreshed["work_orders"][0]["status"] == "waiting_conflict"
 
 
+def test_archive_superseded_waiting_conflict_work_orders_discards_cross_run_contained_same_lane_with_goal_drift(
+    store: DevCoordinationStore,
+) -> None:
+    older = store.create_supervisor_run(
+        goal="Tighten the design partner motion into a bounded founder sales artifact.",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "proj-001",
+                "title": "Narrow docs lane",
+                "status": "waiting_conflict",
+                "file_scope": ["docs/outreach/**", "docs/plans/**", "docs/strategy/**"],
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "tranche_lane_id": "proj-001",
+                },
+            }
+        ],
+    )
+    newer = store.create_supervisor_run(
+        goal="Connect the results page to backend endpoints with truthful live-state behavior.",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "proj-001",
+                "title": "Broader docs lane",
+                "status": "waiting_conflict",
+                "file_scope": ["aragora/live/**", "tests/e2e/**", "tests/handlers/**", "docs/**"],
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "tranche_lane_id": "proj-001",
+                },
+            }
+        ],
+    )
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE supervisor_runs SET created_at = ?, updated_at = ? WHERE run_id = ?",
+            ("2000-01-01T00:00:00+00:00", "2000-01-01T00:00:00+00:00", older["run_id"]),
+        )
+        conn.execute(
+            "UPDATE supervisor_runs SET created_at = ?, updated_at = ? WHERE run_id = ?",
+            ("2000-01-02T00:00:00+00:00", "2000-01-02T00:00:00+00:00", newer["run_id"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    archived = store.archive_superseded_waiting_conflict_work_orders(grace_period_hours=24.0)
+    older_refreshed = store.get_supervisor_run(older["run_id"])
+    newer_refreshed = store.get_supervisor_run(newer["run_id"])
+
+    assert archived == 1
+    assert older_refreshed is not None
+    assert newer_refreshed is not None
+    assert older_refreshed["work_orders"][0]["status"] == "discarded"
+    assert (
+        older_refreshed["work_orders"][0]["metadata"]["archive_reason"]
+        == "cross_run_contained_waiting_conflict_sibling"
+    )
+    assert older_refreshed["work_orders"][0]["metadata"]["canonical_run_id"] == newer["run_id"]
+    assert older_refreshed["work_orders"][0]["metadata"]["canonical_work_order_id"] == "proj-001"
+    assert newer_refreshed["work_orders"][0]["status"] == "waiting_conflict"
+
+
 def test_archive_superseded_waiting_conflict_work_orders_discards_glob_and_trailing_slash_variants(
     store: DevCoordinationStore,
 ) -> None:


### PR DESCRIPTION
## Summary
- group cross-run superseded waiting-conflict archival by `tranche_lane_id` when present
- fall back to goal grouping only when a tranche lane is unavailable
- add regression coverage for same-lane archival even when goal text drifts across runs

## Validation
- `python3 -m pytest tests/nomic/test_dev_coordination.py -q`
- `python3 -m ruff check aragora/nomic/dev_coordination.py tests/nomic/test_dev_coordination.py`