### PR TITLE
fix(deliberations): restore control-plane list compatibility

### DIFF
--- a/aragora/server/handlers/deliberations.py
+++ b/aragora/server/handlers/deliberations.py
@@ -7,6 +7,7 @@ Provides endpoints for the vetted decisionmaking dashboard:
 - WebSocket stream for real-time updates
 
 Usage:
+    GET    /api/v1/deliberations           - Compatibility list of active vetted decisionmaking sessions
     GET    /api/v1/deliberations/active    - List active vetted decisionmaking sessions
     GET    /api/v1/deliberations/stats     - Get aggregate statistics
     GET    /api/v1/deliberations/{id}      - Get vetted decisionmaking details
@@ -76,6 +77,7 @@ class DeliberationsHandler(BaseHandler):
     """
 
     ROUTES = [
+        "/api/v1/deliberations",
         "/api/v1/deliberations/active",
         "/api/v1/deliberations/stats",
         "/api/v1/deliberations/stream",
@@ -145,6 +147,12 @@ class DeliberationsHandler(BaseHandler):
         path = request.path
         method = request.method
 
+        # Compatibility list route used by the live control-plane dashboard
+        if path == "/api/v1/deliberations" and method == "GET":
+            if rbac_error := self._check_rbac_permission(request, "analytics.read"):
+                return rbac_error
+            return await self._get_dashboard_deliberations(request)
+
         # Active deliberations - requires analytics.read
         if path == "/api/v1/deliberations/active" and method == "GET":
             if rbac_error := self._check_rbac_permission(request, "analytics.read"):
@@ -187,6 +195,22 @@ class DeliberationsHandler(BaseHandler):
         except (KeyError, ValueError, TypeError, AttributeError, OSError) as e:
             logger.error("Error fetching deliberations: %s", e)
             return (error_dict("Internal server error", code="INTERNAL_ERROR"), 500)
+
+    async def _get_dashboard_deliberations(self, request: Any) -> tuple[dict[str, Any], int]:
+        """Return active deliberations in the shape expected by the dashboard tracker."""
+        payload, status = await self._get_active_deliberations(request)
+        if status != 200:
+            return payload, status
+
+        deliberations = [
+            self._format_dashboard_deliberation(deliberation)
+            for deliberation in payload.get("deliberations", [])
+        ]
+        return {
+            "deliberations": deliberations,
+            "count": len(deliberations),
+            "timestamp": payload.get("timestamp", datetime.now(timezone.utc).isoformat()),
+        }, 200
 
     async def _fetch_active_from_store(self) -> list[dict[str, Any]]:
         """Fetch active vetted decisionmaking sessions from the debate store."""
@@ -248,6 +272,60 @@ class DeliberationsHandler(BaseHandler):
             "updated_at": debate.get("updated_at", debate.get("started_at", "")),
             "message_count": len(messages),
             "votes": debate.get("votes", {}),
+        }
+
+    def _format_dashboard_deliberation(self, deliberation: dict[str, Any]) -> dict[str, Any]:
+        """Map deliberation data to the control-plane dashboard's legacy shape."""
+        raw_agents = deliberation.get("agents", [])
+        agents: list[dict[str, Any]] = []
+        if isinstance(raw_agents, list):
+            for agent in raw_agents:
+                if isinstance(agent, str):
+                    agents.append({"id": agent, "name": agent})
+                    continue
+                if isinstance(agent, dict):
+                    agent_id = agent.get("id") or agent.get("name") or ""
+                    if agent_id:
+                        agents.append(
+                            {
+                                "id": agent_id,
+                                "name": agent.get("name", agent_id),
+                            }
+                        )
+
+        status = str(deliberation.get("status", "initializing"))
+        dashboard_status = {
+            "initializing": "pending",
+            "pending": "pending",
+            "active": "in_progress",
+            "consensus_forming": "in_progress",
+            "complete": "completed",
+            "completed": "completed",
+            "failed": "failed",
+            "error": "failed",
+        }.get(status, "pending")
+
+        consensus_confidence = deliberation.get("consensus_confidence")
+        if consensus_confidence is None:
+            consensus_confidence = deliberation.get("consensus_score")
+
+        return {
+            "id": deliberation.get("id", ""),
+            "question": deliberation.get("question")
+            or deliberation.get("task")
+            or deliberation.get("content")
+            or "",
+            "status": dashboard_status,
+            "started_at": deliberation.get("started_at") or deliberation.get("created_at"),
+            "completed_at": deliberation.get("completed_at"),
+            "current_round": deliberation.get("current_round", 0),
+            "max_rounds": deliberation.get("max_rounds")
+            or deliberation.get("total_rounds")
+            or DEFAULT_ROUNDS,
+            "agents": agents,
+            "consensus_confidence": consensus_confidence,
+            "final_answer": deliberation.get("final_answer") or deliberation.get("answer"),
+            "consensus_reached": deliberation.get("consensus_reached"),
         }
 
     async def _get_stats(self, request: Any) -> tuple[dict[str, Any], int]:

