### PR TITLE
fix(worker-launcher): fail closed without exit marker

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1169,9 +1169,16 @@ class WorkerLauncher:
         """
         session_meta = cls._read_session_meta(worktree_path)
         session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
-        missing_terminal_marker = session_exit_code is None and pid is not None
+        observed_pid = cls._normalized_pid(pid)
+        if observed_pid is None:
+            observed_pid = cls._normalized_pid(session_meta.get("pid"))
+        missing_terminal_marker = session_exit_code is None
 
-        if missing_terminal_marker and cls._is_pid_running(pid):
+        if (
+            missing_terminal_marker
+            and observed_pid is not None
+            and cls._is_pid_running(observed_pid)
+        ):
             return None
 
         worker = WorkerProcess(
@@ -1179,7 +1186,7 @@ class WorkerLauncher:
             agent=agent,
             worktree_path=worktree_path,
             branch=branch,
-            pid=pid,
+            pid=observed_pid,
             initial_head=initial_head,
             expected_tests=[
                 str(item).strip() for item in expected_tests or [] if str(item).strip()
@@ -1237,14 +1244,7 @@ class WorkerLauncher:
             # fully terminate before removing artifacts.  Without this wait
             # the codex_session.sh trap can recreate .codex_session_meta.json
             # and append to .codex_session.log after Python-side cleanup (#902).
-            _cleanup_pid = pid
-            if _cleanup_pid is None:
-                raw_pid = session_meta.get("pid")
-                if raw_pid is not None:
-                    try:
-                        _cleanup_pid = int(raw_pid)
-                    except (TypeError, ValueError):
-                        pass
+            _cleanup_pid = observed_pid
             if _cleanup_pid is not None:
                 await cls._wait_for_pid_exit(_cleanup_pid)
             cls._cleanup_session_artifacts(worktree_path)
@@ -1273,6 +1273,14 @@ class WorkerLauncher:
         except (FileNotFoundError, OSError, json.JSONDecodeError):
             return {}
         return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _normalized_pid(raw_pid: Any) -> int | None:
+        try:
+            pid = int(raw_pid)
+        except (TypeError, ValueError):
+            return None
+        return pid if pid > 0 else None
 
     @staticmethod
     def _cleanup_session_artifacts(worktree_path: str) -> None:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1098,8 +1098,7 @@ class TestCollectDetachedResult:
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_collects_without_pid(self):
-        """When no PID is stored, always collect (assume finished)."""
+    async def test_returns_none_without_pid_or_terminal_marker_and_no_deliverable(self):
         with (
             patch.object(WorkerLauncher, "_collect_diff", return_value=""),
             patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
@@ -1114,8 +1113,24 @@ class TestCollectDetachedResult:
                 branch="main",
             )
 
-        assert result is not None
-        assert result.exit_code == 0
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_uses_session_meta_pid_to_defer_when_marker_missing(self):
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=True) as mock_running,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-meta-pid-running",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=None,
+            )
+
+        assert result is None
+        mock_running.assert_called_once_with(24680)
 
 
 class TestSnapshotProgress:


### PR DESCRIPTION
## Summary
- fail closed when detached collection has no terminal session marker, even if the supervisor no longer has a PID in memory
- fall back to the session metadata PID for running-process detection and cleanup when the explicit PID is missing
- cover the no-PID/no-marker regression in worker-launcher tests

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q -k 'worker_exited_without_receipt or collect_finished_results or refresh_run_async_context_collects_finished_in_memory_worker or falls_back_when_in_memory_collection_raises'