### PR TITLE
feat(pipeline): complete the golden-path run ledger trust wedge

### DIFF
--- a/aragora/pipeline/backbone_contracts.py
+++ b/aragora/pipeline/backbone_contracts.py
@@ -9,7 +9,10 @@ compose without implicit contracts.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
 from typing import Any
+import uuid
 
 
 def propagate_taint(
@@ -45,7 +48,7 @@ def _string_list(values: Any) -> list[str]:
             continue
         if isinstance(value, str):
             text = value.strip()
-        elif is_dataclass(value):
+        elif is_dataclass(value) and not isinstance(value, type):
             text = str(asdict(value))
         else:
             text = str(value).strip()
@@ -80,6 +83,10 @@ def _risk_mitigations(risks: Any) -> list[str]:
     return mitigations
 
 
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
 @dataclass
 class IntakeBundle:
     source_kind: str
@@ -110,6 +117,100 @@ class IntakeBundle:
             origin_metadata=dict(origin_metadata or {}),
             taint_flags=list(taint_flags or []),
         )
+
+
+class BackboneStage(str, Enum):
+    """Canonical stages for the golden-path run ledger."""
+
+    INTAKE = "intake"
+    INTENT = "intent"
+    RESEARCH = "research"
+    EXTENSION = "extension"
+    SPECIFICATION = "specification"
+    GOALS = "goals"
+    DELIBERATION = "deliberation"
+    PLAN = "plan"
+    EXECUTION = "execution"
+    RECEIPT = "receipt"
+    FEEDBACK = "feedback"
+    ATTESTATION = "attestation"
+
+
+@dataclass
+class RunStageEvent:
+    """Immutable event emitted by one backbone stage."""
+
+    stage: str
+    status: str
+    event_id: str = field(default_factory=lambda: f"evt-{uuid.uuid4().hex[:12]}")
+    artifact_ref: str = ""
+    details: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=_utc_now_iso)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def create(
+        cls,
+        stage: BackboneStage | str,
+        *,
+        status: str,
+        artifact_ref: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> RunStageEvent:
+        stage_name = stage.value if isinstance(stage, BackboneStage) else str(stage).strip()
+        return cls(
+            stage=stage_name,
+            status=str(status).strip() or "unknown",
+            artifact_ref=str(artifact_ref).strip(),
+            details=dict(details or {}),
+        )
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunStageEvent:
+        return cls(
+            stage=str(data.get("stage", "")).strip(),
+            status=str(data.get("status", "")).strip(),
+            event_id=str(data.get("event_id", "")).strip() or f"evt-{uuid.uuid4().hex[:12]}",
+            artifact_ref=str(data.get("artifact_ref", "")).strip(),
+            details=dict(data.get("details", {}) or {}),
+            created_at=str(data.get("created_at", "")).strip() or _utc_now_iso(),
+        )
+
+
+def build_goal_refs_from_implement_plan(
+    implement_plan: Any | None,
+    *,
+    source_stage: BackboneStage | str = BackboneStage.GOALS,
+) -> list[dict[str, Any]]:
+    """Project an implementation plan into canonical goal refs."""
+    if implement_plan is None:
+        return []
+
+    stage_name = (
+        source_stage.value if isinstance(source_stage, BackboneStage) else str(source_stage)
+    )
+    tasks = list(getattr(implement_plan, "tasks", []) or [])
+    refs: list[dict[str, Any]] = []
+    for index, task in enumerate(tasks, start=1):
+        if task is None:
+            continue
+        task_id = str(getattr(task, "id", "") or f"goal-{index}").strip()
+        title = str(getattr(task, "description", "") or task_id).strip()
+        refs.append(
+            {
+                "id": task_id,
+                "title": title,
+                "source_stage": stage_name,
+                "files": list(getattr(task, "files", []) or []),
+                "dependencies": list(getattr(task, "dependencies", []) or []),
+                "complexity": str(getattr(task, "complexity", "") or ""),
+                "task_type": str(getattr(task, "task_type", "") or ""),
+                "requires_approval": bool(getattr(task, "requires_approval", False)),
+            }
+        )
+    return refs
 
 
 @dataclass
@@ -174,7 +275,8 @@ class SpecBundle:
             if str(getattr(item, "path", "") or item.get("path", "")).strip()
         ]
         provenance = getattr(spec, "provenance", None)
-        provenance_refs = [provenance.to_dict()] if hasattr(provenance, "to_dict") else []
+        provenance_to_dict = getattr(provenance, "to_dict", None)
+        provenance_refs = [provenance_to_dict()] if callable(provenance_to_dict) else []
         provenance_refs.extend(list(getattr(spec, "provenance_chain", []) or []))
 
         return cls(
@@ -337,6 +439,37 @@ class ReceiptEnvelope:
             extras={
                 "pipeline_id": receipt.get("pipeline_id"),
                 "generated_at": receipt.get("generated_at"),
+            },
+        )
+
+    @classmethod
+    def from_decision_receipt(
+        cls,
+        receipt: dict[str, Any],
+        *,
+        policy_gate_result: dict[str, Any] | None = None,
+        taint_summary: dict[str, Any] | None = None,
+    ) -> ReceiptEnvelope:
+        provenance_chain = [
+            dict(item)
+            for item in list(receipt.get("provenance_chain", []) or [])
+            if isinstance(item, dict)
+        ]
+        return cls(
+            receipt_id=str(receipt.get("receipt_id", "")).strip(),
+            artifact_hash=str(
+                receipt.get("artifact_hash") or receipt.get("input_hash", "")
+            ).strip(),
+            verdict=str(receipt.get("verdict", "unknown") or "unknown").strip(),
+            confidence=float(receipt.get("confidence", 0.0) or 0.0),
+            signature=str(receipt.get("signature", "")).strip(),
+            policy_gate_result=dict(policy_gate_result or {}),
+            provenance_chain=provenance_chain,
+            taint_summary=dict(taint_summary or {}),
+            extras={
+                "gauntlet_id": receipt.get("gauntlet_id"),
+                "generated_at": receipt.get("timestamp"),
+                "decision_receipt": dict(receipt),
             },
         )
 
@@ -583,6 +716,137 @@ class OutcomeFeedbackRecord:
             calibration_updates=[],
             next_action_recommendation=next_action_recommendation,
             extras={"total_duration_s": float(getattr(outcome, "total_duration_s", 0.0) or 0.0)},
+        )
+
+
+@dataclass
+class RunLedger:
+    """Persistent canonical ledger connecting the golden-path stages."""
+
+    run_id: str
+    entrypoint: str
+    status: str = "received"
+    intake_bundle: IntakeBundle | None = None
+    spec_bundle: SpecBundle | None = None
+    goal_refs: list[dict[str, Any]] = field(default_factory=list)
+    deliberation_bundle: DeliberationBundle | None = None
+    plan_id: str = ""
+    debate_id: str = ""
+    execution_id: str = ""
+    receipt_id: str = ""
+    receipt_envelope: ReceiptEnvelope | None = None
+    feedback_record: OutcomeFeedbackRecord | None = None
+    attestation: dict[str, Any] = field(default_factory=dict)
+    taint_flags: list[str] = field(default_factory=list)
+    stage_events: list[RunStageEvent] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(default_factory=_utc_now_iso)
+    updated_at: str = field(default_factory=_utc_now_iso)
+
+    def touch(self) -> None:
+        self.updated_at = _utc_now_iso()
+
+    def merge_taint(self, taint_flags: list[str] | None = None) -> None:
+        self.taint_flags = propagate_taint(self.taint_flags, taint_flags or [])
+        self.touch()
+
+    def add_event(self, event: RunStageEvent) -> None:
+        self.stage_events.append(event)
+        self.updated_at = event.created_at
+
+    def attach_intake(self, bundle: IntakeBundle | None) -> None:
+        self.intake_bundle = bundle
+        self.merge_taint(getattr(bundle, "taint_flags", []))
+
+    def attach_spec(self, bundle: SpecBundle | None) -> None:
+        self.spec_bundle = bundle
+        self.merge_taint(getattr(bundle, "taint_flags", []))
+
+    def attach_deliberation(self, bundle: DeliberationBundle | None) -> None:
+        self.deliberation_bundle = bundle
+        self.merge_taint(getattr(bundle, "taint_flags", []))
+
+    def attach_receipt(self, envelope: ReceiptEnvelope | None) -> None:
+        self.receipt_envelope = envelope
+        if envelope is not None and envelope.receipt_id:
+            self.receipt_id = envelope.receipt_id
+        self.touch()
+
+    def attach_feedback(self, record: OutcomeFeedbackRecord | None) -> None:
+        self.feedback_record = record
+        self.touch()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "entrypoint": self.entrypoint,
+            "status": self.status,
+            "intake_bundle": self.intake_bundle.to_dict() if self.intake_bundle else None,
+            "spec_bundle": self.spec_bundle.to_dict() if self.spec_bundle else None,
+            "goal_refs": list(self.goal_refs),
+            "deliberation_bundle": (
+                self.deliberation_bundle.to_dict() if self.deliberation_bundle else None
+            ),
+            "plan_id": self.plan_id,
+            "debate_id": self.debate_id,
+            "execution_id": self.execution_id,
+            "receipt_id": self.receipt_id,
+            "receipt_envelope": self.receipt_envelope.to_dict() if self.receipt_envelope else None,
+            "feedback_record": self.feedback_record.to_dict() if self.feedback_record else None,
+            "attestation": dict(self.attestation),
+            "taint_flags": list(self.taint_flags),
+            "stage_events": [event.to_dict() for event in self.stage_events],
+            "metadata": dict(self.metadata),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RunLedger:
+        intake_payload = data.get("intake_bundle")
+        spec_payload = data.get("spec_bundle")
+        if isinstance(spec_payload, dict):
+            spec_payload = dict(spec_payload)
+            spec_payload.pop("missing_required_fields", None)
+            spec_payload.pop("is_execution_grade", None)
+        return cls(
+            run_id=str(data.get("run_id", "")).strip(),
+            entrypoint=str(data.get("entrypoint", "")).strip(),
+            status=str(data.get("status", "received") or "received").strip(),
+            intake_bundle=IntakeBundle(**intake_payload)
+            if isinstance(intake_payload, dict)
+            else None,
+            spec_bundle=SpecBundle(**spec_payload) if isinstance(spec_payload, dict) else None,
+            goal_refs=list(data.get("goal_refs", []) or []),
+            deliberation_bundle=(
+                DeliberationBundle(**data["deliberation_bundle"])
+                if isinstance(data.get("deliberation_bundle"), dict)
+                else None
+            ),
+            plan_id=str(data.get("plan_id", "")).strip(),
+            debate_id=str(data.get("debate_id", "")).strip(),
+            execution_id=str(data.get("execution_id", "")).strip(),
+            receipt_id=str(data.get("receipt_id", "")).strip(),
+            receipt_envelope=(
+                ReceiptEnvelope(**data["receipt_envelope"])
+                if isinstance(data.get("receipt_envelope"), dict)
+                else None
+            ),
+            feedback_record=(
+                OutcomeFeedbackRecord(**data["feedback_record"])
+                if isinstance(data.get("feedback_record"), dict)
+                else None
+            ),
+            attestation=dict(data.get("attestation", {}) or {}),
+            taint_flags=list(data.get("taint_flags", []) or []),
+            stage_events=[
+                RunStageEvent.from_dict(event)
+                for event in list(data.get("stage_events", []) or [])
+                if isinstance(event, dict)
+            ],
+            metadata=dict(data.get("metadata", {}) or {}),
+            created_at=str(data.get("created_at", "")).strip() or _utc_now_iso(),
+            updated_at=str(data.get("updated_at", "")).strip() or _utc_now_iso(),
         )
 
 

--- a/aragora/pipeline/execution_bridge.py
+++ b/aragora/pipeline/execution_bridge.py
@@ -20,9 +20,17 @@ import asyncio
 import logging
 import threading
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 import uuid
 
+from aragora.pipeline.backbone_contracts import (
+    BackboneStage,
+    OutcomeFeedbackRecord,
+    ReceiptEnvelope,
+    RunStageEvent,
+    TaintChecker,
+)
 from aragora.pipeline.decision_plan import PlanOutcome, PlanStatus
 
 if TYPE_CHECKING:
@@ -63,6 +71,153 @@ class ExecutionBridge:
 
             self._executor = PlanExecutor()
         return self._executor
