### PR TITLE
fix(webhook-store): accept native jsonb event payloads

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -157,6 +157,21 @@ def _decrypt_secret(encrypted_secret: str) -> str:
         return encrypted_secret  # Return as-is if decryption fails
 
 
+def _deserialize_events(value: Any) -> list[str]:
+    """Normalize stored event payloads from JSON strings or native sequences."""
+    if value is None:
+        return []
+    payload = value
+    if isinstance(payload, str):
+        payload = json.loads(payload) if payload else []
+    elif isinstance(payload, bytes):
+        payload = json.loads(payload.decode("utf-8")) if payload else []
+    if isinstance(payload, (list, tuple, set)):
+        return [str(item) for item in payload]
+    logger.debug("Unexpected webhook events payload type: %s", type(payload).__name__)
+    return []
+
+
 # Events that can trigger webhooks
 WEBHOOK_EVENTS: set[str] = {
     "debate_start",
@@ -240,7 +255,7 @@ class WebhookConfig:
         return cls(
             id=row[0],
             url=row[1],
-            events=json.loads(row[2]) if row[2] else [],
+            events=_deserialize_events(row[2]),
             secret=_decrypt_secret(row[3] or ""),
             active=bool(row[4]),
             created_at=row[5] or time.time(),
@@ -1095,7 +1110,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
         return WebhookConfig(
             id=row["id"],
             url=row["url"],
-            events=json.loads(row["events_json"]) if row["events_json"] else [],
+            events=_deserialize_events(row["events_json"]),
             secret=_decrypt_secret(row["secret"] or ""),
             active=bool(row["active"]),
             created_at=row["created_at"] or time.time(),

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -503,6 +503,29 @@ class TestWebhookConfig:
         assert config.user_id == "user-row"
         assert config.workspace_id == "ws-row"
 
+    def test_from_row_with_native_events_sequence(self):
+        """Test from_row accepts already-decoded event sequences."""
+        now = time.time()
+        row = (
+            "row-id",
+            "https://example.com/hook",
+            ["debate_end", "vote"],
+            "plain-secret",
+            1,
+            now,
+            now,
+            "Row Hook",
+            "A row-based hook",
+            None,
+            None,
+            0,
+            0,
+            None,
+            None,
+        )
+        config = WebhookConfig.from_row(row)
+        assert config.events == ["debate_end", "vote"]
+
     def test_from_row_with_null_optional_fields(self):
         """Test from_row handles NULL values for optional fields."""
         now = time.time()
@@ -1503,6 +1526,34 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
 
         assert result is None
         mock_run.assert_called_once()
+
+    def test_row_to_config_accepts_native_jsonb_sequence(self, postgres_store) -> None:
+        """Postgres JSONB rows may already be decoded into Python sequences."""
+        now = time.time()
+        row = {
+            "id": "webhook-123",
+            "url": "https://example.com/hook",
+            "events_json": ["debate_end", "vote"],
+            "secret": "plain-secret",
+            "active": True,
+            "created_at": now,
+            "updated_at": now,
+            "name": "Example Hook",
+            "description": "Example description",
+            "last_delivery_at": None,
+            "last_delivery_status": None,
+            "delivery_count": 0,
+            "failure_count": 0,
+            "user_id": "user-123",
+            "workspace_id": "ws-123",
+        }
+
+        config = postgres_store._row_to_config(row)
+
+        assert config.id == "webhook-123"
+        assert config.events == ["debate_end", "vote"]
+        assert config.user_id == "user-123"
+        assert config.workspace_id == "ws-123"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- normalize webhook event payloads from either JSON strings or native Python sequences
- harden both tuple-row and Postgres row decoding so JSONB-backed reads do not assume string-only payloads
- add regressions for native event sequences in the storage test suite

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q