### PR TITLE
fix(api): restore legacy handler route aliases

### DIFF
--- a/aragora/server/handlers/features/evidence.py
+++ b/aragora/server/handlers/features/evidence.py
@@ -79,6 +79,10 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
 
     # Static routes for exact matching
     ROUTES = [
+        "/api/evidence",
+        "/api/evidence/statistics",
+        "/api/evidence/search",
+        "/api/evidence/collect",
         "/api/v1/evidence",
         "/api/v1/evidence/statistics",
         "/api/v1/evidence/search",
@@ -87,7 +91,7 @@ class EvidenceHandler(BaseHandler, PaginatedHandlerMixin):
 
     def can_handle(self, path: str) -> bool:
         """Check if this handler can handle the given path."""
-        return path.startswith("/api/v1/evidence")
+        return path.startswith("/api/v1/evidence") or path.startswith("/api/evidence")
 
     def __init__(self, server_context: dict[str, Any]):
         """Initialize with server context."""

--- a/aragora/server/handlers/memory/learning.py
+++ b/aragora/server/handlers/memory/learning.py
@@ -50,11 +50,22 @@ class LearningHandler(SecureHandler):
         self.ctx = ctx or {}
 
     ROUTES = [
+        "/api/learning/cycles",
+        "/api/learning/patterns",
+        "/api/learning/agent-evolution",
+        "/api/learning/insights",
         "/api/v1/learning/cycles",
         "/api/v1/learning/patterns",
         "/api/v1/learning/agent-evolution",
         "/api/v1/learning/insights",
     ]
+
+    _LEGACY_ROUTE_ALIASES = {
+        "/api/learning/cycles": "/api/v1/learning/cycles",
+        "/api/learning/patterns": "/api/v1/learning/patterns",
+        "/api/learning/agent-evolution": "/api/v1/learning/agent-evolution",
+        "/api/learning/insights": "/api/v1/learning/insights",
+    }
 
     def can_handle(self, path: str) -> bool:
         """Check if this handler can process the given path."""
@@ -64,6 +75,8 @@ class LearningHandler(SecureHandler):
         self, path: str, query_params: dict[str, Any], handler: Any
     ) -> HandlerResult | None:
         """Route GET requests with RBAC."""
+        path = self._LEGACY_ROUTE_ALIASES.get(path, path)
+
         # Rate limit check
         client_ip = get_client_ip(handler)
         if not _learning_limiter.is_allowed(client_ip):

