### PR TITLE
Clear stale cache on webhook update miss

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -946,20 +946,34 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
             description=description,
         )
 
-        # Update Redis cache
-        if webhook:
+        if webhook is None:
+            # SQLite is authoritative. If the webhook no longer exists, clear
+            # any stale Redis payload so later reads cannot resurrect it.
+            # Mark the ID dirty even if delete succeeds so the next read uses
+            # SQLite truth before trusting Redis again.
             redis = self._get_redis()
             if redis:
                 try:
-                    redis.setex(
-                        self._redis_key(webhook_id),
-                        self.REDIS_TTL,
-                        self._serialize_for_cache(webhook),
-                    )
-                    self._clear_dirty(webhook_id)
-                except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
-                    logger.debug("Redis cache update failed: %s", e)
+                    redis.delete(self._redis_key(webhook_id))
                     self._mark_dirty(webhook_id)
+                except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
+                    logger.debug("Redis cache delete on update miss failed: %s", e)
+                    self._mark_dirty(webhook_id)
+            return None
+
+        # Update Redis cache
+        redis = self._get_redis()
+        if redis:
+            try:
+                redis.setex(
+                    self._redis_key(webhook_id),
+                    self.REDIS_TTL,
+                    self._serialize_for_cache(webhook),
+                )
+                self._clear_dirty(webhook_id)
+            except (_RedisError, ConnectionError, TimeoutError, OSError, ValueError) as e:
+                logger.debug("Redis cache update failed: %s", e)
+                self._mark_dirty(webhook_id)
 
         return webhook
 

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1448,6 +1448,37 @@ class TestRedisWebhookConfigStore:
         mock_redis.setex.assert_called_once()
         store.close()
 
+    def test_with_mocked_redis_update_miss_clears_stale_cache(self, tmp_path):
+        """An update miss must clear stale Redis payloads for webhooks deleted elsewhere."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store.register(url="https://example.com", events=["debate_end"])
+        stale_payload = webhook.to_json()
+
+        # Simulate the webhook being deleted out-of-band in durable storage.
+        assert store._sqlite.delete(webhook.id) is True
+
+        mock_redis.reset_mock()
+        updated = store.update(webhook.id, url="https://new.com")
+
+        assert updated is None
+        mock_redis.delete.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+
+        mock_redis.reset_mock()
+        mock_redis.get.return_value = stale_payload
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is None
+        mock_redis.get.assert_not_called()
+        mock_redis.delete.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        store.close()
+
     def test_with_mocked_redis_record_delivery_invalidates(self, tmp_path):
         """Test record_delivery invalidates the Redis cache."""
         db_path = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- clear stale Redis payloads when SQLite truth says a webhook no longer exists during update
- mark update-miss IDs dirty so the next read bypasses Redis and repairs from durable truth
- add a regression for out-of-band delete plus stale cache

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'update_miss_clears_stale_cache or update_failure_bypasses_stale_cache or delete_failure_bypasses_stale_cache'
- python -m pytest tests/storage/test_webhook_config_store.py -q