### PR TITLE
Hide webhook ownership mismatches as not found

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -265,6 +265,11 @@ class WebhookHandler(SecureHandler):
             return True
         return False
 
+    @staticmethod
+    def _hidden_webhook_not_found(webhook_id: str) -> HandlerResult:
+        """Return a generic not-found for unauthorized single-record access."""
+        return error_response(f"Webhook not found: {webhook_id}", 404)
+
     @api_endpoint(
         path="/api/v1/webhooks",
         method="GET",
@@ -628,7 +633,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return error_response("Access denied", 403)
+            return self._hidden_webhook_not_found(webhook_id)
 
         return json_response({"webhook": webhook.to_dict(include_secret=False)})
 
@@ -716,7 +721,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return error_response("Access denied", 403)
+            return self._hidden_webhook_not_found(webhook_id)
 
         store.delete(webhook_id)
 
@@ -752,7 +757,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return error_response("Access denied", 403)
+            return self._hidden_webhook_not_found(webhook_id)
 
         # Validate URL if provided (SSRF check)
         new_url = body.get("url")
@@ -810,7 +815,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return error_response("Access denied", 403)
+            return self._hidden_webhook_not_found(webhook_id)
 
         # Import here to avoid circular dependency
         from aragora.events.dispatcher import dispatch_webhook

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -652,7 +652,7 @@ class TestWebhookHandlerGet:
         handler = MockHandler(headers={})
         result = await handler_obj.handle(f"/api/v1/webhooks/{webhook.id}", {}, handler)
 
-        assert result.status_code == 403
+        assert result.status_code == 404
 
     @pytest.mark.asyncio
     async def test_get_webhook_denies_missing_workspace_context(self, server_context):
@@ -677,7 +677,7 @@ class TestWebhookHandlerGet:
         handler = MockHandler(headers={})
         result = await handler_obj.handle(f"/api/v1/webhooks/{webhook.id}", {}, handler)
 
-        assert result.status_code == 403
+        assert result.status_code == 404
 
 
 class TestWebhookHandlerDelete:
@@ -708,6 +708,30 @@ class TestWebhookHandlerDelete:
         result = await webhook_handler.handle_delete(
             "/api/v1/webhooks/non-existent-id", {}, handler
         )
+
+        assert result.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_webhook_hides_workspace_mismatch(self, server_context):
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com",
+            events=["debate_start"],
+            workspace_id="org-locked",
+        )
+        handler_obj = WebhookHandler(server_context)
+        handler_obj.get_current_user = MagicMock(
+            return_value=SimpleNamespace(
+                user_id="test-user-001",
+                role="admin",
+                org_id="org-other",
+            )
+        )
+
+        handler = MockHandler(headers={})
+        result = await handler_obj.handle_delete(f"/api/v1/webhooks/{webhook.id}", {}, handler)
 
         assert result.status_code == 404
 
@@ -761,6 +785,33 @@ class TestWebhookHandlerUpdate:
 
         result = webhook_handler.handle_patch(f"/api/v1/webhooks/{webhook.id}", {}, handler)
         assert result.status_code == 400
+
+    def test_update_webhook_hides_workspace_mismatch(self, server_context):
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com",
+            events=["debate_start"],
+            workspace_id="org-locked",
+        )
+        handler_obj = WebhookHandler(server_context)
+        handler_obj.get_current_user = MagicMock(
+            return_value=SimpleNamespace(
+                user_id="test-user-001",
+                role="admin",
+                org_id="org-other",
+            )
+        )
+
+        body = json.dumps({"active": False}).encode()
+        handler = MockHandler(
+            headers={"Content-Length": str(len(body)), "Content-Type": "application/json"},
+            body=body,
+        )
+
+        result = handler_obj.handle_patch(f"/api/v1/webhooks/{webhook.id}", {}, handler)
+        assert result.status_code == 404
 
 
 class TestWebhookHandlerTest:
@@ -818,7 +869,30 @@ class TestWebhookHandlerTest:
             assert result.status_code == 502
             body = json.loads(result.body)
             assert body["success"] is False
-            assert "error" in body
+
+    @pytest.mark.asyncio
+    async def test_test_webhook_hides_workspace_mismatch(self, server_context):
+        from aragora.server.handlers.webhooks import WebhookHandler
+
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com/hook",
+            events=["debate_start"],
+            workspace_id="org-locked",
+        )
+        handler_obj = WebhookHandler(server_context)
+        handler_obj.get_current_user = MagicMock(
+            return_value=SimpleNamespace(
+                user_id="test-user-001",
+                role="admin",
+                org_id="org-other",
+            )
+        )
+
+        handler = MockHandler(headers={})
+        result = await handler_obj.handle_post(f"/api/v1/webhooks/{webhook.id}/test", {}, handler)
+
+        assert result.status_code == 404
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- return 404 instead of 403 when a single webhook exists but is outside the caller's ownership scope
- apply the same fail-closed behavior to get, delete, update, and test endpoints
- add regressions for workspace-mismatch access on all affected routes

## Testing
- python -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/test_webhooks_handler.py
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q -k "workspace_mismatch or missing_workspace_context"
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q