### PR TITLE
Peek OAuth state before Slack callback consume

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -366,6 +366,24 @@ class SlackOAuthHandler(SecureHandler):
             return True
         return requester_tenant_id != workspace_tenant_id
 
+    @staticmethod
+    def _extract_state_metadata(state_data: Any) -> tuple[str | None, str | None, str | None]:
+        """Extract tenant, redirect URI, and provider metadata from an OAuth state payload."""
+        if isinstance(state_data, dict):
+            tenant_id = state_data.get("tenant_id")
+            redirect_uri = str(state_data.get("redirect_uri", "") or "").strip() or None
+            provider = str(state_data.get("provider", "") or "").strip() or None
+            return tenant_id, redirect_uri, provider
+
+        metadata = getattr(state_data, "metadata", None)
+        if isinstance(metadata, dict):
+            tenant_id = metadata.get("tenant_id")
+            redirect_uri = str(metadata.get("redirect_uri", "") or "").strip() or None
+            provider = str(metadata.get("provider", "") or "").strip() or None
+            return tenant_id, redirect_uri, provider
+
+        return None, None, None
+
     async def handle(self, *args: Any, **kwargs: Any) -> HandlerResult:
         """Route OAuth requests with dual-signature support.
 
@@ -937,18 +955,33 @@ class SlackOAuthHandler(SecureHandler):
             error: Error code if user denied
         """
         state = query_params.get("state")
+        state_store = _get_state_store()
+        peeked_state_data = None
+        fallback_state_data = None
+
+        if state:
+            _cleanup_oauth_states_fallback()
+            fallback_state_data = _oauth_states_fallback.get(state)
+            try:
+                peeked_state_data = state_store.peek(state)
+            except Exception:
+                logger.debug("Failed to peek Slack OAuth state", exc_info=True)
 
         # Check for error from Slack
         if "error" in query_params:
             if state:
-                try:
-                    _get_state_store().validate_and_consume(state)
-                except Exception:
-                    logger.debug(
-                        "Failed to consume Slack OAuth state after callback error", exc_info=True
-                    )
-                _cleanup_oauth_states_fallback()
-                _oauth_states_fallback.pop(state, None)
+                _, _, state_provider = self._extract_state_metadata(
+                    peeked_state_data or fallback_state_data
+                )
+                if state_provider == "slack":
+                    try:
+                        state_store.validate_and_consume(state)
+                    except Exception:
+                        logger.debug(
+                            "Failed to consume Slack OAuth state after callback error",
+                            exc_info=True,
+                        )
+                    _oauth_states_fallback.pop(state, None)
             error_code = query_params.get("error")
             logger.warning("Slack OAuth error: %s", error_code)
             # Audit log OAuth denial
@@ -969,30 +1002,21 @@ class SlackOAuthHandler(SecureHandler):
         if not state:
             return error_response("Missing state parameter", 400)
 
-        # Verify state token using centralized state store
-        state_store = _get_state_store()
+        if not (peeked_state_data or fallback_state_data):
+            return error_response("Invalid or expired state token", 400)
+
+        tenant_id, state_redirect_uri, state_provider = self._extract_state_metadata(
+            peeked_state_data or fallback_state_data
+        )
+        if state_provider != "slack":
+            return error_response("Invalid or expired state token", 400)
+
+        # Consume only after verifying this state was actually minted for Slack.
         state_data = state_store.validate_and_consume(state)
-        _cleanup_oauth_states_fallback()
         fallback_state_data = _oauth_states_fallback.pop(state, None)
         if not state_data:
             state_data = fallback_state_data
         if not state_data:
-            return error_response("Invalid or expired state token", 400)
-
-        state_redirect_uri: str | None = None
-        state_provider: str | None = None
-        if isinstance(state_data, dict):
-            tenant_id = state_data.get("tenant_id")
-            state_redirect_uri = str(state_data.get("redirect_uri", "") or "").strip() or None
-            state_provider = str(state_data.get("provider", "") or "").strip() or None
-        else:
-            metadata = getattr(state_data, "metadata", None)
-            tenant_id = metadata.get("tenant_id") if isinstance(metadata, dict) else None
-            if isinstance(metadata, dict):
-                state_redirect_uri = str(metadata.get("redirect_uri", "") or "").strip() or None
-                state_provider = str(metadata.get("provider", "") or "").strip() or None
-
-        if state_provider != "slack":
             return error_response("Invalid or expired state token", 400)
 
         client_id = _get_slack_client_id()

