### PR TITLE
Normalize Slack callback token payload

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1161,10 +1161,18 @@ class SlackOAuthHandler(SecureHandler):
 
         # Extract workspace info
         access_token = data.get("access_token")
-        team = data.get("team", {})
+        team_payload = data.get("team")
+        team = team_payload if isinstance(team_payload, dict) else {}
         bot_user_id = data.get("bot_user_id", "")
-        authed_user = data.get("authed_user", {})
-        scope = data.get("scope", "")
+        authed_user_payload = data.get("authed_user")
+        authed_user = authed_user_payload if isinstance(authed_user_payload, dict) else {}
+        raw_scope = data.get("scope", "")
+        if isinstance(raw_scope, str):
+            scope = raw_scope
+        elif isinstance(raw_scope, (list, tuple, set)):
+            scope = ",".join(str(item).strip() for item in raw_scope if str(item).strip())
+        else:
+            scope = str(raw_scope or "").strip()
 
         # Extract token refresh data (if available)
         refresh_token = data.get("refresh_token")
@@ -1173,9 +1181,20 @@ class SlackOAuthHandler(SecureHandler):
         if expires_in:
             token_expires_at = time.time() + expires_in
 
-        workspace_id = team.get("id", "")
-        workspace_name = team.get("name", "Unknown")
-        installed_by = authed_user.get("id")
+        workspace_id = str(
+            team.get("id")
+            or team.get("team_id")
+            or data.get("team_id")
+            or data.get("workspace_id")
+            or ""
+        ).strip()
+        workspace_name = (
+            str(
+                team.get("name") or data.get("team_name") or data.get("workspace_name") or "Unknown"
+            ).strip()
+            or "Unknown"
+        )
+        installed_by = str(authed_user.get("id") or "").strip() or None
 
         if not workspace_id or not access_token:
             return error_response("Invalid response from Slack", 500)

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -918,6 +918,75 @@ class TestCallback:
         assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_malformed_team_payload_without_workspace_identity(
+        self, handler
+    ):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": "not-a-dict",
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history,chat:write",
+            }
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_callback_accepts_top_level_workspace_identity_when_team_payload_is_malformed(
+        self, handler, mock_workspace_store
+    ):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": "not-a-dict",
+                "workspace_id": "W123",
+                "workspace_name": "Top Level Team",
+                "bot_user_id": "B789",
+                "authed_user": "not-a-dict",
+                "scope": ["channels:history", "chat:write"],
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+            patch("aragora.storage.slack_workspace_store.SlackWorkspace") as mock_workspace_cls,
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 200
+        assert mock_workspace_cls.call_args.kwargs["workspace_id"] == "W123"
+        assert mock_workspace_cls.call_args.kwargs["workspace_name"] == "Top Level Team"
+        assert mock_workspace_cls.call_args.kwargs["installed_by"] is None
+        assert mock_workspace_cls.call_args.kwargs["scopes"] == ["channels:history", "chat:write"]
+
+    @pytest.mark.asyncio
     async def test_callback_rejects_cross_tenant_workspace_rebind(
         self, handler, mock_workspace, mock_workspace_store, mock_state_store
     ):


### PR DESCRIPTION
## Summary
- normalize Slack OAuth callback token payload fields before reading workspace and installer identity
- accept safe top-level workspace identity fallbacks instead of assuming  is always a dict
- add regressions so malformed callback payloads return controlled handler results instead of escaping on 

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'malformed_team_payload or top_level_workspace_identity'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q