### PR TITLE
Clear stale blockers on merge gate failure

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3196,6 +3196,9 @@ class SwarmSupervisor:
                     merge_gate["llm_override"] = True
                     item["merge_gate"] = merge_gate
                 else:
+                    for key in ("resource_error", "conflicts", "scope_violation"):
+                        item.pop(key, None)
+                    item.pop("blockers", None)
                     self._mark_needs_human(
                         item,
                         self._merge_gate_failure_reason(merge_gate),

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3508,6 +3508,10 @@ async def test_collect_results_blocks_merge_gate_when_required_checks_fail(
                 "expected_tests": ["python -m pytest tests/swarm/test_supervisor.py -q"],
                 "receipt_id": "receipt-stale",
                 "confidence": 0.91,
+                "resource_error": "old resource wait",
+                "conflicts": [{"source": "lease", "lease_id": "lease-stale"}],
+                "scope_violation": {"violations": [{"path": "old.py"}]},
+                "blockers": ["old blocker"],
             }
         ],
         status="active",
@@ -3561,6 +3565,9 @@ async def test_collect_results_blocks_merge_gate_when_required_checks_fail(
     assert wo["worker_outcome"] == "merge_gate_failed"
     assert wo["merge_gate"]["checks_passed"] is False
     assert "merge gate blocked" in wo["dispatch_error"]
+    for cleared_key in ("resource_error", "conflicts", "scope_violation"):
+        assert cleared_key not in wo
+    assert wo["blockers"] == [wo["dispatch_error"]]
 
     summary = store.status_summary()
     assert summary["counts"]["active_leases"] == 0


### PR DESCRIPTION
## Summary
- clear stale wait-state metadata before persisting a merge-gate failure
- rebuild blocker text from the current merge-gate failure instead of preserving old blockers
- extend the supervisor regression to lock in the cleanup

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'blocks_merge_gate_when_required_checks_fail'
- python -m pytest tests/swarm/test_supervisor.py -q