### PR TITLE
ci(actions): upgrade smoke workflows to node24-ready actions

### DIFF
--- a/.github/actions/setup-node-safe/action.yml
+++ b/.github/actions/setup-node-safe/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Set up Node.js ${{ inputs.node-version }}
       id: setup-node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.cache || '' }}

--- a/.github/actions/setup-python-safe/action.yml
+++ b/.github/actions/setup-python-safe/action.yml
@@ -31,7 +31,7 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }}
       id: setup-python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
         cache: ${{ inputs.cache || '' }}

--- a/.github/workflows/self-hosted-shadow.yml
+++ b/.github/workflows/self-hosted-shadow.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: repo
 
@@ -75,7 +75,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: repo
 

--- a/.github/workflows/smoke-offline.yml
+++ b/.github/workflows/smoke-offline.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify checkout integrity
         shell: bash

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify checkout integrity
         shell: bash
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify checkout integrity
         shell: bash
@@ -145,7 +145,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify checkout integrity
         shell: bash
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify checkout integrity
         shell: bash
@@ -249,7 +249,7 @@ jobs:
 
       - name: Upload decision-to-action smoke artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: decision-action-smoke-artifacts
           path: test-results/decision-action-smoke/


### PR DESCRIPTION
## Summary
- upgrade shared safe setup actions to the current GitHub Actions majors
- update smoke and shadow workflows to use the current checkout/upload-artifact majors
- reduce Node 20 deprecation noise in advisory CI while keeping the change set narrowly scoped

## Context
While triaging post-merge smoke behavior after PR #2111, the advisory smoke run showed two separate issues:
- the long `Smoke Tests` job was canceled after the PR merged, while the other smoke jobs passed
- the workflow logs emitted Node 20 deprecation warnings for `actions/checkout@v4`, `actions/setup-python@v5`, `actions/setup-node@v4`, and `actions/upload-artifact@v4`

The cancellation appears to be merge-time advisory noise rather than a failing smoke test. This follow-up addresses the concrete runtime drift by moving the affected smoke/shadow paths onto the current action majors.

## Validation
- `python - <<'PY' ... yaml.safe_load(...)` on all edited workflow/action files
- `git diff --check`
- pre-commit hooks during commit (`check yaml`, whitespace, etc.)
