### PR TITLE
Clear PR metadata on scope violation

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2979,6 +2979,15 @@ class SwarmSupervisor:
                     )
                     item["review_status"] = "changes_requested"
                     item["receipt_id"] = None
+                    item.pop("confidence", None)
+                    item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
+                    for key in (
+                        "pr_url",
+                        "adopted_pr",
+                        "merge_gate",
+                        "verification_missing_reason",
+                    ):
+                        item.pop(key, None)
                     item["scope_violation"] = {
                         "violations": list(exc.violations),
                         "changed_paths": clean_paths,
@@ -4456,6 +4465,13 @@ class SwarmSupervisor:
         item["blockers"] = blockers
         item.pop("receipt_id", None)
         item.pop("confidence", None)
+        for key in (
+            "pr_url",
+            "adopted_pr",
+            "merge_gate",
+            "verification_missing_reason",
+        ):
+            item.pop(key, None)
         item.pop("pid", None)
 
         # Write violation metadata into the lease so status_summary() surfaces

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3201,6 +3201,10 @@ async def test_collect_results_marks_scope_violation_needs_human(
                 "review_status": "pending",
                 "receipt_id": "receipt-stale",
                 "confidence": 0.88,
+                "pr_url": "https://github.com/synaptent/aragora/pull/9999",
+                "adopted_pr": "https://github.com/synaptent/aragora/pull/9999",
+                "merge_gate": {"checks_passed": True},
+                "verification_missing_reason": "missing_verification_plan",
             }
         ],
         status="active",
@@ -3242,9 +3246,12 @@ async def test_collect_results_marks_scope_violation_needs_human(
     assert wo["review_status"] == "changes_requested"
     assert "outside permitted scope" in wo["dispatch_error"]
     assert wo["failure_reason"] == "scope_violation"
+    assert wo["worker_outcome"] == "scope_violation"
     assert "stay in scope" in wo["blocking_question"]
     assert wo.get("receipt_id") is None
     assert "confidence" not in wo
+    for cleared_key in ("pr_url", "adopted_pr", "merge_gate", "verification_missing_reason"):
+        assert cleared_key not in wo
     assert wo["lease_id"] == lease.lease_id
     assert wo["scope_violation"]["violations"][0]["type"] == "out_of_scope"
 


### PR DESCRIPTION
## Summary
- clear stale PR and merge-gate metadata when a supervisor lane is blocked for file-scope violation
- classify record-completion scope violations as scope_violation instead of leaving completed-looking state behind
- add a regression that starts from stale receipt and PR metadata and proves the blocked lane fails closed

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k "collect_results_marks_scope_violation_needs_human or collect_results_blocks_merge_gate_when_required_checks_fail or collect_results_blocks_merge_gate_without_verification_plan"
- python -m pytest tests/swarm/test_supervisor.py -q