### PR TITLE
Fail closed on non-Slack OAuth state

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -958,14 +958,20 @@ class SlackOAuthHandler(SecureHandler):
             return error_response("Invalid or expired state token", 400)
 
         state_redirect_uri: str | None = None
+        state_provider: str | None = None
         if isinstance(state_data, dict):
             tenant_id = state_data.get("tenant_id")
             state_redirect_uri = str(state_data.get("redirect_uri", "") or "").strip() or None
+            state_provider = str(state_data.get("provider", "") or "").strip() or None
         else:
             metadata = getattr(state_data, "metadata", None)
             tenant_id = metadata.get("tenant_id") if isinstance(metadata, dict) else None
             if isinstance(metadata, dict):
                 state_redirect_uri = str(metadata.get("redirect_uri", "") or "").strip() or None
+                state_provider = str(metadata.get("provider", "") or "").strip() or None
+
+        if state_provider != "slack":
+            return error_response("Invalid or expired state token", 400)
 
         client_id = _get_slack_client_id()
         client_secret = _get_slack_client_secret()

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -838,6 +838,34 @@ class TestCallback:
         mock_workspace_store.save.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_state_from_other_provider(
+        self, handler, mock_state_store, mock_workspace_store
+    ):
+        mock_state_store.validate_and_consume.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "google",
+            "created_at": time.time(),
+        }
+
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 400
+        body = _body(result)
+        assert "invalid or expired state token" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_callback_slack_api_error(self, handler):
         mock_client, _ = _make_httpx_mock({"ok": False, "error": "invalid_code"})
 

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -330,7 +330,7 @@ class TestSlackOAuthCallback:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata=None,
+            metadata={"provider": "slack"},
         )
 
         with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "id"):
@@ -352,7 +352,7 @@ class TestSlackOAuthCallback:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata=None,
+            metadata={"provider": "slack"},
         )
 
         with patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "id"):
@@ -378,7 +378,7 @@ class TestSlackOAuthCallback:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata=None,
+            metadata={"provider": "slack"},
         )
 
         mock_response = MagicMock()
@@ -410,7 +410,7 @@ class TestSlackOAuthCallback:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata={"tenant_id": "tenant-001"},
+            metadata={"tenant_id": "tenant-001", "provider": "slack"},
         )
 
         mock_response = MagicMock()
@@ -459,7 +459,7 @@ class TestSlackOAuthCallback:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata={"tenant_id": "tenant-001"},
+            metadata={"tenant_id": "tenant-001", "provider": "slack"},
         )
 
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary
- reject callback state tokens unless they were issued for the Slack provider
- add callback regression coverage for provider-mismatched state
- update lower-level callback fixtures to use real Slack-issued state metadata

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py -q