### PR TITLE
fix(supervisor): reduce stale waiting conflict overlap

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -7095,6 +7095,10 @@ def _is_concrete_repo_path_hint(path: str, *, repo_root: Path | None) -> bool:
 def _waiting_conflict_inference_text(work_order: dict[str, Any], run: dict[str, Any]) -> str:
     spec = run.get("spec")
     metadata = work_order.get("metadata")
+    spec_acceptance = spec.get("acceptance_criteria") if isinstance(spec, dict) else []
+    spec_constraints = spec.get("constraints") if isinstance(spec, dict) else []
+    metadata_acceptance = metadata.get("acceptance_criteria") if isinstance(metadata, dict) else []
+    metadata_constraints = metadata.get("constraints") if isinstance(metadata, dict) else []
     parts = [
         run.get("goal"),
         spec.get("raw_goal") if isinstance(spec, dict) else None,
@@ -7103,6 +7107,14 @@ def _waiting_conflict_inference_text(work_order: dict[str, Any], run: dict[str, 
         work_order.get("description"),
         metadata.get("description") if isinstance(metadata, dict) else None,
     ]
+    if isinstance(spec_acceptance, list):
+        parts.extend(spec_acceptance)
+    if isinstance(spec_constraints, list):
+        parts.extend(spec_constraints)
+    if isinstance(metadata_acceptance, list):
+        parts.extend(metadata_acceptance)
+    if isinstance(metadata_constraints, list):
+        parts.extend(metadata_constraints)
     return " ".join(str(part).strip() for part in parts if str(part or "").strip())
 
 
@@ -7133,6 +7145,53 @@ def _explicit_scope_paths_for_waiting_conflict(
     return explicit_paths
 
 
+def _docs_only_scope_hints_for_waiting_conflict(
+    work_order: dict[str, Any],
+    *,
+    run: dict[str, Any],
+) -> list[str]:
+    from aragora.swarm.spec import SwarmSpec
+
+    metadata = work_order.get("metadata") or {}
+    constraints = metadata.get("constraints") if isinstance(metadata, dict) else []
+    if not isinstance(constraints, list) or not any(
+        "documentation only" in str(item).strip().lower() for item in constraints
+    ):
+        spec = run.get("spec")
+        spec_constraints = spec.get("constraints") if isinstance(spec, dict) else []
+        if not isinstance(spec_constraints, list) or not any(
+            "documentation only" in str(item).strip().lower() for item in spec_constraints
+        ):
+            return []
+
+    original_scope = [
+        _canonical_scope_pattern(str(path))
+        for path in work_order.get("file_scope", []) or []
+        if _canonical_scope_pattern(str(path))
+    ]
+    if not original_scope:
+        return []
+
+    doc_hints: list[str] = []
+    for path in SwarmSpec.infer_file_scope_hints(_waiting_conflict_inference_text(work_order, run)):
+        clean = _canonical_scope_pattern(path)
+        if not clean.startswith("docs"):
+            continue
+        if any(
+            scope == clean or clean.startswith(f"{scope}/") or scope.startswith(f"{clean}/")
+            for scope in original_scope
+        ):
+            doc_hints.append(clean)
+    if any(hint != "docs" and hint.startswith("docs/") for hint in doc_hints):
+        doc_hints = [hint for hint in doc_hints if hint != "docs"]
+    collapsed = _collapse_scope_patterns(doc_hints)
+    if collapsed:
+        return collapsed
+    if any(scope == "docs" or scope.startswith("docs/") for scope in original_scope):
+        return ["docs"]
+    return []
+
+
 def _narrow_waiting_conflict_scope_from_explicit_paths(
     work_order: dict[str, Any],
     *,
@@ -7151,27 +7210,29 @@ def _narrow_waiting_conflict_scope_from_explicit_paths(
         run=run,
         repo_root=repo_root,
     )
-    if not explicit_paths:
-        return []
+    if explicit_paths:
+        narrowed_scope: list[str] = []
+        replaced = False
+        for scope in original_scope:
+            contains_explicit = any(_path_matches_glob(path, scope) for path in explicit_paths)
+            if (
+                contains_explicit
+                and scope not in explicit_paths
+                and not _is_concrete_repo_path_hint(
+                    scope,
+                    repo_root=repo_root,
+                )
+            ):
+                replaced = True
+                continue
+            narrowed_scope.append(scope)
+        if replaced:
+            return _collapse_scope_patterns(narrowed_scope + explicit_paths)
 
-    narrowed_scope: list[str] = []
-    replaced = False
-    for scope in original_scope:
-        contains_explicit = any(_path_matches_glob(path, scope) for path in explicit_paths)
-        if (
-            contains_explicit
-            and scope not in explicit_paths
-            and not _is_concrete_repo_path_hint(
-                scope,
-                repo_root=repo_root,
-            )
-        ):
-            replaced = True
-            continue
-        narrowed_scope.append(scope)
-    if not replaced:
-        return []
-    return _collapse_scope_patterns(narrowed_scope + explicit_paths)
+    docs_only_scope = _docs_only_scope_hints_for_waiting_conflict(work_order, run=run)
+    if docs_only_scope and tuple(docs_only_scope) != tuple(original_scope):
+        return docs_only_scope
+    return []
 
 
 def _waiting_conflict_sibling_can_be_ignored(

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -136,6 +136,60 @@ def _narrow_scope_to_explicit_paths(
     return item
 
 
+def _narrow_docs_only_scope(
+    item: BoundedWorkOrder,
+    spec: SwarmSpec,
+) -> BoundedWorkOrder:
+    constraints = [str(value).strip() for value in spec.constraints if str(value).strip()]
+    if not any("documentation only" in value.lower() for value in constraints):
+        return item
+
+    original_scope = [str(path).strip() for path in item.file_scope if str(path).strip()]
+    if not original_scope:
+        return item
+
+    inference_text = " ".join(
+        filter(
+            None,
+            [
+                spec.refined_goal or "",
+                spec.raw_goal or "",
+                item.title or "",
+                item.description or "",
+                *list(spec.acceptance_criteria),
+                *constraints,
+            ],
+        )
+    )
+    doc_hints: list[str] = []
+    for path in SwarmSpec.infer_file_scope_hints(inference_text):
+        clean = path.strip().removeprefix("./").rstrip("/")
+        if not clean.startswith("docs"):
+            continue
+        if any(
+            _path_in_scope(clean, scope) or _path_in_scope(scope, clean) for scope in original_scope
+        ):
+            doc_hints.append(clean)
+    if any(hint != "docs" and hint.startswith("docs/") for hint in doc_hints):
+        doc_hints = [hint for hint in doc_hints if hint != "docs"]
+    narrowed_scope = list(dict.fromkeys(doc_hints))
+    if not narrowed_scope and any(
+        scope == "docs" or scope.startswith("docs/") for scope in original_scope
+    ):
+        narrowed_scope = ["docs"]
+    if not narrowed_scope or tuple(narrowed_scope) == tuple(original_scope):
+        return item
+
+    item.file_scope = narrowed_scope
+    logger.info(
+        "Narrowed docs-only file_scope on work order %s: %s -> %s",
+        item.work_order_id,
+        original_scope,
+        item.file_scope,
+    )
+    return item
+
+
 _NON_ACTIONABLE_EXPLICIT_SPEC_TITLES = {
     "validation changes",
     "acceptance criteria changes",
@@ -266,7 +320,8 @@ def _ensure_work_order_scope(
                 item.work_order_id,
             )
 
-    return _narrow_scope_to_explicit_paths(item, spec)
+    item = _narrow_scope_to_explicit_paths(item, spec)
+    return _narrow_docs_only_scope(item, spec)
 
 
 class SupervisorRunStatus(str, Enum):

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -2841,6 +2841,78 @@ def test_rehabilitate_narrowed_waiting_conflict_work_orders_requeues_lane_blocke
     )
 
 
+def test_rehabilitate_narrowed_waiting_conflict_work_orders_requeues_docs_only_lane_after_scope_truth_narrowing(
+    repo: Path,
+    store: DevCoordinationStore,
+) -> None:
+    (repo / "docs" / "ADR").mkdir(parents=True, exist_ok=True)
+
+    store.create_supervisor_run(
+        goal="Keep the broader docs planning lane open.",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        work_orders=[
+            {
+                "work_order_id": "broad-docs",
+                "title": "Broad docs lane",
+                "status": "waiting_conflict",
+                "failure_reason": "waiting_conflict",
+                "file_scope": ["docs"],
+            }
+        ],
+    )
+    candidate = store.create_supervisor_run(
+        goal="Write the worker-model ADR with canonical command, deploy mapping, and compatibility notes.",
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={
+            "raw_goal": "Write the worker-model ADR with canonical command, deploy mapping, and compatibility notes.",
+            "refined_goal": "Write the worker-model ADR with canonical command, deploy mapping, and compatibility notes.",
+            "acceptance_criteria": ["ADR committed under docs/ADR"],
+            "constraints": ["Documentation only"],
+        },
+        work_orders=[
+            {
+                "work_order_id": "docs-only-adr",
+                "title": "Improve Developer Track",
+                "description": "Enhance capabilities in the Developer track. Key folders: sdk/, docs/, tests/sdk/.",
+                "status": "waiting_conflict",
+                "failure_reason": "waiting_conflict",
+                "blocking_question": "Which overlapping lane should finish first?",
+                "blocker": {
+                    "reason": "waiting_conflict",
+                    "question": "Which overlapping lane should finish first?",
+                },
+                "blockers": ["waiting_conflict"],
+                "file_scope": ["sdk/", "docs/", "tests/sdk/"],
+                "metadata": {
+                    "acceptance_criteria": ["ADR committed under docs/ADR"],
+                    "constraints": ["Documentation only"],
+                    "source": "nomic_subtask",
+                },
+            }
+        ],
+    )
+
+    updated = store.rehabilitate_narrowed_waiting_conflict_work_orders(grace_period_hours=0.0)
+    refreshed = store.get_supervisor_run(candidate["run_id"])
+
+    assert updated == 1
+    assert refreshed is not None
+    work_order = refreshed["work_orders"][0]
+    assert work_order["status"] == "queued"
+    assert work_order["file_scope"] == ["docs/ADR"]
+    assert work_order["blockers"] == []
+    assert work_order["conflicts"] == []
+    assert "failure_reason" not in work_order
+    assert work_order["metadata"]["waiting_conflict_requeue_reason"] == (
+        "narrowed_scope_cleared_container_only_blockers"
+    )
+
+
 def test_rehabilitate_narrowed_waiting_conflict_work_orders_preserves_real_overlap(
     repo: Path,
     store: DevCoordinationStore,

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -1704,6 +1704,47 @@ def test_start_run_narrows_explicit_spec_broad_scope_when_description_names_spec
     assert run.work_orders[0]["file_scope"] == ["docs/plans/phase0b_campaign_manifest.yaml"]
 
 
+def test_start_run_narrows_docs_only_scope_to_doc_hints(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    (repo / "docs" / "ADR").mkdir(parents=True, exist_ok=True)
+
+    lifecycle = MagicMock()
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = TaskDecomposition(
+        original_task="Goal",
+        complexity_score=2,
+        complexity_level="low",
+        should_decompose=True,
+        subtasks=[
+            SubTask(
+                id="subtask_1",
+                title="Improve Developer Track",
+                description="Enhance capabilities in the Developer track. Key folders: sdk/, docs/, tests/sdk/.",
+                file_scope=["sdk/", "docs/", "tests/sdk/"],
+            )
+        ],
+    )
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+        decomposer=decomposer,
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal="Write the worker-model ADR with canonical command, deploy mapping, and compatibility notes.",
+            refined_goal="Write the worker-model ADR with canonical command, deploy mapping, and compatibility notes.",
+            acceptance_criteria=["ADR committed under docs/ADR"],
+            constraints=["Documentation only"],
+        ),
+        refresh_scaling=False,
+    )
+
+    assert run.work_orders[0]["file_scope"] == ["docs/ADR"]
+
+
 def test_start_run_drops_non_actionable_explicit_spec_validation_lane(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- reduce overlap between stale waiting conflict lanes before escalation
- tighten supervisor/dev-coordination handling for stale waiting conflicts
- add focused regression coverage

## Testing
- python3 -m pytest tests/nomic/test_dev_coordination.py tests/swarm/test_supervisor.py -q
- python3 -m ruff check aragora/nomic/dev_coordination.py aragora/swarm/supervisor.py tests/nomic/test_dev_coordination.py tests/swarm/test_supervisor.py