### PR TITLE
fix: sync reviewer routing when rebinding active leases

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -983,6 +983,21 @@ class SwarmSupervisor:
         )
         if getattr(lease, "owner_agent", None):
             item["target_agent"] = str(getattr(lease, "owner_agent")).strip()
+        target_agent = str(item.get("target_agent", "")).strip()
+        target_agent_normalized = target_agent.lower()
+        lease_metadata = getattr(lease, "metadata", {}) or {}
+        reviewer_agent = (
+            str(lease_metadata.get("reviewer_agent", "")).strip()
+            or str(lease_metadata.get("requested_reviewer_agent", "")).strip()
+            or str((item.get("metadata") or {}).get("requested_reviewer_agent", "")).strip()
+            or str(item.get("reviewer_agent", "")).strip()
+        )
+        if reviewer_agent.lower() == target_agent_normalized:
+            reviewer_agent = ""
+        if not reviewer_agent:
+            reviewer_agent = SwarmSupervisor._alternate_agent(target_agent) or ""
+        if reviewer_agent:
+            item["reviewer_agent"] = reviewer_agent
         expected_tests = [
             str(test).strip() for test in getattr(lease, "expected_tests", []) if str(test).strip()
         ]

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -1211,6 +1211,7 @@ def test_refresh_run_rebinds_stale_dispatched_lane_to_active_worker_without_stal
             "supervisor_run_id": "run-rebound-active-dispatched",
             "work_order_id": "wo-rebound-active-dispatched",
             "task_key": "run-rebound-active-dispatched:wo-rebound-active-dispatched",
+            "reviewer_agent": "codex",
             "worker_pid": 67890,
         },
     )
@@ -1283,6 +1284,7 @@ def test_refresh_run_rebinds_stale_dispatched_lane_to_active_worker_without_stal
     assert work_order["lease_id"] == replacement_lease.lease_id
     assert work_order["owner_session_id"] == "swarm-rebound-active-dispatched"
     assert work_order["target_agent"] == "claude"
+    assert work_order["reviewer_agent"] == "codex"
     assert work_order["pid"] == 67890
     assert "exit_code" not in work_order
     assert work_order["review_status"] == "pending"


### PR DESCRIPTION
## Summary
- make replacement active leases refresh reviewer routing alongside target-agent rebinding
- prefer reviewer metadata from the replacement lease when available
- fall back to alternate-agent routing so rebound lanes do not self-review

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k "rebinds_stale_dispatched_lane_to_active_worker_without_stale_terminal_state or rebinds_released_work_order_to_new_active_lease or rebinds_stale_dispatched_lane_back_to_leased_without_worker_pid"
- python -m pytest tests/swarm/test_supervisor.py -q