### PR TITLE
fix(worker-launcher): fail closed on missing exit markers

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1169,8 +1169,9 @@ class WorkerLauncher:
         """
         session_meta = cls._read_session_meta(worktree_path)
         session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
+        missing_terminal_marker = session_exit_code is None and pid is not None
 
-        if session_exit_code is None and pid is not None and cls._is_pid_running(pid):
+        if missing_terminal_marker and cls._is_pid_running(pid):
             return None
 
         worker = WorkerProcess(
@@ -1254,6 +1255,14 @@ class WorkerLauncher:
             len(worker.commit_shas),
             len(worker.changed_paths),
         )
+        if missing_terminal_marker:
+            # A dead detached PID with no terminal session marker should not be
+            # reported as a clean success. Only surface it if there is concrete
+            # work to salvage; otherwise let the supervisor classify it as
+            # "without receipt or exit marker".
+            if not worker.commit_shas and not worker.changed_paths:
+                return None
+            worker.exit_code = 1
         return worker
 
     @staticmethod

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1064,7 +1064,7 @@ class TestCollectDetachedResult:
             )
 
         assert result is not None
-        assert result.exit_code == 0
+        assert result.exit_code == 1
         assert result.head_sha == "abc123"
         assert result.commit_shas == ["abc123"]
         assert result.changed_paths == ["file.py"]
@@ -1072,6 +1072,30 @@ class TestCollectDetachedResult:
         assert result.verification_results == verification_results
         assert result.stdout == "some output"
         mock_verify.assert_awaited_once_with("/tmp/wt", [expected_test])
+
+    @pytest.mark.asyncio
+    async def test_returns_none_if_pid_dead_without_terminal_marker_or_deliverable(self):
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-no-marker",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=99999,
+                initial_head="def456",
+            )
+
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_collects_without_pid(self):


### PR DESCRIPTION
## Summary
- stop detached collection from reporting a dead worker as a clean success when the session exit marker is missing
- still surface real salvageable work by returning a non-zero result when commits or changed paths exist
- add launcher coverage for both the salvage and no-deliverable paths

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q -k 'collect_finished_results_backfills_receipt_for_salvaged_detached_deliverable or refresh_run_collects_finished_detached_worker_before_stale_lease_reap or marks_dead_dispatched_worker_needs_human'