--- a/aragora/server/oauth_state_store.py
+++ b/aragora/server/oauth_state_store.py
@@ -106,6 +106,11 @@ class OAuthStateStore(ABC):
         pass
 
     @abstractmethod
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate state token without consuming it."""
+        pass
+
+    @abstractmethod
     def cleanup_expired(self) -> int:
         """Remove expired states. Returns count of removed entries."""
         pass
@@ -163,6 +168,15 @@ class InMemoryOAuthStateStore(OAuthStateStore):
                 return None
             state_data = self._states.pop(state)
             if state_data.is_expired:
+                return None
+            return state_data
+
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate state token without consuming it."""
+        self.cleanup_expired()
+        with self._lock:
+            state_data = self._states.get(state)
+            if state_data is None or state_data.is_expired:
                 return None
             return state_data
 
@@ -341,6 +355,47 @@ class SQLiteOAuthStateStore(OAuthStateStore):
             logger.error("SQLite OAuth store validate failed: %s", e)
             return None
 
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate state token without consuming it."""
+        self.cleanup_expired()
+        conn = self._get_connection()
+
+        try:
+            cursor = conn.execute(
+                """
+                SELECT user_id, redirect_url, expires_at, created_at, metadata
+                FROM oauth_states WHERE state_token = ?
+            """,
+                (state,),
+            )
+            row = cursor.fetchone()
+
+            if not row:
+                return None
+
+            metadata = None
+            if row[4]:
+                try:
+                    metadata = json.loads(row[4])
+                except json.JSONDecodeError:
+                    pass
+
+            state_data = OAuthState(
+                user_id=row[0],
+                redirect_url=row[1],
+                expires_at=row[2],
+                created_at=row[3],
+                metadata=metadata,
+            )
+
+            if state_data.is_expired:
+                return None
+
+            return state_data
+        except sqlite3.Error as e:
+            logger.error("SQLite OAuth store peek failed: %s", e)
+            return None
+
     def cleanup_expired(self) -> int:
         """Remove expired states."""
         now = time.time()
@@ -492,6 +547,26 @@ class RedisOAuthStateStore(OAuthStateStore):
             logger.warning("Invalid OAuth state data for %s...", state[:16])
             return None
 
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate state token in Redis without consuming it."""
+        redis_client = self._get_redis()
+        if not redis_client:
+            raise RedisUnavailableError("OAuth state storage")
+
+        data_str = redis_client.get(self._key(state))
+        if not data_str:
+            return None
+
+        try:
+            data = json.loads(data_str)
+            state_data = OAuthState.from_dict(data)
+            if state_data.is_expired:
+                return None
+            return state_data
+        except (json.JSONDecodeError, KeyError):
+            logger.warning("Invalid OAuth state data for %s...", state[:16])
+            return None
+
     def cleanup_expired(self) -> int:
         """Redis handles TTL expiration automatically."""
         return 0
@@ -601,6 +676,40 @@ class JWTOAuthStateStore(OAuthStateStore):
 
     def validate_and_consume(self, state: str) -> OAuthState | None:
         """Validate JWT state token and mark as consumed."""
