### PR TITLE
Preserve org scope on approval grants

### DIFF
--- a/aragora/rbac/approvals.py
+++ b/aragora/rbac/approvals.py
@@ -741,6 +741,10 @@ class ApprovalWorkflow:
             # Map resource type string to enum
             resource_type_enum = ResourceType(request.resource_type)
 
+            metadata = {"approval_request_id": request.id}
+            if request.workspace_id is not None:
+                metadata["workspace_id"] = request.workspace_id
+
             store.grant_permission(
                 user_id=request.requester_id,
                 permission_id=request.permission,
@@ -748,7 +752,8 @@ class ApprovalWorkflow:
                 resource_id=request.resource_id or "*",
                 granted_by="approval_workflow",
                 expires_at=expires_at,
-                conditions={"approval_request_id": request.id},
+                org_id=request.org_id,
+                metadata=metadata,
             )
 
             logger.info(

--- a/tests/rbac/test_approvals.py
+++ b/tests/rbac/test_approvals.py
@@ -1539,6 +1539,39 @@ class TestGrantTemporaryPermission:
         # Should complete without error
         assert request.status == ApprovalStatus.APPROVED
 
+    @pytest.mark.asyncio
+    async def test_grant_preserves_org_scope_and_metadata(self, workflow):
+        """Test that temporary grants keep org scope and audit metadata."""
+        request = await workflow.request_access(
+            requester_id="user-1",
+            permission="debates:delete",
+            resource_type="debates",
+            resource_id="debate-456",
+            justification="Scoped access",
+            approvers=["admin-1"],
+            org_id="org-123",
+            workspace_id="ws-456",
+            duration_hours=8,
+        )
+
+        with patch("aragora.rbac.resource_permissions.ResourcePermissionStore") as mock_store_cls:
+            mock_store = mock_store_cls.return_value
+            await workflow._grant_temporary_permission(request)
+
+        mock_store.grant_permission.assert_called_once()
+        _, kwargs = mock_store.grant_permission.call_args
+        assert kwargs["user_id"] == "user-1"
+        assert kwargs["permission_id"] == "debates:delete"
+        assert kwargs["resource_type"].value == "debates"
+        assert kwargs["resource_id"] == "debate-456"
+        assert kwargs["granted_by"] == "approval_workflow"
+        assert kwargs["org_id"] == "org-123"
+        assert kwargs.get("conditions") is None
+        assert kwargs["metadata"] == {
+            "approval_request_id": request.id,
+            "workspace_id": "ws-456",
+        }
+
 
 # =============================================================================
 # Workspace and Organization Scoped Tests


### PR DESCRIPTION
## Summary
- preserve org-scoped approval grants when minting temporary resource permissions
- move approval request tracking into permission metadata instead of ABAC conditions
- add a direct regression asserting the grant call keeps org scope and workspace audit context

## Testing
- python -m ruff check aragora/rbac/approvals.py tests/rbac/test_approvals.py
- python -m pytest tests/rbac/test_approvals.py -q -k 'grant_preserves_org_scope_and_metadata or grant_called_on_approval or repeated_rejection or expired_request_becomes_expired_on_reject'
- python -m pytest tests/rbac/test_approvals.py -q