### PR TITLE
fix(pipeline): restore legacy plan store aliases

### DIFF
--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -105,6 +105,11 @@ def _get_backing_store() -> Any:
 _plan_store_fallback: dict[str, DecisionPlan] = {}
 _plan_outcomes_fallback: dict[str, PlanOutcome] = {}
 
+# Backward-compatible aliases for older tests and helper code that still import
+# the original in-memory store symbols directly from this module.
+_plan_store = _plan_store_fallback
+_plan_outcomes = _plan_outcomes_fallback
+
 # Maximum number of plans to keep in the in-memory fallback
 _MAX_PLANS = 1000
 


### PR DESCRIPTION
## Summary
- restore `_plan_store` and `_plan_outcomes` as compatibility aliases in `aragora.pipeline.executor`
- keep the persistent/fallback store refactor intact while unblocking older gold-path imports

## Validation
- python3 -m pytest tests/integration/test_gold_path_pipeline.py --collect-only -q
- python3 -m pytest tests/debate/test_gold_path_integration.py tests/pipeline/test_executor_persistence.py -x -q
- ruff check aragora/pipeline/executor.py