### PR TITLE
fix: clear stale retry failure state on successful webhook delivery

### DIFF
--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -722,6 +722,9 @@ class WebhookRetryQueue:
                 if success:
                     delivery.status = DeliveryStatus.DELIVERED
                     delivery.last_status_code = status_code
+                    # Clear stale retry failure state
+                    delivery.last_error = None
+                    delivery.next_retry_at = None
 
                     async with self._stats_lock:
                         self._stats["delivered"] += 1


### PR DESCRIPTION
On successful delivery, last_error and next_retry_at from previous
failed attempts were persisting on the delivery record. Now these
fields are explicitly cleared when a delivery succeeds.

(cherry picked from commit d7e2101603dfe2c25ccd1a764edbbc19595445bb)
