### PR TITLE
feat(resilience): add Prometheus metrics to circuit breaker

### DIFF
--- a/aragora/resilience/circuit_breaker.py
+++ b/aragora/resilience/circuit_breaker.py
@@ -24,6 +24,133 @@ EntityT = TypeVar("EntityT")
 # Metrics callback - set by metrics module
 _metrics_callback: Callable[[str, int], None] | None = None
 
+# Prometheus metrics - lazily initialized
+_prom_metrics: dict[str, Any] = {}
+_prometheus_available: bool | None = None
+
+
+def _check_prometheus() -> bool:
+    """Check if prometheus_client is available."""
+    global _prometheus_available
+    if _prometheus_available is None:
+        try:
+            import prometheus_client  # noqa: F401
+
+            _prometheus_available = True
+        except ImportError:
+            _prometheus_available = False
+    return _prometheus_available
+
+
+def _get_or_create_prom_metric(
+    name: str,
+    metric_type: type,
+    description: str,
+    labels: list[str] | None = None,
+) -> Any:
+    """Get or lazily create a Prometheus metric."""
+    if not _check_prometheus():
+        return None
+    if name not in _prom_metrics:
+        if labels:
+            _prom_metrics[name] = metric_type(name, description, labels)
+        else:
+            _prom_metrics[name] = metric_type(name, description)
+    return _prom_metrics[name]
+
+
+def _prom_record_state(circuit_name: str, state: int) -> None:
+    """Update Prometheus metrics for a circuit state change.
+
+    Args:
+        circuit_name: Name of the circuit breaker
+        state: 0=closed, 1=open, 2=half-open
+    """
+    if not _check_prometheus():
+        return
+    try:
+        from prometheus_client import Counter, Gauge
+
+        state_gauge = _get_or_create_prom_metric(
+            "aragora_circuit_breaker_state",
+            Gauge,
+            "Current circuit breaker state (0=closed, 1=open, 2=half_open)",
+            ["circuit_name"],
+        )
+        if state_gauge:
+            state_gauge.labels(circuit_name=circuit_name).set(state)
+
+        state_map = {0: "closed", 1: "open", 2: "half_open"}
+        transitions_counter = _get_or_create_prom_metric(
+            "aragora_circuit_breaker_transitions_total",
+            Counter,
+            "Total circuit breaker state transitions",
+            ["circuit_name", "to_state"],
+        )
+        if transitions_counter:
+            transitions_counter.labels(
+                circuit_name=circuit_name,
+                to_state=state_map.get(state, str(state)),
+            ).inc()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Error recording prometheus circuit breaker metrics: %s", e)
+
+
+def _prom_record_failure(circuit_name: str) -> None:
+    """Increment Prometheus failure counter for a circuit."""
+    if not _check_prometheus():
+        return
+    try:
+        from prometheus_client import Counter
+
+        counter = _get_or_create_prom_metric(
+            "aragora_circuit_breaker_failures_total",
+            Counter,
+            "Total circuit breaker recorded failures",
+            ["circuit_name"],
+        )
+        if counter:
+            counter.labels(circuit_name=circuit_name).inc()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Error recording prometheus circuit breaker failure: %s", e)
+
+
+def _prom_record_success(circuit_name: str) -> None:
+    """Increment Prometheus success counter for a circuit."""
+    if not _check_prometheus():
+        return
+    try:
+        from prometheus_client import Counter
+
+        counter = _get_or_create_prom_metric(
+            "aragora_circuit_breaker_successes_total",
+            Counter,
+            "Total circuit breaker recorded successes",
+            ["circuit_name"],
+        )
+        if counter:
+            counter.labels(circuit_name=circuit_name).inc()
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Error recording prometheus circuit breaker success: %s", e)
+
+
+def reset_prometheus_metrics() -> None:
+    """Reset all Prometheus metrics (for testing)."""
+    global _prom_metrics, _prometheus_available
+    if _prometheus_available:
+        try:
+            from prometheus_client import REGISTRY
+
+            for metric in _prom_metrics.values():
+                try:
+                    REGISTRY.unregister(metric)
+                except (ValueError, TypeError, KeyError):
+                    pass
+        except ImportError:
+            pass
+    _prom_metrics.clear()
+    _prometheus_available = None
+
 
 def _set_metrics_callback(callback: Callable[[str, int], None] | None) -> None:
     """Internal: Set the metrics callback."""
@@ -33,6 +160,7 @@ def _set_metrics_callback(callback: Callable[[str, int], None] | None) -> None:
 
 def _emit_metrics(circuit_name: str, state: int) -> None:
     """Emit metrics for circuit state change."""
