### PR TITLE
fix(sdk): correct auth compatibility route methods

### DIFF
--- a/sdk/typescript/src/namespaces/__tests__/auth-compat-routes.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/auth-compat-routes.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { AuthRoutesAPI } from '../auth';
+
+interface MockClient {
+  request: Mock;
+}
+
+describe('AuthRoutesAPI compatibility routes', () => {
+  let api: AuthRoutesAPI;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      request: vi.fn().mockResolvedValue({}),
+    };
+    api = new AuthRoutesAPI(mockClient as any);
+  });
+
+  it('uses POST for legacy password reset compatibility routes', async () => {
+    await api.forgotPasswordAlt({ email: 'user@example.com' });
+    await api.resetPasswordAlt({ token: 'reset-token', new_password: 'new-password' });
+
+    expect(mockClient.request).toHaveBeenNthCalledWith(1, 'POST', '/api/auth/forgot-password', {
+      json: { email: 'user@example.com' },
+    });
+    expect(mockClient.request).toHaveBeenNthCalledWith(2, 'POST', '/api/auth/reset-password', {
+      json: { token: 'reset-token', new_password: 'new-password' },
+    });
+  });
+
+  it('uses POST for the legacy combined MFA compatibility route', async () => {
+    await api.mfa({ action: 'setup', method: 'totp' });
+
+    expect(mockClient.request).toHaveBeenCalledWith('POST', '/api/auth/mfa', {
+      json: { action: 'setup', method: 'totp' },
+    });
+  });
+
+  it('uses POST for auth verification and invite compatibility routes', async () => {
+    await api.verifyEmail({ token: 'verify-token' });
+    await api.resendVerification();
+    await api.resendVerificationAlt({ email: 'user@example.com' });
+    await api.setupOrganization({ name: 'Acme', slug: 'acme' });
+    await api.invite({ email: 'teammate@example.com', role: 'member' });
+    await api.acceptInvite({ token: 'invite-token' });
+
+    expect(mockClient.request).toHaveBeenNthCalledWith(1, 'POST', '/api/auth/verify-email', {
+      json: { token: 'verify-token' },
+    });
+    expect(mockClient.request).toHaveBeenNthCalledWith(2, 'POST', '/api/auth/verify-email/resend');
+    expect(mockClient.request).toHaveBeenNthCalledWith(3, 'POST', '/api/auth/resend-verification', {
+      json: { email: 'user@example.com' },
+    });
+    expect(mockClient.request).toHaveBeenNthCalledWith(4, 'POST', '/api/auth/setup-organization', {
+      json: { name: 'Acme', slug: 'acme' },
+    });
+    expect(mockClient.request).toHaveBeenNthCalledWith(5, 'POST', '/api/auth/invite', {
+      json: { email: 'teammate@example.com', role: 'member' },
+    });
+    expect(mockClient.request).toHaveBeenNthCalledWith(6, 'POST', '/api/auth/accept-invite', {
+      json: { token: 'invite-token' },
+    });
+  });
+});

--- a/sdk/typescript/src/namespaces/auth.ts
+++ b/sdk/typescript/src/namespaces/auth.ts
@@ -591,7 +591,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/forgot-password
    */
   async forgotPasswordAlt(body: { email: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/forgot-password', { json: body });
+    return this.client.request('POST', '/api/auth/forgot-password', { json: body });
   }
 
   /**
@@ -599,7 +599,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/reset-password
    */
   async resetPasswordAlt(body: { token: string; new_password: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/reset-password', { json: body });
+    return this.client.request('POST', '/api/auth/reset-password', { json: body });
   }
 
   /**
@@ -631,7 +631,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/mfa
    */
   async mfa(body: { action: string; code?: string; method?: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/mfa', { json: body });
+    return this.client.request('POST', '/api/auth/mfa', { json: body });
   }
 
   /**
@@ -639,7 +639,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/verify-email
    */
   async verifyEmail(body: { token: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/verify-email', { json: body });
+    return this.client.request('POST', '/api/auth/verify-email', { json: body });
   }
 
   /**
@@ -647,7 +647,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/verify-email/resend
    */
   async resendVerification(): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/verify-email/resend');
+    return this.client.request('POST', '/api/auth/verify-email/resend');
   }
 
   /**
@@ -655,7 +655,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/resend-verification
    */
   async resendVerificationAlt(body?: { email?: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/resend-verification', { json: body });
+    return this.client.request('POST', '/api/auth/resend-verification', { json: body });
   }
 
   /**
@@ -663,7 +663,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/setup-organization
    */
   async setupOrganization(body: { name: string; slug?: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/setup-organization', { json: body });
+    return this.client.request('POST', '/api/auth/setup-organization', { json: body });
   }
 
   /**
@@ -671,7 +671,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/invite
    */
   async invite(body: { email: string; role?: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/invite', { json: body });
+    return this.client.request('POST', '/api/auth/invite', { json: body });
   }
 
   /**
@@ -687,7 +687,7 @@ export class AuthRoutesAPI {
    * @route POST /api/auth/accept-invite
    */
   async acceptInvite(body: { token: string }): Promise<unknown> {
-    return this.client.request('GET', '/api/auth/accept-invite', { json: body });
+    return this.client.request('POST', '/api/auth/accept-invite', { json: body });
   }
 
   /**


### PR DESCRIPTION
## Summary
- correct the raw TypeScript auth compatibility helpers to use the server's real POST methods
- fix the remaining `AuthRoutesAPI.mfa()` mismatch so the combined MFA helper no longer calls an unsupported GET route
- add focused Vitest coverage for the corrected compatibility routes, including MFA

## Testing
- PATH=/Users/armand/Development/aragora/sdk/typescript/node_modules/.bin:$PATH NODE_PATH=/Users/armand/Development/aragora/sdk/typescript/node_modules vitest run sdk/typescript/src/namespaces/__tests__/auth-compat-routes.test.ts sdk/typescript/src/namespaces/__tests__/auth.test.ts
