### PR TITLE
fix: validate webhook cache against durable revision

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -625,6 +625,18 @@ class SQLiteWebhookConfigStore(WebhookConfigStoreBackend):
             return WebhookConfig.from_row(row)
         return None
 
+    def get_cache_revision(self, webhook_id: str) -> float | None:
+        """Return the durable row revision used to validate Redis cache hits."""
+        conn = self._get_conn()
+        cursor = conn.execute(
+            "SELECT updated_at FROM webhook_configs WHERE id = ?",
+            (webhook_id,),
+        )
+        row = cursor.fetchone()
+        if row:
+            return float(row[0])
+        return None
+
     def list(
         self,
         user_id: str | None = None,
@@ -721,21 +733,24 @@ class SQLiteWebhookConfigStore(WebhookConfigStoreBackend):
         success: bool = True,
     ) -> None:
         conn = self._get_conn()
+        now = time.time()
         if success:
             conn.execute(
                 """UPDATE webhook_configs SET
                    last_delivery_at = ?, last_delivery_status = ?,
-                   delivery_count = delivery_count + 1
+                   delivery_count = delivery_count + 1,
+                   updated_at = ?
                    WHERE id = ?""",
-                (time.time(), status_code, webhook_id),
+                (now, status_code, now, webhook_id),
             )
         else:
             conn.execute(
                 """UPDATE webhook_configs SET
                    last_delivery_at = ?, last_delivery_status = ?,
-                   delivery_count = delivery_count + 1, failure_count = failure_count + 1
+                   delivery_count = delivery_count + 1, failure_count = failure_count + 1,
+                   updated_at = ?
                    WHERE id = ?""",
-                (time.time(), status_code, webhook_id),
+                (now, status_code, now, webhook_id),
             )
         conn.commit()
 
@@ -865,7 +880,13 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
             try:
                 data = redis.get(self._redis_key(webhook_id))
                 if data:
-                    return self._deserialize_from_cache(data)
+                    cached_webhook = self._deserialize_from_cache(data)
+                    durable_revision = self._sqlite.get_cache_revision(webhook_id)
+                    if (
+                        durable_revision is not None
+                        and cached_webhook.updated_at == durable_revision
+                    ):
+                        return cached_webhook
             except (
                 _RedisError,
                 ConnectionError,

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1088,6 +1088,18 @@ class TestSQLiteWebhookConfigStore:
         assert updated.delivery_count == 1
         assert updated.failure_count == 0
 
+    def test_record_delivery_updates_revision(self, sqlite_store):
+        """Delivery metadata updates must advance the durable cache revision."""
+        webhook = sqlite_store.register(url="https://a.com", events=["debate_end"])
+        revised_at = webhook.updated_at + 10
+
+        with patch("aragora.storage.webhook_config_store.time.time", return_value=revised_at):
+            sqlite_store.record_delivery(webhook.id, 200, success=True)
+
+        updated = sqlite_store.get(webhook.id)
+        assert updated.updated_at == revised_at
+        assert sqlite_store.get_cache_revision(webhook.id) == revised_at
+
     def test_record_delivery_failure(self, sqlite_store):
         """Test recording failed delivery."""
         webhook = sqlite_store.register(url="https://a.com", events=["debate_end"])
@@ -1309,6 +1321,51 @@ class TestRedisWebhookConfigStore:
         assert retrieved is not None
         assert retrieved.secret == webhook.secret
         mock_decrypt.assert_called_once_with("ENCRYPTED-SECRET")
+        store.close()
+
+    def test_with_mocked_redis_get_cache_hit_bypasses_deleted_sqlite_row(self, tmp_path):
+        """A stale Redis hit must not resurrect a webhook deleted by another instance."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store._sqlite.register(url="https://example.com", events=["debate_end"])
+        mock_redis.get.return_value = webhook.to_json()
+        assert store._sqlite.delete(webhook.id) is True
+
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is None
+        mock_redis.get.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        mock_redis.delete.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        store.close()
+
+    def test_with_mocked_redis_get_cache_hit_refreshes_stale_delivery_state(self, tmp_path):
+        """A stale Redis hit must refresh from SQLite when delivery metadata changed elsewhere."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store._sqlite.register(url="https://example.com", events=["debate_end"])
+        mock_redis.get.return_value = webhook.to_json()
+        store._sqlite.record_delivery(webhook.id, 500, success=False)
+
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is not None
+        assert retrieved.last_delivery_status == 500
+        assert retrieved.delivery_count == 1
+        assert retrieved.failure_count == 1
+        mock_redis.get.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        mock_redis.setex.assert_called_once()
         store.close()
 
     def test_with_mocked_redis_get_cache_miss(self, tmp_path):


### PR DESCRIPTION
## Summary
- validate Redis webhook cache hits against SQLite durable revision before trusting cached payloads
- advance SQLite webhook  when delivery metadata changes so stale delivery state is detectable
- add regressions for stale cached delete and stale cached delivery metadata after out-of-band SQLite changes

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'record_delivery_updates_revision or redis_get_cache_hit_bypasses_deleted_sqlite_row or redis_get_cache_hit_refreshes_stale_delivery_state'
- python -m pytest tests/storage/test_webhook_config_store.py -q