### PR TITLE
fix(swarm): normalize supervisor kill pid

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3970,12 +3970,11 @@ class SwarmSupervisor:
         """Kill a running worker process by PID."""
         import signal
 
-        raw_pid = item.get("pid")
-        if raw_pid is None:
+        if "pid" not in item:
             return
-        try:
-            pid = int(raw_pid)
-        except (TypeError, ValueError):
+        pid = WorkerLauncher._normalized_pid(item.get("pid"))
+        if pid is None:
+            item.pop("pid", None)
             return
         try:
             import os as _os

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5133,3 +5133,19 @@ def test_is_docs_only_path_rejects_scripts_txt() -> None:
 
 def test_is_docs_only_path_rejects_arbitrary_md_in_src() -> None:
     assert not SwarmSupervisor._is_docs_only_path("aragora/notes.md")
+
+
+@pytest.mark.asyncio
+async def test_kill_worker_ignores_invalid_pid_metadata() -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=Path("/tmp/repo"),
+        store=MagicMock(),
+        launcher=MagicMock(spec=WorkerLauncher),
+    )
+    item = {"pid": 0}
+
+    with patch("os.kill") as mock_kill:
+        await supervisor._kill_worker(item)
+
+    mock_kill.assert_not_called()
+    assert "pid" not in item


### PR DESCRIPTION
## Summary\n- normalize supervisor kill-worker PID handling through the shared validator\n- fail closed on malformed or process-group PID values and scrub bad metadata\n- add a regression covering invalid lane PID metadata\n\n## Testing\n- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py\n- python -m pytest tests/swarm/test_supervisor.py -q -k 'kill_worker_ignores_invalid_pid_metadata or rebinds_released_work_order_to_new_active_lease or rebinds_stale_dispatched_lane_back_to_leased_without_worker_pid'\n- python -m pytest tests/swarm/test_supervisor.py -q