### PR TITLE
test(ci): refresh shared test contracts on main

### DIFF
--- a/tests/server/handlers/test_openclaw_gateway_handler.py
+++ b/tests/server/handlers/test_openclaw_gateway_handler.py
@@ -537,6 +537,7 @@ class TestActionExecution:
         body = json.loads(result.body)
         assert body["status"] == "running"
         assert body["error"] is None
+        assert body["output_data"] is None
 
     def test_execute_action_missing_session_id_returns_400(self, handler, mock_user, store):
         """Test that missing session_id returns 400."""
@@ -2331,6 +2332,8 @@ class TestPolicyEndpoints:
         assert result.status_code == 200
         body = json.loads(result.body)
         assert body["success"] is True
+        assert body["status"] == "completed"
+        assert body["action_id"] == "action-001"
 
     def test_deny_action_returns_200(self, handler, mock_user, store):
         """Test denying an action returns success when runtime accepts it."""
@@ -2356,6 +2359,7 @@ class TestPolicyEndpoints:
         assert result.status_code == 200
         body = json.loads(result.body)
         assert body["success"] is True
+        assert body["action_id"] == "action-001"
 
     def test_approve_action_creates_audit_entry(self, handler, mock_user, store):
         """Test that approving an action creates an audit entry."""


### PR DESCRIPTION
Rebuilds the closed shared test-contract refresh branch on top of current `main`.

What changed:
- refreshes handler expectations for plans, webhooks, OpenClaw gateway, and ERC8004 queueing behavior
- updates the cross-debate memory config test to use the worktree-aware nomic directory
- aligns the remaining OpenClaw gateway assertions with the current runtime response shape

Local validation:
- `python3 -m pytest tests/handlers/openclaw/test_models.py tests/server/handlers/test_webhooks.py tests/server/handlers/test_plans.py tests/server/handlers/test_openclaw_gateway_handler.py tests/server/handlers/test_erc8004.py tests/memory/test_cross_debate_rlm.py::TestCrossDebateConfig::test_config_defaults -q`
- `python3 -m ruff check tests/server/handlers/test_openclaw_gateway_handler.py tests/server/handlers/test_webhooks.py tests/server/handlers/test_plans.py tests/server/handlers/test_erc8004.py tests/memory/test_cross_debate_rlm.py tests/handlers/openclaw/test_models.py`
- workflow YAML parse smoke check (`.github/workflows/test.yml`)

This replaces the earlier closed PR #1997.