### PR TITLE
fix(ci): unblock shared webhook and slack oauth tests

### DIFF
--- a/aragora/server/webhook_delivery.py
+++ b/aragora/server/webhook_delivery.py
@@ -956,6 +956,7 @@ class WebhookDeliveryManager:
 
         # Persist status change
         if self._persistence:
+            self._ensure_persistence_initialized()
             url = self._delivery_urls.get(delivery_id, delivery.metadata.get("retry_url", ""))
             secret = self._delivery_secrets.get(delivery_id, delivery.metadata.get("retry_secret"))
             self._persistence.save_delivery(delivery, url, secret)

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -48,6 +48,8 @@ from aragora.server.handlers.playground import (
     _LIVE_RATE_LIMIT,
     _LIVE_RATE_WINDOW,
 )
+from aragora.storage import debate_store as debate_store_module
+from aragora.storage.debate_store import DebateResultStore
 from aragora.storage.landing_review_store import (
     get_landing_review_store,
     reset_landing_review_store,
@@ -109,16 +111,22 @@ def handler():
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limits(tmp_path, monkeypatch):
-    """Reset rate limit and landing review state before each test."""
+    """Reset public demo state before each test."""
     monkeypatch.setenv(
         "ARAGORA_LANDING_REVIEW_DB_PATH",
         str(tmp_path / "landing_review.sqlite3"),
+    )
+    monkeypatch.setattr(
+        debate_store_module,
+        "_store",
+        DebateResultStore(str(tmp_path / "debate_results.sqlite3")),
     )
     reset_landing_review_store()
     _reset_rate_limits()
     yield
     _reset_rate_limits()
     reset_landing_review_store()
+    debate_store_module._store = None
 
 
 # ============================================================================

--- a/tests/handlers/test_slack_oauth.py
+++ b/tests/handlers/test_slack_oauth.py
@@ -147,11 +147,13 @@ def mock_state_store():
     """Create a mock OAuth state store."""
     store = MagicMock()
     store.generate.return_value = "test-state-token-abc123"
-    store.validate_and_consume.return_value = {
+    state_payload = {
         "tenant_id": "tenant-1",
         "provider": "slack",
         "created_at": time.time(),
     }
+    store.peek.return_value = state_payload
+    store.validate_and_consume.return_value = state_payload
     return store
 
 
@@ -811,6 +813,7 @@ class TestCallback:
     ):
         """When centralized store returns None, fall back to in-memory."""
         mock_state_store.validate_and_consume.return_value = None
+        mock_state_store.peek.return_value = None
         handler_module._oauth_states_fallback["fallback-state"] = {
             "tenant_id": "t-1",
             "provider": "slack",
@@ -1508,6 +1511,7 @@ class TestRefreshToken:
             "access_token": "xoxb-new-token",
             "refresh_token": "xoxr-new-refresh",
             "expires_in": 43200,
+            "team": {"id": "W123"},
         }
         mock_response.raise_for_status = MagicMock()
 
@@ -1666,6 +1670,7 @@ class TestRefreshToken:
             "ok": True,
             "access_token": "xoxb-new",
             "expires_in": 43200,
+            "team": {"id": "W123"},
         }
         mock_response.raise_for_status = MagicMock()
 
@@ -1724,6 +1729,7 @@ class TestRefreshToken:
         mock_response.json.return_value = {
             "ok": True,
             "access_token": "xoxb-new-token",
+            "team": {"id": "W123"},
         }
         mock_response.raise_for_status = MagicMock()
 

--- a/tests/server/handlers/test_webhooks.py
+++ b/tests/server/handlers/test_webhooks.py
@@ -388,7 +388,7 @@ class TestGetWebhook:
         handler.get_current_user = MagicMock(return_value=MockUser(user_id="other-user"))
         result = await handler.handle("/api/v1/webhooks/wh-001", {}, _make_mock_http_handler())
         status, body = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================
@@ -557,7 +557,7 @@ class TestDeleteWebhook:
             "/api/v1/webhooks/wh-001", {}, _make_mock_http_handler()
         )
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================
@@ -610,7 +610,7 @@ class TestUpdateWebhook:
         self._mock_body(handler, {"name": "X"})
         result = handler.handle_patch("/api/v1/webhooks/wh-001", {}, _make_mock_http_handler())
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
     def test_update_webhook_invalid_events(self, handler):
         self._mock_body(handler, {"events": ["invalid_event_xyz"]})
@@ -692,7 +692,7 @@ class TestTestWebhook:
             "/api/v1/webhooks/wh-001/test", {}, _make_mock_http_handler()
         )
         status, _ = _parse_result(result)
-        assert status == 403
+        assert status == 404
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- align webhook ownership-denied tests with the handler's current fail-closed 404 behavior
- update Slack OAuth tests for the current state-store peek flow and refresh identity validation
- initialize webhook delivery persistence before dead-letter retries persist state

## Validation
- python3 -m pytest -q tests/server/handlers/test_webhooks.py tests/handlers/test_slack_oauth.py tests/server/test_webhook_delivery.py
- python3 -m ruff format --check tests/server/handlers/test_webhooks.py tests/handlers/test_slack_oauth.py aragora/server/webhook_delivery.py