### PR TITLE
Prefer session-meta PID in worker launcher

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -412,7 +412,7 @@ class WorkerLauncher:
         pid = self._normalized_pid(work_order.get("pid"))
 
         snapshot: dict[str, Any] = {
-            "pid_alive": self._is_pid_running(pid) if pid is not None else False,
+            "pid_alive": False,
             "head_sha": "",
             "changed_paths": [],
             "diff_lines": 0,
@@ -427,9 +427,8 @@ class WorkerLauncher:
         if not worktree_path:
             return snapshot
         session_meta = self._read_session_meta(worktree_path)
-        if pid is None:
-            pid = self._normalized_pid(session_meta.get("pid"))
-            snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
+        pid = self._authoritative_session_pid(pid, session_meta)
+        snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
         lock_pid = self._pid_for_active_lock(worktree_path, pid, session_meta)
         if self._active_session_lock_blocks_collection(worktree_path, lock_pid):
             snapshot["pid_alive"] = True
@@ -1120,8 +1119,8 @@ class WorkerLauncher:
         session_meta = cls._read_session_meta(worktree_path)
         session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
         observed_pid = cls._normalized_pid(pid)
-        if observed_pid is None and allow_session_meta_pid_fallback:
-            observed_pid = cls._normalized_pid(session_meta.get("pid"))
+        if allow_session_meta_pid_fallback:
+            observed_pid = cls._authoritative_session_pid(observed_pid, session_meta)
         lock_pid = (
             cls._pid_for_active_lock(worktree_path, observed_pid, session_meta)
             if allow_session_meta_pid_fallback
@@ -1256,6 +1255,16 @@ class WorkerLauncher:
         return pid if pid > 0 else None
 
     @classmethod
+    def _authoritative_session_pid(
+        cls, pid: int | None, session_meta: dict[str, Any]
+    ) -> int | None:
+        """Prefer the harness-owned session PID over stale caller metadata."""
+        meta_pid = cls._normalized_pid(session_meta.get("pid"))
+        if meta_pid is not None:
+            return meta_pid
+        return pid
+
+    @classmethod
     def _active_session_lock_blocks_collection(cls, worktree_path: str, pid: int | None) -> bool:
         active_lock = Path(worktree_path) / ".codex_session_active"
         if not active_lock.exists():
@@ -1274,20 +1283,11 @@ class WorkerLauncher:
         pid: int | None,
         session_meta: dict[str, Any],
     ) -> int | None:
-        """Prefer a live session-meta PID when the active-session lock still exists."""
+        """Return the harness-owned PID that should qualify an active-session lock."""
         active_lock = Path(worktree_path) / ".codex_session_active"
         if not active_lock.exists():
             return pid
-        meta_pid = cls._normalized_pid(session_meta.get("pid"))
-        if pid is None:
-            return meta_pid
-        if meta_pid is None or meta_pid == pid:
-            return pid
-        if cls._is_pid_running(pid):
-            return pid
-        if cls._is_pid_running(meta_pid):
-            return meta_pid
-        return pid
+        return cls._authoritative_session_pid(pid, session_meta)
 
     @staticmethod
     def _cleanup_session_artifacts(worktree_path: str) -> None:
@@ -2162,9 +2162,7 @@ class WorkerLauncher:
                     if str(item.get("command", "")).strip()
                 ]
         finally:
-            cleanup_pid = worker.pid
-            if cleanup_pid is None:
-                cleanup_pid = self._normalized_pid(session_meta.get("pid"))
+            cleanup_pid = self._authoritative_session_pid(worker.pid, session_meta)
             if cleanup_pid is not None:
                 self._wait_for_pid_exit_sync(cleanup_pid)
             self._cleanup_session_artifacts(worker.worktree_path)

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1426,10 +1426,59 @@ class TestCollectFinishedSync:
             completed = launcher.collect_finished_sync(work_order_ids=["wo-sync-stale-worker-pid"])
 
         assert completed == []
