### PR TITLE
refactor(pipeline): centralize run-ledger runtime side effects

### DIFF
--- a/aragora/pipeline/backbone_runtime.py
+++ b/aragora/pipeline/backbone_runtime.py
@@ -1,0 +1,323 @@
+"""Runtime helpers for canonical RunLedger side effects.
+
+This module centralizes run-ledger mutations that were previously spread
+across handlers, orchestrators, and execution bridges. Persistence stays in
+``PlanStore`` while this service owns the higher-level runtime wiring:
+stage events, trust/taint gate lookup, receipt mirroring, feedback, and
+shadow attestation.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+
+from aragora.pipeline.backbone_contracts import (
+    BackboneStage,
+    OutcomeFeedbackRecord,
+    ReceiptEnvelope,
+    RunLedger,
+    RunStageEvent,
+    TaintChecker,
+)
+
+if TYPE_CHECKING:
+    from aragora.pipeline.decision_plan import PlanOutcome
+    from aragora.pipeline.plan_store import PlanStore
+    from aragora.pipeline.receipt_gate import PlanExecutionGateDecision
+
+logger = logging.getLogger(__name__)
+
+
+class BackboneRuntime:
+    """Service layer for RunLedger runtime mutations."""
+
+    def __init__(self, plan_store: PlanStore | None = None) -> None:
+        self._plan_store = plan_store
+
+    @property
+    def plan_store(self) -> PlanStore:
+        if self._plan_store is None:
+            from aragora.pipeline.plan_store import get_plan_store
+
+            self._plan_store = get_plan_store()
+        return self._plan_store
+
+    def create_run(self, run: RunLedger) -> None:
+        self.plan_store.create_run(run)
+
+    def get_run(self, run_id: str) -> RunLedger | None:
+        return self.plan_store.get_run(run_id)
+
+    def update_run(self, run_id: str, **kwargs: Any) -> bool:
+        return self.plan_store.update_run(run_id, **kwargs)
+
+    def append_stage_event(
+        self,
+        run_id: str,
+        stage: BackboneStage | str,
+        *,
+        status: str,
+        artifact_ref: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> bool:
+        if not run_id:
+            return False
+        return self.plan_store.append_run_stage_event(
+            run_id,
+            RunStageEvent.create(
+                stage,
+                status=status,
+                artifact_ref=artifact_ref,
+                details=details,
+            ),
+        )
+
+    @staticmethod
+    def ensure_plan_metadata(plan: Any, run_id: str, entrypoint: str) -> None:
+        metadata = getattr(plan, "metadata", None)
+        if not isinstance(metadata, dict):
+            metadata = {}
+            setattr(plan, "metadata", metadata)
+        metadata.setdefault("backbone_run_id", run_id)
+        metadata.setdefault("backbone_entrypoint", entrypoint)
+
+    def evaluate_execution_gate(self, plan: Any) -> PlanExecutionGateDecision:
+        from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
+
+        return evaluate_plan_execution_gate(plan, plan_store=self.plan_store)
+
+    def sync_plan_receipt_to_run(
+        self,
+        plan: Any,
+        *,
+        append_event: bool = False,
+    ) -> bool:
+        metadata = getattr(plan, "metadata", None)
+        if not isinstance(metadata, dict):
+            return False
+
+        run_id = str(metadata.get("backbone_run_id", "") or "").strip()
+        if not run_id:
+            return False
+
+        receipt_meta = metadata.get("decision_receipt")
+        receipt_id = ""
+        if isinstance(receipt_meta, dict):
+            receipt_id = str(receipt_meta.get("receipt_id", "") or "").strip()
+        if not receipt_id:
+            receipt_id = str(metadata.get("decision_receipt_id", "") or "").strip()
+        if not receipt_id:
+            return False
+
+        try:
+            from aragora.pipeline.receipt_store_facade import get_receipt_store_facade
+
+            canonical = get_receipt_store_facade().get_canonical(receipt_id)
+        except Exception:  # noqa: BLE001 - best-effort ledger enrichment
+            logger.debug("Backbone receipt fetch failed for %s", receipt_id, exc_info=True)
+            return False
+
+        if not isinstance(canonical, dict):
+            return False
+
+        receipt_payload = canonical.get("receipt_data")
+        if isinstance(receipt_payload, dict):
+            receipt_payload = dict(receipt_payload)
+            receipt_payload.setdefault("receipt_id", receipt_id)
+            receipt_payload.setdefault("signature", canonical.get("signature"))
+            receipt_payload.setdefault("signature_key_id", canonical.get("signature_key_id"))
+            receipt_payload.setdefault("signed_at", canonical.get("signed_at"))
+            receipt_payload.setdefault("signature_algorithm", canonical.get("signature_algorithm"))
+            receipt_payload["state"] = canonical.get("state", receipt_payload.get("state"))
+        else:
+            receipt_payload = canonical
+
+        if not isinstance(receipt_payload, dict):
+            return False
+
+        run = self.get_run(run_id)
+        taint_summary = TaintChecker.collect_taint_summary(
+            intake=getattr(run, "intake_bundle", None),
+            spec=getattr(run, "spec_bundle", None),
+            deliberation=getattr(run, "deliberation_bundle", None),
+            verification=getattr(run, "receipt_envelope", None),
+        )
+        gate = metadata.get("execution_gate")
+        envelope = ReceiptEnvelope.from_decision_receipt(
+            receipt_payload,
+            policy_gate_result=dict(gate or {}) if isinstance(gate, dict) else {},
+            taint_summary=taint_summary,
+        )
+        updated = self.update_run(
+            run_id,
+            receipt_id=receipt_id,
+            receipt_envelope=envelope,
+            metadata={"plan_receipt_state": str(receipt_payload.get("state", "")).lower()},
+        )
+        if append_event:
+            self.append_stage_event(
+                run_id,
+                BackboneStage.RECEIPT,
+                status=str(receipt_payload.get("state", "created") or "created").lower(),
+                artifact_ref=receipt_id,
+                details={"source": "plan_status_transition", "plan_id": getattr(plan, "id", "")},
+            )
+        return updated
+
+    def record_execution_stage(
+        self,
+        run_id: str,
+        *,
+        status: str,
+        artifact_ref: str = "",
+        run_status: str | None = None,
+        execution_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> bool:
+        if not run_id:
+            return False
+
+        update_kwargs: dict[str, Any] = {}
+        if run_status is not None:
+            update_kwargs["status"] = run_status
+        if execution_id is not None:
+            update_kwargs["execution_id"] = execution_id
+        if metadata:
+            update_kwargs["metadata"] = metadata
+        if update_kwargs:
+            self.update_run(run_id, **update_kwargs)
+
+        return self.append_stage_event(
+            run_id,
+            BackboneStage.EXECUTION,
+            status=status,
+            artifact_ref=artifact_ref,
+            details=details,
+        )
+
+    def build_feedback_record(
+        self,
+        plan: Any,
+        outcome: PlanOutcome,
+        *,
+        receipt_ref: str,
+        execution_mode: str,
+    ) -> OutcomeFeedbackRecord:
+        quality_score = 1.0 if outcome.success else 0.25
+        metadata = getattr(plan, "metadata", None)
+        pipeline_like = SimpleNamespace(
+            pipeline_id=getattr(plan, "id", ""),
+            run_type="decision_plan_execution",
+            domain=metadata.get("domain", "") if isinstance(metadata, dict) else "",
+            overall_quality_score=quality_score,
+            spec_completeness=1.0 if outcome.success else 0.5,
+            execution_succeeded=outcome.success,
+            tests_passed=int(getattr(outcome, "tests_passed", 0) or 0),
+            tests_failed=int(getattr(outcome, "tests_failed", 0) or 0),
+            files_changed=int(getattr(outcome, "files_changed", 0) or 0),
+            human_interventions=0,
+            rollback_triggered=bool(getattr(outcome, "rollback_triggered", False)),
+            total_duration_s=outcome.duration_seconds,
+        )
+        next_action = ""
+        if not outcome.success and int(getattr(outcome, "tests_failed", 0) or 0) > 0:
+            next_action = "run_bug_fix_loop"
+        return OutcomeFeedbackRecord.from_pipeline_outcome(
+            pipeline_like,
+            receipt_ref=receipt_ref or getattr(plan, "id", ""),
+            next_action_recommendation=next_action,
+        )
+
+    async def attach_execution_receipt(
+        self,
+        run_id: str,
+        plan: Any,
+        outcome: PlanOutcome,
+    ) -> str:
+        from aragora.blockchain.receipt_settlement import ReceiptSettlementService
+        from aragora.gauntlet.receipt_models import DecisionReceipt
+        from aragora.pipeline.canonical_execution import build_decision_receipt_payload
+
+        if not run_id:
+            return str(getattr(outcome, "receipt_id", "") or getattr(plan, "id", ""))
+
+        run = self.get_run(run_id)
+        receipt_payload = build_decision_receipt_payload(plan, outcome)
+        receipt_ref = str(getattr(outcome, "receipt_id", "") or getattr(plan, "id", ""))
+
+        if not isinstance(receipt_payload, dict):
+            return receipt_ref
+
+        taint_summary = TaintChecker.collect_taint_summary(
+            intake=getattr(run, "intake_bundle", None),
+            spec=getattr(run, "spec_bundle", None),
+            deliberation=getattr(run, "deliberation_bundle", None),
+            verification=getattr(run, "receipt_envelope", None),
+        )
+        metadata = getattr(plan, "metadata", None)
+        gate = metadata.get("execution_gate", {}) if isinstance(metadata, dict) else {}
+        envelope = ReceiptEnvelope.from_decision_receipt(
+            receipt_payload,
+            policy_gate_result=dict(gate or {}),
+            taint_summary=taint_summary,
+        )
+        receipt_ref = envelope.receipt_id or receipt_ref
+        self.update_run(
+            run_id,
+            receipt_id=receipt_ref,
+            receipt_envelope=envelope,
+        )
+        self.append_stage_event(
+            run_id,
+            BackboneStage.RECEIPT,
+            status="completed",
+            artifact_ref=receipt_ref,
+            details={"source": "decision_plan_execution"},
+        )
+
+        try:
+            settled_receipt = await ReceiptSettlementService().anchor_receipt(
+                DecisionReceipt.from_dict(receipt_payload)
+            )
+            attestation = getattr(settled_receipt, "settlement_status", None)
+            if isinstance(attestation, dict):
+                self.update_run(run_id, attestation=attestation)
+                self.append_stage_event(
+                    run_id,
+                    BackboneStage.ATTESTATION,
+                    status="completed",
+                    artifact_ref=receipt_ref,
+                    details=attestation,
+                )
+        except Exception:
+            logger.debug("Backbone shadow attestation failed", exc_info=True)
+
+        return receipt_ref
+
+    def attach_feedback_record(
+        self,
+        run_id: str,
+        feedback_record: OutcomeFeedbackRecord,
+        *,
+        artifact_ref: str = "",
+        details: dict[str, Any] | None = None,
+    ) -> bool:
+        if not run_id:
+            return False
+        self.update_run(run_id, feedback_record=feedback_record)
+        payload = {"next_action": feedback_record.next_action_recommendation}
+        if details:
+            payload.update(details)
+        return self.append_stage_event(
+            run_id,
+            BackboneStage.FEEDBACK,
+            status="completed",
+            artifact_ref=artifact_ref or feedback_record.receipt_ref,
+            details=payload,
+        )
+
+
+__all__ = ["BackboneRuntime"]

--- a/aragora/pipeline/execution_bridge.py
+++ b/aragora/pipeline/execution_bridge.py
@@ -20,17 +20,10 @@ import asyncio
 import logging
 import threading
 from datetime import datetime, timezone
-from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 import uuid
 
-from aragora.pipeline.backbone_contracts import (
-    BackboneStage,
-    OutcomeFeedbackRecord,
-    ReceiptEnvelope,
-    RunStageEvent,
-    TaintChecker,
-)
+from aragora.pipeline.backbone_runtime import BackboneRuntime
 from aragora.pipeline.decision_plan import PlanOutcome, PlanStatus
 
 if TYPE_CHECKING:
@@ -52,9 +45,11 @@ class ExecutionBridge:
         self,
         plan_store: PlanStore | None = None,
         executor: PlanExecutor | None = None,
+        backbone_runtime: BackboneRuntime | None = None,
     ) -> None:
         self._plan_store = plan_store
         self._executor = executor
+        self._backbone_runtime = backbone_runtime
 
     @property
     def plan_store(self) -> PlanStore:
@@ -72,152 +67,18 @@ class ExecutionBridge:
             self._executor = PlanExecutor()
         return self._executor
 
+    @property
+    def backbone_runtime(self) -> BackboneRuntime:
+        if self._backbone_runtime is None:
+            self._backbone_runtime = BackboneRuntime(self.plan_store)
+        return self._backbone_runtime
+
     @staticmethod
     def _extract_backbone_run_id(plan: Any) -> str:
         metadata = getattr(plan, "metadata", None)
         if not isinstance(metadata, dict):
             return ""
         return str(metadata.get("backbone_run_id", "") or "").strip()
-
-    def _record_execution_stage(
-        self,
-        run_id: str,
-        *,
-        status: str,
-        artifact_ref: str = "",
-        details: dict[str, Any] | None = None,
-    ) -> None:
-        if not run_id:
-            return
-        self.plan_store.append_run_stage_event(
-            run_id,
-            RunStageEvent.create(
-                BackboneStage.EXECUTION,
-                status=status,
-                artifact_ref=artifact_ref,
-                details=details,
-            ),
-        )
-
-    def _build_feedback_record(
-        self,
-        plan: Any,
-        outcome: PlanOutcome,
-        *,
-        receipt_ref: str,
-        execution_mode: str,
-    ) -> OutcomeFeedbackRecord:
-        quality_score = 1.0 if outcome.success else 0.25
-        pipeline_like = SimpleNamespace(
-            pipeline_id=plan.id,
-            run_type="decision_plan_execution",
-            domain=(
-                plan.metadata.get("domain", "")
-                if isinstance(getattr(plan, "metadata", None), dict)
-                else ""
-            ),
-            overall_quality_score=quality_score,
-            spec_completeness=1.0 if outcome.success else 0.5,
-            execution_succeeded=outcome.success,
-            tests_passed=int(getattr(outcome, "tests_passed", 0) or 0),
-            tests_failed=int(getattr(outcome, "tests_failed", 0) or 0),
-            files_changed=int(getattr(outcome, "files_changed", 0) or 0),
-            human_interventions=0,
-            rollback_triggered=bool(getattr(outcome, "rollback_triggered", False)),
-            total_duration_s=outcome.duration_seconds,
-        )
-        next_action = ""
-        if not outcome.success and int(getattr(outcome, "tests_failed", 0) or 0) > 0:
-            next_action = "run_bug_fix_loop"
-        return OutcomeFeedbackRecord.from_pipeline_outcome(
-            pipeline_like,
-            receipt_ref=receipt_ref or plan.id,
-            next_action_recommendation=next_action,
-        )
-
-    async def _attach_backbone_receipt_and_feedback(
-        self,
-        *,
-        run_id: str,
-        plan: Any,
-        outcome: PlanOutcome,
-        execution_mode: str,
-    ) -> None:
-        from aragora.blockchain.receipt_settlement import ReceiptSettlementService
-        from aragora.gauntlet.receipt_models import DecisionReceipt
-        from aragora.pipeline.canonical_execution import build_decision_receipt_payload
-
-        run = self.plan_store.get_run(run_id)
-        receipt_payload = build_decision_receipt_payload(plan, outcome)
-        receipt_ref = str(getattr(outcome, "receipt_id", "") or plan.id)
-
-        if isinstance(receipt_payload, dict):
-            taint_summary = TaintChecker.collect_taint_summary(
-                intake=getattr(run, "intake_bundle", None),
-                spec=getattr(run, "spec_bundle", None),
-                deliberation=getattr(run, "deliberation_bundle", None),
-                verification=getattr(run, "receipt_envelope", None),
-            )
-            metadata = getattr(plan, "metadata", None)
-            gate = metadata.get("execution_gate", {}) if isinstance(metadata, dict) else {}
-            envelope = ReceiptEnvelope.from_decision_receipt(
-                receipt_payload,
-                policy_gate_result=dict(gate or {}),
-                taint_summary=taint_summary,
-            )
-            receipt_ref = envelope.receipt_id or receipt_ref
-            self.plan_store.update_run(
-                run_id,
-                receipt_id=receipt_ref,
-                receipt_envelope=envelope,
-            )
-            self.plan_store.append_run_stage_event(
-                run_id,
-                RunStageEvent.create(
-                    BackboneStage.RECEIPT,
-                    status="completed",
-                    artifact_ref=receipt_ref,
-                    details={"source": "decision_plan_execution"},
-                ),
-            )
-            try:
-                settled_receipt = await ReceiptSettlementService().anchor_receipt(
-                    DecisionReceipt.from_dict(receipt_payload)
-                )
-                attestation = getattr(settled_receipt, "settlement_status", None)
-                if isinstance(attestation, dict):
-                    self.plan_store.update_run(run_id, attestation=attestation)
-                    self.plan_store.append_run_stage_event(
-                        run_id,
-                        RunStageEvent.create(
-                            BackboneStage.ATTESTATION,
-                            status="completed",
-                            artifact_ref=receipt_ref,
-                            details=attestation,
-                        ),
-                    )
-            except Exception:
-                logger.debug("Backbone shadow attestation failed", exc_info=True)
-
-        feedback_record = self._build_feedback_record(
-            plan,
-            outcome,
-            receipt_ref=receipt_ref,
-            execution_mode=execution_mode,
-        )
-        self.plan_store.update_run(run_id, feedback_record=feedback_record)
-        self.plan_store.append_run_stage_event(
-            run_id,
-            RunStageEvent.create(
-                BackboneStage.FEEDBACK,
-                status="completed",
-                artifact_ref=receipt_ref,
-                details={
-                    "next_action": feedback_record.next_action_recommendation,
-                    "execution_mode": execution_mode,
-                },
-            ),
-        )
 
     async def execute_approved_plan(
         self,
@@ -266,9 +127,7 @@ class ExecutionBridge:
         resolved_correlation_id = correlation_id or f"corr-{uuid.uuid4().hex[:12]}"
         backbone_run_id = self._extract_backbone_run_id(plan)
 
-        from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
-
-        gate_decision = evaluate_plan_execution_gate(plan, plan_store=store)
+        gate_decision = self.backbone_runtime.evaluate_execution_gate(plan)
         if not gate_decision.allow_execution:
             blocked_status = (
                 "pending_approval" if gate_decision.requires_human_approval else "blocked"
@@ -293,16 +152,13 @@ class ExecutionBridge:
                     metadata={"execution_gate": gate_decision.gate},
                 )
             if backbone_run_id:
-                store.update_run(
-                    backbone_run_id,
-                    status=blocked_status,
-                    execution_id=resolved_execution_id,
-                    metadata={"execution_gate": gate_decision.gate},
-                )
-                self._record_execution_stage(
+                self.backbone_runtime.record_execution_stage(
                     backbone_run_id,
                     status=blocked_status,
                     artifact_ref=resolved_execution_id,
+                    run_status=blocked_status,
+                    execution_id=resolved_execution_id,
+                    metadata={"execution_gate": gate_decision.gate},
                     details={"plan_id": plan.id, "reason_codes": gate_decision.reason_codes},
                 )
             raise ValueError(
@@ -361,19 +217,16 @@ class ExecutionBridge:
                 },
             )
         if backbone_run_id:
-            store.update_run(
+            self.backbone_runtime.record_execution_stage(
                 backbone_run_id,
-                status="execution_running",
+                status="running",
+                artifact_ref=resolved_execution_id,
+                run_status="execution_running",
                 execution_id=resolved_execution_id,
                 metadata={
                     "execution_mode": execution_mode or "default",
                     "execution_gate": gate_decision.gate,
                 },
-            )
-            self._record_execution_stage(
-                backbone_run_id,
-                status="running",
-                artifact_ref=resolved_execution_id,
                 details={
                     "plan_id": plan.id,
                     "execution_mode": execution_mode or "default",
@@ -405,16 +258,13 @@ class ExecutionBridge:
                 },
             )
             if backbone_run_id:
-                store.update_run(
-                    backbone_run_id,
-                    status="execution_failed",
-                    execution_id=resolved_execution_id,
-                    metadata={"execution_terminal_state": "failed"},
-                )
-                self._record_execution_stage(
+                self.backbone_runtime.record_execution_stage(
                     backbone_run_id,
                     status="failed",
                     artifact_ref=resolved_execution_id,
+                    run_status="execution_failed",
+                    execution_id=resolved_execution_id,
+                    metadata={"execution_terminal_state": "failed"},
                     details={"error": str(exc), "plan_id": plan.id},
                 )
             raise
@@ -422,6 +272,8 @@ class ExecutionBridge:
         # Persist final status
         final_status = PlanStatus.COMPLETED if outcome.success else PlanStatus.FAILED
         store.update_status(plan_id, final_status)
+        updated_plan = store.get(plan_id) or plan
+        self.backbone_runtime.sync_plan_receipt_to_run(updated_plan, append_event=True)
         failure_error = None
         if not outcome.success:
             failure_error = {
@@ -442,19 +294,16 @@ class ExecutionBridge:
             },
         )
         if backbone_run_id:
-            store.update_run(
+            self.backbone_runtime.record_execution_stage(
                 backbone_run_id,
-                status="execution_succeeded" if outcome.success else "execution_failed",
+                status="succeeded" if outcome.success else "failed",
+                artifact_ref=resolved_execution_id,
+                run_status="execution_succeeded" if outcome.success else "execution_failed",
                 execution_id=resolved_execution_id,
                 metadata={
                     "execution_terminal_state": "succeeded" if outcome.success else "failed",
                     "execution_duration_seconds": outcome.duration_seconds,
                 },
-            )
-            self._record_execution_stage(
-                backbone_run_id,
-                status="succeeded" if outcome.success else "failed",
-                artifact_ref=resolved_execution_id,
                 details={
                     "plan_id": plan.id,
                     "duration_seconds": outcome.duration_seconds,
@@ -462,11 +311,22 @@ class ExecutionBridge:
                     "tasks_total": outcome.tasks_total,
                 },
             )
-            await self._attach_backbone_receipt_and_feedback(
-                run_id=backbone_run_id,
-                plan=plan,
-                outcome=outcome,
+            receipt_ref = await self.backbone_runtime.attach_execution_receipt(
+                backbone_run_id,
+                updated_plan,
+                outcome,
+            )
+            feedback_record = self.backbone_runtime.build_feedback_record(
+                updated_plan,
+                outcome,
+                receipt_ref=receipt_ref,
                 execution_mode=str(execution_mode or "default"),
+            )
+            self.backbone_runtime.attach_feedback_record(
+                backbone_run_id,
+                feedback_record,
+                artifact_ref=receipt_ref,
+                details={"execution_mode": str(execution_mode or "default")},
             )
 
         logger.info(
@@ -519,9 +379,7 @@ class ExecutionBridge:
         plan = self.plan_store.get(plan_id)
         backbone_run_id = self._extract_backbone_run_id(plan) if plan is not None else ""
         if plan is not None:
-            from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
-
-            gate_decision = evaluate_plan_execution_gate(plan, plan_store=self.plan_store)
+            gate_decision = self.backbone_runtime.evaluate_execution_gate(plan)
             if not gate_decision.allow_execution:
                 blocked_status = (
                     "pending_approval" if gate_decision.requires_human_approval else "blocked"
@@ -540,16 +398,13 @@ class ExecutionBridge:
                     },
                 )
                 if backbone_run_id:
-                    self.plan_store.update_run(
-                        backbone_run_id,
-                        status=blocked_status,
-                        execution_id=record_execution_id,
-                        metadata={"execution_gate": gate_decision.gate},
-                    )
-                    self._record_execution_stage(
+                    self.backbone_runtime.record_execution_stage(
                         backbone_run_id,
                         status=blocked_status,
                         artifact_ref=record_execution_id,
+                        run_status=blocked_status,
+                        execution_id=record_execution_id,
+                        metadata={"execution_gate": gate_decision.gate},
                         details={"plan_id": plan.id, "reason_codes": gate_decision.reason_codes},
                     )
                 logger.warning(
@@ -571,16 +426,13 @@ class ExecutionBridge:
                 },
             )
             if backbone_run_id:
-                self.plan_store.update_run(
-                    backbone_run_id,
-                    status="execution_queued",
-                    execution_id=record_execution_id,
-                    metadata={"execution_mode": execution_mode or "default"},
-                )
-                self._record_execution_stage(
+                self.backbone_runtime.record_execution_stage(
                     backbone_run_id,
                     status="queued",
                     artifact_ref=record_execution_id,
+                    run_status="execution_queued",
+                    execution_id=record_execution_id,
+                    metadata={"execution_mode": execution_mode or "default"},
                     details={
                         "plan_id": plan.id,
                         "execution_mode": execution_mode or "default",

--- a/aragora/pipeline/plan_store.py
+++ b/aragora/pipeline/plan_store.py
@@ -25,7 +25,6 @@ from typing import Any, Iterable, Sequence
 import uuid
 
 from aragora.pipeline.backbone_contracts import (
-    BackboneStage,
     DeliberationBundle,
     IntakeBundle,
     OutcomeFeedbackRecord,
@@ -33,7 +32,6 @@ from aragora.pipeline.backbone_contracts import (
     RunLedger,
     RunStageEvent,
     SpecBundle,
-    TaintChecker,
 )
 from aragora.pipeline.decision_plan.core import (
     ApprovalMode,
@@ -391,7 +389,6 @@ class PlanStore:
                 ),
             )
             conn.commit()
-            self._attach_backbone_receipt_for_plan(plan, append_event=False)
             logger.info("Stored plan %s for debate %s", plan.id, plan.debate_id)
         finally:
             conn.close()
@@ -531,7 +528,6 @@ class PlanStore:
                         plan = self.get(plan_id)
                         if plan is not None:
                             sync_plan_receipt_state(plan, on_status=status)
-                            self._attach_backbone_receipt_for_plan(plan, append_event=True)
                     except Exception as exc:  # noqa: BLE001 - do not mask status update
                         logger.warning(
                             "Failed to synchronize decision receipt for plan %s: %s",
@@ -614,7 +610,6 @@ class PlanStore:
                         plan = self.get(plan_id)
                         if plan is not None:
                             sync_plan_receipt_state(plan, on_status=new_status)
-                            self._attach_backbone_receipt_for_plan(plan, append_event=True)
                     except Exception as exc:  # noqa: BLE001 - do not mask status update
                         logger.warning(
                             "Failed to synchronize decision receipt for plan %s: %s",
@@ -1104,80 +1099,6 @@ class PlanStore:
     # -------------------------------------------------------------------------
     # Helpers
     # -------------------------------------------------------------------------
-
-    def _attach_backbone_receipt_for_plan(
-        self,
-        plan: DecisionPlan,
-        *,
-        append_event: bool = False,
-    ) -> None:
-        metadata = plan.metadata if isinstance(plan.metadata, dict) else {}
-        run_id = str(metadata.get("backbone_run_id", "") or "").strip()
-        if not run_id:
-            return
-
-        receipt_meta = metadata.get("decision_receipt")
-        receipt_id = ""
-        if isinstance(receipt_meta, dict):
-            receipt_id = str(receipt_meta.get("receipt_id", "") or "").strip()
-        if not receipt_id:
-            receipt_id = str(metadata.get("decision_receipt_id", "") or "").strip()
-        if not receipt_id:
-            return
-
-        try:
-            from aragora.pipeline.receipt_store_facade import get_receipt_store_facade
-
-            canonical = get_receipt_store_facade().get_canonical(receipt_id)
-        except Exception:  # noqa: BLE001 - best-effort ledger enrichment
-            logger.debug("Backbone receipt fetch failed for %s", receipt_id, exc_info=True)
-            return
-
-        if not isinstance(canonical, dict):
-            return
-        receipt_payload = canonical.get("receipt_data")
-        if isinstance(receipt_payload, dict):
-            receipt_payload = dict(receipt_payload)
-            receipt_payload.setdefault("receipt_id", receipt_id)
-            receipt_payload.setdefault("signature", canonical.get("signature"))
-            receipt_payload.setdefault("signature_key_id", canonical.get("signature_key_id"))
-            receipt_payload.setdefault("signed_at", canonical.get("signed_at"))
-            receipt_payload.setdefault("signature_algorithm", canonical.get("signature_algorithm"))
-            receipt_payload["state"] = canonical.get("state", receipt_payload.get("state"))
-        else:
-            receipt_payload = canonical
-        if not isinstance(receipt_payload, dict):
-            return
-
-        run = self.get_run(run_id)
-        taint_summary = TaintChecker.collect_taint_summary(
-            intake=getattr(run, "intake_bundle", None),
-            spec=getattr(run, "spec_bundle", None),
-            deliberation=getattr(run, "deliberation_bundle", None),
-            verification=getattr(run, "receipt_envelope", None),
-        )
-        gate = metadata.get("execution_gate")
-        envelope = ReceiptEnvelope.from_decision_receipt(
-            receipt_payload,
-            policy_gate_result=dict(gate or {}) if isinstance(gate, dict) else {},
-            taint_summary=taint_summary,
-        )
-        self.update_run(
-            run_id,
-            receipt_id=receipt_id,
-            receipt_envelope=envelope,
-            metadata={"plan_receipt_state": str(receipt_payload.get("state", "")).lower()},
-        )
-        if append_event:
-            self.append_run_stage_event(
-                run_id,
-                RunStageEvent.create(
-                    BackboneStage.RECEIPT,
-                    status=str(receipt_payload.get("state", "created") or "created").lower(),
-                    artifact_ref=receipt_id,
-                    details={"source": "plan_status_transition", "plan_id": plan.id},
-                ),
-            )
 
     @staticmethod
     def _row_to_plan(row: sqlite3.Row) -> DecisionPlan:

--- a/aragora/pipeline/unified_orchestrator.py
+++ b/aragora/pipeline/unified_orchestrator.py
@@ -35,9 +35,9 @@ from aragora.pipeline.backbone_contracts import (
     RunLedger,
     RunStageEvent,
     SpecBundle,
-    TaintChecker,
     build_goal_refs_from_implement_plan,
 )
+from aragora.pipeline.backbone_runtime import BackboneRuntime
 
 logger = logging.getLogger(__name__)
 
@@ -154,6 +154,7 @@ class UnifiedOrchestrator:
         code_task_factory: Any | None = None,
         # Provider routing
         provider_router: Any | None = None,
+        backbone_runtime: BackboneRuntime | None = None,
     ) -> None:
         self._input_extension = input_extension
         self._researcher = researcher
@@ -171,12 +172,13 @@ class UnifiedOrchestrator:
         self._spec_extractor = spec_extractor
         self._code_task_factory = code_task_factory
         self._provider_router = provider_router
+        self._backbone_runtime = backbone_runtime
 
-    @staticmethod
-    def _backbone_store() -> Any:
-        from aragora.pipeline.plan_store import get_plan_store
-
-        return get_plan_store()
+    @property
+    def backbone_runtime(self) -> BackboneRuntime:
+        if self._backbone_runtime is None:
+            self._backbone_runtime = BackboneRuntime()
+        return self._backbone_runtime
 
     def _create_backbone_run(self, result: OrchestratorResult, cfg: OrchestratorConfig) -> None:
         intake = IntakeBundle(
@@ -206,7 +208,7 @@ class UnifiedOrchestrator:
                 details={"prompt_length": len(result.prompt), "domain": cfg.domain or "general"},
             )
         )
-        self._backbone_store().create_run(run)
+        self.backbone_runtime.create_run(run)
 
     def _append_backbone_event(
         self,
@@ -217,14 +219,12 @@ class UnifiedOrchestrator:
         artifact_ref: str = "",
         details: dict[str, Any] | None = None,
     ) -> None:
-        self._backbone_store().append_run_stage_event(
+        self.backbone_runtime.append_stage_event(
             result.run_id,
-            RunStageEvent.create(
-                stage,
-                status=status,
-                artifact_ref=artifact_ref,
-                details=details,
-            ),
+            stage,
+            status=status,
+            artifact_ref=artifact_ref,
+            details=details,
         )
 
     def _update_backbone_run(
@@ -267,16 +267,11 @@ class UnifiedOrchestrator:
         if metadata is not None:
             update_kwargs["metadata"] = metadata
         if update_kwargs:
-            self._backbone_store().update_run(result.run_id, **update_kwargs)
+            self.backbone_runtime.update_run(result.run_id, **update_kwargs)
 
     @staticmethod
     def _ensure_plan_backbone_metadata(plan: Any, run_id: str) -> None:
-        metadata = getattr(plan, "metadata", None)
-        if not isinstance(metadata, dict):
-            metadata = {}
-            setattr(plan, "metadata", metadata)
-        metadata.setdefault("backbone_run_id", run_id)
-        metadata.setdefault("backbone_entrypoint", "unified_orchestrator.run")
+        BackboneRuntime.ensure_plan_metadata(plan, run_id, "unified_orchestrator.run")
 
     async def _attach_backbone_receipt(
         self,
@@ -284,59 +279,7 @@ class UnifiedOrchestrator:
         plan: Any,
         outcome: Any,
     ) -> str:
-        from aragora.blockchain.receipt_settlement import ReceiptSettlementService
-        from aragora.gauntlet.receipt_models import DecisionReceipt
-        from aragora.pipeline.canonical_execution import build_decision_receipt_payload
-
-        receipt_payload = build_decision_receipt_payload(plan, outcome)
-        if not isinstance(receipt_payload, dict):
-            return ""
-
-        run = self._backbone_store().get_run(result.run_id)
-        taint_summary = TaintChecker.collect_taint_summary(
-            intake=getattr(run, "intake_bundle", None),
-            spec=getattr(run, "spec_bundle", None),
-            deliberation=getattr(run, "deliberation_bundle", None),
-            verification=getattr(run, "receipt_envelope", None),
-        )
-        metadata = getattr(plan, "metadata", None)
-        gate = metadata.get("execution_gate", {}) if isinstance(metadata, dict) else {}
-        envelope = ReceiptEnvelope.from_decision_receipt(
-            receipt_payload,
-            policy_gate_result=dict(gate or {}),
-            taint_summary=taint_summary,
-        )
-        self._update_backbone_run(
-            result,
-            receipt_id=envelope.receipt_id,
-            receipt_envelope=envelope,
-        )
-        self._append_backbone_event(
-            result,
-            BackboneStage.RECEIPT,
-            status="completed",
-            artifact_ref=envelope.receipt_id,
-            details={"source": "decision_plan_execution"},
-        )
-
-        try:
-            settled_receipt = await ReceiptSettlementService().anchor_receipt(
-                DecisionReceipt.from_dict(receipt_payload)
-            )
-            attestation = getattr(settled_receipt, "settlement_status", None)
-            if isinstance(attestation, dict):
-                self._update_backbone_run(result, attestation=attestation)
-                self._append_backbone_event(
-                    result,
-                    BackboneStage.ATTESTATION,
-                    status="completed",
-                    artifact_ref=envelope.receipt_id,
-                    details=attestation,
-                )
-        except Exception:
-            logger.debug("Backbone attestation shadow-mode failed", exc_info=True)
-
-        return envelope.receipt_id
+        return await self.backbone_runtime.attach_execution_receipt(result.run_id, plan, outcome)
 
     def _attach_backbone_feedback(
         self,
@@ -350,13 +293,10 @@ class UnifiedOrchestrator:
             result.pipeline_outcome,
             receipt_ref=receipt_ref or result.run_id,
         )
-        self._update_backbone_run(result, feedback_record=record)
-        self._append_backbone_event(
-            result,
-            BackboneStage.FEEDBACK,
-            status="completed",
+        self.backbone_runtime.attach_feedback_record(
+            result.run_id,
+            record,
             artifact_ref=record.receipt_ref,
-            details={"next_action": record.next_action_recommendation},
         )
 
     async def run(
@@ -669,12 +609,7 @@ class UnifiedOrchestrator:
 
         # --- Stage 5b: Trust/Taint Execution Gate ---
         if result.decision_plan is not None:
-            from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
-
-            execution_gate = evaluate_plan_execution_gate(
-                result.decision_plan,
-                plan_store=self._backbone_store(),
-            )
+            execution_gate = self.backbone_runtime.evaluate_execution_gate(result.decision_plan)
             metadata = getattr(result.decision_plan, "metadata", None)
             if isinstance(metadata, dict):
                 metadata["execution_gate"] = execution_gate.gate

--- a/aragora/server/handlers/plans.py
+++ b/aragora/server/handlers/plans.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from aragora.pipeline.decision_plan.core import DecisionPlan
 
+from aragora.pipeline.backbone_runtime import BackboneRuntime
 from aragora.server.handlers.base import (
     BaseHandler,
     HandlerResult,
@@ -270,7 +271,9 @@ class PlansHandler(BaseHandler):
             plan.metadata["estimated_duration"] = str(estimated_duration)
 
         store = _get_plan_store()
+        runtime = BackboneRuntime(store)
         store.create(plan)
+        runtime.sync_plan_receipt_to_run(plan, append_event=False)
 
         logger.info("Created plan %s for debate %s", plan.id, plan.debate_id)
         _fire_plan_notification("created", plan)
@@ -303,6 +306,7 @@ class PlansHandler(BaseHandler):
             )
 
         approver_id = getattr(user, "user_id", "unknown") if user else "unknown"
+        runtime = BackboneRuntime(store)
 
         body = self.get_json_body() or {}
         reason = body.get("reason", "")
@@ -310,6 +314,8 @@ class PlansHandler(BaseHandler):
 
         plan.approve(approver_id, reason=str(reason), conditions=conditions)
         store.update_status(plan_id, PlanStatus.APPROVED, approved_by=approver_id)
+        plan = store.get(plan_id) or plan
+        runtime.sync_plan_receipt_to_run(plan, append_event=True)
 
         logger.info("Plan %s approved by %s", plan_id, approver_id)
         _fire_plan_notification("approved", plan, approved_by=approver_id)
@@ -369,6 +375,7 @@ class PlansHandler(BaseHandler):
             return error_response("reason is required for rejection", 400)
 
         rejecter_id = getattr(user, "user_id", "unknown") if user else "unknown"
+        runtime = BackboneRuntime(store)
 
         plan.reject(rejecter_id, reason=str(reason))
         store.update_status(
@@ -377,6 +384,8 @@ class PlansHandler(BaseHandler):
             approved_by=rejecter_id,
             rejection_reason=str(reason),
         )
+        plan = store.get(plan_id) or plan
+        runtime.sync_plan_receipt_to_run(plan, append_event=True)
 
         logger.info("Plan %s rejected by %s: %s", plan_id, rejecter_id, reason)
         _fire_plan_notification("rejected", plan, rejected_by=rejecter_id, reason=str(reason))

--- a/aragora/server/handlers/prompt_engine/handler.py
+++ b/aragora/server/handlers/prompt_engine/handler.py
@@ -26,6 +26,7 @@ from aragora.pipeline.backbone_contracts import (
     SpecBundle,
     build_goal_refs_from_implement_plan,
 )
+from aragora.pipeline.backbone_runtime import BackboneRuntime
 from aragora.pipeline.decision_plan.factory import normalize_execution_mode
 from aragora.pipeline.executor import ExecutionMode
 
@@ -360,6 +361,7 @@ class PromptEngineHandler(SecureHandler):
 
         context = data.get("context")
         store = get_plan_store()
+        runtime = BackboneRuntime(store)
         run_id = f"run-{uuid.uuid4().hex[:12]}"
         initial_taint_flags = self._derive_backbone_taint_flags(context)
         initial_intake = IntakeBundle(
@@ -400,7 +402,7 @@ class PromptEngineHandler(SecureHandler):
                 },
             )
         )
-        store.create_run(run)
+        runtime.create_run(run)
 
         conductor = self._make_conductor(data)
 
@@ -444,7 +446,7 @@ class PromptEngineHandler(SecureHandler):
                 "stages_completed": list(result.stages_completed),
             },
         )
-        store.update_run(
+        runtime.update_run(
             run_id,
             status="spec_ready",
             intake_bundle=canonical_intake,
@@ -458,37 +460,31 @@ class PromptEngineHandler(SecureHandler):
                 }
             },
         )
-        store.append_run_stage_event(
+        runtime.append_stage_event(
             run_id,
-            RunStageEvent.create(
-                BackboneStage.INTENT,
-                status="completed",
-                details={
-                    "intent_type": result.intent.to_dict().get("intent_type"),
-                    "ambiguity_count": len(getattr(result.intent, "ambiguities", []) or []),
-                },
-            ),
+            BackboneStage.INTENT,
+            status="completed",
+            details={
+                "intent_type": result.intent.to_dict().get("intent_type"),
+                "ambiguity_count": len(getattr(result.intent, "ambiguities", []) or []),
+            },
         )
         if "research" in result.stages_completed or result.research is not None:
-            store.append_run_stage_event(
+            runtime.append_stage_event(
                 run_id,
-                RunStageEvent.create(
-                    BackboneStage.RESEARCH,
-                    status="completed" if result.research is not None else "skipped",
-                ),
+                BackboneStage.RESEARCH,
+                status="completed" if result.research is not None else "skipped",
             )
-        store.append_run_stage_event(
+        runtime.append_stage_event(
             run_id,
-            RunStageEvent.create(
-                BackboneStage.SPECIFICATION,
-                status="completed",
-                artifact_ref="spec_bundle",
-                details={
-                    "execution_grade": spec_bundle.is_execution_grade,
-                    "missing_required_fields": list(spec_bundle.missing_required_fields),
-                    "validation_passed": bool(getattr(validation, "passed", False)),
-                },
-            ),
+            BackboneStage.SPECIFICATION,
+            status="completed",
+            artifact_ref="spec_bundle",
+            details={
+                "execution_grade": spec_bundle.is_execution_grade,
+                "missing_required_fields": list(spec_bundle.missing_required_fields),
+                "validation_passed": bool(getattr(validation, "passed", False)),
+            },
         )
 
         payload = {
@@ -512,7 +508,6 @@ class PromptEngineHandler(SecureHandler):
         from aragora.pipeline.decision_plan.core import ApprovalMode, PlanStatus
         from aragora.pipeline.executor import store_plan
         from aragora.pipeline.execution_bridge import get_execution_bridge
-        from aragora.pipeline.receipt_gate import evaluate_plan_execution_gate
 
         plan_metadata = dict(plan_request["metadata"] or {})
         plan_metadata["backbone_run_id"] = run_id
@@ -531,18 +526,16 @@ class PromptEngineHandler(SecureHandler):
                 fail_closed_spec_validation=True,
             )
         except ValueError as exc:
-            store.append_run_stage_event(
+            runtime.append_stage_event(
                 run_id,
-                RunStageEvent.create(
-                    BackboneStage.PLAN,
-                    status="blocked",
-                    details={
-                        "reason": "spec_not_execution_grade",
-                        "missing_required_fields": list(spec_bundle.missing_required_fields),
-                    },
-                ),
+                BackboneStage.PLAN,
+                status="blocked",
+                details={
+                    "reason": "spec_not_execution_grade",
+                    "missing_required_fields": list(spec_bundle.missing_required_fields),
+                },
             )
-            store.update_run(
+            runtime.update_run(
                 run_id,
                 status="spec_ready",
                 metadata={"decision_plan_error": str(exc)},
@@ -555,7 +548,7 @@ class PromptEngineHandler(SecureHandler):
             payload["timing"]["request_total_duration_ms"] = round(elapsed_ms(request_start), 2)
             return json_response(payload, status=422)
 
-        execution_gate_decision = evaluate_plan_execution_gate(plan, plan_store=store)
+        execution_gate_decision = runtime.evaluate_execution_gate(plan)
         if execution_gate_decision.requires_human_approval:
             plan.approval_mode = ApprovalMode.ALWAYS
             plan.status = PlanStatus.AWAITING_APPROVAL
@@ -564,6 +557,7 @@ class PromptEngineHandler(SecureHandler):
             plan.metadata["execution_gate"] = execution_gate_decision.gate
 
         store.create(plan)
+        runtime.sync_plan_receipt_to_run(plan, append_event=False)
         store_plan(plan)
         payload["decision_plan"] = plan.to_dict()
         goal_refs = build_goal_refs_from_implement_plan(plan.implement_plan)
@@ -576,7 +570,7 @@ class PromptEngineHandler(SecureHandler):
             if plan.requires_human_approval and not plan.is_approved
             else "plan_ready"
         )
-        store.update_run(
+        runtime.update_run(
             run_id,
             status=run_status,
             plan_id=plan.id,
@@ -590,38 +584,32 @@ class PromptEngineHandler(SecureHandler):
                 "execution_gate": execution_gate_decision.gate,
             },
         )
-        store.append_run_stage_event(
+        runtime.append_stage_event(
             run_id,
-            RunStageEvent.create(
-                BackboneStage.GOALS,
-                status="completed" if goal_refs else "skipped",
-                artifact_ref=plan.id,
-                details={"goal_refs_count": len(goal_refs)},
-            ),
+            BackboneStage.GOALS,
+            status="completed" if goal_refs else "skipped",
+            artifact_ref=plan.id,
+            details={"goal_refs_count": len(goal_refs)},
         )
-        store.append_run_stage_event(
+        runtime.append_stage_event(
             run_id,
-            RunStageEvent.create(
-                BackboneStage.PLAN,
-                status="completed",
-                artifact_ref=plan.id,
-                details={
-                    "plan_status": plan.status.value,
-                    "approval_mode": plan.approval_mode.value,
-                    "requires_human_approval": plan.requires_human_approval,
-                    "execution_gate_reasons": list(execution_gate_decision.reason_codes),
-                },
-            ),
+            BackboneStage.PLAN,
+            status="completed",
+            artifact_ref=plan.id,
+            details={
+                "plan_status": plan.status.value,
+                "approval_mode": plan.approval_mode.value,
+                "requires_human_approval": plan.requires_human_approval,
+                "execution_gate_reasons": list(execution_gate_decision.reason_codes),
+            },
         )
         if receipt_id:
-            store.append_run_stage_event(
+            runtime.append_stage_event(
                 run_id,
-                RunStageEvent.create(
-                    BackboneStage.RECEIPT,
-                    status=str(decision_receipt.get("state", "created") or "created"),
-                    artifact_ref=receipt_id,
-                    details={"source": "decision_plan_receipt"},
-                ),
+                BackboneStage.RECEIPT,
+                status=str(decision_receipt.get("state", "created") or "created"),
+                artifact_ref=receipt_id,
+                details={"source": "decision_plan_receipt"},
             )
 
         execution_id = ""
@@ -637,7 +625,7 @@ class PromptEngineHandler(SecureHandler):
                     or (plan.requires_human_approval and not plan.is_approved)
                     else "blocked"
                 )
-                store.update_run(
+                runtime.update_run(
                     run_id,
                     status=run_status,
                     metadata={
@@ -646,17 +634,15 @@ class PromptEngineHandler(SecureHandler):
                         "execution_gate": execution_gate_decision.gate,
                     },
                 )
-                store.append_run_stage_event(
+                runtime.append_stage_event(
                     run_id,
-                    RunStageEvent.create(
-                        BackboneStage.EXECUTION,
-                        status=run_status,
-                        artifact_ref=plan.id,
-                        details={
-                            "requires_human_approval": run_status == "pending_approval",
-                            "execution_gate_reasons": list(execution_gate_decision.reason_codes),
-                        },
-                    ),
+                    BackboneStage.EXECUTION,
+                    status=run_status,
+                    artifact_ref=plan.id,
+                    details={
+                        "requires_human_approval": run_status == "pending_approval",
+                        "execution_gate_reasons": list(execution_gate_decision.reason_codes),
+                    },
                 )
                 payload["execution"] = {
                     "status": run_status,
@@ -672,7 +658,7 @@ class PromptEngineHandler(SecureHandler):
                     else None
                 )
                 run_status = "execution_requested"
-                store.update_run(
+                runtime.update_run(
                     run_id,
                     status=run_status,
                     metadata={
@@ -680,14 +666,12 @@ class PromptEngineHandler(SecureHandler):
                         "execution_requested": True,
                     },
                 )
-                store.append_run_stage_event(
+                runtime.append_stage_event(
                     run_id,
-                    RunStageEvent.create(
-                        BackboneStage.EXECUTION,
-                        status="requested",
-                        artifact_ref=plan.id,
-                        details={"execution_mode": execution_mode or "default"},
-                    ),
+                    BackboneStage.EXECUTION,
+                    status="requested",
+                    artifact_ref=plan.id,
+                    details={"execution_mode": execution_mode or "default"},
                 )
                 bridge.schedule_execution(
                     plan.id,
@@ -702,7 +686,7 @@ class PromptEngineHandler(SecureHandler):
                 if record:
                     execution_payload["record"] = record
                     execution_id = str(record.get("execution_id", "") or "").strip()
-                    store.update_run(
+                    runtime.update_run(
                         run_id,
                         status="execution_scheduled",
                         execution_id=execution_id,
@@ -712,14 +696,12 @@ class PromptEngineHandler(SecureHandler):
                             )
                         },
                     )
-                    store.append_run_stage_event(
+                    runtime.append_stage_event(
                         run_id,
-                        RunStageEvent.create(
-                            BackboneStage.EXECUTION,
-                            status=str(record.get("status", "queued") or "queued"),
-                            artifact_ref=execution_id,
-                            details={"execution_mode": execution_mode or "default"},
-                        ),
+                        BackboneStage.EXECUTION,
+                        status=str(record.get("status", "queued") or "queued"),
+                        artifact_ref=execution_id,
+                        details={"execution_mode": execution_mode or "default"},
                     )
                     run_status = "execution_scheduled"
                 payload["execution"] = execution_payload

--- a/tests/pipeline/test_backbone_runtime.py
+++ b/tests/pipeline/test_backbone_runtime.py
@@ -1,0 +1,184 @@
+"""Tests for BackboneRuntime ledger side-effect orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.gauntlet.receipt_store import reset_receipt_store
+from aragora.pipeline.backbone_contracts import BackboneStage, RunLedger
+from aragora.pipeline.backbone_runtime import BackboneRuntime
+from aragora.pipeline.decision_plan.core import (
+    ApprovalMode,
+    ApprovalRecord,
+    DecisionPlan,
+    PlanStatus,
+)
+from aragora.pipeline.decision_plan.memory import PlanOutcome
+from aragora.pipeline.plan_store import PlanStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> PlanStore:
+    return PlanStore(db_path=str(tmp_path / "backbone_runtime.db"))
+
+
+@pytest.fixture(autouse=True)
+def _reset_receipts() -> None:
+    reset_receipt_store()
+    yield
+    reset_receipt_store()
+
+
+class TestBackboneRuntime:
+    def test_sync_plan_receipt_to_run_persists_envelope_and_event(self, store: PlanStore) -> None:
+        runtime = BackboneRuntime(store)
+        store.create_run(
+            RunLedger(run_id="run-sync", entrypoint="prompt_engine.run", status="plan_ready")
+        )
+        plan = DecisionPlan(
+            id="dp-sync",
+            debate_id="debate-sync",
+            task="Sync the receipt",
+            status=PlanStatus.AWAITING_APPROVAL,
+            approval_mode=ApprovalMode.ALWAYS,
+            metadata={"backbone_run_id": "run-sync"},
+        )
+
+        store.create(plan)
+        updated_plan = store.get(plan.id)
+        assert updated_plan is not None
+        store.update_status(plan.id, PlanStatus.APPROVED, approved_by="approver-1")
+        updated_plan = store.get(plan.id)
+        assert updated_plan is not None
+
+        synced = runtime.sync_plan_receipt_to_run(updated_plan, append_event=True)
+        run = store.get_run("run-sync")
+
+        assert synced is True
+        assert run is not None
+        assert run.receipt_envelope is not None
+        assert run.metadata["plan_receipt_state"] == "approved"
+        assert any(
+            event.stage == BackboneStage.RECEIPT.value and event.status == "approved"
+            for event in run.stage_events
+        )
+
+    def test_record_execution_stage_updates_run_and_event(self, store: PlanStore) -> None:
+        runtime = BackboneRuntime(store)
+        store.create_run(
+            RunLedger(run_id="run-exec", entrypoint="prompt_engine.run", status="plan_ready")
+        )
+
+        recorded = runtime.record_execution_stage(
+            "run-exec",
+            status="queued",
+            artifact_ref="exec-123",
+            run_status="execution_queued",
+            execution_id="exec-123",
+            metadata={"execution_mode": "workflow"},
+            details={"plan_id": "dp-sync"},
+        )
+        run = store.get_run("run-exec")
+
+        assert recorded is True
+        assert run is not None
+        assert run.status == "execution_queued"
+        assert run.execution_id == "exec-123"
+        assert run.metadata["execution_mode"] == "workflow"
+        assert any(
+            event.stage == BackboneStage.EXECUTION.value and event.artifact_ref == "exec-123"
+            for event in run.stage_events
+        )
+
+    @pytest.mark.asyncio
+    async def test_attach_execution_receipt_persists_attestation(self, store: PlanStore) -> None:
+        runtime = BackboneRuntime(store)
+        store.create_run(
+            RunLedger(run_id="run-receipt", entrypoint="prompt_engine.run", status="plan_ready")
+        )
+        plan = DecisionPlan(
+            id="dp-receipt",
+            debate_id="debate-receipt",
+            task="Execute with receipt",
+            status=PlanStatus.APPROVED,
+            approval_mode=ApprovalMode.ALWAYS,
+            approval_record=ApprovalRecord(approved=True, approver_id="user-1"),
+            metadata={"backbone_run_id": "run-receipt", "execution_gate": {}},
+        )
+        outcome = PlanOutcome(
+            plan_id=plan.id,
+            debate_id=plan.debate_id,
+            task=plan.task,
+            success=True,
+            tasks_completed=1,
+            tasks_total=1,
+            duration_seconds=0.1,
+            receipt_id="receipt-runtime-1",
+        )
+
+        receipt_ref = await runtime.attach_execution_receipt("run-receipt", plan, outcome)
+        run = store.get_run("run-receipt")
+
+        assert receipt_ref == "receipt-runtime-1"
+        assert run is not None
+        assert run.receipt_envelope is not None
+        assert run.receipt_envelope.receipt_id == "receipt-runtime-1"
+        assert run.attestation.get("local_only") is True
+        assert any(
+            event.stage == BackboneStage.RECEIPT.value and event.status == "completed"
+            for event in run.stage_events
+        )
+        assert any(
+            event.stage == BackboneStage.ATTESTATION.value and event.status == "completed"
+            for event in run.stage_events
+        )
+
+    def test_attach_feedback_record_persists_feedback_event(self, store: PlanStore) -> None:
+        runtime = BackboneRuntime(store)
+        store.create_run(
+            RunLedger(run_id="run-feedback", entrypoint="prompt_engine.run", status="plan_ready")
+        )
+        plan = DecisionPlan(
+            id="dp-feedback",
+            debate_id="debate-feedback",
+            task="Feedback task",
+            status=PlanStatus.APPROVED,
+            approval_mode=ApprovalMode.ALWAYS,
+            approval_record=ApprovalRecord(approved=True, approver_id="user-1"),
+        )
+        outcome = PlanOutcome(
+            plan_id=plan.id,
+            debate_id=plan.debate_id,
+            task=plan.task,
+            success=False,
+            tasks_completed=0,
+            tasks_total=1,
+            duration_seconds=0.5,
+            error="tests failed",
+            receipt_id="receipt-feedback-1",
+        )
+        record = runtime.build_feedback_record(
+            plan,
+            outcome,
+            receipt_ref="receipt-feedback-1",
+            execution_mode="workflow",
+        )
+
+        attached = runtime.attach_feedback_record(
+            "run-feedback",
+            record,
+            artifact_ref="receipt-feedback-1",
+            details={"execution_mode": "workflow"},
+        )
+        run = store.get_run("run-feedback")
+
+        assert attached is True
+        assert run is not None
+        assert run.feedback_record is not None
+        assert run.feedback_record.receipt_ref == "receipt-feedback-1"
+        assert any(
+            event.stage == BackboneStage.FEEDBACK.value and event.status == "completed"
+            for event in run.stage_events
+        )

