### PR TITLE
Clear stale blocker fields on completion

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3207,9 +3207,17 @@ class SwarmSupervisor:
             self._register_pr_if_present(item, result)
             item["status"] = "completed"
             item["review_status"] = "pending_heterogeneous_review"
-            item.pop("failure_reason", None)
-            item.pop("blocking_question", None)
-            item.pop("blocker", None)
+            for key in (
+                "dispatch_error",
+                "resource_error",
+                "failure_reason",
+                "blocking_question",
+                "blocker",
+                "conflicts",
+                "scope_violation",
+            ):
+                item.pop(key, None)
+            item.pop("blockers", None)
             return
 
         # Non-zero exit: classify as crash (with or without salvage)

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3234,6 +3234,14 @@ async def test_collect_results_records_passed_merge_gate_checks(
                 "file_scope": ["aragora/swarm/supervisor.py"],
                 "expected_tests": ["python -m pytest tests/swarm/test_supervisor.py -q"],
                 "receipt_id": None,
+                "dispatch_error": "old dispatch failure",
+                "resource_error": "old resource error",
+                "failure_reason": "worker_crash",
+                "blocking_question": "Old blocker?",
+                "blocker": {"reason": "worker_crash", "question": "Old blocker?"},
+                "blockers": ["old blocker"],
+                "conflicts": [{"source": "lease", "lease_id": "old-lease"}],
+                "scope_violation": {"violations": [{"path": "old.py"}]},
             }
         ],
         status="active",
@@ -3286,6 +3294,17 @@ async def test_collect_results_records_passed_merge_gate_checks(
     assert store.get_completion_receipt(wo["receipt_id"]) is not None
     assert wo["merge_gate"]["checks_passed"] is True
     assert wo["merge_gate"]["human_approval_required"] is True
+    for cleared_key in (
+        "dispatch_error",
+        "resource_error",
+        "failure_reason",
+        "blocking_question",
+        "blocker",
+        "blockers",
+        "conflicts",
+        "scope_violation",
+    ):
+        assert cleared_key not in wo
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- clear stale blocker and dispatch metadata when a work order completes successfully
- prevent completed lanes from still carrying old dispatch errors, blockers, conflicts, or stale scope-violation state
- add a regression that seeds stale blocker state on a successful completion path and proves it is removed

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'collect_results_records_passed_merge_gate_checks or collect_results_backfills_receipt_for_salvaged_deliverable'
- python -m pytest tests/swarm/test_supervisor.py -q