### PR TITLE
fix: advance postgres webhook revisions on delivery

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -1334,7 +1334,8 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
                 await conn.execute(
                     """UPDATE webhook_configs SET
                        last_delivery_at = NOW(), last_delivery_status = $1,
-                       delivery_count = delivery_count + 1
+                       delivery_count = delivery_count + 1,
+                       updated_at = NOW()
                        WHERE id = $2""",
                     status_code,
                     webhook_id,
@@ -1343,7 +1344,8 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
                 await conn.execute(
                     """UPDATE webhook_configs SET
                        last_delivery_at = NOW(), last_delivery_status = $1,
-                       delivery_count = delivery_count + 1, failure_count = failure_count + 1
+                       delivery_count = delivery_count + 1, failure_count = failure_count + 1,
+                       updated_at = NOW()
                        WHERE id = $2""",
                     status_code,
                     webhook_id,

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -18,7 +18,7 @@ import time
 import pytest
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock, PropertyMock
+from unittest.mock import patch, MagicMock, PropertyMock, AsyncMock
 
 from aragora.storage.webhook_config_store import (
     WebhookConfig,
@@ -1720,6 +1720,28 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
 
         assert result is None
         mock_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_record_delivery_async_updates_revision_timestamp(self) -> None:
+        """Postgres delivery updates should advance updated_at like SQLite does."""
+        conn = AsyncMock()
+        acquire_cm = AsyncMock()
+        acquire_cm.__aenter__.return_value = conn
+        acquire_cm.__aexit__.return_value = False
+        pool = MagicMock()
+        pool.acquire.return_value = acquire_cm
+        store = PostgresWebhookConfigStore(pool)
+
+        await store.record_delivery_async("webhook-123", 200, success=True)
+
+        query = conn.execute.await_args.args[0]
+        assert "updated_at = NOW()" in query
+
+        conn.reset_mock()
+        await store.record_delivery_async("webhook-123", 500, success=False)
+
+        query = conn.execute.await_args.args[0]
+        assert "updated_at = NOW()" in query
 
     def test_row_to_config_accepts_native_jsonb_sequence(self, postgres_store) -> None:
         """Postgres JSONB rows may already be decoded into Python sequences."""


### PR DESCRIPTION
## Summary
- update Postgres webhook delivery writes to advance updated_at alongside delivery counters
- keep revision semantics aligned with SQLite so delivery-side truth changes are visible consistently
- add an async Postgres regression that asserts delivery writes include updated_at

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'record_delivery and postgres'
- python -m pytest tests/storage/test_webhook_config_store.py -q