--- a/tests/pipeline/test_plan_store.py
+++ b/tests/pipeline/test_plan_store.py
@@ -446,7 +446,7 @@ class TestPlanStoreBackboneRuns:
         assert len(events) == 1
         assert events[0].artifact_ref == "plan-1"
 
-    def test_update_status_syncs_backbone_receipt_envelope(self, store: PlanStore) -> None:
+    def test_update_status_does_not_sync_backbone_receipt_envelope(self, store: PlanStore) -> None:
         store.create_run(
             RunLedger(run_id="run-receipt", entrypoint="prompt_engine.run", status="plan_ready")
         )
@@ -465,12 +465,8 @@ class TestPlanStoreBackboneRuns:
 
         assert updated is True
         assert run is not None
-        assert run.receipt_envelope is not None
-        assert run.metadata["plan_receipt_state"] == "approved"
-        assert any(
-            event.stage == BackboneStage.RECEIPT.value and event.status == "approved"
-            for event in run.stage_events
-        )
+        assert run.receipt_envelope is None
+        assert "plan_receipt_state" not in run.metadata
 
 
 class TestPlanStoreExecutionClaims:


### PR DESCRIPTION
## Summary
- extract a BackboneRuntime service to own run-ledger, receipt, feedback, and attestation side effects
- make PlanStore persistence-only and route prompt engine, plans, execution bridge, and orchestrator flows through the runtime
- add focused runtime coverage and update plan store expectations to reflect the new ownership boundary

