### PR TITLE
fix(swarm): normalize sync cleanup pid fallback

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -2119,12 +2119,7 @@ class WorkerLauncher:
         finally:
             cleanup_pid = worker.pid
             if cleanup_pid is None:
-                raw_pid = session_meta.get("pid")
-                if raw_pid is not None:
-                    try:
-                        cleanup_pid = int(raw_pid)
-                    except (TypeError, ValueError):
-                        pass
+                cleanup_pid = self._normalized_pid(session_meta.get("pid"))
             if cleanup_pid is not None:
                 self._wait_for_pid_exit_sync(cleanup_pid)
             self._cleanup_session_artifacts(worker.worktree_path)

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1032,6 +1032,46 @@ class TestCollectFinishedSync:
         mock_wait_pid.assert_called_once_with(333)
         assert "wo-sync-meta-finished" not in launcher._processes
 
+    def test_collect_finished_sync_ignores_invalid_session_meta_pid_for_cleanup(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        worker = WorkerProcess(
+            work_order_id="wo-sync-invalid-meta-pid",
+            agent="codex",
+            worktree_path="/tmp/wt-invalid-pid",
+            branch="main",
+            pid=None,
+            initial_head="def456",
+        )
+        launcher._workers["wo-sync-invalid-meta-pid"] = worker
+        proc = MagicMock()
+        proc.returncode = None
+        launcher._processes["wo-sync-invalid-meta-pid"] = proc
+
+        session_meta = {
+            "pid": 0,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value=""),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync") as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=["wo-sync-invalid-meta-pid"])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 143
+        assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        mock_wait_pid.assert_not_called()
+        assert "wo-sync-invalid-meta-pid" not in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- normalize sync cleanup pid fallback through the shared PID validator\n- ignore invalid session metadata PIDs instead of waiting on process-group values\n- add a regression for sync collection with malformed session metadata\n\n## Testing\n- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py\n- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'collect_finished_sync_ignores_invalid_session_meta_pid_for_cleanup or collects_in_memory_worker_when_session_meta_marks_complete'\n- python -m pytest tests/swarm/test_worker_launcher.py -q