### PR TITLE
Fail closed on missing-terminal-marker publish

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1183,10 +1183,10 @@ class WorkerLauncher:
             # Ensure the branch is pushed if the worker produced commits.
             # _auto_push only runs inside _auto_commit which is skipped when the
             # worker already committed on its own.
-            if worker.commit_shas:
+            if worker.commit_shas and not missing_terminal_marker:
                 await cls._auto_push(worker)
 
-            if cls._should_run_verification(worker):
+            if not missing_terminal_marker and cls._should_run_verification(worker):
                 worker.verification_results = await cls._run_verification_commands(
                     worktree_path,
                     worker.expected_tests,
@@ -2137,10 +2137,10 @@ class WorkerLauncher:
                 head_sha=worker.head_sha,
             )
 
-            if worker.commit_shas:
+            if worker.commit_shas and not missing_terminal_marker:
                 self._auto_push_sync(worker)
 
-            if self._should_run_verification(worker):
+            if not missing_terminal_marker and self._should_run_verification(worker):
                 worker.verification_results = self._run_verification_commands_sync(
                     worker.worktree_path,
                     worker.expected_tests,

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1409,6 +1409,47 @@ class TestCollectFinishedSync:
         mock_commit.assert_not_called()
         assert worker.work_order_id not in launcher._processes
 
+    def test_collect_finished_sync_skips_auto_push_and_verification_without_terminal_marker(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        worker = WorkerProcess(
+            work_order_id="wo-sync-no-terminal-marker-no-publish",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-no-terminal-marker-no-publish",
+            branch="main",
+            pid=888,
+            initial_head="def456",
+            expected_tests=[expected_test],
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push_sync") as mock_push,
+            patch.object(WorkerLauncher, "_run_verification_commands_sync") as mock_verify,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_called()
+        mock_verify.assert_not_called()
+        assert worker.work_order_id not in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio
@@ -1465,10 +1506,10 @@ class TestCollectDetachedResult:
         assert result.head_sha == "abc123"
         assert result.commit_shas == ["abc123"]
         assert result.changed_paths == ["file.py"]
-        assert result.tests_run == [expected_test]
-        assert result.verification_results == verification_results
+        assert result.tests_run == []
+        assert result.verification_results == []
         assert result.stdout == "some output"
-        mock_verify.assert_awaited_once_with("/tmp/wt", [expected_test])
+        mock_verify.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_collect_detached_result_skips_auto_commit_without_terminal_marker(self):
@@ -1502,6 +1543,45 @@ class TestCollectDetachedResult:
         assert result.commit_shas == []
         assert result.changed_paths == ["file.py"]
         mock_commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_collect_detached_result_skips_auto_push_and_verification_without_terminal_marker(
+        self,
+    ):
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        with (
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push", new_callable=AsyncMock) as mock_push,
+            patch.object(
+                WorkerLauncher,
+                "_run_verification_commands",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-no-marker-no-publish",
+                agent="codex",
+                worktree_path="/tmp/wt",
+                branch="main",
+                pid=99999,
+                initial_head="def456",
+                expected_tests=[expected_test],
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_awaited()
+        mock_verify.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_none_if_pid_dead_without_terminal_marker_or_deliverable(self):


### PR DESCRIPTION
## Summary
- skip auto-push when the harness never writes a terminal session marker
- skip verification on the same missing-terminal-marker paths in sync and detached collection
- add regressions that lock in the fail-closed behavior for both collection paths

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'skips_auto_commit_without_terminal_marker or skips_auto_push_and_verification_without_terminal_marker or downgrades_missing_terminal_marker_with_deliverable or downgrades_missing_terminal_marker_without_deliverable'
- python -m pytest tests/swarm/test_worker_launcher.py -q