### PR TITLE
fix: clear failure metadata on successful webhook delivery

### DIFF
--- a/aragora/webhooks/retry_queue.py
+++ b/aragora/webhooks/retry_queue.py
@@ -722,6 +722,11 @@ class WebhookRetryQueue:
                 if success:
                     delivery.status = DeliveryStatus.DELIVERED
                     delivery.last_status_code = status_code
+                    # Clear failure metadata from previous attempts
+                    delivery.last_error = None
+                    delivery.next_retry_at = None
+                    delivery.metadata.pop("failure_reason", None)
+                    delivery.metadata.pop("failure_context", None)
 
                     async with self._stats_lock:
                         self._stats["delivered"] += 1


### PR DESCRIPTION
When a webhook delivery succeeds after prior failed attempts, clear
last_error, next_retry_at, and failure-related metadata keys so the
delivery record accurately reflects its successful state.

Fixes #2203

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 0af5b59061980fade36e2f932e8ca9962fc7f429)
