### PR TITLE
fix(slack): reject malformed refresh responses

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1589,6 +1589,17 @@ class SlackOAuthHandler(SecureHandler):
 
             # Update stored tokens
             new_access_token = data.get("access_token")
+            if not str(new_access_token or "").strip():
+                logger.error("Token refresh returned no access token for %s", workspace_id)
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: missing access token",
+                    )
+                return error_response("Invalid token refresh response", 502)
             new_refresh_token = data.get("refresh_token", workspace.refresh_token)
             expires_in = data.get("expires_in")
             new_expires_at = time.time() + expires_in if expires_in else None

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -2244,6 +2244,37 @@ class TestRefreshToken:
         assert _status(result) == 500
 
     @pytest.mark.asyncio
+    async def test_refresh_missing_access_token_returns_502(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "",
+                "expires_in": 43200,
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_store_import_error_returns_503(self, handler):
         with patch.dict("sys.modules", {"aragora.storage.slack_workspace_store": None}):
             result = await handler.handle(


### PR DESCRIPTION
## Summary\n- fail closed when Slack token refresh returns no access token\n- avoid saving empty credentials while still reporting success\n- add a regression covering malformed refresh responses\n\n## Testing\n- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'refresh_missing_access_token_returns_502 or successful_refresh or save_failure_returns_500'\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q