### PR TITLE
feat(post-debate): integrate RunLedger into PostDebateCoordinator

### DIFF
--- a/aragora/debate/post_debate_coordinator.py
+++ b/aragora/debate/post_debate_coordinator.py
@@ -28,8 +28,11 @@ import logging
 import os
 import re
 import threading
+import uuid
 from dataclasses import dataclass, field
 from typing import Any
+
+from aragora.pipeline.backbone_contracts import BackboneStage, RunLedger, RunStageEvent
 
 logger = logging.getLogger(__name__)
 # Per-step timeout for async callables run from the sync coordinator.
@@ -238,6 +241,14 @@ class PostDebateCoordinator:
         """
         result = PostDebateResult(debate_id=debate_id)
 
+        # Create a RunLedger entry for backbone traceability
+        ledger = RunLedger(
+            run_id=f"post-debate-{uuid.uuid4().hex[:12]}",
+            entrypoint="post_debate_coordinator",
+            debate_id=debate_id,
+        )
+        self._ledger = ledger
+
         # Step 0: Collect cost data (always attempted, used by downstream steps)
         result.cost_breakdown = self._step_collect_cost_data(debate_id, debate_result)
 
@@ -248,6 +259,17 @@ class PostDebateCoordinator:
         # Step 2: Create decision plan
         if self.config.auto_create_plan and confidence >= self.config.plan_min_confidence:
             result.plan = self._step_create_plan(debate_id, debate_result, task, result.explanation)
+            if result.plan is not None:
+                plan_obj = result.plan.get("plan")
+                plan_id = str(getattr(plan_obj, "plan_id", "")) if plan_obj else ""
+                ledger.plan_id = plan_id
+                ledger.add_event(
+                    RunStageEvent.create(
+                        BackboneStage.PLAN,
+                        status="plan_created",
+                        details={"debate_id": debate_id, "plan_id": plan_id},
+                    )
+                )
 
         # Step 2.5: Gauntlet adversarial validation
         if self.config.auto_gauntlet_validate and confidence >= self.config.gauntlet_min_confidence:
@@ -291,6 +313,14 @@ class PostDebateCoordinator:
 
         # Step 4: Execute plan if approved
         if self.config.auto_execute_plan and result.plan:
+            plan_id = ledger.plan_id
+            ledger.add_event(
+                RunStageEvent.create(
+                    BackboneStage.EXECUTION,
+                    status="execution_requested",
+                    details={"debate_id": debate_id, "plan_id": plan_id},
+                )
+            )
             if self._is_execution_blocked(result.execution_gate):
                 result.execution_result = {
                     "skipped": True,
@@ -299,6 +329,13 @@ class PostDebateCoordinator:
                 }
             else:
                 result.execution_result = self._step_execute_plan(result.plan, result.explanation)
+            ledger.add_event(
+                RunStageEvent.create(
+                    BackboneStage.EXECUTION,
+                    status="execution_completed",
+                    details={"debate_id": debate_id, "plan_id": plan_id},
+                )
+            )
 
         # Step 4.5: Create draft PR for code-related debates
         if (

--- a/tests/debate/test_post_debate_coordinator.py
+++ b/tests/debate/test_post_debate_coordinator.py
@@ -379,3 +379,100 @@ class TestExecutionSafetyGate:
         assert result.plan is not None
         assert plan_obj.metadata.get("execution_gate") is not None
         assert str(plan_obj.status).lower().endswith("awaiting_approval")
+
+
+class TestRunLedgerIntegration:
+    """Test that PostDebateCoordinator creates and populates a RunLedger."""
+
+    def test_ledger_created_on_run(self):
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=False,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_execution_bridge=False,
+        )
+        coordinator = PostDebateCoordinator(config=config)
+        coordinator.run("d1", _make_debate_result())
+
+        ledger = coordinator._ledger
+        assert ledger is not None
+        assert ledger.entrypoint == "post_debate_coordinator"
+        assert ledger.debate_id == "d1"
+        assert ledger.run_id.startswith("post-debate-")
+
+    def test_ledger_plan_created_event(self):
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=True,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_execution_bridge=False,
+            plan_min_confidence=0.5,
+        )
+        coordinator = PostDebateCoordinator(config=config)
+
+        plan_obj = MagicMock()
+        plan_obj.plan_id = "plan-123"
+        with patch.object(coordinator, "_step_create_plan", return_value={"plan": plan_obj}):
+            coordinator.run("d1", _make_debate_result(), confidence=0.9)
+
+        ledger = coordinator._ledger
+        assert ledger.plan_id == "plan-123"
+        plan_events = [e for e in ledger.stage_events if e.status == "plan_created"]
+        assert len(plan_events) == 1
+        assert plan_events[0].stage == "plan"
+        assert plan_events[0].details["debate_id"] == "d1"
+        assert plan_events[0].details["plan_id"] == "plan-123"
+
+    def test_ledger_execution_events(self):
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=True,
+            auto_notify=False,
+            auto_execute_plan=True,
+            auto_persist_receipt=False,
+            auto_execution_bridge=False,
+            enforce_execution_safety_gate=False,
+            plan_min_confidence=0.5,
+        )
+        coordinator = PostDebateCoordinator(config=config)
+
+        plan_obj = MagicMock()
+        plan_obj.plan_id = "plan-456"
+        plan_obj.status = "approved"
+
+        with patch.object(coordinator, "_step_create_plan", return_value={"plan": plan_obj}):
+            with patch.object(coordinator, "_step_execute_plan", return_value={"ok": True}):
+                coordinator.run("d1", _make_debate_result(), confidence=0.9)
+
+        ledger = coordinator._ledger
+        statuses = [e.status for e in ledger.stage_events]
+        assert "execution_requested" in statuses
+        assert "execution_completed" in statuses
+        exec_events = [e for e in ledger.stage_events if e.stage == "execution"]
+        assert len(exec_events) == 2
+        for ev in exec_events:
+            assert ev.details["debate_id"] == "d1"
+            assert ev.details["plan_id"] == "plan-456"
+
+    def test_ledger_no_plan_event_when_plan_none(self):
+        config = PostDebateConfig(
+            auto_explain=False,
+            auto_create_plan=True,
+            auto_notify=False,
+            auto_execute_plan=False,
+            auto_persist_receipt=False,
+            auto_execution_bridge=False,
+            plan_min_confidence=0.5,
+        )
+        coordinator = PostDebateCoordinator(config=config)
+
+        with patch.object(coordinator, "_step_create_plan", return_value=None):
+            coordinator.run("d1", _make_debate_result(), confidence=0.9)
+
+        ledger = coordinator._ledger
+        plan_events = [e for e in ledger.stage_events if e.status == "plan_created"]
+        assert len(plan_events) == 0


### PR DESCRIPTION
Wire the backbone RunLedger into the post-debate coordinator so that
plan creation and execution are tracked as stage events. The coordinator
now creates a RunLedger entry at the start of each run and appends
plan_created, execution_requested, and execution_completed events with
debate_id and plan_id attached. No public API changes.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
