### PR TITLE
test: add webhook retry test for HTTP 500 then 200 behavior

### DIFF
--- a/tests/webhooks/test_retry_queue.py
+++ b/tests/webhooks/test_retry_queue.py
@@ -861,6 +861,53 @@ class TestHTTPRequests:
         assert "timed out" in stored.last_error
 
     @pytest.mark.asyncio
+    async def test_http_500_then_200_clears_error_fields(self, queue):
+        """Test that a delivery failing with HTTP 500 then succeeding with 200
+        ends up delivered with last_error and next_retry_at cleared."""
+        delivery = WebhookDelivery(
+            id="retry-500-200",
+            url="https://example.com/webhook",
+            payload={"event": "retry_test"},
+            max_attempts=5,
+        )
+
+        call_count = 0
+
+        async def mock_send(d):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return False, 500, "HTTP 500"
+            return True, 200, None
+
+        queue._send_webhook = mock_send
+
+        await queue.store.save(delivery)
+
+        # First attempt — should fail with 500
+        await queue._attempt_delivery(delivery)
+        stored = await queue.store.get(delivery.id)
+        assert stored.status == DeliveryStatus.PENDING
+        assert stored.attempts == 1
+        assert stored.last_error == "HTTP 500"
+        assert stored.next_retry_at is not None
+
+        # Second attempt — should succeed with 200
+        await queue._attempt_delivery(delivery)
+        stored = await queue.store.get(delivery.id)
+        assert stored.status == DeliveryStatus.DELIVERED
+        assert stored.attempts == 2
+        assert stored.last_status_code == 200
+        # On successful delivery, error fields should be cleared
+        # NOTE: Current implementation does not clear these fields on success.
+        # When the implementation is fixed, flip these assertions:
+        #   assert stored.last_error is None
+        #   assert stored.next_retry_at is None
+        # For now, document actual behavior:
+        assert stored.last_error == "HTTP 500"  # not cleared yet
+        assert stored.next_retry_at is not None  # not cleared yet
+
+    @pytest.mark.asyncio
     async def test_4xx_errors_retry_behavior(self, queue):
         """Test 4xx error handling (still gets retried in current implementation)."""
         delivery = WebhookDelivery(


### PR DESCRIPTION
Adds test_http_500_then_200_clears_error_fields that simulates a webhook
delivery failing with HTTP 500 on first attempt, then succeeding with
HTTP 200 on retry. Verifies the delivery reaches DELIVERED status with
correct attempt count. Documents that current implementation does not
clear last_error/next_retry_at on success (see issue #2213).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 1e345a079c9f578b0294b7fad1d94634e0960d82)
