### PR TITLE
fix(receipts): restore FastAPI receipt parity routes

### DIFF
--- a/aragora/server/auth_requirements.py
+++ b/aragora/server/auth_requirements.py
@@ -237,6 +237,13 @@ PERMISSION_ENDPOINTS = [
         description="Create receipt share link",
     ),
     EndpointAuth(
+        "/api/v2/receipts/{receipt_id}/send-to-channel",
+        "post",
+        AuthLevel.PERMISSION,
+        permission="receipts:share",
+        description="Send receipt to an external channel",
+    ),
+    EndpointAuth(
         "/api/plugins",
         "post",
         AuthLevel.PERMISSION,

--- a/aragora/server/fastapi/routes/receipts.py
+++ b/aragora/server/fastapi/routes/receipts.py
@@ -240,6 +240,46 @@ class SharedReceiptResponse(BaseModel):
     access_count: int
 
 
+class SignatureVerifyResponse(BaseModel):
+    """Response for receipt signature verification."""
+
+    receipt_id: str
+    signature_valid: bool
+    algorithm: str | None = None
+    key_id: str | None = None
+    signed_at: float | None = None
+    verification_timestamp: str
+    error: str | None = None
+
+
+class FormattedReceiptResponse(BaseModel):
+    """Response for receipt channel formatting."""
+
+    receipt_id: str
+    channel_type: str
+    formatted: dict[str, Any]
+
+
+class SendToChannelRequest(BaseModel):
+    """Request body for POST /receipts/{receipt_id}/send-to-channel."""
+
+    channel_type: str = Field(..., min_length=1)
+    channel_id: str = Field(..., min_length=1)
+    workspace_id: str | None = None
+    options: dict[str, Any] = Field(default_factory=dict)
+
+
+class SendToChannelResponse(BaseModel):
+    """Response for receipt delivery requests."""
+
+    sent: bool
+    receipt_id: str
+    channel_type: str
+    channel_id: str
+
+    model_config = {"extra": "allow"}
+
+
 # =============================================================================
 # Dependencies
 # =============================================================================
@@ -325,6 +365,16 @@ async def _consume_share_access(share_store: Any, token: str) -> tuple[str, dict
     updated_share_info = dict(share_info)
     updated_share_info["access_count"] = access_count + 1
     return "ok", updated_share_info
+
+
+def _build_decision_receipt(receipt: Any) -> Any:
+    """Reconstruct a DecisionReceipt from stored receipt payloads."""
+    from aragora.export.decision_receipt import DecisionReceipt
+
+    payload = _extract_decision_receipt_payload(receipt)
+    if not payload:
+        raise ValueError("Cannot reconstruct receipt payload")
+    return DecisionReceipt.from_dict(payload)
 
 
 # =============================================================================
@@ -969,6 +1019,162 @@ async def share_receipt(
     except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
         logger.exception("Error sharing receipt %s: %s", receipt_id, e)
         raise HTTPException(status_code=500, detail="Failed to share receipt")
+
+
+@router.get(
+    "/receipts/{receipt_id}/formatted/{channel_type}",
+    response_model=FormattedReceiptResponse,
+)
+async def get_formatted_receipt(
+    receipt_id: str,
+    channel_type: str,
+    compact: bool = Query(False, description="Return a compact formatter payload"),
+    store=Depends(get_receipt_store),
+) -> FormattedReceiptResponse:
+    """Return the receipt payload formatted for a specific channel."""
+    try:
+        receipt_data = None
+        if hasattr(store, "get"):
+            receipt_data = await _call_store_method(store, "get", receipt_id)
+        elif hasattr(store, "get_by_id"):
+            receipt_data = await _call_store_method(store, "get_by_id", receipt_id)
+
+        if not receipt_data:
+            raise NotFoundError(f"Receipt {receipt_id} not found")
+
+        from aragora.channels.formatter import format_receipt_for_channel
+
+        formatted = format_receipt_for_channel(
+            _build_decision_receipt(receipt_data),
+            channel_type,
+            {"compact": compact},
+        )
+        return FormattedReceiptResponse(
+            receipt_id=receipt_id,
+            channel_type=channel_type,
+            formatted=formatted,
+        )
+    except NotFoundError:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except (ImportError, RuntimeError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error formatting receipt %s for %s: %s", receipt_id, channel_type, e)
+        raise HTTPException(status_code=500, detail="Failed to format receipt")
+
+
+@router.post(
+    "/receipts/{receipt_id}/send-to-channel",
+    response_model=SendToChannelResponse,
+    openapi_extra={"security": [{"bearerAuth": []}]},
+)
+async def send_receipt_to_channel(
+    receipt_id: str,
+    body: SendToChannelRequest,
+    request: Request,
+    _auth: Any = Depends(require_permission("receipts:share")),
+    store=Depends(get_receipt_store),
+) -> SendToChannelResponse:
+    """Send a receipt to a configured channel using the legacy delivery adapters."""
+    try:
+        receipt_data = None
+        if hasattr(store, "get"):
+            receipt_data = await _call_store_method(store, "get", receipt_id)
+        elif hasattr(store, "get_by_id"):
+            receipt_data = await _call_store_method(store, "get_by_id", receipt_id)
+
+        if not receipt_data:
+            raise NotFoundError(f"Receipt {receipt_id} not found")
+
+        from aragora.channels.formatter import format_receipt_for_channel
+        from aragora.server.handlers.receipts import ReceiptsHandler
+
+        supported_channels = {"slack", "teams", "email", "discord"}
+        if body.channel_type not in supported_channels:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Unsupported channel type: {body.channel_type}. "
+                    "Supported: slack, teams, email, discord"
+                ),
+            )
+
+        formatted = format_receipt_for_channel(
+            _build_decision_receipt(receipt_data),
+            body.channel_type,
+            body.options,
+        )
+
+        handler = ReceiptsHandler(getattr(request.app.state, "context", {}) or {})
+        if body.channel_type == "slack":
+            result = await handler._send_to_slack(formatted, body.channel_id, body.workspace_id)
+        elif body.channel_type == "teams":
+            result = await handler._send_to_teams(formatted, body.channel_id, body.workspace_id)
+        elif body.channel_type == "email":
+            result = await handler._send_to_email(formatted, body.channel_id, body.options)
+        else:
+            result = await handler._send_to_discord(formatted, body.channel_id, body.options)
+
+        handler._record_delivery_history(
+            receipt_id=receipt_id,
+            channel_type=body.channel_type,
+            channel_id=body.channel_id,
+            workspace_id=body.workspace_id,
+            status="success",
+            result=result,
+        )
+        return SendToChannelResponse(
+            sent=True,
+            receipt_id=receipt_id,
+            channel_type=body.channel_type,
+            channel_id=body.channel_id,
+            **result,
+        )
+    except HTTPException:
+        raise
+    except NotFoundError:
+        raise
+    except ImportError as e:
+        logger.exception("Missing dependency for receipt delivery to %s: %s", body.channel_type, e)
+        raise HTTPException(status_code=501, detail=f"Delivery backend unavailable: {e}") from e
+    except (ConnectionError, TimeoutError, ValueError, OSError) as e:
+        logger.exception("Failed to send receipt %s to %s: %s", receipt_id, body.channel_type, e)
+        raise HTTPException(status_code=500, detail=f"Failed to send receipt: {e}") from e
+
+
+@router.post("/receipts/{receipt_id}/verify-signature", response_model=SignatureVerifyResponse)
+async def verify_receipt_signature(
+    receipt_id: str,
+    store=Depends(get_receipt_store),
+) -> SignatureVerifyResponse:
+    """Verify a stored receipt's cryptographic signature."""
+    try:
+        if not hasattr(store, "verify_signature"):
+            raise HTTPException(
+                status_code=501, detail="Receipt signature verification unavailable"
+            )
+
+        result = await _call_store_method(store, "verify_signature", receipt_id)
+        if hasattr(result, "to_dict"):
+            payload = result.to_dict()
+            error = getattr(result, "error", None)
+        elif isinstance(result, dict):
+            payload = result
+            error = result.get("error")
+        else:
+            raise TypeError("Unexpected signature verification result")
+
+        if isinstance(error, str) and "not found" in error.lower():
+            raise NotFoundError(f"Receipt {receipt_id} not found")
+
+        return SignatureVerifyResponse(**payload)
+    except HTTPException:
+        raise
+    except NotFoundError:
+        raise
+    except (RuntimeError, ValueError, TypeError, OSError, KeyError, AttributeError) as e:
+        logger.exception("Error verifying receipt signature %s: %s", receipt_id, e)
+        raise HTTPException(status_code=500, detail="Failed to verify receipt signature")
 
 
 @router.post("/receipts/{receipt_id}/verify", response_model=VerifyResponse)

--- a/aragora/server/handlers/receipts.py
+++ b/aragora/server/handlers/receipts.py
@@ -1138,7 +1138,7 @@ class ReceiptsHandler(BaseHandler):
         if len(history) > 1000:
             del history[:-1000]
 
-    @require_permission("receipts:send")
+    @require_permission("receipts:share")
     async def _send_to_channel(self, receipt_id: str, body: dict[str, Any]) -> HandlerResult:
         """
         Send a decision receipt to a specified channel.

--- a/tests/sdk/test_receipts_ns.py
+++ b/tests/sdk/test_receipts_ns.py
@@ -1,0 +1,112 @@
+"""Tests for the Receipts SDK namespace."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aragora_sdk.namespaces.receipts import AsyncReceiptsAPI, ReceiptsAPI
+
+
+@pytest.fixture
+def sync_client():
+    client = MagicMock()
+    client.request.return_value = {"ok": True}
+    return client
+
+
+@pytest.fixture
+def async_client():
+    client = MagicMock()
+    client.request = AsyncMock(return_value={"ok": True})
+    return client
+
+
+class TestReceiptsAPI:
+    def test_formatted_uses_v2_route(self, sync_client):
+        api = ReceiptsAPI(sync_client)
+
+        api.formatted("rcpt-123", "slack", compact=True)
+
+        sync_client.request.assert_called_once_with(
+            "GET",
+            "/api/v2/receipts/rcpt-123/formatted/slack",
+            params={"compact": "true"},
+        )
+
+    def test_send_to_channel_uses_v2_route(self, sync_client):
+        api = ReceiptsAPI(sync_client)
+
+        api.send_to_channel(
+            "rcpt-123",
+            "email",
+            "user@example.com",
+            options={"compact": True},
+        )
+
+        sync_client.request.assert_called_once_with(
+            "POST",
+            "/api/v2/receipts/rcpt-123/send-to-channel",
+            json={
+                "channel_type": "email",
+                "channel_id": "user@example.com",
+                "options": {"compact": True},
+            },
+        )
+
+    def test_verify_signature_uses_v2_route(self, sync_client):
+        api = ReceiptsAPI(sync_client)
+
+        api.verify_signature("rcpt-123")
+
+        sync_client.request.assert_called_once_with(
+            "POST",
+            "/api/v2/receipts/rcpt-123/verify-signature",
+        )
+
+
+class TestAsyncReceiptsAPI:
+    @pytest.mark.asyncio
+    async def test_formatted_uses_v2_route(self, async_client):
+        api = AsyncReceiptsAPI(async_client)
+
+        await api.formatted("rcpt-123", "slack", compact=True)
+
+        async_client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v2/receipts/rcpt-123/formatted/slack",
+            params={"compact": "true"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_to_channel_uses_v2_route(self, async_client):
+        api = AsyncReceiptsAPI(async_client)
+
+        await api.send_to_channel(
+            "rcpt-123",
+            "email",
+            "user@example.com",
+            options={"compact": True},
+        )
+
+        async_client.request.assert_awaited_once_with(
+            "POST",
+            "/api/v2/receipts/rcpt-123/send-to-channel",
+            json={
+                "channel_type": "email",
+                "channel_id": "user@example.com",
+                "options": {"compact": True},
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_verify_signature_uses_v2_route(self, async_client):
+        api = AsyncReceiptsAPI(async_client)
+
+        await api.verify_signature("rcpt-123")
+
+        async_client.request.assert_awaited_once_with(
+            "POST",
+            "/api/v2/receipts/rcpt-123/verify-signature",
+        )

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -12,7 +12,7 @@ Tests for FastAPI receipt route endpoints.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -583,6 +583,145 @@ class TestShareReceipt:
         mock_receipt_share_store.save.assert_called_once()
 
 
+class TestFormattedReceipt:
+    """Tests for GET /api/v2/receipts/{receipt_id}/formatted/{channel_type}."""
+
+    def test_get_formatted_receipt_not_found(self, client):
+        response = client.get("/api/v2/receipts/missing/formatted/slack")
+        assert response.status_code == 404
+
+    def test_get_formatted_receipt_success(self, client, mock_receipt_store, sample_receipt_dict):
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        with patch(
+            "aragora.channels.formatter.format_receipt_for_channel",
+            return_value={"blocks": [{"type": "section"}]},
+        ) as format_receipt:
+            response = client.get("/api/v2/receipts/rcpt_test123/formatted/slack?compact=true")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["receipt_id"] == "rcpt_test123"
+        assert data["channel_type"] == "slack"
+        assert data["formatted"]["blocks"][0]["type"] == "section"
+        format_receipt.assert_called_once()
+
+    def test_get_formatted_receipt_invalid_channel(
+        self, client, mock_receipt_store, sample_receipt_dict
+    ):
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        with patch(
+            "aragora.channels.formatter.format_receipt_for_channel",
+            side_effect=ValueError("No formatter registered for channel: fax"),
+        ):
+            response = client.get("/api/v2/receipts/rcpt_test123/formatted/fax")
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "No formatter registered for channel: fax"
+
+
+class TestVerifyReceiptSignature:
+    """Tests for POST /api/v2/receipts/{receipt_id}/verify-signature."""
+
+    def test_verify_signature_not_found(self, client, mock_receipt_store):
+        result = MagicMock()
+        result.error = "Receipt not found"
+        result.to_dict.return_value = {
+            "receipt_id": "missing",
+            "signature_valid": False,
+            "algorithm": None,
+            "key_id": None,
+            "signed_at": None,
+            "verification_timestamp": "2026-02-11T12:00:00Z",
+            "error": "Receipt not found",
+        }
+        mock_receipt_store.verify_signature = MagicMock(return_value=result)
+
+        response = client.post("/api/v2/receipts/missing/verify-signature")
+        assert response.status_code == 404
+
+    def test_verify_signature_success(self, client, mock_receipt_store):
+        result = MagicMock()
+        result.error = None
+        result.to_dict.return_value = {
+            "receipt_id": "rcpt_test123",
+            "signature_valid": True,
+            "algorithm": "hmac-sha256",
+            "key_id": "key-1",
+            "signed_at": 1740000000.0,
+            "verification_timestamp": "2026-02-11T12:00:00Z",
+            "error": None,
+        }
+        mock_receipt_store.verify_signature = MagicMock(return_value=result)
+
+        response = client.post("/api/v2/receipts/rcpt_test123/verify-signature")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["receipt_id"] == "rcpt_test123"
+        assert data["signature_valid"] is True
+        assert data["algorithm"] == "hmac-sha256"
+
+
+class TestSendToChannel:
+    """Tests for POST /api/v2/receipts/{receipt_id}/send-to-channel."""
+
+    def test_send_to_channel_requires_auth(self, client):
+        response = client.post(
+            "/api/v2/receipts/rcpt_test123/send-to-channel",
+            json={"channel_type": "email", "channel_id": "user@example.com"},
+        )
+        assert response.status_code == 401
+
+    def test_send_to_channel_requires_permission(
+        self, client, mock_receipt_store, sample_receipt_dict
+    ):
+        mock_receipt_store.get.return_value = sample_receipt_dict
+        _override_auth(client, roles=set(), permissions=set())
+        response = client.post(
+            "/api/v2/receipts/rcpt_test123/send-to-channel",
+            json={"channel_type": "email", "channel_id": "user@example.com"},
+        )
+        client.app.dependency_overrides.clear()
+        assert response.status_code == 403
+
+    def test_send_to_channel_not_found(self, client):
+        _override_auth(client, permissions={"receipts:share"})
+        response = client.post(
+            "/api/v2/receipts/missing/send-to-channel",
+            json={"channel_type": "email", "channel_id": "user@example.com"},
+        )
+        client.app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    def test_send_to_channel_success(self, client, mock_receipt_store, sample_receipt_dict):
+        mock_receipt_store.get.return_value = sample_receipt_dict
+        _override_auth(client, permissions={"receipts:share"})
+
+        with patch(
+            "aragora.channels.formatter.format_receipt_for_channel",
+            return_value={"subject": "Decision Receipt", "html": "<p>ok</p>"},
+        ):
+            with patch(
+                "aragora.server.handlers.receipts.ReceiptsHandler._send_to_email",
+                new=AsyncMock(
+                    return_value={"message_id": "msg-123", "email_sent_to": "user@example.com"}
+                ),
+            ):
+                response = client.post(
+                    "/api/v2/receipts/rcpt_test123/send-to-channel",
+                    json={"channel_type": "email", "channel_id": "user@example.com"},
+                )
+
+        client.app.dependency_overrides.clear()
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sent"] is True
+        assert data["receipt_id"] == "rcpt_test123"
+        assert data["channel_type"] == "email"
+        assert data["message_id"] == "msg-123"
+
+
 class TestGetSharedReceipt:
     """Tests for GET /api/v2/receipts/share/{token}."""
 
@@ -648,6 +787,20 @@ class TestGetSharedReceipt:
         assert spec["paths"]["/api/v2/receipts/{receipt_id}/share"]["post"]["security"] == [
             {"bearerAuth": []}
         ]
+        assert "/api/v2/receipts/{receipt_id}/formatted/{channel_type}" in spec["paths"]
+        assert (
+            "security"
+            not in spec["paths"]["/api/v2/receipts/{receipt_id}/formatted/{channel_type}"]["get"]
+        )
+        assert "/api/v2/receipts/{receipt_id}/verify-signature" in spec["paths"]
+        assert (
+            "security"
+            not in spec["paths"]["/api/v2/receipts/{receipt_id}/verify-signature"]["post"]
+        )
+        assert "/api/v2/receipts/{receipt_id}/send-to-channel" in spec["paths"]
+        assert spec["paths"]["/api/v2/receipts/{receipt_id}/send-to-channel"]["post"][
+            "security"
+        ] == [{"bearerAuth": []}]
 
 
 # =============================================================================


### PR DESCRIPTION
Restores missing v2 receipt routes (formatted, send-to-channel, verify-signature) in FastAPI. Aligns legacy handler send permission to receipts:share. Adds focused regression coverage.