+        state_data, nonce = self._validate_token(state)
+        if state_data is None or not nonce:
+            return None
+
+        with self._nonce_lock:
+            if nonce in self._used_nonces:
+                logger.warning("JWT state: replay detected (nonce reused)")
+                return None
+
+            # Mark nonce as used (simple in-memory tracking)
+            self._used_nonces.add(nonce)
+
+            # Cleanup old nonces periodically
+            if len(self._used_nonces) > self._nonce_cleanup_threshold:
+                # Just clear old nonces - expired states won't validate anyway
+                self._used_nonces.clear()
+
+        return state_data
+
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate JWT state token without consuming it."""
+        state_data, nonce = self._validate_token(state)
+        if state_data is None or not nonce:
+            return None
+
+        with self._nonce_lock:
+            if nonce in self._used_nonces:
+                logger.warning("JWT state: replay detected (nonce reused)")
+                return None
+
+        return state_data
+
+    def _validate_token(self, state: str) -> tuple[OAuthState | None, str]:
+        """Validate a JWT state token and return its decoded payload."""
         import base64
         import hashlib
         import hmac
@@ -609,7 +718,7 @@ class JWTOAuthStateStore(OAuthStateStore):
         parts = state.split(".")
         if len(parts) != 2:
             logger.debug("JWT state: invalid format (expected 2 parts)")
-            return None
+            return None, ""
 
         payload_b64, sig_b64 = parts
 
@@ -624,11 +733,11 @@ class JWTOAuthStateStore(OAuthStateStore):
             actual_sig = base64.urlsafe_b64decode(sig_b64_padded)
         except (ValueError, binascii.Error) as e:
             logger.debug("JWT state: invalid signature encoding: %s", e)
-            return None
+            return None, ""
 
         if not hmac.compare_digest(expected_sig, actual_sig):
             logger.debug("JWT state: signature mismatch")
-            return None
+            return None, ""
 
         # Decode payload
         payload_b64_padded = payload_b64 + "=" * (4 - len(payload_b64) % 4)
@@ -637,35 +746,23 @@ class JWTOAuthStateStore(OAuthStateStore):
             payload = json.loads(payload_json)
         except (ValueError, binascii.Error, UnicodeDecodeError, json.JSONDecodeError) as e:
             logger.debug("JWT state: payload decode failed: %s", e)
-            return None
+            return None, ""
 
         # Check expiration
         expires_at = payload.get("e", 0)
         if time.time() > expires_at:
             logger.debug("JWT state: expired")
-            return None
+            return None, ""
 
-        # Check replay (nonce already used) - thread-safe
-        nonce = payload.get("n", "")
-        with self._nonce_lock:
-            if nonce in self._used_nonces:
-                logger.warning("JWT state: replay detected (nonce reused)")
-                return None
-
-            # Mark nonce as used (simple in-memory tracking)
-            self._used_nonces.add(nonce)
-
-            # Cleanup old nonces periodically
-            if len(self._used_nonces) > self._nonce_cleanup_threshold:
-                # Just clear old nonces - expired states won't validate anyway
-                self._used_nonces.clear()
-
-        return OAuthState(
-            user_id=payload.get("u"),
-            redirect_url=payload.get("r"),
-            expires_at=expires_at,
-            created_at=payload.get("c", 0),
-            metadata=payload.get("m"),
+        return (
+            OAuthState(
+                user_id=payload.get("u"),
+                redirect_url=payload.get("r"),
+                expires_at=expires_at,
+                created_at=payload.get("c", 0),
+                metadata=payload.get("m"),
+            ),
+            str(payload.get("n", "") or ""),
         )
 
     def cleanup_expired(self) -> int:
@@ -895,6 +992,51 @@ class FallbackOAuthStateStore(OAuthStateStore):
                     return result
             except (KeyError, ValueError) as e:
                 logger.debug("Memory OAuth store fallback: %s", e)
+
+        return None
+
+    def peek(self, state: str) -> OAuthState | None:
+        """Validate state without consuming it, checking fallbacks if needed."""
+        store = self._get_active_store()
+        try:
+            result = store.peek(state)
+            if result:
+                return result
+        except _REDIS_ERRORS as e:
+            if store is self._redis_store:
+                logger.warning("Redis peek failed: %s", e)
+                self._redis_failed = True
+            else:
+                logger.warning("OAuth store peek failed: %s", e)
+        except sqlite3.Error as e:
+            if store is self._sqlite_store:
+                logger.warning("SQLite peek failed: %s", e)
+                self._sqlite_failed = True
+            else:
+                logger.warning("OAuth store peek failed: %s", e)
+        except (ValueError, KeyError) as e:
+            if store is self._jwt_store:
+                logger.warning("JWT peek failed: %s", e)
+            else:
+                logger.warning("OAuth store peek failed: %s", e)
+
+        if store is not self._sqlite_store and self._sqlite_store and not self._sqlite_failed:
+            try:
+                result = self._sqlite_store.peek(state)
+                if result:
+                    logger.info("OAuth state peeked from SQLite fallback (migration)")
+                    return result
+            except (OSError, sqlite3.Error) as e:
+                logger.debug("SQLite OAuth store fallback peek: %s", e)
+
+        if store is not self._memory_store:
+            try:
+                result = self._memory_store.peek(state)
+                if result:
+                    logger.info("OAuth state peeked from memory fallback (migration)")
+                    return result
+            except (KeyError, ValueError) as e:
+                logger.debug("Memory OAuth store fallback peek: %s", e)
 
         return None
 

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -151,6 +151,11 @@ def mock_state_store():
     """Create a mock OAuth state store."""
     store = MagicMock()
     store.generate.return_value = "test-state-token-abc123"
+    store.peek.return_value = {
+        "tenant_id": "tenant-1",
+        "provider": "slack",
+        "created_at": time.time(),
+    }
     store.validate_and_consume.return_value = {
         "tenant_id": "tenant-1",
         "provider": "slack",
@@ -978,6 +983,11 @@ class TestCallback:
     async def test_callback_rejects_state_from_other_provider(
         self, handler, mock_state_store, mock_workspace_store
     ):
+        mock_state_store.peek.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "google",
+            "created_at": time.time(),
+        }
         mock_state_store.validate_and_consume.return_value = {
             "tenant_id": "tenant-1",
             "provider": "google",
@@ -1209,6 +1219,12 @@ class TestCallback:
         self, handler, handler_module, mock_state_store, mock_workspace_store, monkeypatch
     ):
         monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+        mock_state_store.peek.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "redirect_uri": "http://localhost:3000/api/integrations/slack/callback",
+            "created_at": time.time(),
+        }
         mock_state_store.validate_and_consume.return_value = {
             "tenant_id": "tenant-1",
             "provider": "slack",

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -324,6 +324,52 @@ class TestSlackOAuthCallback:
         assert state not in oauth_state_store._states
 
     @pytest.mark.asyncio
+    async def test_callback_error_from_slack_does_not_consume_other_provider_state(
+        self, oauth_handler, oauth_state_store
+    ):
+        """Slack callback errors must not burn non-Slack OAuth state tokens."""
+        state = "github-state"
+        oauth_state_store._states[state] = OAuthState(
+            user_id=None,
+            redirect_url=None,
+            expires_at=time.time() + 600,
+            created_at=time.time(),
+            metadata={"provider": "github"},
+        )
+
+        result = await oauth_handler.handle(
+            "GET",
+            "/api/integrations/slack/callback",
+            query_params={"error": "access_denied", "state": state},
+        )
+
+        assert result.status_code == 400
+        assert state in oauth_state_store._states
+
+    @pytest.mark.asyncio
+    async def test_callback_rejects_other_provider_state_without_consuming(
+        self, oauth_handler, oauth_state_store
+    ):
+        """Slack callback must fail closed before burning another provider's state."""
+        state = "github-state"
+        oauth_state_store._states[state] = OAuthState(
+            user_id=None,
+            redirect_url=None,
+            expires_at=time.time() + 600,
+            created_at=time.time(),
+            metadata={"provider": "github"},
+        )
+
+        result = await oauth_handler.handle(
+            "GET",
+            "/api/integrations/slack/callback",
+            query_params={"code": "auth-code", "state": state},
+        )
+
+        assert result.status_code == 400
+        assert state in oauth_state_store._states
+
+    @pytest.mark.asyncio
     async def test_callback_missing_code(self, oauth_handler):
         """Test callback requires authorization code."""
         result = await oauth_handler.handle(
@@ -803,7 +849,7 @@ class TestSlackOAuthState:
             redirect_url=None,
             expires_at=time.time() + 600,
             created_at=time.time(),
-            metadata=None,
+            metadata={"provider": "slack"},
         )
 
         # Make callback fail early but still consume state

