### PR TITLE
Fail closed on Postgres webhook update races

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -1306,10 +1306,12 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
             params.append(webhook_id)
 
             async with self._pool.acquire() as conn:
-                await conn.execute(
+                result = await conn.execute(
                     f"UPDATE webhook_configs SET {', '.join(updates)} WHERE id = ${param_idx}",  # noqa: S608 -- dynamic clause from internal state
                     *params,
                 )
+            if result == "UPDATE 0":
+                return None
             webhook.updated_at = updated_at
 
         return webhook

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1779,6 +1779,38 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
         assert "updated_at = to_timestamp($2)" in query
         assert params == ["https://example.com/new", revised_at, "webhook-123"]
 
+    @pytest.mark.asyncio
+    async def test_update_async_returns_none_when_row_is_deleted_before_write(self) -> None:
+        """A concurrent delete must not surface a phantom successful Postgres update."""
+        conn = AsyncMock()
+        conn.execute.return_value = "UPDATE 0"
+        acquire_cm = AsyncMock()
+        acquire_cm.__aenter__.return_value = conn
+        acquire_cm.__aexit__.return_value = False
+        pool = MagicMock()
+        pool.acquire.return_value = acquire_cm
+        store = PostgresWebhookConfigStore(pool)
+
+        original = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/hook",
+            events=["debate_end"],
+            secret="secret",
+            updated_at=100.0,
+        )
+        revised_at = 200.0
+
+        with (
+            patch.object(store, "get_async", AsyncMock(return_value=original)),
+            patch("aragora.storage.webhook_config_store.time.time", return_value=revised_at),
+        ):
+            updated = await store.update_async("webhook-123", url="https://example.com/new")
+
+        assert updated is None
+        query, *params = conn.execute.await_args.args
+        assert "updated_at = to_timestamp($2)" in query
+        assert params == ["https://example.com/new", revised_at, "webhook-123"]
+
     def test_row_to_config_accepts_native_jsonb_sequence(self, postgres_store) -> None:
         """Postgres JSONB rows may already be decoded into Python sequences."""
         now = time.time()


### PR DESCRIPTION
## Summary
- make Postgres webhook updates trust the durable UPDATE result instead of the earlier prefetch
- return None when the row disappears before the write so delete races cannot surface phantom successful updates
- add a regression covering UPDATE 0 after a pre-read hit

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'update_async_returns_durable_revision_timestamp or update_async_returns_none_when_row_is_deleted_before_write'
- python -m pytest tests/storage/test_webhook_config_store.py -q