### PR TITLE
Fail closed on repeated approval decisions

### DIFF
--- a/aragora/rbac/approvals.py
+++ b/aragora/rbac/approvals.py
@@ -337,14 +337,14 @@ class ApprovalWorkflow:
         if approver_id not in request.approvers:
             raise ValueError(f"User {approver_id} is not an approver for this request")
 
+        # Check status
+        if request.status != ApprovalStatus.PENDING:
+            raise ValueError(f"Request is not pending: {request.status.value}")
+
         # Check if already decided
         existing = [d for d in request.decisions if d.approver_id == approver_id]
         if existing:
             raise ValueError(f"User {approver_id} has already made a decision")
-
-        # Check status
-        if request.status != ApprovalStatus.PENDING:
-            raise ValueError(f"Request is not pending: {request.status.value}")
 
         # Check expiration
         if request.is_expired:
@@ -414,6 +414,16 @@ class ApprovalWorkflow:
         # Check status
         if request.status != ApprovalStatus.PENDING:
             raise ValueError(f"Request is not pending: {request.status.value}")
+
+        # Check if already decided
+        existing = [d for d in request.decisions if d.approver_id == approver_id]
+        if existing:
+            raise ValueError(f"User {approver_id} has already made a decision")
+
+        # Check expiration
+        if request.is_expired:
+            request.status = ApprovalStatus.EXPIRED
+            raise ValueError("Request has expired")
 
         # Record decision
         decision = ApprovalDecision(

--- a/tests/rbac/test_approvals.py
+++ b/tests/rbac/test_approvals.py
@@ -1222,6 +1222,14 @@ class TestMultiApproverScenarios:
         with pytest.raises(ValueError, match="already made a decision"):
             await workflow.approve(approver_id="admin-1", request_id=request.id)
 
+        # Same approver cannot reject after approving either
+        with pytest.raises(ValueError, match="already made a decision"):
+            await workflow.reject(
+                approver_id="admin-1",
+                request_id=request.id,
+                reason="Changing my mind",
+            )
+
     @pytest.mark.asyncio
     async def test_all_approvers_can_approve_independently(self, workflow):
         """Test that all designated approvers can approve."""
@@ -1401,14 +1409,13 @@ class TestDurationAndExpiration:
         # Force expiration
         request.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
 
-        # Note: reject doesn't check expiration, only approve does
-        # This tests current behavior - reject still works on expired pending requests
-        result = await workflow.reject(
-            approver_id="admin-1",
-            request_id=request.id,
-            reason="Too late",
-        )
-        assert result.status == ApprovalStatus.REJECTED
+        with pytest.raises(ValueError, match="expired"):
+            await workflow.reject(
+                approver_id="admin-1",
+                request_id=request.id,
+                reason="Too late",
+            )
+        assert request.status == ApprovalStatus.EXPIRED
 
     @pytest.mark.asyncio
     async def test_expire_multiple_requests(self, workflow):


### PR DESCRIPTION
## Summary
- prevent approvers from rejecting a request after they already approved it
- expire stale requests on reject attempts the same way approve already does
- add regressions for repeated decisions and expired reject attempts

## Testing
- python -m ruff check aragora/rbac/approvals.py tests/rbac/test_approvals.py
- python -m pytest tests/rbac/test_approvals.py -q