### PR TITLE
test(cli): add codex runner probe parser coverage

### DIFF
--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -187,6 +187,26 @@ class TestSwarmParser:
         assert args.probe_limit == 2
         assert args.json is True
 
+    def test_swarm_runner_probe_parser_accepts_codex_runner_type(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "runner",
+                "probe",
+                "--runner-type",
+                "codex",
+                "--json",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "runner"
+        assert args.swarm_goal == "probe"
+        assert args.runner_type == "codex"
+        assert args.json is True
+
     def test_swarm_audit_issues_parser(self):
         from aragora.cli.parser import build_parser
 


### PR DESCRIPTION
## Summary
- add explicit parser coverage for `swarm runner probe --runner-type codex --json`
- keep the fix test-only because `aragora/cli/parser.py` already supports the shape
- preserve the live Boss-loop regression shape from #1975

## Validation
- ARAGORA_DATA_DIR=/tmp/aragora-codex-data python3 -m pytest -q tests/cli/test_swarm_command.py -k codex
- ARAGORA_DATA_DIR=/tmp/aragora-codex-data python -m pytest tests/cli/test_swarm_command.py -q

Closes #1975