### PR TITLE
fix: clear stale deliverables on clean exit no-op

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3006,6 +3006,16 @@ class SwarmSupervisor:
             # strip) and detached workers (changed_paths already stripped by
             # _collect_changed_paths, but commit_shas populated from auto-commit).
             if not clean_paths and (result.changed_paths or result.commit_shas):
+                for key in (
+                    "receipt_id",
+                    "confidence",
+                    "pr_url",
+                    "adopted_pr",
+                    "merge_gate",
+                    "verification_missing_reason",
+                ):
+                    item.pop(key, None)
+                item["commit_shas"] = []
                 self._mark_needs_human(
                     item,
                     "worker produced only session artifacts, no real deliverables",
@@ -3019,6 +3029,15 @@ class SwarmSupervisor:
 
             # Clean exit with zero changes of any kind — fail closed
             if not clean_paths and not result.commit_shas:
+                for key in (
+                    "receipt_id",
+                    "confidence",
+                    "pr_url",
+                    "adopted_pr",
+                    "merge_gate",
+                    "verification_missing_reason",
+                ):
+                    item.pop(key, None)
                 if not _pre_outcome:
                     item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
                 logger.warning(

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4437,6 +4437,60 @@ async def test_dispatch_workers_dispatch_failed_clears_stale_deliverable_state(
         assert cleared_key not in work_order
 
 
+def test_apply_worker_result_clean_exit_no_deliverable_clears_stale_deliverable_state(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo, store=store, launcher=MagicMock(spec=WorkerLauncher)
+    )
+
+    work_order = {
+        "work_order_id": "wo-clean-no-deliverable",
+        "status": "dispatched",
+        "branch": "main",
+        "target_agent": "codex",
+        "review_status": "pending_heterogeneous_review",
+        "receipt_id": "receipt-stale",
+        "confidence": 0.99,
+        "pr_url": "https://github.com/synaptent/aragora/pull/9999",
+        "adopted_pr": "https://github.com/synaptent/aragora/pull/9999",
+        "merge_gate": {"checks_passed": True},
+        "verification_missing_reason": "stale",
+        "lease_id": "lease-123",
+    }
+    result = WorkerProcess(
+        work_order_id="wo-clean-no-deliverable",
+        agent="codex",
+        worktree_path=str(repo),
+        branch="main",
+        exit_code=0,
+        completed_at="2026-04-04T00:00:00+00:00",
+        diff="",
+        initial_head="base123",
+        head_sha="abc123",
+        changed_paths=[".codex_session_meta.json"],
+        commit_shas=["abc123"],
+    )
+
+    with patch.object(supervisor, "_release_terminal_lease") as mock_release:
+        supervisor._apply_worker_result(work_order, result)
+
+    assert work_order["status"] == "needs_human"
+    assert work_order["failure_reason"] == "clean_exit_no_deliverable"
+    assert work_order["worker_outcome"] == "clean_exit_no_effect"
+    assert work_order["commit_shas"] == []
+    for cleared_key in (
+        "receipt_id",
+        "confidence",
+        "pr_url",
+        "adopted_pr",
+        "merge_gate",
+        "verification_missing_reason",
+    ):
+        assert cleared_key not in work_order
+    mock_release.assert_called_once_with(work_order)
+
+
 @pytest.mark.asyncio
 async def test_dispatch_workers_resets_closed_worker_type_circuit_breaker_after_successful_launch(
     repo: Path, store: DevCoordinationStore


### PR DESCRIPTION
## Summary
- clear stale deliverable metadata when a worker exits cleanly but produces no real deliverable
- strip stale branch/PR/receipt state from the session-artifact-only path before the lane is downgraded
- add a focused regression around _apply_worker_result for clean_exit_no_deliverable

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'clean_exit_no_deliverable or worker_type_blocked'
- python -m pytest tests/swarm/test_supervisor.py -q