### PR TITLE
fix(debate): persist live explainability in receipts

### DIFF
--- a/aragora/debate/hooks/receipt_delivery_hook.py
+++ b/aragora/debate/hooks/receipt_delivery_hook.py
@@ -191,6 +191,8 @@ class ReceiptDeliveryHook:
         try:
             import hashlib
 
+            from aragora.gauntlet.receipt_models import normalize_live_explainability
+
             # Build receipt data
             receipt_data = {
                 "debate_id": getattr(result, "debate_id", getattr(result, "id", "")),
@@ -205,8 +207,10 @@ class ReceiptDeliveryHook:
                 "org_id": self.org_id,
             }
             result_metadata = getattr(result, "metadata", {}) or {}
-            live_explainability = result_metadata.get("live_explainability")
-            if isinstance(live_explainability, dict):
+            live_explainability = normalize_live_explainability(
+                result_metadata.get("live_explainability")
+            )
+            if live_explainability is not None:
                 receipt_data["explainability"] = {"live_explainability": live_explainability}
 
             # Generate explainability data

--- a/aragora/debate/phases/feedback_phase.py
+++ b/aragora/debate/phases/feedback_phase.py
@@ -1001,6 +1001,18 @@ class FeedbackPhase:
                 existing_explainability = (
                     dict(receipt.explainability) if isinstance(receipt.explainability, dict) else {}
                 )
