### PR TITLE
[codex] fix(api): restore legacy handler route aliases

### DIFF
--- a/aragora/server/handlers/features/evidence.py
+++ b/aragora/server/handlers/features/evidence.py
@@ -65,6 +65,9 @@ _evidence_write_limiter = RateLimiter(requests_per_minute=10)
 class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
     """Handler for evidence-related API endpoints."""
 
+    _LEGACY_PREFIX = "/api/evidence"
+    _VERSIONED_PREFIX = "/api/v1/evidence"
+
     # Routes this handler responds to
     routes = [
         "GET /api/evidence",
@@ -79,15 +82,27 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
 
     # Static routes for exact matching
     ROUTES = [
+        "/api/evidence",
+        "/api/evidence/statistics",
+        "/api/evidence/search",
+        "/api/evidence/collect",
         "/api/v1/evidence",
         "/api/v1/evidence/statistics",
         "/api/v1/evidence/search",
         "/api/v1/evidence/collect",
     ]
 
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        """Map legacy unversioned evidence aliases to the canonical v1 path."""
+        if path == cls._LEGACY_PREFIX or path.startswith(f"{cls._LEGACY_PREFIX}/"):
+            return f"{cls._VERSIONED_PREFIX}{path[len(cls._LEGACY_PREFIX):]}"
+        return path
+
     def can_handle(self, path: str) -> bool:
         """Check if this handler can handle the given path."""
-        return path.startswith("/api/v1/evidence")
+        path = self._normalize_path(path)
+        return path == self._VERSIONED_PREFIX or path.startswith(f"{self._VERSIONED_PREFIX}/")
 
     def __init__(self, server_context: dict[str, Any]):
         """Initialize with server context."""
@@ -225,6 +240,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
     @handle_errors("evidence retrieval")
     def handle(self, path: str, query_params: dict[str, Any], handler: Any) -> HandlerResult | None:
         """Handle GET requests for evidence endpoints."""
+        path = self._normalize_path(path)
+
         # Rate limit check for read operations
         client_ip = get_client_ip(handler)
         rate_key = client_ip
@@ -272,6 +289,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
         """Handle POST requests for evidence endpoints."""
+        path = self._normalize_path(path)
+
         # Rate limit check for write operations
         client_ip = get_client_ip(handler)
         rate_key = client_ip
@@ -316,6 +335,8 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
         """Handle DELETE requests for evidence endpoints."""
+        path = self._normalize_path(path)
+
         # Rate limit check for delete operations (uses write limiter)
         client_ip = get_client_ip(handler)
         rate_key = client_ip

--- a/aragora/server/handlers/memory/learning.py
+++ b/aragora/server/handlers/memory/learning.py
@@ -45,25 +45,40 @@ class LearningHandler(SecureHandler):
     Requires authentication and memory:read permission (RBAC).
     """
 
+    _LEGACY_PREFIX = "/api/learning"
+    _VERSIONED_PREFIX = "/api/v1/learning"
+
     def __init__(self, ctx: dict | None = None):
         """Initialize handler with optional context."""
         self.ctx = ctx or {}
 
-    ROUTES = [
+    _VERSIONED_ROUTES = [
         "/api/v1/learning/cycles",
         "/api/v1/learning/patterns",
         "/api/v1/learning/agent-evolution",
         "/api/v1/learning/insights",
     ]
+    ROUTES = _VERSIONED_ROUTES + [
+        route.replace("/api/v1/learning", "/api/learning", 1) for route in _VERSIONED_ROUTES
+    ]
+
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        """Map legacy unversioned learning aliases to the canonical v1 path."""
+        if path == cls._LEGACY_PREFIX or path.startswith(f"{cls._LEGACY_PREFIX}/"):
+            return f"{cls._VERSIONED_PREFIX}{path[len(cls._LEGACY_PREFIX):]}"
+        return path
 
     def can_handle(self, path: str) -> bool:
         """Check if this handler can process the given path."""
-        return path in self.ROUTES
+        return self._normalize_path(path) in self._VERSIONED_ROUTES
 
     async def handle(
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
         """Route GET requests with RBAC."""
+        path = self._normalize_path(path)
+
         # Rate limit check
         client_ip = get_client_ip(handler)
         if not _learning_limiter.is_allowed(client_ip):

--- a/aragora/server/handlers/training.py
+++ b/aragora/server/handlers/training.py
@@ -96,6 +96,9 @@ def _clear_training_components() -> None:
 class TrainingHandler(BaseHandler):
     """Handler for training data export endpoints."""
 
+    _LEGACY_PREFIX = "/api/training"
+    _VERSIONED_PREFIX = "/api/v1/training"
+
     _ROUTE_MAP = {
         "/api/v1/training/export/sft": "handle_export_sft",
         "/api/v1/training/export/dpo": "handle_export_dpo",
@@ -105,7 +108,7 @@ class TrainingHandler(BaseHandler):
         "/api/v1/training/jobs": "handle_list_jobs",
     }
 
-    ROUTES = [
+    _VERSIONED_ROUTES = [
         "/api/v1/training/export/sft",
         "/api/v1/training/export/dpo",
         "/api/v1/training/export/gauntlet",
@@ -113,15 +116,22 @@ class TrainingHandler(BaseHandler):
         "/api/v1/training/formats",
         "/api/v1/training/jobs",
     ]
+    ROUTES = _VERSIONED_ROUTES + [
+        route.replace("/api/v1/training", "/api/training", 1) for route in _VERSIONED_ROUTES
+    ]
 
     # Dynamic routes that need special handling
-    JOB_ROUTES = [
+    _VERSIONED_JOB_ROUTES = [
         "/api/v1/training/jobs/*/export",
         "/api/v1/training/jobs/*/start",
         "/api/v1/training/jobs/*/complete",
         "/api/v1/training/jobs/*/metrics",
         "/api/v1/training/jobs/*/artifacts",
         "/api/v1/training/jobs/*",
+    ]
+    JOB_ROUTES = _VERSIONED_JOB_ROUTES + [
+        route.replace("/api/v1/training", "/api/training", 1)
+        for route in _VERSIONED_JOB_ROUTES
     ]
 
     def __init__(self, ctx: dict[str, Any]):
@@ -135,12 +145,20 @@ class TrainingHandler(BaseHandler):
         )
         self._export_dir.mkdir(parents=True, exist_ok=True)
 
+    @classmethod
+    def _normalize_path(cls, path: str) -> str:
+        """Map legacy unversioned training aliases to the canonical v1 path."""
+        if path == cls._LEGACY_PREFIX or path.startswith(f"{cls._LEGACY_PREFIX}/"):
+            return f"{cls._VERSIONED_PREFIX}{path[len(cls._LEGACY_PREFIX):]}"
+        return path
+
     def can_handle(self, path: str, method: str = "GET") -> bool:
         """Check if this handler can process the given path."""
+        path = self._normalize_path(path)
         if path in self._ROUTE_MAP:
             return True
         # Check job routes (dynamic patterns)
-        if path.startswith("/api/v1/training/jobs/"):
+        if path.startswith(f"{self._VERSIONED_PREFIX}/jobs/"):
             return True
         return False
 
@@ -152,6 +170,8 @@ class TrainingHandler(BaseHandler):
         handler: Any,
     ) -> HandlerResult | None:
         """Route training requests to appropriate methods."""
+        path = self._normalize_path(path)
+
         # Check static routes first
         method_name = self._ROUTE_MAP.get(path)
         if method_name and hasattr(self, method_name):
@@ -159,7 +179,7 @@ class TrainingHandler(BaseHandler):
             return cast(HandlerResult | None, result)
 
         # Handle job-specific routes
-        if path.startswith("/api/v1/training/jobs/"):
+        if path.startswith(f"{self._VERSIONED_PREFIX}/jobs/"):
             return self._handle_job_route(path, query_params, handler)
 
         return None

--- a/tests/handlers/memory/test_learning.py
+++ b/tests/handlers/memory/test_learning.py
@@ -218,7 +218,7 @@ class TestCanHandle:
         assert handler.can_handle("/api/v1/learning/unknown") is False
 
     def test_unversioned_route(self, handler):
-        assert handler.can_handle("/api/learning/cycles") is False
+        assert handler.can_handle("/api/learning/cycles") is True
 
     def test_empty_path(self, handler):
         assert handler.can_handle("") is False

--- a/tests/test_handlers_evidence.py
+++ b/tests/test_handlers_evidence.py
@@ -199,6 +199,10 @@ class TestCanHandle:
         """Test handler matches /api/evidence."""
         assert evidence_handler.can_handle("/api/v1/evidence")
 
+    def test_can_handle_legacy_evidence_root(self, evidence_handler):
+        """Test handler also matches the legacy unversioned alias."""
+        assert evidence_handler.can_handle("/api/evidence")
+
     def test_can_handle_evidence_id(self, evidence_handler):
         """Test handler matches /api/evidence/:id."""
         assert evidence_handler.can_handle("/api/v1/evidence/ev-123")
@@ -242,6 +246,14 @@ class TestListEvidence:
         assert result.status_code == 200
         assert "evidence" in parse_body(result)
         assert "total" in parse_body(result)
+
+    def test_list_evidence_legacy_alias(self, evidence_handler, mock_evidence_store, mock_handler):
+        """Test the legacy unversioned alias dispatches to the same handler."""
+        result = evidence_handler.handle("/api/evidence", {}, mock_handler)
+
+        assert result is not None
+        assert result.status_code == 200
+        assert "evidence" in parse_body(result)
 
     def test_list_evidence_with_pagination(
         self, evidence_handler, mock_evidence_store, mock_handler

--- a/tests/test_handlers_learning.py
+++ b/tests/test_handlers_learning.py
@@ -212,6 +212,10 @@ class TestLearningRouting:
         """Test handler recognizes patterns route."""
         assert handler.can_handle("/api/v1/learning/patterns")
 
+    def test_can_handle_legacy_patterns_route(self, handler):
+        """Test handler recognizes the legacy unversioned alias."""
+        assert handler.can_handle("/api/learning/patterns")
+
     def test_can_handle_evolution_route(self, handler):
         """Test handler recognizes agent-evolution route."""
         assert handler.can_handle("/api/v1/learning/agent-evolution")
@@ -335,6 +339,15 @@ class TestGetPatterns:
         assert "failed_patterns" in data
         assert "recurring_themes" in data
         assert "agent_specializations" in data
+
+    @pytest.mark.asyncio
+    async def test_get_patterns_legacy_alias(self, handler):
+        """Legacy unversioned requests should hit the same patterns endpoint."""
+        result = await handler.handle("/api/learning/patterns", {}, None)
+        data = json.loads(result.body)
+
+        assert result.status_code == 200
+        assert "successful_patterns" in data
 
     @pytest.mark.asyncio
     async def test_patterns_from_risk_register(self, handler):

--- a/tests/test_handlers_training.py
+++ b/tests/test_handlers_training.py
@@ -120,6 +120,10 @@ class TestTrainingRouteHandling:
         """Test can_handle recognizes formats path."""
         assert training_handler.can_handle("/api/v1/training/formats") is True
 
+    def test_can_handle_legacy_formats(self, training_handler):
+        """Test can_handle recognizes the legacy formats alias."""
+        assert training_handler.can_handle("/api/training/formats") is True
+
     def test_cannot_handle_unknown_path(self, training_handler):
         """Test can_handle rejects unknown paths."""
         assert training_handler.can_handle("/api/v1/training/unknown") is False
@@ -129,6 +133,14 @@ class TestTrainingRouteHandling:
         """Test handle returns None for unrecognized paths."""
         result = training_handler.handle("/api/training/unknown", {}, mock_handler)
         assert result is None
+
+    def test_handle_routes_legacy_formats_alias(self, training_handler, mock_handler):
+        """Legacy unversioned formats requests should dispatch successfully."""
+        result = training_handler.handle("/api/training/formats", {}, mock_handler)
+        body, status = parse_result(result)
+
+        assert status == 200
+        assert "formats" in body
 
 
 # ============================================================================


### PR DESCRIPTION
## What changed
- restored legacy `/api/...` aliases for evidence, training, and learning handlers while keeping `/api/v1/...` as the canonical internal path
- normalized incoming legacy paths before dispatch so registry prefixes, auth coverage, and older callers hit the same implementations
- added regression tests for legacy route recognition and dispatch across the affected handlers

## Why
Several repo surfaces still advertised or routed unversioned handler paths, but the handler implementations had drifted to accept only `/api/v1/...`. That broke integration expectations on `origin/main` for evidence, training, and learning endpoints.

## Impact
Older route prefixes now work again without changing the canonical v1 handler logic. This brings the handler implementations back in line with the existing registry, docs, and compatibility tests.

## Validation
- `pytest tests/test_unused_endpoints.py tests/test_training_exports.py tests/test_handlers_evidence.py tests/test_handlers_learning.py tests/handlers/memory/test_learning.py tests/test_handlers_training.py::TestTrainingRouteHandling tests/rbac/test_route_coverage.py -q`
- `aragora review --diff-file /tmp/aragora-legacy-route-compat.diff --focus quality --demo --output-format json --output-dir /tmp/aragora-review-legacy-route` (demo output only; no real findings)
