### PR TITLE
fix(supervisor): reseed dependent lanes from prerequisite refs

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1967,6 +1967,87 @@ class SwarmSupervisor:
                 return reference, dependency_id
         return None
 
+    def _reseed_dependent_session_branch(
+        self,
+        *,
+        session: Any,
+        work_order: dict[str, Any],
+        dependency_ref: str,
+        dependency_id: str,
+    ) -> bool:
+        session_path = str(session.path)
+        status_proc = self._run_git_capture_sync(session_path, "status", "--porcelain")
+        if status_proc.returncode != 0:
+            self._mark_needs_human(
+                work_order,
+                (
+                    "Dependent lane could not inspect its managed worktree before applying the "
+                    "prerequisite branch; reconcile the dependency chain before rerunning."
+                ),
+                failure_reason="dependency_base_conflict",
+                blocking_question=(
+                    "Which completed dependency branch or commit should this lane build on?"
+                ),
+            )
+            work_order["dispatch_error"] = (
+                status_proc.stderr.strip()
+                or status_proc.stdout.strip()
+                or "unable to inspect dependent lane worktree before applying dependency base"
+            )
+            work_order["dependency_base_ref"] = dependency_ref
+            work_order["dependency_base_source"] = dependency_id
+            return False
+        if status_proc.stdout.strip():
+            self._mark_needs_human(
+                work_order,
+                (
+                    "Dependent lane already has unmanaged worktree changes; reconcile the "
+                    "dependency chain before rerunning."
+                ),
+                failure_reason="dependency_base_conflict",
+                blocking_question=(
+                    "Which completed dependency branch or commit should this lane build on?"
+                ),
+            )
+            work_order["dispatch_error"] = (
+                "managed dependent lane worktree is dirty before applying dependency base"
+            )
+            work_order["dependency_base_ref"] = dependency_ref
+            work_order["dependency_base_source"] = dependency_id
+            return False
+
+        checkout_proc = self._run_git_capture_sync(
+            session_path,
+            "checkout",
+            "-B",
+            str(session.branch),
+            dependency_ref,
+        )
+        if checkout_proc.returncode != 0:
+            self._mark_needs_human(
+                work_order,
+                (
+                    "Dependent lane could not start from its prerequisite branch; "
+                    "reconcile the dependency chain before rerunning."
+                ),
+                failure_reason="dependency_base_conflict",
+                blocking_question=(
+                    "Which completed dependency branch or commit should this lane build on?"
+                ),
+            )
+            work_order["dispatch_error"] = (
+                checkout_proc.stderr.strip()
+                or checkout_proc.stdout.strip()
+                or f"unable to reseed dependent lane onto {dependency_ref}"
+            )
+            work_order["dependency_base_ref"] = dependency_ref
+            work_order["dependency_base_source"] = dependency_id
+            return False
+
+        work_order["dependency_base_ref"] = dependency_ref
+        work_order["dependency_base_source"] = dependency_id
+        return True
+
     @staticmethod
     def _looks_like_broad_explicit_pytest_umbrella(*, source: str, text: str) -> bool:
         if source.strip() != "explicit_spec_work_order":
@@ -2435,34 +2516,13 @@ class SwarmSupervisor:
         dependency_base = self._dependency_base_reference(work_order, work_orders)
         if dependency_base is not None:
             dependency_ref, dependency_id = dependency_base
-            merge_proc = self._run_git_capture_sync(
-                str(session.path),
-                "merge",
-                "--ff-only",
-                dependency_ref,
-            )
-            if merge_proc.returncode != 0:
-                self._mark_needs_human(
-                    work_order,
-                    (
-                        "Dependent lane could not start from its prerequisite branch; "
-                        "reconcile the dependency chain before rerunning."
-                    ),
-                    failure_reason="dependency_base_conflict",
-                    blocking_question=(
-                        "Which completed dependency branch or commit should this lane build on?"
-                    ),
-                )
-                work_order["dispatch_error"] = (
-                    merge_proc.stderr.strip()
-                    or merge_proc.stdout.strip()
-                    or f"unable to fast-forward dependent lane onto {dependency_ref}"
-                )
-                work_order["dependency_base_ref"] = dependency_ref
-                work_order["dependency_base_source"] = dependency_id
+            if not self._reseed_dependent_session_branch(
+                session=session,
+                work_order=work_order,
+                dependency_ref=dependency_ref,
+                dependency_id=dependency_id,
+            ):
                 return False
-            work_order["dependency_base_ref"] = dependency_ref
-            work_order["dependency_base_source"] = dependency_id
         else:
             work_order.pop("dependency_base_ref", None)
             work_order.pop("dependency_base_source", None)

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5123,6 +5123,14 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
     dependency_head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
     _run(repo, "git", "checkout", "main")
 
+    unrelated_branch = "codex/swarm-unrelated-base"
+    _run(repo, "git", "checkout", "-b", unrelated_branch)
+    (repo / "README.md").write_text("hello\nunrelated\n", encoding="utf-8")
+    _run(repo, "git", "add", "README.md")
+    _run(repo, "git", "commit", "-m", "unrelated commit")
+    unrelated_head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+    _run(repo, "git", "checkout", "main")
+
     session_path = repo / "wt-dependent-base"
     _run(
         repo,
@@ -5132,7 +5140,7 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
         "-b",
         "codex/swarm-dependent-base",
         str(session_path),
-        "main",
+        unrelated_branch,
     )
 
     lifecycle = MagicMock()
@@ -5189,6 +5197,11 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
     assert dependent["dependency_base_ref"] == dependency_branch
     assert dependent["dependency_base_source"] == "micro-task-1"
     assert _run(session_path, "git", "rev-parse", "HEAD").stdout.strip() == dependency_head
+    assert (
+        _run(session_path, "git", "rev-parse", "codex/swarm-dependent-base").stdout.strip()
+        == dependency_head
+    )
+    assert unrelated_head != dependency_head
 
 
 def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordinationStore) -> None:


### PR DESCRIPTION
## Summary
- reseed dependent supervisor session branches directly from the completed dependency ref instead of assuming an ff-only merge from a fresh branch head
- fail closed if the managed dependent worktree cannot be inspected or is already dirty before dependency application
- upgrade the supervisor regression to the live failure shape where the dependent branch starts from an unrelated head

## Testing
- python3 -m pytest -q tests/swarm/test_supervisor.py
- python3 -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python3 -m ruff format --check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py

## Live Note
- reran boss-loop issue #2007 from this branch
- micro-1 produced the expected scoped test-only commit (b41f789561490ed6bf5aabaae59eabba8d35ac25) in tests/cli/test_swarm_command.py
- micro-2 now dispatches with dependency_base_ref=codex/swarm-67f723e0-micro-1 and initial_head=b41f789561490ed6bf5aabaae59eabba8d35ac25
- both codex/swarm-67f723e0-micro-1 and codex/swarm-67f723e0-micro-2 resolve to the same dependency commit, which is the exact live handoff that previously failed with dependency_base_conflict
