### PR TITLE
fix: fail closed sync worker collection without terminal marker

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -2063,6 +2063,7 @@ class WorkerLauncher:
 
         session_meta = self._read_session_meta(worker.worktree_path)
         session_exit_code, session_completed_at = self._terminal_session_result(session_meta)
+        missing_terminal_marker = session_exit_code is None
         exit_code = proc.returncode if proc.returncode is not None else session_exit_code
         if exit_code is None:
             raise KeyError(f"No finished worker for {work_order_id}")
@@ -2135,4 +2136,8 @@ class WorkerLauncher:
         )
 
         self._processes.pop(work_order_id, None)
+        if missing_terminal_marker:
+            # Trust the harness session marker, not a bare subprocess return
+            # code, before classifying the run as a clean success.
+            worker.exit_code = 1
         return worker

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1001,6 +1001,15 @@ class TestCollectFinishedSync:
         launcher._processes["wo-sync-finished"] = proc
 
         with (
+            patch.object(
+                WorkerLauncher,
+                "_read_session_meta",
+                return_value={
+                    "pid": 222,
+                    "exit_code": 0,
+                    "ended_at": "2026-03-31T12:34:56+00:00",
+                },
+            ),
             patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
             patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
             patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
@@ -1244,6 +1253,80 @@ class TestCollectFinishedSync:
         assert any(call.args == (24680,) for call in mock_running.call_args_list)
         mock_diff.assert_not_called()
         assert "wo-sync-stale-worker-pid" in launcher._processes
+
+    def test_collect_finished_sync_downgrades_missing_terminal_marker_with_deliverable(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        worker = WorkerProcess(
+            work_order_id="wo-sync-no-terminal-marker-deliverable",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-no-terminal-marker-deliverable",
+            branch="main",
+            pid=444,
+            initial_head="def456",
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.completed_at
+        assert worker.work_order_id not in launcher._processes
+
+    def test_collect_finished_sync_downgrades_missing_terminal_marker_without_deliverable(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        worker = WorkerProcess(
+            work_order_id="wo-sync-no-terminal-marker-no-deliverable",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-no-terminal-marker-no-deliverable",
+            branch="main",
+            pid=555,
+            initial_head="def456",
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value=""),
+            patch.object(
+                WorkerLauncher,
+                "_has_working_tree_changes_sync",
+                return_value=False,
+            ),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="stderr evidence"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.commit_shas == []
+        assert result.changed_paths == []
+        assert result.stdout == "stderr evidence"
+        assert result.stderr == "stderr evidence"
+        assert worker.work_order_id not in launcher._processes
 
 
 class TestCollectDetachedResult:


### PR DESCRIPTION
## Summary
- treat sync-collected workers without a terminal session marker as non-clean results
- require an explicit terminal session marker for the clean in-memory sync path
- add regressions covering sync collection with and without deliverables when the marker is missing

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'missing_terminal_marker or collect_finished_sync_downgrades_missing_terminal_marker'
- python -m pytest tests/swarm/test_worker_launcher.py -q