### PR TITLE
test: add retry metadata cleanup coverage

### DIFF
--- a/tests/webhooks/test_retry_queue.py
+++ b/tests/webhooks/test_retry_queue.py
@@ -566,6 +566,41 @@ class TestWebhookRetryQueue:
         assert stored.last_error == "HTTP 500"
 
     @pytest.mark.asyncio
+    async def test_successful_retry_clears_stale_metadata(self, queue):
+        """Successful retries clear stale error and retry metadata."""
+        delivery = WebhookDelivery(
+            id="test-1",
+            url="https://example.com/webhook",
+            payload={"event": "test"},
+            max_attempts=3,
+        )
+        responses = iter([(False, 500, "HTTP 500"), (True, 200, None)])
+
+        async def mock_send(d):
+            return next(responses)
+
+        queue._send_webhook = mock_send
+
+        await queue.store.save(delivery)
+        await queue._attempt_delivery(delivery)
+
+        stored = await queue.store.get(delivery.id)
+        assert stored is not None
+        assert stored.status == DeliveryStatus.PENDING
+        assert stored.last_error == "HTTP 500"
+        assert stored.next_retry_at is not None
+
+        await queue._attempt_delivery(stored)
+
+        stored = await queue.store.get(delivery.id)
+        assert stored is not None
+        assert stored.status == DeliveryStatus.DELIVERED
+        assert stored.attempts == 2
+        assert stored.last_status_code == 200
+        assert stored.last_error is None
+        assert stored.next_retry_at is None
+
+    @pytest.mark.asyncio
     async def test_dead_letter_after_max_attempts(self, queue):
         """Test that deliveries move to dead-letter after max attempts."""
         delivery = WebhookDelivery(


### PR DESCRIPTION
(cherry picked from commit 28324adc0e8b28dc1c47482d90bd1acc366aa137)
