### PR TITLE
test(openclaw): include approval request export

### DIFF
--- a/tests/handlers/openclaw/test_models.py
+++ b/tests/handlers/openclaw/test_models.py
@@ -800,10 +800,15 @@ class TestModuleExports:
 
         assert "AuditEntry" in mod.__all__
 
+    def test_approval_request_exported(self):
+        import aragora.server.handlers.openclaw.models as mod
+
+        assert "ApprovalRequest" in mod.__all__
+
     def test_all_count(self):
         import aragora.server.handlers.openclaw.models as mod
 
-        assert len(mod.__all__) == 7
+        assert len(mod.__all__) == 8
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- add ApprovalRequest to the OpenClaw module export expectations
- update the module export count to match the current __all__
- unblock shared baseline failures affecting active PRs

## Validation
- python3 -m pytest tests/handlers/openclaw/test_models.py::TestModuleExports -q
- python3 -m pytest tests/handlers/openclaw/test_models.py -q
- python3 -m ruff check tests/handlers/openclaw/test_models.py