### PR TITLE
fix(debate): harden async protocol cleanup cutoff

### DIFF
--- a/aragora/debate/protocol_messages/store.py
+++ b/aragora/debate/protocol_messages/store.py
@@ -863,7 +863,7 @@ class AsyncProtocolMessageStore:
 
         def _cleanup_sync() -> int:
             cutoff = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
-            cutoff = cutoff.replace(day=cutoff.day - days)
+            cutoff = cutoff - timedelta(days=days)
 
             with self._sync_store._cursor() as cursor:
                 cursor.execute(

--- a/tests/debate/protocol_messages/test_store.py
+++ b/tests/debate/protocol_messages/test_store.py
@@ -1365,17 +1365,26 @@ class TestAsyncProtocolMessageStoreClass:
         store.close()
 
     async def test_cleanup_old(self):
-        # Use days=1 with a 2-day-old message to avoid the source's
-        # cutoff.replace(day=cutoff.day - days) month boundary bug.
-        # This works as long as today's date >= 2 (which is always true
-        # except on the 1st of the month).
         store = fresh_async_store()
-        now = datetime.now(timezone.utc)
-        old_ts = now - timedelta(days=2)
-        store._sync_store.record_sync(make_message(debate_id="d-aclean", ts=old_ts))
-        store._sync_store.record_sync(make_message(debate_id="d-aclean"))
-        n = await store.cleanup_old(days=1)
+        fixed_now = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+        old_ts = fixed_now - timedelta(days=2)
+        recent_ts = fixed_now - timedelta(hours=12)
+        store._sync_store.record_sync(make_message(debate_id="d-aclean-old", ts=old_ts))
+        store._sync_store.record_sync(make_message(debate_id="d-aclean-recent", ts=recent_ts))
+
+        class FixedDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                if tz is None:
+                    return fixed_now.replace(tzinfo=None)
+                return fixed_now.astimezone(tz)
+
+        with patch("aragora.debate.protocol_messages.store.datetime", FixedDateTime):
+            n = await store.cleanup_old(days=1)
+
         assert n == 1
+        remaining = await store.query(QueryFilters())
+        assert [message.debate_id for message in remaining] == ["d-aclean-recent"]
         store.close()
 
     def test_db_path_property(self):


### PR DESCRIPTION
## Summary
- fix the async protocol-message cleanup cutoff to use `timedelta`, matching the sync store path
- make the async cleanup regression test deterministic at a month boundary so the bug cannot hide until the first day of a month
- unblock the shared core shard failure currently affecting multiple open PRs

## Testing
- python3 -m pytest tests/debate/protocol_messages/test_store.py -q
- python3 -m ruff check aragora/debate/protocol_messages/store.py tests/debate/protocol_messages/test_store.py
