### PR TITLE
[codex] docs: repair consolidated doc references

### DIFF
--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -2,7 +2,7 @@
 
 *Complete catalog of 230+ features for developers exploring Aragora capabilities*
 
-> Compatibility mirror for older links. This file is currently the maintained feature inventory; the older `status/FEATURE_DISCOVERY.md` target is not present in the repo.
+> Compatibility mirror for older links. The canonical current-state inventory lives at [status/FEATURE_DISCOVERY.md](status/FEATURE_DISCOVERY.md).
 
 This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
 

--- a/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
+++ b/docs/outreach/DESIGN_PARTNER_ONEPAGER.md
@@ -55,7 +55,7 @@ Your input -> multi-agent debate -> consensus + receipt -> KM feedback -> Slack 
 
 Use these phrases consistently in outreach and sales conversations. The full
 internal glossary lives in
-[`docs/strategy/TERMINOLOGY_GLOSSARY.md`](../strategy/TERMINOLOGY_GLOSSARY.md).
+[`docs/strategy/PRECISION_AND_TERMS.md`](../strategy/PRECISION_AND_TERMS.md#part-1-terminology-and-phrase-glossary).
 
 - **Debate** = structured adversarial review, not generic multi-agent chatter.
 - **Receipt** = the audit artifact that records evidence, dissent, confidence,
@@ -108,7 +108,7 @@ Default order for week one:
 3. Bounded repo execution only after receipt review feels trustworthy
 
 See the canonical journey and exit gate:
-`docs/plans/2026-03-25-design-partner-first-week-journey.md`.
+[`docs/outreach/DESIGN_PARTNER_OPERATIONS_PLAYBOOK.md`](./DESIGN_PARTNER_OPERATIONS_PLAYBOOK.md#part-4-first-week-journey).
 
 ## Explicit Truth Boundaries
 
@@ -187,7 +187,7 @@ is:
   critical fixes, and makes an honest go/no-go call instead of dragging the
   pilot out.
 
-See also: [Bounded pilot structure](../plans/2026-03-24-design-partner-pilot-structure.md)
+See also: [Bounded pilot structure](./DESIGN_PARTNER_OPERATIONS_PLAYBOOK.md#part-3-pilot-structure)
 
 ## Who This Is For
 

--- a/docs/plans/2026-03-10-bootstrap-plan.md
+++ b/docs/plans/2026-03-10-bootstrap-plan.md
@@ -10,12 +10,13 @@ execute a structured hardening backlog against the rest of the codebase.
 
 ## Related Documents
 
-- **Execution gating policy:**
-  [`docs/plans/2026-03-10-bootstrap-gates.md`](2026-03-10-bootstrap-gates.md)
+- **Execution gating policy:** defined in the phase gates below, especially
+  [Phase 0A](#phase-0a-prove-governance) and [Phase 0B](#phase-0b-prove-verified-execution)
 - **First evidence report:**
-  [`docs/plans/2026-03-10-dogfood-6-evidence.md`](2026-03-10-dogfood-6-evidence.md)
-- **Phase 0A campaign manifest:**
-  [`docs/plans/phase0a_campaign_manifest.yaml`](phase0a_campaign_manifest.yaml)
+  [`docs/plans/2026-03-10-campaign-validated.md`](2026-03-10-campaign-validated.md)
+- **Phase 0A surviving manifests:**
+  [`docs/plans/phase0a_proof_manifest.yaml`](phase0a_proof_manifest.yaml) and
+  [`docs/plans/phase0a_campaign2_manifest.yaml`](phase0a_campaign2_manifest.yaml)
 - **Existing roadmap:**
   [`ROADMAP.md`](../../ROADMAP.md)
 
@@ -53,7 +54,7 @@ On March 10, 2026, the first confirmed end-to-end campaign execution:
 - Campaign state was updated to mark the project completed
 - Dependency handling blocked downstream project correctly
 
-See full evidence: `docs/plans/2026-03-10-dogfood-6-evidence.md`
+See full evidence: [`docs/plans/2026-03-10-campaign-validated.md`](2026-03-10-campaign-validated.md)
 
 ### Known gaps in the engine
 
@@ -98,7 +99,10 @@ tasks in a narrow safe lane without human rescue.
 
 ### Campaign 1: artifacts produced manually after failed automation
 
-See `docs/plans/phase0a_campaign_manifest.yaml` for the original manifest.
+The original `phase0a_campaign_manifest.yaml` is no longer in the repo. Use
+[`docs/plans/phase0a_proof_manifest.yaml`](phase0a_proof_manifest.yaml) and
+[`docs/plans/phase0a_campaign2_manifest.yaml`](phase0a_campaign2_manifest.yaml)
+for the surviving Phase 0A manifests.
 
 | Task | Title | Depends On | Est. Cost | Automation Result |
 |------|-------|------------|-----------|-------------------|

--- a/docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md
+++ b/docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md
@@ -172,7 +172,7 @@ All items below are **PASSED** as of March 24, 2026:
 
 When the founder loop does not complete successfully, label the run with one
 primary canonical state from
-[`docs/strategy/FOUNDER_RUN_FAILURE_TAXONOMY.md`](../strategy/FOUNDER_RUN_FAILURE_TAXONOMY.md):
+[`docs/strategy/PRECISION_AND_TERMS.md`](../strategy/PRECISION_AND_TERMS.md#part-2-founder-run-failure-taxonomy):
 
 - `auth_failure`
 - `no_evidence`


### PR DESCRIPTION
## Summary
- fix six broken markdown links found by `python3 scripts/validate_doc_links.py` on current `origin/main`
- retarget outreach and PMF references to consolidated docs under `docs/strategy/PRECISION_AND_TERMS.md` and `docs/outreach/DESIGN_PARTNER_OPERATIONS_PLAYBOOK.md`
- replace missing bootstrap-plan references with current surviving artifacts and accurate in-doc guidance
- correct the stale compatibility note in `docs/FEATURE_DISCOVERY.md` so it points at `docs/status/FEATURE_DISCOVERY.md`

## Verification
- `python3 scripts/validate_doc_links.py`
- `git diff --check`

## Notes
- attempted `python3 -m aragora.cli.main review --diff-file /tmp/eng-auto2-doc-links.diff --agents codex --rounds 1 --focus quality --output-format json`, but the review flow failed in this environment with `OMP: Error #179: Function Can't open SHM2 failed` after startup warnings
