### PR TITLE
feat(pipeline): route decision-integrity flows through backbone runs

### DIFF
--- a/aragora/pipeline/canonical_execution.py
+++ b/aragora/pipeline/canonical_execution.py
@@ -479,7 +479,10 @@ def queue_plan_execution(
         existing_run_id or f"run-{uuid.uuid4().hex[:12]}",
         _backbone_entrypoint(plan),
     )
-    store.create(plan)
+    if store.get(plan.id) is None:
+        store.create(plan)
+    else:
+        store.save(plan)
     store_plan(plan)
     run_id = _ensure_backbone_run(
         plan,

--- a/aragora/pipeline/executor.py
+++ b/aragora/pipeline/executor.py
@@ -130,11 +130,10 @@ def store_plan(plan: DecisionPlan) -> None:
     store = _get_backing_store()
     if store is not None:
         try:
-            # Try create first; on duplicate key (re-store for status update),
-            # fall back to update_status which is the expected re-store path.
+            # Try create first; on existing plans, persist the latest full plan state.
             existing = store.get(plan.id)
             if existing is not None:
-                store.update_status(plan.id, plan.status)
+                store.save(plan)
             else:
                 store.create(plan)
             return

--- a/aragora/pipeline/plan_store.py
+++ b/aragora/pipeline/plan_store.py
@@ -393,6 +393,110 @@ class PlanStore:
         finally:
             conn.close()
 
+    def save(self, plan: DecisionPlan) -> bool:
+        """Persist the full current state of an existing plan."""
+        try:
+            from aragora.pipeline.receipt_gate import ensure_plan_receipt
+
+            ensure_plan_receipt(plan)
+        except Exception as exc:  # noqa: BLE001 - keep persistence available; execution gate enforces
+            logger.warning("Failed to pre-persist decision receipt for plan %s: %s", plan.id, exc)
+
+        now = datetime.now(timezone.utc).isoformat()
+        budget_json = json.dumps(plan.budget.to_dict()) if plan.budget else "{}"
+        approval_json = json.dumps(plan.approval_record.to_dict()) if plan.approval_record else None
+        implementation_profile_json = (
+            json.dumps(plan.implementation_profile.to_dict())
+            if plan.implementation_profile
+            else None
+        )
+        risk_register_json = (
+            json.dumps(plan.risk_register.to_dict()) if plan.risk_register else None
+        )
+        verification_plan_json = (
+            json.dumps(plan.verification_plan.to_dict()) if plan.verification_plan else None
+        )
+        implement_plan_json = (
+            json.dumps(plan.implement_plan.to_dict()) if plan.implement_plan else None
+        )
+        metadata_json = json.dumps(plan.metadata) if plan.metadata else "{}"
+        approved_by = plan.approval_record.approver_id if plan.approval_record else None
+        rejection_reason = (
+            plan.approval_record.reason
+            if plan.approval_record and not plan.approval_record.approved
+            else None
+        )
+        approved_at = (
+            plan.approval_record.timestamp.isoformat()
+            if plan.approval_record and plan.approval_record.approved
+            else None
+        )
+
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                """
+                UPDATE plans
+                SET debate_id = ?,
+                    task = ?,
+                    status = ?,
+                    approval_mode = ?,
+                    max_auto_risk = ?,
+                    approved_by = ?,
+                    rejection_reason = ?,
+                    approved_at = ?,
+                    budget_json = ?,
+                    approval_record_json = ?,
+                    implementation_profile_json = ?,
+                    risk_register_json = ?,
+                    verification_plan_json = ?,
+                    implement_plan_json = ?,
+                    metadata_json = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    plan.debate_id,
+                    plan.task,
+                    plan.status.value,
+                    plan.approval_mode.value,
+                    plan.max_auto_risk.value,
+                    approved_by,
+                    rejection_reason,
+                    approved_at,
+                    budget_json,
+                    approval_json,
+                    implementation_profile_json,
+                    risk_register_json,
+                    verification_plan_json,
+                    implement_plan_json,
+                    metadata_json,
+                    now,
+                    plan.id,
+                ),
+            )
+            conn.commit()
+            updated = cursor.rowcount > 0
+        finally:
+            conn.close()
+
+        if updated and plan.status in (
+            PlanStatus.APPROVED,
+            PlanStatus.REJECTED,
+            PlanStatus.COMPLETED,
+        ):
+            try:
+                from aragora.pipeline.receipt_gate import sync_plan_receipt_state
+
+                sync_plan_receipt_state(plan, on_status=plan.status)
+            except Exception as exc:  # noqa: BLE001 - do not mask save
+                logger.warning(
+                    "Failed to synchronize decision receipt for plan %s: %s",
+                    plan.id,
+                    exc,
+                )
+        return updated
+
     def get(self, plan_id: str) -> DecisionPlan | None:
         """Retrieve a plan by ID."""
         conn = self._connect()

--- a/aragora/server/decision_integrity_utils.py
+++ b/aragora/server/decision_integrity_utils.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +110,194 @@ def _serialize_approval_request(approval_request: Any) -> dict[str, Any]:
         "rejection_reason": approval_request.rejection_reason,
         "metadata": approval_request.metadata,
     }
+
+
+def _extract_spec_bundle(plan: Any) -> Any | None:
+    metadata = getattr(plan, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    spec_payload = metadata.get("spec_bundle")
+    if not isinstance(spec_payload, dict):
+        return None
+    payload = dict(spec_payload)
+    payload.pop("missing_required_fields", None)
+    payload.pop("is_execution_grade", None)
+    try:
+        from aragora.pipeline.backbone_contracts import SpecBundle
+
+        return SpecBundle(**payload)
+    except (ImportError, TypeError):
+        logger.debug("Ignoring malformed spec bundle on plan %s", getattr(plan, "id", ""))
+        return None
+
+
+def ensure_decision_plan_backbone_run(
+    plan: Any,
+    *,
+    auth_context: Any | None,
+    source_surface: str,
+    source_id: str,
+) -> str:
+    """Seed a RunLedger for a decision plan before persistence or execution."""
+    from aragora.pipeline.backbone_contracts import (
+        BackboneStage,
+        IntakeBundle,
+        RunLedger,
+        build_goal_refs_from_implement_plan,
+    )
+    from aragora.pipeline.backbone_runtime import BackboneRuntime
+    from aragora.pipeline.plan_store import get_plan_store
+
+    metadata = getattr(plan, "metadata", None)
+    if not isinstance(metadata, dict):
+        metadata = {}
+        setattr(plan, "metadata", metadata)
+
+    metadata.setdefault("source_surface", source_surface)
+    if source_id:
+        metadata.setdefault("source_id", source_id)
+
+    run_id = (
+        str(metadata.get("backbone_run_id", "") or "").strip() or f"run-{uuid.uuid4().hex[:12]}"
+    )
+    entrypoint = f"decision_integrity.{source_surface}"
+    BackboneRuntime.ensure_plan_metadata(plan, run_id, entrypoint)
+
+    runtime = BackboneRuntime(get_plan_store())
+    scheduled_by = str(getattr(auth_context, "user_id", "") or "").strip()
+    goal_refs = build_goal_refs_from_implement_plan(getattr(plan, "implement_plan", None))
+    run_metadata: dict[str, Any] = {"source_surface": source_surface}
+    if source_id:
+        run_metadata["source_id"] = source_id
+    if scheduled_by:
+        run_metadata["scheduled_by"] = scheduled_by
+
+    if runtime.get_run(run_id) is None:
+        intake = IntakeBundle(
+            source_kind=source_surface,
+            raw_intent=str(getattr(plan, "task", "") or "").strip(),
+            context_refs=(
+                [{"kind": "debate", "id": str(getattr(plan, "debate_id", "") or "").strip()}]
+                if str(getattr(plan, "debate_id", "") or "").strip()
+                else []
+            )
+            + ([{"kind": "source", "id": source_id}] if source_id else []),
+            trust_tiers=["authenticated-user"] if scheduled_by else ["service-authored"],
+            origin_metadata={
+                "debate_id": str(getattr(plan, "debate_id", "") or "").strip(),
+                "source_surface": source_surface,
+                **({"source_id": source_id} if source_id else {}),
+                **({"scheduled_by": scheduled_by} if scheduled_by else {}),
+            },
+            taint_flags=[
+                str(flag).strip() for flag in metadata.get("taint_flags", []) if str(flag).strip()
+            ]
+            if isinstance(metadata.get("taint_flags"), list | tuple)
+            else [],
+        )
+        spec_bundle = _extract_spec_bundle(plan)
+        run = RunLedger(
+            run_id=run_id,
+            entrypoint=entrypoint,
+            status="plan_ready",
+            intake_bundle=intake,
+            spec_bundle=spec_bundle,
+            goal_refs=goal_refs,
+            plan_id=str(getattr(plan, "id", "") or "").strip(),
+            debate_id=str(getattr(plan, "debate_id", "") or "").strip(),
+            taint_flags=list(intake.taint_flags)
+            + (list(spec_bundle.taint_flags) if spec_bundle is not None else []),
+            metadata=run_metadata,
+        )
+        runtime.create_run(run)
+        runtime.append_stage_event(
+            run_id,
+            BackboneStage.INTAKE,
+            status="completed",
+            details={"source_surface": source_surface},
+        )
+        runtime.append_stage_event(
+            run_id,
+            BackboneStage.SPECIFICATION,
+            status="completed" if spec_bundle is not None else "skipped",
+            artifact_ref="spec_bundle" if spec_bundle is not None else "",
+            details={"has_spec_bundle": spec_bundle is not None},
+        )
+        runtime.append_stage_event(
+            run_id,
+            BackboneStage.GOALS,
+            status="completed" if goal_refs else "skipped",
+            artifact_ref=str(getattr(plan, "id", "") or "").strip(),
+            details={"goal_refs_count": len(goal_refs)},
+        )
+        runtime.append_stage_event(
+            run_id,
+            BackboneStage.PLAN,
+            status="completed",
+            artifact_ref=str(getattr(plan, "id", "") or "").strip(),
+            details={
+                "plan_status": getattr(getattr(plan, "status", None), "value", str(plan.status)),
+                "approval_mode": getattr(
+                    getattr(plan, "approval_mode", None),
+                    "value",
+                    str(getattr(plan, "approval_mode", "")),
+                ),
+            },
+        )
+    else:
+        runtime.update_run(
+            run_id,
+            status="plan_ready",
+            goal_refs=goal_refs,
+            plan_id=str(getattr(plan, "id", "") or "").strip(),
+            debate_id=str(getattr(plan, "debate_id", "") or "").strip(),
+            metadata=run_metadata,
+        )
+
+    return run_id
+
+
+def sync_decision_plan_backbone_receipt(
+    plan: Any,
+    *,
+    append_event: bool,
+) -> bool:
+    """Mirror the current decision receipt state into the RunLedger."""
+    from aragora.pipeline.backbone_runtime import BackboneRuntime
+    from aragora.pipeline.plan_store import get_plan_store
+
+    return BackboneRuntime(get_plan_store()).sync_plan_receipt_to_run(
+        plan,
+        append_event=append_event,
+    )
+
+
+async def execute_decision_plan_with_backbone(
+    plan: Any,
+    *,
+    executor: Any,
+    auth_context: Any | None,
+    execution_mode: str | None,
+) -> tuple[dict[str, Any], Any]:
+    """Queue and execute a decision plan through ExecutionBridge with a supplied executor."""
+    from aragora.pipeline.canonical_execution import queue_plan_execution
+    from aragora.pipeline.execution_bridge import ExecutionBridge
+    from aragora.pipeline.plan_store import get_plan_store
+
+    launch = queue_plan_execution(
+        plan,
+        auth_context=auth_context,
+        execution_mode=execution_mode,
+    )
+    bridge = ExecutionBridge(plan_store=get_plan_store(), executor=executor)
+    outcome = await bridge.execute_approved_plan(
+        plan.id,
+        auth_context=auth_context,
+        execution_mode=str(launch.get("execution_mode", execution_mode or "")) or None,
+        execution_id=str(launch.get("execution_id", "") or ""),
+        correlation_id=str(launch.get("correlation_id", "") or ""),
+    )
+    return launch, outcome
 
 
 async def build_decision_integrity_payload(
@@ -269,6 +458,8 @@ async def build_decision_integrity_payload(
                 metadata: dict[str, Any] = {
                     "source": "decision_integrity",
                     "debate_id": debate_key,
+                    "source_surface": "decision_integrity_payload",
+                    "source_id": str(debate_key or ""),
                 }
                 if isinstance(cfg.get("openclaw_actions"), list):
                     metadata["openclaw_actions"] = cfg.get("openclaw_actions")
@@ -312,9 +503,17 @@ async def build_decision_integrity_payload(
                     implement_plan=package.plan,
                     implementation_profile=implementation_profile,
                 )
+                run_id = ensure_decision_plan_backbone_run(
+                    plan,
+                    auth_context=auth_context,
+                    source_surface="decision_integrity_payload",
+                    source_id=str(debate_key or ""),
+                )
                 store_plan(plan)
+                sync_decision_plan_backbone_receipt(plan, append_event=False)
                 payload["decision_plan"] = plan.to_dict()
                 payload["plan_id"] = plan.id
+                payload["run_id"] = run_id
             except (ImportError, ValueError, TypeError, KeyError, RuntimeError) as exc:
                 logger.debug("Decision plan creation failed: %s", exc)
 
@@ -367,6 +566,7 @@ async def build_decision_integrity_payload(
                         from aragora.pipeline.executor import store_plan
 
                         store_plan(plan)
+                        sync_decision_plan_backbone_receipt(plan, append_event=True)
                 except (ImportError, OSError, RuntimeError):
                     logger.debug("Failed to store approved plan", exc_info=True)
             except (ImportError, ValueError, TypeError, RuntimeError, OSError) as exc:
@@ -384,6 +584,7 @@ async def build_decision_integrity_payload(
             execution_payload = {
                 "status": "pending_approval",
                 "approval_id": approval_request.id if approval_request else None,
+                "run_id": payload.get("run_id"),
             }
         else:
             try:
@@ -394,7 +595,6 @@ async def build_decision_integrity_payload(
                 parallel_execution = bool(cfg.get("parallel_execution", False))
 
                 notifier = None
-                on_task_complete = None
                 if engine == "hybrid":
                     notifier = ExecutionNotifier(
                         debate_id=plan.debate_id or str(debate_key or ""),
@@ -404,7 +604,6 @@ async def build_decision_integrity_payload(
                     )
                     if plan.implement_plan is not None:
                         notifier.set_task_descriptions(plan.implement_plan.tasks)
-                    on_task_complete = notifier.on_task_complete
 
                 executor = PlanExecutor(
                     continuum_memory=getattr(arena, "continuum_memory", None),
@@ -412,22 +611,27 @@ async def build_decision_integrity_payload(
                     parallel_execution=parallel_execution,
                     execution_mode=engine,  # type: ignore[arg-type]
                 )
-                outcome = await executor.execute(
+                launch, outcome = await execute_decision_plan_with_backbone(
                     plan,
-                    parallel_execution=parallel_execution,
-                    execution_mode=engine,  # type: ignore[arg-type]
-                    on_task_complete=on_task_complete,
+                    executor=executor,
+                    auth_context=auth_context,
+                    execution_mode=engine,
                 )
                 if notifier and notify_origin:
                     await notifier.send_completion_summary()
                 execution_payload = {
-                    "status": "completed",
-                    "mode": engine,
+                    "status": "completed" if outcome.success else "failed",
+                    "mode": str(launch.get("execution_mode", engine) or engine),
+                    "run_id": launch.get("run_id"),
+                    "execution_id": launch.get("execution_id"),
+                    "correlation_id": launch.get("correlation_id"),
                     "outcome": outcome.to_dict(),
                 }
             except (ImportError, ValueError, TypeError, RuntimeError, OSError) as exc:
                 execution_payload = {
                     "status": "failed",
+                    "mode": execution_engine or ("workflow" if workflow_mode else "hybrid"),
+                    "run_id": payload.get("run_id"),
                     "error": str(exc),
                 }
 

--- a/aragora/server/handlers/debates/implementation.py
+++ b/aragora/server/handlers/debates/implementation.py
@@ -26,6 +26,11 @@ from aragora.pipeline.decision_integrity import (
     build_decision_integrity_package,
     coerce_debate_result,
 )
+from aragora.server.decision_integrity_utils import (
+    ensure_decision_plan_backbone_run,
+    execute_decision_plan_with_backbone,
+    sync_decision_plan_backbone_receipt,
+)
 from aragora.server.result_router import route_result
 from aragora.implement import HybridExecutor
 from aragora.pipeline.execution_notifier import ExecutionNotifier
@@ -490,8 +495,16 @@ class ImplementationOperationsMixin:
                         package.plan,
                         debate_id=debate_id,
                     )
+                    run_id = ensure_decision_plan_backbone_run(
+                        computer_use_plan,
+                        auth_context=None,
+                        source_surface="debates_decision_integrity_computer_use",
+                        source_id=debate_id,
+                    )
                     store_plan(computer_use_plan)
+                    sync_decision_plan_backbone_receipt(computer_use_plan, append_event=False)
                     response_payload["plan_id"] = computer_use_plan.id
+                    response_payload["run_id"] = run_id
                 except (
                     ImportError,
                     KeyError,
@@ -565,6 +578,7 @@ class ImplementationOperationsMixin:
         from aragora.pipeline.risk_register import RiskLevel
 
         debate_result = coerce_debate_result(debate)
+        user = self.get_current_user(handler)
 
         try:
             approval_mode_enum = ApprovalMode(rc.approval_mode)
@@ -583,7 +597,12 @@ class ImplementationOperationsMixin:
             except (TypeError, ValueError):
                 budget_limit = None
 
-        metadata: dict[str, Any] = {"source": "decision_integrity", "debate_id": debate_id}
+        metadata: dict[str, Any] = {
+            "source": "decision_integrity",
+            "debate_id": debate_id,
+            "source_surface": "debates_decision_integrity_workflow",
+            "source_id": debate_id,
+        }
         if isinstance(rc.openclaw_actions, list):
             metadata["openclaw_actions"] = rc.openclaw_actions
         if isinstance(rc.computer_use_actions, list):
@@ -624,10 +643,18 @@ class ImplementationOperationsMixin:
             implement_plan=package.plan,
             implementation_profile=implementation_profile,
         )
+        run_id = ensure_decision_plan_backbone_run(
+            plan,
+            auth_context=user,
+            source_surface="debates_decision_integrity_workflow",
+            source_id=debate_id,
+        )
         store_plan(plan)
+        sync_decision_plan_backbone_receipt(plan, append_event=False)
 
         response_payload["decision_plan"] = plan.to_dict()
         response_payload["plan_id"] = plan.id
+        response_payload["run_id"] = run_id
 
         # Approval flow
         approval_request = None
@@ -636,7 +663,6 @@ class ImplementationOperationsMixin:
             if perm_err is not None:
                 return perm_err
 
-            user = self.get_current_user(handler)
             requested_by = getattr(user, "user_id", None) if user else "system"
             changes = self._build_changes_list(plan.implement_plan)
 
@@ -673,6 +699,7 @@ class ImplementationOperationsMixin:
                     else "Approved",
                 )
                 store_plan(plan)
+                sync_decision_plan_backbone_receipt(plan, append_event=True)
 
         # Execute workflow if requested
         if rc.execute_workflow:
@@ -686,17 +713,26 @@ class ImplementationOperationsMixin:
                     knowledge_mound=self.ctx.get("knowledge_mound"),
                     parallel_execution=rc.parallel_execution,
                 )
-                outcome = run_async(
-                    plan_executor.execute(plan, parallel_execution=rc.parallel_execution)
+                launch, outcome = run_async(
+                    execute_decision_plan_with_backbone(
+                        plan,
+                        executor=plan_executor,
+                        auth_context=user,
+                        execution_mode="workflow",
+                    )
                 )
                 response_payload["workflow_execution"] = {
-                    "status": "completed",
+                    "status": "completed" if outcome.success else "failed",
+                    "run_id": launch.get("run_id"),
+                    "execution_id": launch.get("execution_id"),
+                    "correlation_id": launch.get("correlation_id"),
                     "outcome": outcome.to_dict(),
                 }
             else:
                 response_payload["workflow_execution"] = {
                     "status": "pending_approval",
                     "approval_id": approval_request.id if approval_request else None,
+                    "run_id": run_id,
                 }
 
         return self._route_and_respond(response_payload, debate_id, rc.notify_origin)
@@ -780,6 +816,7 @@ class ImplementationOperationsMixin:
             response_payload["execution"] = {
                 "status": "pending_approval",
                 "approval_id": approval_request.id,
+                "run_id": response_payload.get("run_id"),
             }
             return None
 
@@ -831,6 +868,7 @@ class ImplementationOperationsMixin:
             plan_metadata.setdefault("execution_target_resource", f"plan:{computer_use_plan.id}")
             computer_use_plan.metadata = plan_metadata
             store_plan(computer_use_plan)
+            sync_decision_plan_backbone_receipt(computer_use_plan, append_event=True)
             plan_executor = PlanExecutor(
                 continuum_memory=self.ctx.get("continuum_memory"),
                 knowledge_mound=self.ctx.get("knowledge_mound"),
@@ -839,16 +877,20 @@ class ImplementationOperationsMixin:
                 repo_path=rc.repo_path or Path.cwd(),
                 sandbox_config=self.ctx.get("sandbox_config"),
             )
-            outcome = run_async(
-                plan_executor.execute(
+            launch, outcome = run_async(
+                execute_decision_plan_with_backbone(
                     computer_use_plan,
-                    parallel_execution=rc.parallel_execution,
+                    executor=plan_executor,
+                    auth_context=None,
                     execution_mode="computer_use",
                 )
             )
             response_payload["execution"] = {
-                "status": "completed",
+                "status": "completed" if outcome.success else "failed",
                 "mode": "computer_use",
+                "run_id": launch.get("run_id"),
+                "execution_id": launch.get("execution_id"),
+                "correlation_id": launch.get("correlation_id"),
                 "outcome": outcome.to_dict(),
                 "progress": {
                     "total_steps": outcome.tasks_total,

--- a/tests/pipeline/test_canonical_execution.py
+++ b/tests/pipeline/test_canonical_execution.py
@@ -139,3 +139,20 @@ class TestQueuePlanExecution:
             and event.artifact_ref == launch["execution_id"]
             for event in run.stage_events
         )
+
+    def test_queue_plan_execution_reuses_existing_stored_plan(
+        self,
+        store: PlanStore,
+    ) -> None:
+        plan, _tasks = _build_plan(source_surface="decision_integrity_payload")
+        store.create(plan)
+
+        launch = queue_plan_execution(plan, execution_mode="hybrid")
+        stored_plan = store.get(plan.id)
+        record = store.get_execution_record(launch["execution_id"])
+
+        assert store.count() == 1
+        assert stored_plan is not None
+        assert stored_plan.metadata["backbone_run_id"] == launch["run_id"]
+        assert record is not None
+        assert record["metadata"]["backbone_run_id"] == launch["run_id"]

--- a/tests/pipeline/test_executor_persistence.py
+++ b/tests/pipeline/test_executor_persistence.py
@@ -82,6 +82,26 @@ class TestPersistentBackendDelegation:
         assert retrieved.id == "dp-persist-001"
         assert retrieved.task == "Test task"
 
+    def test_store_plan_persists_metadata_updates_for_existing_plan(self, tmp_path: Path):
+        """Re-storing an existing plan should persist updated metadata, not only status."""
+        from aragora.pipeline.plan_store import PlanStore
+        import aragora.pipeline.executor as executor_mod
+
+        db_path = str(tmp_path / "test_plans.db")
+        store = PlanStore(db_path=db_path)
+        executor_mod._backing_store = store
+        executor_mod._backing_store_init_failed = False
+
+        plan = _make_plan("dp-persist-003")
+        executor_mod.store_plan(plan)
+
+        plan.metadata = {"backbone_run_id": "run-123"}
+        executor_mod.store_plan(plan)
+
+        retrieved = store.get("dp-persist-003")
+        assert retrieved is not None
+        assert retrieved.metadata["backbone_run_id"] == "run-123"
+
     def test_get_plan_delegates_to_plan_store(self, tmp_path: Path):
         """get_plan should retrieve from the persistent PlanStore backend."""
         from aragora.pipeline.plan_store import PlanStore

--- a/tests/server/handlers/debates/test_implementation.py
+++ b/tests/server/handlers/debates/test_implementation.py
@@ -782,6 +782,75 @@ class TestApprovalFlow:
 
 
 # =============================================================================
+# Tests for workflow backbone execution
+# =============================================================================
+
+
+class TestWorkflowBackbone:
+    def test_execute_workflow_routes_through_backbone_wrapper(
+        self, handler, mock_storage, mock_package
+    ):
+        handler._body = {"execution_mode": "workflow_execute"}
+
+        from aragora.pipeline.decision_plan import ApprovalMode, DecisionPlan, PlanStatus
+        from aragora.pipeline.decision_plan.core import ApprovalRecord
+
+        plan = DecisionPlan(
+            debate_id="debate-001",
+            task="Should we use microservices?",
+            approval_mode=ApprovalMode.NEVER,
+            status=PlanStatus.APPROVED,
+            approval_record=ApprovalRecord(approved=True, approver_id="system"),
+        )
+
+        mock_outcome = MagicMock()
+        mock_outcome.success = True
+        mock_outcome.to_dict.return_value = {"success": True}
+        launch = {
+            "run_id": "run-workflow-1",
+            "execution_id": "exec-workflow-1",
+            "correlation_id": "corr-workflow-1",
+            "execution_mode": "workflow",
+        }
+
+        with (
+            patch(
+                "aragora.server.handlers.debates.implementation.run_async",
+            ) as mock_run,
+            patch(
+                "aragora.server.handlers.debates.implementation._persist_receipt",
+                return_value=None,
+            ),
+            patch(
+                "aragora.pipeline.decision_plan.DecisionPlanFactory.from_debate_result",
+                return_value=plan,
+            ),
+            patch(
+                "aragora.server.handlers.debates.implementation.ensure_decision_plan_backbone_run",
+                return_value="run-workflow-1",
+            ),
+            patch(
+                "aragora.server.handlers.debates.implementation.sync_decision_plan_backbone_receipt",
+                return_value=True,
+            ),
+            patch.dict(
+                "os.environ",
+                {"ARAGORA_ENABLE_IMPLEMENTATION_EXECUTION": "1"},
+            ),
+        ):
+            mock_run.side_effect = [mock_package, (launch, mock_outcome)]
+            result = handler._create_decision_integrity(None, "debate-001")
+
+        body, status = parse_result(result)
+        assert status == 200
+        assert body["run_id"] == "run-workflow-1"
+        assert body["workflow_execution"]["status"] == "completed"
+        assert body["workflow_execution"]["run_id"] == "run-workflow-1"
+        assert body["workflow_execution"]["execution_id"] == "exec-workflow-1"
+        assert body["workflow_execution"]["outcome"]["success"] is True
+
+
+# =============================================================================
 # Tests for execute mode
 # =============================================================================
 
@@ -952,7 +1021,7 @@ class TestExecuteMode:
     def test_execute_approved_computer_use(
         self, handler, mock_storage, mock_package, mock_approval_request
     ):
-        """Approved execution uses PlanExecutor computer_use mode."""
+        """Approved computer-use execution queues through the backbone wrapper."""
         handler._body = {"execution_mode": "execute", "execution_engine": "computer_use"}
 
         from aragora.autonomous.loop_enhancement import ApprovalStatus
@@ -967,6 +1036,12 @@ class TestExecuteMode:
         mock_outcome.tasks_total = 5
         mock_outcome.tasks_completed = 3
         mock_outcome.duration_seconds = 1.2
+        launch = {
+            "run_id": "run-cu-1",
+            "execution_id": "exec-cu-1",
+            "correlation_id": "corr-cu-1",
+            "execution_mode": "computer_use",
+        }
 
         with (
             patch(
@@ -984,6 +1059,14 @@ class TestExecuteMode:
                 "aragora.server.handlers.debates.implementation.get_permission_checker",
             ),
             patch(
+                "aragora.server.handlers.debates.implementation.ensure_decision_plan_backbone_run",
+                return_value="run-cu-1",
+            ),
+            patch(
+                "aragora.server.handlers.debates.implementation.sync_decision_plan_backbone_receipt",
+                return_value=True,
+            ),
+            patch(
                 "aragora.pipeline.executor.PlanExecutor",
             ) as mock_executor_cls,
             patch.dict(
@@ -992,13 +1075,12 @@ class TestExecuteMode:
             ),
         ):
             mock_executor = MagicMock()
-            mock_executor.execute = AsyncMock(return_value=mock_outcome)
             mock_executor_cls.return_value = mock_executor
 
             mock_run.side_effect = [
                 mock_package,
                 mock_approval_request,
-                mock_outcome,
+                (launch, mock_outcome),
             ]
             result = handler._create_decision_integrity(None, "debate-001")
 
@@ -1006,6 +1088,8 @@ class TestExecuteMode:
         assert status == 200
         assert body["execution"]["status"] == "completed"
         assert body["execution"]["mode"] == "computer_use"
+        assert body["execution"]["run_id"] == "run-cu-1"
+        assert body["execution"]["execution_id"] == "exec-cu-1"
         assert body["execution"]["outcome"]["success"] is True
         assert body["execution"]["progress"]["total_steps"] >= 0
         assert mock_executor_cls.called is True

--- a/tests/server/test_decision_integrity_utils.py
+++ b/tests/server/test_decision_integrity_utils.py
@@ -82,21 +82,27 @@ async def test_build_payload_executes_hybrid(monkeypatch):
         task=plan.task,
         success=True,
     )
-
-    captured: dict[str, object] = {}
-
-    async def _execute(*_args, **kwargs):
-        captured.update(kwargs)
-        return outcome
+    launch = {
+        "run_id": "run-di-1",
+        "execution_id": "exec-di-1",
+        "correlation_id": "corr-di-1",
+        "execution_mode": "hybrid",
+    }
 
     with (
         patch(
-            "aragora.pipeline.executor.PlanExecutor.execute",
-            new=AsyncMock(side_effect=_execute),
+            "aragora.server.decision_integrity_utils.ensure_decision_plan_backbone_run",
+            return_value="run-di-1",
+        ),
+        patch(
+            "aragora.server.decision_integrity_utils.sync_decision_plan_backbone_receipt",
+            return_value=True,
+        ),
+        patch(
+            "aragora.server.decision_integrity_utils.execute_decision_plan_with_backbone",
+            new=AsyncMock(return_value=(launch, outcome)),
         ) as mock_execute,
-        patch("aragora.pipeline.execution_notifier.ExecutionNotifier") as mock_notifier,
     ):
-        mock_notifier.return_value.on_task_complete = object()
         payload = await build_decision_integrity_payload(
             result=DummyResult(),
             debate_id="debate-1",
@@ -109,9 +115,11 @@ async def test_build_payload_executes_hybrid(monkeypatch):
             },
         )
 
-    assert mock_execute.called is True
-    assert captured.get("on_task_complete") is not None
+    assert mock_execute.await_count == 1
     assert payload is not None
     assert payload["execution"]["status"] == "completed"
+    assert payload["run_id"] == "run-di-1"
+    assert payload["execution"]["run_id"] == "run-di-1"
+    assert payload["execution"]["execution_id"] == "exec-di-1"
     assert payload["execution_mode"] == "execute"
     assert payload["execution_engine"] == "hybrid"


### PR DESCRIPTION
## Summary
- seed backbone runs for decision-integrity payload, workflow, and computer-use entrypoints
- execute decision-integrity plans through canonical queue/execution bridge wiring and surface run identifiers in responses
- persist updated plan metadata for already-stored plans via PlanStore.save and cover the new behavior with focused tests

## Validation
- python3 -m ruff check aragora/pipeline/plan_store.py aragora/pipeline/executor.py aragora/pipeline/canonical_execution.py aragora/server/decision_integrity_utils.py aragora/server/handlers/debates/implementation.py tests/pipeline/test_executor_persistence.py tests/pipeline/test_canonical_execution.py tests/server/test_decision_integrity_utils.py tests/server/handlers/debates/test_implementation.py
- python3 -m pytest tests/pipeline/test_executor_persistence.py tests/pipeline/test_canonical_execution.py tests/server/test_decision_integrity_utils.py tests/server/handlers/debates/test_implementation.py
- python3 -m mypy --follow-imports=skip --ignore-missing-imports aragora/pipeline/plan_store.py aragora/pipeline/executor.py aragora/pipeline/canonical_execution.py aragora/server/decision_integrity_utils.py aragora/server/handlers/debates/implementation.py