### PR TITLE
Fail closed on invalid Slack refresh responses

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1563,6 +1563,20 @@ class SlackOAuthHandler(SecureHandler):
             if not workspace.is_active:
                 return error_response("Workspace is inactive. Re-installation required.", 400)
 
+            client_id = _get_slack_client_id()
+            client_secret = _get_slack_client_secret()
+            if not client_id or not client_secret:
+                logger.error("Slack OAuth refresh not configured for workspace %s", workspace_id)
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Slack OAuth not configured",
+                    )
+                return error_response("Slack OAuth not configured", 503)
+
             # Attempt token refresh
             import httpx
 
@@ -1571,8 +1585,8 @@ class SlackOAuthHandler(SecureHandler):
                     response = await client.post(
                         SLACK_OAUTH_TOKEN_URL,
                         data={
-                            "client_id": _get_slack_client_id(),
-                            "client_secret": _get_slack_client_secret(),
+                            "client_id": client_id,
+                            "client_secret": client_secret,
                             "grant_type": "refresh_token",
                             "refresh_token": workspace.refresh_token,
                         },
@@ -1605,6 +1619,33 @@ class SlackOAuthHandler(SecureHandler):
                         error=error_msg,
                     )
                 return error_response(f"Token refresh failed: {error_msg}", 400)
+
+            response_workspace_id = ""
+            team = data.get("team")
+            if isinstance(team, dict):
+                response_workspace_id = str(team.get("id") or team.get("team_id") or "").strip()
+            if not response_workspace_id:
+                response_workspace_id = str(
+                    data.get("team_id") or data.get("workspace_id") or ""
+                ).strip()
+            expected_workspace_id = str(
+                getattr(workspace, "workspace_id", "") or workspace_id
+            ).strip()
+            if response_workspace_id and response_workspace_id != expected_workspace_id:
+                logger.error(
+                    "Token refresh workspace mismatch for %s: got %s",
+                    workspace_id,
+                    response_workspace_id,
+                )
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: workspace mismatch",
+                    )
+                return error_response("Invalid token refresh response", 502)
 
             # Update stored tokens
             new_access_token = data.get("access_token")

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -2369,6 +2369,73 @@ class TestRefreshToken:
         mock_workspace_store.save.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_refresh_requires_client_credentials(
+        self,
+        handler,
+        handler_module,
+        monkeypatch,
+        mock_workspace_store,
+    ):
+        mock_client, _ = _make_httpx_mock({"ok": True, "access_token": "xoxb-new"})
+        monkeypatch.setattr(handler_module, "SLACK_CLIENT_ID", "")
+        monkeypatch.setattr(handler_module, "SLACK_CLIENT_SECRET", "")
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 503
+        body = _body(result)
+        assert "not configured" in body.get("error", "").lower()
+        mock_client.post.assert_not_called()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_workspace_mismatch(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "refresh_token": "xoxr-new-refresh",
+                "team": {"id": "W999"},
+                "expires_in": 43200,
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_store_import_error_returns_503(self, handler):
         with patch.dict("sys.modules", {"aragora.storage.slack_workspace_store": None}):
             result = await handler.handle(


### PR DESCRIPTION
## Summary
- require Slack refresh client credentials before sending a refresh token upstream
- reject refresh responses that identify a different workspace than the one being refreshed
- add regressions for both fail-closed cases in the Slack OAuth suite

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q