### PR TITLE
test(ci): align openclaw and webhook access expectations

### DIFF
--- a/tests/handlers/openclaw/test_gateway.py
+++ b/tests/handlers/openclaw/test_gateway.py
@@ -893,7 +893,12 @@ class TestPostAddPolicyRule:
 class TestPostApproveAction:
     """Tests for POST /approvals/:id/approve."""
 
-    def test_approve_action(self, handler, mock_http):
+    @patch("aragora.server.handlers.openclaw.policies.get_openclaw_execution_runtime")
+    def test_approve_action(self, mock_runtime_factory, handler, mock_http):
+        mock_runtime_factory.return_value.approve_action.return_value = MagicMock(
+            status=ActionStatus.COMPLETED,
+            action_id=None,
+        )
         body = {"reason": "Looks safe"}
         result = handler.handle_post(
             "/api/v1/openclaw/approvals/approval-1/approve",
@@ -917,7 +922,11 @@ class TestPostApproveAction:
 class TestPostDenyAction:
     """Tests for POST /approvals/:id/deny."""
 
-    def test_deny_action(self, handler, mock_http):
+    @patch("aragora.server.handlers.openclaw.policies.get_openclaw_execution_runtime")
+    def test_deny_action(self, mock_runtime_factory, handler, mock_http):
+        mock_runtime = mock_runtime_factory.return_value
+        mock_runtime.get_approval.return_value = MagicMock(action_id="action-1")
+        mock_runtime.deny_action.return_value = True
         body = {"reason": "Too risky"}
         result = handler.handle_post(
             "/api/v1/openclaw/approvals/approval-1/deny",

--- a/tests/server/handlers/test_webhooks.py
+++ b/tests/server/handlers/test_webhooks.py
@@ -388,7 +388,7 @@ class TestGetWebhook:
         handler.get_current_user = MagicMock(return_value=MockUser(user_id="other-user"))
         result = await handler.handle("/api/v1/webhooks/wh-001", {}, _make_mock_http_handler())
         status, body = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================
@@ -557,7 +557,7 @@ class TestDeleteWebhook:
             "/api/v1/webhooks/wh-001", {}, _make_mock_http_handler()
         )
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================
@@ -610,7 +610,7 @@ class TestUpdateWebhook:
         self._mock_body(handler, {"name": "X"})
         result = handler.handle_patch("/api/v1/webhooks/wh-001", {}, _make_mock_http_handler())
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
     def test_update_webhook_invalid_events(self, handler):
         self._mock_body(handler, {"events": ["invalid_event_xyz"]})
@@ -692,7 +692,7 @@ class TestTestWebhook:
             "/api/v1/webhooks/wh-001/test", {}, _make_mock_http_handler()
         )
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- align webhook access-denied tests with the handler's fail-closed 404 behavior
- stub OpenClaw approval runtime in gateway routing tests instead of depending on live execution state
- keep the scope limited to the currently reproducible baseline CI drift on main

## Validation
- python3 -m pytest tests/server/handlers/test_webhooks.py::TestGetWebhook::test_get_webhook_access_denied_different_user tests/server/handlers/test_webhooks.py::TestDeleteWebhook::test_delete_webhook_access_denied tests/server/handlers/test_webhooks.py::TestUpdateWebhook::test_update_webhook_access_denied tests/server/handlers/test_webhooks.py::TestTestWebhook::test_test_webhook_access_denied tests/handlers/openclaw/test_gateway.py::TestPostApproveAction::test_approve_action tests/handlers/openclaw/test_gateway.py::TestPostDenyAction::test_deny_action -q
- python3 -m pytest tests/server/handlers/test_webhooks.py tests/handlers/openclaw/test_gateway.py -q -k 'approve_action or deny_action or access_denied'