+
+    @staticmethod
+    def _extract_backbone_run_id(plan: Any) -> str:
+        metadata = getattr(plan, "metadata", None)
+        if not isinstance(metadata, dict):
+            return ""
+        return str(metadata.get("backbone_run_id", "") or "").strip()
+
+    def _record_execution_stage(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        artifact_ref: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        if not run_id:
+            return
+        self.plan_store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.EXECUTION,
+                status=status,
+                artifact_ref=artifact_ref,
+                details=details,
+            ),
+        )
+
+    def _build_feedback_record(
+        self,
+        plan: Any,
+        outcome: PlanOutcome,
+        *,
+        receipt_ref: str,
+        execution_mode: str,
+    ) -> OutcomeFeedbackRecord:
+        quality_score = 1.0 if outcome.success else 0.25
+        pipeline_like = SimpleNamespace(
+            pipeline_id=plan.id,
+            run_type="decision_plan_execution",
+            domain=(
+                plan.metadata.get("domain", "")
+                if isinstance(getattr(plan, "metadata", None), dict)
+                else ""
+            ),
+            overall_quality_score=quality_score,
+            spec_completeness=1.0 if outcome.success else 0.5,
+            execution_succeeded=outcome.success,
+            tests_passed=int(getattr(outcome, "tests_passed", 0) or 0),
+            tests_failed=int(getattr(outcome, "tests_failed", 0) or 0),
+            files_changed=int(getattr(outcome, "files_changed", 0) or 0),
+            human_interventions=0,
+            rollback_triggered=bool(getattr(outcome, "rollback_triggered", False)),
+            total_duration_s=outcome.duration_seconds,
+        )
+        next_action = ""
+        if not outcome.success and int(getattr(outcome, "tests_failed", 0) or 0) > 0:
+            next_action = "run_bug_fix_loop"
+        return OutcomeFeedbackRecord.from_pipeline_outcome(
+            pipeline_like,
+            receipt_ref=receipt_ref or plan.id,
+            next_action_recommendation=next_action,
+        )
+
+    async def _attach_backbone_receipt_and_feedback(
+        self,
+        *,
+        run_id: str,
+        plan: Any,
+        outcome: PlanOutcome,
+        execution_mode: str,
+    ) -> None:
+        from aragora.blockchain.receipt_settlement import ReceiptSettlementService
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+        from aragora.pipeline.canonical_execution import build_decision_receipt_payload
+
+        run = self.plan_store.get_run(run_id)
+        receipt_payload = build_decision_receipt_payload(plan, outcome)
+        receipt_ref = str(getattr(outcome, "receipt_id", "") or plan.id)
+
+        if isinstance(receipt_payload, dict):
+            taint_summary = TaintChecker.collect_taint_summary(
+                intake=getattr(run, "intake_bundle", None),
+                spec=getattr(run, "spec_bundle", None),
+                deliberation=getattr(run, "deliberation_bundle", None),
+                verification=getattr(run, "receipt_envelope", None),
+            )
+            metadata = getattr(plan, "metadata", None)
+            gate = metadata.get("execution_gate", {}) if isinstance(metadata, dict) else {}
+            envelope = ReceiptEnvelope.from_decision_receipt(
+                receipt_payload,
+                policy_gate_result=dict(gate or {}),
+                taint_summary=taint_summary,
+            )
+            receipt_ref = envelope.receipt_id or receipt_ref
+            self.plan_store.update_run(
+                run_id,
+                receipt_id=receipt_ref,
+                receipt_envelope=envelope,
+            )
+            self.plan_store.append_run_stage_event(
+                run_id,
+                RunStageEvent.create(
+                    BackboneStage.RECEIPT,
+                    status="completed",
+                    artifact_ref=receipt_ref,
+                    details={"source": "decision_plan_execution"},
+                ),
+            )
+            try:
+                settled_receipt = await ReceiptSettlementService().anchor_receipt(
+                    DecisionReceipt.from_dict(receipt_payload)
+                )
+                attestation = getattr(settled_receipt, "settlement_status", None)
+                if isinstance(attestation, dict):
+                    self.plan_store.update_run(run_id, attestation=attestation)
+                    self.plan_store.append_run_stage_event(
+                        run_id,
+                        RunStageEvent.create(
+                            BackboneStage.ATTESTATION,
+                            status="completed",
+                            artifact_ref=receipt_ref,
+                            details=attestation,
+                        ),
+                    )
+            except Exception:
+                logger.debug("Backbone shadow attestation failed", exc_info=True)
+
+        feedback_record = self._build_feedback_record(
+            plan,
+            outcome,
+            receipt_ref=receipt_ref,
+            execution_mode=execution_mode,
+        )
+        self.plan_store.update_run(run_id, feedback_record=feedback_record)
+        self.plan_store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.FEEDBACK,
+                status="completed",
+                artifact_ref=receipt_ref,
+                details={
+                    "next_action": feedback_record.next_action_recommendation,
+                    "execution_mode": execution_mode,
+                },
+            ),
+        )
 
     async def execute_approved_plan(
         self,
@@ -107,6 +262,53 @@ class ExecutionBridge:
         if plan.requires_human_approval and not plan.is_approved:
             raise ValueError(f"Plan {plan_id} requires approval before execution")
 
+        resolved_execution_id = execution_id or f"exec-{uuid.uuid4().hex[:12]}"
+        resolved_correlation_id = correlation_id or f"corr-{uuid.uuid4().hex[:12]}"
+        backbone_run_id = self._extract_backbone_run_id(plan)
+
+        from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
+
+        gate_decision = evaluate_plan_execution_gate(plan, plan_store=store)
+        if not gate_decision.allow_execution:
+            blocked_status = (
+                "pending_approval" if gate_decision.requires_human_approval else "blocked"
+            )
+            if store.get_execution_record(resolved_execution_id) is None:
+                store.create_execution_record(
+                    execution_id=resolved_execution_id,
+                    plan_id=plan.id,
+                    debate_id=plan.debate_id,
+                    correlation_id=resolved_correlation_id,
+                    status=blocked_status,
+                    metadata={
+                        "execution_mode": execution_mode or "default",
+                        "backbone_run_id": backbone_run_id or None,
+                        "execution_gate": gate_decision.gate,
+                    },
+                )
+            else:
+                store.update_execution_record(
+                    resolved_execution_id,
+                    status=blocked_status,
+                    metadata={"execution_gate": gate_decision.gate},
+                )
+            if backbone_run_id:
+                store.update_run(
+                    backbone_run_id,
+                    status=blocked_status,
+                    execution_id=resolved_execution_id,
+                    metadata={"execution_gate": gate_decision.gate},
+                )
+                self._record_execution_stage(
+                    backbone_run_id,
+                    status=blocked_status,
+                    artifact_ref=resolved_execution_id,
+                    details={"plan_id": plan.id, "reason_codes": gate_decision.reason_codes},
+                )
+            raise ValueError(
+                f"Plan {plan_id} blocked by execution gate ({', '.join(gate_decision.reason_codes)})"
+            )
+
         expected_statuses = [PlanStatus.APPROVED]
         if not plan.requires_human_approval:
             expected_statuses.append(PlanStatus.CREATED)
@@ -133,9 +335,6 @@ class ExecutionBridge:
 
         plan.status = PlanStatus.EXECUTING
         plan.execution_started_at = datetime.now()
-
-        resolved_execution_id = execution_id or f"exec-{uuid.uuid4().hex[:12]}"
-        resolved_correlation_id = correlation_id or f"corr-{uuid.uuid4().hex[:12]}"
         if store.get_execution_record(resolved_execution_id) is None:
             store.create_execution_record(
                 execution_id=resolved_execution_id,
@@ -146,6 +345,8 @@ class ExecutionBridge:
                 metadata={
                     "execution_mode": execution_mode or "default",
                     "started_by": getattr(auth_context, "user_id", None),
+                    "backbone_run_id": backbone_run_id or None,
+                    "execution_gate": gate_decision.gate,
                 },
             )
         else:
@@ -155,6 +356,27 @@ class ExecutionBridge:
                 metadata={
                     "execution_mode": execution_mode or "default",
                     "started_by": getattr(auth_context, "user_id", None),
+                    "backbone_run_id": backbone_run_id or None,
+                    "execution_gate": gate_decision.gate,
+                },
+            )
+        if backbone_run_id:
+            store.update_run(
+                backbone_run_id,
+                status="execution_running",
+                execution_id=resolved_execution_id,
+                metadata={
+                    "execution_mode": execution_mode or "default",
+                    "execution_gate": gate_decision.gate,
+                },
+            )
+            self._record_execution_stage(
+                backbone_run_id,
+                status="running",
+                artifact_ref=resolved_execution_id,
+                details={
+                    "plan_id": plan.id,
+                    "execution_mode": execution_mode or "default",
                 },
             )
 
@@ -182,6 +404,19 @@ class ExecutionBridge:
                     "terminal_state": "failed",
                 },
             )
+            if backbone_run_id:
+                store.update_run(
+                    backbone_run_id,
+                    status="execution_failed",
+                    execution_id=resolved_execution_id,
+                    metadata={"execution_terminal_state": "failed"},
+                )
+                self._record_execution_stage(
+                    backbone_run_id,
+                    status="failed",
+                    artifact_ref=resolved_execution_id,
+                    details={"error": str(exc), "plan_id": plan.id},
+                )
             raise
 
         # Persist final status
@@ -206,6 +441,33 @@ class ExecutionBridge:
                 "terminal_state": "succeeded" if outcome.success else "failed",
             },
         )
+        if backbone_run_id:
+            store.update_run(
+                backbone_run_id,
+                status="execution_succeeded" if outcome.success else "execution_failed",
+                execution_id=resolved_execution_id,
+                metadata={
+                    "execution_terminal_state": "succeeded" if outcome.success else "failed",
+                    "execution_duration_seconds": outcome.duration_seconds,
+                },
+            )
+            self._record_execution_stage(
+                backbone_run_id,
+                status="succeeded" if outcome.success else "failed",
+                artifact_ref=resolved_execution_id,
+                details={
+                    "plan_id": plan.id,
+                    "duration_seconds": outcome.duration_seconds,
+                    "tasks_completed": outcome.tasks_completed,
+                    "tasks_total": outcome.tasks_total,
+                },
+            )
+            await self._attach_backbone_receipt_and_feedback(
+                run_id=backbone_run_id,
+                plan=plan,
+                outcome=outcome,
+                execution_mode=str(execution_mode or "default"),
+            )
 
         logger.info(
             "Plan %s execution %s (%.1fs, %d/%d tasks)",
@@ -255,7 +517,47 @@ class ExecutionBridge:
         record_execution_id = f"exec-{uuid.uuid4().hex[:12]}"
         record_correlation_id = f"corr-{uuid.uuid4().hex[:12]}"
         plan = self.plan_store.get(plan_id)
+        backbone_run_id = self._extract_backbone_run_id(plan) if plan is not None else ""
         if plan is not None:
+            from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
+
+            gate_decision = evaluate_plan_execution_gate(plan, plan_store=self.plan_store)
+            if not gate_decision.allow_execution:
+                blocked_status = (
+                    "pending_approval" if gate_decision.requires_human_approval else "blocked"
+                )
+                self.plan_store.create_execution_record(
+                    execution_id=record_execution_id,
+                    plan_id=plan.id,
+                    debate_id=plan.debate_id,
+                    correlation_id=record_correlation_id,
+                    status=blocked_status,
+                    metadata={
+                        "execution_mode": execution_mode or "default",
+                        "scheduled_by": getattr(auth_context, "user_id", None),
+                        "backbone_run_id": backbone_run_id or None,
+                        "execution_gate": gate_decision.gate,
+                    },
+                )
+                if backbone_run_id:
+                    self.plan_store.update_run(
+                        backbone_run_id,
+                        status=blocked_status,
+                        execution_id=record_execution_id,
+                        metadata={"execution_gate": gate_decision.gate},
+                    )
+                    self._record_execution_stage(
+                        backbone_run_id,
+                        status=blocked_status,
+                        artifact_ref=record_execution_id,
+                        details={"plan_id": plan.id, "reason_codes": gate_decision.reason_codes},
+                    )
+                logger.warning(
+                    "Execution scheduling blocked for plan %s: %s",
+                    plan.id,
+                    gate_decision.reason_codes,
+                )
+                return
             self.plan_store.create_execution_record(
                 execution_id=record_execution_id,
                 plan_id=plan.id,
@@ -265,8 +567,25 @@ class ExecutionBridge:
                 metadata={
                     "execution_mode": execution_mode or "default",
                     "scheduled_by": getattr(auth_context, "user_id", None),
+                    "backbone_run_id": backbone_run_id or None,
                 },
             )
+            if backbone_run_id:
+                self.plan_store.update_run(
+                    backbone_run_id,
+                    status="execution_queued",
+                    execution_id=record_execution_id,
+                    metadata={"execution_mode": execution_mode or "default"},
+                )
+                self._record_execution_stage(
+                    backbone_run_id,
+                    status="queued",
+                    artifact_ref=record_execution_id,
+                    details={
+                        "plan_id": plan.id,
+                        "execution_mode": execution_mode or "default",
+                    },
+                )
 
         async def _run() -> None:
             try:

--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -406,7 +406,13 @@ class PlanExecutor:
             plan.metadata.setdefault("org_id", getattr(auth_context, "org_id", None))
             plan.metadata.setdefault("requested_by", getattr(auth_context, "user_id", None))
 
-        from aragora.pipeline.receipt_gate import ensure_plan_receipt, sync_plan_receipt_state
+        from aragora.pipeline.receipt_gate import (
+            enforce_plan_execution_gate,
+            ensure_plan_receipt,
+            sync_plan_receipt_state,
+        )
+
+        enforce_plan_execution_gate(plan)
 
         ensure_plan_receipt(plan)
 

--- a/aragora/pipeline/plan_store.py
+++ b/aragora/pipeline/plan_store.py
@@ -21,9 +21,20 @@ import os
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Iterable, Sequence
 import uuid
 
+from aragora.pipeline.backbone_contracts import (
+    BackboneStage,
+    DeliberationBundle,
+    IntakeBundle,
+    OutcomeFeedbackRecord,
+    ReceiptEnvelope,
+    RunLedger,
+    RunStageEvent,
+    SpecBundle,
+    TaintChecker,
+)
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     ApprovalRecord,
@@ -41,6 +52,7 @@ logger = logging.getLogger(__name__)
 # Default database location
 _DEFAULT_DB_DIR = os.environ.get("ARAGORA_DATA_DIR", str(Path.home() / ".aragora"))
 _DEFAULT_DB_PATH = os.path.join(_DEFAULT_DB_DIR, "plans.db")
+_UNSET = object()
 
 
 def _get_db_path() -> str:
@@ -53,7 +65,7 @@ def _get_db_path() -> str:
         return _DEFAULT_DB_PATH
 
 
-def _dedupe_strings(values: Sequence[Any]) -> list[str]:
+def _dedupe_strings(values: Iterable[Any]) -> list[str]:
     """Preserve order while removing blank or duplicate string-like values."""
     seen: set[str] = set()
     deduped: list[str] = []
@@ -75,6 +87,16 @@ def _parse_metadata_json(raw: str | None) -> dict[str, Any]:
     except (TypeError, ValueError, json.JSONDecodeError):
         return {}
     return parsed if isinstance(parsed, dict) else {}
+
+
+def _load_json_value(raw: str | None) -> Any:
+    """Parse arbitrary JSON payloads safely."""
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
 
 
 def _extract_refresh_scope(metadata: dict[str, Any]) -> dict[str, Any]:
@@ -224,6 +246,64 @@ class PlanStore:
                 CREATE INDEX IF NOT EXISTS idx_plan_executions_started_at
                 ON plan_executions(started_at DESC)
             """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS backbone_runs (
+                    run_id TEXT PRIMARY KEY,
+                    entrypoint TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'received',
+                    intake_bundle_json TEXT,
+                    spec_bundle_json TEXT,
+                    goal_refs_json TEXT,
+                    deliberation_bundle_json TEXT,
+                    plan_id TEXT,
+                    debate_id TEXT,
+                    execution_id TEXT,
+                    receipt_id TEXT,
+                    receipt_envelope_json TEXT,
+                    feedback_record_json TEXT,
+                    attestation_json TEXT,
+                    taint_flags_json TEXT,
+                    metadata_json TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_runs_status
+                ON backbone_runs(status)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_runs_plan_id
+                ON backbone_runs(plan_id)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_runs_debate_id
+                ON backbone_runs(debate_id)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_runs_execution_id
+                ON backbone_runs(execution_id)
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS backbone_run_events (
+                    event_id TEXT PRIMARY KEY,
+                    run_id TEXT NOT NULL,
+                    stage TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    artifact_ref TEXT,
+                    details_json TEXT,
+                    created_at TEXT NOT NULL,
+                    FOREIGN KEY (run_id) REFERENCES backbone_runs(run_id) ON DELETE CASCADE
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_run_events_run_id
+                ON backbone_run_events(run_id)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_backbone_run_events_stage
+                ON backbone_run_events(stage)
+            """)
 
             # Backward-compatible schema migration for existing databases.
             columns = {row["name"] for row in conn.execute("PRAGMA table_info(plans)").fetchall()}
@@ -311,6 +391,7 @@ class PlanStore:
                 ),
             )
             conn.commit()
+            self._attach_backbone_receipt_for_plan(plan, append_event=False)
             logger.info("Stored plan %s for debate %s", plan.id, plan.debate_id)
         finally:
             conn.close()
