### PR TITLE
fix(supervisor): ignore stale-reaped duplicate blockers

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1931,6 +1931,82 @@ class SwarmSupervisor:
         return False
 
     @staticmethod
+    def _duplicate_candidate_has_stale_reaped_dependency(
+        work_order: dict[str, Any],
+        run_work_orders: list[dict[str, Any]],
+    ) -> bool:
+        dependency_ids = {
+            str(dep).strip() for dep in work_order.get("dependency_ids", []) if str(dep).strip()
+        }
+        if not dependency_ids:
+            return False
+
+        stale_failure_reasons = {"stale_lease_reaped", "expired_lease_reaped"}
+        dependency_lookup: dict[str, dict[str, Any]] = {}
+        for candidate in run_work_orders:
+            if not isinstance(candidate, dict):
+                continue
+            for key in ("pipeline_task_id", "work_order_id", "task_key"):
+                candidate_id = str(candidate.get(key, "")).strip()
+                if candidate_id:
+                    dependency_lookup[candidate_id] = candidate
+
+        for dependency_id in dependency_ids:
+            dependency = dependency_lookup.get(dependency_id)
+            if not isinstance(dependency, dict):
+                continue
+            if str(dependency.get("status", "")).strip().lower() != "needs_human":
+                continue
+            failure_reason = str(dependency.get("failure_reason", "")).strip().lower()
+            if failure_reason in stale_failure_reasons:
+                return True
+        return False
+
+    def _duplicate_candidate_should_block(
+        self,
+        task: Any,
+        *,
+        run_cache: dict[str, dict[str, Any] | None],
+    ) -> bool:
+        stale_failure_reasons = {"stale_lease_reaped", "expired_lease_reaped"}
+        metadata = getattr(task, "metadata", {}) or {}
+        status = str(getattr(task, "status", "")).strip().lower()
+        failure_reason = str(metadata.get("failure_reason") or "").strip().lower()
+        if status == "needs_human" and failure_reason in stale_failure_reasons:
+            return False
+        if status != "queued":
+            return True
+
+        run_id = str(getattr(task, "run_id", "")).strip()
+        task_id = str(getattr(task, "task_id", "")).strip()
+        if not run_id or not task_id:
+            return True
+
+        record = run_cache.get(run_id)
+        if record is None:
+            record = self.store.get_supervisor_run(run_id)
+            run_cache[run_id] = record
+        if not isinstance(record, dict):
+            return True
+
+        work_order = next(
+            (
+                item
+                for item in record.get("work_orders", [])
+                if isinstance(item, dict) and str(item.get("work_order_id", "")).strip() == task_id
+            ),
+            None,
+        )
+        if not isinstance(work_order, dict):
+            return True
+        if self._duplicate_candidate_has_stale_reaped_dependency(
+            work_order,
+            [item for item in record.get("work_orders", []) if isinstance(item, dict)],
+        ):
+            return False
+        return True
+
+    @staticmethod
     def _dependency_base_reference(
         item: dict[str, Any],
         work_orders: list[dict[str, Any]],
@@ -2097,10 +2173,13 @@ class SwarmSupervisor:
         goal_key = self._normalized_goal_signature(goal)
         existing_by_group: dict[tuple[str, str, tuple[str, ...]], dict[str, Any]] = {}
         existing_overlap_candidates: list[dict[str, Any]] = []
+        run_cache: dict[str, dict[str, Any] | None] = {}
         for task in self.store.list_developer_tasks(open_only=True, limit=1000):
             if str(getattr(task, "status", "")).strip().lower() not in active_duplicate_statuses:
                 continue
             if self._task_has_concrete_deliverable(task):
+                continue
+            if not self._duplicate_candidate_should_block(task, run_cache=run_cache):
                 continue
             task_goal = self._normalized_goal_signature(str(getattr(task, "goal", "") or ""))
             task_metadata = getattr(task, "metadata", {}) or {}

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -563,6 +563,99 @@ def test_start_run_preserves_dependent_validation_work_order_in_same_batch(
     )
 
 
+def test_start_run_preserves_rerun_when_existing_duplicate_chain_was_stale_reaped(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    goal = "[Issue #2007] Add gemini-cli runner probe parser coverage to swarm CLI tests"
+    store.create_supervisor_run(
+        goal=goal,
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        status="needs_human",
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "Write tests for parser.py",
+                "status": "needs_human",
+                "failure_reason": "stale_lease_reaped",
+                "blocking_question": "Should this stale lane be requeued, recovered, or discarded?",
+                "blocker": {
+                    "reason": "stale_lease_reaped",
+                    "question": "Should this stale lane be requeued, recovered, or discarded?",
+                },
+                "file_scope": ["tests/cli/test_swarm_command.py"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {"source": "explicit_spec_work_order"},
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Run validation and fix failures",
+                "status": "queued",
+                "dependency_ids": ["micro-task-1"],
+                "file_scope": [
+                    "tests/cli/test_swarm_command.py",
+                    "aragora/cli/parser.py",
+                ],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {"source": "explicit_spec_work_order"},
+            },
+        ],
+    )
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal=goal,
+            refined_goal=goal,
+            work_orders=[
+                {
+                    "work_order_id": "micro-1",
+                    "pipeline_task_id": "micro-task-1",
+                    "title": "Write tests for parser.py",
+                    "description": "Write tests only for gemini-cli runner probe parsing.",
+                    "file_scope": ["tests/cli/test_swarm_command.py"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {"source": "explicit_spec_work_order"},
+                },
+                {
+                    "work_order_id": "micro-2",
+                    "pipeline_task_id": "micro-task-2",
+                    "title": "Run validation and fix failures",
+                    "description": "Run the acceptance tests and fix any failures.",
+                    "file_scope": [
+                        "tests/cli/test_swarm_command.py",
+                        "aragora/cli/parser.py",
+                    ],
+                    "dependency_ids": ["micro-task-1"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {"source": "explicit_spec_work_order"},
+                },
+            ],
+        ),
+        refresh_scaling=False,
+    )
+
+    assert [item["status"] for item in run.work_orders] == ["queued", "queued"]
+    for work_order in run.work_orders:
+        assert work_order.get("metadata", {}).get("archived_due_to") != "duplicate_open_work_order"
+
+
 def test_start_run_discards_duplicate_scope_less_explicit_lane_by_tranche_lane_id(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- ignore stale-reaped and expired stale dependency chains when duplicate-open-work-order suppression scans existing supervisor lanes
- add a supervisor regression for the live issue-#2007 rerun shape

## Testing
- python3 -m pytest -q tests/swarm/test_supervisor.py
- python3 -m pytest -q tests/swarm/test_supervisor.py -k "stale_reaped or duplicate_open_work_order or preserves_dependent_validation"
- python3 -m ruff check tests/swarm/test_supervisor.py
- python3 -m ruff format --check tests/swarm/test_supervisor.py