+                try:
+                    from aragora.gauntlet.receipt_models import normalize_live_explainability
+
+                    live_explainability = normalize_live_explainability(
+                        existing_explainability.get("live_explainability")
+                    )
+                    if live_explainability is None:
+                        existing_explainability.pop("live_explainability", None)
+                    else:
+                        existing_explainability["live_explainability"] = live_explainability
+                except ImportError:
+                    existing_explainability.pop("live_explainability", None)
                 receipt.explainability = {
                     **existing_explainability,
                     "summary": builder.generate_summary(decision),

--- a/aragora/gauntlet/receipt_models.py
+++ b/aragora/gauntlet/receipt_models.py
@@ -27,6 +27,81 @@ if TYPE_CHECKING:
     from .signing import ReceiptSigner
 
 
+def _normalize_live_explainability_text(value: Any, *, max_len: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized[:max_len]
+
+
+def _normalize_live_explainability_number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def normalize_live_explainability(payload: Any) -> dict[str, Any] | None:
+    """Normalize live explainability snapshots before persisting them in receipts."""
+    if not isinstance(payload, dict):
+        return None
+
+    normalized: dict[str, Any] = {}
+
+    factors = payload.get("factors")
+    if isinstance(factors, list):
+        normalized_factors: list[dict[str, Any]] = []
+        for raw_factor in factors[:12]:
+            if not isinstance(raw_factor, dict):
+                continue
+            factor: dict[str, Any] = {}
+            name = _normalize_live_explainability_text(raw_factor.get("name"), max_len=160)
+            if name is not None:
+                factor["name"] = name
+            contribution = _normalize_live_explainability_number(raw_factor.get("contribution"))
+            if contribution is not None:
+                factor["contribution"] = round(contribution, 3)
+            explanation = _normalize_live_explainability_text(
+                raw_factor.get("explanation"),
+                max_len=600,
+            )
+            if explanation is not None:
+                factor["explanation"] = explanation
+            trend = _normalize_live_explainability_text(raw_factor.get("trend"), max_len=64)
+            if trend is not None:
+                factor["trend"] = trend
+            if factor:
+                normalized_factors.append(factor)
+        if normalized_factors:
+            normalized["factors"] = normalized_factors
+
+    narrative = _normalize_live_explainability_text(payload.get("narrative"), max_len=2000)
+    if narrative is not None:
+        normalized["narrative"] = narrative
+
+    leading_position = _normalize_live_explainability_text(
+        payload.get("leading_position"),
+        max_len=160,
+    )
+    if leading_position is not None:
+        normalized["leading_position"] = leading_position
+
+    for key in ("agent_agreement", "evidence_quality", "position_confidence"):
+        number = _normalize_live_explainability_number(payload.get(key))
+        if number is not None:
+            normalized[key] = round(number, 3)
+
+    for key in ("round_num", "evidence_count", "vote_count", "belief_shifts"):
+        number = payload.get(key)
+        if isinstance(number, int) and number >= 0:
+            normalized[key] = number
+
+    return normalized or None
+
+
 @dataclass
 class ProvenanceRecord:
     """A single provenance record in the chain."""
@@ -1089,8 +1164,8 @@ class DecisionReceipt:
         if isinstance(large_roster_runtime, dict):
             config_used["large_roster_runtime"] = large_roster_runtime
         explainability: dict[str, Any] | None = None
-        live_explainability = metadata.get("live_explainability")
-        if isinstance(live_explainability, dict):
+        live_explainability = normalize_live_explainability(metadata.get("live_explainability"))
+        if live_explainability is not None:
             explainability = {"live_explainability": live_explainability}
 
         # Determine verdict from consensus

--- a/tests/debate/test_live_explainability_e2e.py
+++ b/tests/debate/test_live_explainability_e2e.py
@@ -176,17 +176,30 @@ async def test_eventbus_snapshot_survives_receipt_roundtrip(fake_arena, executio
 
     result = execution_state.ctx.result
     live_explainability = result.metadata["live_explainability"]
+    live_explainability["unexpected"] = "<script>alert(1)</script>"
+    live_explainability["factors"].append(
+        {
+            "name": "Injected factor",
+            "contribution": 0.42,
+            "explanation": "  Extra factor with bounded text.  ",
+            "trend": "up",
+            "ignored": "<svg onload=alert(1)>",
+        }
+    )
     assert live_explainability["factors"]
     assert live_explainability["vote_count"] == 3
     assert live_explainability["evidence_count"] == 3
 
     receipt = DecisionReceipt.from_debate_result(result)
     assert receipt.explainability is not None
-    assert receipt.explainability["live_explainability"]["factors"]
-    assert (
-        receipt.explainability["live_explainability"]["leading_position"]
-        == "preserve_live_explainability"
-    )
+    stored_explainability = receipt.explainability["live_explainability"]
+    assert stored_explainability["factors"]
+    assert stored_explainability["leading_position"] == "preserve_live_explainability"
+    assert "unexpected" not in stored_explainability
+    assert "ignored" not in stored_explainability["factors"][-1]
+
+    receipt.sign()
+    assert receipt.verify_signature()
 
     restored = DecisionReceipt.from_dict(receipt.to_dict())
     assert restored.explainability is not None
@@ -195,5 +208,10 @@ async def test_eventbus_snapshot_survives_receipt_roundtrip(fake_arena, executio
         == live_explainability["narrative"]
     )
     assert (
-        restored.explainability["live_explainability"]["factors"] == live_explainability["factors"]
+        restored.explainability["live_explainability"]["factors"]
+        == stored_explainability["factors"]
     )
+    assert restored.verify_signature()
+
+    restored.explainability["live_explainability"]["narrative"] = "tampered"
+    assert not restored.verify_signature()


### PR DESCRIPTION
Fixes #1757

## Summary
- preserve `result.metadata["live_explainability"]` when building debate receipts
- keep that payload during explainability enrichment and receipt-delivery hook generation
- add an end-to-end test covering EventBus -> snapshot -> receipt round-trip

## Validation
- python3 -m pytest tests/debate/test_live_explainability_e2e.py tests/debate/test_live_explainability_wiring.py tests/test_decision_receipt.py -x -q
- ruff check aragora/gauntlet/receipt_models.py aragora/debate/phases/feedback_phase.py aragora/debate/hooks/receipt_delivery_hook.py tests/debate/test_live_explainability_e2e.py