@@ -450,6 +531,7 @@ class PlanStore:
                         plan = self.get(plan_id)
                         if plan is not None:
                             sync_plan_receipt_state(plan, on_status=status)
+                            self._attach_backbone_receipt_for_plan(plan, append_event=True)
                     except Exception as exc:  # noqa: BLE001 - do not mask status update
                         logger.warning(
                             "Failed to synchronize decision receipt for plan %s: %s",
@@ -532,6 +614,7 @@ class PlanStore:
                         plan = self.get(plan_id)
                         if plan is not None:
                             sync_plan_receipt_state(plan, on_status=new_status)
+                            self._attach_backbone_receipt_for_plan(plan, append_event=True)
                     except Exception as exc:  # noqa: BLE001 - do not mask status update
                         logger.warning(
                             "Failed to synchronize decision receipt for plan %s: %s",
@@ -610,8 +693,11 @@ class PlanStore:
                 params.append(now)
 
         if metadata is not None:
+            existing = self.get_execution_record(execution_id)
+            merged_metadata = dict(existing.get("metadata", {}) or {}) if existing else {}
+            merged_metadata.update(metadata)
             fields.append("metadata_json = ?")
-            params.append(json.dumps(metadata))
+            params.append(json.dumps(merged_metadata))
 
         if error is not None:
             fields.append("error_json = ?")
@@ -747,6 +833,264 @@ class PlanStore:
         finally:
             conn.close()
 
+    # -------------------------------------------------------------------------
+    # Backbone run ledger
+    # -------------------------------------------------------------------------
+
+    def create_run(self, run: RunLedger) -> None:
+        """Insert a new persisted backbone run ledger."""
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO backbone_runs (
+                    run_id, entrypoint, status, intake_bundle_json, spec_bundle_json,
+                    goal_refs_json, deliberation_bundle_json, plan_id, debate_id,
+                    execution_id, receipt_id, receipt_envelope_json, feedback_record_json,
+                    attestation_json, taint_flags_json, metadata_json, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run.run_id,
+                    run.entrypoint,
+                    run.status,
+                    json.dumps(run.intake_bundle.to_dict()) if run.intake_bundle else None,
+                    json.dumps(run.spec_bundle.to_dict()) if run.spec_bundle else None,
+                    json.dumps(run.goal_refs),
+                    json.dumps(run.deliberation_bundle.to_dict())
+                    if run.deliberation_bundle
+                    else None,
+                    run.plan_id or None,
+                    run.debate_id or None,
+                    run.execution_id or None,
+                    run.receipt_id or None,
+                    json.dumps(run.receipt_envelope.to_dict()) if run.receipt_envelope else None,
+                    json.dumps(run.feedback_record.to_dict()) if run.feedback_record else None,
+                    json.dumps(run.attestation),
+                    json.dumps(run.taint_flags),
+                    json.dumps(run.metadata),
+                    run.created_at,
+                    run.updated_at,
+                ),
+            )
+            for event in run.stage_events:
+                conn.execute(
+                    """
+                    INSERT INTO backbone_run_events (
+                        event_id, run_id, stage, status, artifact_ref, details_json, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event.event_id,
+                        run.run_id,
+                        event.stage,
+                        event.status,
+                        event.artifact_ref or None,
+                        json.dumps(event.details),
+                        event.created_at,
+                    ),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def get_run(self, run_id: str) -> RunLedger | None:
+        """Fetch one backbone run ledger by ID."""
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT * FROM backbone_runs WHERE run_id = ?",
+                (run_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            event_rows = conn.execute(
+                """
+                SELECT * FROM backbone_run_events
+                WHERE run_id = ?
+                ORDER BY created_at ASC, event_id ASC
+                """,
+                (run_id,),
+            ).fetchall()
+            return self._row_to_run(row, event_rows)
+        finally:
+            conn.close()
+
+    def list_runs(
+        self,
+        *,
+        status: str | None = None,
+        plan_id: str | None = None,
+        debate_id: str | None = None,
+        execution_id: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> builtins.list[RunLedger]:
+        """List backbone run ledgers with optional filters."""
+        clauses: builtins.list[str] = []
+        params: builtins.list[Any] = []
+
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status)
+        if plan_id is not None:
+            clauses.append("plan_id = ?")
+            params.append(plan_id)
+        if debate_id is not None:
+            clauses.append("debate_id = ?")
+            params.append(debate_id)
+        if execution_id is not None:
+            clauses.append("execution_id = ?")
+            params.append(execution_id)
+
+        where = ""
+        if clauses:
+            where = "WHERE " + " AND ".join(clauses)
+
+        query = f"SELECT * FROM backbone_runs {where} ORDER BY created_at DESC LIMIT ? OFFSET ?"  # noqa: S608 -- internal query construction
+        params.extend([limit, offset])
+
+        conn = self._connect()
+        try:
+            rows = conn.execute(query, params).fetchall()
+            results: builtins.list[RunLedger] = []
+            for row in rows:
+                event_rows = conn.execute(
+                    """
+                    SELECT * FROM backbone_run_events
+                    WHERE run_id = ?
+                    ORDER BY created_at ASC, event_id ASC
+                    """,
+                    (row["run_id"],),
+                ).fetchall()
+                results.append(self._row_to_run(row, event_rows))
+            return results
+        finally:
+            conn.close()
+
+    def update_run(
+        self,
+        run_id: str,
+        *,
+        status: str | None = None,
+        intake_bundle: IntakeBundle | None | object = _UNSET,
+        spec_bundle: SpecBundle | None | object = _UNSET,
+        goal_refs: builtins.list[dict[str, Any]] | object = _UNSET,
+        deliberation_bundle: DeliberationBundle | None | object = _UNSET,
+        plan_id: str | None = None,
+        debate_id: str | None = None,
+        execution_id: str | None = None,
+        receipt_id: str | None = None,
+        receipt_envelope: ReceiptEnvelope | None | object = _UNSET,
+        feedback_record: OutcomeFeedbackRecord | None | object = _UNSET,
+        attestation: dict[str, Any] | object = _UNSET,
+        taint_flags: builtins.list[str] | None | object = _UNSET,
+        metadata: dict[str, Any] | object = _UNSET,
+        merge_metadata: bool = True,
+    ) -> bool:
+        """Update one run ledger in-place."""
+        run = self.get_run(run_id)
+        if run is None:
+            return False
+
+        if status is not None:
+            run.status = str(status).strip() or run.status
+        if intake_bundle is not _UNSET:
+            run.attach_intake(intake_bundle if isinstance(intake_bundle, IntakeBundle) else None)
+        if spec_bundle is not _UNSET:
+            run.attach_spec(spec_bundle if isinstance(spec_bundle, SpecBundle) else None)
+        if goal_refs is not _UNSET:
+            run.goal_refs = list(goal_refs) if isinstance(goal_refs, list) else []
+            run.touch()
+        if deliberation_bundle is not _UNSET:
+            run.attach_deliberation(
+                deliberation_bundle if isinstance(deliberation_bundle, DeliberationBundle) else None
+            )
+        if plan_id is not None:
+            run.plan_id = str(plan_id).strip()
+            run.touch()
+        if debate_id is not None:
+            run.debate_id = str(debate_id).strip()
+            run.touch()
+        if execution_id is not None:
+            run.execution_id = str(execution_id).strip()
+            run.touch()
+        if receipt_id is not None:
+            run.receipt_id = str(receipt_id).strip()
+            run.touch()
+        if receipt_envelope is not _UNSET:
+            run.attach_receipt(
+                receipt_envelope if isinstance(receipt_envelope, ReceiptEnvelope) else None
+            )
+        if feedback_record is not _UNSET:
+            run.attach_feedback(
+                feedback_record if isinstance(feedback_record, OutcomeFeedbackRecord) else None
+            )
+        if attestation is not _UNSET:
+            run.attestation = dict(attestation) if isinstance(attestation, dict) else {}
+            run.touch()
+        if taint_flags is not _UNSET:
+            run.merge_taint(list(taint_flags) if isinstance(taint_flags, list | tuple) else [])
+        if metadata is not _UNSET:
+            next_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+            if merge_metadata:
+                run.metadata.update(next_metadata)
+            else:
+                run.metadata = next_metadata
+            run.touch()
+
+        run.touch()
+        return self._save_run(run)
+
+    def append_run_stage_event(self, run_id: str, event: RunStageEvent) -> bool:
+        """Append a single stage event to a run."""
+        conn = self._connect()
+        try:
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO backbone_run_events (
+                        event_id, run_id, stage, status, artifact_ref, details_json, created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event.event_id,
+                        run_id,
+                        event.stage,
+                        event.status,
+                        event.artifact_ref or None,
+                        json.dumps(event.details),
+                        event.created_at,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                return False
+
+            cursor = conn.execute(
+                "UPDATE backbone_runs SET updated_at = ? WHERE run_id = ?",
+                (event.created_at, run_id),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def list_run_stage_events(self, run_id: str) -> builtins.list[RunStageEvent]:
+        """List all persisted stage events for a run."""
+        conn = self._connect()
+        try:
+            rows = conn.execute(
+                """
+                SELECT * FROM backbone_run_events
+                WHERE run_id = ?
+                ORDER BY created_at ASC, event_id ASC
+                """,
+                (run_id,),
+            ).fetchall()
+            return [self._row_to_run_event(row) for row in rows]
+        finally:
+            conn.close()
+
     def delete(self, plan_id: str) -> bool:
         """Delete a plan by ID. Returns True if deleted."""
         conn = self._connect()
@@ -760,6 +1104,80 @@ class PlanStore:
     # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------
+
+    def _attach_backbone_receipt_for_plan(
+        self,
+        plan: DecisionPlan,
+        *,
+        append_event: bool = False,
+    ) -> None:
+        metadata = plan.metadata if isinstance(plan.metadata, dict) else {}
+        run_id = str(metadata.get("backbone_run_id", "") or "").strip()
+        if not run_id:
+            return
+
+        receipt_meta = metadata.get("decision_receipt")
+        receipt_id = ""
+        if isinstance(receipt_meta, dict):
+            receipt_id = str(receipt_meta.get("receipt_id", "") or "").strip()
+        if not receipt_id:
+            receipt_id = str(metadata.get("decision_receipt_id", "") or "").strip()
+        if not receipt_id:
+            return
+
+        try:
+            from aragora.pipeline.receipt_store_facade import get_receipt_store_facade
+
+            canonical = get_receipt_store_facade().get_canonical(receipt_id)
+        except Exception:  # noqa: BLE001 - best-effort ledger enrichment
+            logger.debug("Backbone receipt fetch failed for %s", receipt_id, exc_info=True)
+            return
+
+        if not isinstance(canonical, dict):
+            return
+        receipt_payload = canonical.get("receipt_data")
+        if isinstance(receipt_payload, dict):
+            receipt_payload = dict(receipt_payload)
+            receipt_payload.setdefault("receipt_id", receipt_id)
+            receipt_payload.setdefault("signature", canonical.get("signature"))
+            receipt_payload.setdefault("signature_key_id", canonical.get("signature_key_id"))
+            receipt_payload.setdefault("signed_at", canonical.get("signed_at"))
+            receipt_payload.setdefault("signature_algorithm", canonical.get("signature_algorithm"))
+            receipt_payload["state"] = canonical.get("state", receipt_payload.get("state"))
+        else:
+            receipt_payload = canonical
+        if not isinstance(receipt_payload, dict):
+            return
+
+        run = self.get_run(run_id)
+        taint_summary = TaintChecker.collect_taint_summary(
+            intake=getattr(run, "intake_bundle", None),
+            spec=getattr(run, "spec_bundle", None),
+            deliberation=getattr(run, "deliberation_bundle", None),
+            verification=getattr(run, "receipt_envelope", None),
+        )
+        gate = metadata.get("execution_gate")
+        envelope = ReceiptEnvelope.from_decision_receipt(
+            receipt_payload,
+            policy_gate_result=dict(gate or {}) if isinstance(gate, dict) else {},
+            taint_summary=taint_summary,
+        )
+        self.update_run(
+            run_id,
+            receipt_id=receipt_id,
+            receipt_envelope=envelope,
+            metadata={"plan_receipt_state": str(receipt_payload.get("state", "")).lower()},
+        )
+        if append_event:
+            self.append_run_stage_event(
+                run_id,
+                RunStageEvent.create(
+                    BackboneStage.RECEIPT,
+                    status=str(receipt_payload.get("state", "created") or "created").lower(),
+                    artifact_ref=receipt_id,
+                    details={"source": "plan_status_transition", "plan_id": plan.id},
+                ),
+            )
 
     @staticmethod
     def _row_to_plan(row: sqlite3.Row) -> DecisionPlan:
@@ -885,6 +1303,104 @@ class PlanStore:
             "completed_at": row["completed_at"],
             "updated_at": row["updated_at"],
         }
+
+    def _save_run(self, run: RunLedger) -> bool:
+        """Persist the current snapshot of a run ledger."""
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                UPDATE backbone_runs
+                SET entrypoint = ?,
+                    status = ?,
+                    intake_bundle_json = ?,
+                    spec_bundle_json = ?,
+                    goal_refs_json = ?,
+                    deliberation_bundle_json = ?,
+                    plan_id = ?,
+                    debate_id = ?,
+                    execution_id = ?,
+                    receipt_id = ?,
+                    receipt_envelope_json = ?,
+                    feedback_record_json = ?,
+                    attestation_json = ?,
+                    taint_flags_json = ?,
+                    metadata_json = ?,
+                    updated_at = ?
+                WHERE run_id = ?
+                """,
+                (
+                    run.entrypoint,
+                    run.status,
+                    json.dumps(run.intake_bundle.to_dict()) if run.intake_bundle else None,
+                    json.dumps(run.spec_bundle.to_dict()) if run.spec_bundle else None,
+                    json.dumps(run.goal_refs),
+                    json.dumps(run.deliberation_bundle.to_dict())
+                    if run.deliberation_bundle
+                    else None,
+                    run.plan_id or None,
+                    run.debate_id or None,
+                    run.execution_id or None,
+                    run.receipt_id or None,
+                    json.dumps(run.receipt_envelope.to_dict()) if run.receipt_envelope else None,
+                    json.dumps(run.feedback_record.to_dict()) if run.feedback_record else None,
+                    json.dumps(run.attestation),
+                    json.dumps(run.taint_flags),
+                    json.dumps(run.metadata),
+                    run.updated_at,
+                    run.run_id,
+                ),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _row_to_run_event(row: sqlite3.Row) -> RunStageEvent:
+        details = _load_json_value(row["details_json"])
+        return RunStageEvent.from_dict(
+            {
+                "event_id": row["event_id"],
+                "stage": row["stage"],
+                "status": row["status"],
+                "artifact_ref": row["artifact_ref"] or "",
+                "details": details if isinstance(details, dict) else {},
+                "created_at": row["created_at"],
+            }
+        )
+
+    @staticmethod
+    def _row_to_run(
+        row: sqlite3.Row,
+        event_rows: Sequence[sqlite3.Row] | None = None,
+    ) -> RunLedger:
+        return RunLedger.from_dict(
+            {
+                "run_id": row["run_id"],
+                "entrypoint": row["entrypoint"],
+                "status": row["status"],
+                "intake_bundle": _load_json_value(row["intake_bundle_json"]),
+                "spec_bundle": _load_json_value(row["spec_bundle_json"]),
+                "goal_refs": _load_json_value(row["goal_refs_json"]) or [],
+                "deliberation_bundle": _load_json_value(row["deliberation_bundle_json"]),
+                "plan_id": row["plan_id"] or "",
+                "debate_id": row["debate_id"] or "",
+                "execution_id": row["execution_id"] or "",
+                "receipt_id": row["receipt_id"] or "",
+                "receipt_envelope": _load_json_value(row["receipt_envelope_json"]),
+                "feedback_record": _load_json_value(row["feedback_record_json"]),
+                "attestation": _load_json_value(row["attestation_json"]) or {},
+                "taint_flags": _load_json_value(row["taint_flags_json"]) or [],
+                "metadata": _parse_metadata_json(row["metadata_json"]),
+                "stage_events": [
+                    PlanStore._row_to_run_event(event_row).to_dict()
+                    for event_row in list(event_rows or [])
+                ],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            }
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/aragora/pipeline/receipt_gate.py
+++ b/aragora/pipeline/receipt_gate.py
@@ -25,9 +25,22 @@ from aragora.pipeline.decision_plan.core import PlanStatus
 
 logger = logging.getLogger(__name__)
 
+_SAFE_AUTO_EXECUTION_TRUST_TIERS = frozenset({"operator-authored", "internal-retrieved"})
+_HUMAN_OVERRIDE_REASON_CODES = frozenset(
+    {
+        "tainted_context_detected",
+        "backbone_taint_detected",
+        "untrusted_intake_tier",
+    }
+)
+
 
 class PlanReceiptGateError(RuntimeError):
     """Raised when a plan lacks a valid pre-execution decision receipt."""
+
+
+class PlanExecutionGateError(RuntimeError):
+    """Raised when execution is blocked by trust/taint execution gating."""
 
 
 @dataclass
@@ -39,6 +52,18 @@ class PlanReceiptStatus:
     signature_valid: bool
     integrity_valid: bool
     exempted: bool = False
+
+
+@dataclass
+class PlanExecutionGateDecision:
+    """Resolved execution permission for a plan at the trust wedge."""
+
+    allow_auto_execution: bool
+    allow_execution: bool
+    requires_human_approval: bool
+    human_override_applied: bool
+    reason_codes: list[str]
+    gate: dict[str, Any]
 
 
 def _metadata(plan: Any) -> dict[str, Any]:
@@ -102,6 +127,134 @@ def _list_of_strings(value: Any) -> list[str]:
                 result.append(text)
         return result
     return []
+
+
+def _resolve_backbone_run(plan: Any, plan_store: Any | None = None) -> Any | None:
+    metadata = _metadata(plan)
+    run_id = str(metadata.get("backbone_run_id", "") or "").strip()
+    if not run_id:
+        return None
+    store = plan_store
+    if store is None:
+        try:
+            from aragora.pipeline.plan_store import get_plan_store
+
+            store = get_plan_store()
+        except Exception:  # noqa: BLE001 - gating must degrade safely
+            logger.debug("Backbone run store unavailable during execution gate lookup")
+            return None
+    try:
+        return store.get_run(run_id)
+    except Exception:  # noqa: BLE001 - treat missing run as absent evidence
+        logger.debug("Backbone run lookup failed for %s", run_id, exc_info=True)
+        return None
+
+
+def _collect_backbone_taint(run: Any | None) -> tuple[list[str], dict[str, Any]]:
+    if run is None:
+        return [], {}
+
+    from aragora.pipeline.backbone_contracts import TaintChecker
+
+    taint_summary = TaintChecker.collect_taint_summary(
+        intake=getattr(run, "intake_bundle", None),
+        spec=getattr(run, "spec_bundle", None),
+        deliberation=getattr(run, "deliberation_bundle", None),
+        verification=getattr(run, "receipt_envelope", None),
+    )
+    flags = _list_of_strings(getattr(run, "taint_flags", []))
+    flags.extend(_list_of_strings(taint_summary.get("flags")))
+    unique_flags = list(dict.fromkeys(flags))
+    taint_summary["flags"] = unique_flags
+    taint_summary["tainted"] = bool(unique_flags)
+    return unique_flags, taint_summary
+
+
+def evaluate_plan_execution_gate(
+    plan: Any,
+    *,
+    plan_store: Any | None = None,
+) -> PlanExecutionGateDecision:
+    """Evaluate trust/taint gating on top of any existing execution gate metadata."""
+
+    metadata = _metadata(plan)
+    gate = metadata.get("execution_gate")
+    if not isinstance(gate, dict):
+        gate = {}
+
+    reason_codes = _list_of_strings(gate.get("reason_codes"))
+    allow_auto_execution = bool(gate.get("allow_auto_execution", True))
+    if "gate_evaluation_failed" in reason_codes:
+        allow_auto_execution = False
+
+    run = _resolve_backbone_run(plan, plan_store=plan_store)
+    run_id = str(metadata.get("backbone_run_id", "") or "").strip()
+    trust_tiers = _list_of_strings(
+        getattr(getattr(run, "intake_bundle", None), "trust_tiers", []) if run else []
+    )
+    taint_flags, taint_summary = _collect_backbone_taint(run)
+
+    if trust_tiers and any(tier not in _SAFE_AUTO_EXECUTION_TRUST_TIERS for tier in trust_tiers):
+        reason_codes.append("untrusted_intake_tier")
+        allow_auto_execution = False
+    if taint_flags:
+        reason_codes.append("backbone_taint_detected")
+        allow_auto_execution = False
+    if not allow_auto_execution and not reason_codes:
+        reason_codes.append("execution_gate_blocked")
+
+    ordered_reason_codes = list(dict.fromkeys(reason_codes))
+    overrideable = bool(set(ordered_reason_codes) & _HUMAN_OVERRIDE_REASON_CODES)
+    only_overrideable = bool(ordered_reason_codes) and set(ordered_reason_codes).issubset(
+        _HUMAN_OVERRIDE_REASON_CODES
+    )
+    human_override_applied = bool(getattr(plan, "approval_record", None)) and bool(
+        getattr(getattr(plan, "approval_record", None), "approved", False)
+    )
+    allow_execution = allow_auto_execution and not ordered_reason_codes
+    requires_human_approval = False
+    if not allow_execution and overrideable and only_overrideable:
+        requires_human_approval = not human_override_applied
+        allow_execution = human_override_applied
+
+    gate_payload = {
+        **gate,
+        "allow_auto_execution": allow_auto_execution and not ordered_reason_codes,
+        "allow_execution": allow_execution,
+        "requires_human_approval": requires_human_approval,
+        "human_override_applied": human_override_applied,
+        "reason_codes": ordered_reason_codes,
+        "backbone_run_id": run_id,
+        "trust_tiers": trust_tiers,
+        "taint_flags": taint_flags,
+        "context_taint_detected": bool(gate.get("context_taint_detected")) or bool(taint_flags),
+        "taint_summary": taint_summary,
+    }
+    metadata["execution_gate"] = gate_payload
+    return PlanExecutionGateDecision(
+        allow_auto_execution=bool(gate_payload["allow_auto_execution"]),
+        allow_execution=allow_execution,
+        requires_human_approval=requires_human_approval,
+        human_override_applied=human_override_applied,
+        reason_codes=ordered_reason_codes,
+        gate=gate_payload,
+    )
+
+
+def enforce_plan_execution_gate(
+    plan: Any,
+    *,
+    plan_store: Any | None = None,
+) -> PlanExecutionGateDecision:
+    """Raise if a plan is not allowed to execute at the trust wedge."""
+
+    decision = evaluate_plan_execution_gate(plan, plan_store=plan_store)
+    if not decision.allow_execution:
+        reasons = ", ".join(decision.reason_codes) or "execution_gate_blocked"
+        raise PlanExecutionGateError(
+            f"Plan {getattr(plan, 'id', '')} blocked by execution gate: {reasons}"
+        )
+    return decision
 
 
 def _synthetic_debate_result(plan: Any) -> Any:
@@ -405,23 +558,27 @@ def sync_plan_receipt_state(
         if status.exempted or status.receipt_id is None:
             return status
 
+    resolved_receipt_id = status.receipt_id
+    if resolved_receipt_id is None:
+        return status
+
     store = get_receipt_store()
-    stored = store.get(status.receipt_id)
+    stored = store.get(resolved_receipt_id)
     if stored is None:
-        raise PlanReceiptGateError(f"Decision receipt {status.receipt_id} missing during sync")
+        raise PlanReceiptGateError(f"Decision receipt {resolved_receipt_id} missing during sync")
 
     if stored.state != target_state:
         try:
-            stored = store.transition(status.receipt_id, target_state)
+            stored = store.transition(resolved_receipt_id, target_state)
         except ReceiptStateError as exc:
             raise PlanReceiptGateError(
-                f"Could not transition decision receipt {status.receipt_id} "
+                f"Could not transition decision receipt {resolved_receipt_id} "
                 f"from {stored.state.value} to {target_state.value}"
             ) from exc
 
     _update_metadata_from_store(
         plan,
-        receipt_id=status.receipt_id,
+        receipt_id=resolved_receipt_id,
         state=stored.state,
         stored=stored,
     )
@@ -429,8 +586,12 @@ def sync_plan_receipt_state(
 
 
 __all__ = [
+    "PlanExecutionGateDecision",
+    "PlanExecutionGateError",
     "PlanReceiptGateError",
     "PlanReceiptStatus",
+    "enforce_plan_execution_gate",
     "ensure_plan_receipt",
+    "evaluate_plan_execution_gate",
     "sync_plan_receipt_state",
 ]

--- a/aragora/pipeline/unified_orchestrator.py
+++ b/aragora/pipeline/unified_orchestrator.py
@@ -26,6 +26,19 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any
 
+from aragora.pipeline.backbone_contracts import (
+    BackboneStage,
+    DeliberationBundle,
+    IntakeBundle,
+    OutcomeFeedbackRecord,
+    ReceiptEnvelope,
+    RunLedger,
+    RunStageEvent,
+    SpecBundle,
+    TaintChecker,
+    build_goal_refs_from_implement_plan,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -159,6 +172,193 @@ class UnifiedOrchestrator:
         self._code_task_factory = code_task_factory
         self._provider_router = provider_router
 
+    @staticmethod
+    def _backbone_store() -> Any:
+        from aragora.pipeline.plan_store import get_plan_store
+
+        return get_plan_store()
+
+    def _create_backbone_run(self, result: OrchestratorResult, cfg: OrchestratorConfig) -> None:
+        intake = IntakeBundle(
+            source_kind="unified_orchestrator",
+            raw_intent=result.prompt,
+            context_refs=[],
+            trust_tiers=["operator-authored"],
+            origin_metadata={
+                "entrypoint": "unified_orchestrator.run",
+                "domain": cfg.domain,
+                "preset_name": cfg.preset_name,
+                "execution_mode": cfg.execution_mode,
+            },
+            taint_flags=[],
+        )
+        run = RunLedger(
+            run_id=result.run_id,
+            entrypoint="unified_orchestrator.run",
+            status="running",
+            intake_bundle=intake,
+            metadata={"skip_execution": cfg.skip_execution},
+        )
+        run.add_event(
+            RunStageEvent.create(
+                BackboneStage.INTAKE,
+                status="received",
+                details={"prompt_length": len(result.prompt), "domain": cfg.domain or "general"},
+            )
+        )
+        self._backbone_store().create_run(run)
+
+    def _append_backbone_event(
+        self,
+        result: OrchestratorResult,
+        stage: BackboneStage | str,
+        *,
+        status: str,
+        artifact_ref: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        self._backbone_store().append_run_stage_event(
+            result.run_id,
+            RunStageEvent.create(
+                stage,
+                status=status,
+                artifact_ref=artifact_ref,
+                details=details,
+            ),
+        )
+
+    def _update_backbone_run(
+        self,
+        result: OrchestratorResult,
+        *,
+        status: str | None = None,
+        spec_bundle: SpecBundle | None | object = None,
+        deliberation_bundle: DeliberationBundle | None | object = None,
+        goal_refs: list[dict[str, Any]] | None = None,
+        plan_id: str | None = None,
+        debate_id: str | None = None,
+        receipt_id: str | None = None,
+        receipt_envelope: ReceiptEnvelope | None | object = None,
+        feedback_record: OutcomeFeedbackRecord | None | object = None,
+        attestation: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        update_kwargs: dict[str, Any] = {}
+        if status is not None:
+            update_kwargs["status"] = status
+        if spec_bundle is not None:
+            update_kwargs["spec_bundle"] = spec_bundle
+        if deliberation_bundle is not None:
+            update_kwargs["deliberation_bundle"] = deliberation_bundle
+        if goal_refs is not None:
+            update_kwargs["goal_refs"] = goal_refs
+        if plan_id is not None:
+            update_kwargs["plan_id"] = plan_id
+        if debate_id is not None:
+            update_kwargs["debate_id"] = debate_id
+        if receipt_id is not None:
+            update_kwargs["receipt_id"] = receipt_id
+        if receipt_envelope is not None:
+            update_kwargs["receipt_envelope"] = receipt_envelope
+        if feedback_record is not None:
+            update_kwargs["feedback_record"] = feedback_record
+        if attestation is not None:
+            update_kwargs["attestation"] = attestation
+        if metadata is not None:
+            update_kwargs["metadata"] = metadata
+        if update_kwargs:
+            self._backbone_store().update_run(result.run_id, **update_kwargs)
+
+    @staticmethod
+    def _ensure_plan_backbone_metadata(plan: Any, run_id: str) -> None:
+        metadata = getattr(plan, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            setattr(plan, "metadata", metadata)
+        metadata.setdefault("backbone_run_id", run_id)
+        metadata.setdefault("backbone_entrypoint", "unified_orchestrator.run")
+
+    async def _attach_backbone_receipt(
+        self,
+        result: OrchestratorResult,
+        plan: Any,
+        outcome: Any,
+    ) -> str:
+        from aragora.blockchain.receipt_settlement import ReceiptSettlementService
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+        from aragora.pipeline.canonical_execution import build_decision_receipt_payload
+
+        receipt_payload = build_decision_receipt_payload(plan, outcome)
+        if not isinstance(receipt_payload, dict):
+            return ""
+
+        run = self._backbone_store().get_run(result.run_id)
+        taint_summary = TaintChecker.collect_taint_summary(
+            intake=getattr(run, "intake_bundle", None),
+            spec=getattr(run, "spec_bundle", None),
+            deliberation=getattr(run, "deliberation_bundle", None),
+            verification=getattr(run, "receipt_envelope", None),
+        )
+        metadata = getattr(plan, "metadata", None)
+        gate = metadata.get("execution_gate", {}) if isinstance(metadata, dict) else {}
+        envelope = ReceiptEnvelope.from_decision_receipt(
+            receipt_payload,
+            policy_gate_result=dict(gate or {}),
+            taint_summary=taint_summary,
+        )
+        self._update_backbone_run(
+            result,
+            receipt_id=envelope.receipt_id,
+            receipt_envelope=envelope,
+        )
+        self._append_backbone_event(
+            result,
+            BackboneStage.RECEIPT,
+            status="completed",
+            artifact_ref=envelope.receipt_id,
+            details={"source": "decision_plan_execution"},
+        )
+
+        try:
+            settled_receipt = await ReceiptSettlementService().anchor_receipt(
+                DecisionReceipt.from_dict(receipt_payload)
+            )
+            attestation = getattr(settled_receipt, "settlement_status", None)
+            if isinstance(attestation, dict):
+                self._update_backbone_run(result, attestation=attestation)
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.ATTESTATION,
+                    status="completed",
+                    artifact_ref=envelope.receipt_id,
+                    details=attestation,
+                )
+        except Exception:
+            logger.debug("Backbone attestation shadow-mode failed", exc_info=True)
+
+        return envelope.receipt_id
+
+    def _attach_backbone_feedback(
+        self,
+        result: OrchestratorResult,
+        *,
+        receipt_ref: str,
+    ) -> None:
+        if result.pipeline_outcome is None:
+            return
+        record = OutcomeFeedbackRecord.from_pipeline_outcome(
+            result.pipeline_outcome,
+            receipt_ref=receipt_ref or result.run_id,
+        )
+        self._update_backbone_run(result, feedback_record=record)
+        self._append_backbone_event(
+            result,
+            BackboneStage.FEEDBACK,
+            status="completed",
+            artifact_ref=record.receipt_ref,
+            details={"next_action": record.next_action_recommendation},
+        )
+
     async def run(
         self,
         prompt: str,
@@ -181,6 +381,10 @@ class UnifiedOrchestrator:
         cfg = config or OrchestratorConfig()
         result = OrchestratorResult(run_id=str(uuid.uuid4()), prompt=prompt)
         start = time.monotonic()
+        try:
+            self._create_backbone_run(result, cfg)
+        except Exception:
+            logger.debug("Backbone run initialization failed", exc_info=True)
 
         # Load preset defaults
         preset_config = self._load_preset(cfg.preset_name)
@@ -199,9 +403,19 @@ class UnifiedOrchestrator:
         try:
             result.research_context = await self._do_research(prompt)
             result.stages_completed.append("research")
+            self._append_backbone_event(
+                result,
+                BackboneStage.RESEARCH,
+                status="completed",
+            )
         except Exception:
             logger.warning("Research stage failed, continuing without context")
             result.stages_skipped.append("research")
+            self._append_backbone_event(
+                result,
+                BackboneStage.RESEARCH,
+                status="skipped",
+            )
 
         # --- Stage 2: Extend Input ---
         try:
@@ -209,9 +423,19 @@ class UnifiedOrchestrator:
                 prompt, cfg.domain, result.research_context
             )
             result.stages_completed.append("extend")
+            self._append_backbone_event(
+                result,
+                BackboneStage.EXTENSION,
+                status="completed",
+            )
         except Exception:
             logger.warning("Input extension failed, using raw prompt")
             result.stages_skipped.append("extend")
+            self._append_backbone_event(
+                result,
+                BackboneStage.EXTENSION,
+                status="skipped",
+            )
 
         # --- Stage 3: Debate ---
         try:
@@ -254,6 +478,25 @@ class UnifiedOrchestrator:
                 diversity_report=result.diversity_report,
             )
             result.stages_completed.append("debate")
+            deliberation_bundle = DeliberationBundle.from_debate_result(result.debate_result)
+            self._update_backbone_run(
+                result,
+                status="deliberation_ready",
+                deliberation_bundle=deliberation_bundle,
+                debate_id=str(getattr(result.debate_result, "debate_id", "") or ""),
+            )
+            self._append_backbone_event(
+                result,
+                BackboneStage.DELIBERATION,
+                status="completed",
+                artifact_ref=str(getattr(result.debate_result, "debate_id", "") or ""),
+                details={
+                    "confidence": getattr(result.debate_result, "confidence", 0.0),
+                    "consensus_reached": bool(
+                        getattr(result.debate_result, "consensus_reached", False)
+                    ),
+                },
+            )
 
             # Update phase ELO from debate
             if self._elo_tracker is not None and result.debate_result is not None:
@@ -284,6 +527,15 @@ class UnifiedOrchestrator:
             logger.error("Debate stage failed: %s", exc)
             result.errors.append(f"Debate failed: {exc}")
             result.duration_s = time.monotonic() - start
+            self._update_backbone_run(
+                result, status="failed", metadata={"errors": list(result.errors)}
+            )
+            self._append_backbone_event(
+                result,
+                BackboneStage.DELIBERATION,
+                status="failed",
+                details={"error": str(exc)},
+            )
             return result
 
         # --- Stage 3b: Quality Gate ---
@@ -318,18 +570,65 @@ class UnifiedOrchestrator:
             try:
                 result.spec_bundle = self._spec_extractor(result.debate_result)
                 result.stages_completed.append("spec_extraction")
+                spec_bundle = result.spec_bundle
+                if isinstance(spec_bundle, SpecBundle):
+                    self._update_backbone_run(
+                        result,
+                        status="spec_ready",
+                        spec_bundle=spec_bundle,
+                    )
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.SPECIFICATION,
+                        status="completed",
+                        details={"execution_grade": spec_bundle.is_execution_grade},
+                    )
             except Exception:
                 logger.warning("Spec extraction failed")
                 result.stages_skipped.append("spec_extraction")
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.SPECIFICATION,
+                    status="skipped",
+                )
 
         # --- Stage 4: Create Decision Plan ---
         if result.debate_result is not None and self._plan_factory is not None:
             try:
                 result.decision_plan = self._plan_factory.from_debate_result(result.debate_result)
+                self._ensure_plan_backbone_metadata(result.decision_plan, result.run_id)
+                goal_refs = build_goal_refs_from_implement_plan(
+                    getattr(result.decision_plan, "implement_plan", None)
+                )
+                self._update_backbone_run(
+                    result,
+                    status="plan_ready",
+                    plan_id=str(getattr(result.decision_plan, "id", "") or ""),
+                    debate_id=str(getattr(result.decision_plan, "debate_id", "") or ""),
+                    goal_refs=goal_refs,
+                )
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.GOALS,
+                    status="completed" if goal_refs else "skipped",
+                    artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                    details={"goal_refs_count": len(goal_refs)},
+                )
                 result.stages_completed.append("plan")
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.PLAN,
+                    status="completed",
+                    artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                )
             except Exception:
                 logger.warning("Plan creation failed")
                 result.stages_skipped.append("plan")
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.PLAN,
+                    status="failed",
+                )
 
         # --- Stage 5: Approval Gate ---
         if result.decision_plan is not None and gates.get("spec") is not None:
@@ -340,13 +639,71 @@ class UnifiedOrchestrator:
                     if not approved:
                         result.approvals_needed.append("spec")
                         result.duration_s = time.monotonic() - start
+                        self._update_backbone_run(
+                            result,
+                            status="pending_approval",
+                            metadata={"approvals_needed": list(result.approvals_needed)},
+                        )
+                        self._append_backbone_event(
+                            result,
+                            BackboneStage.PLAN,
+                            status="pending_approval",
+                            artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                        )
                         return result
                 else:
                     result.approvals_needed.append("spec")
                     result.duration_s = time.monotonic() - start
+                    self._update_backbone_run(
+                        result,
+                        status="pending_approval",
+                        metadata={"approvals_needed": list(result.approvals_needed)},
+                    )
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.PLAN,
+                        status="pending_approval",
+                        artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                    )
                     return result
 
+        # --- Stage 5b: Trust/Taint Execution Gate ---
+        if result.decision_plan is not None:
+            from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
+
+            execution_gate = evaluate_plan_execution_gate(
+                result.decision_plan,
+                plan_store=self._backbone_store(),
+            )
+            metadata = getattr(result.decision_plan, "metadata", None)
+            if isinstance(metadata, dict):
+                metadata["execution_gate"] = execution_gate.gate
+            self._update_backbone_run(
+                result,
+                metadata={"execution_gate": execution_gate.gate},
+            )
+            if not execution_gate.allow_execution:
+                result.approvals_needed.append("execution")
+                result.duration_s = time.monotonic() - start
+                pending_status = (
+                    "pending_approval" if execution_gate.requires_human_approval else "blocked"
+                )
+                self._update_backbone_run(
+                    result,
+                    status=pending_status,
+                    metadata={"approvals_needed": list(result.approvals_needed)},
+                )
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.EXECUTION,
+                    status=pending_status,
+                    artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                    details={"reason_codes": list(execution_gate.reason_codes)},
+                )
+                return result
+
         # --- Stage 6: Execute Plan ---
