### PR TITLE
Use live encryption key in slack workspace store

### DIFF
--- a/aragora/storage/slack_workspace_store.py
+++ b/aragora/storage/slack_workspace_store.py
@@ -282,9 +282,11 @@ class SlackWorkspaceStore:
         from cryptography.hazmat.primitives import hashes
         from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+        encryption_key = self._current_encryption_key()
+
         # Use SHA-256 of key as deterministic salt (16 bytes)
         # This provides domain separation while remaining deterministic
-        salt = hashlib.sha256(b"aragora-slack-token-salt:" + ENCRYPTION_KEY.encode()).digest()[:16]
+        salt = hashlib.sha256(b"aragora-slack-token-salt:" + encryption_key.encode()).digest()[:16]
 
         kdf = PBKDF2HMAC(
             algorithm=hashes.SHA256(),
@@ -292,14 +294,25 @@ class SlackWorkspaceStore:
             salt=salt,
             iterations=480000,  # OWASP recommended minimum for PBKDF2-SHA256
         )
-        return base64.urlsafe_b64encode(kdf.derive(ENCRYPTION_KEY.encode()))
+        return base64.urlsafe_b64encode(kdf.derive(encryption_key.encode()))
 
     def _derive_key_v1(self) -> bytes:
         """Derive key using legacy SHA-256 method (for backward compatibility)."""
         import base64
         import hashlib
 
-        return base64.urlsafe_b64encode(hashlib.sha256(ENCRYPTION_KEY.encode()).digest())
+        encryption_key = self._current_encryption_key()
+        return base64.urlsafe_b64encode(hashlib.sha256(encryption_key.encode()).digest())
+
+    @staticmethod
+    def _current_encryption_key() -> str:
+        """Resolve the active encryption key at call time.
+
+        This avoids stale import-time snapshots when the environment is loaded
+        after module import, while still preserving explicit test monkeypatches
+        of the module-level constant when no env override is present.
+        """
+        return os.environ.get("ARAGORA_ENCRYPTION_KEY", ENCRYPTION_KEY)
 
     def _encrypt_token(self, token: str) -> str:
         """Encrypt token using PBKDF2-derived key.
@@ -308,7 +321,7 @@ class SlackWorkspaceStore:
         - v2: PBKDF2HMAC with 480k iterations
         - (no prefix): Legacy SHA-256 single-pass
         """
-        if not ENCRYPTION_KEY:
+        if not self._current_encryption_key():
             return token
 
         try:
@@ -334,7 +347,7 @@ class SlackWorkspaceStore:
         - v2: prefix - PBKDF2HMAC derived key
         - No prefix - Legacy SHA-256 derived key
         """
-        if not ENCRYPTION_KEY:
+        if not self._current_encryption_key():
             return encrypted
 
         # Check if it looks like an unencrypted or revoked token

--- a/tests/storage/test_slack_workspace_store.py
+++ b/tests/storage/test_slack_workspace_store.py
@@ -398,6 +398,37 @@ class TestSlackWorkspaceStoreEncryption:
         workspace = store.get("T12345678")
         assert workspace.access_token == "xoxb-test-token-12345"
 
+    def test_token_encrypted_when_env_key_arrives_after_import(
+        self, temp_db_path, sample_workspace
+    ):
+        """Encryption should use the live env key, not a stale import snapshot."""
+        from cryptography.fernet import Fernet  # noqa: F401
+
+        with (
+            patch("aragora.storage.slack_workspace_store.ENCRYPTION_KEY", ""),
+            patch.dict(
+                "os.environ",
+                {"ARAGORA_ENCRYPTION_KEY": "test-encryption-key-32chars!!"},
+                clear=False,
+            ),
+        ):
+            store = SlackWorkspaceStore(db_path=temp_db_path)
+            store.save(sample_workspace)
+
+            conn = store._get_connection()
+            cursor = conn.execute(
+                "SELECT access_token FROM slack_workspaces WHERE workspace_id = ?",
+                ("T12345678",),
+            )
+            row = cursor.fetchone()
+            raw_token = row["access_token"]
+
+            assert not raw_token.startswith("xoxb-")
+
+            workspace = store.get("T12345678")
+            assert workspace is not None
+            assert workspace.access_token == "xoxb-test-token-12345"
+
     def test_decrypt_unencrypted_token(self, workspace_store):
         """Test decrypting an already unencrypted token returns as-is."""
         # Simulate token that's already unencrypted


### PR DESCRIPTION
## Summary
- resolve Slack workspace store encryption keys at call time instead of using the import-time snapshot
- encrypt and decrypt with the live ARAGORA_ENCRYPTION_KEY value while preserving tests that monkeypatch the module constant
- add a regression proving tokens are still encrypted when the env key arrives after module import

## Testing
- python -m ruff check aragora/storage/slack_workspace_store.py tests/storage/test_slack_workspace_store.py
- python -m pytest tests/storage/test_slack_workspace_store.py -q -k 'token_encrypted_when_env_key_arrives_after_import or token_encrypted_with_key or token_stored_unencrypted_without_key'
- python -m pytest tests/storage/test_slack_workspace_store.py -q
- python -m pytest tests/storage/test_slack_token_refresh.py tests/schedulers/test_slack_token_refresh.py -q