### PR TITLE
fix(cli): keep triage gmail auth local-first

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -43,8 +43,45 @@ def _get_secret_fallback(name: str) -> str:
         return ""
 
 
-def _resolve_gmail_oauth_credentials() -> tuple[str, str]:
-    """Resolve Gmail OAuth client credentials from env, dotenv, or secrets."""
+def _parse_bool_env(name: str) -> bool | None:
+    """Parse a conventional boolean environment variable."""
+    value = os.environ.get(name)
+    if value is None:
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def _should_use_remote_gmail_oauth_secrets() -> bool:
+    """Use remote secret fallback only when explicitly enabled or clearly non-local."""
+    use_aws = _parse_bool_env("ARAGORA_USE_SECRETS_MANAGER")
+    if use_aws is not None:
+        return use_aws
+
+    env = os.environ.get("ARAGORA_ENV", "").strip().lower()
+    return env in {"production", "prod", "staging", "stage"}
+
+
+def _resolve_first_env_value(candidates: tuple[str, ...]) -> str:
+    """Return the first populated environment variable in priority order."""
+    for name in candidates:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return ""
+
+
+def _resolve_gmail_oauth_credentials(
+    *, allow_secret_fallback: bool | None = None
+) -> tuple[str, str]:
+    """Resolve Gmail OAuth client credentials from env/dotenv and optional remote secrets."""
     _load_local_dotenv()
 
     client_id_candidates = (
@@ -58,13 +95,11 @@ def _resolve_gmail_oauth_credentials() -> tuple[str, str]:
         "GOOGLE_CLIENT_SECRET",
     )
 
-    client_id = ""
-    for name in client_id_candidates:
-        value = os.environ.get(name)
-        if value:
-            client_id = value
-            break
-    if not client_id:
+    if allow_secret_fallback is None:
+        allow_secret_fallback = _should_use_remote_gmail_oauth_secrets()
+
+    client_id = _resolve_first_env_value(client_id_candidates)
+    if not client_id and allow_secret_fallback:
         for name in client_id_candidates:
             value = _get_secret_fallback(name)
             if value:
@@ -72,13 +107,8 @@ def _resolve_gmail_oauth_credentials() -> tuple[str, str]:
                 os.environ.setdefault("GMAIL_CLIENT_ID", value)
                 break
 
-    client_secret = ""
-    for name in client_secret_candidates:
-        value = os.environ.get(name)
-        if value:
-            client_secret = value
-            break
-    if not client_secret:
+    client_secret = _resolve_first_env_value(client_secret_candidates)
+    if not client_secret and allow_secret_fallback:
         for name in client_secret_candidates:
             value = _get_secret_fallback(name)
             if value:

--- a/tests/cli/test_triage_command.py
+++ b/tests/cli/test_triage_command.py
@@ -386,6 +386,26 @@ def test_get_gmail_connector_loads_refresh_token_from_home_file(tmp_path, monkey
     assert connector._refresh_token == "refresh-from-file"
 
 
+def test_resolve_gmail_oauth_credentials_skips_remote_secret_fallback_by_default(monkeypatch):
+    monkeypatch.delenv("ARAGORA_ENV", raising=False)
+    monkeypatch.delenv("ARAGORA_USE_SECRETS_MANAGER", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+
+    with (
+        patch.object(
+            triage_cmd,
+            "_get_secret_fallback",
+            side_effect=AssertionError("remote fallback should stay disabled for local runs"),
+        ),
+        patch.object(triage_cmd, "_load_local_dotenv"),
+    ):
+        client_id, client_secret = triage_cmd._resolve_gmail_oauth_credentials()
+
+    assert client_id == ""
+    assert client_secret == ""
+
+
 def test_get_gmail_connector_uses_secret_fallback_for_credentials(tmp_path, monkeypatch):
     class _FakeConnector:
         def __init__(self):
@@ -396,6 +416,7 @@ def test_get_gmail_connector_uses_secret_fallback_for_credentials(tmp_path, monk
     (token_dir / "gmail_refresh_token").write_text("refresh-from-file\n")
 
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("ARAGORA_ENV", "production")
     monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
     monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
 
@@ -408,6 +429,7 @@ def test_get_gmail_connector_uses_secret_fallback_for_credentials(tmp_path, monk
                 "GMAIL_CLIENT_SECRET": "secret-client-secret",
             }.get(name, ""),
         ),
+        patch.object(triage_cmd, "_load_local_dotenv"),
         patch(
             "aragora.connectors.enterprise.communication.gmail.GmailConnector",
             _FakeConnector,
@@ -450,16 +472,20 @@ def test_show_status_reports_gmail_from_secret_fallback(tmp_path, monkeypatch, c
     (token_dir / "signing.key").write_text("dummy-signing-key")
 
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("ARAGORA_ENV", "production")
     monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
     monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
 
-    with patch.object(
-        triage_cmd,
-        "_get_secret_fallback",
-        side_effect=lambda name: {
-            "GMAIL_CLIENT_ID": "secret-client-id",
-            "GMAIL_CLIENT_SECRET": "secret-client-secret",
-        }.get(name, ""),
+    with (
+        patch.object(
+            triage_cmd,
+            "_get_secret_fallback",
+            side_effect=lambda name: {
+                "GMAIL_CLIENT_ID": "secret-client-id",
+                "GMAIL_CLIENT_SECRET": "secret-client-secret",
+            }.get(name, ""),
+        ),
+        patch.object(triage_cmd, "_load_local_dotenv"),
     ):
         triage_cmd._show_status()
 
@@ -467,6 +493,29 @@ def test_show_status_reports_gmail_from_secret_fallback(tmp_path, monkeypatch, c
     assert "Gmail configured:     yes" in out
     assert "Durable signing key:  yes" in out
     assert "Gmail refresh token:  yes" in out
+
+
+@pytest.mark.asyncio
+async def test_run_gmail_auth_fails_fast_without_remote_secret_fallback(monkeypatch, capsys):
+    monkeypatch.delenv("ARAGORA_ENV", raising=False)
+    monkeypatch.delenv("ARAGORA_USE_SECRETS_MANAGER", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GMAIL_CLIENT_SECRET", raising=False)
+
+    with (
+        patch.object(
+            triage_cmd,
+            "_get_secret_fallback",
+            side_effect=AssertionError("triage auth should not hit remote secrets for local runs"),
+        ),
+        patch.object(triage_cmd, "_load_local_dotenv"),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            await triage_cmd._run_gmail_auth()
+
+    assert excinfo.value.code == 1
+    err = capsys.readouterr().err
+    assert "Set GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET environment" in err
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep `aragora triage` Gmail OAuth credential lookup local-first for local/dev runs
- only allow remote secret fallback when Secrets Manager is explicitly enabled or the environment is clearly non-local
- add CLI tests covering local no-fallback behavior, production-like fallback, and fast auth failure without AWS chatter

## Repro
- `python3 -m aragora.cli.main triage status` previously exited `0` but printed AWS Secrets Manager endpoint failures to stderr first
- `python3 -m aragora.cli.main triage auth` previously hit the same remote fallback path before printing the local setup guidance

## Validation
- `PATH=/Users/armand/Development/aragora/.venv/bin:$PATH python -m pytest tests/cli/test_triage_command.py -q -k 'gmail or status'`
- `python3 -m aragora.cli.main triage status >/tmp/triage_status_stdout.txt 2>/tmp/triage_status_stderr.txt`
- `python3 -m aragora.cli.main triage auth >/tmp/triage_auth_stdout.txt 2>/tmp/triage_auth_stderr.txt`
