### PR TITLE
fix: clear stale deliverable state on dependency conflict

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2067,7 +2067,32 @@ class SwarmSupervisor:
         dependency_ref: str,
         dependency_id: str,
     ) -> bool:
+        def _clear_stale_deliverable_state() -> None:
+            for key in (
+                "receipt_id",
+                "confidence",
+                "worker_outcome",
+                "completed_at",
+                "exit_code",
+                "head_sha",
+                "commit_shas",
+                "changed_paths",
+                "diff",
+                "diff_lines",
+                "stdout_tail",
+                "stderr_tail",
+                "tests_run",
+                "verification_results",
+                "merge_gate",
+                "verification_missing_reason",
+                "pr_url",
+                "adopted_pr",
+                "scope_violation",
+            ):
+                work_order.pop(key, None)
+
         if not self._is_safe_dependency_ref(str(session.path), dependency_ref):
+            _clear_stale_deliverable_state()
             self._mark_needs_human(
                 work_order,
                 (
@@ -2087,6 +2112,7 @@ class SwarmSupervisor:
         session_path = str(session.path)
         status_proc = self._run_git_capture_sync(session_path, "status", "--porcelain")
         if status_proc.returncode != 0:
+            _clear_stale_deliverable_state()
             self._mark_needs_human(
                 work_order,
                 (
@@ -2107,6 +2133,7 @@ class SwarmSupervisor:
             work_order["dependency_base_source"] = dependency_id
             return False
         if status_proc.stdout.strip():
+            _clear_stale_deliverable_state()
             self._mark_needs_human(
                 work_order,
                 (
@@ -2133,6 +2160,7 @@ class SwarmSupervisor:
             dependency_ref,
         )
         if checkout_proc.returncode != 0:
+            _clear_stale_deliverable_state()
             self._mark_needs_human(
                 work_order,
                 (

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5751,6 +5751,15 @@ def test_refresh_run_marks_invalid_dependency_ref_needs_human(
                 "file_scope": ["README.md"],
                 "target_agent": "codex",
                 "reviewer_agent": "claude",
+                "receipt_id": "rcpt-stale",
+                "confidence": 0.91,
+                "worker_outcome": "completed",
+                "commit_shas": ["deadbeef"],
+                "changed_paths": ["README.md"],
+                "head_sha": "deadbeef",
+                "pr_url": "https://github.com/synaptent/aragora/pull/9999",
+                "merge_gate": {"checks_passed": True},
+                "verification_missing_reason": "missing_verification_plan",
             },
         ],
         status="active",
@@ -5766,6 +5775,19 @@ def test_refresh_run_marks_invalid_dependency_ref_needs_human(
     assert dependent["dependency_base_ref"] == "-bad-ref"
     assert dependent["dependency_base_source"] == "micro-task-1"
     assert "unsafe dependency base reference" in dependent["dispatch_error"]
+    assert dependent["review_status"] == "changes_requested"
+    for key in (
+        "receipt_id",
+        "confidence",
+        "worker_outcome",
+        "commit_shas",
+        "changed_paths",
+        "head_sha",
+        "pr_url",
+        "merge_gate",
+        "verification_missing_reason",
+    ):
+        assert key not in dependent
 
 
 def test_refresh_run_reaps_stale_leased_work_order(repo: Path, store: DevCoordinationStore) -> None:


### PR DESCRIPTION
## Summary
- clear stale deliverable metadata before dependency-base conflicts land in needs_human
- cover invalid dependency refs with preexisting stale receipt/PR state

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'invalid_dependency_ref_needs_human or dependency_branch_reuse'
- python -m pytest tests/swarm/test_supervisor.py -q