### PR TITLE
Preserve detached worker logs on timeout

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -388,7 +388,16 @@ class WorkerLauncher:
                 ]
                 worker.stderr = "\n".join(stderr_parts)
             else:
-                worker.stderr = f"Timed out after {effective_timeout}s"
+                worker.stdout = self._read_log_file(worker.worktree_path, "stdout")
+                stderr_parts = [
+                    part
+                    for part in [
+                        self._read_log_file(worker.worktree_path, "stderr").strip(),
+                        f"Timed out after {effective_timeout}s",
+                    ]
+                    if part
+                ]
+                worker.stderr = "\n".join(stderr_parts)
             logger.warning("Worker %s timed out", work_order_id)
 
         worker.completed_at = datetime.now(UTC).isoformat()

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -684,6 +684,40 @@ class TestWait:
         mock_verify.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_wait_preserves_detached_logs_on_timeout(self, tmp_path: Path):
+        launcher = WorkerLauncher(
+            LaunchConfig(timeout_seconds=0.01, auto_commit=False, detach=True)
+        )
+        worktree = tmp_path / "wt-detached-timeout"
+        worktree.mkdir()
+        (worktree / ".swarm_worker_stdout.log").write_text("partial stdout\n", encoding="utf-8")
+        (worktree / ".swarm_worker_stderr.log").write_text("partial stderr\n", encoding="utf-8")
+
+        worker = WorkerProcess(
+            work_order_id="wo-detached-timeout",
+            agent="codex",
+            worktree_path=str(worktree),
+            branch="main",
+            pid=200,
+        )
+        launcher._workers["wo-detached-timeout"] = worker
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        launcher._processes["wo-detached-timeout"] = mock_proc
+
+        with patch.object(WorkerLauncher, "_collect_diff", return_value=""):
+            result = await launcher.wait("wo-detached-timeout")
+
+        assert result.exit_code == -1
+        assert result.stdout == "partial stdout\n"
+        assert "partial stderr" in result.stderr
+        assert "Timed out after 0.01s" in result.stderr
+        mock_proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_wait_unknown_raises(self):
         launcher = WorkerLauncher()
         with pytest.raises(KeyError, match="No running worker"):


### PR DESCRIPTION
## Summary
- preserve detached worker stdout when wait() times out
- append timeout context to existing detached stderr instead of replacing it
- add a regression for the detached timeout log-preservation path

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'wait_handles_timeout or wait_preserves_detached_logs_on_timeout or wait_handles_none_stdout_stderr'