--- a/aragora/server/openapi/endpoints/deliberations.py
+++ b/aragora/server/openapi/endpoints/deliberations.py
@@ -43,6 +43,69 @@ def _deliberation_schema() -> dict[str, Any]:
     }
 
 
+def _dashboard_deliberation_schema() -> dict[str, Any]:
+    """Compatibility schema used by the live control-plane dashboard."""
+    return {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Unique deliberation identifier"},
+            "question": {
+                "type": "string",
+                "description": "Decision question rendered in the control-plane tracker",
+            },
+            "status": {
+                "type": "string",
+                "enum": ["pending", "in_progress", "completed", "failed"],
+                "description": "Dashboard-friendly status for tracker cards",
+            },
+            "started_at": {
+                "type": "string",
+                "format": "date-time",
+                "description": "When the deliberation started",
+            },
+            "completed_at": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": True,
+                "description": "When the deliberation completed, if available",
+            },
+            "current_round": {
+                "type": "integer",
+                "description": "Current round number",
+            },
+            "max_rounds": {
+                "type": "integer",
+                "description": "Configured maximum round count",
+            },
+            "agents": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string"},
+                        "name": {"type": "string"},
+                    },
+                },
+                "description": "Participant list normalized for dashboard cards",
+            },
+            "consensus_confidence": {
+                "type": "number",
+                "description": "Current consensus confidence, if available",
+            },
+            "final_answer": {
+                "type": "string",
+                "nullable": True,
+                "description": "Final answer or synthesis, when available",
+            },
+            "consensus_reached": {
+                "type": "boolean",
+                "nullable": True,
+                "description": "Whether consensus was explicitly reached",
+            },
+        },
+    }
+
+
 def _stats_schema() -> dict[str, Any]:
     """Deliberation statistics schema."""
     return {
@@ -88,6 +151,39 @@ DELIBERATIONS_ENDPOINTS = {
     # =========================================================================
     # GET Endpoints - Query and Monitoring
     # =========================================================================
+    "/api/v1/deliberations": {
+        "get": {
+            "tags": ["Deliberations"],
+            "summary": "List active deliberations for the control-plane dashboard",
+            "operationId": "listDashboardDeliberations",
+            "description": "Compatibility alias for the live control-plane dashboard. Returns active deliberations in the tracker-friendly shape expected by the existing UI.",
+            "responses": {
+                "200": {
+                    "description": "List of active deliberations in dashboard shape",
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "Number of active deliberations",
+                                    },
+                                    "deliberations": {
+                                        "type": "array",
+                                        "items": _dashboard_deliberation_schema(),
+                                    },
+                                },
+                            }
+                        }
+                    },
+                },
+                "401": {"description": "Authentication required"},
+                "403": {"description": "Insufficient permissions"},
+            },
+            "security": [{"bearerAuth": []}],
+        }
+    },
     "/api/v1/deliberations/active": {
         "get": {
             "tags": ["Deliberations"],

--- a/aragora/server/openapi/stability_manifest.json
+++ b/aragora/server/openapi/stability_manifest.json
@@ -454,6 +454,7 @@
     "GET /api/v1/decisions/{param}",
     "GET /api/v1/decisions/{param}/explain",
     "GET /api/v1/decisions/{param}/status",
+    "GET /api/v1/deliberations",
     "GET /api/v1/deliberations/active",
     "GET /api/v1/deliberations/stats",
     "GET /api/v1/deliberations/stream",

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -152,6 +152,7 @@ Active AI debate sessions and stats.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
+| GET | `/api/v1/deliberations` | Compatibility list for the control-plane tracker |
 | GET | `/api/v1/deliberations/active` | List active deliberations |
 | GET | `/api/v1/deliberations/stats` | Deliberation statistics |
 | GET | `/api/v1/deliberations/{id}` | Get deliberation details |

--- a/docs/reference/HANDLERS.md
+++ b/docs/reference/HANDLERS.md
@@ -125,6 +125,7 @@ GET  /api/v1/auth/sso/login - SSO login (OIDC)
 POST /api/v1/decisions              - Submit a decision request
 GET  /api/v1/decisions/:id          - Get decision status/result
 POST /api/control-plane/deliberations - Run or queue a vetted decisionmaking session
+GET  /api/v1/deliberations          - Compatibility list for the control-plane tracker
 GET  /api/v1/deliberations/active   - List active deliberations
 ```
 

--- a/tests/server/handlers/test_deliberations.py
+++ b/tests/server/handlers/test_deliberations.py
@@ -39,6 +39,7 @@ class TestDeliberationsHandler:
 
     def test_routes_include_active(self):
         handler = self._make_handler()
+        assert "/api/v1/deliberations" in handler.ROUTES
         assert "/api/v1/deliberations/active" in handler.ROUTES
 
     def test_routes_include_stats(self):
@@ -79,6 +80,23 @@ class TestDeliberationsHandler:
     # -------------------------------------------------------------------------
     # Request handling tests
     # -------------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_handle_request_dashboard_list_route(self):
+        handler = self._make_handler()
+        request = self._make_request(path="/api/v1/deliberations")
+
+        with patch.object(handler, "_check_rbac_permission", return_value=None):
+            with patch.object(
+                handler,
+                "_get_dashboard_deliberations",
+                new_callable=AsyncMock,
+                return_value=({"deliberations": [], "count": 0}, 200),
+            ) as mock_get:
+                result = await handler.handle_request(request)
+
+                mock_get.assert_called_once_with(request)
+                assert result[1] == 200
 
     @pytest.mark.asyncio
     async def test_handle_request_active_route(self):
@@ -191,6 +209,59 @@ class TestDeliberationsHandler:
         assert status == 200
         assert result["count"] == 2
         assert len(result["deliberations"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_get_dashboard_deliberations_maps_legacy_shape(self):
+        handler = self._make_handler()
+        request = self._make_request(path="/api/v1/deliberations")
+
+        with patch.object(
+            handler,
+            "_get_active_deliberations",
+            new_callable=AsyncMock,
+            return_value=(
+                {
+                    "deliberations": [
+                        {
+                            "id": "d1",
+                            "task": "Restore live tracker parity",
+                            "status": "consensus_forming",
+                            "agents": ["claude", "gpt4"],
+                            "current_round": 3,
+                            "total_rounds": 5,
+                            "consensus_score": 0.71,
+                            "started_at": "2026-04-02T18:00:00+00:00",
+                        }
+                    ],
+                    "count": 1,
+                    "timestamp": "2026-04-02T18:01:00+00:00",
+                },
+                200,
+            ),
+        ):
+            result, status = await handler._get_dashboard_deliberations(request)
+
+        assert status == 200
+        assert result["count"] == 1
+        assert result["timestamp"] == "2026-04-02T18:01:00+00:00"
+        assert result["deliberations"] == [
+            {
+                "id": "d1",
+                "question": "Restore live tracker parity",
+                "status": "in_progress",
+                "started_at": "2026-04-02T18:00:00+00:00",
+                "completed_at": None,
+                "current_round": 3,
+                "max_rounds": 5,
+                "agents": [
+                    {"id": "claude", "name": "claude"},
+                    {"id": "gpt4", "name": "gpt4"},
+                ],
+                "consensus_confidence": 0.71,
+                "final_answer": None,
+                "consensus_reached": None,
+            }
+        ]
 
     @pytest.mark.asyncio
     async def test_get_active_deliberations_error(self):

--- a/tests/server/handlers/test_deliberations_handler.py
+++ b/tests/server/handlers/test_deliberations_handler.py
@@ -64,6 +64,7 @@ class TestDeliberationsHandlerInit:
 
     def test_handler_routes(self, handler):
         """Should define correct routes."""
+        assert "/api/v1/deliberations" in handler.ROUTES
         assert "/api/v1/deliberations/active" in handler.ROUTES
         assert "/api/v1/deliberations/stats" in handler.ROUTES
         assert "/api/v1/deliberations/stream" in handler.ROUTES
@@ -77,6 +78,40 @@ class TestDeliberationsHandlerInit:
 
 class TestActiveDeliberations:
     """Tests for active deliberations endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_dashboard_deliberations_compat_route(self, handler, mock_request):
+        """Bare deliberations route returns dashboard-friendly active sessions."""
+        register_deliberation(
+            "test-compat-123",
+            {
+                "task": "Investigate a live integration mismatch",
+                "status": "active",
+                "agents": ["claude", "gpt4"],
+                "current_round": 2,
+                "total_rounds": 4,
+                "consensus_score": 0.64,
+            },
+        )
+
+        mock_request.path = "/api/v1/deliberations"
+        mock_request.method = "GET"
+
+        with patch.object(handler, "_check_rbac_permission", return_value=None):
+            result, status = await handler.handle_request(mock_request)
+
+        assert status == 200
+        assert result["count"] == 1
+        deliberation = result["deliberations"][0]
+        assert deliberation["id"] == "test-compat-123"
+        assert deliberation["question"] == "Investigate a live integration mismatch"
+        assert deliberation["status"] == "in_progress"
+        assert deliberation["max_rounds"] == 4
+        assert deliberation["consensus_confidence"] == 0.64
+        assert deliberation["agents"] == [
+            {"id": "claude", "name": "claude"},
+            {"id": "gpt4", "name": "gpt4"},
+        ]
 
     @pytest.mark.asyncio
     async def test_get_active_deliberations_empty(self, handler, mock_request):


### PR DESCRIPTION
## Summary
- restore a GET /api/v1/deliberations compatibility route for the live control-plane tracker
- normalize active deliberation payloads into the dashboard shape the existing UI already expects
- add focused handler coverage and sync the deliberations docs source

## Repro
- the live control-plane page fetched GET /api/v1/deliberations
- the backend only exposed /api/v1/deliberations/active, /stats, /stream, and /{id}
- result: the deliberation tracker silently fell back to an empty list on latest origin/main

## Validation
- python -m pytest -q tests/server/handlers/test_deliberations_handler.py tests/server/handlers/test_deliberations.py tests/handlers/test_deliberations.py --maxfail=5
- git diff --check

## Notes
- attempted aragora review on the diff, but it was blocked by network-restricted secret/model fetches in this environment