### PR TITLE
Prefer managed session exit code in sync collection

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -2072,7 +2072,9 @@ class WorkerLauncher:
         session_meta = self._read_session_meta(worker.worktree_path)
         session_exit_code, session_completed_at = self._terminal_session_result(session_meta)
         missing_terminal_marker = session_exit_code is None
-        exit_code = proc.returncode if proc.returncode is not None else session_exit_code
+        # The managed-session marker is authoritative when present: it records
+        # the inner worker outcome after the shell wrapper's EXIT trap runs.
+        exit_code = session_exit_code if session_exit_code is not None else proc.returncode
         if exit_code is None:
             raise KeyError(f"No finished worker for {work_order_id}")
 

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1100,6 +1100,47 @@ class TestCollectFinishedSync:
         mock_wait_pid.assert_called_once_with(333)
         assert "wo-sync-meta-finished" not in launcher._processes
 
+    def test_collect_finished_sync_prefers_session_exit_code_over_returncode(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        worker = WorkerProcess(
+            work_order_id="wo-sync-prefers-session-exit",
+            agent="codex",
+            worktree_path="/tmp/wt-meta-prefers-session-exit",
+            branch="main",
+            pid=333,
+            initial_head="def456",
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        session_meta = {
+            "pid": 333,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync"),
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 143
+        assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert worker.work_order_id not in launcher._processes
+
     def test_collect_finished_sync_ignores_invalid_session_meta_pid_for_cleanup(self):
         launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
         worker = WorkerProcess(


### PR DESCRIPTION
## Summary
- prefer the managed-session terminal exit marker over a bare subprocess return code in sync worker collection
- prevent sync-collected managed workers from being misclassified as clean success when the session marker recorded a failure
- add a regression for the mismatched returncode/session-exit path

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'prefers_session_exit_code_over_returncode or collects_in_memory_worker_when_session_meta_marks_complete'
- python -m pytest tests/swarm/test_worker_launcher.py -q