### PR TITLE
Fail closed when launcher misses terminal marker auto-commit

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1149,7 +1149,14 @@ class WorkerLauncher:
             _has_changes = bool(worker.diff) or (
                 _can_query_dirty_tree and await cls._has_working_tree_changes(worktree_path)
             )
-            if auto_commit and cls._should_attempt_auto_commit(worker, has_changes=_has_changes):
+            # Without a terminal session marker, treat dirty-tree state as
+            # evidence only. Auto-committing here can manufacture a synthetic
+            # deliverable from a partial run.
+            if (
+                auto_commit
+                and not missing_terminal_marker
+                and cls._should_attempt_auto_commit(worker, has_changes=_has_changes)
+            ):
                 await cls._auto_commit(worker)
 
             worker.head_sha = await cls._git_output(worktree_path, "rev-parse", "HEAD")
@@ -2099,8 +2106,13 @@ class WorkerLauncher:
             has_changes = bool(worker.diff) or (
                 can_query_dirty_tree and self._has_working_tree_changes_sync(worker.worktree_path)
             )
-            if self.config.auto_commit and self._should_attempt_auto_commit(
-                worker, has_changes=has_changes
+            # A bare wrapper returncode is not enough to bless dirty-tree
+            # state. If the harness never wrote a terminal marker, do not
+            # auto-commit partial changes into a salvageable deliverable.
+            if (
+                self.config.auto_commit
+                and not missing_terminal_marker
+                and self._should_attempt_auto_commit(worker, has_changes=has_changes)
             ):
                 self._auto_commit_sync(worker)
 

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1369,6 +1369,46 @@ class TestCollectFinishedSync:
         assert result.stderr == "stderr evidence"
         assert worker.work_order_id not in launcher._processes
 
+    def test_collect_finished_sync_skips_auto_commit_without_terminal_marker(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=True))
+        worker = WorkerProcess(
+            work_order_id="wo-sync-no-terminal-marker-no-autocommit",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-no-terminal-marker-no-autocommit",
+            branch="main",
+            pid=777,
+            initial_head="def456",
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value=""),
+            patch.object(
+                WorkerLauncher,
+                "_has_working_tree_changes_sync",
+                return_value=True,
+            ),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_auto_commit_sync") as mock_commit,
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.commit_shas == []
+        assert result.changed_paths == ["file.py"]
+        mock_commit.assert_not_called()
+        assert worker.work_order_id not in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio
@@ -1429,6 +1469,39 @@ class TestCollectDetachedResult:
         assert result.verification_results == verification_results
         assert result.stdout == "some output"
         mock_verify.assert_awaited_once_with("/tmp/wt", [expected_test])
+
+    @pytest.mark.asyncio
+    async def test_collect_detached_result_skips_auto_commit_without_terminal_marker(self):
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher,
+                "_has_working_tree_changes",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(WorkerLauncher, "_auto_commit", new_callable=AsyncMock) as mock_commit,
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-no-marker-no-autocommit",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=99999,
+                initial_head="def456",
+                auto_commit=True,
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert result.commit_shas == []
+        assert result.changed_paths == ["file.py"]
+        mock_commit.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_none_if_pid_dead_without_terminal_marker_or_deliverable(self):


### PR DESCRIPTION
## Summary
- skip auto-commit in sync and detached collection when the harness never wrote a terminal session marker
- prevent dirty partial runs from being turned into synthetic commit deliverables
- add regressions for both sync and detached collection paths

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'skips_auto_commit_without_terminal_marker or downgrades_missing_terminal_marker_with_deliverable or downgrades_missing_terminal_marker_without_deliverable'
- python -m pytest tests/swarm/test_worker_launcher.py -q