### PR TITLE
fix(swarm): auto-cleanup stale runs and relax test scope enforcement

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -3338,6 +3338,71 @@ class DevCoordinationStore:
         self.rehabilitate_narrowed_waiting_conflict_work_orders()
         return expired
 
+    def cleanup_stale_supervisor_runs(
+        self,
+        *,
+        max_age_hours: float = 24.0,
+        limit: int = 200,
+    ) -> int:
+        """Mark stale supervisor runs as completed so duplicate detection doesn't block new dispatches.
+
+        A run is stale when:
+        - Its status is 'needs_human' or 'completed'
+        - ALL of its work orders are in non-actionable states (discarded, needs_human,
+          dispatch_failed, failed, timed_out, completed, scope_violation)
+        - No work order has an active lease or running process
+
+        This prevents the duplicate_open_work_order detector in
+        _suppress_duplicate_open_work_orders from permanently blocking new work
+        orders that share file scope with old, abandoned runs.
+
+        Returns:
+            Number of runs cleaned up.
+        """
+        terminal_wo_statuses = {
+            "completed",
+            "discarded",
+            "needs_human",
+            "dispatch_failed",
+            "failed",
+            "timed_out",
+            "scope_violation",
+            "cancelled",
+        }
+        runs = self.list_supervisor_runs(limit=limit)
+        cleaned = 0
+        for run in runs:
+            status = str(run.get("status", "")).strip().lower()
+            if status not in ("needs_human", "completed"):
+                continue
+            work_orders = run.get("work_orders", [])
+            if not work_orders:
+                continue
+            all_terminal = all(
+                str(wo.get("status", "")).strip().lower() in terminal_wo_statuses
+                for wo in work_orders
+                if isinstance(wo, dict)
+            )
+            if not all_terminal:
+                continue
+            # Mark non-terminal work orders as completed
+            changed = False
+            for wo in work_orders:
+                if not isinstance(wo, dict):
+                    continue
+                wo_status = str(wo.get("status", "")).strip().lower()
+                if wo_status not in ("completed",):
+                    wo["status"] = "completed"
+                    changed = True
+            if changed or status == "needs_human":
+                self.update_supervisor_run(
+                    run["run_id"],
+                    status="completed",
+                    work_orders=work_orders,
+                )
+                cleaned += 1
+        return cleaned
+
     def reap_stale_leases(
         self,
         *,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1844,6 +1844,20 @@ class BossLoop:
         start_time = time.monotonic()
         iteration = 0
 
+        # Clean stale supervisor runs that would block dispatch via
+        # duplicate_open_work_order detection.  Previous runs with
+        # needs_human/discarded work orders accumulate across sessions
+        # and permanently block new dispatches for the same file scopes.
+        try:
+            from aragora.nomic.dev_coordination import DevCoordinationStore
+
+            store = DevCoordinationStore()
+            cleaned = store.cleanup_stale_supervisor_runs()
+            if cleaned:
+                logger.info("Cleaned %d stale supervisor runs before starting boss loop", cleaned)
+        except Exception:
+            logger.debug("Stale supervisor run cleanup skipped", exc_info=True)
+
         while iteration < self.config.max_iterations:
             iteration += 1
 

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -4091,12 +4091,31 @@ class SwarmSupervisor:
         if not file_scope or not changed_paths:
             return []
 
+        # Expand scope: for specific test file paths, also allow sibling
+        # test files in the same directory.  Workers often choose a more
+        # descriptive file name than the issue suggested (e.g.
+        # test_live_explainability_wiring.py vs test_live_explainability_e2e.py).
+        expanded_scope = list(file_scope)
+        for scope in file_scope:
+            clean = scope.strip().removeprefix("./")
+            parts = clean.split("/")
+            # If it's a specific test file (e.g. tests/debate/test_foo.py),
+            # add the parent directory as an allowed scope
+            if (
+                len(parts) >= 2
+                and any(part.startswith("test") for part in parts)
+                and "." in parts[-1]
+            ):
+                parent = "/".join(parts[:-1])
+                if parent not in expanded_scope:
+                    expanded_scope.append(parent)
+
         violations: list[dict[str, Any]] = []
         for path in changed_paths:
             normalized = str(path).strip().removeprefix("./")
             if not normalized:
                 continue
-            if not any(_path_in_scope(normalized, scope) for scope in file_scope):
+            if not any(_path_in_scope(normalized, scope) for scope in expanded_scope):
                 violations.append(
                     {
                         "type": "out_of_scope",

--- a/tests/nomic/test_dev_coordination.py
+++ b/tests/nomic/test_dev_coordination.py
@@ -6865,3 +6865,59 @@ def test_resolve_verification_worktree_rejects_sha_mismatch(
         assert result_path != str(worktree_dir)
     if cleanup:
         store._cleanup_verification_worktree(cleanup)
+
+
+def test_cleanup_stale_supervisor_runs(store: DevCoordinationStore) -> None:
+    """Stale needs_human runs with non-terminal work orders should be cleaned up."""
+    # Create a run with discarded work orders (simulates a stale dispatch)
+    record = store.create_supervisor_run(
+        goal="Test stale cleanup",
+        target_branch="main",
+        supervisor_agents={"planner": "codex"},
+        approval_policy={},
+        spec={"raw_goal": "test"},
+        work_orders=[
+            {"work_order_id": "wo-1", "status": "discarded"},
+            {"work_order_id": "wo-2", "status": "needs_human"},
+        ],
+        status="needs_human",
+    )
+    run_id = record["run_id"]
+
+    # Before cleanup: run is needs_human
+    run = store.get_supervisor_run(run_id)
+    assert run is not None
+    assert run["status"] == "needs_human"
+
+    # Run cleanup
+    cleaned = store.cleanup_stale_supervisor_runs()
+    assert cleaned >= 1
+
+    # After cleanup: run is completed, work orders are completed
+    run = store.get_supervisor_run(run_id)
+    assert run is not None
+    assert run["status"] == "completed"
+    for wo in run["work_orders"]:
+        assert wo["status"] == "completed"
+
+
+def test_cleanup_skips_active_runs(store: DevCoordinationStore) -> None:
+    """Runs with active work orders should NOT be cleaned up."""
+    record = store.create_supervisor_run(
+        goal="Active run",
+        target_branch="main",
+        supervisor_agents={"planner": "codex"},
+        approval_policy={},
+        spec={"raw_goal": "active"},
+        work_orders=[
+            {"work_order_id": "wo-active", "status": "leased"},
+        ],
+        status="running",
+    )
+    run_id = record["run_id"]
+
+    cleaned = store.cleanup_stale_supervisor_runs()
+    # Should not clean active runs
+    run = store.get_supervisor_run(run_id)
+    assert run is not None
+    assert run["status"] == "running"


### PR DESCRIPTION
## Summary

Two operational fixes discovered during boss loop batch testing:

- **Stale run cleanup**: Previous sessions leave supervisor runs in `needs_human` with `discarded`/`dispatch_failed` work orders. The duplicate detector blocks all new dispatches for overlapping file scopes indefinitely. Added `cleanup_stale_supervisor_runs()` method called at boss loop startup — marks completed runs with all-terminal work orders so duplicate detection starts clean.

- **Test scope relaxation**: Workers that chose a different test file name than the issue suggested (e.g. `test_live_explainability_wiring.py` vs `test_live_explainability_e2e.py`) triggered false scope violations. Expanded scope check to allow sibling files in the same directory when the scope hint is a specific test file path.

## Test plan

- [ ] 2 new cleanup tests pass (test_cleanup_stale_supervisor_runs, test_cleanup_skips_active_runs)
- [ ] 91 supervisor tests pass
- [ ] 73 worker launcher tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)