### PR TITLE
test(ci): align playground assess handler fixtures

### DIFF
--- a/tests/server/handlers/test_playground_assess.py
+++ b/tests/server/handlers/test_playground_assess.py
@@ -11,17 +11,24 @@ Covers:
 
 from __future__ import annotations
 
+import io
 import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aragora.server.handlers.playground import PlaygroundHandler
+from aragora.server.handlers.playground import PlaygroundHandler, _reset_rate_limits
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def reset_rate_limits() -> None:
+    """Reset rate limit state before each test to prevent cross-test interference."""
+    _reset_rate_limits()
 
 
 @pytest.fixture()
@@ -33,7 +40,12 @@ def handler() -> PlaygroundHandler:
 def _make_http_handler(body: dict) -> MagicMock:
     """Build a fake HTTP handler with a JSON body."""
     h = MagicMock()
-    h.body = json.dumps(body).encode()
+    raw = json.dumps(body).encode()
+    h.headers = {
+        "Content-Length": str(len(raw)),
+        "Content-Type": "application/json",
+    }
+    h.rfile = io.BytesIO(raw)
     h.client_address = ("127.0.0.1", 12345)
     return h
 


### PR DESCRIPTION
## Summary
- feed  a real JSON request shape in tests instead of the old synthetic  shortcut
- reset the shared assess rate-limit state between tests to remove order-dependent failures
- keep the scope limited to the current reproducible  drift on main

## Validation
- python3 -m pytest tests/server/handlers/test_playground_assess.py::TestHandleAssess::test_ambiguous_question_returns_confirm tests/server/handlers/test_playground_assess.py::TestHandleAssess::test_option_fields_are_complete tests/server/handlers/test_playground_assess.py::TestHandleAssess::test_timeout_returns_ready tests/server/handlers/test_playground_assess.py::TestHandleAssess::test_clear_question_returns_ready tests/server/handlers/test_playground_assess.py::TestHandleAssess::test_malformed_model_json_returns_ready -q
- python3 -m pytest tests/server/handlers/test_playground_assess.py -q