### PR TITLE
Hide cross-tenant Slack workspace existence

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1469,7 +1469,7 @@ class SlackOAuthHandler(SecureHandler):
             if not workspace:
                 return error_response(f"Workspace {workspace_id} not found", 404)
             if self._is_workspace_access_denied(workspace, auth_context):
-                return error_response("Workspace access denied", 403)
+                return error_response(f"Workspace {workspace_id} not found", 404)
 
             current_time = time.time()
 
@@ -1536,7 +1536,7 @@ class SlackOAuthHandler(SecureHandler):
             if not workspace:
                 return error_response(f"Workspace {workspace_id} not found", 404)
             if self._is_workspace_access_denied(workspace, auth_context):
-                return error_response("Workspace access denied", 403)
+                return error_response(f"Workspace {workspace_id} not found", 404)
 
             if not workspace.refresh_token:
                 return error_response("No refresh token available. Re-installation required.", 400)

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1999,7 +1999,7 @@ class TestWorkspaceStatus:
                 None,
             )
 
-        assert _status(result) == 403
+        assert _status(result) == 404
 
     @pytest.mark.asyncio
     async def test_store_import_error_returns_503(self, handler):
@@ -2415,7 +2415,7 @@ class TestRefreshToken:
                 None,
             )
 
-        assert _status(result) == 403
+        assert _status(result) == 404
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- return the same not-found response for missing and cross-tenant Slack workspace status lookups
- do the same for manual refresh so callers cannot distinguish existence from ownership
- keep the scoped-owner and auth-required paths unchanged

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'workspace_status_denies_cross_tenant_access or refresh_denies_cross_tenant_access or workspace_status_requires_auth'