### PR TITLE
fix: preserve dead detached worker logs without exit marker

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1252,6 +1252,8 @@ class WorkerLauncher:
         if observed_pid is None:
             observed_pid = cls._normalized_pid(session_meta.get("pid"))
         missing_terminal_marker = session_exit_code is None
+        cleanup_artifacts = True
+        preserve_terminal_evidence = False
         if cls._active_session_lock_blocks_collection(worktree_path, observed_pid):
             return None
         elif (
@@ -1319,15 +1321,18 @@ class WorkerLauncher:
                     for item in worker.verification_results
                     if str(item.get("command", "")).strip()
                 ]
+            if missing_terminal_marker and not worker.commit_shas and not worker.changed_paths:
+                preserve_terminal_evidence = True
         finally:
-            # Wait for the worker process (including its shell EXIT trap) to
-            # fully terminate before removing artifacts.  Without this wait
-            # the codex_session.sh trap can recreate .codex_session_meta.json
-            # and append to .codex_session.log after Python-side cleanup (#902).
-            _cleanup_pid = observed_pid
-            if _cleanup_pid is not None:
-                await cls._wait_for_pid_exit(_cleanup_pid)
-            cls._cleanup_session_artifacts(worktree_path)
+            if cleanup_artifacts and not preserve_terminal_evidence:
+                # Wait for the worker process (including its shell EXIT trap) to
+                # fully terminate before removing artifacts.  Without this wait
+                # the codex_session.sh trap can recreate .codex_session_meta.json
+                # and append to .codex_session.log after Python-side cleanup (#902).
+                _cleanup_pid = observed_pid
+                if _cleanup_pid is not None:
+                    await cls._wait_for_pid_exit(_cleanup_pid)
+                cls._cleanup_session_artifacts(worktree_path)
 
         logger.info(
             "Collected detached worker %s: commits=%d changed_paths=%d",
@@ -1339,7 +1344,9 @@ class WorkerLauncher:
             # A dead detached PID with no terminal session marker should not be
             # reported as a clean success. Only surface it if there is concrete
             # work to salvage; otherwise let the supervisor classify it as
-            # "without receipt or exit marker".
+            # "without receipt or exit marker". Preserve the session artifacts
+            # in that case so the supervisor can still snapshot the worker's
+            # logs before deciding how to escalate the lane.
             if not worker.commit_shas and not worker.changed_paths:
                 return None
             worker.exit_code = 1

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1269,6 +1269,41 @@ class TestCollectDetachedResult:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_preserves_logs_when_dead_pid_has_no_terminal_marker_or_deliverable(
+        self, tmp_path: Path
+    ):
+        stdout_log = tmp_path / ".swarm_worker_stdout.log"
+        stderr_log = tmp_path / ".swarm_worker_stderr.log"
+        stdout_log.write_text("worker stdout\n", encoding="utf-8")
+        stderr_log.write_text("worker stderr\n", encoding="utf-8")
+
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-no-marker-logs",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=99999,
+                initial_head="def456",
+                auto_commit=False,
+            )
+
+        assert result is None
+        assert stdout_log.exists()
+        assert stderr_log.exists()
+        assert stdout_log.read_text(encoding="utf-8") == "worker stdout\n"
+        assert stderr_log.read_text(encoding="utf-8") == "worker stderr\n"
+
+    @pytest.mark.asyncio
     async def test_returns_none_if_active_lock_exists_without_usable_pid(self, tmp_path: Path):
         (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- keep detached session artifacts when a dead worker has no terminal marker and no salvageable deliverable
- let the supervisor snapshot stdout/stderr evidence before escalating the lane
- add a regression proving the no-marker path preserves worker logs

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k "no_terminal_marker_or_deliverable or active_lock or meta_pid_running"
- python -m pytest tests/swarm/test_worker_launcher.py -q