### PR TITLE
fix(webhooks): clear stale retry failure state on successful delivery

### DIFF
--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -722,6 +722,9 @@ class WebhookRetryQueue:
                 if success:
                     delivery.status = DeliveryStatus.DELIVERED
                     delivery.last_status_code = status_code
+                    # Clear stale failure state from prior attempts
+                    delivery.last_error = None
+                    delivery.next_retry_at = None
 
                     async with self._stats_lock:
                         self._stats["delivered"] += 1


### PR DESCRIPTION
On successful webhook delivery, clear last_error and next_retry_at
fields that may contain stale data from prior failed attempts.
This prevents confusing failure metadata from persisting on
successfully delivered records.

Refs #2031

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit a118535c5983df59a6e87c5940b2e470acc79a05)
