### PR TITLE
Clear stale blockers on crash without deliverable

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3409,8 +3409,11 @@ class SwarmSupervisor:
             "merge_gate",
             "verification_missing_reason",
             "scope_violation",
+            "resource_error",
+            "conflicts",
         ):
             item.pop(key, None)
+        item.pop("blockers", None)
         failure_reason = (
             "worker_timeout_no_deliverable" if result.exit_code == -1 else "worker_crash"
         )
@@ -3428,7 +3431,7 @@ class SwarmSupervisor:
             "reason": failure_reason,
             "question": blocking_question,
         }
-        blockers = [str(value).strip() for value in item.get("blockers", []) if str(value).strip()]
+        blockers: list[str] = []
         if item["dispatch_error"] not in blockers:
             blockers.append(item["dispatch_error"])
         item["blockers"] = blockers

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5146,6 +5146,9 @@ async def test_collect_finished_results_failed_worker_clears_stale_completion_me
     run.work_orders[0]["merge_gate"] = {"checks_passed": True}
     run.work_orders[0]["verification_missing_reason"] = "missing_verification_plan"
     run.work_orders[0]["scope_violation"] = {"violations": [{"path": "README.md"}]}
+    run.work_orders[0]["resource_error"] = "old resource wait"
+    run.work_orders[0]["conflicts"] = [{"source": "lease", "lease_id": "lease-stale"}]
+    run.work_orders[0]["blockers"] = ["old blocker"]
     store.update_supervisor_run(run.run_id, work_orders=run.work_orders, status="active")
 
     completed = await supervisor.collect_finished_results(run.run_id)
@@ -5165,8 +5168,11 @@ async def test_collect_finished_results_failed_worker_clears_stale_completion_me
         "merge_gate",
         "verification_missing_reason",
         "scope_violation",
+        "resource_error",
+        "conflicts",
     ):
         assert cleared_key not in work_order
+    assert work_order["blockers"] == ["fatal: boom"]
 
 
 def test_reset_worker_type_circuit_breaker_preserves_run_metadata(


### PR DESCRIPTION
## Summary
- clear stale waiting metadata when a worker crashes or times out without a deliverable
- rebuild blocker text from the current terminal failure instead of preserving old wait-state blockers
- extend the supervisor regression to lock in the cleanup

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'failed_worker_clears_stale_completion_metadata'
- python -m pytest tests/swarm/test_supervisor.py -q