### PR TITLE
Clear stale tests on lease rebind

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -984,8 +984,7 @@ class SwarmSupervisor:
         expected_tests = [
             str(test).strip() for test in getattr(lease, "expected_tests", []) if str(test).strip()
         ]
-        if expected_tests:
-            item["expected_tests"] = expected_tests
+        item["expected_tests"] = expected_tests
         item["review_status"] = "pending"
         for key in (
             "dispatch_error",

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -974,6 +974,7 @@ def test_refresh_run_rebinds_released_work_order_to_new_active_lease(
     assert work_order["status"] == "leased"
     assert work_order["lease_id"] == new_lease.lease_id
     assert work_order["owner_session_id"] == "swarm-rebound-lease"
+    assert work_order["expected_tests"] == []
 
 
 def test_refresh_run_rebinds_stale_dispatched_lane_back_to_leased_without_worker_pid(


### PR DESCRIPTION
## Summary
- make replacement active leases authoritative for expected_tests
- clear stale expected_tests when a rebind target has no verification commands
- extend the lease-rebind regression to prove the old tests are dropped

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'rebinds_released_work_order_to_new_active_lease or rebinds_stale_dispatched_lane_back_to_leased_without_worker_pid or rebinds_stale_dispatched_lane_to_active_worker_without_stale_terminal_state'
- python -m pytest tests/swarm/test_supervisor.py -q