+        backbone_receipt_ref = ""
         if not cfg.skip_execution:
             if (
                 cfg.execution_mode == "openclaw"
@@ -354,6 +711,13 @@ class UnifiedOrchestrator:
                 and result.spec_bundle is not None
             ):
                 try:
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="running",
+                        artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                        details={"execution_mode": cfg.execution_mode},
+                    )
                     spec = result.spec_bundle
                     exec_result = await self._code_task_factory(
                         implementation_prompt=spec.implementation_prompt
@@ -371,19 +735,66 @@ class UnifiedOrchestrator:
                         else 0,
                     }
                     result.stages_completed.append("execute")
+                    if (
+                        result.decision_plan is not None
+                        and result.plan_outcome is not None
+                        and hasattr(result.plan_outcome, "receipt_id")
+                    ):
+                        backbone_receipt_ref = await self._attach_backbone_receipt(
+                            result,
+                            result.decision_plan,
+                            result.plan_outcome,
+                        )
+                    self._update_backbone_run(result, status="execution_completed")
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="succeeded",
+                    )
                 except Exception:
                     logger.warning("OpenClaw execution failed")
                     result.stages_skipped.append("execute")
+                    self._update_backbone_run(result, status="execution_failed")
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="failed",
+                    )
             elif result.decision_plan is not None and self._plan_executor is not None:
                 try:
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="running",
+                        artifact_ref=str(getattr(result.decision_plan, "id", "") or ""),
+                        details={"execution_mode": cfg.execution_mode},
+                    )
                     result.plan_outcome = await self._plan_executor.execute(
                         result.decision_plan,
                         execution_mode=cfg.execution_mode,
                     )
                     result.stages_completed.append("execute")
