### PR TITLE
fix(swarm): harden codex worker exec guidance

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -824,6 +824,13 @@ class WorkerLauncher:
                 'git commit -m "..."` BEFORE running any validation or tests.\n'
                 "  - Do not spend tokens on exploration after code is written — commit first, "
                 "then validate if budget remains.\n"
+                "  - If you start a long-running `exec_command` that you plan to poll or follow "
+                "with `write_stdin`, launch it with `tty=true`; otherwise stdin will be closed "
+                "and the session can wedge.\n"
+                "  - Use non-tty `exec_command` only for one-shot commands where you do not need "
+                "to send more input later.\n"
+                "  - For ad hoc interpreter probes and timeout-wrapped scripts, prefer `python3` "
+                "over `python`; on this repo `python` may resolve to a non-runtime shim.\n"
                 "  - Do not exit 0 with staged or unstaged changes remaining.\n"
                 "  - If validation is slow or fails, the commit still preserves your deliverable "
                 "with an honest commit message."

--- a/tests/swarm/test_session_artifact_prevention.py
+++ b/tests/swarm/test_session_artifact_prevention.py
@@ -140,14 +140,19 @@ class TestStripSessionArtifacts:
 class TestWorkerPromptNoGitAddAll:
     """Verify the worker prompt no longer instructs git add -A."""
 
-    def test_prompt_does_not_instruct_git_add_all(self) -> None:
-        """Prompt must not tell the worker to USE git add -A (warning against it is fine)."""
-        work_order = {
+    @staticmethod
+    def _codex_work_order() -> dict[str, object]:
+        return {
             "title": "Test task",
             "description": "Do something",
             "file_scope": [],
             "metadata": {},
+            "target_agent": "codex",
         }
+
+    def test_prompt_does_not_instruct_git_add_all(self) -> None:
+        """Prompt must not tell the worker to USE git add -A (warning against it is fine)."""
+        work_order = self._codex_work_order()
         prompt = WorkerLauncher._build_prompt(work_order)
         # Must not contain an affirmative instruction to use git add -A
         assert "Stage all changed files with `git add -A`" not in prompt
@@ -155,15 +160,21 @@ class TestWorkerPromptNoGitAddAll:
         assert "Do NOT use `git add -A`" in prompt
 
     def test_prompt_instructs_explicit_staging(self) -> None:
-        work_order = {
-            "title": "Test task",
-            "description": "Do something",
-            "file_scope": [],
-            "metadata": {},
-        }
+        work_order = self._codex_work_order()
         prompt = WorkerLauncher._build_prompt(work_order)
         assert "git add <file>" in prompt
         assert "session metadata files must not be committed" in prompt
+
+    def test_prompt_requires_tty_for_long_lived_exec_sessions(self) -> None:
+        work_order = self._codex_work_order()
+        prompt = WorkerLauncher._build_prompt(work_order)
+        assert "launch it with `tty=true`" in prompt
+        assert "Use non-tty `exec_command` only for one-shot commands" in prompt
+
+    def test_prompt_prefers_python3_for_ad_hoc_probes(self) -> None:
+        work_order = self._codex_work_order()
+        prompt = WorkerLauncher._build_prompt(work_order)
+        assert "prefer `python3` over `python`" in prompt
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- require the Codex worker prompt to use `tty=true` for long-lived `exec_command` sessions that will be polled or resumed
- prefer `python3` over `python` for ad hoc probes because this machine resolves `python` to a non-runtime shim
- add prompt regressions in session-artifact prevention tests

## Validation
- python3 -m pytest -q tests/swarm/test_session_artifact_prevention.py
- python3 -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_session_artifact_prevention.py
- python3 -m ruff format --check aragora/swarm/worker_launcher.py tests/swarm/test_session_artifact_prevention.py

## Live Context
This came from the live run on supervisor run `93da0f02-c00`, where a Codex lane hit a closed-stdin session and a bad `python` interpreter resolution while working inside a managed worktree.