### PR TITLE
Escape Slack OAuth HTML output

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -23,6 +23,7 @@ import logging
 import os
 import secrets
 import time
+from html import escape
 from typing import Any
 from urllib.parse import urlencode, urlsplit
 
@@ -724,7 +725,7 @@ class SlackOAuthHandler(SecureHandler):
         # Build install URL with tenant_id
         install_url = "/api/integrations/slack/install"
         if tenant_id:
-            install_url += f"?tenant_id={tenant_id}"
+            install_url = f"{install_url}?{urlencode({'tenant_id': tenant_id})}"
 
         # Generate HTML consent preview page
         html = self._render_consent_preview(
@@ -749,13 +750,15 @@ class SlackOAuthHandler(SecureHandler):
         """Render the consent preview HTML page."""
         required_html = ""
         for s in required_scopes:
-            icon = s["icon"] if s["icon"] else "&#128274;"
+            icon = escape(str(s["icon"])) if s["icon"] else "&#128274;"
+            name = escape(str(s["name"]))
+            description = escape(str(s["description"]))
             required_html += f"""
             <div class="scope-item">
                 <span class="scope-icon">{icon}</span>
                 <div class="scope-details">
-                    <div class="scope-name">{s["name"]}</div>
-                    <div class="scope-desc">{s["description"]}</div>
+                    <div class="scope-name">{name}</div>
+                    <div class="scope-desc">{description}</div>
                 </div>
                 <span class="scope-badge required">Required</span>
             </div>
@@ -763,13 +766,15 @@ class SlackOAuthHandler(SecureHandler):
 
         optional_html = ""
         for s in optional_scopes:
-            icon = s["icon"] if s["icon"] else "&#128274;"
+            icon = escape(str(s["icon"])) if s["icon"] else "&#128274;"
+            name = escape(str(s["name"]))
+            description = escape(str(s["description"]))
             optional_html += f"""
             <div class="scope-item">
                 <span class="scope-icon">{icon}</span>
                 <div class="scope-details">
-                    <div class="scope-name">{s["name"]}</div>
-                    <div class="scope-desc">{s["description"]}</div>
+                    <div class="scope-name">{name}</div>
+                    <div class="scope-desc">{description}</div>
                 </div>
                 <span class="scope-badge optional">Optional</span>
             </div>
@@ -781,6 +786,8 @@ class SlackOAuthHandler(SecureHandler):
                 "<div class='section-title' style='margin-top: 24px;'>Optional Features</div>"
                 + optional_html
             )
+
+        safe_install_url = escape(install_url, quote=True)
 
         return f"""<!DOCTYPE html>
 <html lang="en">
@@ -911,7 +918,7 @@ class SlackOAuthHandler(SecureHandler):
             </div>
         </div>
         <div class="actions">
-            <a href="{install_url}" class="btn btn-primary">
+            <a href="{safe_install_url}" class="btn btn-primary">
                 &#128241; Continue to Slack Authorization
             </a>
             <a href="javascript:history.back()" class="btn btn-secondary">Cancel</a>
@@ -1203,6 +1210,7 @@ class SlackOAuthHandler(SecureHandler):
             return error_response("Workspace storage not available", 503)
 
         # Return success page
+        safe_workspace_name = escape(workspace_name)
         success_html = f"""
         <!DOCTYPE html>
         <html>
@@ -1245,7 +1253,7 @@ class SlackOAuthHandler(SecureHandler):
                 <div class="check">&#10003;</div>
                 <h1>Connected!</h1>
                 <p>Aragora is now installed in</p>
-                <p class="workspace">{workspace_name}</p>
+                <p class="workspace">{safe_workspace_name}</p>
                 <p>You can close this window and return to Slack.</p>
             </div>
         </body>

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -25,6 +25,7 @@ import os
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlencode
 
 import pytest
 from aragora.rbac.models import AuthorizationContext
@@ -593,6 +594,33 @@ class TestPreview:
         assert "tenant_id=test-org-001" in html
 
     @pytest.mark.asyncio
+    async def test_preview_escapes_tenant_bound_install_url(self, handler):
+        malicious_tenant = 'tenant" onclick="alert(1)<script>'
+        expected_query = urlencode({"tenant_id": malicious_tenant})
+
+        with (
+            patch.object(
+                handler,
+                "get_auth_context",
+                AsyncMock(return_value=MagicMock(org_id=malicious_tenant)),
+            ),
+            patch.object(handler, "_check_permission", return_value=True),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/preview",
+                {},
+                {"tenant_id": "ignored"},
+                {},
+                None,
+            )
+
+        html = _html(result)
+        assert malicious_tenant not in html
+        assert expected_query in html
+        assert "onclick=" not in html
+
+    @pytest.mark.asyncio
     async def test_preview_no_client_id_returns_503(self, handler, handler_module, monkeypatch):
         monkeypatch.setattr(handler_module, "SLACK_CLIENT_ID", None)
         result = await handler.handle("GET", "/api/integrations/slack/preview", {}, {}, {}, None)
@@ -752,6 +780,44 @@ class TestCallback:
         html = _html(result)
         assert "Connected" in html
         assert "My Team" in html
+
+    @pytest.mark.asyncio
+    async def test_successful_callback_escapes_workspace_name(self, handler, mock_workspace_store):
+        malicious_workspace_name = '<img src=x onerror="alert(1)">'
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": {"id": "W123", "name": malicious_workspace_name},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history,chat:write",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch(
+                "aragora.storage.slack_workspace_store.SlackWorkspace",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        html = _html(result)
+        assert malicious_workspace_name not in html
+        assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
 
     @pytest.mark.asyncio
     async def test_callback_rejects_cross_tenant_workspace_rebind(


### PR DESCRIPTION
## Summary
- escape Slack OAuth preview HTML values before rendering them into the consent page
- build tenant-bound install links with URL encoding instead of raw string concatenation
- escape Slack workspace names in the callback success page and cover both paths with regressions

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'preview_escapes_tenant_bound_install_url or successful_callback_escapes_workspace_name or successful_callback or preview_with_tenant_id'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q