### PR TITLE
Defer sync collection while session lock is active

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -506,6 +506,14 @@ class WorkerLauncher:
             if worker is not None:
                 session_meta = self._read_session_meta(worker.worktree_path)
                 session_exit_code, _ = self._terminal_session_result(session_meta)
+                if proc is not None and proc.returncode is None:
+                    observed_pid = self._normalized_pid(worker.pid)
+                    if observed_pid is None:
+                        observed_pid = self._normalized_pid(session_meta.get("pid"))
+                    if self._active_session_lock_blocks_collection(
+                        worker.worktree_path, observed_pid
+                    ):
+                        continue
             if proc is None or (proc.returncode is None and session_exit_code is None):
                 continue
             completed.append(self._wait_sync(work_order_id))
@@ -1238,15 +1246,8 @@ class WorkerLauncher:
         if observed_pid is None:
             observed_pid = cls._normalized_pid(session_meta.get("pid"))
         missing_terminal_marker = session_exit_code is None
-        active_lock = Path(worktree_path) / ".codex_session_active"
-        if active_lock.exists():
-            # codex_session.sh writes ended_at/exit_code before it removes the
-            # active lock in its EXIT trap. Treat the lock as authoritative
-            # while it still exists unless the session PID is clearly gone.
-            if observed_pid is None:
-                return None
-            if cls._is_pid_running(observed_pid):
-                return None
+        if cls._active_session_lock_blocks_collection(worktree_path, observed_pid):
+            return None
         elif (
             missing_terminal_marker
             and observed_pid is not None
@@ -1354,6 +1355,18 @@ class WorkerLauncher:
         except (TypeError, ValueError):
             return None
         return pid if pid > 0 else None
+
+    @classmethod
+    def _active_session_lock_blocks_collection(cls, worktree_path: str, pid: int | None) -> bool:
+        active_lock = Path(worktree_path) / ".codex_session_active"
+        if not active_lock.exists():
+            return False
+        # codex_session.sh writes ended_at/exit_code before it removes the
+        # active lock in its EXIT trap. Treat the lock as authoritative while
+        # it still exists unless the session PID is clearly gone.
+        if pid is None:
+            return True
+        return cls._is_pid_running(pid)
 
     @staticmethod
     def _cleanup_session_artifacts(worktree_path: str) -> None:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1131,6 +1131,40 @@ class TestCollectFinishedSync:
         mock_wait_pid.assert_not_called()
         assert "wo-sync-invalid-meta-pid" not in launcher._processes
 
+    def test_collect_finished_sync_defers_while_active_lock_still_exists(self, tmp_path: Path):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        worker = WorkerProcess(
+            work_order_id="wo-sync-active-lock",
+            agent="codex",
+            worktree_path=str(tmp_path),
+            branch="main",
+            pid=333,
+            initial_head="def456",
+        )
+        launcher._workers["wo-sync-active-lock"] = worker
+        proc = MagicMock()
+        proc.returncode = None
+        launcher._processes["wo-sync-active-lock"] = proc
+
+        session_meta = {
+            "pid": 333,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=True) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff_sync") as mock_diff,
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=["wo-sync-active-lock"])
+
+        assert completed == []
+        mock_running.assert_called_once_with(333)
+        mock_diff.assert_not_called()
+        assert "wo-sync-active-lock" in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make collect_finished_sync honor the managed-session active lock before trusting terminal session metadata
- reuse the same active-lock gating in detached result collection
- add regressions for the refresh_run sync-path race

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'sync_active_lock or collects_in_memory_worker_when_session_meta_marks_complete or active_lock_exists_with_terminal_marker or active_lock_exists_without_usable_pid'
- python -m pytest tests/swarm/test_worker_launcher.py -q