### PR TITLE
feat(playground): persist landing review telemetry

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -30,7 +30,6 @@ import logging
 import os
 import random
 import re
-import threading
 import time
 import uuid
 from datetime import datetime, timezone
@@ -44,6 +43,7 @@ from aragora.server.handlers.base import (
     handle_errors,
 )
 from aragora.server.validation.query_params import safe_query_float, safe_query_int
+from aragora.storage.landing_review_store import get_landing_review_store
 
 logger = logging.getLogger(__name__)
 
@@ -78,12 +78,6 @@ OPENROUTER_PLAYGROUND_MODELS: list[tuple[str, str]] = [
 # IP -> list of timestamps
 _request_timestamps: dict[str, list[float]] = {}
 _live_request_timestamps: dict[str, list[float]] = {}
-_landing_event_lock = threading.Lock()
-_landing_events: list[dict[str, Any]] = []
-_LANDING_EVENT_LIMIT = 5000
-_landing_feedback_lock = threading.Lock()
-_landing_feedback_reports: list[dict[str, Any]] = []
-_LANDING_FEEDBACK_LIMIT = 1000
 _LANDING_EVENT_TYPE_ORDER = (
     "preflight_shown",
     "preflight_selected",
@@ -182,10 +176,7 @@ def _reset_rate_limits() -> None:
     global _daily_debate_count, _daily_debate_reset_time  # noqa: PLW0603
     _request_timestamps.clear()
     _live_request_timestamps.clear()
-    with _landing_event_lock:
-        _landing_events.clear()
-    with _landing_feedback_lock:
-        _landing_feedback_reports.clear()
+    get_landing_review_store().clear()
     _daily_debate_count = 0
     _daily_debate_reset_time = 0.0
 
@@ -244,21 +235,19 @@ def _record_landing_event(
     client_ip: str,
     data: dict[str, Any] | None = None,
 ) -> None:
-    """Record a bounded in-memory landing telemetry event."""
+    """Record a bounded landing telemetry event."""
     if event_type not in _LANDING_EVENT_TYPES:
         return
 
-    with _landing_event_lock:
-        _landing_events.append(
-            {
-                "event_type": event_type,
-                "client_ip": client_ip,
-                "data": _sanitize_landing_event_data(data or {}),
-                "timestamp": datetime.now(timezone.utc).isoformat(),
-            }
+    try:
+        get_landing_review_store().record_event(
+            event_type=event_type,
+            client_tag=_client_tag(client_ip),
+            data=_sanitize_landing_event_data(data or {}),
+            timestamp=datetime.now(timezone.utc).isoformat(),
         )
-        if len(_landing_events) > _LANDING_EVENT_LIMIT:
-            del _landing_events[:-_LANDING_EVENT_LIMIT]
+    except Exception as exc:  # noqa: BLE001 - telemetry should not block user-facing requests
+        logger.warning("Failed to persist landing telemetry event: %s", exc)
 
 
 def _record_landing_feedback(
@@ -288,10 +277,10 @@ def _record_landing_feedback(
     if isinstance(participant_count, int):
         report["participant_count"] = max(0, min(20, participant_count))
 
-    with _landing_feedback_lock:
-        _landing_feedback_reports.append(report)
-        if len(_landing_feedback_reports) > _LANDING_FEEDBACK_LIMIT:
-            del _landing_feedback_reports[:-_LANDING_FEEDBACK_LIMIT]
+    try:
+        get_landing_review_store().record_feedback(report)
+    except Exception as exc:  # noqa: BLE001 - feedback capture should be best-effort
+        logger.warning("Failed to persist landing feedback report: %s", exc)
 
     return report
 
@@ -320,15 +309,16 @@ def _build_landing_event_summary(
 ) -> dict[str, Any]:
     """Aggregate recent landing telemetry into a compact funnel summary."""
     now = datetime.now(timezone.utc)
-    cutoff = now.timestamp() - window_seconds
-
-    with _landing_event_lock:
-        snapshot = list(_landing_events)
+    try:
+        snapshot = get_landing_review_store().list_recent_events(window_seconds=window_seconds)
+    except Exception as exc:  # noqa: BLE001 - degrade to an empty summary if storage is unavailable
+        logger.warning("Failed to load landing telemetry summary: %s", exc)
+        snapshot = []
 
     recent_events: list[tuple[datetime, dict[str, Any]]] = []
     for event in snapshot:
         event_dt = _parse_landing_event_timestamp(event.get("timestamp"))
-        if event_dt is None or event_dt.timestamp() < cutoff:
+        if event_dt is None:
             continue
         recent_events.append((event_dt, event))
 
@@ -347,9 +337,9 @@ def _build_landing_event_summary(
         if event_type in event_counts:
             event_counts[event_type] += 1
 
-        client_ip = str(event.get("client_ip", "") or "").strip()
-        if client_ip and client_ip != "unknown":
-            unique_clients.add(client_ip)
+        client_tag = str(event.get("client_tag", "") or "").strip()
+        if client_tag and client_tag != "unknown":
+            unique_clients.add(client_tag)
 
         if last_event_at is None or event_dt > last_event_at:
             last_event_at = event_dt
@@ -455,20 +445,24 @@ def _build_landing_feedback_summary(
 ) -> dict[str, Any]:
     """Return recent landing wrong-answer reports for internal review."""
     now = datetime.now(timezone.utc)
-    cutoff = now.timestamp() - window_seconds
-
-    with _landing_feedback_lock:
-        snapshot = list(_landing_feedback_reports)
+    try:
+        snapshot = get_landing_review_store().list_recent_feedback(
+            window_seconds=window_seconds,
+            limit=limit,
+        )
+    except Exception as exc:  # noqa: BLE001 - degrade to an empty queue if storage is unavailable
+        logger.warning("Failed to load landing feedback summary: %s", exc)
+        snapshot = []
 
     recent_reports: list[tuple[datetime, dict[str, Any]]] = []
     for report in snapshot:
         report_dt = _parse_landing_event_timestamp(report.get("timestamp"))
-        if report_dt is None or report_dt.timestamp() < cutoff:
+        if report_dt is None:
             continue
         recent_reports.append((report_dt, report))
 
     recent_reports.sort(key=lambda item: item[0], reverse=True)
-    trimmed = [report for _, report in recent_reports[:limit]]
+    trimmed = [report for _, report in recent_reports]
     rewritten_count = sum(1 for report in trimmed if report.get("rewritten") is True)
     preview_mode_count = sum(1 for report in trimmed if report.get("result_mode") == "preview")
     unique_clients = {
@@ -2385,6 +2379,15 @@ class PlaygroundHandler(BaseHandler):
             return error_response("Debate not found", 404)
 
     def _handle_status(self) -> HandlerResult:
+        try:
+            review_store = get_landing_review_store()
+            landing_event_count = review_store.count_events()
+            landing_feedback_count = review_store.count_feedback()
+        except Exception as exc:  # noqa: BLE001 - health endpoint should remain available
+            logger.warning("Failed to read landing review counts: %s", exc)
+            landing_event_count = 0
+            landing_feedback_count = 0
+
         return json_response(
             {
                 "status": "ok",
@@ -2393,8 +2396,8 @@ class PlaygroundHandler(BaseHandler):
                 "max_rounds": _MAX_ROUNDS,
                 "max_agents": _MAX_AGENTS,
                 "rate_limit": f"{_PLAYGROUND_RATE_LIMIT} requests per {int(_PLAYGROUND_RATE_WINDOW)}s",
-                "landing_event_count": len(_landing_events),
-                "landing_feedback_count": len(_landing_feedback_reports),
+                "landing_event_count": landing_event_count,
+                "landing_feedback_count": landing_feedback_count,
             }
         )
 

--- a/aragora/storage/landing_review_store.py
+++ b/aragora/storage/landing_review_store.py
@@ -1,0 +1,275 @@
+"""SQLite-backed storage for landing telemetry and wrong-answer review reports."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from aragora.persistence.db_config import DatabaseType, get_db_path
+from aragora.storage.base_store import SQLiteStore
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_EVENT_LIMIT = 5_000
+_DEFAULT_FEEDBACK_LIMIT = 1_000
+
+
+def _utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _cutoff_iso(window_seconds: float) -> str:
+    """Return the lower timestamp bound for a rolling UTC window."""
+    return (datetime.now(timezone.utc) - timedelta(seconds=window_seconds)).isoformat()
+
+
+class LandingReviewStore(SQLiteStore):
+    """Persist bounded landing telemetry and wrong-answer reports."""
+
+    SCHEMA_NAME = "landing_review_store"
+    SCHEMA_VERSION = 1
+    INITIAL_SCHEMA = """
+        CREATE TABLE IF NOT EXISTS landing_events (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type TEXT NOT NULL,
+            client_tag TEXT NOT NULL,
+            data_json TEXT NOT NULL,
+            timestamp TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_landing_events_timestamp
+            ON landing_events(timestamp DESC);
+        CREATE INDEX IF NOT EXISTS idx_landing_events_type_timestamp
+            ON landing_events(event_type, timestamp DESC);
+
+        CREATE TABLE IF NOT EXISTS landing_feedback_reports (
+            sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+            id TEXT NOT NULL UNIQUE,
+            timestamp TEXT NOT NULL,
+            client_tag TEXT NOT NULL,
+            question TEXT,
+            interpreted_question TEXT,
+            final_answer_preview TEXT,
+            result_warning TEXT,
+            result_mode TEXT NOT NULL DEFAULT 'preview',
+            debate_id TEXT,
+            verdict TEXT,
+            participant_count INTEGER,
+            rewritten INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_landing_feedback_timestamp
+            ON landing_feedback_reports(timestamp DESC);
+        CREATE INDEX IF NOT EXISTS idx_landing_feedback_client_tag
+            ON landing_feedback_reports(client_tag, timestamp DESC);
+    """
+
+    def record_event(
+        self,
+        *,
+        event_type: str,
+        client_tag: str,
+        data: dict[str, Any] | None = None,
+        timestamp: str | None = None,
+    ) -> None:
+        """Persist a single landing telemetry event."""
+        with self.connection() as conn:
+            conn.execute(
+                """
+                INSERT INTO landing_events (event_type, client_tag, data_json, timestamp)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    event_type,
+                    client_tag,
+                    json.dumps(data or {}, sort_keys=True),
+                    timestamp or _utc_now_iso(),
+                ),
+            )
+            self._trim_table(conn, "landing_events", keep_limit=_DEFAULT_EVENT_LIMIT)
+
+    def list_recent_events(self, *, window_seconds: float) -> list[dict[str, Any]]:
+        """Return recent landing telemetry events within the requested window."""
+        rows = self.fetch_all(
+            """
+            SELECT event_type, client_tag, data_json, timestamp
+            FROM landing_events
+            WHERE timestamp >= ?
+            ORDER BY sequence ASC
+            """,
+            (_cutoff_iso(window_seconds),),
+        )
+        return [
+            {
+                "event_type": row[0],
+                "client_tag": row[1],
+                "data": self._load_json_object(row[2]),
+                "timestamp": row[3],
+            }
+            for row in rows
+        ]
+
+    def record_feedback(self, report: dict[str, Any]) -> None:
+        """Persist a bounded wrong-answer report."""
+        with self.connection() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO landing_feedback_reports (
+                    id,
+                    timestamp,
+                    client_tag,
+                    question,
+                    interpreted_question,
+                    final_answer_preview,
+                    result_warning,
+                    result_mode,
+                    debate_id,
+                    verdict,
+                    participant_count,
+                    rewritten
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    report["id"],
+                    report.get("timestamp") or _utc_now_iso(),
+                    report.get("client_tag") or "unknown",
+                    report.get("question"),
+                    report.get("interpreted_question"),
+                    report.get("final_answer_preview"),
+                    report.get("result_warning"),
+                    report.get("result_mode") or "preview",
+                    report.get("debate_id"),
+                    report.get("verdict"),
+                    report.get("participant_count"),
+                    1 if report.get("rewritten") is True else 0,
+                ),
+            )
+            self._trim_table(
+                conn,
+                "landing_feedback_reports",
+                keep_limit=_DEFAULT_FEEDBACK_LIMIT,
+            )
+
+    def list_recent_feedback(
+        self,
+        *,
+        window_seconds: float,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Return recent landing wrong-answer reports for review."""
+        rows = self.fetch_all(
+            """
+            SELECT
+                id,
+                timestamp,
+                client_tag,
+                question,
+                interpreted_question,
+                final_answer_preview,
+                result_warning,
+                result_mode,
+                debate_id,
+                verdict,
+                participant_count,
+                rewritten
+            FROM landing_feedback_reports
+            WHERE timestamp >= ?
+            ORDER BY sequence DESC
+            LIMIT ?
+            """,
+            (_cutoff_iso(window_seconds), limit),
+        )
+        return [
+            {
+                "id": row[0],
+                "timestamp": row[1],
+                "client_tag": row[2],
+                "question": row[3],
+                "interpreted_question": row[4],
+                "final_answer_preview": row[5],
+                "result_warning": row[6],
+                "result_mode": row[7],
+                "debate_id": row[8],
+                "verdict": row[9],
+                "participant_count": row[10],
+                "rewritten": bool(row[11]),
+            }
+            for row in rows
+        ]
+
+    def count_events(self) -> int:
+        """Return the persisted landing telemetry event count."""
+        row = self.fetch_one("SELECT COUNT(*) FROM landing_events")
+        return int(row[0]) if row else 0
+
+    def count_feedback(self) -> int:
+        """Return the persisted landing feedback report count."""
+        row = self.fetch_one("SELECT COUNT(*) FROM landing_feedback_reports")
+        return int(row[0]) if row else 0
+
+    def clear(self) -> None:
+        """Clear all persisted landing review data. Used by tests."""
+        with self.connection() as conn:
+            conn.execute("DELETE FROM landing_events")
+            conn.execute("DELETE FROM landing_feedback_reports")
+
+    @staticmethod
+    def _trim_table(conn: Any, table: str, *, keep_limit: int) -> None:
+        """Keep only the most recent rows in a bounded table."""
+        conn.execute(
+            f"""
+            DELETE FROM {table}
+            WHERE sequence NOT IN (
+                SELECT sequence
+                FROM {table}
+                ORDER BY sequence DESC
+                LIMIT ?
+            )
+            """,
+            (keep_limit,),
+        )
+
+    @staticmethod
+    def _load_json_object(raw: Any) -> dict[str, Any]:
+        """Best-effort JSON decoding for persisted event payloads."""
+        if not isinstance(raw, str):
+            return {}
+        try:
+            value = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Corrupt landing event payload encountered")
+            return {}
+        return value if isinstance(value, dict) else {}
+
+
+_store: LandingReviewStore | None = None
+
+
+def _resolve_store_path() -> Path:
+    """Resolve the landing review database path."""
+    override = os.environ.get("ARAGORA_LANDING_REVIEW_DB_PATH")
+    if override:
+        return Path(override)
+    return get_db_path(DatabaseType.SUGGESTION_FEEDBACK)
+
+
+def get_landing_review_store() -> LandingReviewStore:
+    """Return the singleton landing review store, creating it if needed."""
+    global _store  # noqa: PLW0603
+    resolved_path = _resolve_store_path()
+    if _store is None or _store.db_path != resolved_path:
+        if _store is not None:
+            _store.close()
+        _store = LandingReviewStore(resolved_path)
+    return _store
+
+
+def reset_landing_review_store() -> None:
+    """Reset the singleton landing review store. Used by tests."""
+    global _store  # noqa: PLW0603
+    if _store is not None:
+        _store.close()
+    _store = None

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -48,6 +48,10 @@ from aragora.server.handlers.playground import (
     _LIVE_RATE_LIMIT,
     _LIVE_RATE_WINDOW,
 )
+from aragora.storage.landing_review_store import (
+    get_landing_review_store,
+    reset_landing_review_store,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -104,11 +108,17 @@ def handler():
 
 
 @pytest.fixture(autouse=True)
-def _clear_rate_limits():
-    """Reset rate limit state before each test."""
+def _clear_rate_limits(tmp_path, monkeypatch):
+    """Reset rate limit and landing review state before each test."""
+    monkeypatch.setenv(
+        "ARAGORA_LANDING_REVIEW_DB_PATH",
+        str(tmp_path / "landing_review.sqlite3"),
+    )
+    reset_landing_review_store()
     _reset_rate_limits()
     yield
     _reset_rate_limits()
+    reset_landing_review_store()
 
 
 # ============================================================================
@@ -514,8 +524,6 @@ class TestLandingTelemetry:
     """Tests for the landing telemetry endpoint."""
 
     def test_records_bounded_public_event(self, handler):
-        from aragora.server.handlers import playground as playground_module
-
         mock_h = _MockHTTPHandler(
             "POST",
             body={
@@ -529,10 +537,11 @@ class TestLandingTelemetry:
         )
         result = handler.handle_post("/api/v1/playground/landing/events", {}, mock_h)
         assert _status(result) == 202
-        assert len(playground_module._landing_events) == 1
-        assert playground_module._landing_events[0]["event_type"] == "preflight_shown"
-        assert playground_module._landing_events[0]["data"]["question_length"] == 91
-        assert len(playground_module._landing_events[0]["data"]["raw_prompt"]) == 160
+        events = get_landing_review_store().list_recent_events(window_seconds=3600)
+        assert len(events) == 1
+        assert events[0]["event_type"] == "preflight_shown"
+        assert events[0]["data"]["question_length"] == 91
+        assert len(events[0]["data"]["raw_prompt"]) == 160
 
     def test_rejects_unknown_event_type(self, handler):
         mock_h = _MockHTTPHandler(
@@ -543,47 +552,42 @@ class TestLandingTelemetry:
         assert _status(result) == 400
 
     def test_returns_recent_landing_summary(self, handler):
-        from aragora.server.handlers import playground as playground_module
-
         now = datetime.now(timezone.utc)
-        playground_module._landing_events.extend(
-            [
-                {
-                    "event_type": "preflight_shown",
-                    "client_ip": "203.0.113.10",
-                    "data": {"question_length": 120},
-                    "timestamp": now.isoformat(),
-                },
-                {
-                    "event_type": "preflight_selected",
-                    "client_ip": "203.0.113.10",
-                    "data": {
-                        "option_id": "practical-food",
-                        "recommended": True,
-                        "rewritten": True,
-                        "question_length": 120,
-                    },
-                    "timestamp": now.isoformat(),
-                },
-                {
-                    "event_type": "preview_rendered",
-                    "client_ip": "203.0.113.10",
-                    "data": {"participant_count": 3, "has_warning": True},
-                    "timestamp": now.isoformat(),
-                },
-                {
-                    "event_type": "wrong_answer_clicked",
-                    "client_ip": "203.0.113.10",
-                    "data": {"result_mode": "preview", "rewritten": True},
-                    "timestamp": now.isoformat(),
-                },
-                {
-                    "event_type": "preflight_shown",
-                    "client_ip": "198.51.100.8",
-                    "data": {"question_length": 40},
-                    "timestamp": (now - timedelta(days=2)).isoformat(),
-                },
-            ]
+        store = get_landing_review_store()
+        store.record_event(
+            event_type="preflight_shown",
+            client_tag="ip:test-client",
+            data={"question_length": 120},
+            timestamp=now.isoformat(),
+        )
+        store.record_event(
+            event_type="preflight_selected",
+            client_tag="ip:test-client",
+            data={
+                "option_id": "practical-food",
+                "recommended": True,
+                "rewritten": True,
+                "question_length": 120,
+            },
+            timestamp=now.isoformat(),
+        )
+        store.record_event(
+            event_type="preview_rendered",
+            client_tag="ip:test-client",
+            data={"participant_count": 3, "has_warning": True},
+            timestamp=now.isoformat(),
+        )
+        store.record_event(
+            event_type="wrong_answer_clicked",
+            client_tag="ip:test-client",
+            data={"result_mode": "preview", "rewritten": True},
+            timestamp=now.isoformat(),
+        )
+        store.record_event(
+            event_type="preflight_shown",
+            client_tag="ip:old-client",
+            data={"question_length": 40},
+            timestamp=(now - timedelta(days=2)).isoformat(),
         )
 
         result = handler.handle(
@@ -631,8 +635,6 @@ class TestLandingTelemetry:
         assert body["question_length"]["samples"] == 0
 
     def test_records_bounded_wrong_answer_report(self, handler):
-        from aragora.server.handlers import playground as playground_module
-
         mock_h = _MockHTTPHandler(
             "POST",
             body={
@@ -651,8 +653,9 @@ class TestLandingTelemetry:
         result = handler.handle_post("/api/v1/playground/landing/feedback", {}, mock_h)
 
         assert _status(result) == 202
-        assert len(playground_module._landing_feedback_reports) == 1
-        report = playground_module._landing_feedback_reports[0]
+        reports = get_landing_review_store().list_recent_feedback(window_seconds=3600, limit=10)
+        assert len(reports) == 1
+        report = reports[0]
         assert report["question"] == "x" * 500
         assert len(report["final_answer_preview"]) == 1200
         assert len(report["result_warning"]) == 280
@@ -677,40 +680,39 @@ class TestLandingTelemetry:
         assert _status(result) == 403
 
     def test_feedback_list_returns_recent_reports_for_admin(self, handler):
-        from aragora.server.handlers import playground as playground_module
-
         now = datetime.now(timezone.utc)
-        playground_module._landing_feedback_reports.extend(
-            [
-                {
-                    "id": "lfb_1",
-                    "timestamp": now.isoformat(),
-                    "client_tag": "ip:abc123",
-                    "question": "Should I microwave chicken nuggets for my child?",
-                    "interpreted_question": "Is it safe to reheat pre-cooked chicken nuggets?",
-                    "final_answer_preview": "Yes, reheat until hot all the way through.",
-                    "result_warning": None,
-                    "result_mode": "preview",
-                    "debate_id": "debate-123",
-                    "verdict": "needs_review",
-                    "participant_count": 3,
-                    "rewritten": True,
-                },
-                {
-                    "id": "lfb_2",
-                    "timestamp": (now - timedelta(days=10)).isoformat(),
-                    "client_tag": "ip:def456",
-                    "question": "Old report",
-                    "interpreted_question": "Old interpreted question",
-                    "final_answer_preview": "Old answer",
-                    "result_warning": None,
-                    "result_mode": "preview",
-                    "debate_id": "debate-456",
-                    "verdict": "needs_review",
-                    "participant_count": 2,
-                    "rewritten": False,
-                },
-            ]
+        store = get_landing_review_store()
+        store.record_feedback(
+            {
+                "id": "lfb_1",
+                "timestamp": now.isoformat(),
+                "client_tag": "ip:abc123",
+                "question": "Should I microwave chicken nuggets for my child?",
+                "interpreted_question": "Is it safe to reheat pre-cooked chicken nuggets?",
+                "final_answer_preview": "Yes, reheat until hot all the way through.",
+                "result_warning": None,
+                "result_mode": "preview",
+                "debate_id": "debate-123",
+                "verdict": "needs_review",
+                "participant_count": 3,
+                "rewritten": True,
+            }
+        )
+        store.record_feedback(
+            {
+                "id": "lfb_2",
+                "timestamp": (now - timedelta(days=10)).isoformat(),
+                "client_tag": "ip:def456",
+                "question": "Old report",
+                "interpreted_question": "Old interpreted question",
+                "final_answer_preview": "Old answer",
+                "result_warning": None,
+                "result_mode": "preview",
+                "debate_id": "debate-456",
+                "verdict": "needs_review",
+                "participant_count": 2,
+                "rewritten": False,
+            }
         )
 
         with patch.object(handler, "require_admin_or_error", return_value=(MagicMock(), None)):

--- a/tests/storage/test_landing_review_store.py
+++ b/tests/storage/test_landing_review_store.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from aragora.storage.landing_review_store import (
+    get_landing_review_store,
+    reset_landing_review_store,
+)
+
+
+def test_landing_review_store_persists_events_and_feedback(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "landing_review.sqlite3"
+    monkeypatch.setenv("ARAGORA_LANDING_REVIEW_DB_PATH", str(db_path))
+    reset_landing_review_store()
+
+    store = get_landing_review_store()
+    now = datetime.now(timezone.utc)
+    store.record_event(
+        event_type="preflight_shown",
+        client_tag="ip:test-client",
+        data={"question_length": 88},
+        timestamp=now.isoformat(),
+    )
+    store.record_feedback(
+        {
+            "id": "lfb_test",
+            "timestamp": now.isoformat(),
+            "client_tag": "ip:test-client",
+            "question": "Should I microwave chicken nuggets?",
+            "interpreted_question": "Is it safe to reheat pre-cooked chicken nuggets?",
+            "final_answer_preview": "Yes, reheat until hot throughout.",
+            "result_warning": None,
+            "result_mode": "preview",
+            "debate_id": "debate-123",
+            "verdict": "needs_review",
+            "participant_count": 3,
+            "rewritten": True,
+        }
+    )
+
+    reset_landing_review_store()
+    reopened = get_landing_review_store()
+
+    events = reopened.list_recent_events(window_seconds=3600)
+    feedback = reopened.list_recent_feedback(window_seconds=3600, limit=10)
+    assert reopened.count_events() == 1
+    assert reopened.count_feedback() == 1
+    assert events == [
+        {
+            "event_type": "preflight_shown",
+            "client_tag": "ip:test-client",
+            "data": {"question_length": 88},
+            "timestamp": now.isoformat(),
+        }
+    ]
+    assert feedback == [
+        {
+            "id": "lfb_test",
+            "timestamp": now.isoformat(),
+            "client_tag": "ip:test-client",
+            "question": "Should I microwave chicken nuggets?",
+            "interpreted_question": "Is it safe to reheat pre-cooked chicken nuggets?",
+            "final_answer_preview": "Yes, reheat until hot throughout.",
+            "result_warning": None,
+            "result_mode": "preview",
+            "debate_id": "debate-123",
+            "verdict": "needs_review",
+            "participant_count": 3,
+            "rewritten": True,
+        }
+    ]
+
+    reset_landing_review_store()
+
+
+def test_landing_review_store_filters_by_window(tmp_path, monkeypatch) -> None:
+    db_path = tmp_path / "landing_review.sqlite3"
+    monkeypatch.setenv("ARAGORA_LANDING_REVIEW_DB_PATH", str(db_path))
+    reset_landing_review_store()
+
+    store = get_landing_review_store()
+    now = datetime.now(timezone.utc)
+    store.record_event(
+        event_type="preflight_shown",
+        client_tag="ip:recent",
+        data={"question_length": 42},
+        timestamp=now.isoformat(),
+    )
+    store.record_event(
+        event_type="preflight_shown",
+        client_tag="ip:stale",
+        data={"question_length": 12},
+        timestamp=(now - timedelta(days=7)).isoformat(),
+    )
+
+    recent_events = store.list_recent_events(window_seconds=3600)
+    assert len(recent_events) == 1
+    assert recent_events[0]["client_tag"] == "ip:recent"
+
+    reset_landing_review_store()


### PR DESCRIPTION
## Summary
- persist landing telemetry and wrong-answer review reports in a SQLite-backed store
- read playground admin summary and feedback review endpoints from persisted storage instead of in-memory globals
- add focused storage and playground regression coverage for the persisted landing review path

## Testing
- pytest -q tests/storage/test_landing_review_store.py tests/handlers/test_playground.py -k 'LandingTelemetry or landing_review_store'
