### PR TITLE
Scope boss retry freshness to selected issues

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -632,17 +632,29 @@ class BossLoop:
             normalized.append(runner_type)
         return normalized
 
-    def _has_retryable_attempts(self) -> bool:
-        return any(
-            isinstance(issue_number, int) and attempt_count > 0
-            for issue_number, attempt_count in self._issue_attempt_counts.items()
-        )
+    def _selected_issues_need_retry_routing(self, issues: list[GitHubIssue]) -> bool:
+        for issue in issues:
+            issue_number = int(getattr(issue, "number", 0) or 0)
+            if issue_number <= 0:
+                continue
+            if issue_number in self._pending_handoff_prompts:
+                return True
+            if int(self._issue_attempt_counts.get(issue_number, 0) or 0) > 0:
+                return True
+        return False
 
-    def _requested_runner_type_for_freshness(self) -> str | None:
-        # Once retries are in play, keep the freshness pool broad enough that
-        # dispatch can rotate to the next runner type instead of reusing the
-        # original default forever.
-        if self._has_retryable_attempts() and len(self._normalized_model_rotation()) > 1:
+    def _requested_runner_type_for_freshness(
+        self,
+        selected_issues: list[GitHubIssue],
+    ) -> str | None:
+        # Broaden the freshness pool only for the issue(s) we are about to
+        # dispatch when they are actually on a retry/handoff path. Historical
+        # retries on unrelated issues must not let fresh issues bypass the
+        # default target runner requirement.
+        if (
+            self._selected_issues_need_retry_routing(selected_issues)
+            and len(self._normalized_model_rotation()) > 1
+        ):
             return None
         return self.config.default_target_agent
 
@@ -1731,7 +1743,7 @@ class BossLoop:
             freshness_ttl_seconds=self.config.freshness_ttl_seconds,
             registry_path=self.config.registry_path,
             env=self._env,
-            requested_runner_type=self._requested_runner_type_for_freshness(),
+            requested_runner_type=self._requested_runner_type_for_freshness([selected]),
             allowed_profiles=self.config.allowed_runner_profiles,
             rotation_interval_seconds=self.config.runner_rotation_interval_seconds,
             verified_runner_target=self.config.verified_runner_target,
@@ -1883,7 +1895,7 @@ class BossLoop:
             freshness_ttl_seconds=self.config.freshness_ttl_seconds,
             registry_path=self.config.registry_path,
             env=self._env,
-            requested_runner_type=self._requested_runner_type_for_freshness(),
+            requested_runner_type=self._requested_runner_type_for_freshness(selected_issues),
             allowed_profiles=self.config.allowed_runner_profiles,
             rotation_interval_seconds=self.config.runner_rotation_interval_seconds,
         )

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1157,6 +1157,69 @@ class TestBossLoop:
         assert second_call["default_target_agent"] == "codex"
         assert second_call["selected_runner"]["runner_type"] == "codex"
 
+    def test_historical_retry_on_other_issue_does_not_broaden_freshness_pool(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(99, "Fresh issue should keep default routing")]
+
+        freshness_requests: list[str | None] = []
+
+        def _freshness_checker(**kwargs):
+            freshness_requests.append(kwargs.get("requested_runner_type"))
+            return RunnerFreshnessResult(
+                fresh=True,
+                runner_ids=["claude-runner-1"],
+                checked_at=datetime.now(UTC).isoformat(),
+                details={
+                    "routing": {
+                        "selected_runners": [
+                            {"runner_id": "claude-runner-1", "runner_type": "claude"},
+                        ],
+                        "selected_runner_ids": ["claude-runner-1"],
+                    }
+                },
+            )
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                default_target_agent="claude",
+                model_rotation=["claude", "codex"],
+            ),
+            issue_feed=feed,
+            freshness_checker=_freshness_checker,
+        )
+        loop._issue_attempt_counts[42] = 1  # Unrelated historical retry
+
+        def _claim_runner(freshness, *, requested_target_agent=None):
+            runner_type = requested_target_agent or "claude"
+            return (
+                {
+                    "runner_id": f"{runner_type}-runner-1",
+                    "runner_type": runner_type,
+                },
+                f"{runner_type}-runner-1",
+            )
+
+        loop._claim_runner_for_dispatch = _claim_runner
+        loop._release_runner_claim = lambda runner_id: None
+
+        dispatch_results = AsyncMock(
+            return_value={
+                "status": "completed",
+                "outcome": "deliverable_created",
+                "deliverable": {"type": "branch"},
+            }
+        )
+
+        with patch("aragora.swarm.boss_loop.dispatch_bounded_spec", dispatch_results):
+            result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert freshness_requests == ["claude"]
+        dispatch_call = dispatch_results.await_args.kwargs
+        assert dispatch_call["default_target_agent"] == "claude"
+        assert dispatch_call["selected_runner"]["runner_type"] == "claude"
+
     def test_retry_skips_maxed_issues(self):
         """Issues that have been attempted max_retries_per_issue times are skipped."""
         feed = MagicMock(spec=GitHubIssueFeed)


### PR DESCRIPTION
## Summary
- broaden runner-freshness routing only for the issue(s) actually selected for retry or handoff
- stop historical retries on unrelated issues from loosening the default runner requirement for fresh issues
- add a regression proving a fresh issue still requests the default runner pool even after another issue has retried

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k "retry_rotation_switches_target_agent_after_needs_human or historical_retry_on_other_issue_does_not_broaden_freshness_pool or retry_skips_maxed_issues"
- python -m pytest tests/swarm/test_boss_loop.py -q