+                    if result.plan_outcome is not None:
+                        backbone_receipt_ref = await self._attach_backbone_receipt(
+                            result,
+                            result.decision_plan,
+                            result.plan_outcome,
+                        )
+                    self._update_backbone_run(result, status="execution_completed")
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="succeeded",
+                    )
                 except Exception:
                     logger.warning("Execution failed")
                     result.stages_skipped.append("execute")
+                    self._update_backbone_run(result, status="execution_failed")
+                    self._append_backbone_event(
+                        result,
+                        BackboneStage.EXECUTION,
+                        status="failed",
+                    )
 
         # --- Stage 6b: Bug-Fix Loop (CLB-008) ---
         # Auto-trigger when tests fail, even without explicit enable_bug_fix_loop.
@@ -408,9 +819,19 @@ class UnifiedOrchestrator:
                 self._feedback_recorder.record(outcome)
                 result.pipeline_outcome = outcome
                 result.stages_completed.append("feedback")
+                self._attach_backbone_feedback(
+                    result,
+                    receipt_ref=backbone_receipt_ref
+                    or str(getattr(result.plan_outcome, "receipt_id", "") or ""),
+                )
             except Exception:
                 logger.warning("Feedback recording failed")
                 result.stages_skipped.append("feedback")
+                self._append_backbone_event(
+                    result,
+                    BackboneStage.FEEDBACK,
+                    status="failed",
+                )
 
         # --- Stage 8: Meta-Loop Check ---
         if cfg.enable_meta_loop and self._meta_loop is not None:
@@ -425,6 +846,22 @@ class UnifiedOrchestrator:
                 result.stages_skipped.append("meta_loop")
 
         result.duration_s = time.monotonic() - start
+        final_status = "completed"
+        if result.errors:
+            final_status = "failed"
+        elif result.approvals_needed:
+            final_status = "pending_approval"
+        elif (
+            not cfg.skip_execution
+            and result.decision_plan is not None
+            and "execute" in result.stages_skipped
+        ):
+            final_status = "execution_failed"
+        self._update_backbone_run(
+            result,
+            status=final_status,
+            metadata={"duration_s": result.duration_s},
+        )
         return result
 
     def _load_preset(self, preset_name: str) -> dict[str, Any]:
@@ -569,13 +1006,14 @@ class UnifiedOrchestrator:
 
     def _update_phase_elo(self, debate_result: Any, domain: str) -> None:
         """Update phase ELO ratings from debate results."""
-        if not hasattr(debate_result, "participants"):
+        elo_tracker = self._elo_tracker
+        if elo_tracker is None or not hasattr(debate_result, "participants"):
             return
         domain_key = domain or "general"
         for participant in debate_result.participants:
             name = participant if isinstance(participant, str) else str(participant)
             won = hasattr(debate_result, "final_answer") and debate_result.final_answer