--- a/aragora/server/handlers/training.py
+++ b/aragora/server/handlers/training.py
@@ -97,6 +97,12 @@ class TrainingHandler(BaseHandler):
     """Handler for training data export endpoints."""
 
     _ROUTE_MAP = {
+        "/api/training/export/sft": "handle_export_sft",
+        "/api/training/export/dpo": "handle_export_dpo",
+        "/api/training/export/gauntlet": "handle_export_gauntlet",
+        "/api/training/stats": "handle_stats",
+        "/api/training/formats": "handle_formats",
+        "/api/training/jobs": "handle_list_jobs",
         "/api/v1/training/export/sft": "handle_export_sft",
         "/api/v1/training/export/dpo": "handle_export_dpo",
         "/api/v1/training/export/gauntlet": "handle_export_gauntlet",
@@ -106,6 +112,12 @@ class TrainingHandler(BaseHandler):
     }
 
     ROUTES = [
+        "/api/training/export/sft",
+        "/api/training/export/dpo",
+        "/api/training/export/gauntlet",
+        "/api/training/stats",
+        "/api/training/formats",
+        "/api/training/jobs",
         "/api/v1/training/export/sft",
         "/api/v1/training/export/dpo",
         "/api/v1/training/export/gauntlet",
@@ -116,6 +128,12 @@ class TrainingHandler(BaseHandler):
 
     # Dynamic routes that need special handling
     JOB_ROUTES = [
+        "/api/training/jobs/*/export",
+        "/api/training/jobs/*/start",
+        "/api/training/jobs/*/complete",
+        "/api/training/jobs/*/metrics",
+        "/api/training/jobs/*/artifacts",
+        "/api/training/jobs/*",
         "/api/v1/training/jobs/*/export",
         "/api/v1/training/jobs/*/start",
         "/api/v1/training/jobs/*/complete",
@@ -135,12 +153,22 @@ class TrainingHandler(BaseHandler):
         )
         self._export_dir.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _normalize_route_path(path: str) -> str:
+        """Map legacy unversioned training routes to the canonical v1 path."""
+        if path == "/api/training/jobs" or path.startswith("/api/training/jobs/"):
+            return path.replace("/api/training/jobs", "/api/v1/training/jobs", 1)
+        if path.startswith("/api/training/"):
+            return path.replace("/api/training/", "/api/v1/training/", 1)
+        return path
+
     def can_handle(self, path: str, method: str = "GET") -> bool:
         """Check if this handler can process the given path."""
-        if path in self._ROUTE_MAP:
+        normalized_path = self._normalize_route_path(path)
+        if normalized_path in self._ROUTE_MAP:
             return True
         # Check job routes (dynamic patterns)
-        if path.startswith("/api/v1/training/jobs/"):
+        if normalized_path.startswith("/api/v1/training/jobs/"):
             return True
         return False
 
@@ -152,15 +180,17 @@ class TrainingHandler(BaseHandler):
         handler: Any,
     ) -> HandlerResult | None:
         """Route training requests to appropriate methods."""
+        normalized_path = self._normalize_route_path(path)
+
         # Check static routes first
-        method_name = self._ROUTE_MAP.get(path)
+        method_name = self._ROUTE_MAP.get(normalized_path)
         if method_name and hasattr(self, method_name):
-            result = getattr(self, method_name)(path, query_params, handler)
+            result = getattr(self, method_name)(normalized_path, query_params, handler)
             return cast(HandlerResult | None, result)
 
         # Handle job-specific routes
-        if path.startswith("/api/v1/training/jobs/"):
-            return self._handle_job_route(path, query_params, handler)
+        if normalized_path.startswith("/api/v1/training/jobs/"):
+            return self._handle_job_route(normalized_path, query_params, handler)
 
         return None
 

--- a/tests/handlers/memory/test_learning.py
+++ b/tests/handlers/memory/test_learning.py
@@ -218,7 +218,15 @@ class TestCanHandle:
         assert handler.can_handle("/api/v1/learning/unknown") is False
 
     def test_unversioned_route(self, handler):
-        assert handler.can_handle("/api/learning/cycles") is False
+        assert handler.can_handle("/api/learning/cycles") is True
+
+    @pytest.mark.asyncio
+    async def test_unversioned_route_dispatches(self, handler, nomic_dir, mock_http):
+        (nomic_dir / "replays").mkdir()
+        result = await handler.handle("/api/learning/cycles", {}, mock_http)
+        body = _body(result)
+        assert _status(result) == 200
+        assert body["cycles"] == []
 
     def test_empty_path(self, handler):
         assert handler.can_handle("") is False

--- a/tests/server/handler_registry/test_core.py
+++ b/tests/server/handler_registry/test_core.py
@@ -256,6 +256,33 @@ class TestRouteIndex:
         prefixes = [p for p, _, _ in idx._prefix_routes]
         assert "/api/v1/decisions/plans" in prefixes
 
