### PR TITLE
Anchor Slack workspace route dispatch

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -539,7 +539,7 @@ class SlackOAuthHandler(SecureHandler):
         # Check for dynamic workspace routes
         import re
 
-        status_match = re.match(r"/api/integrations/slack/workspaces/([^/]+)/status", path)
+        status_match = re.fullmatch(r"/api/integrations/slack/workspaces/([^/]+)/status", path)
         if status_match:
             workspace_id = status_match.group(1)
             if method == "GET":
@@ -562,7 +562,7 @@ class SlackOAuthHandler(SecureHandler):
                 )
             return error_response("Method not allowed", 405)
 
-        refresh_match = re.match(r"/api/integrations/slack/workspaces/([^/]+)/refresh", path)
+        refresh_match = re.fullmatch(r"/api/integrations/slack/workspaces/([^/]+)/refresh", path)
         if refresh_match:
             workspace_id = refresh_match.group(1)
             if method == "POST":

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -2699,6 +2699,35 @@ class TestNotFound:
         assert _status(result) == 404
 
     @pytest.mark.asyncio
+    async def test_workspace_status_suffix_skips_dynamic_dispatch(
+        self, handler, mock_workspace_store
+    ):
+        scoped_ctx = AuthorizationContext(
+            user_id="tenant-user",
+            org_id="tenant-1",
+            roles={"member"},
+            permissions={"connectors.read"},
+        )
+        handler.get_auth_context = AsyncMock(return_value=scoped_ctx)
+        handler.check_permission = MagicMock(return_value=True)
+
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/workspaces/W123/status/extra",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 404
+        mock_workspace_store.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_workspace_refresh_suffix_returns_404(self, handler):
         result = await handler.handle(
             "POST",
@@ -2709,6 +2738,35 @@ class TestNotFound:
             None,
         )
         assert _status(result) == 404
+
+    @pytest.mark.asyncio
+    async def test_workspace_refresh_suffix_skips_dynamic_dispatch(
+        self, handler, mock_workspace_store
+    ):
+        scoped_ctx = AuthorizationContext(
+            user_id="tenant-user",
+            org_id="tenant-1",
+            roles={"member"},
+            permissions={"connectors.authorize"},
+        )
+        handler.get_auth_context = AsyncMock(return_value=scoped_ctx)
+        handler.check_permission = MagicMock(return_value=True)
+
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh/extra",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 404
+        mock_workspace_store.get.assert_not_called()
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- use anchored workspace status and refresh matches inside SlackOAuthHandler.handle()
- add dispatch-level regressions proving suffix paths do not reach workspace lookup
- keep can_handle() and handle() route surfaces aligned

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q