### PR TITLE
Clear stale blockers on fallback retry

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2987,6 +2987,7 @@ class SwarmSupervisor:
         for key in (
             "pid",
             "blockers",
+            "conflicts",
             "dispatched_at",
             "last_observed_at",
             "last_progress_at",
@@ -2997,6 +2998,7 @@ class SwarmSupervisor:
             "failure_reason",
             "blocking_question",
             "blocker",
+            "resource_error",
             "worker_outcome",
             "confidence",
             "initial_head",

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3882,6 +3882,14 @@ async def test_collect_finished_results_requeues_capacity_failure_to_fallback_ag
     run.work_orders[0]["pr_url"] = "https://github.com/synaptent/aragora/pull/9999"
     run.work_orders[0]["adopted_pr"] = "https://github.com/synaptent/aragora/pull/9999"
     run.work_orders[0]["scope_violation"] = {"violations": [{"path": "README.md"}]}
+    run.work_orders[0]["resource_error"] = "old disk pressure"
+    run.work_orders[0]["conflicts"] = [
+        {
+            "source": "lease",
+            "lease_id": "stale-conflict",
+            "worktree_path": str(repo / "stale-conflict"),
+        }
+    ]
     store.update_supervisor_run(run.run_id, work_orders=run.work_orders, status="active")
 
     completed = await supervisor.collect_finished_results(run.run_id)
@@ -3916,6 +3924,8 @@ async def test_collect_finished_results_requeues_capacity_failure_to_fallback_ag
         "pr_url",
         "adopted_pr",
         "scope_violation",
+        "resource_error",
+        "conflicts",
     ):
         assert cleared_key not in work_order
     breaker = refreshed["metadata"][WORKER_TYPE_CIRCUIT_BREAKERS_KEY]["claude"]


### PR DESCRIPTION
## Summary
- clear stale conflicts and resource_error state when requeueing a lane onto a fallback worker type
- extend the capacity-fallback regression to prove those dead blockers do not survive the fresh attempt

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'requeues_capacity_failure_to_fallback_agent or keeps_explicit_target_agent_sticky_on_capacity_failure'
- python -m pytest tests/swarm/test_supervisor.py -q