### PR TITLE
test: add webhook retry success + error clearing tests (#2233)

### DIFF
--- a/tests/webhooks/test_retry_queue.py
+++ b/tests/webhooks/test_retry_queue.py
@@ -754,6 +754,98 @@ class TestWebhookRetryQueue:
         assert dead_letters[0].id == "test-1"
 
     @pytest.mark.asyncio
+    async def test_retry_success_after_failure(self, queue):
+        """Test retry lifecycle: HTTP 500 on first attempt, HTTP 200 on second.
+
+        Verifies the full retry cycle: first attempt fails setting last_error
+        and next_retry_at, then second attempt succeeds with DELIVERED status.
+        """
+        delivery = WebhookDelivery(
+            id="retry-clear-1",
+            url="https://example.com/webhook",
+            payload={"event": "test"},
+            max_attempts=3,
+        )
+
+        call_count = 0
+
+        async def mock_send(d):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return False, 500, "HTTP 500 Internal Server Error"
+            return True, 200, None
+
+        queue._send_webhook = mock_send
+
+        # Enqueue and execute first attempt — should fail
+        await queue.enqueue(delivery)
+        await queue._attempt_delivery(delivery)
+
+        stored = await queue.store.get(delivery.id)
+        assert stored.status == DeliveryStatus.PENDING
+        assert stored.attempts == 1
+        assert stored.last_error == "HTTP 500 Internal Server Error"
+        assert stored.next_retry_at is not None
+
+        # Execute second attempt — should succeed
+        stored.next_retry_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        await queue.store.save(stored)
+
+        await queue._attempt_delivery(stored)
+
+        final = await queue.store.get(delivery.id)
+        assert final.status == DeliveryStatus.DELIVERED
+        assert final.attempts == 2
+        assert final.last_status_code == 200
+
+    @pytest.mark.asyncio
+    @pytest.mark.xfail(
+        reason="Bug #2233: successful retry should clear last_error and next_retry_at",
+        strict=True,
+    )
+    async def test_retry_success_clears_error_fields(self, queue):
+        """Test that a successful retry clears last_error and next_retry_at.
+
+        After failing with HTTP 500 and then succeeding with HTTP 200, the
+        delivery should have last_error=None and next_retry_at=None.
+
+        Currently fails because _attempt_delivery does not clear these fields
+        on the success path.  See issue #2233.
+        """
+        delivery = WebhookDelivery(
+            id="retry-clear-2",
+            url="https://example.com/webhook",
+            payload={"event": "test"},
+            max_attempts=3,
+        )
+
+        call_count = 0
+
+        async def mock_send(d):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return False, 500, "HTTP 500 Internal Server Error"
+            return True, 200, None
+
+        queue._send_webhook = mock_send
+
+        await queue.enqueue(delivery)
+        await queue._attempt_delivery(delivery)
+
+        stored = await queue.store.get(delivery.id)
+        stored.next_retry_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        await queue.store.save(stored)
+
+        await queue._attempt_delivery(stored)
+
+        final = await queue.store.get(delivery.id)
+        assert final.status == DeliveryStatus.DELIVERED
+        assert final.last_error is None
+        assert final.next_retry_at is None
+
+    @pytest.mark.asyncio
     async def test_get_delivery(self, queue, delivery):
         """Test getting a delivery by ID."""
         await queue.enqueue(delivery)


### PR DESCRIPTION
Add two tests for webhook retry behavior after initial failure:
- test_retry_success_after_failure: verifies full retry lifecycle (500→200)
  with correct status transitions and attempt counting
- test_retry_success_clears_error_fields: xfail test documenting that
  successful retry should clear last_error and next_retry_at (bug #2233)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 711628dfef78f54d142bdcf74679b23df12cc0c2)
