### PR TITLE
test(shared-inbox): sync GET handler expectation

### DIFF
--- a/tests/handlers/shared_inbox/test_handler.py
+++ b/tests/handlers/shared_inbox/test_handler.py
@@ -135,9 +135,10 @@ class TestCanHandle:
 class TestHandle:
     """Tests for SharedInboxHandler.handle() sync method."""
 
-    def test_returns_none(self, handler: SharedInboxHandler):
+    def test_dispatches_get_shared_inboxes_for_exact_route(self, handler: SharedInboxHandler):
         result = handler.handle("/api/v1/inbox/shared", {}, MagicMock())
-        assert result is None
+        assert _status(result) == 400
+        assert _body(result) == {"error": "workspace_id required"}
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- update the stale sync-dispatch expectation for `SharedInboxHandler.handle`
- assert the current GET `/api/v1/inbox/shared` behavior when `workspace_id` is missing
- keep the change bounded to the shared inbox handler test baseline

## Validation
- `python3 -m pytest tests/handlers/shared_inbox/test_handler.py -q`
- `python3 -m ruff check tests/handlers/shared_inbox/test_handler.py`