### PR TITLE
Clear stale deliverables on lease failure

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -651,6 +651,7 @@ class SwarmSupervisor:
                         item["status"] = "waiting_resource"
                         item["resource_error"] = str(exc)
                     else:
+                        self._clear_stale_prelaunch_deliverable_state(item)
                         self._mark_needs_human(
                             item,
                             str(exc),

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5678,6 +5678,73 @@ def test_refresh_run_waiting_resource_clears_stale_terminal_state(
         assert cleared_key not in work_order
 
 
+def test_refresh_run_work_order_leasing_failure_clears_stale_deliverable_state(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.side_effect = RuntimeError(
+        "managed worktree metadata unreadable"
+    )
+    supervisor = SwarmSupervisor(repo_root=repo, store=store, lifecycle=lifecycle)
+    run_record = store.create_supervisor_run(
+        goal="leasing failure clears stale deliverable state",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "leasing failure clears stale deliverable state"},
+        metadata={"max_concurrency": 1},
+        work_orders=[
+            {
+                "work_order_id": "wo-leasing-failed-cleanup",
+                "title": "Leasing failure lane",
+                "description": "Leasing failure lane",
+                "status": "queued",
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["aragora/swarm/supervisor.py"],
+                "review_status": "pending_heterogeneous_review",
+                "receipt_id": "receipt-stale",
+                "confidence": 0.91,
+                "worker_outcome": "completed",
+                "completed_at": "2026-04-02T00:00:00+00:00",
+                "head_sha": "deadbeef",
+                "commit_shas": ["deadbeef"],
+                "changed_paths": ["aragora/swarm/supervisor.py"],
+                "merge_gate": {"checks_passed": True},
+                "pr_url": "https://github.com/synaptent/aragora/pull/9999",
+                "verification_missing_reason": "missing_verification_plan",
+                "scope_violation": {
+                    "violations": [{"path": "aragora/swarm/supervisor.py"}],
+                },
+            }
+        ],
+        status="active",
+    )
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    work_order = refreshed.work_orders[0]
+    assert refreshed.status == "needs_human"
+    assert work_order["status"] == "needs_human"
+    assert work_order["review_status"] == "changes_requested"
+    assert work_order["dispatch_error"] == "managed worktree metadata unreadable"
+    assert work_order["failure_reason"] == "work_order_leasing_failed"
+    for cleared_key in (
+        "receipt_id",
+        "confidence",
+        "worker_outcome",
+        "completed_at",
+        "head_sha",
+        "commit_shas",
+        "changed_paths",
+        "merge_gate",
+        "pr_url",
+        "verification_missing_reason",
+        "scope_violation",
+    ):
+        assert cleared_key not in work_order
+
+
 def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when refresh-time work-order leasing hits a non-resource RuntimeError
- clear stale deliverable metadata before marking the lane needs_human for work_order_leasing_failed
- add a regression that proves old receipt, PR, merge-gate, and scope metadata are scrubbed

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'refresh_run_work_order_leasing_failure_clears_stale_deliverable_state or refresh_run_waiting_resource_clears_stale_terminal_state'
- python -m pytest tests/swarm/test_supervisor.py -q