+    _prom_record_state(circuit_name, state)
     if _metrics_callback:
         try:
             _metrics_callback(circuit_name, state)
@@ -208,6 +336,7 @@ class CircuitBreaker:
         """Record failure in single-entity mode."""
         self._single_failures += 1
         self._single_successes = 0
+        _prom_record_failure(self.name)
 
         if self._single_failures >= self.failure_threshold:
             if self._single_open_at == 0.0:
@@ -239,6 +368,7 @@ class CircuitBreaker:
         self._prune_stale_entities()
         self._failures[entity] = self._failures.get(entity, 0) + 1
         self._half_open_successes[entity] = 0
+        _prom_record_failure(f"{self.name}:{entity}")
 
         if self._failures[entity] >= self.failure_threshold:
             if entity not in self._circuit_open_at:
@@ -264,6 +394,7 @@ class CircuitBreaker:
 
     def _record_single_success(self) -> None:
         """Record success in single-entity mode."""
+        _prom_record_success(self.name)
         if self._single_open_at > 0.0:
             # Single success closes circuit in single-entity mode
             self._single_open_at = 0.0
@@ -276,6 +407,7 @@ class CircuitBreaker:
 
     def _record_entity_success(self, entity: str) -> None:
         """Record success for a specific entity."""
+        _prom_record_success(f"{self.name}:{entity}")
         if entity in self._circuit_open_at:
             self._half_open_successes[entity] = self._half_open_successes.get(entity, 0) + 1
             if self._half_open_successes[entity] >= self.half_open_success_threshold:
@@ -587,4 +719,5 @@ class CircuitBreaker:
 __all__ = [
     "CircuitBreaker",
     "CircuitOpenError",
+    "reset_prometheus_metrics",
 ]