--- a/tests/test_oauth_state_store.py
+++ b/tests/test_oauth_state_store.py
@@ -97,6 +97,18 @@ class TestInMemoryOAuthStateStore:
         result2 = store.validate_and_consume(state)
         assert result2 is None
 
+    def test_peek_does_not_consume(self):
+        """Peek should validate without burning single-use state."""
+        store = InMemoryOAuthStateStore()
+        state = store.generate(user_id="user123", redirect_url="http://localhost")
+
+        peeked = store.peek(state)
+        assert peeked is not None
+        assert peeked.user_id == "user123"
+
+        consumed = store.validate_and_consume(state)
+        assert consumed is not None
+
     def test_invalid_state(self):
         """Test validation of non-existent state."""
         store = InMemoryOAuthStateStore()
@@ -186,6 +198,20 @@ class TestSQLiteOAuthStateStore:
         # Second validation should fail (single use)
         result2 = sqlite_store.validate_and_consume(state)
         assert result2 is None
+
+    def test_peek_does_not_consume(self, sqlite_store):
+        """Peek should not delete valid SQLite-backed state."""
+        state = sqlite_store.generate(
+            user_id="user123",
+            redirect_url="http://localhost:3000/callback",
+        )
+
+        peeked = sqlite_store.peek(state)
+        assert peeked is not None
+        assert peeked.user_id == "user123"
+
+        consumed = sqlite_store.validate_and_consume(state)
+        assert consumed is not None
 
     def test_invalid_state(self, sqlite_store):
         """Test validation of non-existent state."""
