### PR TITLE
fix(stream): redact spectator PII in live events

### DIFF
--- a/aragora/server/handlers/debates/spectate.py
+++ b/aragora/server/handlers/debates/spectate.py
@@ -15,6 +15,7 @@ from typing import Any
 from aragora.rbac.decorators import require_permission
 from aragora.rbac.models import AuthorizationContext
 from aragora.server.handlers.base import HandlerResult, json_response
+from aragora.spectate.redaction import redact_spectator_payload
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ def push_spectator_event(
         "metric": metric,
         "round": round_number,
     }
+    event = redact_spectator_payload(event)
 
     pushed = 0
     dead: list[asyncio.Queue] = []

--- a/aragora/server/stream/servers_ws_handler.py
+++ b/aragora/server/stream/servers_ws_handler.py
@@ -34,6 +34,7 @@ from .events import (
 from aragora.config import WS_MAX_MESSAGE_SIZE
 from aragora.server.cors_config import WS_ALLOWED_ORIGINS
 from aragora.server.security.request_limits import check_json_depth
+from aragora.spectate.redaction import redact_spectator_payload
 
 # RFC 6455 close codes
 WS_CLOSE_UNSUPPORTED_DATA = 1003  # Unsupported data (e.g., invalid JSON)
@@ -333,11 +334,11 @@ class WebSocketHandlerMixin:
                 payload["current_round"] = state.get("current_round", 0)
                 payload["message_count"] = len(state.get("messages", []))
 
-        return payload
+        return redact_spectator_payload(payload)
 
     def _serialize_spectate_event(self, event: Any) -> dict[str, Any]:
         """Translate buffered spectate bridge events into the live client protocol."""
-        data = getattr(event, "data", {}) or {}
+        data = redact_spectator_payload(getattr(event, "data", {}) or {})
         payload: dict[str, Any] = {
             "type": getattr(event, "event_type", "system"),
             "timestamp": self._spectate_timestamp_to_epoch(getattr(event, "timestamp", None)),
@@ -359,7 +360,7 @@ class WebSocketHandlerMixin:
             if key in data:
                 payload[key] = data[key]
 
-        return payload
+        return redact_spectator_payload(payload)
 
     async def _handle_spectate_websocket(self, request) -> aiohttp.web.StreamResponse:
         """Handle debate or pipeline spectate sockets used by the live UI."""

--- a/aragora/spectate/redaction.py
+++ b/aragora/spectate/redaction.py
@@ -1,0 +1,80 @@
+"""PII redaction helpers for spectator-facing event payloads."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aragora.services.pii_redactor import PIIRedactor, PIIType
+
+_REDACTABLE_TEXT_KEYS = frozenset(
+    {
+        "content",
+        "description",
+        "details",
+        "message",
+        "reason",
+        "summary",
+        "task",
+        "text",
+    }
+)
+
+_spectator_redactor = PIIRedactor(
+    enabled_types=[
+        PIIType.EMAIL,
+        PIIType.PHONE,
+        PIIType.SSN,
+    ],
+    log_redactions=False,
+)
+
+
+def redact_spectator_text(value: str) -> str:
+    """Redact high-confidence spectator-facing PII from freeform text."""
+    return _spectator_redactor.redact(value).redacted_text
+
+
+def redact_spectator_payload(
+    value: Any,
+    *,
+    key: str | None = None,
+    redact_nested: bool = False,
+) -> Any:
+    """Recursively redact spectator payload fields that carry freeform text."""
+    should_redact = redact_nested or key in _REDACTABLE_TEXT_KEYS
+
+    if isinstance(value, dict):
+        nested_redaction = should_redact
+        return {
+            item_key: redact_spectator_payload(
+                item_value,
+                key=item_key,
+                redact_nested=nested_redaction,
+            )
+            for item_key, item_value in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            redact_spectator_payload(
+                item,
+                key=key,
+                redact_nested=should_redact,
+            )
+            for item in value
+        ]
+
+    if isinstance(value, tuple):
+        return tuple(
+            redact_spectator_payload(
+                item,
+                key=key,
+                redact_nested=should_redact,
+            )
+            for item in value
+        )
+
+    if should_redact and isinstance(value, str):
+        return redact_spectator_text(value)
+
+    return value

--- a/aragora/spectate/ws_bridge.py
+++ b/aragora/spectate/ws_bridge.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable
 
+from aragora.spectate.redaction import redact_spectator_payload
+
 logger = logging.getLogger(__name__)
 
 _spectate_context: contextvars.ContextVar[dict[str, Any]] = contextvars.ContextVar(
@@ -99,7 +101,7 @@ class SpectateEvent:
         return {
             "event_type": self.event_type,
             "timestamp": self.timestamp,
-            "data": self.data,
+            "data": redact_spectator_payload(self.data),
             "debate_id": self.debate_id,
             "pipeline_id": self.pipeline_id,
             "agent_name": self.agent_name,
@@ -281,6 +283,8 @@ class SpectateWebSocketBridge:
         agents = context.get("agents")
         if isinstance(agents, list) and agents and "agents" not in data:
             data["agents"] = list(agents)
+
+        data = redact_spectator_payload(data)
 
         event = SpectateEvent(
             event_type=event_type,

--- a/tests/server/stream/test_pii_redaction.py
+++ b/tests/server/stream/test_pii_redaction.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+import aiohttp
+import aiohttp.web
+import pytest
+
+from aragora.server.handlers.debates.spectate import (
+    get_active_collectors,
+    push_spectator_event,
+)
+from aragora.server.stream.servers import AiohttpUnifiedServer
+from aragora.spectate.ws_bridge import SpectateEvent, get_spectate_bridge, reset_spectate_bridge
+
+PII_TEXT = "Contact patient@example.com or 555-123-4567 with SSN 123-45-6789."
+
+
+def _assert_pii_redacted(value: str) -> None:
+    assert "patient@example.com" not in value
+    assert "555-123-4567" not in value
+    assert "123-45-6789" not in value
+    assert "[EMAIL_REDACTED]" in value
+    assert "[PHONE_REDACTED]" in value
+    assert "[SSN_REDACTED]" in value
+
+
+@dataclass
+class _FakeWSMsg:
+    type: aiohttp.WSMsgType
+    data: str = ""
+
+
+class _StubWSIter:
+    def __init__(self, messages: list[_FakeWSMsg]):
+        self._messages = iter(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> _FakeWSMsg:
+        try:
+            return next(self._messages)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class _StubWebSocket:
+    def __init__(self, messages: list[_FakeWSMsg] | None = None):
+        self._messages = list(messages or [])
+        self.sent_json: list[dict[str, Any]] = []
+        self.closed = False
+
+    async def prepare(self, request: Any) -> "_StubWebSocket":
+        return self
+
+    async def send_json(self, data: dict[str, Any]) -> None:
+        self.sent_json.append(data)
+
+    async def close(self, *args: Any, **kwargs: Any) -> None:
+        self.closed = True
+
+    def __aiter__(self):
+        return _StubWSIter(self._messages)
+
+
+@dataclass
+class _MockRequest:
+    headers: dict[str, str]
+    match_info: dict[str, str]
+    query: dict[str, str]
+    remote: str = "127.0.0.1"
+
+
+@pytest.fixture(autouse=True)
+def _reset_spectate_state():
+    reset_spectate_bridge()
+    get_active_collectors().clear()
+    yield
+    get_active_collectors().clear()
+    reset_spectate_bridge()
+
+
+def _make_request(*, debate_id: str | None = None) -> _MockRequest:
+    match_info = {"debate_id": debate_id} if debate_id else {}
+    return _MockRequest(
+        headers={"Origin": "https://aragora.ai"},
+        match_info=match_info,
+        query={},
+    )
+
+
+class TestPIIRedaction:
+    def test_bridge_redacts_pii_in_buffered_raw_events(self):
+        bridge = get_spectate_bridge()
+
+        bridge._forward_event(
+            "proposal",
+            agent="claude",
+            details=PII_TEXT,
+            round_number=1,
+        )
+
+        event = bridge.get_recent_events(1)[0]
+        _assert_pii_redacted(event.data["details"])
+        _assert_pii_redacted(event.to_dict()["data"]["details"])
+
+    def test_push_spectator_event_redacts_pii_before_queueing(self):
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        get_active_collectors()["debate-123"] = {queue}
+
+        pushed = push_spectator_event(
+            "debate-123",
+            "proposal",
+            agent="claude",
+            details=PII_TEXT,
+            round_number=1,
+        )
+
+        assert pushed == 1
+        event = queue.get_nowait()
+        _assert_pii_redacted(event["details"])
+
+    @pytest.mark.asyncio
+    async def test_websocket_redacts_pii_in_metadata_and_backlog_payload(self, monkeypatch):
+        ws_stub = _StubWebSocket(messages=[_FakeWSMsg(type=aiohttp.WSMsgType.CLOSE)])
+        monkeypatch.setattr(aiohttp.web, "WebSocketResponse", lambda **_: ws_stub)
+
+        server = AiohttpUnifiedServer(port=0, host="127.0.0.1")
+        server.set_debate_state(
+            "debate-123",
+            {
+                "loop_id": "debate-123",
+                "task": f"Review proposal: {PII_TEXT}",
+                "agents": ["claude", "gpt4"],
+                "status": "running",
+                "current_round": 2,
+                "messages": [],
+            },
+        )
+
+        bridge = get_spectate_bridge()
+        bridge._event_buffer.append(
+            SpectateEvent(
+                event_type="proposal",
+                timestamp="2026-03-31T20:00:00+00:00",
+                debate_id="debate-123",
+                agent_name="claude",
+                round_number=2,
+                data={
+                    "details": PII_TEXT,
+                    "task": f"Backlog task: {PII_TEXT}",
+                },
+            )
+        )
+
+        await server._handle_spectate_websocket(_make_request(debate_id="debate-123"))
+
+        _assert_pii_redacted(ws_stub.sent_json[0]["task"])
+        _assert_pii_redacted(ws_stub.sent_json[1]["details"])
+        _assert_pii_redacted(ws_stub.sent_json[1]["task"])


### PR DESCRIPTION
## Summary
- redact spectator-facing freeform text in buffered spectate events and SSE fan-out
- scrub task/details fields again at websocket metadata and backlog serialization boundaries
- add a focused regression suite for raw buffered events, SSE queueing, and websocket payloads

Closes #1760

## Validation
- python3 -m pytest tests/server/stream/test_pii_redaction.py tests/server/stream/test_spectate_websocket.py tests/server/handlers/test_spectate.py -x -q
- python3 -m ruff check aragora/spectate/redaction.py aragora/spectate/ws_bridge.py aragora/server/handlers/debates/spectate.py aragora/server/stream/servers_ws_handler.py tests/server/stream/test_pii_redaction.py