### PR TITLE
Fix stale duplicate cleanup and autopilot branch reuse

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2587,6 +2587,7 @@ class SwarmSupervisor:
         try:
             self.store.rehabilitate_dependency_deferred_missing_verification_plan_work_orders()
             self.store.archive_failed_no_deliverable_work_orders(grace_period_hours=0.0)
+            self.store.archive_clean_exit_no_deliverable_work_orders(grace_period_hours=0.0)
             self.store.archive_terminal_dependency_failure_work_orders()
         except Exception:
             logger.debug(

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -768,6 +768,7 @@ class SwarmSupervisor:
                         self._clear_waiting_state(item)
                         item["status"] = "waiting_resource"
                         item["resource_error"] = str(exc)
+                        break
                     else:
                         self._clear_stale_prelaunch_deliverable_state(item)
                         self._mark_needs_human(
@@ -775,7 +776,7 @@ class SwarmSupervisor:
                             str(exc),
                             failure_reason="work_order_leasing_failed",
                         )
-                    break
+                        continue
 
         refreshed = self.store.update_supervisor_run(
             run_id,

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -43,10 +43,10 @@ from aragora.swarm.terminal_truth import (
     qualify_work_order_terminal_state,
 )
 from aragora.swarm.worker_launcher import (
-    SESSION_ARTIFACTS,
     LaunchConfig,
     WorkerLauncher,
     WorkerProcess,
+    is_ignored_changed_path,
 )
 from aragora.worktree.lifecycle import WorktreeLifecycleService
 
@@ -1058,6 +1058,9 @@ class SwarmSupervisor:
             if self._should_requeue_reaped_needs_human(item, active_leases):
                 self._reset_work_order_for_requeue(item)
                 continue
+            if self._should_requeue_ignorable_scope_violation(item):
+                self._reset_work_order_for_requeue(item)
+                continue
             if self._should_requeue_terminal_dependency_failure(item, work_orders):
                 self._reset_work_order_for_requeue(item)
                 continue
@@ -1578,6 +1581,40 @@ class SwarmSupervisor:
             return False
         dependency_status = str(dependency.get("status", "")).strip().lower()
         return dependency_status not in {"discarded", "failed", "timed_out", "scope_violation"}
+
+    @staticmethod
+    def _should_requeue_ignorable_scope_violation(item: dict[str, Any]) -> bool:
+        status = str(item.get("status", "")).strip().lower()
+        if status not in {"scope_violation", "needs_human", "discarded"}:
+            return False
+        failure_reason = str(item.get("failure_reason", "")).strip().lower()
+        metadata = item.get("metadata")
+        archived_due_to = (
+            str(metadata.get("archived_due_to", "")).strip().lower()
+            if isinstance(metadata, dict)
+            else ""
+        )
+        if failure_reason != "scope_violation" and archived_due_to != "scope_violation":
+            return False
+        if str(item.get("receipt_id") or "").strip():
+            return False
+        if item.get("commit_shas") or item.get("pr_url") or item.get("adopted_pr"):
+            return False
+
+        candidate_paths: set[str] = {
+            str(path).strip() for path in item.get("changed_paths", []) if str(path).strip()
+        }
+        scope_violation = item.get("scope_violation")
+        if isinstance(scope_violation, dict):
+            for violation in scope_violation.get("violations", []) or []:
+                if not isinstance(violation, dict):
+                    continue
+                path = str(violation.get("path", "")).strip()
+                if path:
+                    candidate_paths.add(path)
+        if not candidate_paths:
+            return False
+        return all(is_ignored_changed_path(path) for path in candidate_paths)
 
     @staticmethod
     def _reset_work_order_for_requeue(item: dict[str, Any]) -> None:
@@ -3185,13 +3222,14 @@ class SwarmSupervisor:
 
     @staticmethod
     def _strip_session_artifacts(paths: list[str]) -> list[str]:
-        """Remove harness session metadata from a list of changed paths.
+        """Remove harness and runtime noise from a list of changed paths.
 
         Session artifacts like ``.codex_session_meta.json`` are infrastructure
-        metadata created by the harness, not user deliverables.  Stripping them
-        prevents workers from claiming credit for non-work output.
+        metadata created by the harness, while runtime directories like
+        ``node_modules`` are environment noise. Stripping them prevents workers
+        from claiming credit for non-work output or tripping false scope checks.
         """
-        return [p for p in paths if Path(p).name not in SESSION_ARTIFACTS]
+        return [p for p in paths if not is_ignored_changed_path(p)]
 
     def _campaign_metadata(
         self,

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -1052,7 +1052,13 @@ class SwarmSupervisor:
                 if self._should_requeue_stale_work_order(item, active_leases):
                     self._reset_work_order_for_requeue(item)
                     continue
+            if self._should_requeue_recoverable_work_order_leasing_failed(item, active_leases):
+                self._reset_work_order_for_requeue(item)
+                continue
             if self._should_requeue_reaped_needs_human(item, active_leases):
+                self._reset_work_order_for_requeue(item)
+                continue
+            if self._should_requeue_terminal_dependency_failure(item, work_orders):
                 self._reset_work_order_for_requeue(item)
                 continue
             if self._should_requeue_conflict_only_needs_human(item):
@@ -1496,6 +1502,84 @@ class SwarmSupervisor:
         return True
 
     @staticmethod
+    def _should_requeue_recoverable_work_order_leasing_failed(
+        item: dict[str, Any],
+        active_leases: dict[str, Any],
+    ) -> bool:
+        status = str(item.get("status", "")).strip().lower()
+        if status not in {"needs_human", "discarded"}:
+            return False
+        failure_reason = str(item.get("failure_reason", "")).strip().lower()
+        metadata = item.get("metadata")
+        archived_due_to = (
+            str(metadata.get("archived_due_to", "")).strip().lower()
+            if isinstance(metadata, dict)
+            else ""
+        )
+        if (
+            failure_reason != "work_order_leasing_failed"
+            and archived_due_to != "work_order_leasing_failed"
+        ):
+            return False
+        lease_id = str(item.get("lease_id", "")).strip()
+        if lease_id and lease_id in active_leases:
+            return False
+        if str(item.get("receipt_id") or "").strip():
+            return False
+        if item.get("commit_shas") or item.get("changed_paths") or item.get("pr_url"):
+            return False
+        dispatch_error = str(item.get("dispatch_error", "")).strip().lower()
+        if not dispatch_error:
+            return False
+        return (
+            "autopilot ensure failed" in dispatch_error
+            and "a branch named" in dispatch_error
+            and "already exists" in dispatch_error
+        )
+
+    @staticmethod
+    def _should_requeue_terminal_dependency_failure(
+        item: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+    ) -> bool:
+        status = str(item.get("status", "")).strip().lower()
+        if status not in {"needs_human", "discarded"}:
+            return False
+        failure_reason = str(item.get("failure_reason", "")).strip().lower()
+        metadata = item.get("metadata")
+        archived_due_to = (
+            str(metadata.get("archived_due_to", "")).strip().lower()
+            if isinstance(metadata, dict)
+            else ""
+        )
+        if (
+            failure_reason != "terminal_dependency_failure"
+            and archived_due_to != "terminal_dependency_failure"
+        ):
+            return False
+        dependency_id = ""
+        if isinstance(metadata, dict):
+            dependency_id = str(metadata.get("blocking_dependency_id", "")).strip()
+        blocker = item.get("blocker")
+        if not dependency_id and isinstance(blocker, dict):
+            dependency_id = str(blocker.get("dependency_id", "")).strip()
+        if not dependency_id:
+            return False
+        dependency_lookup: dict[str, dict[str, Any]] = {}
+        for candidate in work_orders:
+            if not isinstance(candidate, dict):
+                continue
+            for key in ("pipeline_task_id", "work_order_id", "task_key"):
+                candidate_id = str(candidate.get(key, "")).strip()
+                if candidate_id:
+                    dependency_lookup[candidate_id] = candidate
+        dependency = dependency_lookup.get(dependency_id)
+        if not isinstance(dependency, dict):
+            return False
+        dependency_status = str(dependency.get("status", "")).strip().lower()
+        return dependency_status not in {"discarded", "failed", "timed_out", "scope_violation"}
+
+    @staticmethod
     def _reset_work_order_for_requeue(item: dict[str, Any]) -> None:
         item["status"] = "queued"
         item["review_status"] = "pending"
@@ -1543,6 +1627,24 @@ class SwarmSupervisor:
         ):
             item.pop(key, None)
         item.pop("blockers", None)
+        metadata = dict(item.get("metadata") or {})
+        for key in (
+            "archived_due_to",
+            "archived_at",
+            "archive_reason",
+            "previous_status",
+            "canonical_task_key",
+            "canonical_work_order_id",
+            "canonical_run_id",
+            "blocking_dependency_id",
+            "blocking_dependency_status",
+            "blocking_dependency_reason",
+        ):
+            metadata.pop(key, None)
+        if metadata:
+            item["metadata"] = metadata
+        else:
+            item.pop("metadata", None)
 
     def _backfill_missing_completion_receipt(self, item: dict[str, Any]) -> None:
         """Heal older completed lanes that predate receipt propagation fixes."""

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -35,6 +35,7 @@ from aragora.swarm.worker_process import (
     UTC,
     WorkerProcess,
     _SALVAGEABLE_EXIT_CODES,
+    is_ignored_changed_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -71,8 +72,8 @@ class WorkerLauncher:
 
     @staticmethod
     def _strip_session_artifacts(paths: set[str]) -> list[str]:
-        """Normalize changed paths by removing harness-owned artifacts by basename."""
-        return sorted(path for path in paths if Path(path).name not in SESSION_ARTIFACTS)
+        """Normalize changed paths by removing harness/runtime-owned artifacts."""
+        return sorted(path for path in paths if not is_ignored_changed_path(path))
 
     async def launch(
         self,
@@ -930,7 +931,7 @@ class WorkerLauncher:
             if len(line) < 4:
                 continue
             path = line[3:].strip()
-            if path and Path(path).name not in SESSION_ARTIFACTS:
+            if path and not is_ignored_changed_path(path):
                 return True
         return False
 
@@ -946,7 +947,7 @@ class WorkerLauncher:
             if len(line) < 4:
                 continue
             path = line[3:].strip()
-            if path and Path(path).name not in SESSION_ARTIFACTS:
+            if path and not is_ignored_changed_path(path):
                 return True
         return False
 

--- a/aragora/swarm/worker_process.py
+++ b/aragora/swarm/worker_process.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from pathlib import PurePosixPath
 from typing import Any
 
 from aragora.pipeline.execution_mode import ExecutionMode
@@ -29,6 +30,23 @@ SESSION_ARTIFACTS: frozenset[str] = frozenset(
         ".swarm_worker_stderr.log",
     }
 )
+
+# Runtime dependency directories can appear in worker status output when the
+# harness reuses local frontend tooling state. They are environment noise, not
+# lane deliverables.
+IGNORED_RUNTIME_PATH_PARTS: frozenset[str] = frozenset({"node_modules"})
+
+
+def is_ignored_changed_path(path: str) -> bool:
+    """Return True when a changed path is harness/runtime noise."""
+    clean = str(path).strip().removeprefix("./").rstrip("/")
+    if not clean:
+        return False
+    pure_path = PurePosixPath(clean)
+    if pure_path.name in SESSION_ARTIFACTS:
+        return True
+    return any(part in IGNORED_RUNTIME_PATH_PARTS for part in pure_path.parts)
+
 
 # Exit codes where the worker likely completed its work but the process was
 # terminated by a transport-level signal (e.g. broken pipe). Only these codes

--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -458,6 +458,23 @@ def _branch_exists(repo_root: Path, branch: str) -> bool:
     return proc.returncode == 0
 
 
+def _local_branches_with_prefix(repo_root: Path, prefix: str) -> list[str]:
+    proc = _run_git(repo_root, "for-each-ref", "--format=%(refname:short)", "refs/heads")
+    if proc.returncode != 0:
+        return []
+    prefix = str(prefix or "").strip()
+    if not prefix:
+        return []
+    branches: list[str] = []
+    for line in proc.stdout.splitlines():
+        branch = str(line).strip()
+        if not branch:
+            continue
+        if branch == prefix or branch.startswith(f"{prefix}-"):
+            branches.append(branch)
+    return branches
+
+
 def _branch_collision_error(stderr: str, branch: str) -> bool:
     message = str(stderr or "").lower()
     return (
@@ -632,6 +649,44 @@ def _create_managed_worktree(
         for entry in _get_worktree_entries(repo_root)
         if str(entry.branch or "").strip()
     }
+    reusable_branches = (
+        [
+            branch
+            for branch in _local_branches_with_prefix(repo_root, base_branch_name)
+            if branch not in attached_branches
+        ]
+        if session_id
+        else []
+    )
+    reusable_branches.sort(key=lambda branch: (0 if branch == base_branch_name else 1, branch))
+    for existing_branch in reusable_branches:
+        add_proc = _run_git(
+            repo_root,
+            "worktree",
+            "add",
+            str(worktree_path),
+            existing_branch,
+        )
+        if add_proc.returncode == 0:
+            return {
+                "session_id": sid,
+                "agent": agent,
+                "branch": existing_branch,
+                "path": str(worktree_path),
+                "base_branch": base,
+                "base_sha": _resolve_ref_sha(repo_root, _base_ref(base)),
+                "created_at": now.isoformat(),
+                "last_seen_at": now.isoformat(),
+                "cleanup_lock": False,
+                "cleanup_lock_reason": None,
+                "last_heartbeat_at": None,
+                "lease_status": None,
+                "lease_expires_at": None,
+                "lifecycle_state": "grace",
+            }
+        if worktree_path.exists():
+            shutil.rmtree(worktree_path, ignore_errors=True)
+
     if (
         session_id
         and _branch_exists(repo_root, base_branch_name)

--- a/scripts/codex_worktree_autopilot.py
+++ b/scripts/codex_worktree_autopilot.py
@@ -475,6 +475,55 @@ def _local_branches_with_prefix(repo_root: Path, prefix: str) -> list[str]:
     return branches
 
 
+def _worktree_admin_dir(repo_root: Path, session_id: str) -> Path:
+    return _git_common_dir(repo_root) / "worktrees" / str(session_id or "").strip()
+
+
+def _clear_stale_initializing_worktree_registration(
+    repo_root: Path,
+    *,
+    session_id: str,
+    worktree_path: Path,
+) -> bool:
+    """Remove a stale `.git/worktrees/<session>` entry left by an aborted add.
+
+    Failed `git worktree add` calls can leave an admin dir behind with
+    `locked=initializing` even when the target worktree path never materialized.
+    Future retries then fail before checkout and leak retry branches. Clearing
+    only this narrow stale shape is safe and lets the session recover in place.
+    """
+    sid = str(session_id or "").strip()
+    if not sid or worktree_path.exists():
+        return False
+    admin_dir = _worktree_admin_dir(repo_root, sid)
+    if not admin_dir.exists():
+        return False
+    locked_path = admin_dir / "locked"
+    try:
+        locked_reason = locked_path.read_text(encoding="utf-8").strip().lower()
+    except OSError:
+        return False
+    if locked_reason != "initializing":
+        return False
+    try:
+        shutil.rmtree(admin_dir)
+    except OSError:
+        return False
+    return not admin_dir.exists()
+
+
+def _cleanup_leaked_retry_branch(
+    repo_root: Path,
+    *,
+    branch: str,
+    worktree_path: Path,
+) -> None:
+    """Drop a just-created branch when worktree creation failed before checkout."""
+    if worktree_path.exists() or not _branch_exists(repo_root, branch):
+        return
+    _run_git(repo_root, "branch", "-D", branch)
+
+
 def _branch_collision_error(stderr: str, branch: str) -> bool:
     message = str(stderr or "").lower()
     return (
@@ -642,6 +691,11 @@ def _create_managed_worktree(
 
     if worktree_path.exists():
         shutil.rmtree(worktree_path, ignore_errors=True)
+    _clear_stale_initializing_worktree_registration(
+        repo_root,
+        session_id=sid,
+        worktree_path=worktree_path,
+    )
     worktree_path.parent.mkdir(parents=True, exist_ok=True)
 
     attached_branches = {
@@ -739,6 +793,11 @@ def _create_managed_worktree(
             )
             if add_proc.returncode == 0:
                 break
+            _cleanup_leaked_retry_branch(
+                repo_root,
+                branch=branch,
+                worktree_path=worktree_path,
+            )
             if _branch_collision_error(add_proc.stderr, branch):
                 branch = f"{base_branch_name}-{uuid4().hex[:4]}"
                 retry_branch = True

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -372,6 +372,139 @@ def test_create_managed_worktree_reuses_existing_unattached_retry_branch_for_sam
     ) in calls
 
 
+def test_create_managed_worktree_clears_stale_initializing_registration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    managed_root = repo_root / ".worktrees" / "codex-auto"
+    stale_admin = repo_root / ".git" / "worktrees" / "swarm-stale"
+    stale_admin.mkdir(parents=True)
+    (stale_admin / "locked").write_text("initializing", encoding="utf-8")
+    (stale_admin / "gitdir").write_text(
+        str((managed_root / "swarm-stale" / ".git").resolve()),
+        encoding="utf-8",
+    )
+    calls: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(mod, "_ensure_fetched", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "_git_common_dir", lambda _repo: repo_root / ".git")
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entries",
+        lambda _repo: [mod.WorktreeEntry(path=repo_root, branch="main")],
+    )
+    monkeypatch.setattr(mod, "_local_branches_with_prefix", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(mod, "_branch_exists", lambda *_args, **_kwargs: False)
+
+    def _run_git(
+        _repo_root: Path, *args: str, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(args))
+        if args[:2] == ("worktree", "add"):
+            assert not stale_admin.exists()
+            return subprocess.CompletedProcess(
+                args=("git", *args), returncode=0, stdout="", stderr=""
+            )
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(mod, "_run_git", _run_git)
+
+    session = mod._create_managed_worktree(
+        repo_root,
+        managed_root,
+        agent="codex",
+        base="main",
+        session_id="swarm-stale",
+    )
+
+    assert session["branch"] == "codex/swarm-stale"
+    assert not stale_admin.exists()
+    assert (
+        "worktree",
+        "add",
+        "-b",
+        "codex/swarm-stale",
+        str((managed_root / "swarm-stale").resolve()),
+        "origin/main",
+    ) in calls
+
+
+def test_create_managed_worktree_cleans_leaked_branch_before_second_source_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    managed_root = repo_root / ".worktrees" / "codex-auto"
+    existing_branches: set[str] = set()
+    calls: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(mod, "_ensure_fetched", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entries",
+        lambda _repo: [mod.WorktreeEntry(path=repo_root, branch="main")],
+    )
+    monkeypatch.setattr(mod, "_local_branches_with_prefix", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        mod,
+        "_branch_exists",
+        lambda _repo, branch: branch in existing_branches,
+    )
+
+    def _proc(returncode: int, stderr: str = "") -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
+
+    def _run_git(
+        _repo_root: Path, *args: str, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(args))
+        if args[:2] == ("worktree", "add"):
+            branch = args[3]
+            source = args[5]
+            if source == "origin/main":
+                existing_branches.add(branch)
+                return _proc(
+                    128,
+                    "fatal: '/repo/.worktrees/codex-auto/swarm-race' is a missing but already "
+                    "registered worktree; use 'add -f' to override",
+                )
+            if source == "main":
+                assert branch not in existing_branches
+                return _proc(0)
+        if args[:2] == ("branch", "-D"):
+            existing_branches.discard(args[2])
+            return _proc(0)
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(mod, "_run_git", _run_git)
+
+    session = mod._create_managed_worktree(
+        repo_root,
+        managed_root,
+        agent="codex",
+        base="main",
+        session_id="swarm-race",
+    )
+
+    assert session["branch"] == "codex/swarm-race"
+    assert ("branch", "-D", "codex/swarm-race") in calls
+    assert (
+        "worktree",
+        "add",
+        "-b",
+        "codex/swarm-race",
+        str((managed_root / "swarm-race").resolve()),
+        "main",
+    ) in calls
+
+
 def test_cmd_cleanup_keeps_session_when_worktree_remove_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/scripts/test_codex_worktree_autopilot.py
+++ b/tests/scripts/test_codex_worktree_autopilot.py
@@ -311,6 +311,67 @@ def test_create_managed_worktree_retries_add_time_branch_collision(
     ) in calls
 
 
+def test_create_managed_worktree_reuses_existing_unattached_retry_branch_for_same_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import codex_worktree_autopilot as mod
+
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    managed_root = repo_root / ".worktrees" / "codex-auto"
+    attached_path = tmp_path / "attached"
+    attached_path.mkdir()
+    calls: list[tuple[str, ...]] = []
+    now = datetime(2026, 4, 4, 5, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr(mod, "_ensure_fetched", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "_resolve_ref_sha", lambda *_args, **_kwargs: "abc123")
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(
+        mod,
+        "_get_worktree_entries",
+        lambda _repo: [
+            mod.WorktreeEntry(path=repo_root, branch="main"),
+            mod.WorktreeEntry(path=attached_path, branch="codex/swarm-race"),
+        ],
+    )
+    monkeypatch.setattr(
+        mod,
+        "_local_branches_with_prefix",
+        lambda _repo, prefix: [prefix, f"{prefix}-b16b"],
+    )
+    monkeypatch.setattr(mod, "_branch_exists", lambda *_args, **_kwargs: True)
+
+    def _run_git(
+        _repo_root: Path, *args: str, **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(tuple(args))
+        if args[:2] == ("worktree", "add") and args[2] != "-b":
+            assert args[3] == "codex/swarm-race-b16b"
+            return subprocess.CompletedProcess(
+                args=("git", *args), returncode=0, stdout="", stderr=""
+            )
+        raise AssertionError(f"unexpected git args: {args}")
+
+    monkeypatch.setattr(mod, "_run_git", _run_git)
+
+    session = mod._create_managed_worktree(
+        repo_root,
+        managed_root,
+        agent="codex",
+        base="main",
+        session_id="swarm-race",
+    )
+
+    assert session["branch"] == "codex/swarm-race-b16b"
+    assert (
+        "worktree",
+        "add",
+        str((managed_root / "swarm-race").resolve()),
+        "codex/swarm-race-b16b",
+    ) in calls
+
+
 def test_cmd_cleanup_keeps_session_when_worktree_remove_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -725,6 +786,8 @@ def test_create_managed_worktree_retries_when_branch_is_created_concurrently(
         return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
 
     def _run_git(_repo: Path, *args: str, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[:1] == ("for-each-ref",):
+            return _proc(0)
         if args[:2] == ("worktree", "add"):
             branch = args[3]
             branches_seen.append(branch)

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -131,6 +131,11 @@ class TestStripSessionArtifacts:
         result = SwarmSupervisor._strip_session_artifacts(paths)
         assert result == ["aragora/live/app.ts"]
 
+    def test_runtime_node_modules_path_stripped(self) -> None:
+        paths = ["aragora/live/node_modules/react/index.js", "aragora/live/app.ts"]
+        result = SwarmSupervisor._strip_session_artifacts(paths)
+        assert result == ["aragora/live/app.ts"]
+
 
 # ---------------------------------------------------------------------------
 # Worker prompt regression
@@ -509,6 +514,15 @@ class TestWorkingTreeChangeFiltering:
         with patch.object(WorkerLauncher, "_git_output_sync", side_effect=_git_output_sync):
             assert not WorkerLauncher._has_working_tree_changes_sync("/tmp/wt")
 
+    @pytest.mark.asyncio
+    async def test_has_working_tree_changes_ignores_runtime_node_modules(self) -> None:
+        async def _git_output(_worktree_path: str, *args: str) -> str:
+            assert args[:2] == ("status", "--porcelain")
+            return "?? aragora/live/node_modules/react/index.js\n"
+
+        with patch.object(WorkerLauncher, "_git_output", side_effect=_git_output):
+            assert not await WorkerLauncher._has_working_tree_changes("/tmp/wt")
+
 
 # ---------------------------------------------------------------------------
 # _collect_changed_paths filtering
@@ -573,6 +587,24 @@ class TestCollectChangedPathsFiltering:
         assert "real.py" in paths
         assert "subdir/.codex_session_meta.json" not in paths
         assert "subdir/.swarm_worker_stdout.log" not in paths
+
+    def test_collect_excludes_runtime_node_modules(self, repo: Path) -> None:
+        """Runtime dependency directories must not count as deliverable paths."""
+        initial = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+        node_modules = repo / "aragora" / "live" / "node_modules" / "react"
+        node_modules.mkdir(parents=True)
+        (node_modules / "index.js").write_text("module.exports = {}\n", encoding="utf-8")
+        (repo / "real.py").write_text("x = 1\n", encoding="utf-8")
+        _run(repo, "git", "add", "-A")
+        _run(repo, "git", "commit", "-m", "test runtime artifacts")
+        head = _run(repo, "git", "rev-parse", "HEAD").stdout.strip()
+
+        paths = asyncio.run(
+            WorkerLauncher._collect_changed_paths(str(repo), initial_head=initial, head_sha=head)
+        )
+        assert "real.py" in paths
+        assert "aragora/live/node_modules/react/index.js" not in paths
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -7153,6 +7153,112 @@ def test_refresh_run_continues_after_work_order_leasing_failure_for_independent_
     assert work_orders["micro-2"]["lease_id"] == "lease-micro-2"
 
 
+def test_refresh_run_requeues_recoverable_work_order_leasing_failed_lane_and_dependency_children(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+    run_record = store.create_supervisor_run(
+        goal="requeue recoverable leasing failure lane",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "requeue recoverable leasing failure lane"},
+        metadata={"max_concurrency": 1},
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "Primary lane",
+                "description": "Primary lane",
+                "status": "discarded",
+                "failure_reason": "work_order_leasing_failed",
+                "dispatch_error": (
+                    "autopilot ensure failed (1): fatal: a branch named "
+                    "'codex/swarm-requeue-micro-1-a123' already exists"
+                ),
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["aragora/server/handlers/runs.py"],
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "archived_due_to": "work_order_leasing_failed",
+                    "archived_at": "2026-04-04T00:00:00+00:00",
+                    "archive_reason": "work_order_leasing_failed",
+                    "previous_status": "needs_human",
+                },
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Dependent test lane",
+                "description": "Dependent test lane",
+                "status": "discarded",
+                "failure_reason": "terminal_dependency_failure",
+                "dependency_ids": ["micro-task-1"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["tests/server/handlers/test_runs_handler.py"],
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "archived_due_to": "terminal_dependency_failure",
+                    "archived_at": "2026-04-04T00:00:01+00:00",
+                    "archive_reason": "terminal_dependency_failure:micro-task-1",
+                    "previous_status": "queued",
+                    "blocking_dependency_id": "micro-task-1",
+                    "blocking_dependency_status": "discarded",
+                    "blocking_dependency_reason": "work_order_leasing_failed",
+                },
+                "blocker": {
+                    "reason": "terminal_dependency_failure",
+                    "dependency_id": "micro-task-1",
+                    "dependency_status": "discarded",
+                    "dependency_reason": "work_order_leasing_failed",
+                },
+                "blocking_question": (
+                    "Dependency micro-task-1 ended in discarded; should that dependency be rerun "
+                    "or replaced before retrying this lane?"
+                ),
+            },
+        ],
+        status="active",
+    )
+
+    def fake_lease_work_order(
+        *,
+        run_id: str,
+        target_branch: str,
+        work_order: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+        managed_dir_pattern: str,
+        approval_policy: SwarmApprovalPolicy,
+    ) -> bool:
+        del run_id, target_branch, work_orders, managed_dir_pattern, approval_policy
+        work_order["status"] = "leased"
+        work_order["lease_id"] = "lease-requeued-micro-1"
+        work_order["owner_session_id"] = "swarm-session-micro-1"
+        return True
+
+    supervisor._lease_work_order = fake_lease_work_order  # type: ignore[method-assign]
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    work_orders = {item["work_order_id"]: item for item in refreshed.work_orders}
+    assert refreshed.status == "active"
+    assert work_orders["micro-1"]["status"] == "leased"
+    assert work_orders["micro-1"]["lease_id"] == "lease-requeued-micro-1"
+    assert work_orders["micro-1"].get("failure_reason") in {"", None}
+    assert "archived_due_to" not in work_orders["micro-1"].get("metadata", {})
+    assert work_orders["micro-2"]["status"] == "queued"
+    assert work_orders["micro-2"].get("failure_reason") in {"", None}
+    assert work_orders["micro-2"].get("blocking_question") in {"", None}
+    assert "archived_due_to" not in work_orders["micro-2"].get("metadata", {})
+
+
 def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
     repo: Path, store: DevCoordinationStore
 ) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -1343,6 +1343,161 @@ def test_start_run_preserves_rerun_when_existing_failed_validation_lane_has_no_d
         assert work_order.get("metadata", {}).get("archived_due_to") != "duplicate_open_work_order"
 
 
+def test_start_run_preserves_rerun_when_existing_clean_exit_no_deliverable_lane_has_no_deliverable(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    goal = "[Issue #2066] Add run-ledger read API for operator visibility"
+    store.create_supervisor_run(
+        goal=goal,
+        target_branch="main",
+        supervisor_agents={"planner": "codex", "judge": "claude"},
+        approval_policy={},
+        spec={},
+        status="needs_human",
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "Update runs.py",
+                "status": "needs_human",
+                "worker_outcome": "clean_exit_no_effect",
+                "failure_reason": "clean_exit_no_deliverable",
+                "dispatch_error": "worker exited 0 with no commits and no changed paths",
+                "blocking_question": (
+                    "What concrete branch, commit, or PR should this lane produce before rerunning?"
+                ),
+                "blocker": {
+                    "reason": "clean_exit_no_deliverable",
+                    "question": (
+                        "What concrete branch, commit, or PR should this lane produce before rerunning?"
+                    ),
+                },
+                "file_scope": ["aragora/server/handlers/runs.py"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "acceptance_criteria": [
+                        "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                    ],
+                    "deferred_verification_to_dependency_ids": ["micro-task-4"],
+                },
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Update runs.py",
+                "status": "needs_human",
+                "failure_reason": "stale_lease_reaped",
+                "file_scope": ["aragora/server/fastapi/routes/runs.py"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "acceptance_criteria": [
+                        "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                    ],
+                    "deferred_verification_to_dependency_ids": ["micro-task-4"],
+                },
+            },
+        ],
+    )
+
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+
+    run = supervisor.start_run(
+        spec=SwarmSpec(
+            raw_goal=goal,
+            refined_goal=goal,
+            work_orders=[
+                {
+                    "work_order_id": "micro-1",
+                    "pipeline_task_id": "micro-task-1",
+                    "title": "Update runs.py",
+                    "description": "Add the read-only RunLedger handler.",
+                    "file_scope": ["aragora/server/handlers/runs.py"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {
+                        "source": "explicit_spec_work_order",
+                        "acceptance_criteria": [
+                            "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                        ],
+                        "deferred_verification_to_dependency_ids": ["micro-task-4"],
+                    },
+                },
+                {
+                    "work_order_id": "micro-2",
+                    "pipeline_task_id": "micro-task-2",
+                    "title": "Update runs.py",
+                    "description": "Expose the new read-only route entries.",
+                    "file_scope": ["aragora/server/fastapi/routes/runs.py"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {
+                        "source": "explicit_spec_work_order",
+                        "acceptance_criteria": [
+                            "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                        ],
+                        "deferred_verification_to_dependency_ids": ["micro-task-4"],
+                    },
+                },
+                {
+                    "work_order_id": "micro-3",
+                    "pipeline_task_id": "micro-task-3",
+                    "title": "Write tests for runs.py",
+                    "description": "Add focused coverage for the new read endpoints.",
+                    "file_scope": ["tests/server/handlers/test_runs_handler.py"],
+                    "dependency_ids": ["micro-task-1", "micro-task-2"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {
+                        "source": "explicit_spec_work_order",
+                        "acceptance_criteria": [
+                            "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                        ],
+                        "deferred_verification_to_dependency_ids": ["micro-task-4"],
+                    },
+                },
+                {
+                    "work_order_id": "micro-4",
+                    "pipeline_task_id": "micro-task-4",
+                    "title": "Run validation and fix failures",
+                    "description": "Run the acceptance test and fix anything that breaks.",
+                    "file_scope": [
+                        "aragora/server/handlers/runs.py",
+                        "aragora/server/fastapi/routes/runs.py",
+                        "tests/server/handlers/test_runs_handler.py",
+                    ],
+                    "dependency_ids": ["micro-task-1", "micro-task-2", "micro-task-3"],
+                    "target_agent": "codex",
+                    "reviewer_agent": "claude",
+                    "approval_required": True,
+                    "metadata": {
+                        "source": "explicit_spec_work_order",
+                        "acceptance_criteria": [
+                            "`pytest tests/server/handlers/test_runs_handler.py -x -q` passes"
+                        ],
+                    },
+                },
+            ],
+        ),
+        refresh_scaling=False,
+    )
+
+    assert [item["status"] for item in run.work_orders] == ["queued", "queued", "queued", "queued"]
+    for work_order in run.work_orders:
+        assert work_order.get("metadata", {}).get("archived_due_to") != "duplicate_open_work_order"
+
+
 def test_start_run_discards_duplicate_scope_less_explicit_lane_by_tranche_lane_id(
     repo: Path, store: DevCoordinationStore
 ) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -7259,6 +7259,112 @@ def test_refresh_run_requeues_recoverable_work_order_leasing_failed_lane_and_dep
     assert "archived_due_to" not in work_orders["micro-2"].get("metadata", {})
 
 
+def test_refresh_run_requeues_ignorable_scope_violation_and_dependency_children(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+    run_record = store.create_supervisor_run(
+        goal="requeue ignorable runtime scope violation lane",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "requeue ignorable runtime scope violation lane"},
+        metadata={"max_concurrency": 1},
+        work_orders=[
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Route lane",
+                "description": "Route lane",
+                "status": "scope_violation",
+                "failure_reason": "scope_violation",
+                "dispatch_error": (
+                    "worker edited files outside permitted scope: aragora/live/node_modules"
+                ),
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["aragora/server/fastapi/routes/runs.py"],
+                "changed_paths": ["aragora/live/node_modules"],
+                "scope_violation": {
+                    "violations": [
+                        {
+                            "path": "aragora/live/node_modules",
+                            "type": "out_of_scope",
+                            "reason": "outside permitted scope",
+                        }
+                    ]
+                },
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                },
+            },
+            {
+                "work_order_id": "micro-3",
+                "pipeline_task_id": "micro-task-3",
+                "title": "Dependent lane",
+                "description": "Dependent lane",
+                "status": "discarded",
+                "failure_reason": "terminal_dependency_failure",
+                "dependency_ids": ["micro-task-2"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["tests/server/fastapi/test_runs_routes.py"],
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "archived_due_to": "terminal_dependency_failure",
+                    "archived_at": "2026-04-04T00:00:01+00:00",
+                    "archive_reason": "terminal_dependency_failure:micro-task-2",
+                    "previous_status": "queued",
+                    "blocking_dependency_id": "micro-task-2",
+                    "blocking_dependency_status": "scope_violation",
+                    "blocking_dependency_reason": "scope_violation",
+                },
+                "blocker": {
+                    "reason": "terminal_dependency_failure",
+                    "dependency_id": "micro-task-2",
+                    "dependency_status": "scope_violation",
+                    "dependency_reason": "scope_violation",
+                },
+            },
+        ],
+        status="active",
+    )
+
+    def fake_lease_work_order(
+        *,
+        run_id: str,
+        target_branch: str,
+        work_order: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+        managed_dir_pattern: str,
+        approval_policy: SwarmApprovalPolicy,
+    ) -> bool:
+        del run_id, target_branch, work_orders, managed_dir_pattern, approval_policy
+        work_order["status"] = "leased"
+        work_order["lease_id"] = "lease-requeued-micro-2"
+        work_order["owner_session_id"] = "swarm-session-micro-2"
+        return True
+
+    supervisor._lease_work_order = fake_lease_work_order  # type: ignore[method-assign]
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    work_orders = {item["work_order_id"]: item for item in refreshed.work_orders}
+    assert refreshed.status == "active"
+    assert work_orders["micro-2"]["status"] == "leased"
+    assert work_orders["micro-2"]["lease_id"] == "lease-requeued-micro-2"
+    assert "scope_violation" not in work_orders["micro-2"]
+    assert "changed_paths" not in work_orders["micro-2"]
+    assert work_orders["micro-3"]["status"] == "queued"
+    assert work_orders["micro-3"].get("failure_reason") in {"", None}
+    assert "archived_due_to" not in work_orders["micro-3"].get("metadata", {})
+
+
 def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
     repo: Path, store: DevCoordinationStore
 ) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -7083,6 +7083,76 @@ def test_refresh_run_work_order_leasing_failure_clears_stale_deliverable_state(
         assert cleared_key not in work_order
 
 
+def test_refresh_run_continues_after_work_order_leasing_failure_for_independent_lane(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+    run_record = store.create_supervisor_run(
+        goal="continue after lane-specific leasing failure",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "continue after lane-specific leasing failure"},
+        metadata={"max_concurrency": 2},
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "First lane fails to lease",
+                "description": "First lane fails to lease",
+                "status": "queued",
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["aragora/server/handlers/runs.py"],
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Second independent lane still leases",
+                "description": "Second independent lane still leases",
+                "status": "queued",
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "file_scope": ["aragora/server/fastapi/routes/runs.py"],
+            },
+        ],
+        status="active",
+    )
+
+    def fake_lease_work_order(
+        *,
+        run_id: str,
+        target_branch: str,
+        work_order: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+        managed_dir_pattern: str,
+        approval_policy: SwarmApprovalPolicy,
+    ) -> bool:
+        del run_id, target_branch, work_orders, managed_dir_pattern, approval_policy
+        if work_order["work_order_id"] == "micro-1":
+            raise RuntimeError("autopilot ensure failed (1): branch already exists")
+        work_order["status"] = "leased"
+        work_order["lease_id"] = "lease-micro-2"
+        work_order["owner_session_id"] = "swarm-session-micro-2"
+        return True
+
+    supervisor._lease_work_order = fake_lease_work_order  # type: ignore[method-assign]
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    work_orders = {item["work_order_id"]: item for item in refreshed.work_orders}
+    assert refreshed.status == "needs_human"
+    assert work_orders["micro-1"]["status"] == "needs_human"
+    assert work_orders["micro-1"]["failure_reason"] == "work_order_leasing_failed"
+    assert work_orders["micro-2"]["status"] == "leased"
+    assert work_orders["micro-2"]["lease_id"] == "lease-micro-2"
+
+
 def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
     repo: Path, store: DevCoordinationStore
 ) -> None:


### PR DESCRIPTION
## Summary
- archive stale clean-exit-no-deliverable lanes during duplicate-suppression pre-maintenance so fresh issue reruns are not blocked by receiptless no-op lanes
- reuse unattached managed branches with the same session prefix in codex worktree autopilot before minting more suffixed branches
- add regressions for the live #2066 duplicate/branch-collision shapes

## Validation
- python3 -m pytest -q tests/swarm/test_supervisor.py tests/scripts/test_codex_worktree_autopilot.py
- python3 -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py
- python3 -m ruff format --check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py scripts/codex_worktree_autopilot.py tests/scripts/test_codex_worktree_autopilot.py
- git diff --check

## Live proof
- fresh #2066 run 93da0f02-c00 no longer archived micro-1 as duplicate_open_work_order against the stale clean-exit lane
- autopilot branch collision now has a regression covering reuse of unattached `codex/swarm-...-*` retry branches