### PR TITLE
Preserve dev host through Slack preview flow

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -709,6 +709,15 @@ class SlackOAuthHandler(SecureHandler):
             )
 
         tenant_id = self._resolved_tenant_id(query_params, auth_context) or ""
+        install_params: dict[str, str] = {}
+        if tenant_id:
+            install_params["tenant_id"] = tenant_id
+        if not _get_slack_redirect_uri() and _get_aragora_env().lower() != "production":
+            host = str(query_params.get("host", "") or "").strip()
+            if host:
+                if not _is_loopback_redirect_host(host):
+                    return error_response("Only localhost allowed in development mode", 400)
+                install_params["host"] = host
 
         # Build scope information for display
         current_scopes = _get_slack_scopes().split(",")
@@ -742,8 +751,8 @@ class SlackOAuthHandler(SecureHandler):
 
         # Build install URL with tenant_id
         install_url = "/api/integrations/slack/install"
-        if tenant_id:
-            install_url = f"{install_url}?{urlencode({'tenant_id': tenant_id})}"
+        if install_params:
+            install_url = f"{install_url}?{urlencode(install_params)}"
 
         # Generate HTML consent preview page
         html = self._render_consent_preview(

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -605,6 +605,45 @@ class TestPreview:
         assert "tenant_id=test-org-001" in html
 
     @pytest.mark.asyncio
+    async def test_preview_preserves_valid_dev_host_in_install_url(
+        self, handler, handler_module, monkeypatch
+    ):
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/preview",
+            {},
+            {"host": "localhost:3000"},
+            {},
+            None,
+        )
+
+        assert _status(result) == 200
+        html = _html(result)
+        assert "tenant_id=test-org-001" in html
+        assert "host=localhost%3A3000" in html
+
+    @pytest.mark.asyncio
+    async def test_preview_rejects_invalid_dev_host(self, handler, handler_module, monkeypatch):
+        monkeypatch.setattr(handler_module, "ARAGORA_ENV", "development")
+        monkeypatch.setattr(handler_module, "SLACK_REDIRECT_URI", None)
+
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/preview",
+            {},
+            {"host": "evil.com:3000"},
+            {},
+            None,
+        )
+
+        assert _status(result) == 400
+        body = _body(result)
+        assert "localhost" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_preview_escapes_tenant_bound_install_url(self, handler):
         malicious_tenant = 'tenant" onclick="alert(1)<script>'
         expected_query = urlencode({"tenant_id": malicious_tenant})


### PR DESCRIPTION
## Summary
- preserve the validated loopback host in the Slack consent preview install URL when development fallback redirect handling is active
- reject invalid preview hosts up front so preview and install enforce the same loopback-only rule
- add regressions for valid host preservation and invalid host rejection

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'preview_preserves_valid_dev_host_in_install_url or preview_rejects_invalid_dev_host'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q