--- a/tests/resilience/test_circuit_breaker_metrics.py
+++ b/tests/resilience/test_circuit_breaker_metrics.py
@@ -1,0 +1,260 @@
+"""
+Tests for Prometheus metrics integration in circuit_breaker.py.
+
+Tests cover:
+- Prometheus metric lazy initialization
+- Failure counter increments on record_failure
+- Success counter increments on record_success
+- State gauge updates on state transitions (open/closed)
+- Transition counter increments on state changes
+- Entity-mode metrics use name:entity labels
+- No-op behavior when prometheus_client is unavailable
+- reset_prometheus_metrics clears metric state
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import aragora.resilience.circuit_breaker as cb_module
+from aragora.resilience.circuit_breaker import (
+    CircuitBreaker,
+    reset_prometheus_metrics,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_prometheus_state():
+    """Reset prometheus metrics before and after each test."""
+    reset_prometheus_metrics()
+    yield
+    reset_prometheus_metrics()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class FakeMetric:
+    """Minimal fake for Counter / Gauge that tracks .labels().inc()/.set()."""
+
+    def __init__(self, name, description, labels=None):
+        self.metric_name = name
+        self.description = description
+        self._labels = labels or []
+        self._children: dict[tuple, MagicMock] = {}
+
+    def labels(self, **kwargs):
+        key = tuple(sorted(kwargs.items()))
+        if key not in self._children:
+            child = MagicMock()
+            child.inc = MagicMock()
+            child.set = MagicMock()
+            child.observe = MagicMock()
+            self._children[key] = child
+        return self._children[key]
+
+
+def _fake_counter(name, description, labels=None):
+    return FakeMetric(name, description, labels)
+
+
+def _fake_gauge(name, description, labels=None):
+    return FakeMetric(name, description, labels)
+
+
+def _patch_prometheus():
+    """Patch prometheus imports to use fakes."""
+    fake_mod = MagicMock()
+    fake_mod.Counter = _fake_counter
+    fake_mod.Gauge = _fake_gauge
+    return patch.dict("sys.modules", {"prometheus_client": fake_mod})
+
+
+# ---------------------------------------------------------------------------
+# Tests: Prometheus availability check
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPrometheus:
+    def test_returns_true_when_available(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            assert cb_module._check_prometheus() is True
+
+    def test_returns_false_when_unavailable(self):
+        cb_module._prometheus_available = None
+        with patch.dict("sys.modules", {"prometheus_client": None}):
+            # Force re-check
+            cb_module._prometheus_available = False
+            assert cb_module._check_prometheus() is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: Failure counter
+# ---------------------------------------------------------------------------
+
+
+class TestFailureMetrics:
+    def test_single_mode_failure_increments_counter(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=5)
+            cb.record_failure()
+
+            metric = cb_module._prom_metrics.get("aragora_circuit_breaker_failures_total")
+            assert metric is not None
+            child = metric.labels(circuit_name="test-cb")
+            child.inc.assert_called()
+
+    def test_entity_mode_failure_increments_counter(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=5)
+            cb.record_failure("agent-1")
+
+            metric = cb_module._prom_metrics["aragora_circuit_breaker_failures_total"]
+            child = metric.labels(circuit_name="test-cb:agent-1")
+            child.inc.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Success counter
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessMetrics:
+    def test_single_mode_success_increments_counter(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb")
+            cb.record_success()
+
+            metric = cb_module._prom_metrics.get("aragora_circuit_breaker_successes_total")
+            assert metric is not None
+            child = metric.labels(circuit_name="test-cb")
+            child.inc.assert_called()
+
+    def test_entity_mode_success_increments_counter(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb")
+            cb.record_success("agent-1")
+
+            metric = cb_module._prom_metrics["aragora_circuit_breaker_successes_total"]
+            child = metric.labels(circuit_name="test-cb:agent-1")
+            child.inc.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: State gauge and transition counter on open/close
+# ---------------------------------------------------------------------------
+
+
+class TestStateTransitionMetrics:
+    def test_circuit_open_sets_state_gauge_to_1(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+            cb.record_failure()
+            cb.record_failure()  # triggers open
+
+            state_metric = cb_module._prom_metrics.get("aragora_circuit_breaker_state")
+            assert state_metric is not None
+            child = state_metric.labels(circuit_name="test-cb")
+            child.set.assert_called_with(1)  # 1 = open
+
+    def test_circuit_close_sets_state_gauge_to_0(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+            cb.record_failure()
+            cb.record_failure()  # open
+            cb.record_success()  # close
+
+            state_metric = cb_module._prom_metrics["aragora_circuit_breaker_state"]
+            child = state_metric.labels(circuit_name="test-cb")
+            child.set.assert_called_with(0)  # 0 = closed
+
+    def test_transition_counter_incremented_on_open(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+            cb.record_failure()
+            cb.record_failure()
+
+            trans_metric = cb_module._prom_metrics.get("aragora_circuit_breaker_transitions_total")
+            assert trans_metric is not None
+            child = trans_metric.labels(circuit_name="test-cb", to_state="open")
+            child.inc.assert_called()
+
+    def test_transition_counter_incremented_on_close(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+            cb.record_failure()
+            cb.record_failure()
+            cb.record_success()
+
+            trans_metric = cb_module._prom_metrics["aragora_circuit_breaker_transitions_total"]
+            child = trans_metric.labels(circuit_name="test-cb", to_state="closed")
+            child.inc.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Entity-mode state transitions
+# ---------------------------------------------------------------------------
+
+
+class TestEntityStateTransitionMetrics:
+    def test_entity_circuit_open_sets_gauge(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="svc", failure_threshold=2)
+            cb.record_failure("node-a")
+            cb.record_failure("node-a")
+
+            state_metric = cb_module._prom_metrics["aragora_circuit_breaker_state"]
+            child = state_metric.labels(circuit_name="svc:node-a")
+            child.set.assert_called_with(1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: No-op when prometheus unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestNoOpWithoutPrometheus:
+    def test_no_metrics_created_when_unavailable(self):
+        cb_module._prometheus_available = False
+        cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()
+        # No prometheus metrics should be created
+        assert len(cb_module._prom_metrics) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset_prometheus_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestResetPrometheusMetrics:
+    def test_clears_metrics_dict(self):
+        with _patch_prometheus():
+            cb_module._prometheus_available = None
+            cb = CircuitBreaker(name="test-cb", failure_threshold=2)
+            cb.record_failure()
+            assert len(cb_module._prom_metrics) > 0
+
+            reset_prometheus_metrics()
+            assert len(cb_module._prom_metrics) == 0
+
+    def test_resets_availability_flag(self):
+        cb_module._prometheus_available = True
+        reset_prometheus_metrics()
+        assert cb_module._prometheus_available is None


### PR DESCRIPTION
Add lazy-initialized Prometheus metrics directly to circuit_breaker.py:
- aragora_circuit_breaker_state gauge (0=closed, 1=open, 2=half_open)
- aragora_circuit_breaker_transitions_total counter by to_state
- aragora_circuit_breaker_failures_total counter per circuit
- aragora_circuit_breaker_successes_total counter per circuit

Metrics are no-ops when prometheus_client is not installed.
Includes 14 tests covering all metric paths.

Closes #2037

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
