### PR TITLE
fix: clear failure metadata on successful webhook delivery

### DIFF
--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -722,6 +722,11 @@ class WebhookRetryQueue:
                 if success:
                     delivery.status = DeliveryStatus.DELIVERED
                     delivery.last_status_code = status_code
+                    # Clear failure metadata from prior failed attempts
+                    delivery.last_error = None
+                    delivery.next_retry_at = None
+                    for _key in ("failure_reason", "failure_timestamp", "failure_count"):
+                        delivery.metadata.pop(_key, None)
 
                     async with self._stats_lock:
                         self._stats["delivered"] += 1


### PR DESCRIPTION
When a webhook delivery succeeds after prior failed attempts, the
retry queue now clears last_error, next_retry_at, and failure-related
metadata keys (failure_reason, failure_timestamp, failure_count).
Previously these stale fields persisted on the delivered record.

Fixes #2194

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ac0ca2c28abbc82996b08497db04fe3e131db6a9)
