### PR TITLE
feat(cli): route decide commands through backbone runs

### DIFF
--- a/aragora/cli/commands/decide.py
+++ b/aragora/cli/commands/decide.py
@@ -13,7 +13,33 @@ import logging
 import sys
 from typing import Any, Literal, cast
 
+from aragora.server.decision_integrity_utils import execute_decision_plan_with_backbone
+
 logger = logging.getLogger(__name__)
+
+
+def _seed_cli_backbone_run(
+    plan: Any,
+    *,
+    source_surface: str,
+    source_id: str,
+) -> str:
+    """Seed a RunLedger for CLI-created plans and mirror receipt state."""
+    from aragora.pipeline.executor import store_plan
+    from aragora.server.decision_integrity_utils import (
+        ensure_decision_plan_backbone_run,
+        sync_decision_plan_backbone_receipt,
+    )
+
+    run_id = ensure_decision_plan_backbone_run(
+        plan,
+        auth_context=None,
+        source_surface=source_surface,
+        source_id=source_id,
+    )
+    store_plan(plan)
+    sync_decision_plan_backbone_receipt(plan, append_event=False)
+    return run_id
 
 
 async def run_decide(
@@ -54,7 +80,7 @@ async def run_decide(
         ApprovalMode,
         DecisionPlanFactory,
     )
-    from aragora.pipeline.executor import PlanExecutor, store_plan
+    from aragora.pipeline.executor import PlanExecutor
 
     result: dict[str, Any] = {}
 
@@ -145,8 +171,13 @@ async def run_decide(
             budget_limit_usd=budget_limit,
             approval_mode=approval_mode,
         )
-        store_plan(plan)
+        run_id = _seed_cli_backbone_run(
+            plan,
+            source_surface="cli_decide_spec",
+            source_id=str(spec_path),
+        )
         result["plan"] = plan
+        result["run_id"] = run_id
         result["spec_file"] = str(spec_path)
 
         if verbose:
@@ -182,12 +213,19 @@ async def run_decide(
             approval_mode=approval_mode,
             implementation_profile=implementation_profile,
         )
-        store_plan(plan)
+        run_id = _seed_cli_backbone_run(
+            plan,
+            source_surface="cli_decide",
+            source_id=str(getattr(debate_result, "debate_id", "") or task),
+        )
         result["plan"] = plan
+        result["run_id"] = run_id
 
     if verbose:
         print(f"[decide] Plan created: {plan.id[:12]}...")
         print(f"[decide] Plan status: {plan.status.value}")
+        if result.get("run_id"):
+            print(f"[decide] Run: {result['run_id']}")
         if plan.risk_register:
             print(f"[decide] Risk summary: {plan.risk_register.summary}")
 
@@ -214,12 +252,22 @@ async def run_decide(
     executor = PlanExecutor(execution_mode=_mode)
 
     try:
-        outcome = await executor.execute(plan, execution_mode=_mode)
+        launch, outcome = await execute_decision_plan_with_backbone(
+            plan,
+            executor=executor,
+            auth_context=None,
+            execution_mode=_mode,
+        )
         result["outcome"] = outcome
+        result["run_id"] = launch.get("run_id") or result.get("run_id")
+        result["execution_id"] = launch.get("execution_id")
+        result["correlation_id"] = launch.get("correlation_id")
 
         if verbose:
             print(f"[decide] Execution complete. Success: {outcome.success}")
             print(f"[decide] Tasks: {outcome.tasks_completed}/{outcome.tasks_total}")
+            if result.get("execution_id"):
+                print(f"[decide] Execution: {result['execution_id']}")
             if outcome.receipt_id:
                 print(f"[decide] Receipt: {outcome.receipt_id[:12]}...")
             if outcome.lessons:
@@ -787,12 +835,23 @@ def cmd_plans_execute(args: argparse.Namespace) -> None:
     print(f"Executing plan {plan.id[:12]}...")
 
     try:
-        outcome = asyncio.run(executor.execute(plan, execution_mode=execution_mode))
+        launch, outcome = asyncio.run(
+            execute_decision_plan_with_backbone(
+                plan,
+                executor=executor,
+                auth_context=None,
+                execution_mode=execution_mode,
+            )
+        )
         print()
         print("Execution complete:")
         print(f"  Success: {outcome.success}")
         print(f"  Tasks: {outcome.tasks_completed}/{outcome.tasks_total}")
         print(f"  Duration: {outcome.duration_seconds:.1f}s")
+        if launch.get("run_id"):
+            print(f"  Run: {launch['run_id']}")
+        if launch.get("execution_id"):
+            print(f"  Execution: {launch['execution_id']}")
         if outcome.receipt_id:
             print(f"  Receipt: {outcome.receipt_id}")
         if outcome.error:

--- a/tests/cli/test_decide_command.py
+++ b/tests/cli/test_decide_command.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import argparse
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 
 def _make_args(**overrides):
@@ -94,3 +97,154 @@ def test_cmd_decide_normalizes_execution_mode_alias() -> None:
     kwargs = mock_run_decide.call_args.kwargs
     assert kwargs["execution_mode"] == "workflow"
     assert kwargs["implementation_profile"]["execution_mode"] == "workflow"
+
+
+@pytest.mark.asyncio
+async def test_run_decide_seeds_backbone_run_for_spec_dry_run(tmp_path) -> None:
+    """Spec-driven dry runs should still seed a backbone run."""
+    from aragora.cli.commands.decide import run_decide
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text('{"title":"Spec"}')
+
+    plan = MagicMock()
+    plan.id = "plan-cli-1"
+    plan.status = SimpleNamespace(value="approved")
+    plan.risk_register = None
+    plan.requires_human_approval = False
+
+    with (
+        patch(
+            "aragora.pipeline.decision_plan.DecisionPlanFactory.from_specification",
+            return_value=plan,
+        ),
+        patch(
+            "aragora.cli.commands.decide._seed_cli_backbone_run",
+            return_value="run-cli-1",
+        ) as mock_seed,
+    ):
+        result = await run_decide(
+            task="Ship the feature",
+            agents_str="claude,gemini",
+            dry_run=True,
+            spec_file=str(spec_path),
+        )
+
+    assert result["plan"] is plan
+    assert result["run_id"] == "run-cli-1"
+    assert result["dry_run"] is True
+    mock_seed.assert_called_once_with(
+        plan,
+        source_surface="cli_decide_spec",
+        source_id=str(spec_path),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_decide_executes_via_backbone_helper(tmp_path) -> None:
+    """run_decide should execute plans through the backbone helper and surface IDs."""
+    from aragora.cli.commands.decide import run_decide
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text('{"title":"Spec"}')
+
+    plan = MagicMock()
+    plan.id = "plan-cli-2"
+    plan.status = SimpleNamespace(value="approved")
+    plan.risk_register = None
+    plan.requires_human_approval = False
+
+    outcome = MagicMock()
+    outcome.success = True
+    outcome.tasks_completed = 2
+    outcome.tasks_total = 2
+    outcome.receipt_id = "receipt-1"
+    outcome.lessons = []
+    launch = {
+        "run_id": "run-cli-2",
+        "execution_id": "exec-cli-2",
+        "correlation_id": "corr-cli-2",
+    }
+    executor = MagicMock()
+
+    with (
+        patch(
+            "aragora.pipeline.decision_plan.DecisionPlanFactory.from_specification",
+            return_value=plan,
+        ),
+        patch(
+            "aragora.cli.commands.decide._seed_cli_backbone_run",
+            return_value="run-cli-2",
+        ),
+        patch("aragora.pipeline.executor.PlanExecutor", return_value=executor),
+        patch(
+            "aragora.cli.commands.decide.execute_decision_plan_with_backbone",
+            new=AsyncMock(return_value=(launch, outcome)),
+        ) as mock_execute,
+    ):
+        result = await run_decide(
+            task="Ship the feature",
+            agents_str="claude,gemini",
+            dry_run=False,
+            spec_file=str(spec_path),
+            execution_mode="hybrid",
+        )
+
+    assert result["plan"] is plan
+    assert result["outcome"] is outcome
+    assert result["run_id"] == "run-cli-2"
+    assert result["execution_id"] == "exec-cli-2"
+    assert result["correlation_id"] == "corr-cli-2"
+    mock_execute.assert_awaited_once_with(
+        plan,
+        executor=executor,
+        auth_context=None,
+        execution_mode="hybrid",
+    )
+
+
+def test_cmd_plans_execute_routes_through_backbone_helper() -> None:
+    """plans execute should use the backbone helper rather than direct executor execution."""
+    from aragora.cli.commands import decide as decide_cmd
+
+    args = argparse.Namespace(
+        plan_id="plan-cli-3",
+        execution_mode=None,
+        computer_use=False,
+        hybrid=True,
+    )
+    plan = MagicMock()
+    plan.id = "plan-cli-3"
+    outcome = MagicMock()
+    outcome.success = True
+    outcome.tasks_completed = 3
+    outcome.tasks_total = 3
+    outcome.duration_seconds = 1.5
+    outcome.receipt_id = None
+    outcome.error = None
+    launch = {
+        "run_id": "run-cli-3",
+        "execution_id": "exec-cli-3",
+        "correlation_id": "corr-cli-3",
+    }
+    executor = MagicMock()
+
+    with (
+        patch("aragora.pipeline.executor.get_plan", return_value=plan),
+        patch("aragora.pipeline.executor.PlanExecutor", return_value=executor),
+        patch.object(
+            decide_cmd,
+            "execute_decision_plan_with_backbone",
+            return_value="coro",
+        ) as mock_execute,
+        patch.object(decide_cmd.asyncio, "run", return_value=(launch, outcome)),
+        patch("builtins.print"),
+    ):
+        decide_cmd.cmd_plans_execute(args)
+
+    mock_execute.assert_called_once_with(
+        plan,
+        executor=executor,
+        auth_context=None,
+        execution_mode="hybrid",
+    )

--- a/tests/pipeline/backbone_entrypoints_inventory.py
+++ b/tests/pipeline/backbone_entrypoints_inventory.py
@@ -202,17 +202,17 @@ ENTRYPOINT_INVENTORY: Final[tuple[BackboneEntrypoint, ...]] = (
         file_path="aragora/cli/commands/decide.py",
         qualname="run_decide",
         lifecycle="mixed",
-        coverage="legacy_bypass",
-        wiring_mode="direct_execute",
-        signals=("decision_plan_factory", "plan_executor_execute", "store_plan"),
+        coverage="green",
+        wiring_mode="canonical_queue",
+        signals=("decision_plan_factory", "execute_decision_plan_with_backbone"),
     ),
     BackboneEntrypoint(
         file_path="aragora/cli/commands/decide.py",
         qualname="cmd_plans_execute",
         lifecycle="execute",
-        coverage="legacy_bypass",
-        wiring_mode="direct_execute",
-        signals=("plan_executor_execute",),
+        coverage="green",
+        wiring_mode="canonical_queue",
+        signals=("execute_decision_plan_with_backbone",),
     ),
     BackboneEntrypoint(
         file_path="aragora/debate/orchestrator_runner.py",
@@ -252,6 +252,9 @@ INTERNAL_BACKBONE_HELPERS: Final[dict[str, str]] = {
     ),
     "aragora/pipeline/unified_orchestrator.py::UnifiedOrchestrator._create_backbone_run": (
         "internal orchestrator run-seeding helper"
+    ),
+    "aragora/cli/commands/decide.py::_seed_cli_backbone_run": (
+        "internal CLI helper for run-ledger seeding and receipt sync"
     ),
 }
 


### PR DESCRIPTION
## Summary
- seed backbone runs for CLI-created plans in `run_decide`, including spec-first and debate-first flows
- execute `run_decide` and `plans execute` through the canonical queue/execution-bridge path and surface run and execution identifiers in CLI results/output
- promote the CLI decision commands to green coverage in the backbone entrypoint contract and add focused tests for dry-run and execution behavior

## Validation
- python3 -m ruff check aragora/cli/commands/decide.py tests/cli/test_decide_command.py tests/pipeline/backbone_entrypoints_inventory.py tests/pipeline/test_backbone_entrypoints_contract.py
- python3 -m pytest tests/cli/test_decide_command.py tests/cli/test_mode_flag.py tests/pipeline/test_backbone_entrypoints_contract.py
- python3 -m mypy --follow-imports=skip --ignore-missing-imports aragora/cli/commands/decide.py tests/cli/test_decide_command.py tests/pipeline/backbone_entrypoints_inventory.py tests/pipeline/test_backbone_entrypoints_contract.py