### PR TITLE
Defer sync collection while session lock is live

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -382,16 +382,13 @@ class WorkerLauncher:
             if worker is not None:
                 session_meta = self._read_session_meta(worker.worktree_path)
                 session_exit_code, _ = self._terminal_session_result(session_meta)
-                if proc is not None and proc.returncode is None:
-                    observed_pid = self._pid_for_active_lock(
-                        worker.worktree_path,
-                        worker.pid,
-                        session_meta,
-                    )
-                    if self._active_session_lock_blocks_collection(
-                        worker.worktree_path, observed_pid
-                    ):
-                        continue
+                observed_pid = self._pid_for_active_lock(
+                    worker.worktree_path,
+                    worker.pid,
+                    session_meta,
+                )
+                if self._active_session_lock_blocks_collection(worker.worktree_path, observed_pid):
+                    continue
             if proc is None or (proc.returncode is None and session_exit_code is None):
                 continue
             completed.append(self._wait_sync(work_order_id))

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1165,6 +1165,44 @@ class TestCollectFinishedSync:
         mock_diff.assert_not_called()
         assert "wo-sync-active-lock" in launcher._processes
 
+    def test_collect_finished_sync_defers_on_active_lock_even_after_returncode_set(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        worker = WorkerProcess(
+            work_order_id="wo-sync-active-lock-returncode",
+            agent="codex",
+            worktree_path=str(tmp_path),
+            branch="main",
+            pid=333,
+            initial_head="def456",
+        )
+        launcher._workers["wo-sync-active-lock-returncode"] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes["wo-sync-active-lock-returncode"] = proc
+
+        session_meta = {
+            "pid": 333,
+            "exit_code": 0,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=True) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff_sync") as mock_diff,
+        ):
+            completed = launcher.collect_finished_sync(
+                work_order_ids=["wo-sync-active-lock-returncode"]
+            )
+
+        assert completed == []
+        mock_running.assert_called_once_with(333)
+        mock_diff.assert_not_called()
+        assert "wo-sync-active-lock-returncode" in launcher._processes
+
     def test_collect_finished_sync_prefers_live_session_meta_pid_when_worker_pid_is_stale(
         self, tmp_path: Path
     ):


### PR DESCRIPTION
## Summary
- honor the managed-session active lock in collect_finished_sync even after proc.returncode is set
- prevent refresh-run sync collection from racing the shell EXIT trap
- add a regression for returncode-present workers with a live session lock

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k "active_lock_still_exists or active_lock_even_after_returncode_set"
- python -m pytest tests/swarm/test_worker_launcher.py -q