### PR TITLE
fix(spectate): subscribe to full SSE event set in useSpectate

### DIFF
--- a/aragora/live/src/hooks/__tests__/useSpectate.test.tsx
+++ b/aragora/live/src/hooks/__tests__/useSpectate.test.tsx
@@ -148,6 +148,54 @@ describe('useSpectate', () => {
     expect(stream.closed).toBe(true);
   });
 
+  it('consumes finite snapshot SSE event types without falling back to polling', async () => {
+    const mockFetch = global.fetch as jest.Mock;
+    mockFetch.mockImplementation((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/api/v1/spectate/status')) {
+        return createJsonResponse(createStatusPayload());
+      }
+      throw new Error(`Unexpected fetch URL: ${url}`);
+    });
+
+    const { result } = renderHook(() =>
+      useSpectate('debate-1', undefined, { pollInterval: 1000, maxEvents: 5 }),
+    );
+
+    await waitFor(() => {
+      expect(MockEventSource.instances).toHaveLength(1);
+    });
+
+    const stream = MockEventSource.instances[0];
+
+    act(() => {
+      stream.simulateOpen();
+      stream.emit('connected', { mode: 'snapshot' });
+      stream.emit('proposal', {
+        event_type: 'proposal',
+        timestamp: '2026-04-03T11:00:01Z',
+        data: { details: 'Snapshot fallback still needs to populate the transcript.' },
+        debate_id: 'debate-1',
+        pipeline_id: null,
+        agent_name: 'judge',
+        round_number: 1,
+      });
+      stream.emit('snapshot_complete', { mode: 'snapshot' });
+    });
+
+    await waitFor(() => {
+      expect(result.current.connected).toBe(true);
+      expect(result.current.loaded).toBe(true);
+      expect(result.current.events).toHaveLength(1);
+    });
+
+    expect(result.current.events[0].event_type).toBe('proposal');
+    expect(result.current.events[0].agent_name).toBe('judge');
+    expect(
+      mockFetch.mock.calls.some(([url]) => String(url).includes('/api/v1/spectate/recent')),
+    ).toBe(false);
+  });
+
   it('falls back to recent-event polling when the SSE stream errors', async () => {
     const mockFetch = global.fetch as jest.Mock;
     mockFetch.mockImplementation((input: RequestInfo | URL) => {

--- a/aragora/live/src/hooks/useSpectate.ts
+++ b/aragora/live/src/hooks/useSpectate.ts
@@ -64,6 +64,27 @@ interface UseSpectateReturn {
   refresh: () => Promise<void>;
 }
 
+const SPECTATE_STREAM_EVENT_TYPES = [
+  'spectate',
+  'debate_start',
+  'debate_end',
+  'round_start',
+  'round_end',
+  'proposal',
+  'critique',
+  'refine',
+  'vote',
+  'judge',
+  'consensus',
+  'convergence',
+  'converged',
+  'memory_recall',
+  'breakpoint',
+  'breakpoint_resolved',
+  'system',
+  'error',
+] as const;
+
 function buildSpectateParams(
   debateId?: string,
   pipelineId?: string,
@@ -262,7 +283,9 @@ export function useSpectate(
     source.onopen = handleConnected;
     source.addEventListener('connected', handleConnected as EventListener);
     source.addEventListener('snapshot_complete', handleConnected as EventListener);
-    source.addEventListener('spectate', handleSpectateMessage as EventListener);
+    SPECTATE_STREAM_EVENT_TYPES.forEach((eventType) => {
+      source.addEventListener(eventType, handleSpectateMessage as EventListener);
+    });
     source.addEventListener('resync_required', handleResyncRequired as EventListener);
     source.onerror = () => {
       if (eventSourceRef.current !== source) return;


### PR DESCRIPTION
Backend snapshot stream emits event names like proposal/critique but the frontend hook only listened for spectate. Updates useSpectate.ts to handle the full event set.