### PR TITLE
Clear stale blocker state on salvage completion

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3261,9 +3261,24 @@ class SwarmSupervisor:
         deliverable_present = bool(self._work_order_deliverable_type(item))
         if deliverable_present and is_salvage:
             # Salvaged deliverables proceed to completion — the recovery was
-            # intentional and the deliverable (commits/PR) is real.
+            # intentional and the deliverable (commits/PR) is real. Clear any
+            # stale blocker metadata from the failed attempt so the lane does
+            # not remain "completed" while still looking blocked.
             item["status"] = "completed"
             item["review_status"] = "pending_heterogeneous_review"
+            for key in (
+                "dispatch_error",
+                "resource_error",
+                "failure_reason",
+                "blocking_question",
+                "blocker",
+                "conflicts",
+                "merge_gate",
+                "verification_missing_reason",
+                "scope_violation",
+            ):
+                item.pop(key, None)
+            item.pop("blockers", None)
             item["exit_code"] = result.exit_code
             self._release_terminal_lease(item)
             self._register_pr_if_present(item, result)

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3492,6 +3492,14 @@ async def test_collect_results_backfills_receipt_for_salvaged_deliverable(
                 "review_status": "pending",
                 "file_scope": ["aragora/swarm/supervisor.py"],
                 "receipt_id": None,
+                "dispatch_error": "old crash",
+                "failure_reason": "worker_crash",
+                "blocking_question": "Old blocker?",
+                "blocker": {"reason": "worker_crash", "question": "Old blocker?"},
+                "blockers": ["old blocker"],
+                "merge_gate": {"checks_passed": False},
+                "verification_missing_reason": "missing_verification_plan",
+                "scope_violation": {"violations": [{"path": "old.py"}]},
             }
         ],
         status="active",
@@ -3531,6 +3539,17 @@ async def test_collect_results_backfills_receipt_for_salvaged_deliverable(
     receipt = store.get_completion_receipt(wo["receipt_id"])
     assert receipt is not None
     assert receipt.outcome == "deliverable_created"
+    for cleared_key in (
+        "dispatch_error",
+        "failure_reason",
+        "blocking_question",
+        "blocker",
+        "blockers",
+        "merge_gate",
+        "verification_missing_reason",
+        "scope_violation",
+    ):
+        assert cleared_key not in wo
 
 
 def test_merge_gate_state_allows_docs_only_lane_without_verification_plan() -> None:


### PR DESCRIPTION
## Summary
- clear stale blocker and merge-gate metadata when a salvaged deliverable completes
- stop recovered crash/timeout lanes from staying completed while still looking blocked
- add a supervisor regression that seeds stale blocker state and proves it is removed

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'collect_results_backfills_receipt_for_salvaged_deliverable or collect_finished_results_backfills_receipt_for_salvaged_detached_deliverable'
- python -m pytest tests/swarm/test_supervisor.py -q