### PR TITLE
Fail closed on missing worker initial head

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -955,22 +955,10 @@ class WorkerLauncher:
             if shas:
                 return shas
 
-        # Fallback: if initial_head is empty/missing or same as head_sha,
-        # check for commits ahead of origin/main.  This catches cases where
-        # the worker committed but initial_head was not captured correctly.
-        fallback_output = await cls._git_output(
-            worktree_path, "rev-list", "--reverse", "origin/main..HEAD"
-        )
-        shas = [line.strip() for line in fallback_output.splitlines() if line.strip()]
-        if shas:
-            logger.info(
-                "commit_shas fallback: found %d commits ahead of origin/main "
-                "(initial_head=%r, head_sha=%r)",
-                len(shas),
-                initial_head[:12] if initial_head else "",
-                head_sha[:12] if head_sha else "",
-            )
-        return shas
+        # Fail closed when initial_head is missing or unchanged. Falling back
+        # to origin/main can misattribute pre-existing branch commits to the
+        # current worker when the lane starts from stale or non-main history.
+        return []
 
     @classmethod
     def _collect_commit_shas_sync(
@@ -991,19 +979,10 @@ class WorkerLauncher:
             if shas:
                 return shas
 
-        fallback_output = cls._git_output_sync(
-            worktree_path, "rev-list", "--reverse", "origin/main..HEAD"
-        )
-        shas = [line.strip() for line in fallback_output.splitlines() if line.strip()]
-        if shas:
-            logger.info(
-                "commit_shas sync fallback: found %d commits ahead of origin/main "
-                "(initial_head=%r, head_sha=%r)",
-                len(shas),
-                initial_head[:12] if initial_head else "",
-                head_sha[:12] if head_sha else "",
-            )
-        return shas
+        # Fail closed when initial_head is missing or unchanged. Falling back
+        # to origin/main can misattribute pre-existing branch commits to the
+        # current worker when the lane starts from stale or non-main history.
+        return []
 
     @classmethod
     async def _collect_changed_paths(
@@ -1017,9 +996,6 @@ class WorkerLauncher:
         diff_range = ""
         if initial_head and head_sha and initial_head != head_sha:
             diff_range = f"{initial_head}..{head_sha}"
-        elif head_sha and not initial_head:
-            # Fallback: compare against origin/main when initial_head is missing
-            diff_range = "origin/main..HEAD"
         if diff_range:
             diff_names = await cls._git_output(
                 worktree_path,
@@ -1074,8 +1050,6 @@ class WorkerLauncher:
         diff_range = ""
         if initial_head and head_sha and initial_head != head_sha:
             diff_range = f"{initial_head}..{head_sha}"
-        elif head_sha and not initial_head:
-            diff_range = "origin/main..HEAD"
         if diff_range:
             diff_names = cls._git_output_sync(
                 worktree_path,

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1632,6 +1632,26 @@ class TestSnapshotProgress:
 
 class TestCollectChangedPaths:
     @pytest.mark.asyncio
+    async def test_skips_origin_main_fallback_when_initial_head_is_missing(self):
+        calls: list[tuple[str, ...]] = []
+
+        async def _git_output(_worktree_path: str, *args: str) -> str:
+            calls.append(tuple(args))
+            if args[:2] == ("status", "--porcelain"):
+                return ""
+            return "aragora/swarm/boss_loop.py\n"
+
+        with patch.object(WorkerLauncher, "_git_output", side_effect=_git_output):
+            changed = await WorkerLauncher._collect_changed_paths(
+                "/tmp/wt",
+                initial_head="",
+                head_sha="def456",
+            )
+
+        assert changed == []
+        assert ("diff", "--name-only", "origin/main..HEAD") not in calls
+
+    @pytest.mark.asyncio
     async def test_skips_origin_main_fallback_when_initial_head_matches_head_sha(self):
         calls: list[tuple[str, ...]] = []
 
@@ -1671,6 +1691,43 @@ class TestCollectChangedPaths:
 
         assert changed == ["real.py"]
         assert ("diff", "--name-only", "abc123..def456") in calls
+
+
+class TestCollectCommitShas:
+    @pytest.mark.asyncio
+    async def test_returns_empty_without_initial_head_instead_of_falling_back_to_origin_main(self):
+        calls: list[tuple[str, ...]] = []
+
+        async def _git_output(_worktree_path: str, *args: str) -> str:
+            calls.append(tuple(args))
+            return "abc123\n"
+
+        with patch.object(WorkerLauncher, "_git_output", side_effect=_git_output):
+            shas = await WorkerLauncher._collect_commit_shas(
+                "/tmp/wt",
+                initial_head="",
+                head_sha="def456",
+            )
+
+        assert shas == []
+        assert ("rev-list", "--reverse", "origin/main..HEAD") not in calls
+
+    def test_returns_empty_sync_without_initial_head_instead_of_falling_back_to_origin_main(self):
+        calls: list[tuple[str, ...]] = []
+
+        def _git_output_sync(_worktree_path: str, *args: str) -> str:
+            calls.append(tuple(args))
+            return "abc123\n"
+
+        with patch.object(WorkerLauncher, "_git_output_sync", side_effect=_git_output_sync):
+            shas = WorkerLauncher._collect_commit_shas_sync(
+                "/tmp/wt",
+                initial_head="",
+                head_sha="def456",
+            )
+
+        assert shas == []
+        assert ("rev-list", "--reverse", "origin/main..HEAD") not in calls
 
 
 class TestIsPidRunning:


### PR DESCRIPTION
## Summary
- stop commit and changed-path collection from falling back to origin/main when initial_head is missing
- fail closed so stale branch history is not attributed to the current worker as a deliverable
- add async and sync regressions covering the missing-initial-head path

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q