### PR TITLE
Fail closed on dirty webhook Redis cache

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -777,6 +777,7 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         self._redis: Any | None = None
         self._redis_url = redis_url or os.environ.get("ARAGORA_REDIS_URL", "redis://localhost:6379")
         self._redis_checked = False
+        self._dirty_ids: set[str] = set()
         logger.info("RedisWebhookConfigStore initialized with SQLite fallback")
 
     def _get_redis(self) -> Any | None:
@@ -800,6 +801,12 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
 
     def _redis_key(self, webhook_id: str) -> str:
         return f"{self.REDIS_PREFIX}:{webhook_id}"
+
+    def _mark_dirty(self, webhook_id: str) -> None:
+        self._dirty_ids.add(webhook_id)
+
+    def _clear_dirty(self, webhook_id: str) -> None:
+        self._dirty_ids.discard(webhook_id)
 
     @staticmethod
     def _serialize_for_cache(webhook: WebhookConfig) -> str:
@@ -854,7 +861,7 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         redis = self._get_redis()
 
         # Try Redis first
-        if redis is not None:
+        if redis is not None and webhook_id not in self._dirty_ids:
             try:
                 data = redis.get(self._redis_key(webhook_id))
                 if data:
@@ -865,6 +872,8 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
                 TimeoutError,
                 OSError,
                 ValueError,
+                TypeError,
+                KeyError,
                 json.JSONDecodeError,
             ) as e:
                 logger.debug("Redis get failed, falling back to SQLite: %s", e)
@@ -872,16 +881,24 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         # Fall back to SQLite
         webhook = self._sqlite.get(webhook_id)
 
-        # Populate Redis cache if found
-        if webhook and redis:
+        # Repair or clear Redis cache from authoritative durable state.
+        if redis:
             try:
-                redis.setex(
-                    self._redis_key(webhook_id), self.REDIS_TTL, self._serialize_for_cache(webhook)
-                )
+                if webhook is None:
+                    redis.delete(self._redis_key(webhook_id))
+                else:
+                    redis.setex(
+                        self._redis_key(webhook_id),
+                        self.REDIS_TTL,
+                        self._serialize_for_cache(webhook),
+                    )
+                self._clear_dirty(webhook_id)
             except (_RedisError, ConnectionError, TimeoutError) as e:
-                logger.debug("Redis cache population failed (connection issue): %s", e)
+                logger.debug("Redis cache repair failed (connection issue): %s", e)
+                self._mark_dirty(webhook_id)
             except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
-                logger.debug("Redis cache population failed: %s", e)
+                logger.debug("Redis cache repair failed: %s", e)
+                self._mark_dirty(webhook_id)
 
         return webhook
 
@@ -901,10 +918,13 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         if redis:
             try:
                 redis.delete(self._redis_key(webhook_id))
+                self._clear_dirty(webhook_id)
             except (_RedisError, ConnectionError, TimeoutError) as e:
                 logger.debug("Redis cache delete failed (connection issue): %s", e)
+                self._mark_dirty(webhook_id)
             except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
                 logger.debug("Redis cache delete failed: %s", e)
+                self._mark_dirty(webhook_id)
 
         return self._sqlite.delete(webhook_id)
 
@@ -936,8 +956,10 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
                         self.REDIS_TTL,
                         self._serialize_for_cache(webhook),
                     )
+                    self._clear_dirty(webhook_id)
                 except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
                     logger.debug("Redis cache update failed: %s", e)
+                    self._mark_dirty(webhook_id)
 
         return webhook
 
@@ -954,8 +976,10 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
         if redis:
             try:
                 redis.delete(self._redis_key(webhook_id))
+                self._clear_dirty(webhook_id)
             except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
                 logger.debug("Redis cache invalidation failed: %s", e)
+                self._mark_dirty(webhook_id)
 
     def get_for_event(self, event_type: str) -> _list[WebhookConfig]:
         return self._sqlite.get_for_event(event_type)

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1372,6 +1372,33 @@ class TestRedisWebhookConfigStore:
         mock_redis.delete.assert_called_with(f"aragora:webhook_configs:{webhook.id}")
         store.close()
 
+    def test_with_mocked_redis_delete_failure_bypasses_stale_cache(self, tmp_path):
+        """A failed Redis invalidation must not resurrect a deleted webhook on later reads."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store.register(url="https://example.com", events=["debate_end"])
+        stale_payload = webhook.to_json()
+
+        mock_redis.delete.side_effect = ConnectionError("Redis down")
+        assert store.delete(webhook.id) is True
+
+        mock_redis.delete.side_effect = None
+        mock_redis.reset_mock()
+        mock_redis.get.return_value = stale_payload
+
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is None
+        mock_redis.get.assert_not_called()
+        mock_redis.delete.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        store.close()
+
     def test_with_mocked_redis_update_refreshes_cache(self, tmp_path):
         """Test update refreshes the Redis cache."""
         db_path = tmp_path / "test.db"
@@ -1386,6 +1413,38 @@ class TestRedisWebhookConfigStore:
         store.update(webhook.id, url="https://new.com")
 
         # Redis cache should be updated
+        mock_redis.setex.assert_called_once()
+        store.close()
+
+    def test_with_mocked_redis_update_failure_bypasses_stale_cache(self, tmp_path):
+        """A failed Redis refresh must not let an older cached payload override SQLite truth."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store.register(url="https://old.com", events=["debate_end"])
+        stale_payload = webhook.to_json()
+
+        mock_redis.reset_mock()
+        mock_redis.setex.side_effect = ConnectionError("Redis down")
+
+        updated = store.update(webhook.id, url="https://new.com")
+        assert updated is not None
+        assert updated.url == "https://new.com"
+
+        mock_redis.setex.side_effect = None
+        mock_redis.reset_mock()
+        mock_redis.get.return_value = stale_payload
+
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is not None
+        assert retrieved.url == "https://new.com"
+        mock_redis.get.assert_not_called()
         mock_redis.setex.assert_called_once()
         store.close()
 


### PR DESCRIPTION
## Summary
- mark webhook IDs dirty when Redis invalidation or refresh fails
- bypass stale Redis entries for dirty webhook IDs until SQLite truth repairs or clears cache
- add regressions for stale delete and stale update resurrection paths

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'delete_failure_bypasses_stale_cache or update_failure_bypasses_stale_cache'
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'redis and (delete_failure_bypasses_stale_cache or update_failure_bypasses_stale_cache or delete_invalidates_cache or update_refreshes_cache or mocked_redis_get_cache_hit or mocked_redis_get_cache_miss)'