### PR TITLE
fix(playground): preserve mock fallback on missing live agents

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -2974,7 +2974,17 @@ class PlaygroundHandler(BaseHandler):
 
         # Keep the readiness gate aligned with the actual live debate resolver.
         # Otherwise provider-specific keys can incorrectly fall back to mock mode.
-        if len(_get_available_live_agents(agent_count)) < 2:
+        try:
+            live_agents = _get_available_live_agents(agent_count)
+        except ValueError as exc:
+            logger.info(
+                "Live playground agents unavailable during readiness check, "
+                "falling back to mock debate: %s",
+                exc,
+            )
+            live_agents = []
+
+        if len(live_agents) < 2:
             # Fall back to mock debate with a note
             result = self._run_debate(
                 topic,


### PR DESCRIPTION
## Summary
- treat live-agent readiness  as an unavailable-live-provider signal instead of a handler error
- preserve the existing mock fallback path for live playground requests with no configured providers
- keep the live playground test suite green on current 

## Validation
- ..................                                                       [100%]
18 passed in 2.29s
- All checks passed!

Supersedes the in-flight fix that missed PR #2092 because that branch merged before the fallback guard landed.