### PR TITLE
Defer detached collection while session lock is active

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1238,13 +1238,16 @@ class WorkerLauncher:
         if observed_pid is None:
             observed_pid = cls._normalized_pid(session_meta.get("pid"))
         missing_terminal_marker = session_exit_code is None
-
-        if missing_terminal_marker and observed_pid is None:
-            active_lock = Path(worktree_path) / ".codex_session_active"
-            if active_lock.exists():
+        active_lock = Path(worktree_path) / ".codex_session_active"
+        if active_lock.exists():
+            # codex_session.sh writes ended_at/exit_code before it removes the
+            # active lock in its EXIT trap. Treat the lock as authoritative
+            # while it still exists unless the session PID is clearly gone.
+            if observed_pid is None:
                 return None
-
-        if (
+            if cls._is_pid_running(observed_pid):
+                return None
+        elif (
             missing_terminal_marker
             and observed_pid is not None
             and cls._is_pid_running(observed_pid)

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1256,6 +1256,68 @@ class TestCollectDetachedResult:
         mock_diff.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_returns_none_if_active_lock_exists_with_terminal_marker_and_running_pid(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_read_session_meta",
+                return_value={
+                    "pid": 24680,
+                    "ended_at": "2026-04-02T01:23:45+00:00",
+                    "exit_code": 0,
+                },
+            ),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=True) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff") as mock_diff,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-terminal-running",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=None,
+            )
+
+        assert result is None
+        mock_running.assert_called_once_with(24680)
+        mock_diff.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_returns_none_if_active_lock_exists_with_terminal_marker_and_no_usable_pid(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_read_session_meta",
+                return_value={
+                    "pid": "oops",
+                    "ended_at": "2026-04-02T01:23:45+00:00",
+                    "exit_code": 0,
+                },
+            ),
+            patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff") as mock_diff,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-terminal-no-pid",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=None,
+            )
+
+        assert result is None
+        mock_running.assert_not_called()
+        mock_diff.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_uses_session_meta_pid_to_defer_when_marker_missing(self):
         with (
             patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),


### PR DESCRIPTION
## Summary
- defer detached result collection while .codex_session_active still marks the managed session as live
- treat the active lock as authoritative even if ended_at/exit_code were already written
- add regressions for terminal-marker-plus-active-lock races

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'active_lock_exists or marker_missing or collects_results_when_pid_dead or returns_none_if_pid_dead_without_terminal_marker_or_deliverable'
- python -m pytest tests/swarm/test_worker_launcher.py -q