### PR TITLE
feat(blockchain): add ShadowReconciler for attestation hash reconciliation

### DIFF
--- a/aragora/blockchain/shadow_reconciler.py
+++ b/aragora/blockchain/shadow_reconciler.py
@@ -1,0 +1,206 @@
+"""Shadow reconciler for comparing attestation hashes against receipt anchors.
+
+Queries PlanStore for pipeline runs that carry attestation payloads, recomputes
+the expected receipt hash via ReceiptAnchor logic, and reports any drift between
+the stored (shadow) hash and the freshly computed value.
+
+This reconciler is **stateless and query-only** — it never writes to the
+blockchain or mutates plan store data.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DriftRecord:
+    """One reconciliation result for a single pipeline run.
+
+    Attributes:
+        run_id: The pipeline run identifier.
+        shadow_hash: The hash stored in the attestation payload.
+        computed_hash: The hash recomputed from receipt data.
+        match: Whether shadow and computed hashes agree.
+        detail: Optional human-readable detail about the drift.
+    """
+
+    run_id: str
+    shadow_hash: str
+    computed_hash: str
+    match: bool
+    detail: str = ""
+
+
+@dataclass
+class ReconciliationReport:
+    """Aggregated result of a reconciliation pass.
+
+    Attributes:
+        total: Number of runs examined.
+        matched: Number of runs where hashes matched.
+        drifted: Number of runs where hashes diverged.
+        skipped: Number of runs skipped (missing data).
+        records: Per-run drift records.
+    """
+
+    total: int = 0
+    matched: int = 0
+    drifted: int = 0
+    skipped: int = 0
+    records: list[DriftRecord] = field(default_factory=list)
+
+
+def _compute_receipt_hash(receipt_data: str) -> str:
+    """Compute a SHA-256 hex digest from receipt data, mirroring ReceiptAnchor."""
+    return hashlib.sha256(receipt_data.encode()).hexdigest()
+
+
+class ShadowReconciler:
+    """Compares attestation hashes stored in PlanStore against recomputed values.
+
+    The reconciler is stateless: it receives a PlanStore (or any object exposing
+    ``list_runs`` and ``get_run``) and performs read-only queries.  No blockchain
+    writes are ever issued.
+
+    Args:
+        plan_store: A PlanStore instance (or duck-typed equivalent).
+    """
+
+    def __init__(self, plan_store: Any) -> None:
+        self._store = plan_store
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def reconcile(
+        self,
+        *,
+        limit: int = 100,
+        run_ids: list[str] | None = None,
+    ) -> ReconciliationReport:
+        """Run a reconciliation pass.
+
+        Args:
+            limit: Maximum number of runs to examine when *run_ids* is not
+                provided.
+            run_ids: If given, reconcile only these specific runs.
+
+        Returns:
+            A :class:`ReconciliationReport` summarising the results.
+        """
+        report = ReconciliationReport()
+
+        runs = self._fetch_runs(limit=limit, run_ids=run_ids)
+
+        for run in runs:
+            attestation = self._get_attestation(run)
+            if not attestation:
+                report.skipped += 1
+                report.total += 1
+                continue
+
+            shadow_hash = attestation.get("receipt_hash", "")
+            receipt_data = self._extract_receipt_data(run, attestation)
+
+            if not shadow_hash or not receipt_data:
+                report.skipped += 1
+                report.total += 1
+                continue
+
+            computed_hash = _compute_receipt_hash(receipt_data)
+            match = shadow_hash == computed_hash
+
+            record = DriftRecord(
+                run_id=self._get_run_id(run),
+                shadow_hash=shadow_hash,
+                computed_hash=computed_hash,
+                match=match,
+                detail="" if match else "hash mismatch",
+            )
+            report.records.append(record)
+            report.total += 1
+
+            if match:
+                report.matched += 1
+            else:
+                report.drifted += 1
+                logger.warning(
+                    "Drift detected for run %s: shadow=%s computed=%s",
+                    record.run_id,
+                    shadow_hash[:16],
+                    computed_hash[:16],
+                )
+
+        logger.info(
+            "Reconciliation complete: total=%d matched=%d drifted=%d skipped=%d",
+            report.total,
+            report.matched,
+            report.drifted,
+            report.skipped,
+        )
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _fetch_runs(
+        self,
+        *,
+        limit: int,
+        run_ids: list[str] | None,
+    ) -> list[Any]:
+        """Retrieve runs from the plan store."""
+        if run_ids:
+            runs = []
+            for rid in run_ids:
+                run = self._store.get_run(rid)
+                if run is not None:
+                    runs.append(run)
+            return runs
+        return list(self._store.list_runs(limit=limit))
+
+    @staticmethod
+    def _get_attestation(run: Any) -> dict[str, Any]:
+        """Extract the attestation dict from a run object."""
+        if isinstance(run, dict):
+            return dict(run.get("attestation") or {})
+        return dict(getattr(run, "attestation", None) or {})
+
+    @staticmethod
+    def _get_run_id(run: Any) -> str:
+        """Extract the run ID from a run object."""
+        if isinstance(run, dict):
+            return str(run.get("run_id", ""))
+        return str(getattr(run, "run_id", ""))
+
+    @staticmethod
+    def _extract_receipt_data(run: Any, attestation: dict[str, Any]) -> str:
+        """Build the canonical receipt data string for hashing.
+
+        Tries ``attestation["receipt_data"]`` first, then falls back to
+        the run's ``receipt_id``.
+        """
+        explicit = attestation.get("receipt_data")
+        if explicit:
+            return str(explicit)
+
+        if isinstance(run, dict):
+            receipt_id = run.get("receipt_id", "")
+        else:
+            receipt_id = getattr(run, "receipt_id", "")
+        return str(receipt_id) if receipt_id else ""
+
+
+__all__ = [
+    "DriftRecord",
+    "ReconciliationReport",
+    "ShadowReconciler",
+]

--- a/tests/blockchain/test_shadow_reconciler.py
+++ b/tests/blockchain/test_shadow_reconciler.py
@@ -1,0 +1,276 @@
+"""Tests for ShadowReconciler — stateless attestation hash reconciliation."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from aragora.blockchain.shadow_reconciler import (
+    DriftRecord,
+    ReconciliationReport,
+    ShadowReconciler,
+    _compute_receipt_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256(data: str) -> str:
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+@dataclass
+class FakeRun:
+    """Minimal stand-in for RunLedger."""
+
+    run_id: str = ""
+    receipt_id: str = ""
+    attestation: dict[str, Any] = field(default_factory=dict)
+
+
+class FakePlanStore:
+    """In-memory plan store exposing list_runs / get_run."""
+
+    def __init__(self, runs: list[FakeRun] | None = None) -> None:
+        self._runs: dict[str, FakeRun] = {}
+        for run in runs or []:
+            self._runs[run.run_id] = run
+
+    def get_run(self, run_id: str) -> FakeRun | None:
+        return self._runs.get(run_id)
+
+    def list_runs(self, *, limit: int = 50, **_kw: Any) -> list[FakeRun]:
+        return list(self._runs.values())[:limit]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _compute_receipt_hash
+# ---------------------------------------------------------------------------
+
+
+class TestComputeReceiptHash:
+    def test_deterministic(self) -> None:
+        assert _compute_receipt_hash("hello") == _sha256("hello")
+
+    def test_different_inputs(self) -> None:
+        assert _compute_receipt_hash("a") != _compute_receipt_hash("b")
+
+
+# ---------------------------------------------------------------------------
+# DriftRecord / ReconciliationReport dataclass sanity
+# ---------------------------------------------------------------------------
+
+
+class TestDataclasses:
+    def test_drift_record_defaults(self) -> None:
+        rec = DriftRecord(run_id="r1", shadow_hash="a", computed_hash="b", match=False)
+        assert rec.detail == ""
+
+    def test_report_defaults(self) -> None:
+        rpt = ReconciliationReport()
+        assert rpt.total == 0
+        assert rpt.matched == 0
+        assert rpt.drifted == 0
+        assert rpt.skipped == 0
+        assert rpt.records == []
+
+
+# ---------------------------------------------------------------------------
+# ShadowReconciler tests
+# ---------------------------------------------------------------------------
+
+
+class TestReconcileMatching:
+    """Runs where shadow hash matches the recomputed hash."""
+
+    def test_single_matching_run(self) -> None:
+        receipt_data = "receipt-content-1"
+        expected_hash = _sha256(receipt_data)
+        run = FakeRun(
+            run_id="r1",
+            attestation={"receipt_hash": expected_hash, "receipt_data": receipt_data},
+        )
+        store = FakePlanStore([run])
+        reconciler = ShadowReconciler(store)
+        report = reconciler.reconcile()
+
+        assert report.total == 1
+        assert report.matched == 1
+        assert report.drifted == 0
+        assert report.skipped == 0
+        assert len(report.records) == 1
+        assert report.records[0].match is True
+
+    def test_multiple_matching_runs(self) -> None:
+        runs = []
+        for i in range(3):
+            data = f"data-{i}"
+            runs.append(
+                FakeRun(
+                    run_id=f"r{i}",
+                    attestation={"receipt_hash": _sha256(data), "receipt_data": data},
+                )
+            )
+        report = ShadowReconciler(FakePlanStore(runs)).reconcile()
+        assert report.matched == 3
+        assert report.drifted == 0
+
+
+class TestReconcileDrift:
+    """Runs where shadow hash does NOT match."""
+
+    def test_single_drifted_run(self) -> None:
+        run = FakeRun(
+            run_id="r1",
+            attestation={"receipt_hash": "wrong-hash", "receipt_data": "actual-data"},
+        )
+        report = ShadowReconciler(FakePlanStore([run])).reconcile()
+
+        assert report.total == 1
+        assert report.drifted == 1
+        assert report.matched == 0
+        assert report.records[0].match is False
+        assert report.records[0].detail == "hash mismatch"
+
+    def test_mixed_match_and_drift(self) -> None:
+        good_data = "good"
+        runs = [
+            FakeRun(
+                run_id="match",
+                attestation={"receipt_hash": _sha256(good_data), "receipt_data": good_data},
+            ),
+            FakeRun(
+                run_id="drift",
+                attestation={"receipt_hash": "bad", "receipt_data": "something"},
+            ),
+        ]
+        report = ShadowReconciler(FakePlanStore(runs)).reconcile()
+        assert report.matched == 1
+        assert report.drifted == 1
+        assert report.total == 2
+
+
+class TestReconcileSkipped:
+    """Runs that should be skipped due to missing data."""
+
+    def test_no_attestation(self) -> None:
+        run = FakeRun(run_id="r1", attestation={})
+        report = ShadowReconciler(FakePlanStore([run])).reconcile()
+        assert report.skipped == 1
+        assert report.total == 1
+        assert len(report.records) == 0
+
+    def test_missing_receipt_hash(self) -> None:
+        run = FakeRun(run_id="r1", attestation={"receipt_data": "data"})
+        report = ShadowReconciler(FakePlanStore([run])).reconcile()
+        assert report.skipped == 1
+
+    def test_missing_receipt_data_and_receipt_id(self) -> None:
+        run = FakeRun(run_id="r1", attestation={"receipt_hash": "abc"})
+        report = ShadowReconciler(FakePlanStore([run])).reconcile()
+        assert report.skipped == 1
+
+
+class TestReconcileFallbackToReceiptId:
+    """When attestation has no receipt_data, fall back to run.receipt_id."""
+
+    def test_uses_receipt_id(self) -> None:
+        receipt_id = "receipt-42"
+        run = FakeRun(
+            run_id="r1",
+            receipt_id=receipt_id,
+            attestation={"receipt_hash": _sha256(receipt_id)},
+        )
+        report = ShadowReconciler(FakePlanStore([run])).reconcile()
+        assert report.matched == 1
+        assert report.drifted == 0
+
+
+class TestReconcileByRunIds:
+    """Filter reconciliation to specific run IDs."""
+
+    def test_specific_run_ids(self) -> None:
+        data = "d"
+        runs = [
+            FakeRun(run_id="a", attestation={"receipt_hash": _sha256(data), "receipt_data": data}),
+            FakeRun(run_id="b", attestation={"receipt_hash": _sha256(data), "receipt_data": data}),
+            FakeRun(run_id="c", attestation={"receipt_hash": _sha256(data), "receipt_data": data}),
+        ]
+        report = ShadowReconciler(FakePlanStore(runs)).reconcile(run_ids=["a", "c"])
+        assert report.total == 2
+        assert report.matched == 2
+
+    def test_missing_run_id_ignored(self) -> None:
+        report = ShadowReconciler(FakePlanStore([])).reconcile(run_ids=["nonexistent"])
+        assert report.total == 0
+
+
+class TestReconcileLimit:
+    """Limit parameter caps the number of runs examined."""
+
+    def test_limit(self) -> None:
+        data = "x"
+        runs = [
+            FakeRun(
+                run_id=f"r{i}", attestation={"receipt_hash": _sha256(data), "receipt_data": data}
+            )
+            for i in range(10)
+        ]
+        report = ShadowReconciler(FakePlanStore(runs)).reconcile(limit=3)
+        assert report.total == 3
+
+
+class TestReconcileEmptyStore:
+    """Edge case: empty plan store."""
+
+    def test_empty(self) -> None:
+        report = ShadowReconciler(FakePlanStore([])).reconcile()
+        assert report.total == 0
+        assert report.matched == 0
+        assert report.drifted == 0
+        assert report.skipped == 0
+        assert report.records == []
+
+
+class TestDictBasedRuns:
+    """ShadowReconciler should also work with dict-based run representations."""
+
+    def test_dict_run_matching(self) -> None:
+        data = "dict-receipt"
+
+        class DictStore:
+            def list_runs(self, *, limit: int = 50, **_kw: Any) -> list[dict[str, Any]]:
+                return [
+                    {
+                        "run_id": "d1",
+                        "receipt_id": "",
+                        "attestation": {"receipt_hash": _sha256(data), "receipt_data": data},
+                    }
+                ]
+
+            def get_run(self, run_id: str) -> dict[str, Any] | None:
+                return None
+
+        report = ShadowReconciler(DictStore()).reconcile()
+        assert report.matched == 1
+        assert report.drifted == 0
+
+
+class TestNoBlockchainWrites:
+    """Verify the reconciler is truly query-only."""
+
+    def test_no_write_methods(self) -> None:
+        reconciler = ShadowReconciler(FakePlanStore([]))
+        # Ensure no public methods suggest mutation
+        public = [m for m in dir(reconciler) if not m.startswith("_")]
+        write_keywords = {"write", "save", "insert", "update", "delete", "anchor", "submit"}
+        for method in public:
+            assert not any(kw in method.lower() for kw in write_keywords), (
+                f"Unexpected write-like method: {method}"
+            )


### PR DESCRIPTION
Stateless, query-only reconciler that compares attestation hashes stored
in PlanStore runs against recomputed SHA-256 values. Reports drift with
per-run DriftRecord and aggregated ReconciliationReport. No blockchain
writes are performed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