-            self._elo_tracker.record_match(
+            elo_tracker.record_match(
                 agent_name=name,
                 domain=domain_key,
                 phase="debate",
@@ -635,13 +1073,18 @@ class UnifiedOrchestrator:
         if test_output is None:
             return {"status": "skipped", "reason": "no test output"}
 
+        bug_fixer = self._bug_fixer
+        plan_executor = self._plan_executor
+        if bug_fixer is None:
+            return {"status": "skipped", "reason": "bug fixer unavailable"}
+
         fixes_applied: list[dict[str, Any]] = []
         for attempt in range(cfg.bug_fix_max_retries):
-            diagnosis = self._bug_fixer.diagnose_failure(test_output, diff=diff)
+            diagnosis = bug_fixer.diagnose_failure(test_output, diff=diff)
             if diagnosis is None or getattr(diagnosis, "confidence", 0) < 0.3:
                 break
 
-            fix = self._bug_fixer.suggest_fix(diagnosis)
+            fix = bug_fixer.suggest_fix(diagnosis)
             if fix is None:
                 break
 
@@ -655,8 +1098,8 @@ class UnifiedOrchestrator:
             )
 
             # If executor supports re-run, apply fix and re-test
-            if hasattr(self._plan_executor, "apply_fix_and_retest"):
-                test_output = await self._plan_executor.apply_fix_and_retest(fix)
+            if plan_executor is not None and hasattr(plan_executor, "apply_fix_and_retest"):
+                test_output = await plan_executor.apply_fix_and_retest(fix)
                 if test_output is None or "FAILED" not in str(test_output).upper():
                     return {
                         "status": "fixed",

--- a/aragora/server/handlers/prompt_engine/handler.py
+++ b/aragora/server/handlers/prompt_engine/handler.py
@@ -1,6 +1,8 @@
 """Prompt Engine API Handler.
 
 Endpoints:
+- GET /api/prompt-engine/runs       - List persisted backbone runs
+- GET /api/prompt-engine/runs/{id}  - Fetch one persisted backbone run
 - POST /api/prompt-engine/run        - Full pipeline (decompose → interrogate → research → specify)
 - POST /api/prompt-engine/decompose  - Decompose a vague prompt into structured intent
 - POST /api/prompt-engine/interrogate - Generate clarifying questions for an intent
@@ -13,9 +15,17 @@ from __future__ import annotations
 
 import json
 import logging
+import uuid
 from typing import Any, cast
 
-from aragora.pipeline.backbone_contracts import SpecBundle
+from aragora.pipeline.backbone_contracts import (
+    BackboneStage,
+    IntakeBundle,
+    RunLedger,
+    RunStageEvent,
+    SpecBundle,
+    build_goal_refs_from_implement_plan,
+)
 from aragora.pipeline.decision_plan.factory import normalize_execution_mode
 from aragora.pipeline.executor import ExecutionMode
 
@@ -36,19 +46,46 @@ class PromptEngineHandler(SecureHandler):
     """Handler for the prompt-to-specification engine."""
 
     ROUTES = [
-        ("POST", "/api/prompt-engine/run"),
-        ("POST", "/api/prompt-engine/decompose"),
-        ("POST", "/api/prompt-engine/interrogate"),
-        ("POST", "/api/prompt-engine/research"),
-        ("POST", "/api/prompt-engine/specify"),
-        ("POST", "/api/prompt-engine/validate"),
+        "/api/prompt-engine/run",
+        "/api/prompt-engine/decompose",
+        "/api/prompt-engine/interrogate",
+        "/api/prompt-engine/research",
+        "/api/prompt-engine/specify",
+        "/api/prompt-engine/validate",
+        "/api/prompt-engine/runs",
+        "/api/prompt-engine/runs/{run_id}",
     ]
 
     def can_handle(self, path: str, method: str | None = None) -> bool:
         # Backward-compatible signature: can_handle(method, path)
         if method is not None and not path.startswith("/") and method.startswith("/"):
             path, method = method, path
-        return (method or "POST") == "POST" and path.startswith("/api/prompt-engine/")
+        if not path.startswith("/api/prompt-engine/"):
+            return False
+        if method is None:
+            return True
+        resolved_method = method.upper()
+        if resolved_method == "GET":
+            return path == "/api/prompt-engine/runs" or path.startswith("/api/prompt-engine/runs/")
+        return resolved_method == "POST"
+
+    def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
+        """Router-compatible GET entrypoint."""
+        method = getattr(handler, "command", "GET") if handler else "GET"
+        if method != "GET":
+            return None
+        return self._handle_get(path, query_params)
+
+    def handle_post(
+        self,
+        path: str,
+        query_params: dict[str, Any],
+        handler: Any,
+    ) -> HandlerResult | None:
+        """Router-compatible POST entrypoint."""
+        if getattr(handler, "command", "POST") != "POST":
+            return None
+        return self.handle_POST(handler)
 
     @handle_errors("prompt engine")
     def handle_POST(self, handler: Any) -> HandlerResult:
@@ -68,6 +105,15 @@ class PromptEngineHandler(SecureHandler):
             return self._handle_validate(handler)
 
         return error_response("Unknown prompt-engine endpoint", 404)
+
+    @handle_errors("prompt engine")
+    def handle_GET(
+        self,
+        handler: Any,
+        query_params: dict[str, Any] | None = None,
+    ) -> HandlerResult:
+        path = getattr(handler, "path", "")
+        return self._handle_get(path, query_params or {})
 
     # ------------------------------------------------------------------
     # Body parsing helper
@@ -126,6 +172,84 @@ class PromptEngineHandler(SecureHandler):
             stage_durations_ms={stage: total_duration_ms},
             operation_timings=list(operation_timings or []),
         ).to_dict()
+
+    @staticmethod
+    def _derive_backbone_taint_flags(context: Any) -> list[str]:
+        if context in (None, "", {}, [], ()):
+            return []
+        return ["user_context_supplied"]
+
+    @classmethod
+    def _derive_backbone_trust_tiers(
+        cls,
+        context: Any,
+        intent: Any | None = None,
+    ) -> list[str]:
+        tiers = ["operator-authored"]
+        if list(getattr(intent, "related_knowledge", []) or []):
+            tiers.append("internal-retrieved")
+        if cls._derive_backbone_taint_flags(context):
+            tiers.append("user-supplied-context")
+        return list(dict.fromkeys(tiers))
+
+    @staticmethod
+    def _run_payload(
+        *,
+        run_id: str,
+        status: str,
+        plan_id: str = "",
+        execution_id: str = "",
+        receipt_id: str = "",
+    ) -> dict[str, Any]:
+        return {
+            "run_id": run_id,
+            "status": status,
+            "plan_id": plan_id,
+            "execution_id": execution_id,
+            "receipt_id": receipt_id,
+        }
+
+    @staticmethod
+    def _query_limit(value: Any, default: int = 20) -> int:
+        try:
+            return max(1, min(int(value), 100))
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _query_offset(value: Any, default: int = 0) -> int:
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return default
+
+    def _handle_get(self, path: str, query_params: dict[str, Any]) -> HandlerResult:
+        from aragora.pipeline.plan_store import get_plan_store
+
+        store = get_plan_store()
+        if path == "/api/prompt-engine/runs":
+            runs = store.list_runs(
+                status=str(query_params.get("status", "")).strip() or None,
+                plan_id=str(query_params.get("plan_id", "")).strip() or None,
+                debate_id=str(query_params.get("debate_id", "")).strip() or None,
+                execution_id=str(query_params.get("execution_id", "")).strip() or None,
+                limit=self._query_limit(query_params.get("limit", 20), default=20),
+                offset=self._query_offset(query_params.get("offset", 0), default=0),
+            )
+            runs = cast(list[RunLedger], runs)
+            return json_response({"runs": [run.to_dict() for run in runs]})
+
+        prefix = "/api/prompt-engine/runs/"
+        if path.startswith(prefix):
+            run_id = path[len(prefix) :].strip()
+            if not run_id:
+                return error_response("run_id is required", 400)
+            run = store.get_run(run_id)
+            if run is None:
+                return error_response("Run not found", 404)
+            return json_response({"run": run.to_dict()})
+
+        return error_response("Unknown prompt-engine endpoint", 404)
 
     # ------------------------------------------------------------------
     # Endpoint handlers
@@ -218,6 +342,7 @@ class PromptEngineHandler(SecureHandler):
     def _handle_run(self, handler: Any) -> HandlerResult:
         """Run the full prompt-to-specification pipeline."""
         import asyncio
+        from aragora.pipeline.plan_store import get_plan_store
         from aragora.prompt_engine.timing import elapsed_ms, start_timer
 
         request_start = start_timer()
@@ -233,8 +358,51 @@ class PromptEngineHandler(SecureHandler):
         if plan_error:
             return plan_error
 
-        conductor = self._make_conductor(data)
         context = data.get("context")
+        store = get_plan_store()
+        run_id = f"run-{uuid.uuid4().hex[:12]}"
+        initial_taint_flags = self._derive_backbone_taint_flags(context)
+        initial_intake = IntakeBundle(
+            source_kind="prompt_engine_request",
+            raw_intent=prompt,
+            context_refs=[],
+            trust_tiers=self._derive_backbone_trust_tiers(context),
+            origin_metadata={
+                "entrypoint": "prompt_engine.run",
+                "profile": data.get("profile"),
+                "autonomy": data.get("autonomy"),
+                "skip_research": bool(data.get("skip_research", False)),
+                "skip_interrogation": bool(data.get("skip_interrogation", False)),
+            },
+            taint_flags=initial_taint_flags,
+        )
+        run = RunLedger(
+            run_id=run_id,
+            entrypoint="prompt_engine.run",
+            status="running",
+            intake_bundle=initial_intake,
+            taint_flags=list(initial_taint_flags),
+            metadata={
+                "decision_plan_requested": bool(plan_request),
+                "schedule_execution_requested": bool(
+                    plan_request and plan_request["schedule_execution"]
+                ),
+                "has_context": context not in (None, "", {}, [], ()),
+            },
+        )
+        run.add_event(
+            RunStageEvent.create(
+                BackboneStage.INTAKE,
+                status="received",
+                details={
+                    "prompt_length": len(prompt),
+                    "has_context": context not in (None, "", {}, [], ()),
+                },
+            )
+        )
+        store.create_run(run)
+
+        conductor = self._make_conductor(data)
 
         result = asyncio.run(conductor.run(prompt, context=context))
 
@@ -264,6 +432,65 @@ class PromptEngineHandler(SecureHandler):
             },
         }
 
+        canonical_intake = IntakeBundle.from_prompt_intent(
+            result.intent,
+            source_kind="prompt_engine_run",
+            trust_tiers=self._derive_backbone_trust_tiers(context, result.intent),
+            taint_flags=initial_taint_flags,
+            origin_metadata={
+                "entrypoint": "prompt_engine.run",
+                "question_count": len(result.questions),
+                "auto_approved": bool(result.auto_approved),
+                "stages_completed": list(result.stages_completed),
+            },
+        )
+        store.update_run(
+            run_id,
+            status="spec_ready",
+            intake_bundle=canonical_intake,
+            spec_bundle=spec_bundle,
+            metadata={
+                "prompt_engine": {
+                    "question_count": len(result.questions),
+                    "auto_approved": bool(result.auto_approved),
+                    "stages_completed": list(result.stages_completed),
+                    "validation_passed": bool(getattr(validation, "passed", False)),
+                }
+            },
+        )
+        store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.INTENT,
+                status="completed",
+                details={
+                    "intent_type": result.intent.to_dict().get("intent_type"),
+                    "ambiguity_count": len(getattr(result.intent, "ambiguities", []) or []),
+                },
+            ),
+        )
+        if "research" in result.stages_completed or result.research is not None:
+            store.append_run_stage_event(
+                run_id,
+                RunStageEvent.create(
+                    BackboneStage.RESEARCH,
+                    status="completed" if result.research is not None else "skipped",
+                ),
+            )
+        store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.SPECIFICATION,
+                status="completed",
+                artifact_ref="spec_bundle",
+                details={
+                    "execution_grade": spec_bundle.is_execution_grade,
+                    "missing_required_fields": list(spec_bundle.missing_required_fields),
+                    "validation_passed": bool(getattr(validation, "passed", False)),
+                },
+            ),
+        )
+
         payload = {
             "specification": result.specification.to_dict(),
             "spec_bundle": spec_bundle.to_dict(),
@@ -277,14 +504,19 @@ class PromptEngineHandler(SecureHandler):
         }
 
         if not plan_request:
+            payload["run"] = self._run_payload(run_id=run_id, status="spec_ready")
             payload["timing"]["request_total_duration_ms"] = round(elapsed_ms(request_start), 2)
             return json_response(payload)
 
         from aragora.pipeline.decision_plan import DecisionPlanFactory
+        from aragora.pipeline.decision_plan.core import ApprovalMode, PlanStatus
         from aragora.pipeline.executor import store_plan
         from aragora.pipeline.execution_bridge import get_execution_bridge
-        from aragora.pipeline.plan_store import get_plan_store
+        from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
 
+        plan_metadata = dict(plan_request["metadata"] or {})
+        plan_metadata["backbone_run_id"] = run_id
+        plan_metadata["backbone_entrypoint"] = "prompt_engine.run"
         try:
             plan = DecisionPlanFactory.from_specification(
                 result.specification,
@@ -293,30 +525,144 @@ class PromptEngineHandler(SecureHandler):
                 budget_limit_usd=plan_request["budget_limit_usd"],
                 approval_mode=plan_request["approval_mode"],
                 max_auto_risk=plan_request["max_auto_risk"],
-                metadata=plan_request["metadata"],
+                metadata=plan_metadata,
                 implementation_profile=plan_request["implementation_profile"],
                 validation_result=validation,
                 fail_closed_spec_validation=True,
             )
         except ValueError as exc:
+            store.append_run_stage_event(
+                run_id,
+                RunStageEvent.create(
+                    BackboneStage.PLAN,
+                    status="blocked",
+                    details={
+                        "reason": "spec_not_execution_grade",
+                        "missing_required_fields": list(spec_bundle.missing_required_fields),
+                    },
+                ),
+            )
+            store.update_run(
+                run_id,
+                status="spec_ready",
+                metadata={"decision_plan_error": str(exc)},
+            )
             payload["decision_plan_error"] = {
                 "message": str(exc),
                 "missing_required_fields": list(spec_bundle.missing_required_fields),
             }
+            payload["run"] = self._run_payload(run_id=run_id, status="spec_ready")
             payload["timing"]["request_total_duration_ms"] = round(elapsed_ms(request_start), 2)
             return json_response(payload, status=422)
 
-        store = get_plan_store()
+        execution_gate_decision = evaluate_plan_execution_gate(plan, plan_store=store)
+        if execution_gate_decision.requires_human_approval:
+            plan.approval_mode = ApprovalMode.ALWAYS
+            plan.status = PlanStatus.AWAITING_APPROVAL
+            if not isinstance(plan.metadata, dict):
+                plan.metadata = {}
+            plan.metadata["execution_gate"] = execution_gate_decision.gate
+
         store.create(plan)
         store_plan(plan)
         payload["decision_plan"] = plan.to_dict()
+        goal_refs = build_goal_refs_from_implement_plan(plan.implement_plan)
+        decision_receipt = (
+            plan.metadata.get("decision_receipt", {}) if isinstance(plan.metadata, dict) else {}
+        )
+        receipt_id = str(decision_receipt.get("receipt_id", "") or "").strip()
+        run_status = (
+            "plan_pending_approval"
+            if plan.requires_human_approval and not plan.is_approved
+            else "plan_ready"
+        )
+        store.update_run(
+            run_id,
+            status=run_status,
+            plan_id=plan.id,
+            debate_id=plan.debate_id,
+            receipt_id=receipt_id,
+            goal_refs=goal_refs,
+            metadata={
+                "decision_plan_status": plan.status.value,
+                "decision_plan_requires_human_approval": plan.requires_human_approval,
+                "goal_refs_count": len(goal_refs),
+                "execution_gate": execution_gate_decision.gate,
+            },
+        )
+        store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.GOALS,
+                status="completed" if goal_refs else "skipped",
+                artifact_ref=plan.id,
+                details={"goal_refs_count": len(goal_refs)},
+            ),
+        )
+        store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                BackboneStage.PLAN,
+                status="completed",
+                artifact_ref=plan.id,
+                details={
+                    "plan_status": plan.status.value,
+                    "approval_mode": plan.approval_mode.value,
+                    "requires_human_approval": plan.requires_human_approval,
+                    "execution_gate_reasons": list(execution_gate_decision.reason_codes),
+                },
+            ),
+        )
+        if receipt_id:
+            store.append_run_stage_event(
+                run_id,
+                RunStageEvent.create(
+                    BackboneStage.RECEIPT,
+                    status=str(decision_receipt.get("state", "created") or "created"),
+                    artifact_ref=receipt_id,
+                    details={"source": "decision_plan_receipt"},
+                ),
+            )
 
+        execution_id = ""
         if plan_request["schedule_execution"]:
-            if plan.requires_human_approval and not plan.is_approved:
+            if (
+                not execution_gate_decision.allow_execution
+                or execution_gate_decision.requires_human_approval
+                or (plan.requires_human_approval and not plan.is_approved)
+            ):
+                run_status = (
+                    "pending_approval"
+                    if execution_gate_decision.requires_human_approval
+                    or (plan.requires_human_approval and not plan.is_approved)
+                    else "blocked"
+                )
+                store.update_run(
+                    run_id,
+                    status=run_status,
+                    metadata={
+                        "execution_pending_approval": run_status == "pending_approval",
+                        "execution_gate_blocked": run_status == "blocked",
+                        "execution_gate": execution_gate_decision.gate,
+                    },
+                )
+                store.append_run_stage_event(
+                    run_id,
+                    RunStageEvent.create(
+                        BackboneStage.EXECUTION,
+                        status=run_status,
+                        artifact_ref=plan.id,
+                        details={
+                            "requires_human_approval": run_status == "pending_approval",
+                            "execution_gate_reasons": list(execution_gate_decision.reason_codes),
+                        },
+                    ),
+                )
                 payload["execution"] = {
-                    "status": "pending_approval",
+                    "status": run_status,
                     "plan_id": plan.id,
-                    "requires_human_approval": True,
+                    "requires_human_approval": run_status == "pending_approval",
+                    "execution_gate": execution_gate_decision.gate,
                 }
             else:
                 bridge = get_execution_bridge()
@@ -324,6 +670,24 @@ class PromptEngineHandler(SecureHandler):
                     plan.implementation_profile.execution_mode
                     if plan.implementation_profile
                     else None
+                )
+                run_status = "execution_requested"
+                store.update_run(
+                    run_id,
+                    status=run_status,
+                    metadata={
+                        "execution_mode": execution_mode or "default",
+                        "execution_requested": True,
+                    },
+                )
+                store.append_run_stage_event(
+                    run_id,
+                    RunStageEvent.create(
+                        BackboneStage.EXECUTION,
+                        status="requested",
+                        artifact_ref=plan.id,
+                        details={"execution_mode": execution_mode or "default"},
+                    ),
                 )
                 bridge.schedule_execution(
                     plan.id,
@@ -337,8 +701,36 @@ class PromptEngineHandler(SecureHandler):
                 }
                 if record:
                     execution_payload["record"] = record
+                    execution_id = str(record.get("execution_id", "") or "").strip()
+                    store.update_run(
+                        run_id,
+                        status="execution_scheduled",
+                        execution_id=execution_id,
+                        metadata={
+                            "scheduled_execution_status": str(
+                                record.get("status", "queued") or "queued"
+                            )
+                        },
+                    )
+                    store.append_run_stage_event(
+                        run_id,
+                        RunStageEvent.create(
+                            BackboneStage.EXECUTION,
+                            status=str(record.get("status", "queued") or "queued"),
+                            artifact_ref=execution_id,
+                            details={"execution_mode": execution_mode or "default"},
+                        ),
+                    )
+                    run_status = "execution_scheduled"
                 payload["execution"] = execution_payload
 
+        payload["run"] = self._run_payload(
+            run_id=run_id,
+            status=run_status,
+            plan_id=plan.id,
+            execution_id=execution_id,
+            receipt_id=receipt_id,
+        )
         payload["timing"]["request_total_duration_ms"] = round(elapsed_ms(request_start), 2)
         return json_response(payload)
 

--- a/tests/pipeline/test_execution_bridge.py
+++ b/tests/pipeline/test_execution_bridge.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime
 from pathlib import Path
 import threading
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.pipeline.backbone_contracts import BackboneStage, RunLedger
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     ApprovalRecord,
@@ -45,6 +46,7 @@ def mock_executor() -> MagicMock:
             tasks_completed=2,
             tasks_total=2,
             duration_seconds=1.5,
+            receipt_id="receipt-bridge-001",
         )
     )
     return executor
@@ -320,6 +322,86 @@ class TestExecutionBridgeExecute:
         assert records[0]["completed_at"] is not None
         assert records[0]["error"]["type"] == "RuntimeError"
         assert records[0]["error"]["message"] == "workflow exploded"
+
+    @pytest.mark.asyncio
+    async def test_execute_updates_backbone_run(
+        self, bridge: ExecutionBridge, store: PlanStore, approved_plan: DecisionPlan
+    ) -> None:
+        store.create_run(
+            RunLedger(
+                run_id="run-bridge",
+                entrypoint="prompt_engine.run",
+                status="plan_ready",
+                plan_id=approved_plan.id,
+            )
+        )
+        approved_plan.metadata["backbone_run_id"] = "run-bridge"
+        store.create(approved_plan)
+
+        outcome = await bridge.execute_approved_plan(approved_plan.id, execution_mode="workflow")
+        run = store.get_run("run-bridge")
+
+        assert outcome.success is True
+        assert run is not None
+        assert run.execution_id
+        assert run.status == "execution_succeeded"
+        assert run.receipt_envelope is not None
+        assert run.receipt_envelope.receipt_id == "receipt-bridge-001"
+        assert run.feedback_record is not None
+        assert run.attestation.get("local_only") is True
+        assert any(
+            event.stage == BackboneStage.EXECUTION.value and event.status == "running"
+            for event in run.stage_events
+        )
+        assert any(
+            event.stage == BackboneStage.EXECUTION.value and event.status == "succeeded"
+            for event in run.stage_events
+        )
+        assert any(
+            event.stage == BackboneStage.RECEIPT.value and event.status == "completed"
+            for event in run.stage_events
+        )
+        assert any(
+            event.stage == BackboneStage.FEEDBACK.value and event.status == "completed"
+            for event in run.stage_events
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_blocks_tainted_backbone_run_without_manual_override(
+        self, bridge: ExecutionBridge, store: PlanStore
+    ) -> None:
+        plan = DecisionPlan(
+            id="dp-tainted",
+            debate_id="debate-tainted",
+            task="Tainted task",
+            status=PlanStatus.CREATED,
+            approval_mode=ApprovalMode.NEVER,
+            metadata={"backbone_run_id": "run-tainted"},
+        )
+        store.create_run(
+            RunLedger(
+                run_id="run-tainted",
+                entrypoint="prompt_engine.run",
+                status="plan_ready",
+                plan_id=plan.id,
+                taint_flags=["user_context_supplied"],
+            )
+        )
+        store.create(plan)
+
+        with pytest.raises(ValueError, match="blocked by execution gate"):
+            await bridge.execute_approved_plan(plan.id)
+
+        records = bridge.list_execution_records(plan_id=plan.id)
+        run = store.get_run("run-tainted")
+
+        assert records[0]["status"] == "pending_approval"
+        assert run is not None
+        assert run.status == "pending_approval"
+        assert any(
+            event.stage == BackboneStage.EXECUTION.value and event.status == "pending_approval"
+            for event in run.stage_events
+        )
 
 
 class TestExecutionBridgeSchedule:

--- a/tests/pipeline/test_plan_store.py
+++ b/tests/pipeline/test_plan_store.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-import tempfile
-from datetime import datetime
 from pathlib import Path
 
 import pytest
 
 from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
+from aragora.pipeline.backbone_contracts import BackboneStage, RunLedger, RunStageEvent
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     BudgetAllocation,
@@ -366,6 +365,112 @@ class TestPlanStoreCombinedFilters:
         result = store.list(debate_id="dA", status=PlanStatus.APPROVED)
         assert len(result) == 1
         assert result[0].id == "dp-1"
+
+
+class TestPlanStoreBackboneRuns:
+    def test_create_and_get_run(self, store: PlanStore) -> None:
+        run = RunLedger(run_id="run-001", entrypoint="prompt_engine.run", status="spec_ready")
+        run.add_event(RunStageEvent.create(BackboneStage.INTAKE, status="received"))
+
+        store.create_run(run)
+        retrieved = store.get_run("run-001")
+
+        assert retrieved is not None
+        assert retrieved.run_id == "run-001"
+        assert retrieved.status == "spec_ready"
+        assert len(retrieved.stage_events) == 1
+        assert retrieved.stage_events[0].stage == BackboneStage.INTAKE.value
+
+    def test_list_runs_filters_by_plan_and_status(self, store: PlanStore) -> None:
+        store.create_run(
+            RunLedger(
+                run_id="run-a",
+                entrypoint="prompt_engine.run",
+                status="plan_ready",
+                plan_id="plan-a",
+            )
+        )
+        store.create_run(
+            RunLedger(
+                run_id="run-b",
+                entrypoint="prompt_engine.run",
+                status="execution_running",
+                plan_id="plan-b",
+            )
+        )
+
+        filtered = store.list_runs(status="plan_ready", plan_id="plan-a")
+        assert [run.run_id for run in filtered] == ["run-a"]
+
+    def test_update_run_merges_metadata_and_taint(self, store: PlanStore) -> None:
+        store.create_run(
+            RunLedger(
+                run_id="run-meta",
+                entrypoint="prompt_engine.run",
+                status="received",
+                metadata={"source": "prompt"},
+                taint_flags=["user_context_supplied"],
+            )
+        )
+
+        updated = store.update_run(
+            "run-meta",
+            status="plan_ready",
+            metadata={"plan_status": "approved"},
+            taint_flags=["external_action_requested"],
+        )
+        retrieved = store.get_run("run-meta")
+
+        assert updated is True
+        assert retrieved is not None
+        assert retrieved.status == "plan_ready"
+        assert retrieved.metadata["source"] == "prompt"
+        assert retrieved.metadata["plan_status"] == "approved"
+        assert set(retrieved.taint_flags) == {
+            "user_context_supplied",
+            "external_action_requested",
+        }
+
+    def test_append_run_stage_event_persists(self, store: PlanStore) -> None:
+        store.create_run(
+            RunLedger(run_id="run-events", entrypoint="orchestrator", status="running")
+        )
+
+        appended = store.append_run_stage_event(
+            "run-events",
+            RunStageEvent.create(BackboneStage.PLAN, status="completed", artifact_ref="plan-1"),
+        )
+        events = store.list_run_stage_events("run-events")
+
+        assert appended is True
+        assert len(events) == 1
+        assert events[0].artifact_ref == "plan-1"
+
+    def test_update_status_syncs_backbone_receipt_envelope(self, store: PlanStore) -> None:
+        store.create_run(
+            RunLedger(run_id="run-receipt", entrypoint="prompt_engine.run", status="plan_ready")
+        )
+        plan = DecisionPlan(
+            id="dp-receipt-sync",
+            debate_id="debate-receipt-sync",
+            task="Review receipt sync",
+            status=PlanStatus.AWAITING_APPROVAL,
+            approval_mode=ApprovalMode.ALWAYS,
+            metadata={"backbone_run_id": "run-receipt"},
+        )
+
+        store.create(plan)
+        updated = store.update_status(plan.id, PlanStatus.APPROVED, approved_by="approver-1")
+        run = store.get_run("run-receipt")
+
+        assert updated is True
+        assert run is not None
+        assert run.receipt_envelope is not None
+        assert run.metadata["plan_receipt_state"] == "approved"
+        assert any(
+            event.stage == BackboneStage.RECEIPT.value and event.status == "approved"
+            for event in run.stage_events
+        )
 
 
 class TestPlanStoreExecutionClaims:

--- a/tests/pipeline/test_receipt_gate.py
+++ b/tests/pipeline/test_receipt_gate.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aragora.gauntlet.receipt_store import ReceiptState, get_receipt_store, reset_receipt_store
+from aragora.pipeline.backbone_contracts import RunLedger
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
     ApprovalRecord,
@@ -15,7 +16,12 @@ from aragora.pipeline.decision_plan.core import (
 )
 from aragora.pipeline.decision_plan.memory import PlanOutcome
 from aragora.pipeline.executor import PlanExecutor
-from aragora.pipeline.receipt_gate import PlanReceiptGateError, ensure_plan_receipt
+from aragora.pipeline.plan_store import PlanStore
+from aragora.pipeline.receipt_gate import (
+    PlanExecutionGateError,
+    PlanReceiptGateError,
+    ensure_plan_receipt,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -146,3 +152,29 @@ async def test_executor_verifies_receipt_before_running_actions() -> None:
     assert stored.state == ReceiptState.EXECUTED
     assert stored.receipt_data["config_used"]["taint_analysis"]["tainted"] is True
     assert stored.receipt_data["config_used"]["execution_gate"]["provider_diversity"] == 2
+
+
+@pytest.mark.asyncio
+async def test_executor_blocks_backbone_taint_without_manual_override(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PlanStore(db_path=str(tmp_path / "receipt-gate.db"))
+    monkeypatch.setattr("aragora.pipeline.plan_store.get_plan_store", lambda: store)
+    store.create_run(
+        RunLedger(
+            run_id="run-tainted",
+            entrypoint="prompt_engine.run",
+            status="plan_ready",
+            taint_flags=["user_context_supplied"],
+        )
+    )
+    plan = _plan(
+        status=PlanStatus.CREATED,
+        approval_mode=ApprovalMode.NEVER,
+        metadata={"backbone_run_id": "run-tainted"},
+    )
+
+    executor = PlanExecutor()
+
+    with pytest.raises(PlanExecutionGateError, match="blocked by execution gate"):
+        await executor.execute(plan, execution_mode="workflow")

--- a/tests/pipeline/test_unified_orchestrator.py
+++ b/tests/pipeline/test_unified_orchestrator.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
+from aragora.pipeline.backbone_contracts import BackboneStage
+from aragora.pipeline.decision_plan.memory import PlanOutcome
+from aragora.pipeline.plan_store import PlanStore
 from aragora.pipeline.unified_orchestrator import (
     OrchestratorConfig,
     OrchestratorResult,
@@ -45,7 +48,10 @@ class FakePlanOutcome:
 @dataclass
 class FakeDecisionPlan:
     id: str = "plan-1"
+    debate_id: str = "test-debate-1"
+    task: str = "Test task"
     status: str = "created"
+    metadata: dict = field(default_factory=dict)
 
 
 def make_researcher(results=None):
@@ -113,6 +119,13 @@ def make_meta_loop(should_trigger=False):
     meta.identify_targets.return_value = []
     meta.execute.return_value = MagicMock(improved=False)
     return meta
+
+
+@pytest.fixture(autouse=True)
+def isolated_plan_store(tmp_path, monkeypatch):
+    store = PlanStore(db_path=str(tmp_path / "unified_orchestrator.db"))
+    monkeypatch.setattr("aragora.pipeline.plan_store.get_plan_store", lambda: store)
+    return store
 
 
 # --- Tests ---
@@ -207,6 +220,85 @@ class TestUnifiedOrchestrator:
         assert "execute" in result.stages_completed
         assert "feedback" in result.stages_completed
         assert result.duration_s > 0
+
+    @pytest.mark.asyncio
+    async def test_persists_backbone_run_progress(self, isolated_plan_store):
+        orch = UnifiedOrchestrator(
+            researcher=make_researcher(),
+            input_extension=make_input_extension(),
+            arena_factory=make_arena_factory(),
+            plan_factory=make_plan_factory(),
+        )
+
+        cfg = OrchestratorConfig(skip_execution=True, autonomy_level="fully_autonomous")
+        result = await orch.run("Build a ledger", config=cfg)
+        run = isolated_plan_store.get_run(result.run_id)
+
+        assert run is not None
+        assert run.plan_id == "plan-1"
+        assert run.status == "completed"
+        assert any(event.stage == BackboneStage.DELIBERATION.value for event in run.stage_events)
+        assert any(event.stage == BackboneStage.PLAN.value for event in run.stage_events)
+
+    @pytest.mark.asyncio
+    async def test_execution_gate_blocks_tainted_plan(self, isolated_plan_store):
+        plan = FakeDecisionPlan(
+            metadata={
+                "execution_gate": {
+                    "allow_auto_execution": False,
+                    "reason_codes": ["tainted_context_detected"],
+                }
+            }
+        )
+        executor = make_plan_executor()
+        orch = UnifiedOrchestrator(
+            arena_factory=make_arena_factory(),
+            plan_factory=make_plan_factory(plan),
+            plan_executor=executor,
+        )
+
+        cfg = OrchestratorConfig(autonomy_level="fully_autonomous")
+        result = await orch.run("Handle untrusted context", config=cfg)
+        run = isolated_plan_store.get_run(result.run_id)
+
+        assert "execution" in result.approvals_needed
+        assert run is not None
+        assert run.status == "pending_approval"
+        executor.execute.assert_not_called()
+        assert any(
+            event.stage == BackboneStage.EXECUTION.value and event.status == "pending_approval"
+            for event in run.stage_events
+        )
+
+    @pytest.mark.asyncio
+    async def test_persists_receipt_feedback_and_attestation(self, isolated_plan_store):
+        outcome = PlanOutcome(
+            plan_id="plan-1",
+            debate_id="test-debate-1",
+            task="Test task",
+            success=True,
+            tasks_completed=1,
+            tasks_total=1,
+            duration_seconds=0.2,
+            receipt_id="receipt-shadow-1",
+        )
+        orch = UnifiedOrchestrator(
+            arena_factory=make_arena_factory(),
+            plan_factory=make_plan_factory(),
+            plan_executor=make_plan_executor(outcome),
+            feedback_recorder=make_feedback_recorder(),
+        )
+
+        cfg = OrchestratorConfig(autonomy_level="fully_autonomous")
+        result = await orch.run("Ship the feature", config=cfg)
+        run = isolated_plan_store.get_run(result.run_id)
+
+        assert run is not None
+        assert run.receipt_envelope is not None
+        assert run.receipt_envelope.receipt_id == "receipt-shadow-1"
+        assert run.feedback_record is not None
+        assert run.attestation.get("local_only") is True
+        assert any(event.stage == BackboneStage.ATTESTATION.value for event in run.stage_events)
 
     @pytest.mark.asyncio
     async def test_debate_only_no_execution(self):

--- a/tests/server/handlers/test_prompt_engine_handler.py
+++ b/tests/server/handlers/test_prompt_engine_handler.py
@@ -9,7 +9,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.pipeline.backbone_contracts import BackboneStage, RunLedger, RunStageEvent
 from aragora.pipeline.decision_plan import ApprovalMode, PlanStatus
+from aragora.pipeline.plan_store import PlanStore
 from aragora.prompt_engine.spec_validator import ValidationResult
 from aragora.prompt_engine.types import RiskItem, SpecFile, Specification
 from aragora.server.handlers.prompt_engine.handler import PromptEngineHandler
@@ -78,6 +80,13 @@ def handler() -> PromptEngineHandler:
     return PromptEngineHandler({})
 
 
+@pytest.fixture(autouse=True)
+def isolated_plan_store(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> PlanStore:
+    store = PlanStore(db_path=str(tmp_path / "prompt_engine_handler.db"))
+    monkeypatch.setattr("aragora.pipeline.plan_store.get_plan_store", lambda: store)
+    return store
+
+
 # ---------------------------------------------------------------------------
 # Route matching
 # ---------------------------------------------------------------------------
@@ -102,7 +111,13 @@ class TestCanHandle:
     def test_matches_validate(self, handler: PromptEngineHandler) -> None:
         assert handler.can_handle("POST", "/api/prompt-engine/validate")
 
-    def test_rejects_get(self, handler: PromptEngineHandler) -> None:
+    def test_matches_runs_get(self, handler: PromptEngineHandler) -> None:
+        assert handler.can_handle("GET", "/api/prompt-engine/runs")
+
+    def test_matches_single_run_get(self, handler: PromptEngineHandler) -> None:
+        assert handler.can_handle("GET", "/api/prompt-engine/runs/run-123")
+
+    def test_rejects_get_run_pipeline(self, handler: PromptEngineHandler) -> None:
         assert not handler.can_handle("GET", "/api/prompt-engine/run")
 
     def test_rejects_other_paths(self, handler: PromptEngineHandler) -> None:
@@ -277,8 +292,25 @@ class TestRunPipeline:
         handler: PromptEngineHandler,
     ) -> None:
         # Mock conductor result
-        mock_spec = MagicMock()
-        mock_spec.to_dict.return_value = {"title": "Test", "confidence": 0.9}
+        mock_spec = Specification(
+            title="Test",
+            problem_statement="Problem",
+            proposed_solution="Solution",
+            constraints=["Keep API stable"],
+            success_criteria=["It works"],
+            file_changes=[
+                SpecFile(path="aragora/server/example.py", action="modify", description="Patch")
+            ],
+            risks=[
+                RiskItem(
+                    description="Regression risk",
+                    likelihood="medium",
+                    impact="medium",
+                    mitigation="Rollback quickly",
+                )
+            ],
+            confidence=0.9,
+        )
         mock_intent = MagicMock()
         mock_intent.to_dict.return_value = {"raw_prompt": "test", "intent_type": "feature"}
 
@@ -301,8 +333,11 @@ class TestRunPipeline:
         instance.run = AsyncMock(return_value=mock_result)
 
         # Mock validator
-        mock_validation = MagicMock()
-        mock_validation.to_dict.return_value = {"passed": True, "overall_confidence": 0.85}
+        mock_validation = ValidationResult(
+            role_results={},
+            passed=True,
+            overall_confidence=0.85,
+        )
         mock_validator = mock_validator_cls.return_value
         mock_validator.validate_heuristic.return_value = mock_validation
         mock_validator.last_operation_timings = []
@@ -321,6 +356,7 @@ class TestRunPipeline:
         assert "spec_bundle" in parsed["data"]
         assert parsed["data"]["validation"]["passed"] is True
         assert "stages_completed" in parsed["data"]
+        assert parsed["data"]["run"]["status"] == "spec_ready"
         assert parsed["data"]["timing"]["slowest_stage"]["stage"] == "specify"
 
     @patch("aragora.pipeline.executor.store_plan")
@@ -410,6 +446,7 @@ class TestRunPipeline:
         assert parsed["status"] == 200
         assert parsed["data"]["decision_plan"]["status"] == PlanStatus.APPROVED.value
         assert parsed["data"]["execution"]["status"] == "scheduled"
+        assert parsed["data"]["run"]["execution_id"] == "exec-123"
         assert parsed["data"]["timing"]["slowest_stage"]["stage"] == "specify"
         mock_get_plan_store.return_value.create.assert_called_once()
         mock_store_plan.assert_called_once()
@@ -481,9 +518,124 @@ class TestRunPipeline:
         )
         mock_get_plan_store.return_value.create.assert_not_called()
 
+    @patch("aragora.pipeline.execution_bridge.get_execution_bridge")
+    @patch("aragora.prompt_engine.SpecValidator")
+    @patch("aragora.prompt_engine.PromptConductor")
+    @patch("aragora.prompt_engine.ConductorConfig")
+    def test_run_forces_manual_lane_when_context_is_tainted(
+        self,
+        mock_config_cls: MagicMock,
+        mock_conductor_cls: MagicMock,
+        mock_validator_cls: MagicMock,
+        mock_get_execution_bridge: MagicMock,
+        handler: PromptEngineHandler,
+    ) -> None:
+        spec = Specification(
+            title="Tainted spec",
+            problem_statement="Problem",
+            proposed_solution="Ship carefully",
+            constraints=["Keep controls"],
+            success_criteria=["Criterion"],
+            file_changes=[
+                SpecFile(path="aragora/server/example.py", action="modify", description="Patch")
+            ],
+            risks=[
+                RiskItem(
+                    description="Regression risk",
+                    likelihood="medium",
+                    impact="medium",
+                    mitigation="Rollback quickly",
+                )
+            ],
+            confidence=0.95,
+        )
+        mock_intent = MagicMock()
+        mock_intent.to_dict.return_value = {"raw_prompt": "test", "intent_type": "feature"}
+        mock_result = MagicMock(
+            specification=spec,
+            intent=mock_intent,
+            questions=[],
+            research=None,
+            auto_approved=False,
+            stages_completed=["decompose", "specify"],
+            timing=_FakeTiming(),
+        )
+        mock_conductor_cls.return_value.run = AsyncMock(return_value=mock_result)
+        validation = ValidationResult(role_results={}, passed=True, overall_confidence=0.95)
+        mock_validator = mock_validator_cls.return_value
+        mock_validator.validate_heuristic.return_value = validation
+        mock_validator.last_operation_timings = []
+        mock_config_cls.return_value = MagicMock()
+        mock_config_cls.from_profile.return_value = MagicMock()
+        handler.require_permission_or_error = MagicMock(return_value=(MagicMock(), None))
+
+        req = _make_handler_request(
+            {
+                "prompt": "Build something",
+                "context": {"repo": "user supplied"},
+                "decision_plan": {
+                    "create": True,
+                    "schedule_execution": True,
+                    "approval_mode": ApprovalMode.NEVER.value,
+                },
+            }
+        )
+        req.path = "/api/prompt-engine/run"
+
+        result = handler.handle_POST(req)
+        parsed = _parse(result)
+
+        assert parsed["status"] == 200
+        assert parsed["data"]["decision_plan"]["status"] == PlanStatus.AWAITING_APPROVAL.value
+        assert parsed["data"]["execution"]["status"] == "pending_approval"
+        assert parsed["data"]["execution"]["requires_human_approval"] is True
+        assert (
+            "backbone_taint_detected"
+            in parsed["data"]["execution"]["execution_gate"]["reason_codes"]
+        )
+        mock_get_execution_bridge.return_value.schedule_execution.assert_not_called()
+
     def test_unknown_endpoint_returns_404(self, handler: PromptEngineHandler) -> None:
         req = _make_handler_request({"prompt": "test"})
         req.path = "/api/prompt-engine/unknown"
         result = handler.handle_POST(req)
         parsed = _parse(result)
         assert parsed["status"] == 404
+
+
+class TestBackboneRunEndpoints:
+    def test_list_runs_returns_persisted_ledgers(
+        self,
+        handler: PromptEngineHandler,
+        isolated_plan_store: PlanStore,
+    ) -> None:
+        run = RunLedger(run_id="run-1", entrypoint="prompt_engine.run", status="spec_ready")
+        run.add_event(RunStageEvent.create(BackboneStage.INTAKE, status="received"))
+        isolated_plan_store.create_run(run)
+
+        req = MagicMock()
+        req.path = "/api/prompt-engine/runs"
+        result = handler.handle_GET(req, {"status": "spec_ready"})
+        parsed = _parse(result)
+
+        assert parsed["status"] == 200
+        assert len(parsed["data"]["runs"]) == 1
+        assert parsed["data"]["runs"][0]["run_id"] == "run-1"
+
+    def test_get_run_returns_single_ledger(
+        self,
+        handler: PromptEngineHandler,
+        isolated_plan_store: PlanStore,
+    ) -> None:
+        run = RunLedger(run_id="run-2", entrypoint="prompt_engine.run", status="plan_ready")
+        run.add_event(RunStageEvent.create(BackboneStage.PLAN, status="completed"))
+        isolated_plan_store.create_run(run)
+
+        req = MagicMock()
+        req.path = "/api/prompt-engine/runs/run-2"
+        result = handler.handle_GET(req)
+        parsed = _parse(result)
+
+        assert parsed["status"] == 200
+        assert parsed["data"]["run"]["run_id"] == "run-2"
+        assert parsed["data"]["run"]["stage_events"][0]["stage"] == BackboneStage.PLAN.value


### PR DESCRIPTION
## Summary
- add the persistent RunLedger model, stage events, storage, and prompt-engine read/write surfaces
- fail closed on trust and taint at execution time while wiring plan approval and execution state into the ledger
- attach decision receipts, outcome feedback, and local-only shadow attestation to the golden-path ledger with focused coverage

## Validation
- python3 -m ruff check aragora/pipeline/backbone_contracts.py aragora/pipeline/plan_store.py aragora/pipeline/execution_bridge.py aragora/pipeline/executor.py aragora/pipeline/receipt_gate.py aragora/pipeline/unified_orchestrator.py aragora/server/handlers/prompt_engine/handler.py tests/pipeline/test_plan_store.py tests/pipeline/test_execution_bridge.py tests/pipeline/test_receipt_gate.py tests/pipeline/test_unified_orchestrator.py tests/server/handlers/test_prompt_engine_handler.py
- python3 -m mypy --ignore-missing-imports --follow-imports=skip aragora/pipeline/plan_store.py aragora/pipeline/execution_bridge.py aragora/pipeline/executor.py aragora/pipeline/receipt_gate.py aragora/pipeline/unified_orchestrator.py aragora/server/handlers/prompt_engine/handler.py
- python3 -m pytest tests/server/handlers/test_prompt_engine_handler.py tests/pipeline/test_plan_store.py tests/pipeline/test_execution_bridge.py tests/pipeline/test_receipt_gate.py tests/pipeline/test_unified_orchestrator.py -q
- python3 -m pytest tests/blockchain/test_receipt_settlement.py -q