### PR TITLE
fix(swarm): preserve dependent validation lanes

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -616,6 +616,7 @@ class SwarmSupervisor:
                         run_id=run_id,
                         target_branch=str(record.get("target_branch", "main")),
                         work_order=item,
+                        work_orders=work_orders,
                         managed_dir_pattern=managed_dir_pattern,
                         approval_policy=SwarmApprovalPolicy.from_dict(
                             record.get("approval_policy")
@@ -631,6 +632,7 @@ class SwarmSupervisor:
                                 run_id=run_id,
                                 target_branch=str(record.get("target_branch", "main")),
                                 work_order=item,
+                                work_orders=work_orders,
                                 managed_dir_pattern=managed_dir_pattern,
                                 approval_policy=SwarmApprovalPolicy.from_dict(
                                     record.get("approval_policy")
@@ -1930,6 +1932,43 @@ class SwarmSupervisor:
         return False
 
     @staticmethod
+    def _dependency_base_reference(
+        item: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+    ) -> tuple[str, str] | None:
+        dependency_ids = [
+            str(dep).strip() for dep in item.get("dependency_ids", []) if str(dep).strip()
+        ]
+        if not dependency_ids:
+            return None
+
+        completed_statuses = {"completed", "merged", "salvage"}
+        references: dict[str, str] = {}
+        for candidate in work_orders:
+            if not isinstance(candidate, dict):
+                continue
+            status = str(candidate.get("status", "")).strip().lower()
+            if status not in completed_statuses:
+                continue
+            reference = (
+                str(candidate.get("branch", "")).strip()
+                or str(candidate.get("head_sha", "")).strip()
+                or str(candidate.get("initial_head", "")).strip()
+            )
+            if not reference:
+                continue
+            for key in ("pipeline_task_id", "work_order_id", "task_key"):
+                candidate_id = str(candidate.get(key, "")).strip()
+                if candidate_id:
+                    references[candidate_id] = reference
+
+        for dependency_id in reversed(dependency_ids):
+            reference = references.get(dependency_id)
+            if reference:
+                return reference, dependency_id
+        return None
+
+    @staticmethod
     def _looks_like_broad_explicit_pytest_umbrella(*, source: str, text: str) -> bool:
         if source.strip() != "explicit_spec_work_order":
             return False
@@ -2359,6 +2398,7 @@ class SwarmSupervisor:
         run_id: str,
         target_branch: str,
         work_order: dict[str, Any],
+        work_orders: list[dict[str, Any]],
         managed_dir_pattern: str,
         approval_policy: SwarmApprovalPolicy,
     ) -> bool:
@@ -2393,6 +2433,40 @@ class SwarmSupervisor:
                 failure_reason="scope_violation",
             )
             return False
+        dependency_base = self._dependency_base_reference(work_order, work_orders)
+        if dependency_base is not None:
+            dependency_ref, dependency_id = dependency_base
+            merge_proc = self._run_git_capture_sync(
+                str(session.path),
+                "merge",
+                "--ff-only",
+                dependency_ref,
+            )
+            if merge_proc.returncode != 0:
+                self._mark_needs_human(
+                    work_order,
+                    (
+                        "Dependent lane could not start from its prerequisite branch; "
+                        "reconcile the dependency chain before rerunning."
+                    ),
+                    failure_reason="dependency_base_conflict",
+                    blocking_question=(
+                        "Which completed dependency branch or commit should this lane build on?"
+                    ),
+                )
+                work_order["dispatch_error"] = (
+                    merge_proc.stderr.strip()
+                    or merge_proc.stdout.strip()
+                    or f"unable to fast-forward dependent lane onto {dependency_ref}"
+                )
+                work_order["dependency_base_ref"] = dependency_ref
+                work_order["dependency_base_source"] = dependency_id
+                return False
+            work_order["dependency_base_ref"] = dependency_ref
+            work_order["dependency_base_source"] = dependency_id
+        else:
+            work_order.pop("dependency_base_ref", None)
+            work_order.pop("dependency_base_source", None)
         claimed_paths = [item for item in file_scope if not self._looks_like_glob(item)]
         allowed_globs = [item for item in file_scope if self._looks_like_glob(item)]
         if not allowed_globs and not claimed_paths and file_scope:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5105,6 +5105,85 @@ def test_refresh_run_requeues_conflict_only_needs_human_when_fleet_claims_are_st
     assert "scope_violation" not in work_order
 
 
+def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    dependency_branch = "codex/swarm-dependency-base"
+    _run(repo, "git", "checkout", "-b", dependency_branch)
+    (repo / "README.md").write_text("hello\ndependency\n", encoding="utf-8")
+    _run(repo, "git", "add", "README.md")
+    _run(repo, "git", "commit", "-m", "dependency commit")
+    dependency_head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+    _run(repo, "git", "checkout", "main")
+
+    session_path = repo / "wt-dependent-base"
+    _run(
+        repo,
+        "git",
+        "worktree",
+        "add",
+        "-b",
+        "codex/swarm-dependent-base",
+        str(session_path),
+        "main",
+    )
+
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = ManagedWorktreeSession(
+        session_id="swarm-dependent-base",
+        agent="codex",
+        branch="codex/swarm-dependent-base",
+        path=session_path,
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    supervisor = SwarmSupervisor(repo_root=repo, store=store, lifecycle=lifecycle)
+    run_record = store.create_supervisor_run(
+        goal="validate dependency branch reuse",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "validate dependency branch reuse"},
+        metadata={"max_concurrency": 1},
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "Write tests",
+                "status": "completed",
+                "review_status": "pending_heterogeneous_review",
+                "branch": dependency_branch,
+                "head_sha": dependency_head,
+                "file_scope": ["README.md"],
+                "target_agent": "codex",
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Run validation and fix failures",
+                "status": "queued",
+                "review_status": "pending",
+                "dependency_ids": ["micro-task-1"],
+                "file_scope": ["README.md"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+            },
+        ],
+        status="active",
+    )
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    dependent = next(
+        item for item in refreshed.work_orders if item.get("pipeline_task_id") == "micro-task-2"
+    )
+    assert dependent["status"] == "leased"
+    assert dependent["dependency_base_ref"] == dependency_branch
+    assert dependent["dependency_base_source"] == "micro-task-1"
+    assert _run(session_path, "git", "rev-parse", "HEAD").stdout.strip() == dependency_head
+
+
 def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordinationStore) -> None:
     """refresh_run should not leave dead leased work orders active forever."""
     lifecycle = MagicMock()


### PR DESCRIPTION
## Summary
- stop duplicate-open-work-order suppression from collapsing a same-batch work order into an earlier item it explicitly depends on
- keep existing duplicate suppression for real overlapping open lanes
- add a regression covering the `micro-1 -> micro-2` validation sequence from the live #1975 Boss run

## Validation
- python3 -m pytest -q tests/swarm/test_supervisor.py -k "duplicate_open_work_order or preserves_dependent_validation_work_order_in_same_batch or specific_pytest_child or duplicate_scope or duplicate_explicit_lane"
- python3 -m pytest -q tests/swarm/test_supervisor.py
- python3 -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python3 -m ruff format --check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- git diff --check