### PR TITLE
Ignore unauthenticated Slack install tenant scope

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -342,7 +342,12 @@ class SlackOAuthHandler(SecureHandler):
                     authenticated_tenant_id,
                 )
             return authenticated_tenant_id
-        return requested_tenant_id
+        if requested_tenant_id:
+            logger.warning(
+                "Ignoring unauthenticated Slack OAuth tenant_id=%s during install flow",
+                requested_tenant_id,
+            )
+        return None
 
     def _is_workspace_access_denied(
         self,

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -362,7 +362,7 @@ class TestInstall:
         assert "text/html" in result.content_type
 
     @pytest.mark.asyncio
-    async def test_with_tenant_id(self, handler, mock_state_store):
+    async def test_unauthenticated_install_ignores_tenant_id(self, handler, mock_state_store):
         result = await handler.handle(
             "GET", "/api/integrations/slack/install", {}, {"tenant_id": "t-123"}, {}, None
         )
@@ -370,7 +370,7 @@ class TestInstall:
         mock_state_store.generate.assert_called_once()
         call_kwargs = mock_state_store.generate.call_args
         metadata = call_kwargs[1].get("metadata") or call_kwargs.kwargs.get("metadata")
-        assert metadata["tenant_id"] == "t-123"
+        assert metadata["tenant_id"] is None
 
     @pytest.mark.asyncio
     async def test_authenticated_install_prefers_auth_tenant(

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -231,6 +231,28 @@ class TestSlackOAuthInstall:
         assert found, "tenant_id not stored in state"
 
     @pytest.mark.asyncio
+    async def test_unauthenticated_install_ignores_tenant_id(
+        self, oauth_handler, oauth_state_store
+    ):
+        """Unauthenticated dev installs must not bind arbitrary tenant scope."""
+        with (
+            patch("aragora.server.handlers.social.slack_oauth.SLACK_CLIENT_ID", "test-client-id"),
+            patch("aragora.server.handlers.social.slack_oauth.ARAGORA_ENV", "test"),
+        ):
+            result = await oauth_handler.handle(
+                "GET",
+                "/api/integrations/slack/install",
+                query_params={"tenant_id": "tenant-001"},
+            )
+
+        assert result.status_code == 302
+        found = any(
+            data.metadata and data.metadata.get("tenant_id") is None
+            for data in oauth_state_store._states.values()
+        )
+        assert found, "unauthenticated install should not persist tenant_id"
+
+    @pytest.mark.asyncio
     async def test_install_cleans_old_states(self, oauth_handler, oauth_state_store):
         """Test install cleans up expired states."""
         # Add old state


### PR DESCRIPTION
## Summary
- ignore caller-supplied tenant_id during unauthenticated non-production Slack installs
- continue to prefer authenticated org scope when auth is present
- add regressions covering unauthenticated install state metadata

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py -q