### PR TITLE
fix(swarm): normalize snapshot progress pid checks

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -494,11 +494,7 @@ class WorkerLauncher:
         """Capture lightweight progress state for a dispatched worker."""
         worktree_path = str(work_order.get("worktree_path", "")).strip()
         initial_head = str(work_order.get("initial_head", "")).strip()
-        raw_pid = work_order.get("pid")
-        try:
-            pid = int(raw_pid) if raw_pid is not None else None
-        except (TypeError, ValueError):
-            pid = None
+        pid = self._normalized_pid(work_order.get("pid"))
 
         snapshot: dict[str, Any] = {
             "pid_alive": self._is_pid_running(pid) if pid is not None else False,

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1217,6 +1217,26 @@ class TestSnapshotProgress:
         assert snapshot["diff_lines"] == 2
 
     @pytest.mark.asyncio
+    async def test_ignores_invalid_pid_values(self):
+        launcher = WorkerLauncher()
+        work_order = {
+            "pid": 0,
+            "worktree_path": "/tmp/wt",
+            "initial_head": "abc123",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        mock_running.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):
         launcher = WorkerLauncher()
         work_order = {


### PR DESCRIPTION
## Summary\n- normalize worker snapshot PID parsing through the shared validator\n- treat invalid or process-group PID values as not alive instead of probing them\n- add a regression for malformed snapshot PID input\n\n## Testing\n- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py\n- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'ignores_invalid_pid_values or collects_git_state'\n- python -m pytest tests/swarm/test_worker_launcher.py -q