### PR TITLE
fix(slack-oauth): preserve workspace tenant binding

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1082,6 +1082,37 @@ class SlackOAuthHandler(SecureHandler):
                 get_slack_workspace_store,
             )
 
+            store = get_slack_workspace_store()
+            existing_workspace = store.get(workspace_id)
+            existing_tenant_id = (
+                str(getattr(existing_workspace, "tenant_id", "") or "").strip() or None
+            )
+            requested_tenant_id = str(tenant_id or "").strip() or None
+            if (
+                existing_tenant_id
+                and requested_tenant_id
+                and existing_tenant_id != requested_tenant_id
+            ):
+                logger.warning(
+                    "Rejecting Slack workspace %s tenant rebind from %s to %s",
+                    workspace_id,
+                    existing_tenant_id,
+                    requested_tenant_id,
+                )
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="install",
+                        success=False,
+                        user_id=installed_by or "",
+                        error="Workspace is already linked to a different tenant",
+                    )
+                return error_response(
+                    "Workspace is already linked to a different tenant",
+                    409,
+                )
+
             workspace = SlackWorkspace(
                 workspace_id=workspace_id,
                 workspace_name=workspace_name,
@@ -1090,13 +1121,12 @@ class SlackOAuthHandler(SecureHandler):
                 installed_at=time.time(),
                 installed_by=installed_by,
                 scopes=scope.split(",") if scope else [],
-                tenant_id=tenant_id,
+                tenant_id=requested_tenant_id or existing_tenant_id,
                 is_active=True,
                 refresh_token=refresh_token,
                 token_expires_at=token_expires_at,
             )
 
-            store = get_slack_workspace_store()
             if not store.save(workspace):
                 # Audit log save failure
                 audit = _get_oauth_audit_logger()

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -690,6 +690,90 @@ class TestCallback:
         assert "My Team" in html
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_cross_tenant_workspace_rebind(
+        self, handler, mock_workspace, mock_workspace_store, mock_state_store
+    ):
+        mock_workspace.tenant_id = "tenant-2"
+        mock_state_store.validate_and_consume.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": {"id": "W123", "name": "My Team"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history,chat:write",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch("aragora.storage.slack_workspace_store.SlackWorkspace") as mock_workspace_cls,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 409
+        body = _body(result)
+        assert "different tenant" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+        mock_workspace_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_callback_preserves_existing_tenant_when_state_has_no_tenant(
+        self, handler, mock_workspace_store, mock_state_store
+    ):
+        mock_state_store.validate_and_consume.return_value = {
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": {"id": "W123", "name": "My Team"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history,chat:write",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch("aragora.storage.slack_workspace_store.SlackWorkspace") as mock_workspace_cls,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        assert mock_workspace_cls.call_args.kwargs["tenant_id"] == "tenant-1"
+        mock_workspace_store.save.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_callback_slack_api_error(self, handler):
         mock_client, _ = _make_httpx_mock({"ok": False, "error": "invalid_code"})
 
@@ -915,6 +999,7 @@ class TestCallback:
         )
 
         mock_ws_store = MagicMock()
+        mock_ws_store.get.return_value = None
         mock_ws_store.save.return_value = True
 
         with (
@@ -948,6 +1033,7 @@ class TestCallback:
         state_obj = MagicMock()
         state_obj.metadata = {"tenant_id": "t-obj", "provider": "slack"}
         mock_state_store.validate_and_consume.return_value = state_obj
+        mock_workspace_store.get.return_value = None
 
         mock_client, _ = _make_httpx_mock(
             {

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -408,6 +408,7 @@ class TestSlackOAuthCallback:
         mock_response.raise_for_status = MagicMock()
 
         mock_store = MagicMock()
+        mock_store.get.return_value = None
         mock_store.save.return_value = True
 
         with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "id"):
@@ -431,6 +432,55 @@ class TestSlackOAuthCallback:
         assert b"Connected" in result.body
         assert b"Test Workspace" in result.body
         mock_store.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_cross_tenant_rebind(self, oauth_handler, oauth_state_store):
+        """Existing workspaces cannot be rebound to a different tenant via callback."""
+        state = "valid-state"
+        oauth_state_store._states[state] = OAuthState(
+            user_id=None,
+            redirect_url=None,
+            expires_at=time.time() + 600,
+            created_at=time.time(),
+            metadata={"tenant_id": "tenant-001"},
+        )
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "access_token": "xoxb-test-token",
+            "team": {"id": "T12345678", "name": "Test Workspace"},
+            "bot_user_id": "U87654321",
+            "authed_user": {"id": "U11111111"},
+            "scope": "channels:history,chat:write",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        existing_workspace = MagicMock()
+        existing_workspace.tenant_id = "tenant-002"
+        mock_store = MagicMock()
+        mock_store.get.return_value = existing_workspace
+
+        with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "id"):
+            with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_SECRET", "secret"):
+                with patch("httpx.AsyncClient") as mock_client:
+                    mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                        return_value=mock_response
+                    )
+                    with patch(
+                        "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                        return_value=mock_store,
+                    ):
+                        result = await oauth_handler.handle(
+                            "GET",
+                            "/api/integrations/slack/callback",
+                            query_params={"code": "auth-code", "state": state},
+                        )
+
+        assert result.status_code == 409
+        data = parse_handler_response(result)
+        assert "different tenant" in data.get("error", "").lower()
+        mock_store.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_callback_method_not_allowed(self, oauth_handler):


### PR DESCRIPTION
## Summary
- reject Slack OAuth callbacks that would rebind an existing workspace to a different tenant
- preserve the existing tenant binding when the callback state has no tenant scope instead of clearing it
- add regressions in both Slack OAuth test suites for cross-tenant reinstall rejection and tenant preservation

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q
