### PR TITLE
fix(slack): persist callback redirect uri in oauth state

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -602,14 +602,6 @@ class SlackOAuthHandler(SecureHandler):
 
         tenant_id = self._resolved_tenant_id(query_params, auth_context)
 
-        # Generate state using centralized OAuth state store
-        state_store = _get_state_store()
-        try:
-            state = state_store.generate(metadata={"tenant_id": tenant_id, "provider": "slack"})
-        except (ValueError, TypeError, OSError, RuntimeError) as e:
-            logger.error("Failed to generate OAuth state: %s", e)
-            return error_response("Failed to initialize OAuth flow", 503)
-
         # Build OAuth URL
         redirect_uri = _get_slack_redirect_uri()
         if not redirect_uri:
@@ -627,6 +619,20 @@ class SlackOAuthHandler(SecureHandler):
             redirect_uri = f"{scheme}://{host}/api/integrations/slack/callback"
             logger.warning("Using fallback redirect_uri in development: %s", redirect_uri)
 
+        # Generate state using centralized OAuth state store
+        state_store = _get_state_store()
+        try:
+            state = state_store.generate(
+                metadata={
+                    "tenant_id": tenant_id,
+                    "provider": "slack",
+                    "redirect_uri": redirect_uri,
+                }
+            )
+        except (ValueError, TypeError, OSError, RuntimeError) as e:
+            logger.error("Failed to generate OAuth state: %s", e)
+            return error_response("Failed to initialize OAuth flow", 503)
+
         oauth_params = {
             "client_id": client_id,
             "scope": _get_slack_scopes(),
@@ -641,6 +647,7 @@ class SlackOAuthHandler(SecureHandler):
             "created_at": time.time(),
             "tenant_id": tenant_id,
             "provider": "slack",
+            "redirect_uri": redirect_uri,
         }
 
         logger.info("Initiating Slack OAuth flow (state: %s...)", state[:8])
@@ -950,15 +957,19 @@ class SlackOAuthHandler(SecureHandler):
         if not state_data:
             return error_response("Invalid or expired state token", 400)
 
+        state_redirect_uri: str | None = None
         if isinstance(state_data, dict):
             tenant_id = state_data.get("tenant_id")
+            state_redirect_uri = str(state_data.get("redirect_uri", "") or "").strip() or None
         else:
             metadata = getattr(state_data, "metadata", None)
             tenant_id = metadata.get("tenant_id") if isinstance(metadata, dict) else None
+            if isinstance(metadata, dict):
+                state_redirect_uri = str(metadata.get("redirect_uri", "") or "").strip() or None
 
         client_id = _get_slack_client_id()
         client_secret = _get_slack_client_secret()
-        redirect_uri = _get_slack_redirect_uri()
+        redirect_uri = state_redirect_uri or _get_slack_redirect_uri()
         if not client_id or not client_secret:
             return error_response("Slack OAuth not configured", 503)
 

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -510,6 +510,24 @@ class TestInstall:
         assert _status(result) == 400
 
     @pytest.mark.asyncio
+    async def test_dev_fallback_persists_redirect_uri_in_state_metadata(
+        self, handler, handler_module, monkeypatch, mock_state_store
+    ):
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+
+        result = await handler.handle(
+            "GET", "/api/integrations/slack/install", {}, {"host": "localhost:3000"}, {}, None
+        )
+
+        assert _status(result) == 302
+        generate_kwargs = mock_state_store.generate.call_args.kwargs
+        assert (
+            generate_kwargs["metadata"]["redirect_uri"]
+            == "http://localhost:3000/api/integrations/slack/callback"
+        )
+
+    @pytest.mark.asyncio
     async def test_production_requires_redirect_uri(self, handler, handler_module, monkeypatch):
         monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
         monkeypatch.setattr(handler_module, "ARAGORA_ENV", "production")
@@ -1020,6 +1038,55 @@ class TestCallback:
                 None,
             )
         assert _status(result) == 200
+
+    @pytest.mark.asyncio
+    async def test_callback_uses_redirect_uri_from_state_metadata_when_config_missing(
+        self, handler, handler_module, mock_state_store, mock_workspace_store, monkeypatch
+    ):
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        mock_state_store.validate_and_consume.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "redirect_uri": "http://localhost:3000/api/integrations/slack/callback",
+            "created_at": time.time(),
+        }
+        mock_workspace_store.get.return_value = None
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-token",
+                "team": {"id": "W123", "name": "Redirect URI Team"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch(
+                "aragora.storage.slack_workspace_store.SlackWorkspace",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        assert (
+            mock_client.post.await_args.kwargs["data"]["redirect_uri"]
+            == "http://localhost:3000/api/integrations/slack/callback"
+        )
 
     @pytest.mark.asyncio
     async def test_callback_fallback_state_validation(

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -17,6 +17,7 @@ import time
 import hmac
 import hashlib
 from typing import Any
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -202,13 +203,26 @@ class TestSlackOAuthInstall:
     @pytest.mark.asyncio
     async def test_install_with_tenant_id(self, oauth_handler, oauth_state_store):
         """Authenticated install should prefer the caller tenant over query scope."""
-        with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "test-client-id"):
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "test-client-id"),
+            patch(
+                "aragora.server.handlers.social.slack_oauth.SLACK_REDIRECT_URI",
+                "https://example.com/callback",
+            ),
+            patch.object(
+                oauth_handler,
+                "get_auth_context",
+                AsyncMock(return_value=SimpleNamespace(org_id="test-org-001")),
+            ),
+            patch.object(oauth_handler, "_check_permission", return_value=True),
+        ):
             result = await oauth_handler.handle(
                 "GET",
                 "/api/integrations/slack/install",
                 query_params={"tenant_id": "tenant-001"},
             )
 
+        assert result.status_code == 302
         # Find the new state
         found = any(
             data.metadata and data.metadata.get("tenant_id") == "test-org-001"
@@ -229,7 +243,10 @@ class TestSlackOAuthInstall:
             metadata=None,
         )
 
-        with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "test-client-id"):
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "test-client-id"),
+            patch("aragora.server.handlers.social.slack_oauth.ARAGORA_ENV", "test"),
+        ):
             await oauth_handler.handle("GET", "/api/integrations/slack/install")
 
         assert old_state not in oauth_state_store._states


### PR DESCRIPTION
## Summary\n- persist the effective install redirect URI in Slack OAuth state metadata\n- reuse that redirect URI during callback token exchange when config is absent\n- add install/callback regressions across both Slack OAuth test suites\n\n## Testing\n- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py\n- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q\n- python -m pytest tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py -q