### PR TITLE
Mark needs-human lanes as changes requested

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -4053,6 +4053,7 @@ class SwarmSupervisor:
         blocking_question: str | None = None,
     ) -> None:
         item["status"] = "needs_human"
+        item["review_status"] = "changes_requested"
         item["dispatch_error"] = reason
         normalized_reason = (
             str(failure_reason or cls._infer_failure_reason(item, reason)).strip() or "needs_human"

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4529,6 +4529,7 @@ async def test_collect_finished_results_marks_dead_dispatched_worker_needs_human
             {
                 "work_order_id": "wo-dead",
                 "status": "dispatched",
+                "review_status": "pending_heterogeneous_review",
                 "worktree_path": str(repo),
                 "branch": "main",
                 "target_agent": "codex",
@@ -4568,6 +4569,7 @@ async def test_collect_finished_results_marks_dead_dispatched_worker_needs_human
     assert updated is not None
     work_order = updated["work_orders"][0]
     assert work_order["status"] == "needs_human"
+    assert work_order["review_status"] == "changes_requested"
     assert "without receipt or exit marker" in work_order["dispatch_error"]
     assert work_order["failure_reason"] == "worker_exited_without_receipt"
     assert "existing worktree" in work_order["blocking_question"]
@@ -4832,6 +4834,7 @@ async def test_collect_finished_results_marks_no_progress_timeout_needs_human(
             {
                 "work_order_id": "wo-stalled",
                 "status": "dispatched",
+                "review_status": "pending_heterogeneous_review",
                 "worktree_path": str(repo),
                 "branch": "main",
                 "target_agent": "claude",
@@ -4871,6 +4874,7 @@ async def test_collect_finished_results_marks_no_progress_timeout_needs_human(
     assert updated is not None
     work_order = updated["work_orders"][0]
     assert work_order["status"] == "needs_human"
+    assert work_order["review_status"] == "changes_requested"
     assert "no-progress timeout" in work_order["dispatch_error"]
     assert work_order["failure_reason"] == "worker_no_progress_timeout"
     assert "stalled lane" in work_order["blocking_question"]


### PR DESCRIPTION
## Summary
- mark needs-human lanes as changes requested so blocked work does not still advertise a live review state
- add regressions for dead-worker and no-progress timeout paths carrying stale pending review state

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k "marks_dead_dispatched_worker_needs_human or marks_no_progress_timeout_needs_human"
- python -m pytest tests/swarm/test_supervisor.py -q