### PR TITLE
fix(server): restore shared handler baselines

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -271,8 +271,8 @@ class WebhookHandler(SecureHandler):
 
     @staticmethod
     def _forbidden_webhook_access() -> HandlerResult:
-        """Return the documented forbidden response for non-owner access."""
-        return error_response("Access denied - not the webhook owner", 403)
+        """Hide non-owned webhook records to avoid cross-tenant leaks."""
+        return error_response("Webhook not found", 404)
 
     @api_endpoint(
         path="/api/v1/webhooks",

--- a/tests/server/fastapi/test_runs_routes.py
+++ b/tests/server/fastapi/test_runs_routes.py
@@ -96,9 +96,16 @@ def test_list_runs_route_is_registered(client) -> None:
     assert response.json() == {
         "runs": [
             {
+                "created_at": None,
                 "run_id": "run-fastapi-list",
                 "status": "plan_ready",
-                "stages": [{"stage": BackboneStage.PLAN.value, "status": "completed"}],
+                "stages": [
+                    {
+                        "created_at": None,
+                        "stage": BackboneStage.PLAN.value,
+                        "status": "completed",
+                    }
+                ],
                 "execution_id": "exec-fastapi",
                 "receipt_id": "receipt-fastapi",
                 "safety_mode": ExecutionMode.INTERACTIVE.value,
@@ -130,9 +137,16 @@ def test_get_run_route_is_registered(client) -> None:
     assert response.status_code == 200
     assert response.json() == {
         "run": {
+            "created_at": None,
             "run_id": "run-fastapi-detail",
             "status": "execution_started",
-            "stages": [{"stage": BackboneStage.EXECUTION.value, "status": "running"}],
+            "stages": [
+                {
+                    "created_at": None,
+                    "stage": BackboneStage.EXECUTION.value,
+                    "status": "running",
+                }
+            ],
             "execution_id": None,
             "receipt_id": None,
             "safety_mode": None,

--- a/tests/server/handlers/auth/test_sso_timing_safe.py
+++ b/tests/server/handlers/auth/test_sso_timing_safe.py
@@ -210,25 +210,26 @@ class TestJWTStoreTimingSafeComparison:
         fake_sig = "A" * len(signature)
         forged_state = f"{payload}.{fake_sig}"
 
-        # Both should be validated consistently - the forged one should fail
-        # This demonstrates that signature comparison is happening correctly
-        valid_result = jwt_state_store.validate_and_consume(state)
-        assert valid_result is not None, "Valid state should pass validation"
+        with patch.object(
+            hmac_module,
+            "compare_digest",
+            wraps=hmac_module.compare_digest,
+        ) as mock_compare_digest:
+            # Both should be validated consistently - the forged one should fail
+            # This demonstrates that signature comparison is happening correctly
+            valid_result = jwt_state_store.validate_and_consume(state)
+            assert valid_result is not None, "Valid state should pass validation"
 
-        # Generate another valid state to test forged signature
-        state2 = jwt_state_store.generate(ttl_seconds=3600)
-        parts2 = state2.split(".")
-        forged_state2 = f"{parts2[0]}.{fake_sig}"
+            # Generate another valid state to test forged signature
+            state2 = jwt_state_store.generate(ttl_seconds=3600)
+            parts2 = state2.split(".")
+            forged_state2 = f"{parts2[0]}.{fake_sig}"
 
-        # Forged state should fail
-        forged_result = jwt_state_store.validate_and_consume(forged_state2)
-        assert forged_result is None, "Forged state should fail validation"
+            # Forged state should fail
+            forged_result = jwt_state_store.validate_and_consume(forged_state2)
+            assert forged_result is None, "Forged state should fail validation"
 
-        # Verify the implementation uses compare_digest by examining the source
-        import inspect
-
-        source = inspect.getsource(jwt_state_store.validate_and_consume)
-        assert "compare_digest" in source, (
+        assert mock_compare_digest.called, (
             "JWTOAuthStateStore.validate_and_consume should use compare_digest"
         )
 

--- a/tests/server/handlers/test_shared_inbox.py
+++ b/tests/server/handlers/test_shared_inbox.py
@@ -620,6 +620,7 @@ class TestGetInboxMessages:
             store=store,
             signer=signer,
         )
+        sample_message.email_id = f"test-{sample_message.email_id}"
 
         service.create_receipt(
             ActionIntent.create(


### PR DESCRIPTION
## Summary
- restore hidden 404 behavior for non-owned webhook records
- update stale timing-safe and runs route tests to current behavior
- make the shared inbox latest-receipt test use a synthetic message id so it exercises non-deduped ordering

## Validation
- python3 -m pytest tests/server/handlers/auth/test_sso_timing_safe.py::TestJWTStoreTimingSafeComparison::test_jwt_store_compare_digest_is_called tests/server/fastapi/test_runs_routes.py::test_list_runs_route_is_registered tests/server/fastapi/test_runs_routes.py::test_get_run_route_is_registered tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerGet::test_get_webhook_denies_workspace_mismatch tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerGet::test_get_webhook_hides_ownerless_record tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerGet::test_get_webhook_denies_missing_workspace_context tests/server/handlers/test_shared_inbox.py::TestGetInboxMessages::test_get_messages_include_latest_trust_wedge_envelope tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerTest::test_test_webhook_hides_workspace_mismatch tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerUpdate::test_update_webhook_hides_workspace_mismatch tests/server/handlers/test_demo_live_proof_surface.py::test_demo_source_can_replay_cached_live_results tests/server/handlers/test_webhooks_handler.py::TestWebhookHandlerDelete::test_delete_webhook_hides_workspace_mismatch tests/server/handlers/features/test_marketplace.py::TestDeleteTemplate::test_delete_builtin_template_forbidden tests/server/handlers/features/test_marketplace.py::TestDeleteTemplate::test_delete_template_success tests/server/handlers/features/test_marketplace.py::TestDeleteTemplate::test_delete_template_requires_auth -q
- python3 -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/auth/test_sso_timing_safe.py tests/server/fastapi/test_runs_routes.py tests/server/handlers/test_shared_inbox.py