### PR TITLE
fix(pipeline): restore plan store compatibility

### DIFF
--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -89,9 +89,13 @@ def _get_backing_store() -> Any:
     attempts are made (avoids repeated expensive retries).
     """
     global _backing_store, _backing_store_init_failed
-    if "pytest" in sys.modules and os.environ.get("ARAGORA_FORCE_PERSISTENT_PLAN_STORE") != "1":
-        return None
+    # Tests often inject a fake or temporary persistent store directly. Honor
+    # that explicit override even when auto-init is disabled under pytest.
+    if _backing_store is not None:
+        return _backing_store
     if _backing_store_init_failed:
+        return None
+    if "pytest" in sys.modules and os.environ.get("ARAGORA_FORCE_PERSISTENT_PLAN_STORE") != "1":
         return None
     if _backing_store is None:
         try:

--- a/tests/pipeline/test_executor_persistence.py
+++ b/tests/pipeline/test_executor_persistence.py
@@ -8,6 +8,7 @@ initialization fails.
 from __future__ import annotations
 
 import importlib
+import os
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -232,17 +233,18 @@ class TestLazySingletonInit:
         executor_mod._backing_store = None
         executor_mod._backing_store_init_failed = False
 
-        with patch("aragora.pipeline.plan_store.PlanStore") as MockStore:
-            mock_instance = MagicMock()
-            MockStore.return_value = mock_instance
+        with patch.dict(os.environ, {"ARAGORA_FORCE_PERSISTENT_PLAN_STORE": "1"}):
+            with patch("aragora.pipeline.plan_store.PlanStore") as MockStore:
+                mock_instance = MagicMock()
+                MockStore.return_value = mock_instance
 
-            store1 = executor_mod._get_backing_store()
-            store2 = executor_mod._get_backing_store()
+                store1 = executor_mod._get_backing_store()
+                store2 = executor_mod._get_backing_store()
 
-            # Should create only once
-            MockStore.assert_called_once()
-            assert store1 is mock_instance
-            assert store2 is mock_instance
+                # Should create only once
+                MockStore.assert_called_once()
+                assert store1 is mock_instance
+                assert store2 is mock_instance
 
     def test_get_backing_store_remembers_failure(self):
         """_get_backing_store does not retry after init failure."""
@@ -251,17 +253,18 @@ class TestLazySingletonInit:
         executor_mod._backing_store = None
         executor_mod._backing_store_init_failed = False
 
-        with patch(
-            "aragora.pipeline.executor._try_init_backing_store",
-            side_effect=RuntimeError("Cannot create DB"),
-        ):
-            store1 = executor_mod._get_backing_store()
-            assert store1 is None
-            assert executor_mod._backing_store_init_failed is True
+        with patch.dict(os.environ, {"ARAGORA_FORCE_PERSISTENT_PLAN_STORE": "1"}):
+            with patch(
+                "aragora.pipeline.executor._try_init_backing_store",
+                side_effect=RuntimeError("Cannot create DB"),
+            ):
+                store1 = executor_mod._get_backing_store()
+                assert store1 is None
+                assert executor_mod._backing_store_init_failed is True
 
-            # Second call should not retry
-            store2 = executor_mod._get_backing_store()
-            assert store2 is None
+                # Second call should not retry
+                store2 = executor_mod._get_backing_store()
+                assert store2 is None
 
 
 class TestStoreOutcomeFallback:


### PR DESCRIPTION
## Summary
- restore the legacy `_plan_store` and `_plan_outcomes` aliases expected by older gold-path imports
- honor explicitly injected backing stores under pytest while still disabling automatic PlanStore init unless forced
- update the persistence tests to force persistent mode only when they intentionally exercise lazy init

## Testing
- python3 -m pytest tests/integration/test_gold_path_pipeline.py --collect-only -q
- python3 -m pytest tests/debate/test_gold_path_integration.py tests/pipeline/test_executor_persistence.py -x -q
- python3 -m ruff check aragora/pipeline/executor.py tests/pipeline/test_executor_persistence.py