### PR TITLE
fix(ci): raise budgets for timing-out required checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -409,7 +409,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Zero Coverage Check
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     needs: baseline-determinism
 
     steps:
@@ -495,7 +495,7 @@ jobs:
   test-fast:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: baseline-determinism
     strategy:
       fail-fast: false
@@ -1499,7 +1499,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Frontend E2E Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     services:
       redis:
@@ -2099,7 +2099,7 @@ jobs:
   test-analytics:
     name: Test Analytics
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 12
     needs: [test-fast]
     if: (github.event_name != 'pull_request' || !github.event.pull_request.draft) && (always() && github.event_name == 'pull_request')
 


### PR DESCRIPTION
## Summary
- raise the `test-fast` matrix timeout from 15 to 20 minutes
- raise `Zero Coverage Check` and `Test Analytics` from 10 to 12 minutes
- raise `Frontend E2E Tests` from 30 to 35 minutes

## Why
Recent PRs are failing these required checks by timing out seconds after their current budget, without assertion failures in the job summaries. This gives the existing workloads enough headroom to finish while we decide whether deeper sharding or optimization is still needed.

## Validation
- python3 - <<'PY'
from pathlib import Path
import yaml
with Path('.github/workflows/test.yml').open() as f:
    yaml.safe_load(f)
print('yaml ok')
PY