### PR TITLE
fix: fail closed on slack store refresh responses

### DIFF
--- a/aragora/storage/slack_workspace_store.py
+++ b/aragora/storage/slack_workspace_store.py
@@ -692,18 +692,30 @@ class SlackWorkspaceStore:
                     self.deactivate(workspace_id)
                 return None
 
-            # Update workspace with new tokens
-            workspace.access_token = result.get("access_token", workspace.access_token)
+            new_access_token = str(result.get("access_token") or "").strip()
+            if not new_access_token:
+                logger.error(
+                    "Token refresh returned no access token for workspace: %s",
+                    workspace_id,
+                )
+                return None
 
             # Handle new refresh token (rotation)
             new_refresh = result.get("refresh_token")
-            if new_refresh:
-                workspace.refresh_token = new_refresh
+            new_refresh_token = (
+                str(new_refresh).strip()
+                if str(new_refresh or "").strip()
+                else workspace.refresh_token
+            )
 
             # Calculate expiration time
             expires_in = result.get("expires_in")
-            if expires_in:
-                workspace.token_expires_at = time.time() + expires_in
+            new_expires_at = time.time() + expires_in if expires_in else workspace.token_expires_at
+
+            # Update workspace with validated tokens
+            workspace.access_token = new_access_token
+            workspace.refresh_token = new_refresh_token
+            workspace.token_expires_at = new_expires_at
 
             # Save updated workspace
             if self.save(workspace):

--- a/tests/storage/test_slack_workspace_store.py
+++ b/tests/storage/test_slack_workspace_store.py
@@ -12,7 +12,7 @@ Tests cover:
 import tempfile
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -454,6 +454,49 @@ class TestSlackWorkspaceStoreErrors:
             result = store.list_active()
 
         assert result == []
+
+
+class TestSlackWorkspaceStoreTokenRefresh:
+    """Tests for store-level Slack token refresh handling."""
+
+    @pytest.mark.asyncio
+    async def test_refresh_workspace_token_rejects_missing_access_token(
+        self, workspace_store, sample_workspace
+    ):
+        sample_workspace.refresh_token = "xoxr-refresh-token"
+        sample_workspace.token_expires_at = time.time() + 3600
+        assert workspace_store.save(sample_workspace) is True
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "ok": True,
+            "access_token": "",
+            "refresh_token": "xoxr-rotated-refresh",
+            "expires_in": 7200,
+        }
+
+        mock_client = AsyncMock()
+        mock_client.__aenter__.return_value = mock_client
+        mock_client.__aexit__.return_value = False
+        mock_client.post.return_value = mock_response
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch.object(workspace_store, "save", wraps=workspace_store.save) as spy_save,
+        ):
+            result = await workspace_store.refresh_workspace_token(
+                "T12345678",
+                client_id="test-client-id",
+                client_secret="test-client-secret",
+            )
+
+        assert result is None
+        spy_save.assert_not_called()
+
+        persisted = workspace_store.get("T12345678")
+        assert persisted is not None
+        assert persisted.access_token == "xoxb-test-token-12345"
+        assert persisted.refresh_token == "xoxr-refresh-token"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- reject Slack store refresh responses that omit a new access token
- avoid mutating persisted workspace credentials on invalid refresh responses
- add store-level regression coverage for the fail-closed path

## Testing
- python -m ruff check aragora/storage/slack_workspace_store.py tests/storage/test_slack_workspace_store.py
- python -m pytest tests/storage/test_slack_workspace_store.py -q -k 'refresh_workspace_token_rejects_missing_access_token'
- python -m pytest tests/storage/test_slack_workspace_store.py -q
- python -m pytest tests/storage/test_slack_token_refresh.py tests/schedulers/test_slack_token_refresh.py -q