### PR TITLE
Ignore nested session artifacts in worker launcher

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1026,7 +1026,7 @@ class WorkerLauncher:
             if len(line) < 4:
                 continue
             path = line[3:].strip()
-            if path and path not in SESSION_ARTIFACTS:
+            if path and Path(path).name not in SESSION_ARTIFACTS:
                 return True
         return False
 
@@ -1042,7 +1042,7 @@ class WorkerLauncher:
             if len(line) < 4:
                 continue
             path = line[3:].strip()
-            if path and path not in SESSION_ARTIFACTS:
+            if path and Path(path).name not in SESSION_ARTIFACTS:
                 return True
         return False
 
@@ -1403,6 +1403,24 @@ class WorkerLauncher:
         except (TypeError, ValueError):
             return None, None
         return exit_code, ended_at
+
+    @classmethod
+    async def _collect_staged_session_artifact_paths(cls, worktree_path: str) -> list[str]:
+        staged_output = await cls._git_output(worktree_path, "diff", "--cached", "--name-only")
+        return [
+            path
+            for raw_path in staged_output.splitlines()
+            if (path := raw_path.strip()) and Path(path).name in SESSION_ARTIFACTS
+        ]
+
+    @classmethod
+    def _collect_staged_session_artifact_paths_sync(cls, worktree_path: str) -> list[str]:
+        staged_output = cls._git_output_sync(worktree_path, "diff", "--cached", "--name-only")
+        return [
+            path
+            for raw_path in staged_output.splitlines()
+            if (path := raw_path.strip()) and Path(path).name in SESSION_ARTIFACTS
+        ]
 
     @staticmethod
     def _is_pid_running(pid: int) -> bool:
@@ -1872,14 +1890,17 @@ class WorkerLauncher:
                 )
                 return
 
-            # Unstage session artifacts — ignore errors if files are not staged
-            for artifact in SESSION_ARTIFACTS:
+            # Unstage staged session artifacts by basename so nested harness
+            # metadata cannot slip through as a deliverable.
+            for artifact_path in await WorkerLauncher._collect_staged_session_artifact_paths(
+                worker.worktree_path
+            ):
                 reset_proc = await asyncio.create_subprocess_exec(
                     "git",
                     "reset",
                     "HEAD",
                     "--",
-                    artifact,
+                    artifact_path,
                     cwd=worker.worktree_path,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
@@ -1978,9 +1999,11 @@ class WorkerLauncher:
                 )
                 return
 
-            for artifact in SESSION_ARTIFACTS:
+            for artifact_path in WorkerLauncher._collect_staged_session_artifact_paths_sync(
+                worker.worktree_path
+            ):
                 subprocess.run(
-                    ["git", "reset", "HEAD", "--", artifact],
+                    ["git", "reset", "HEAD", "--", artifact_path],
                     cwd=worker.worktree_path,
                     capture_output=True,
                     text=True,

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -380,7 +380,15 @@ class TestAutoCommitSessionArtifactPrevention:
             branch="main",
         )
 
-        asyncio.run(WorkerLauncher._auto_commit(worker))
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_authorize_worker_capability",
+                return_value=("approval-id", {}),
+            ),
+            patch.object(WorkerLauncher, "_auto_push", new=AsyncMock()),
+        ):
+            asyncio.run(WorkerLauncher._auto_commit(worker))
 
         # Check what was committed
         result = _run(repo, "git", "diff", "--name-only", "HEAD~1", "HEAD")
@@ -400,7 +408,15 @@ class TestAutoCommitSessionArtifactPrevention:
             branch="main",
         )
 
-        asyncio.run(WorkerLauncher._auto_commit(worker))
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_authorize_worker_capability",
+                return_value=("approval-id", {}),
+            ),
+            patch.object(WorkerLauncher, "_auto_push", new=AsyncMock()),
+        ):
+            asyncio.run(WorkerLauncher._auto_commit(worker))
 
         result = _run(repo, "git", "diff", "--name-only", "HEAD~1", "HEAD")
         committed_files = set(result.stdout.strip().splitlines())
@@ -419,10 +435,68 @@ class TestAutoCommitSessionArtifactPrevention:
             branch="main",
         )
 
-        asyncio.run(WorkerLauncher._auto_commit(worker))
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_authorize_worker_capability",
+                return_value=("approval-id", {}),
+            ),
+            patch.object(WorkerLauncher, "_auto_push", new=AsyncMock()),
+        ):
+            asyncio.run(WorkerLauncher._auto_commit(worker))
 
         # HEAD should not advance — no real changes to commit
         assert _head(repo) == initial_head
+
+    def test_auto_commit_excludes_nested_session_artifacts(self, repo: Path) -> None:
+        """Nested harness artifacts must not be auto-committed by basename."""
+        nested = repo / "subdir"
+        nested.mkdir()
+        (nested / ".codex_session_meta.json").write_text('{"pid": 3}', encoding="utf-8")
+        (repo / "real_work.py").write_text("print('hello')\n", encoding="utf-8")
+
+        worker = WorkerProcess(
+            work_order_id="nested-artifact-test",
+            agent="codex",
+            worktree_path=str(repo),
+            branch="main",
+        )
+
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_authorize_worker_capability",
+                return_value=("approval-id", {}),
+            ),
+            patch.object(WorkerLauncher, "_auto_push", new=AsyncMock()),
+        ):
+            asyncio.run(WorkerLauncher._auto_commit(worker))
+
+        result = _run(repo, "git", "diff", "--name-only", "HEAD~1", "HEAD")
+        committed_files = set(result.stdout.strip().splitlines())
+        assert "real_work.py" in committed_files
+        assert "subdir/.codex_session_meta.json" not in committed_files
+
+
+class TestWorkingTreeChangeFiltering:
+    """Test that dirty-tree detection ignores nested harness artifacts."""
+
+    @pytest.mark.asyncio
+    async def test_has_working_tree_changes_ignores_nested_session_artifacts(self) -> None:
+        async def _git_output(_worktree_path: str, *args: str) -> str:
+            assert args[:2] == ("status", "--porcelain")
+            return "?? subdir/.codex_session_meta.json\n?? logs/.swarm_worker_stdout.log\n"
+
+        with patch.object(WorkerLauncher, "_git_output", side_effect=_git_output):
+            assert not await WorkerLauncher._has_working_tree_changes("/tmp/wt")
+
+    def test_has_working_tree_changes_sync_ignores_nested_session_artifacts(self) -> None:
+        def _git_output_sync(_worktree_path: str, *args: str) -> str:
+            assert args[:2] == ("status", "--porcelain")
+            return "?? subdir/.codex_session_meta.json\n?? logs/.swarm_worker_stderr.log\n"
+
+        with patch.object(WorkerLauncher, "_git_output_sync", side_effect=_git_output_sync):
+            assert not WorkerLauncher._has_working_tree_changes_sync("/tmp/wt")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- ignore nested session artifacts when checking whether a worker worktree has real changes
- unstage staged session artifacts by basename-aware staged path lookup before auto-commit
- add regressions for nested artifact dirtiness and auto-commit behavior under the capability gate

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_session_artifact_prevention.py
- python -m pytest tests/swarm/test_session_artifact_prevention.py -q
- python -m pytest tests/swarm/test_worker_launcher.py -q