### PR TITLE
fix: honor live session pid during worker collection

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -507,9 +507,11 @@ class WorkerLauncher:
                 session_meta = self._read_session_meta(worker.worktree_path)
                 session_exit_code, _ = self._terminal_session_result(session_meta)
                 if proc is not None and proc.returncode is None:
-                    observed_pid = self._normalized_pid(worker.pid)
-                    if observed_pid is None:
-                        observed_pid = self._normalized_pid(session_meta.get("pid"))
+                    observed_pid = self._pid_for_active_lock(
+                        worker.worktree_path,
+                        worker.pid,
+                        session_meta,
+                    )
                     if self._active_session_lock_blocks_collection(
                         worker.worktree_path, observed_pid
                     ):
@@ -539,11 +541,12 @@ class WorkerLauncher:
         }
         if not worktree_path:
             return snapshot
+        session_meta = self._read_session_meta(worktree_path)
         if pid is None:
-            session_meta = self._read_session_meta(worktree_path)
             pid = self._normalized_pid(session_meta.get("pid"))
             snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
-        if self._active_session_lock_blocks_collection(worktree_path, pid):
+        lock_pid = self._pid_for_active_lock(worktree_path, pid, session_meta)
+        if self._active_session_lock_blocks_collection(worktree_path, lock_pid):
             snapshot["pid_alive"] = True
 
         head_sha = await self._git_output(worktree_path, "rev-parse", "HEAD")
@@ -1249,12 +1252,13 @@ class WorkerLauncher:
         session_meta = cls._read_session_meta(worktree_path)
         session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
         observed_pid = cls._normalized_pid(pid)
+        lock_pid = cls._pid_for_active_lock(worktree_path, observed_pid, session_meta)
         if observed_pid is None:
             observed_pid = cls._normalized_pid(session_meta.get("pid"))
         missing_terminal_marker = session_exit_code is None
         cleanup_artifacts = True
         preserve_terminal_evidence = False
-        if cls._active_session_lock_blocks_collection(worktree_path, observed_pid):
+        if cls._active_session_lock_blocks_collection(worktree_path, lock_pid):
             return None
         elif (
             missing_terminal_marker
@@ -1380,6 +1384,28 @@ class WorkerLauncher:
         if pid is None:
             return True
         return cls._is_pid_running(pid)
+
+    @classmethod
+    def _pid_for_active_lock(
+        cls,
+        worktree_path: str,
+        pid: int | None,
+        session_meta: dict[str, Any],
+    ) -> int | None:
+        """Prefer a live session-meta PID when the active-session lock still exists."""
+        active_lock = Path(worktree_path) / ".codex_session_active"
+        if not active_lock.exists():
+            return pid
+        meta_pid = cls._normalized_pid(session_meta.get("pid"))
+        if pid is None:
+            return meta_pid
+        if meta_pid is None or meta_pid == pid:
+            return pid
+        if cls._is_pid_running(pid):
+            return pid
+        if cls._is_pid_running(meta_pid):
+            return meta_pid
+        return pid
 
     @staticmethod
     def _cleanup_session_artifacts(worktree_path: str) -> None:

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1165,6 +1165,48 @@ class TestCollectFinishedSync:
         mock_diff.assert_not_called()
         assert "wo-sync-active-lock" in launcher._processes
 
+    def test_collect_finished_sync_prefers_live_session_meta_pid_when_worker_pid_is_stale(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        worker = WorkerProcess(
+            work_order_id="wo-sync-stale-worker-pid",
+            agent="codex",
+            worktree_path=str(tmp_path),
+            branch="main",
+            pid=11111,
+            initial_head="def456",
+        )
+        launcher._workers["wo-sync-stale-worker-pid"] = worker
+        proc = MagicMock()
+        proc.returncode = None
+        launcher._processes["wo-sync-stale-worker-pid"] = proc
+
+        session_meta = {
+            "pid": 24680,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 24680
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff_sync") as mock_diff,
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=["wo-sync-stale-worker-pid"])
+
+        assert completed == []
+        assert any(call.args == (11111,) for call in mock_running.call_args_list)
+        assert any(call.args == (24680,) for call in mock_running.call_args_list)
+        mock_diff.assert_not_called()
+        assert "wo-sync-stale-worker-pid" in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio
@@ -1387,6 +1429,43 @@ class TestCollectDetachedResult:
         mock_diff.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_returns_none_if_active_lock_exists_with_stale_pid_but_live_session_meta_pid(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 24680
+
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_read_session_meta",
+                return_value={
+                    "pid": 24680,
+                    "ended_at": "2026-04-02T01:23:45+00:00",
+                    "exit_code": 0,
+                },
+            ),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff") as mock_diff,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-stale-pid",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=11111,
+            )
+
+        assert result is None
+        assert any(call.args == (11111,) for call in mock_running.call_args_list)
+        assert any(call.args == (24680,) for call in mock_running.call_args_list)
+        mock_diff.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_uses_session_meta_pid_to_defer_when_marker_missing(self):
         with (
             patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),
@@ -1491,6 +1570,36 @@ class TestSnapshotProgress:
 
         assert snapshot["pid_alive"] is True
         mock_running.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_prefers_live_session_meta_pid_when_worker_pid_is_stale(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        work_order = {
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 24680
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is True
+        assert any(call.args == (11111,) for call in mock_running.call_args_list)
+        assert any(call.args == (24680,) for call in mock_running.call_args_list)
 
     @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- prefer a live session-meta PID over a stale work-order PID when the active-session lock still exists
- apply that lock gating consistently in detached collection, sync collection, and progress snapshots
- add regressions for stale worker PID vs live session-meta PID across all three paths

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'stale_pid_but_live_session_meta_pid or prefers_live_session_meta_pid_when_worker_pid_is_stale'
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q -k 'active_lock or without_receipt or no_progress_timeout or dead_dispatched_worker'
