### PR TITLE
Preserve Slack refresh token when omitted

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1140,6 +1140,9 @@ class SlackOAuthHandler(SecureHandler):
             existing_tenant_id = (
                 str(getattr(existing_workspace, "tenant_id", "") or "").strip() or None
             )
+            existing_refresh_token = (
+                str(getattr(existing_workspace, "refresh_token", "") or "").strip() or None
+            )
             requested_tenant_id = str(tenant_id or "").strip() or None
             if (
                 existing_tenant_id
@@ -1165,6 +1168,8 @@ class SlackOAuthHandler(SecureHandler):
                     "Workspace is already linked to a different tenant",
                     409,
                 )
+            if not str(refresh_token or "").strip():
+                refresh_token = existing_refresh_token
 
             workspace = SlackWorkspace(
                 workspace_id=workspace_id,
@@ -1670,7 +1675,9 @@ class SlackOAuthHandler(SecureHandler):
                         error="Invalid refresh response: missing access token",
                     )
                 return error_response("Invalid token refresh response", 502)
-            new_refresh_token = data.get("refresh_token", workspace.refresh_token)
+            new_refresh_token = data.get("refresh_token")
+            if not str(new_refresh_token or "").strip():
+                new_refresh_token = workspace.refresh_token
             expires_in = data.get("expires_in")
             new_expires_at = time.time() + expires_in if expires_in else None
 

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -933,6 +933,48 @@ class TestCallback:
         mock_workspace_store.save.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_callback_preserves_existing_refresh_token_when_response_omits_it(
+        self, handler, mock_workspace, mock_workspace_store, mock_state_store
+    ):
+        mock_workspace.refresh_token = "xoxr-existing-refresh"
+        mock_state_store.validate_and_consume.return_value = {
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": {"id": "W123", "name": "My Team"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history,chat:write",
+                "refresh_token": "",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch("aragora.storage.slack_workspace_store.SlackWorkspace") as mock_workspace_cls,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        assert mock_workspace_cls.call_args.kwargs["refresh_token"] == "xoxr-existing-refresh"
+        mock_workspace_store.save.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_callback_rejects_state_from_other_provider(
         self, handler, mock_state_store, mock_workspace_store
     ):
@@ -2620,6 +2662,41 @@ class TestRefreshToken:
         assert _status(result) == 200
         assert mock_workspace.access_token == "xoxb-updated-token"
         assert mock_workspace.refresh_token == "xoxr-updated-refresh"
+        mock_workspace_store.save.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_preserves_existing_refresh_token_when_response_is_blank(
+        self, handler, mock_workspace, mock_workspace_store
+    ):
+        mock_workspace.refresh_token = "xoxr-existing-refresh"
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-updated-token",
+                "refresh_token": "",
+                "expires_in": 86400,
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        assert mock_workspace.access_token == "xoxb-updated-token"
+        assert mock_workspace.refresh_token == "xoxr-existing-refresh"
         mock_workspace_store.save.assert_called_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- preserve an existing workspace refresh token when Slack callback omits or blanks the replacement
- preserve the stored refresh token on manual refresh when Slack returns an empty refresh token
- add regressions for callback reinstall and refresh token rotation edge cases

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k "preserves_existing_refresh_token_when_response_omits_it or preserves_existing_refresh_token_when_response_is_blank"
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q