### PR TITLE
Use session PID in progress snapshots

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -539,6 +539,10 @@ class WorkerLauncher:
         }
         if not worktree_path:
             return snapshot
+        if pid is None:
+            session_meta = self._read_session_meta(worktree_path)
+            pid = self._normalized_pid(session_meta.get("pid"))
+            snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
 
         head_sha = await self._git_output(worktree_path, "rev-parse", "HEAD")
         diff = await self._collect_diff(worktree_path)

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1413,6 +1413,27 @@ class TestSnapshotProgress:
         mock_running.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_snapshot_progress_falls_back_to_session_meta_pid(self, tmp_path: Path):
+        launcher = WorkerLauncher()
+        work_order = {
+            "pid": "oops",
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=True) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is True
+        mock_running.assert_called_once_with(24680)
+
+    @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):
         launcher = WorkerLauncher()
         work_order = {


### PR DESCRIPTION
## Summary
- fall back to session metadata PID when snapshotting worker progress
- keep liveness reporting truthful when the control-plane copy of pid is missing or malformed
- add a regression for session-meta PID fallback

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q