## Validation
- python3 -m ruff check aragora/pipeline/backbone_runtime.py aragora/pipeline/plan_store.py aragora/pipeline/execution_bridge.py aragora/pipeline/unified_orchestrator.py aragora/server/handlers/prompt_engine/handler.py aragora/server/handlers/plans.py tests/pipeline/test_backbone_runtime.py tests/pipeline/test_plan_store.py tests/pipeline/test_execution_bridge.py tests/pipeline/test_unified_orchestrator.py tests/server/handlers/test_prompt_engine_handler.py tests/server/handlers/test_plans.py
- python3 -m pytest tests/pipeline/test_backbone_runtime.py tests/pipeline/test_plan_store.py tests/pipeline/test_execution_bridge.py tests/pipeline/test_unified_orchestrator.py tests/server/handlers/test_prompt_engine_handler.py tests/server/handlers/test_plans.py
- python3 -m mypy --follow-imports=skip --ignore-missing-imports aragora/pipeline/backbone_runtime.py aragora/pipeline/plan_store.py aragora/pipeline/execution_bridge.py aragora/pipeline/unified_orchestrator.py aragora/server/handlers/prompt_engine/handler.py aragora/server/handlers/plans.py

## Notes
- repo-wide mypy still has unrelated baseline failures outside this refactor scope
