### PR TITLE
test(playground): remove duplicate assess-path case

### DIFF
--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -141,9 +141,6 @@ class TestCanHandle:
     def test_cost_estimate_path(self, handler):
         assert handler.can_handle("/api/v1/playground/debate/live/cost-estimate")
 
-    def test_assess_path(self, handler):
-        assert handler.can_handle("/api/v1/playground/assess")
-
     def test_status_path(self, handler):
         assert handler.can_handle("/api/v1/playground/status")
 


### PR DESCRIPTION
## Summary
- remove the duplicate \ definition in \
- restore the shared lint baseline on branches still based before this cleanup

## Validation
- python3 -m ruff check tests/handlers/test_playground.py
- python3 -m pytest tests/handlers/test_playground.py -q -k TestCanHandle