### PR TITLE
Keep Postgres webhook update revisions stable

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -1299,8 +1299,9 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
             webhook.description = description
 
         if updates:
+            updated_at = time.time()
             updates.append(f"updated_at = to_timestamp(${param_idx})")
-            params.append(time.time())
+            params.append(updated_at)
             param_idx += 1
             params.append(webhook_id)
 
@@ -1309,7 +1310,7 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
                     f"UPDATE webhook_configs SET {', '.join(updates)} WHERE id = ${param_idx}",  # noqa: S608 -- dynamic clause from internal state
                     *params,
                 )
-            webhook.updated_at = time.time()
+            webhook.updated_at = updated_at
 
         return webhook
 

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1743,6 +1743,42 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
         query = conn.execute.await_args.args[0]
         assert "updated_at = NOW()" in query
 
+    @pytest.mark.asyncio
+    async def test_update_async_returns_durable_revision_timestamp(self) -> None:
+        """Returned updated_at should match the durable revision written to Postgres."""
+        conn = AsyncMock()
+        acquire_cm = AsyncMock()
+        acquire_cm.__aenter__.return_value = conn
+        acquire_cm.__aexit__.return_value = False
+        pool = MagicMock()
+        pool.acquire.return_value = acquire_cm
+        store = PostgresWebhookConfigStore(pool)
+
+        original = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/hook",
+            events=["debate_end"],
+            secret="secret",
+            updated_at=100.0,
+        )
+        revised_at = 200.0
+
+        with (
+            patch.object(store, "get_async", AsyncMock(return_value=original)),
+            patch(
+                "aragora.storage.webhook_config_store.time.time",
+                side_effect=[revised_at, revised_at + 1],
+            ),
+        ):
+            updated = await store.update_async("webhook-123", url="https://example.com/new")
+
+        assert updated is not None
+        assert updated.url == "https://example.com/new"
+        assert updated.updated_at == revised_at
+        query, *params = conn.execute.await_args.args
+        assert "updated_at = to_timestamp($2)" in query
+        assert params == ["https://example.com/new", revised_at, "webhook-123"]
+
     def test_row_to_config_accepts_native_jsonb_sequence(self, postgres_store) -> None:
         """Postgres JSONB rows may already be decoded into Python sequences."""
         now = time.time()


### PR DESCRIPTION
## Summary
- reuse the same timestamp for the Postgres webhook update SQL write and returned WebhookConfig
- add a regression proving update_async returns the durable revision it wrote

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'update_async_returns_durable_revision_timestamp or record_delivery_async_updates_revision_timestamp or sync_wrappers_delegate_via_run_async or record_delivery_delegates_via_run_async'
- python -m pytest tests/storage/test_webhook_config_store.py -q