### PR TITLE
fix(supervisor): ignore boilerplate in duplicate conflict goals

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -6460,8 +6460,30 @@ def _collapse_scope_patterns(patterns: list[str]) -> list[str]:
 
 
 def _canonical_goal_key(value: Any) -> str:
-    text = " ".join(str(value or "").split()).strip().lower()
-    return text
+    text = str(value or "").strip()
+    for paragraph in re.split(r"\n\s*\n", text):
+        candidate = " ".join(paragraph.split()).strip()
+        if not candidate:
+            continue
+        lower = candidate.lower()
+        if lower.startswith(
+            (
+                "## ",
+                "validation",
+                "allowed write scope",
+                "verification commands",
+                "source issue context",
+                "acceptance criteria",
+                "context",
+                "goal",
+            )
+        ):
+            continue
+        first_sentence = re.split(r"(?<=[.!?])\s+", candidate, maxsplit=1)[0]
+        normalized = " ".join(first_sentence.split()).strip().lower()
+        if normalized:
+            return normalized
+    return " ".join(text.split()).strip().lower()
 
 
 def _claim_contains(container: str, containee: str) -> bool:

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1552,7 +1552,30 @@ class SwarmSupervisor:
 
     @staticmethod
     def _normalized_goal_signature(value: Any) -> str:
-        return " ".join(str(value or "").split()).strip().lower()
+        text = str(value or "").strip()
+        for paragraph in re.split(r"\n\s*\n", text):
+            candidate = " ".join(paragraph.split()).strip()
+            if not candidate:
+                continue
+            lower = candidate.lower()
+            if lower.startswith(
+                (
+                    "## ",
+                    "validation",
+                    "allowed write scope",
+                    "verification commands",
+                    "source issue context",
+                    "acceptance criteria",
+                    "context",
+                    "goal",
+                )
+            ):
+                continue
+            first_sentence = re.split(r"(?<=[.!?])\s+", candidate, maxsplit=1)[0]
+            normalized = " ".join(first_sentence.split()).strip().lower()
+            if normalized:
+                return normalized
+        return " ".join(text.split()).strip().lower()
 
     @staticmethod
     def _task_has_concrete_deliverable(task: Any) -> bool:

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -2327,6 +2327,74 @@ def test_archive_duplicate_waiting_conflict_work_orders_discards_same_tranche_la
     assert newer_refreshed["work_orders"][0]["status"] == "waiting_conflict"
 
 
+def test_archive_duplicate_waiting_conflict_work_orders_discards_same_scope_same_first_sentence_with_boilerplate(
+    store: DevCoordinationStore,
+) -> None:
+    older = store.create_supervisor_run(
+        goal=(
+            "Connect the results page to backend endpoints to display debate outcomes, "
+            "consensus/dissent analysis, and confidence scores.\n\n"
+            "Tranche objective: Make one already reachable core page functional."
+        ),
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "lane-old",
+                "title": "Results lane",
+                "status": "waiting_conflict",
+                "file_scope": ["aragora/live/**", "tests/e2e/**", "tests/handlers/**", "docs/**"],
+            }
+        ],
+    )
+    newer = store.create_supervisor_run(
+        goal=(
+            "Connect the results page to backend endpoints to display debate outcomes, "
+            "consensus/dissent analysis, and confidence scores. Include empty-state handling.\n\n"
+            "Verification commands:\n- python3 -m pytest tests/swarm/test_tranche_e2e.py -q"
+        ),
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "lane-new",
+                "title": "Results lane",
+                "status": "waiting_conflict",
+                "file_scope": ["aragora/live/**", "tests/e2e/**", "tests/handlers/**", "docs/**"],
+            }
+        ],
+    )
+
+    conn = store._connect()
+    try:
+        conn.execute(
+            "UPDATE supervisor_runs SET created_at = ?, updated_at = ? WHERE run_id = ?",
+            ("2000-01-01T00:00:00+00:00", "2000-01-01T00:00:00+00:00", older["run_id"]),
+        )
+        conn.execute(
+            "UPDATE supervisor_runs SET created_at = ?, updated_at = ? WHERE run_id = ?",
+            ("2000-01-02T00:00:00+00:00", "2000-01-02T00:00:00+00:00", newer["run_id"]),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    archived = store.archive_duplicate_waiting_conflict_work_orders()
+    older_refreshed = store.get_supervisor_run(older["run_id"])
+    newer_refreshed = store.get_supervisor_run(newer["run_id"])
+
+    assert archived == 1
+    assert older_refreshed is not None
+    assert newer_refreshed is not None
+    assert older_refreshed["work_orders"][0]["status"] == "discarded"
+    assert older_refreshed["work_orders"][0]["metadata"]["canonical_run_id"] == newer["run_id"]
+    assert newer_refreshed["work_orders"][0]["status"] == "waiting_conflict"
+
+
 def test_archive_duplicate_waiting_conflict_work_orders_discards_scope_less_duplicate(
     store: DevCoordinationStore,
 ) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -376,6 +376,74 @@ def test_start_run_discards_duplicate_scope_less_open_lane(
     assert work_order["metadata"]["canonical_task_key"].endswith(":existing")
 
 
+def test_start_run_discards_duplicate_open_lane_when_goal_differs_only_by_boilerplate(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    store.create_supervisor_run(
+        goal=(
+            "Connect the results page to backend endpoints to display debate outcomes, "
+            "consensus/dissent analysis, and confidence scores.\n\n"
+            "Tranche objective: Make one already reachable core page functional."
+        ),
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "existing",
+                "title": "Results lane",
+                "status": "waiting_conflict",
+                "file_scope": ["aragora/live/**", "tests/e2e/**", "tests/handlers/**", "docs/**"],
+            }
+        ],
+    )
+
+    lifecycle = MagicMock()
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="subtask_1",
+                title="Results lane",
+                description="Connect the results page to backend endpoints and include empty-state handling.",
+                file_scope=["aragora/live/**", "tests/e2e/**", "tests/handlers/**", "docs/**"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal=(
+                "Connect the results page to backend endpoints to display debate outcomes, "
+                "consensus/dissent analysis, and confidence scores. Include empty-state handling.\n\n"
+                "Verification commands:\n- python3 -m pytest tests/swarm/test_tranche_e2e.py -q"
+            ),
+            refined_goal=(
+                "Connect the results page to backend endpoints to display debate outcomes, "
+                "consensus/dissent analysis, and confidence scores. Include empty-state handling.\n\n"
+                "Verification commands:\n- python3 -m pytest tests/swarm/test_tranche_e2e.py -q"
+            ),
+        ),
+        refresh_scaling=False,
+    )
+
+    work_order = run.work_orders[0]
+    assert work_order["status"] == "discarded"
+    assert work_order["metadata"]["archived_due_to"] == "duplicate_open_work_order"
+    assert work_order["metadata"]["canonical_task_key"].endswith(":existing")
+
+
 def test_start_run_discards_duplicate_scope_less_explicit_lane_by_tranche_lane_id(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- normalize duplicate conflict goal matching by ignoring validation and tranche boilerplate
- use the first substantive sentence for duplicate detection in both the coordination store and supervisor
- add regression coverage for goal text that differs only by boilerplate

## Validation
- `python3 -m pytest tests/nomic/test_dev_coordination.py tests/swarm/test_supervisor.py -q`
- `python3 -m ruff check aragora/nomic/dev_coordination.py aragora/swarm/supervisor.py tests/nomic/test_dev_coordination.py tests/swarm/test_supervisor.py`