### PR TITLE
Fail closed on Slack refresh without workspace identity

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1691,6 +1691,20 @@ class SlackOAuthHandler(SecureHandler):
             expected_workspace_id = str(
                 getattr(workspace, "workspace_id", "") or workspace_id
             ).strip()
+            if not response_workspace_id:
+                logger.error(
+                    "Token refresh returned no workspace identity for %s",
+                    workspace_id,
+                )
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: missing workspace identity",
+                    )
+                return error_response("Invalid token refresh response", 502)
             if response_workspace_id and response_workspace_id != expected_workspace_id:
                 logger.error(
                     "Token refresh workspace mismatch for %s: got %s",

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -2491,6 +2491,7 @@ class TestRefreshToken:
                 "access_token": "xoxb-new-token",
                 "refresh_token": "xoxr-new-refresh",
                 "expires_in": 43200,
+                "team": {"id": "W123"},
             }
         )
 
@@ -2632,6 +2633,7 @@ class TestRefreshToken:
                 "ok": True,
                 "access_token": "xoxb-new",
                 "expires_in": 43200,
+                "team": {"id": "W123"},
             }
         )
 
@@ -2659,6 +2661,7 @@ class TestRefreshToken:
                 "ok": True,
                 "access_token": "",
                 "expires_in": 43200,
+                "team": {"id": "W123"},
             }
         )
 
@@ -2751,6 +2754,38 @@ class TestRefreshToken:
         mock_workspace_store.save.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_refresh_rejects_missing_workspace_identity(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "refresh_token": "xoxr-new-refresh",
+                "expires_in": 43200,
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_store_import_error_returns_503(self, handler):
         with patch.dict("sys.modules", {"aragora.storage.slack_workspace_store": None}):
             result = await handler.handle(
@@ -2782,6 +2817,7 @@ class TestRefreshToken:
             {
                 "ok": True,
                 "access_token": "xoxb-new-token",
+                "team": {"id": "W123"},
             }
         )
 
@@ -2816,6 +2852,7 @@ class TestRefreshToken:
                 "access_token": "xoxb-updated-token",
                 "refresh_token": "xoxr-updated-refresh",
                 "expires_in": 86400,
+                "team": {"id": "W123"},
             }
         )
 
@@ -2850,6 +2887,7 @@ class TestRefreshToken:
                 "access_token": "xoxb-updated-token",
                 "refresh_token": "",
                 "expires_in": 86400,
+                "team": {"id": "W123"},
             }
         )
 


### PR DESCRIPTION
## Summary
- require Slack token refresh responses to identify the workspace they belong to
- reject malformed refresh payloads that omit workspace identity instead of silently trusting them
- align refresh success fixtures with Slack's documented  response shape

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'refresh and (successful_refresh or save_failure_returns_500 or refresh_missing_access_token_returns_502 or refresh_rejects_workspace_mismatch or refresh_rejects_missing_workspace_identity or refresh_without_expires_in or refresh_updates_workspace_tokens or refresh_preserves_existing_refresh_token_when_response_is_blank)'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q