-        assert any(call.args == (11111,) for call in mock_running.call_args_list)
-        assert any(call.args == (24680,) for call in mock_running.call_args_list)
+        mock_running.assert_called_once_with(24680)
         mock_diff.assert_not_called()
         assert "wo-sync-stale-worker-pid" in launcher._processes
+
+    def test_collect_finished_sync_ignores_live_stale_worker_pid_when_session_meta_pid_is_dead(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        worker = WorkerProcess(
+            work_order_id="wo-sync-stale-live-worker-pid",
+            agent="codex",
+            worktree_path=str(tmp_path),
+            branch="main",
+            pid=11111,
+            initial_head="def456",
+        )
+        launcher._workers["wo-sync-stale-live-worker-pid"] = worker
+        proc = MagicMock()
+        proc.returncode = None
+        launcher._processes["wo-sync-stale-live-worker-pid"] = proc
+
+        session_meta = {
+            "pid": 24680,
+            "exit_code": 143,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value=""),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=[]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync") as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(
+                work_order_ids=["wo-sync-stale-live-worker-pid"]
+            )
+
+        assert len(completed) == 1
+        assert completed[0].exit_code == 143
+        mock_running.assert_called_once_with(24680)
+        mock_wait_pid.assert_called_once_with(24680)
+        assert "wo-sync-stale-live-worker-pid" not in launcher._processes
 
     def test_collect_finished_sync_downgrades_missing_terminal_marker_with_deliverable(self):
         launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
@@ -1912,9 +1961,57 @@ class TestCollectDetachedResult:
             )
 
         assert result is None
-        assert any(call.args == (11111,) for call in mock_running.call_args_list)
-        assert any(call.args == (24680,) for call in mock_running.call_args_list)
+        mock_running.assert_called_once_with(24680)
         mock_diff.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_collects_when_session_meta_pid_is_dead_even_if_worker_pid_was_reused(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(
+                WorkerLauncher,
+                "_read_session_meta",
+                return_value={
+                    "pid": 24680,
+                    "ended_at": "2026-04-02T01:23:45+00:00",
+                    "exit_code": 0,
+                },
+            ),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=[]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new=AsyncMock()) as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts") as mock_cleanup,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-reused-worker-pid",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=11111,
+                initial_head="def456",
+                auto_commit=False,
+            )
+
+        assert result is not None
+        assert result.exit_code == 0
+        mock_running.assert_called_once_with(24680)
+        mock_wait_pid.assert_awaited_once_with(24680)
+        mock_cleanup.assert_called_once_with(str(tmp_path))
 
     @pytest.mark.asyncio
     async def test_skips_session_meta_pid_fallback_when_disabled(self, tmp_path: Path):
@@ -2030,7 +2127,8 @@ class TestSnapshotProgress:
             snapshot = await launcher.snapshot_progress(work_order)
 
         assert snapshot["pid_alive"] is True
-        mock_running.assert_called_once_with(24680)
+        assert mock_running.call_args_list
+        assert all(call.args == (24680,) for call in mock_running.call_args_list)
 
     @pytest.mark.asyncio
     async def test_snapshot_progress_treats_active_lock_without_usable_pid_as_alive(
@@ -2083,8 +2181,38 @@ class TestSnapshotProgress:
             snapshot = await launcher.snapshot_progress(work_order)
 
         assert snapshot["pid_alive"] is True
-        assert any(call.args == (11111,) for call in mock_running.call_args_list)
-        assert any(call.args == (24680,) for call in mock_running.call_args_list)
+        assert mock_running.call_args_list
+        assert all(call.args == (24680,) for call in mock_running.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_ignores_live_stale_worker_pid_when_session_meta_pid_is_dead(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
+        work_order = {
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        assert mock_running.call_args_list
+        assert all(call.args == (24680,) for call in mock_running.call_args_list)
 
     @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- prefer the harness-owned session PID over stale caller metadata for launcher liveness and cleanup decisions
- prevent active session locks and cleanup waits from trusting reused unrelated PIDs
- add regressions for sync, detached, and snapshot paths when worker pid metadata is stale

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'stale_worker_pid or reused_worker_pid or session_meta_pid_is_dead'
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q