### PR TITLE
Require peek-verified Slack state before consume

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -976,13 +976,19 @@ class SlackOAuthHandler(SecureHandler):
             except Exception:
                 logger.debug("Failed to peek Slack OAuth state", exc_info=True)
 
+        peeked_tenant_id, peeked_redirect_uri, peeked_provider = self._extract_state_metadata(
+            peeked_state_data
+        )
+        fallback_tenant_id, fallback_redirect_uri, fallback_provider = self._extract_state_metadata(
+            fallback_state_data
+        )
+        store_state_is_slack = peeked_provider == "slack"
+        fallback_state_is_slack = fallback_provider == "slack"
+
         # Check for error from Slack
         if "error" in query_params:
             if state:
-                _, _, state_provider = self._extract_state_metadata(
-                    peeked_state_data or fallback_state_data
-                )
-                if state_provider == "slack":
+                if store_state_is_slack:
                     try:
                         state_store.validate_and_consume(state)
                     except Exception:
@@ -990,6 +996,7 @@ class SlackOAuthHandler(SecureHandler):
                             "Failed to consume Slack OAuth state after callback error",
                             exc_info=True,
                         )
+                if fallback_state_is_slack:
                     _oauth_states_fallback.pop(state, None)
             error_code = query_params.get("error")
             logger.warning("Slack OAuth error: %s", error_code)
@@ -1014,15 +1021,20 @@ class SlackOAuthHandler(SecureHandler):
         if not (peeked_state_data or fallback_state_data):
             return error_response("Invalid or expired state token", 400)
 
-        tenant_id, state_redirect_uri, state_provider = self._extract_state_metadata(
-            peeked_state_data or fallback_state_data
-        )
-        if state_provider != "slack":
+        if store_state_is_slack:
+            tenant_id = peeked_tenant_id
+            state_redirect_uri = peeked_redirect_uri
+        elif peeked_state_data is None and fallback_state_is_slack:
+            tenant_id = fallback_tenant_id
+            state_redirect_uri = fallback_redirect_uri
+        else:
             return error_response("Invalid or expired state token", 400)
 
         # Consume only after verifying this state was actually minted for Slack.
-        state_data = state_store.validate_and_consume(state)
-        fallback_state_data = _oauth_states_fallback.pop(state, None)
+        state_data = state_store.validate_and_consume(state) if store_state_is_slack else None
+        fallback_state_data = (
+            _oauth_states_fallback.pop(state, None) if fallback_state_is_slack else None
+        )
         if not state_data:
             state_data = fallback_state_data
         if not state_data:

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -765,6 +765,30 @@ class TestCallback:
         assert "error-state" not in handler_module._oauth_states_fallback
 
     @pytest.mark.asyncio
+    async def test_error_param_does_not_consume_store_when_peek_fails_and_only_fallback_is_slack(
+        self, handler, handler_module, mock_state_store
+    ):
+        handler_module._oauth_states_fallback["error-state"] = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_state_store.peek.side_effect = RuntimeError("state store unavailable")
+
+        result = await handler.handle(
+            "GET",
+            "/api/integrations/slack/callback",
+            {},
+            {"error": "access_denied", "state": "error-state"},
+            {},
+            None,
+        )
+
+        assert _status(result) == 400
+        mock_state_store.validate_and_consume.assert_not_called()
+        assert "error-state" not in handler_module._oauth_states_fallback
+
+    @pytest.mark.asyncio
     async def test_missing_code_returns_400(self, handler):
         result = await handler.handle(
             "GET",
@@ -1356,6 +1380,57 @@ class TestCallback:
             )
         assert _status(result) == 200
         # Fallback state should have been consumed (popped)
+        assert "fallback-state" not in handler_module._oauth_states_fallback
+
+    @pytest.mark.asyncio
+    async def test_callback_fallback_state_skips_store_consume_when_peek_fails(
+        self, handler, handler_module, mock_state_store
+    ):
+        """Fallback Slack state should not authorize consuming unknown shared state."""
+        mock_state_store.peek.side_effect = RuntimeError("state store unavailable")
+        handler_module._oauth_states_fallback["fallback-state"] = {
+            "tenant_id": "t-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-token",
+                "team": {"id": "W111", "name": "Fallback"},
+                "bot_user_id": "B1",
+                "authed_user": {"id": "U1"},
+                "scope": "channels:history",
+            }
+        )
+
+        mock_ws_store = MagicMock()
+        mock_ws_store.get.return_value = None
+        mock_ws_store.save.return_value = True
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_ws_store,
+            ),
+            patch(
+                "aragora.storage.slack_workspace_store.SlackWorkspace",
+                return_value=MagicMock(),
+            ),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "code", "state": "fallback-state"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        mock_state_store.validate_and_consume.assert_not_called()
         assert "fallback-state" not in handler_module._oauth_states_fallback
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- only consume centralized OAuth state when peek() itself confirmed the token belongs to Slack
- still allow fallback Slack state to complete the callback flow without burning shared state in another provider store
- add regressions for both the error callback path and the success callback path when peek fails

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q