### PR TITLE
test(server): refresh stale playground and learning baselines

### DIFF
--- a/tests/server/handlers/memory/test_learning.py
+++ b/tests/server/handlers/memory/test_learning.py
@@ -1074,12 +1074,13 @@ class TestConstants:
         assert MEMORY_WRITE_PERMISSION == "memory:write"
 
     def test_routes_defined(self):
-        assert len(LearningHandler.ROUTES) == 8
-        assert "/api/learning/cycles" in LearningHandler.ROUTES
-        assert "/api/learning/patterns" in LearningHandler.ROUTES
-        assert "/api/learning/agent-evolution" in LearningHandler.ROUTES
-        assert "/api/learning/insights" in LearningHandler.ROUTES
-        assert "/api/v1/learning/cycles" in LearningHandler.ROUTES
-        assert "/api/v1/learning/patterns" in LearningHandler.ROUTES
-        assert "/api/v1/learning/agent-evolution" in LearningHandler.ROUTES
-        assert "/api/v1/learning/insights" in LearningHandler.ROUTES
+        assert set(LearningHandler.ROUTES) == {
+            "/api/learning/cycles",
+            "/api/learning/patterns",
+            "/api/learning/agent-evolution",
+            "/api/learning/insights",
+            "/api/v1/learning/cycles",
+            "/api/v1/learning/patterns",
+            "/api/v1/learning/agent-evolution",
+            "/api/v1/learning/insights",
+        }

--- a/tests/server/handlers/test_playground.py
+++ b/tests/server/handlers/test_playground.py
@@ -24,6 +24,7 @@ import pytest
 
 from aragora.server.handlers.playground import (
     PlaygroundHandler,
+    _DEFAULT_AGENTS,
     _check_rate_limit,
     _reset_rate_limits,
     _PLAYGROUND_RATE_LIMIT,
@@ -215,7 +216,7 @@ class TestDebateEndpoint:
         assert "receipt" in data
         assert "receipt_hash" in data
         assert "participants" in data
-        assert len(data["participants"]) == 4  # default agent count
+        assert len(data["participants"]) == _DEFAULT_AGENTS
         assert data["duration_seconds"] >= 0
 
     def test_debate_with_trailing_slash_path(self, handler, mock_http_handler):


### PR DESCRIPTION
## Summary
- update the playground default participant assertion to use the current default agent count
- assert the full legacy plus v1 learning route set instead of the pre-versioning count
- validate the exact server-shard failures reproduced on current main

## Testing
- python3 -m pytest tests/server/handlers/test_playground.py::TestDebateEndpoint::test_debate_with_defaults tests/server/handlers/memory/test_learning.py::TestConstants::test_routes_defined -q
- python3 -m pytest tests/server/handlers/test_playground.py::TestDebateEndpoint::test_debate_with_defaults tests/server/handlers/admin/health/test_detailed.py tests/server/test_debate_factory_routing.py tests/server/handlers/test_demo_live_proof_surface.py::test_demo_source_can_replay_cached_live_results tests/server/handlers/memory/test_learning.py::TestConstants::test_routes_defined tests/server/middleware/test_distributed_rate_limit.py::TestMetricsRecording::test_records_rate_limit_decisions tests/server/test_lifecycle.py::TestPrometheusMetrics -q
- python3 -m ruff check tests/server/handlers/test_playground.py tests/server/handlers/memory/test_learning.py