### PR TITLE
Fail closed on active worker session lock

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1185,6 +1185,11 @@ class WorkerLauncher:
             observed_pid = cls._normalized_pid(session_meta.get("pid"))
         missing_terminal_marker = session_exit_code is None
 
+        if missing_terminal_marker and observed_pid is None:
+            active_lock = Path(worktree_path) / ".codex_session_active"
+            if active_lock.exists():
+                return None
+
         if (
             missing_terminal_marker
             and observed_pid is not None

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1200,6 +1200,27 @@ class TestCollectDetachedResult:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_returns_none_if_active_lock_exists_without_usable_pid(self, tmp_path: Path):
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": "oops"}),
+            patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff") as mock_diff,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-no-pid",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=None,
+            )
+
+        assert result is None
+        mock_running.assert_not_called()
+        mock_diff.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_uses_session_meta_pid_to_defer_when_marker_missing(self):
         with (
             patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),


### PR DESCRIPTION
## Summary
- fail detached result collection closed when the session lock still exists and there is no usable PID or terminal marker
- prevent session-meta races from surfacing partial work as a finished detached worker
- add a regression for the active-lock plus unusable-PID path

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'active_lock_exists_without_usable_pid or uses_session_meta_pid_to_defer_when_marker_missing'