+    def test_get_handler_resolves_legacy_training_learning_and_evidence_paths(self, monkeypatch):
+        """Legacy /api/* aliases should continue to dispatch through the route index."""
+        from aragora.server.handlers.features.evidence import EvidenceHandler
+        from aragora.server.handlers.memory.learning import LearningHandler
+        from aragora.server.handlers.training import TrainingHandler
+
+        monkeypatch.setenv("ARAGORA_USE_SECRETS_MANAGER", "0")
+
+        idx = RouteIndex()
+        mixin = MagicMock()
+        mixin._evidence_handler = EvidenceHandler({})
+        mixin._learning_handler = LearningHandler({})
+        mixin._training_handler = TrainingHandler({})
+
+        handlers = [
+            ("_evidence_handler", EvidenceHandler),
+            ("_learning_handler", LearningHandler),
+            ("_training_handler", TrainingHandler),
+        ]
+
+        idx.build(mixin, handlers)
+
+        with patch("aragora.server.versioning.strip_version_prefix", side_effect=lambda p: p):
+            assert idx.get_handler("/api/evidence")[0] == "_evidence_handler"
+            assert idx.get_handler("/api/learning/cycles")[0] == "_learning_handler"
+            assert idx.get_handler("/api/training/stats")[0] == "_training_handler"
+
 
 class TestGetRouteIndex:
     """Tests for global route index singleton."""

--- a/tests/server/handlers/test_evidence.py
+++ b/tests/server/handlers/test_evidence.py
@@ -131,6 +131,11 @@ class TestEvidenceHandlerRouting:
         from aragora.server.handlers.features.evidence import EvidenceHandler
 
         handler = EvidenceHandler({})
+        assert handler.can_handle("/api/evidence") is True
+        assert handler.can_handle("/api/evidence/123") is True
+        assert handler.can_handle("/api/evidence/statistics") is True
+        assert handler.can_handle("/api/evidence/debate/d-123") is True
+        assert handler.can_handle("/api/evidence/search") is True
         assert handler.can_handle("/api/v1/evidence") is True
         assert handler.can_handle("/api/v1/evidence/123") is True
         assert handler.can_handle("/api/v1/evidence/statistics") is True

--- a/tests/server/handlers/test_training.py
+++ b/tests/server/handlers/test_training.py
@@ -54,26 +54,31 @@ class TestTrainingHandlerCanHandle:
     def test_can_handle_sft_export(self):
         """Should handle SFT export path."""
         handler = TrainingHandler({})
+        assert handler.can_handle("/api/training/export/sft") is True
         assert handler.can_handle("/api/v1/training/export/sft") is True
 
     def test_can_handle_dpo_export(self):
         """Should handle DPO export path."""
         handler = TrainingHandler({})
+        assert handler.can_handle("/api/training/export/dpo") is True
         assert handler.can_handle("/api/v1/training/export/dpo") is True
 
     def test_can_handle_gauntlet_export(self):
         """Should handle Gauntlet export path."""
         handler = TrainingHandler({})
+        assert handler.can_handle("/api/training/export/gauntlet") is True
         assert handler.can_handle("/api/v1/training/export/gauntlet") is True
 
     def test_can_handle_stats(self):
         """Should handle stats path."""
         handler = TrainingHandler({})
+        assert handler.can_handle("/api/training/stats") is True
         assert handler.can_handle("/api/v1/training/stats") is True
 
     def test_can_handle_formats(self):
         """Should handle formats path."""
         handler = TrainingHandler({})
+        assert handler.can_handle("/api/training/formats") is True
         assert handler.can_handle("/api/v1/training/formats") is True
 
     def test_cannot_handle_unknown_path(self):
@@ -209,6 +214,9 @@ class TestTrainingHandlerHandle:
     def test_handle_formats_dispatches_correctly(self):
         """Should dispatch formats path to handle_formats."""
         handler = TrainingHandler({})
+        legacy_result = handler.handle("/api/training/formats", {}, None)
+        assert legacy_result is not None
+        assert legacy_result.status_code == 200
         result = handler.handle("/api/v1/training/formats", {}, None)
         assert result is not None
         assert result.status_code == 200


### PR DESCRIPTION
Restores legacy alias handling in evidence, learning, and training handlers. Fixes 3 test failures in test_unused_endpoints.py.