### PR TITLE
fix: anchor slack workspace route matching

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -231,8 +231,8 @@ class SlackOAuthHandler(SecureHandler):
 
     # Route patterns for dynamic paths
     ROUTE_PATTERNS = [
-        r"/api/integrations/slack/workspaces/([^/]+)/status",
-        r"/api/integrations/slack/workspaces/([^/]+)/refresh",
+        r"^/api/integrations/slack/workspaces/([^/]+)/status$",
+        r"^/api/integrations/slack/workspaces/([^/]+)/refresh$",
     ]
 
     def can_handle(self, path: str, method: str = "GET") -> bool:

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -238,6 +238,12 @@ class TestCanHandle:
     def test_workspace_refresh_path(self, handler):
         assert handler.can_handle("/api/integrations/slack/workspaces/W123/refresh")
 
+    def test_rejects_workspace_status_suffix(self, handler):
+        assert not handler.can_handle("/api/integrations/slack/workspaces/W123/status/extra")
+
+    def test_rejects_workspace_refresh_suffix(self, handler):
+        assert not handler.can_handle("/api/integrations/slack/workspaces/W123/refresh/extra")
+
     def test_rejects_unrelated_path(self, handler):
         assert not handler.can_handle("/api/v1/debates")
 
@@ -2673,6 +2679,30 @@ class TestNotFound:
         result = await handler.handle(
             "GET",
             "/api/integrations/slack/settings",
+            {},
+            {},
+            {},
+            None,
+        )
+        assert _status(result) == 404
+
+    @pytest.mark.asyncio
+    async def test_workspace_status_suffix_returns_404(self, handler):
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/workspaces/W123/status/extra",
+            {},
+            {},
+            {},
+            None,
+        )
+        assert _status(result) == 404
+
+    @pytest.mark.asyncio
+    async def test_workspace_refresh_suffix_returns_404(self, handler):
+        result = await handler.handle(
+            "POST",
+            "/api/integrations/slack/workspaces/W123/refresh/extra",
             {},
             {},
             {},


### PR DESCRIPTION
## Summary
- anchor dynamic Slack workspace status and refresh route patterns
- reject suffix paths that previously matched the workspace handlers
- add regressions for both can_handle() and handler dispatch on suffix paths

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k "workspace_status_suffix or workspace_refresh_suffix or rejects_workspace_status_suffix or rejects_workspace_refresh_suffix"
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q