@@ -289,6 +315,19 @@ class TestFallbackOAuthStateStore:
         result = store.validate_and_consume(state)
         assert result is not None
         assert result.user_id == "user123"
+        store.close()
+
+    def test_peek_with_sqlite(self, temp_db_path):
+        """Peek should not consume fallback-store state."""
+        store = FallbackOAuthStateStore(redis_url="", sqlite_path=temp_db_path, use_sqlite=True)
+        state = store.generate(user_id="user123", metadata={"provider": "slack"})
+
+        peeked = store.peek(state)
+        assert peeked is not None
+        assert peeked.user_id == "user123"
+
+        consumed = store.validate_and_consume(state)
+        assert consumed is not None
         store.close()
 
     def test_redis_fallback_to_sqlite(self, temp_db_path):
@@ -415,6 +454,28 @@ class TestRedisOAuthStateStore:
             assert result is not None
             assert result.user_id == "user123"
 
+    def test_peek_with_mock_redis(self, mock_redis):
+        """Peek should read Redis state without deleting it."""
+        import json
+        import redis as redis_module
+
+        state_data = {
+            "user_id": "user123",
+            "redirect_url": "http://localhost",
+            "expires_at": time.time() + 600,
+            "created_at": time.time(),
+            "metadata": {"provider": "slack"},
+        }
+        mock_redis.get.return_value = json.dumps(state_data)
+
+        with patch.object(redis_module, "from_url", return_value=mock_redis):
+            store = RedisOAuthStateStore(redis_url="redis://localhost:6379")
+            result = store.peek("test_state")
+
+            assert result is not None
+            assert result.user_id == "user123"
+            mock_redis.pipeline.assert_not_called()
+
 
 class TestConvenienceFunctions:
     """Tests for module-level convenience functions."""
@@ -534,6 +595,18 @@ class TestJWTOAuthStateStore:
         assert result.user_id == "user456"
         assert result.redirect_url == "http://example.com/cb"
         assert result.is_expired is False
+
+    def test_jwt_peek_does_not_consume(self):
+        """Peek should validate a JWT state without marking its nonce used."""
+        store = JWTOAuthStateStore(secret_key="test-secret")
+        token = store.generate(user_id="user456", redirect_url="http://example.com/cb")
+
+        peeked = store.peek(token)
+        assert peeked is not None
+        assert peeked.user_id == "user456"
+
+        consumed = store.validate_and_consume(token)
+        assert consumed is not None
 
     def test_jwt_validate_with_metadata(self):
         """Test JWT preserves metadata through roundtrip."""


### PR DESCRIPTION
## Summary
- add non-destructive OAuth state peeking across the shared state-store backends
- verify Slack callback state provider before consuming the token so non-Slack state cannot be burned by Slack routes
- add regressions for provider-gated callback consumption and peek semantics

## Testing
- python -m ruff check aragora/server/oauth_state_store.py aragora/server/handlers/social/slack_oauth.py tests/test_oauth_state_store.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/test_oauth_state_store.py -q
- python -m pytest tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py -q