### PR TITLE
fix(ci): dedupe frontend specialty playwright suites

### DIFF
--- a/aragora/live/__tests__/playwright-config.test.ts
+++ b/aragora/live/__tests__/playwright-config.test.ts
@@ -1,0 +1,45 @@
+jest.mock('@playwright/test', () => ({
+  defineConfig: <T>(config: T) => config,
+  devices: {
+    'Desktop Chrome': {},
+    'Desktop Firefox': {},
+    'Desktop Safari': {},
+    'Pixel 5': {},
+    'iPhone 12': {},
+  },
+}));
+
+const {
+  default: config,
+  SPECIALTY_PROJECT_TEST_IGNORE,
+} = require('../playwright.config') as typeof import('../playwright.config');
+
+type PlaywrightProject = {
+  name?: string;
+  testDir?: string;
+  testIgnore?: unknown;
+  testMatch?: unknown;
+};
+
+const projects = (config.projects ?? []) as PlaywrightProject[];
+
+function getProject(name: string): PlaywrightProject {
+  const project = projects.find(candidate => candidate.name === name);
+  expect(project).toBeDefined();
+  return project as PlaywrightProject;
+}
+
+describe('playwright config', () => {
+  it('keeps specialty suites out of the default browser matrix', () => {
+    for (const projectName of ['chromium', 'firefox', 'webkit', 'Mobile Chrome', 'Mobile Safari']) {
+      expect(getProject(projectName).testIgnore).toEqual(SPECIALTY_PROJECT_TEST_IGNORE);
+    }
+  });
+
+  it('keeps the specialty projects scoped to their dedicated specs', () => {
+    expect(getProject('accessibility').testMatch).toEqual(/accessibility\.spec\.ts/);
+    expect(getProject('visual-regression').testMatch).toEqual(/visual-regression\.spec\.ts/);
+    expect(getProject('mobile-audit').testDir).toBe('./e2e/mobile');
+    expect(getProject('mobile-audit').testMatch).toEqual(/mobile-audit\.spec\.ts/);
+  });
+});

--- a/aragora/live/playwright.config.ts
+++ b/aragora/live/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+export const SPECIALTY_PROJECT_TEST_IGNORE = [
+  '**/accessibility.spec.ts',
+  '**/visual-regression.spec.ts',
+  '**/mobile/mobile-audit.spec.ts',
+] as const;
+
 /**
  * Playwright configuration for Aragora Live Dashboard E2E tests.
  * @see https://playwright.dev/docs/test-configuration
@@ -68,26 +74,31 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: SPECIALTY_PROJECT_TEST_IGNORE,
     },
 
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
+      testIgnore: SPECIALTY_PROJECT_TEST_IGNORE,
     },
 
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
+      testIgnore: SPECIALTY_PROJECT_TEST_IGNORE,
     },
 
     // Test against mobile viewports (for responsiveness)
     {
       name: 'Mobile Chrome',
       use: { ...devices['Pixel 5'] },
+      testIgnore: SPECIALTY_PROJECT_TEST_IGNORE,
     },
     {
       name: 'Mobile Safari',
       use: { ...devices['iPhone 12'] },
+      testIgnore: SPECIALTY_PROJECT_TEST_IGNORE,
     },
 
     // Accessibility tests - run with: npx playwright test --project=accessibility


### PR DESCRIPTION
## Summary
- exclude specialty Playwright suites from the shared browser/mobile projects
- keep the dedicated accessibility, visual-regression, and mobile-audit projects owning those specs
- add config regression coverage for the shared ignore list

## Validation
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules jest --runTestsByPath __tests__/playwright-config.test.ts --runInBand`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/accessibility.spec.ts --list --project=chromium`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/accessibility.spec.ts --list --project=accessibility`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/visual-regression.spec.ts --list --project=chromium`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/visual-regression.spec.ts --list --project=visual-regression`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/mobile/mobile-audit.spec.ts --list --project='Mobile Chrome'`
- `PATH=/Users/armand/Development/aragora/aragora/live/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/aragora/live/node_modules playwright test e2e/mobile/mobile-audit.spec.ts --list --project=mobile-audit`
