### PR TITLE
fix(live): harden landing preview fallback

### DIFF
--- a/aragora/live/src/components/landing/CompactDebateResult.tsx
+++ b/aragora/live/src/components/landing/CompactDebateResult.tsx
@@ -68,6 +68,8 @@ export interface CompactDebateResultProps {
 export function CompactDebateResult({ result, onWrongAnswer, onShare }: CompactDebateResultProps) {
   const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
   const [shareCopied, setShareCopied] = useState(false);
+  const participants = result.participants ?? [];
+  const proposals = result.proposals ?? {};
 
   const tldr = result.tldr
     || (result.final_answer ? stripMarkdown(result.final_answer).slice(0, 200) : '');
@@ -78,7 +80,7 @@ export function CompactDebateResult({ result, onWrongAnswer, onShare }: CompactD
     Boolean(interpretedQuestion) && interpretedQuestion !== originalQuestion;
 
   const confidencePct = Math.round(result.confidence * 100);
-  const agentCount = result.participants.length || Object.keys(result.proposals).length;
+  const agentCount = participants.length || Object.keys(proposals).length;
   const rounds = result.rounds_used;
   const duration = result.duration_seconds;
 
@@ -96,11 +98,11 @@ export function CompactDebateResult({ result, onWrongAnswer, onShare }: CompactD
 
   // Get proposal text for an agent (look up by name, stripping round suffix)
   function getProposalText(agent: string): string {
-    if (result.proposals[agent]) {
-      return stripMarkdown(result.proposals[agent]).slice(0, 200);
+    if (proposals[agent]) {
+      return stripMarkdown(proposals[agent]).slice(0, 200);
     }
     // Try matching by display name prefix
-    for (const [key, val] of Object.entries(result.proposals)) {
+    for (const [key, val] of Object.entries(proposals)) {
       if (key === agent || agentDisplayName(key) === agent) {
         return stripMarkdown(val).slice(0, 200);
       }
@@ -110,9 +112,9 @@ export function CompactDebateResult({ result, onWrongAnswer, onShare }: CompactD
 
   // Agents to show as chips: participants list, or fall back to proposal keys
   const chipAgents =
-    result.participants.length > 0
-      ? result.participants
-      : Object.keys(result.proposals);
+    participants.length > 0
+      ? participants
+      : Object.keys(proposals);
 
   async function handleShare() {
     const shareUrl = result.id

--- a/aragora/live/src/components/landing/__tests__/HeroSection.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/HeroSection.test.tsx
@@ -4,7 +4,6 @@ import { HeroSection } from '../HeroSection';
 
 const mockPush = jest.fn();
 const mockBackendConfig = { api: 'http://localhost:8080' };
-const mockDebateResultPreview = jest.fn();
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
@@ -15,10 +14,6 @@ jest.mock('@/context/ThemeContext', () => ({
 }));
 
 jest.mock('../../DebateResultPreview', () => ({
-  DebateResultPreview: (props: Record<string, unknown>) => {
-    mockDebateResultPreview(props);
-    return <div data-testid="debate-result-preview">Debate result</div>;
-  },
   RETURN_URL_KEY: 'return_url',
   PENDING_DEBATE_KEY: 'pending_debate',
 }));
@@ -32,6 +27,47 @@ jest.mock('../../BackendSelector', () => ({
 jest.mock('../../DebateInput', () => ({
   DebateInput: () => <div data-testid="debate-input">MockDebateInput</div>,
 }));
+
+function createResponse(body: unknown, init: { ok?: boolean; status?: number } = {}) {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+  };
+}
+
+function createNuggetsAssessResponse(question: string) {
+  return createResponse({
+    type: 'confirm',
+    preflight: {
+      title: 'This question could mean a few things',
+      prompt: 'Pick the interpretation you want Aragora to debate.',
+      options: [
+        {
+          id: 'interp-0',
+          label: 'Practical food-safety first',
+          description: 'Focus on whether reheating pre-cooked chicken nuggets is safe and practical for a 4 year old.',
+          originalQuestion: question,
+          interpretedQuestion: 'Should I microwave pre-cooked chicken nuggets for my 4 year old?',
+          debatePrompt: 'Should I microwave pre-cooked chicken nuggets for my 4 year old?',
+          agents: 3,
+          rounds: 2,
+          recommended: true,
+        },
+        {
+          id: 'original',
+          label: 'Use original wording',
+          description: 'Debate the question exactly as written.',
+          originalQuestion: question,
+          interpretedQuestion: question,
+          debatePrompt: question,
+          agents: 3,
+          rounds: 2,
+        },
+      ],
+    },
+  });
+}
 
 describe('HeroSection', () => {
   const defaultProps = {
@@ -225,23 +261,20 @@ describe('HeroSection', () => {
 
     it('shows a preflight chooser for ambiguous landing prompts before debating', async () => {
       const user = userEvent.setup();
-      const fetchMock = jest.fn().mockResolvedValue({
-        ok: true,
-        json: async () => ({}),
-      });
+      const question = 'Should I cook my chickens in a microwave? What if they are alive, and what if they are dead?';
+      const fetchMock = jest.fn().mockResolvedValue(createNuggetsAssessResponse(question));
       global.fetch = fetchMock as typeof fetch;
 
       render(<HeroSection />);
 
       await user.type(
         screen.getByRole('textbox'),
-        'Should I cook my chickens in a microwave? What if they are alive, and what if they are dead?'
+        question,
       );
       await user.click(screen.getByRole('button', { name: /start debate/i }));
 
-      expect(
-        screen.getByRole('heading', { name: /choose which version of the question to debate/i })
-      ).toBeInTheDocument();
+      expect(await screen.findByText('This question could mean a few things')).toBeInTheDocument();
+      expect(screen.getByText('Pick the interpretation you want Aragora to debate.')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /practical food-safety first/i })).toBeInTheDocument();
       expect(fetchMock).not.toHaveBeenCalledWith(
         expect.stringContaining('/api/v1/playground/debate'),
@@ -293,21 +326,10 @@ describe('HeroSection', () => {
       await user.click(screen.getByRole('button', { name: /start debate/i }));
 
       await waitFor(() => {
-        expect(screen.getByTestId('debate-result-preview')).toBeInTheDocument();
+        expect(screen.getByText(/Aragora's Answer/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /view full debate/i })).toBeInTheDocument();
       });
-
-      expect(mockDebateResultPreview).toHaveBeenCalledWith(
-        expect.objectContaining({
-          condensed: true,
-          onFlagWrongAnswer: expect.any(Function),
-          onOpenFullDebate: expect.any(Function),
-          onShare: expect.any(Function),
-          result: expect.objectContaining({
-            original_question: 'Can I microwave frozen chicken nuggets for my 4-year-old?',
-            interpreted_question: 'Can I microwave frozen chicken nuggets for my 4-year-old?',
-          }),
-        }),
-      );
+      expect(screen.getByRole('button', { name: /try another/i })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- guard CompactDebateResult against missing participants/proposals in preview payloads
- refresh HeroSection landing tests to match the current preflight and condensed preview UI

## Validation
- cd aragora/live && npx jest src/components/landing/__tests__/HeroSection.test.tsx --runInBand
- cd aragora/live && npx tsc --noEmit
