### PR TITLE
fix(slack): tighten dev redirect host validation

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -24,7 +24,7 @@ import os
 import secrets
 import time
 from typing import Any
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlsplit
 
 logger = logging.getLogger(__name__)
 
@@ -146,6 +146,20 @@ def _get_slack_scopes() -> str:
 def _get_slack_signing_secret() -> str:
     """Resolve Slack signing secret from Secrets Manager or env."""
     return get_secret("SLACK_SIGNING_SECRET", SLACK_SIGNING_SECRET, strict=False) or ""
+
+
+def _is_loopback_redirect_host(host: str) -> bool:
+    """Allow only exact loopback authorities for dev-only redirect fallbacks."""
+    candidate = str(host or "").strip()
+    if not candidate:
+        return False
+    parsed = urlsplit(f"http://{candidate}")
+    if parsed.username or parsed.password:
+        return False
+    if parsed.path not in ("", "/") or parsed.query or parsed.fragment:
+        return False
+    hostname = (parsed.hostname or "").strip().lower()
+    return hostname in {"localhost", "127.0.0.1", "::1"}
 
 
 def _cleanup_oauth_states_fallback(now: float | None = None) -> None:
@@ -607,7 +621,7 @@ class SlackOAuthHandler(SecureHandler):
                 )
             # Development fallback only - restrict to localhost to prevent open redirect
             host = query_params.get("host", "localhost:8080")
-            if not host.startswith(("localhost", "127.0.0.1", "[::1]")):
+            if not _is_loopback_redirect_host(host):
                 return error_response("Only localhost allowed in development mode", 400)
             scheme = "http"
             redirect_uri = f"{scheme}://{host}/api/integrations/slack/callback"

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -464,6 +464,52 @@ class TestInstall:
         assert _status(result) == 400
 
     @pytest.mark.asyncio
+    async def test_dev_fallback_rejects_localhost_prefix_host(
+        self, handler, handler_module, monkeypatch
+    ):
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/install",
+            {},
+            {"host": "localhost.evil.com:8080"},
+            {},
+            None,
+        )
+        assert _status(result) == 400
+
+    @pytest.mark.asyncio
+    async def test_dev_fallback_rejects_host_with_path(self, handler, handler_module, monkeypatch):
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/install",
+            {},
+            {"host": "localhost:3000/evil"},
+            {},
+            None,
+        )
+        assert _status(result) == 400
+
+    @pytest.mark.asyncio
+    async def test_dev_fallback_rejects_host_with_userinfo(
+        self, handler, handler_module, monkeypatch
+    ):
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/install",
+            {},
+            {"host": "localhost@evil.com:3000"},
+            {},
+            None,
+        )
+        assert _status(result) == 400
+
+    @pytest.mark.asyncio
     async def test_production_requires_redirect_uri(self, handler, handler_module, monkeypatch):
         monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
         monkeypatch.setattr(handler_module, "ARAGORA_ENV", "production")


### PR DESCRIPTION
## Summary\n- tighten dev-mode Slack redirect host validation to exact loopback hosts\n- reject crafted authorities with localhost prefixes, paths, or userinfo\n- add install-path regressions for those malformed host values\n\n## Testing\n- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'dev_fallback or production_requires_redirect_uri'\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q