### PR TITLE
Consume Slack state on callback errors

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -936,8 +936,19 @@ class SlackOAuthHandler(SecureHandler):
             state: State token for CSRF verification
             error: Error code if user denied
         """
+        state = query_params.get("state")
+
         # Check for error from Slack
         if "error" in query_params:
+            if state:
+                try:
+                    _get_state_store().validate_and_consume(state)
+                except Exception:
+                    logger.debug(
+                        "Failed to consume Slack OAuth state after callback error", exc_info=True
+                    )
+                _cleanup_oauth_states_fallback()
+                _oauth_states_fallback.pop(state, None)
             error_code = query_params.get("error")
             logger.warning("Slack OAuth error: %s", error_code)
             # Audit log OAuth denial
@@ -950,9 +961,7 @@ class SlackOAuthHandler(SecureHandler):
                     error=f"User denied: {error_code}",
                 )
             return error_response(f"Slack authorization denied: {error_code}", 400)
-
         code = query_params.get("code")
-        state = query_params.get("state")
 
         if not code:
             return error_response("Missing authorization code", 400)

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -698,6 +698,29 @@ class TestCallback:
         assert "access_denied" in body.get("error", "")
 
     @pytest.mark.asyncio
+    async def test_error_param_consumes_state_and_fallback_copy(
+        self, handler, handler_module, mock_state_store
+    ):
+        handler_module._oauth_states_fallback["error-state"] = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/callback",
+            {},
+            {"error": "access_denied", "state": "error-state"},
+            {},
+            None,
+        )
+
+        assert _status(result) == 400
+        mock_state_store.validate_and_consume.assert_called_once_with("error-state")
+        assert "error-state" not in handler_module._oauth_states_fallback
+
+    @pytest.mark.asyncio
     async def test_missing_code_returns_400(self, handler):
         result = await handler.handle(
             "GET",

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -303,6 +303,27 @@ class TestSlackOAuthCallback:
         assert "denied" in data.get("error", "").lower()
 
     @pytest.mark.asyncio
+    async def test_callback_error_from_slack_consumes_state(self, oauth_handler, oauth_state_store):
+        """Test callback burns state even when Slack returns an error."""
+        state = "error-state"
+        oauth_state_store._states[state] = OAuthState(
+            user_id=None,
+            redirect_url=None,
+            expires_at=time.time() + 600,
+            created_at=time.time(),
+            metadata={"provider": "slack"},
+        )
+
+        result = await oauth_handler.handle(
+            "GET",
+            "/api/integrations/slack/callback",
+            query_params={"error": "access_denied", "state": state},
+        )
+
+        assert result.status_code == 400
+        assert state not in oauth_state_store._states
+
+    @pytest.mark.asyncio
     async def test_callback_missing_code(self, oauth_handler):
         """Test callback requires authorization code."""
         result = await oauth_handler.handle(


### PR DESCRIPTION
## Summary
- consume OAuth state when Slack redirects back with an error
- clear the fallback state cache copy on the same error path to prevent replay
- add callback regressions in both Slack OAuth test suites

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q