### PR TITLE
Catch Slack callback HTTP status errors

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1143,7 +1143,14 @@ class SlackOAuthHandler(SecureHandler):
 
         except ImportError:
             return error_response("httpx not available", 503)
-        except (ConnectionError, TimeoutError, OSError, ValueError, TypeError) as e:
+        except (
+            ConnectionError,
+            TimeoutError,
+            OSError,
+            ValueError,
+            TypeError,
+            httpx.HTTPError,
+        ) as e:
             logger.error("[%s] Slack token exchange failed: %s", request_id, e)
             return error_response("Token exchange failed", 500)
 

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -27,6 +27,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import urlencode
 
+import httpx
 import pytest
 from aragora.rbac.models import AuthorizationContext
 
@@ -1091,6 +1092,30 @@ class TestCallback:
         assert _status(result) == 400
         body = _body(result)
         assert "invalid_code" in body.get("error", "")
+
+    @pytest.mark.asyncio
+    async def test_callback_http_status_error_returns_500(self, handler):
+        mock_client, mock_response = _make_httpx_mock({"ok": False, "error": "invalid_code"}, 400)
+        request = httpx.Request("POST", "https://slack.com/api/oauth.v2.access")
+        response = httpx.Response(400, request=request)
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400 Client Error",
+            request=request,
+            response=response,
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "bad-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+        assert _status(result) == 500
+        body = _body(result)
+        assert "token exchange failed" in body.get("error", "").lower()
 
     @pytest.mark.asyncio
     async def test_callback_missing_workspace_id_returns_500(self, handler):


### PR DESCRIPTION
## Summary
- catch upstream httpx HTTP errors in the Slack OAuth callback token exchange path
- return a controlled 500 response instead of letting HTTPStatusError escape out of the handler
- add a direct callback regression for raise_for_status failures

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'callback_http_status_error_returns_500 or callback_slack_api_error'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q