### PR TITLE
fix(pipeline): add fail-closed HTTP status to BackbonePersistenceError

### DIFF
--- a/aragora/pipeline/backbone_errors.py
+++ b/aragora/pipeline/backbone_errors.py
@@ -4,9 +4,22 @@ from __future__ import annotations
 
 FAIL_CLOSED_BACKBONE_MESSAGE = "Backbone persistence failed; interactive execution blocked"
 
+FAIL_CLOSED_HTTP_STATUS = 503
+
 
 class BackbonePersistenceError(RuntimeError):
-    """Raised when interactive execution cannot guarantee backbone persistence."""
+    """Raised when interactive execution cannot guarantee backbone persistence.
+
+    Carries a ``status_code`` so HTTP handlers can return an explicit
+    503 Service Unavailable without hard-coding the value.
+    """
+
+    status_code: int = FAIL_CLOSED_HTTP_STATUS
+
+    def __init__(self, message: str | None = None, *, status_code: int | None = None) -> None:
+        super().__init__(message or FAIL_CLOSED_BACKBONE_MESSAGE)
+        if status_code is not None:
+            self.status_code = status_code
 
 
 def ensure_backbone_persisted(ok: bool, message: str) -> None:
@@ -18,5 +31,6 @@ def ensure_backbone_persisted(ok: bool, message: str) -> None:
 __all__ = [
     "BackbonePersistenceError",
     "FAIL_CLOSED_BACKBONE_MESSAGE",
+    "FAIL_CLOSED_HTTP_STATUS",
     "ensure_backbone_persisted",
 ]


### PR DESCRIPTION
BackbonePersistenceError now carries a `status_code` attribute (default
503) and `FAIL_CLOSED_HTTP_STATUS` constant so interactive API handlers
can return explicit 503 without hard-coding the value.

Closes #2068

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
