### PR TITLE
Honor active session locks in progress snapshots

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -543,6 +543,8 @@ class WorkerLauncher:
             session_meta = self._read_session_meta(worktree_path)
             pid = self._normalized_pid(session_meta.get("pid"))
             snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
+        if self._active_session_lock_blocks_collection(worktree_path, pid):
+            snapshot["pid_alive"] = True
 
         head_sha = await self._git_output(worktree_path, "rev-parse", "HEAD")
         diff = await self._collect_diff(worktree_path)

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4880,6 +4880,57 @@ async def test_collect_finished_results_marks_no_progress_timeout_needs_human(
     assert "stalled lane" in work_order["blocking_question"]
 
 
+@pytest.mark.asyncio
+async def test_collect_finished_results_defers_with_active_lock_and_no_usable_pid(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    (repo / ".codex_session_active").write_text("1\n", encoding="utf-8")
+    run_record = store.create_supervisor_run(
+        goal="active lock without usable pid",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "active lock without usable pid"},
+        work_orders=[
+            {
+                "work_order_id": "wo-active-lock",
+                "status": "dispatched",
+                "review_status": "pending",
+                "worktree_path": str(repo),
+                "branch": "main",
+                "target_agent": "codex",
+                "pid": "oops",
+                "initial_head": "abc123",
+                "dispatched_at": "2026-03-06T00:00:00+00:00",
+                "last_progress_at": "2026-03-06T00:00:00+00:00",
+                "progress_fingerprint": {
+                    "head_sha": "abc123",
+                    "changed_paths": [],
+                    "diff_lines": 0,
+                },
+            }
+        ],
+        status="active",
+    )
+
+    launcher = WorkerLauncher()
+    launcher.collect_finished = AsyncMock(return_value=[])
+    launcher.config = SimpleNamespace(auto_commit=True, no_progress_timeout_seconds=120.0)
+
+    supervisor = SwarmSupervisor(repo_root=repo, store=store, launcher=launcher)
+
+    with patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": "oops"}):
+        completed = await supervisor.collect_finished_results(run_record["run_id"])
+
+    assert completed == []
+    updated = store.get_supervisor_run(run_record["run_id"])
+    assert updated is not None
+    work_order = updated["work_orders"][0]
+    assert work_order["status"] == "dispatched"
+    assert work_order["review_status"] == "pending"
+    assert "dispatch_error" not in work_order
+
+
 def test_session_key_unique_per_work_order() -> None:
     """Regression: subtask_1/subtask_2/subtask_3 must NOT collide into one worktree."""
     run_id = "abcdef12-3456"

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1434,6 +1434,30 @@ class TestSnapshotProgress:
         mock_running.assert_called_once_with(24680)
 
     @pytest.mark.asyncio
+    async def test_snapshot_progress_treats_active_lock_without_usable_pid_as_alive(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        work_order = {
+            "pid": "oops",
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": "oops"}),
+            patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is True
+        mock_running.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):
         launcher = WorkerLauncher()
         work_order = {


### PR DESCRIPTION
## Summary
- make worker progress snapshots honor active session locks even when no usable PID is available
- prevent supervisor refresh from misclassifying a live locked detached session as a dead worker
- add launcher and supervisor regressions for the active-lock/no-usable-pid path

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q