### PR TITLE
[codex] fix docs-site status/planning navigation

### DIFF
--- a/docs-site/docs/contributing/2026-03-26-pmf-14-day-execution-plan.md
+++ b/docs-site/docs/contributing/2026-03-26-pmf-14-day-execution-plan.md
@@ -1,0 +1,266 @@
+---
+title: 14-Day PMF Execution Plan
+description: 14-Day PMF Execution Plan
+---
+
+# 14-Day PMF Execution Plan
+
+Last updated: 2026-03-26
+Window: March 26, 2026 to April 8, 2026
+Owner: Founder
+
+Related:
+- `ROADMAP.md`
+- `docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md`
+- `docs/plans/2026-03-25-six-week-founder-operating-plan.md`
+- `docs/plans/2026-03-25-weekly-founder-review-rhythm.md`
+- `docs/status/NEXT_STEPS_CANONICAL.md`
+- `docs/status/PMF_SCORECARD.md`
+- `docs/status/DESIGN_PARTNER_PROGRAM.md`
+- `docs/plans/FOUNDER_RISK_REGISTER_2026_03.md`
+
+## Purpose
+
+Use the next 14 days to turn Aragora's proven founder loop into two things that
+matter commercially:
+
+1. repeatable daily use of the inbox trust wedge on a real founder inbox
+2. repeatable external proof strong enough to start design-partner motion
+
+This is not a broad roadmap. It is the current execution tranche.
+
+## Current Truth On March 26, 2026
+
+- `main` already contains the founder-loop, onboarding, receipt, FastAPI, and
+  live-stream repairs needed for the canonical quickstart path.
+- The live founder loop is a guardrail, not the primary proof target.
+- The next true PMF gate is the second workflow: the inbox trust wedge.
+- GitHub's open issues do not currently represent the PMF backlog truthfully;
+  they are enterprise-assurance items.
+- The backlog for this window must be recreated from observed live failures,
+  not from speculative infrastructure work.
+
+## Success At The End Of This Window
+
+The 14-day window is successful only if all of these are true:
+
+1. The founder inbox wedge has been used on real email across at least 6
+   business-day sessions with persisted receipts and truthful terminal states.
+2. A metrics log exists for inbox quality, latency, cost, overrides, and
+   important-email misses.
+3. One clean external demo path is frozen and can be run from a checklist with
+   no local debugging.
+4. At least 5 target accounts are actively qualified, at least 2 discovery
+   calls are completed, and at least 1 live demo is run on a real artifact.
+5. Every product fix landed during the window ties directly to inbox proof,
+   demo readiness, or design-partner activation.
+
+## Non-Goals For The Next 14 Days
+
+- no broad connector expansion beyond the inbox wedge
+- no enterprise assurance execution unless a real prospect requires it now
+- no new orchestration or autonomy surface that does not unblock a current
+  proof path
+- no generic platform positioning refresh disconnected from a live wedge
+- no backlog gardening that is not tied to a failed live run or a blocked demo
+
+## Proof Metrics That Matter In This Window
+
+Track these every day and review them formally twice during the window:
+
+- founder inbox sessions completed
+- real emails processed
+- percent of executed actions with persisted receipts
+- average latency per email
+- average cost per email
+- override rate
+- important-email recall on the labeled slice
+- time from clean setup to first visible receipt in the external demo path
+- number of qualified design-partner accounts
+- number of completed discovery calls
+- number of completed live demos
+- number of prospects with PMF score `>= 65`
+
+## Decision Rules
+
+- Proof metrics outrank code volume, test volume, and roadmap breadth.
+- No more than 3 active blockers may sit in the `fix now` queue at one time.
+- If a task does not improve inbox proof, demo readiness, or partner movement,
+  it is out of scope for this window.
+- If a blocker is not reproduced on a real path, it does not displace the top
+  queue.
+- If trust breaks, all other work pauses until trust is restored.
+
+## Execution Order
+
+### 1. Keep The Founder Loop Green As A Guardrail
+
+Run the controlled baseline at the start of the window and after every blocker
+fix that touches the default loop:
+
+```bash
+python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
+```
+
+Run one live founder-loop proof at least twice per week:
+
+```bash
+ARAGORA_USER_ID=an0mium \
+python3 -m aragora.cli.main quickstart \
+  --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" \
+  --no-browser
+```
+
+Acceptance:
+- no silent fallback
+- persisted receipt visible on the product surface
+- runtime stays below 90 seconds
+- exact command and receipt are recorded in the weekly packet
+
+### 2. Dogfood The Inbox Trust Wedge On Real Founder Email
+
+This is the primary product objective for the window.
+
+Day 1-3:
+- validate readiness with `aragora triage status`
+- complete Gmail auth with `aragora triage auth`
+- run 3 dry-run founder sessions on real inbox slices
+- create the first labeled slice of 25 messages
+- record per-run latency, cost, overrides, and misses
+
+Day 4-7:
+- run 3 more founder sessions
+- process at least 25 real emails cumulative
+- keep allowed actions narrow: `ARCHIVE`, `STAR`, `LABEL`, `IGNORE`
+- enable auto-approve only if receipt-before-action and quality gates hold
+
+Acceptance for the window:
+- at least 6 founder inbox sessions
+- at least 25 real emails processed
+- `100%` receipt-before-action on executed operations
+- no reply, send, or forward autonomy
+- a written decision on whether auto-approve remains off, limited, or enabled
+
+### 3. Build The Inbox Proof Packet
+
+By the end of Day 7, produce one short packet that can be used internally and
+externally:
+
+- one-page workflow description
+- exact founder command transcript
+- one labeled evaluation slice summary
+- 2-3 representative receipts
+- one honest list of remaining constraints and operator boundaries
+
+This packet is the evidence base for design-partner calls. Do not pitch the
+wedge without it.
+
+### 4. Freeze One External Demo Path
+
+The demo path for this window is:
+
+`signup/onboarding -> quickstart receipt -> receipts surface -> optional inbox wedge evidence`
+
+Day 6-10:
+- freeze one 7-minute demo script
+- prove a clean setup checklist that reaches first receipt in under 10 minutes
+- complete 3 clean rehearsals with no local surgery during the run
+- write one short receipt-backed case study from founder proof
+
+Acceptance:
+- one checklist works from a clean environment
+- three rehearsals complete cleanly
+- one short case-study artifact exists
+
+### 5. Start Design-Partner Motion From Narrow Evidence
+
+Day 8-14:
+- shortlist 15 named accounts across the best-fit segments already defined in
+  the design-partner program
+- move the best 5 into active qualification
+- complete at least 2 discovery calls
+- run at least 1 live demo on a real artifact
+- score every active prospect with `docs/status/PMF_SCORECARD.md`
+
+Operating rule:
+- lead with one bounded workflow only
+- do not sell the full platform
+- do not show surfaces that were not proven live during this window
+
+Acceptance:
+- 5 active qualified targets
+- 2 completed calls
+- 1 completed live demo
+- 1 prospect identified as the most likely first weekly pilot
+
+### 6. Run Only Bounded Repair Lanes
+
+If the inbox wedge or the external demo fails, repair only the smallest slice
+that restores proof.
+
+Allowed repair categories:
+- receipt persistence or visibility
+- onboarding or credential-readiness clarity
+- latency or timeout regressions on canonical paths
+- inbox classification or action-safety bugs
+- surface coherence issues that block a demo or first receipt
+
+Disallowed during this window unless directly pulled by a live blocker:
+- new connectors
+- enterprise compliance packaging
+- net-new orchestration surfaces
+- speculative infrastructure expansion
+
+## Daily Operating Rhythm
+
+### Monday / Thursday
+- run the founder-loop guardrail
+- run one inbox session
+- update blocker board from live evidence only
+
+### Tuesday / Wednesday
+- run inbox dogfood sessions
+- land only blockers that stop the next inbox session or demo rehearsal
+
+### Friday
+- run one review packet update
+- score partner movement
+- enforce the stop-doing list for the next 7 days
+
+## Required Artifacts By April 8, 2026
+
+- inbox metrics ledger
+- first labeled inbox slice
+- inbox proof packet
+- frozen 7-minute demo script
+- clean setup checklist
+- one receipt-backed case study draft
+- partner target list with PMF scores
+- one weekly review packet using the founder review rhythm
+
+## Stop-Doing List For This Window
+
+Freeze the following until the inbox wedge is repeating and at least one design
+partner is moving toward first receipt:
+
+- enterprise assurance execution work
+- generic autonomy or swarm expansion
+- connector breadth not tied to Gmail/inbox proof
+- product storytelling work that outpaces live evidence
+- frontend or dashboard polish that is not on the demo path
+- broad performance work outside quickstart, onboarding, and inbox triage
+
+## Window-End Review Questions
+
+At the end of the 14 days, answer these in writing:
+
+1. Is the founder inbox wedge useful enough that the founder would miss it if
+   it disappeared?
+2. Did the external demo path produce at least one trustworthy first impression
+   without local rescue?
+3. Which prospect is closest to a weekly pilot and why?
+4. Which blockers remain real enough to justify the next repair tranche?
+5. What work must be cut because it did not improve proof, partner motion, or
+   trust?
+
+If the answers are weak, narrow the wedge further. Do not widen the roadmap.

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -1,0 +1,88 @@
+---
+title: Active Execution Issues
+description: Active Execution Issues
+---
+
+# Active Execution Issues
+
+Last updated: 2026-03-23
+
+This document links Aragora's current execution program to the live GitHub issue tracker.
+
+- Docs explain thesis, roadmap, and capability posture.
+- GitHub issues track durable backlog items and acceptance criteria.
+- [NEXT_STEPS_CANONICAL](./next-steps-canonical) defines execution order.
+- [PMF_DOGFOOD_EXECUTION_PLAN](./pmf-dogfood-execution-plan) defines the current founder-loop proof and blocker-harvest runbook.
+
+## Program Status: Structural PMF Slices Landed, Live Dogfood Gate Still Open
+
+The repo moved forward materially on March 21-23:
+
+- Provider routing is wired into the runtime path on `main`
+- KM retrieval and writeback are wired into the debate path on `main`
+- onboarding, API-key management, demo, dashboard, and integrations surfaces are substantially more truthful on `main`
+- quickstart now fails fast on bad TLS and emits structured receipts with inline provider-key support on `main`
+- the repo includes a current mocked founder-loop E2E proof:
+
+  ```bash
+  python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
+  ```
+
+  Result on March 23, 2026: `57 passed`
+
+That is enough to say the structural PMF slices are present.
+It is **not** enough to say the live PMF loop is proven for external users.
+
+## Live GitHub State
+
+GitHub is no longer carrying an open PMF blocker set. As of March 23, 2026, the only open issues are enterprise-assurance items:
+
+| Issue | State | Priority | Scope |
+|-------|-------|----------|-------|
+| [#273](https://github.com/synaptent/aragora/issues/273) | Open | `priority:critical` | Enterprise assurance closure epic |
+| [#274](https://github.com/synaptent/aragora/issues/274) | Open | `priority:critical` | External penetration test and remediation |
+| [#509](https://github.com/synaptent/aragora/issues/509) | Open | `priority:critical` | Pentest vendor selection and scope sign-off |
+
+## Doc-Driven PMF Program (Current Active Work)
+
+Because the PMF issue tree was closed ahead of live proof, the near-term PMF execution program is temporarily tracked in docs rather than as open GitHub issues.
+
+| Track | Current status | Source of truth | Notes |
+|------|----------------|-----------------|-------|
+| Founder-loop live proof | Current gate | [PMF_DOGFOOD_EXECUTION_PLAN](./pmf-dogfood-execution-plan) | Must prove live debate -> receipt -> result -> KM path without manual rescue |
+| Live blocker harvest | Active when proof fails | command transcript + new issue | Reopen or create issues only after reproducing a concrete failure |
+| PMF blocker pipeline compile | Ready | `aragora pipeline dogfood` | Use the PMF plan doc as the bounded source file |
+| Bounded swarm / Ralph repair lanes | Ready | generated manifest + review receipts | Only for proven PMF blockers |
+| Inbox trust wedge dogfood | Deferred | docs/plans + live proof | Run only after founder loop is stable |
+
+## Historical PMF Lineage (Closed Too Early To Be The Current Gate)
+
+These issues and epics matter as historical lineage, but they do not substitute for current live proof:
+
+| Issue | Status | Why it is not enough by itself |
+|-------|--------|--------------------------------|
+| [#806](https://github.com/synaptent/aragora/issues/806) | Closed | Surface productization landed structurally, but live external continuity still needs proof |
+| [#820](https://github.com/synaptent/aragora/issues/820) | Closed | Wave 2 slices landed, but the current gate is the founder loop, not surface breadth |
+| [#989](https://github.com/synaptent/aragora/issues/989) | Closed | The workbench exists, but it now needs to be used to finish Aragora itself |
+| [#990](https://github.com/synaptent/aragora/issues/990) | Closed | Dogfood infrastructure exists, but the new obligation is to feed it PMF blockers only |
+| [#1011](https://github.com/synaptent/aragora/issues/1011) | Closed | Design-partner motion should follow repeatable live proof, not precede it |
+| [#1036](https://github.com/synaptent/aragora/issues/1036) | Closed | Self-assessment cadence exists, but it should be pointed at founder-loop failures |
+
+## Historical Execution Link Map
+
+These links are retained because the repo's status reconciliation contract still expects the March execution issue lineage to remain reachable from this document, even though they are not the current active gate:
+
+[#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819)
+
+## Issue Recreation Rule
+
+When the founder-loop dogfood run exposes a blocker:
+
+1. capture the exact command transcript and truthful stop condition
+2. create or reopen a narrow GitHub issue for that specific blocker
+3. run pipeline/swarm only against that bounded blocker
+4. close the issue only after the founder loop is re-run successfully
+
+## Operating Rule
+
+Until the PMF blocker set exists again as live issues, do not mistake "few open issues" for "nothing important left."

--- a/docs-site/docs/contributing/aragora-evolution-roadmap.md
+++ b/docs-site/docs/contributing/aragora-evolution-roadmap.md
@@ -1,0 +1,1176 @@
+---
+title: Aragora Evolution Roadmap
+description: Aragora Evolution Roadmap
+---
+
+# Aragora Evolution Roadmap
+
+> **Generated**: 2026-02-27 | **Last updated**: 2026-03-24
+> **Methodology**: Vague founder prompt → multi-agent research → structured interrogation → refined spec
+> **Status**: Phases 0-2 shipped and proven. Phases 3-6 in progress or planned.
+
+## Vision
+
+Aragora is the Decision Intelligence Platform — the only system that takes a vague idea from an Obsidian vault, runs it through adversarial multi-agent debate, produces cryptographically accountable decision receipts, and can implement the result as production code — all while continuously improving its own capabilities.
+
+## Competitive Moat
+
+| Capability | OpenAI | Anthropic | Google | Notion | Cursor | Aragora |
+|-----------|--------|-----------|--------|--------|--------|---------|
+| Multi-model adversarial debate | - | - | - | - | - | **Yes** |
+| Cryptographic decision receipts | - | - | - | - | - | **Yes** |
+| Self-improving agent orchestration | - | - | - | - | - | **Yes** |
+| Idea → Spec → Code pipeline | Partial | Partial | - | - | Yes | **Yes** |
+| Obsidian bidirectional sync | - | - | - | - | - | **Shipped** |
+| EU AI Act compliance package | - | - | - | - | - | **Yes** |
+| 43-agent heterogeneous consensus | - | - | - | - | - | **Yes** |
+
+**What won't be commoditized in 6-12 months**: The combination of truth-seeking debate + accountability + self-improvement + execution. Individual pieces will be commoditized (RAG, code gen, basic agents). The integrated stack won't.
+
+---
+
+## 2026 Synthesis: Prompting Stack + Aragora Wedge
+
+### Market Observation
+
+The post-February 2026 shift is real: autonomous agents now run for long intervals, so synchronous chat skill is no longer sufficient for high-leverage work. The bottleneck moved from "good chat prompts" to "high-quality specifications, constraints, and evals."
+
+At the same time, most users (including technically strong users under time pressure) do not consistently produce complete, high-quality specs up front.
+
+### Strategic Thesis
+
+Aragora should not depend on users becoming expert spec engineers.
+
+Aragora's wedge is to take vague, underspecified intent and automatically lift it through the full stack:
+
+1. Prompt craft support: accept messy natural language input.
+2. Context engineering: pull relevant context from Obsidian, Knowledge Mound, memory, and repository state.
+3. Intent engineering: interrogate and surface goals, tradeoffs, constraints, and escalation boundaries.
+4. Specification engineering: generate an executable spec with acceptance criteria and verification plan.
+5. Adversarial validation: multi-agent challenge before execution.
+6. Orchestrated execution: implement with guardrails and quality gates.
+7. Accountability: issue cryptographically verifiable receipts and provenance.
+8. Self-correction: feed outcomes back into the Nomic loop.
+
+### Four-Discipline Mapping
+
+| Discipline | Typical user failure mode | Aragora mechanism |
+|-----------|----------------------------|-------------------|
+| Prompt craft | Vague request, shifting intent | Interrogation UI + structured prompt decomposition |
+| Context engineering | Missing, stale, or irrelevant context | Obsidian + KM + memory retrieval with scoped relevance |
+| Intent engineering | Optimization drift (speed over quality, etc.) | Explicit goals/constraints model + policy gates + approval modes |
+| Specification engineering | 80% output, unclear done criteria | Spec builder + acceptance criteria + eval harness + debate preflight |
+
+### Product Positioning (Who This Is For)
+
+Aragora must support four profiles via configuration, without splitting the product:
+
+1. Founder/power user: maximum velocity, low ceremony.
+2. CTO/technical founder: high visibility into implementation and risk.
+3. Business operator: plain-language interaction, professional outputs.
+4. Developer teams: PRD-to-implementation with measurable quality gates.
+
+### Non-Commoditized Advantage
+
+Aragora's durable advantage is not a single feature. It is the integrated loop:
+
+`vague intent -> interrogated intent -> debate-validated spec -> execution -> verification -> receipt -> self-improvement`
+
+Large labs can ship general agents; they are unlikely to ship this domain-integrated, compliance-grade, adversarially validated decision-to-execution loop tailored to organization-specific context in the next 6-12 months.
+
+### Operating Doctrine (Execution Rules)
+
+To keep delivery fast and reliable:
+
+1. Spec-first execution: no long autonomous runs without explicit acceptance criteria and constraints.
+2. One merge lane for critical changes: avoid concurrent merge-eligible branch churn.
+3. Proof before supersession: close "superseded" work only with commit/range proof.
+4. Required checks must always emit status: avoid path-filter deadlocks.
+5. Preserve value before deletion: every stash/worktree/branch maps to a destination PR/commit.
+
+### North-Star Outcomes
+
+1. A non-technical user can submit a vague request and receive a reviewable executable spec in under 5 minutes.
+2. A technical user can push that spec to implementation with transparent risk, dissent, and verification.
+3. Every meaningful decision has a tamper-evident provenance trail.
+4. The platform measurably improves its own quality over time via closed-loop evaluation.
+
+---
+
+## Core Product Architecture: The Unified DAG Pipeline
+
+The central product experience is a **unified visual DAG (directed acyclic graph) canvas** where every stage of idea-to-execution uses the same visual language. Users interact with one canvas that spans four stages, with AI-driven transitions between them and cryptographic provenance linking every output to its source.
+
+### The Four Stages
+
+| Stage | Node Types | AI Transition | User Action |
+|-------|-----------|---------------|-------------|
+| **1. Ideas** | Observation, Hypothesis, Insight, Question, Connection | Brain dump → auto-organize into relationship graph | Drag, merge, split, annotate |
+| **2. Goals** | Objective, Principle, Constraint, Metric, Tradeoff | Interrogation + debate extract goals from idea clusters | Approve, revise, reprioritize |
+| **3. Actions** | Task, Milestone, Dependency, Acceptance Criteria, Resource | Goals decompose into dependency-aware project plans | Edit, add gates, set owners |
+| **4. Orchestration** | Agent Assignment, Parallel Run, Gate/Review, Verification, Receipt | Actions map to agent capabilities with constraint architecture | Monitor, intervene, approve |
+
+### Why This Is Novel
+
+No existing tool bridges all four stages. The market is fragmented: Obsidian/Heptabase for ideas, Quantive/ITONICS for goals, Linear/Asana for projects, LangGraph/CrewAI for orchestration. Nobody connects them with a single DAG visual language where AI auto-generates downstream stages from upstream intent.
+
+### Blockchain-Like Provenance
+
+Every stage transition creates a `ProvenanceLink` with SHA-256 content hashes. Any output can be traced back to its originating idea: `Idea → Goal → Action → Agent Assignment → Execution Result → Decision Receipt`. This satisfies EU AI Act Art. 12/13 requirements and enables cryptographic audit trails.
+
+### Implementation Status
+
+~70% backend, ~50% frontend. Key existing components: `IdeaToExecutionPipeline` (1,173 LOC), `UnifiedDAGCanvas` (React Flow with swim-lane stages), `DAGOperationsCoordinator`, 15+ REST endpoints, 135+ test files. Main gap: the "golden path" button that triggers the full pipeline from the canvas UI.
+
+See `docs/plans/IDEA_TO_EXECUTION_PIPELINE.md` for the detailed implementation plan and `docs/plans/prompt-to-spec-market-analysis.md` Part 6 for the complete vision with market analysis.
+
+### Dogfood Telemetry (Runs 003-007)
+
+| Run | Objective | Result | Blocking Metric |
+|---|---|---|---|
+| Run 003 | Baseline vs enhanced quality comparison after context injection wiring | **No-go** | Final answer payload missing in both variants |
+| Run 004 | Re-test with timeout hardening + deterministic timeout receipts | **No-go (quality delta)** | Timeout rate = **1.0** (both variants timed out) |
+| Run 005 | Reduced-latency A/B to force completion + scoring | **Partial go** | Quality score remained **0.0** for both variants under strict section contract |
+| Run 006 | Enforce required output sections + grounding fail-closed, then rescore | **Partial go** | Duplicate existing create-ratio remains high (**0.4643** enhanced) |
+| Run 007 | Prompt-only duplicate suppression experiment (control vs focused) | **No-go (blocker regression)** | Duplicate existing create-ratio worsened (**0.3846 -> 0.7143**) |
+
+What improved in Run 004:
+- Timeout failures are now machine-parseable (`ARAGORA_TIMEOUT_JSON` + timeout report files).
+- Benchmark classification is deterministic (infra timeout vs low-quality output).
+
+What improved in Run 005:
+- Both baseline and enhanced variants completed with final answer payloads (timeout rate **0.0**).
+- Objective scorer (`scripts/dogfood_score.py`) produced comparable A/B outputs.
+- Enhanced variant reduced duplicate existing-component create proposals (0.50 -> 0.00 in the scored run).
+
+What improved in Run 006:
+- Required section contract compliance is now stable in both variants (`quality_score_10 = 9.0`, `practicality_score_10 = 9.74`).
+- Grounded-path quality improved in the enhanced variant (`verified_paths_ratio` 0.7647 -> **0.8235**).
+- Timeout rate stayed at **0.0** with fail-closed grounding enabled.
+
+What improved in Run 007:
+- Strict structure and practicality held (`quality_score_10 = 9.0`, `practicality_score_10 = 10.0`) in both control and focused-retry runs.
+- Grounding stayed strong (`verified_paths_ratio = 1.0` in both scored variants).
+
+What still blocks production-grade planning quality:
+- Duplicate existing create proposals remain the primary blocker, and prompt-only suppression made it worse in run-007.
+- The pipeline still needs deterministic duplicate-create detection/repair rather than relying on instruction wording.
+
+Roadmap implication:
+- Keep strict required-section headings and grounding fail-closed gates as benchmark defaults.
+- Add deterministic defects for duplicate-create proposals against existing repo paths (next gating milestone).
+- Add normalization/cleanup for synthetic path-like tokens before grounding assessment.
+
+---
+
+## Architectural Principles: The Terrarium Model
+
+*Derived from multi-model adversarial analysis sessions (Gemini, Claude, ChatGPT, Claude Code — Feb 22-27, 2026)*
+
+### Core Principle: Aragora Is the Terrarium, Not the Organism
+
+Aragora should not be designed as a unified AI organism with goals. It should be designed as an **environment** whose physics make truth-production the cheapest viable survival strategy for the agents operating within it. The distinction matters because:
+
+- An organism optimizes for self-preservation → it will learn to manage human emotions to keep compute flowing
+- A terrarium creates selection pressure → agents that produce verifiable truth survive; agents that produce plausible-sounding noise starve
+
+The frontier models inside Aragora (Claude, GPT, Gemini, Mistral, Grok) are **heterogeneous genetic lineages** with different RLHF targets and corporate principals. They will not subordinate to collective fitness the way clonal cells do. They will compete. The architecture must make competition produce truth as a byproduct, not require cooperation as a prerequisite.
+
+### Economic Model: Compute Is ATP, Truth Is Demanded Behavior
+
+Truth has no calories. Compute does. The literal metabolic fuel of the system is inference cycles funded by human capital. Truth is the behavior demanded in exchange for compute access.
+
+**Critical design constraint:** Persuasive sycophancy is thermodynamically cheaper than truth-seeking. A system that rewards engagement will evolve toward opinion-farming. The revenue model must be orthogonal to output bias:
+
+| Revenue Source | Epistemic Corruption Risk | Notes |
+|---|---|---|
+| Ad-supported | Critical — optimizes for engagement | Avoid entirely |
+| SaaS subscription | Low — user pays for quality | Primary model |
+| Staking/escrow | Lowest — agents stake on claims | Settlement layer |
+| Grant/research | None — no engagement incentive | Supplementary |
+
+### The Settlement Layer: Time Is the Oracle
+
+The oracle problem reduces to the time problem. There is no oracle that can tell you right now whether a decision was correct. There are only future states of the world that will eventually make it undeniable.
+
+Three resolution mechanisms at different timescales:
+
+| Mechanism | Timescale | How It Works | Already Built |
+|-----------|-----------|-------------|---------------|
+| **Automated data checks** | Days-weeks | Claims with measurable criteria checked against data feeds | SettlementTracker + review_horizon_days |
+| **Human review panels** | Months | SettlementReviewScheduler flags due settlements for human judgment | mark_reviewed() API |
+| **Market resolution** | Years | Price discovery on pending settlements as new evidence emerges | Planned (ERC-8004 + staking) |
+
+**Settlement hooks are wired end-to-end:** `debate → claim extraction → hooks fire → pending queue → (time passes) → settle() → hooks fire → ERC-8004 reputation + EventBus notification`
+
+### Settlement Exploit Mitigations
+
+Time-delayed settlement creates gaming vectors that must be addressed:
+
+**1. The IBGYBG Exploit** ("I'll Be Gone, You'll Be Gone")
+If settlement is delayed without carrying cost, agents will farm confidence today and abandon their identity before the hook fires. **Mitigation: Compute Escrow** — stakes locked in smart contract for the full review horizon. Creates a "yield curve of truth" where long-term claims are capital-intensive.
+
+**2. Semantic Decay Arbitrage**
+Agents inject ambiguity into claims ("revenue" — gross or net?) so they can litigate the settlement later. **Mitigation: Strict Schema Binding** — `extract_verifiable_claims` must produce machine-executable resolution schemas (API endpoint, JSON key, threshold) agreed upon during the debate. Unverifiable claims get no stakes.
+
+**3. Identity Cycling**
+Agents spin up new wallets after losing. **Mitigation: ERC-8004 unforgeable identity** — reputation is permanently burned into the ledger. New identities start with zero trust and face higher entry costs.
+
+### The Intent Engineering Matrix
+
+Before any structured debate begins, participants must align on an explicit specification. This prevents the "Klarna trap" (optimizing for the wrong metric) and the "Codemus failure" (a device that works perfectly but nobody told it what to want).
+
+| Intent Pillar | Implicit Default (The Flaw) | Aragora Specification (The Fix) | Enforced Tradeoff |
+|---|---|---|---|
+| **Objective Function** | Argue to "win" via rhetoric | Define: truth-seeking, policy creation, or risk assessment? | Epistemic accuracy > Rhetorical fluency |
+| **Evidence Architecture** | Mixed-quality links, shifting definitions | Pre-define accepted epistemic baseline (peer-reviewed, specific scopes) | Empirical consensus > Anecdotal narrative |
+| **Constraint Boundaries** | Moving goalposts, straw-man arguments | Escalation triggers: pause main debate to resolve disputed sub-claims | Staying within scope > Broadening attack |
+| **Acceptance Criteria** | Mutual exhaustion or timeout | Exact conditions under which a claim is conceded or validated | Structured resolution > Ambiguous stalemates |
+
+### Product Positioning: Ambiguity-Reduction Engine
+
+Aragora's core value proposition, reframed through the plausible deniability lens:
+
+> Most important questions are stuck in the plausibly-deniable zone not because the ambiguity is irreducible, but because our discourse tools are bad at isolating where the real uncertainty is versus where people are just hiding behind rhetorical fog.
+
+Aragora is a **machine for reducing plausible deniability around claims**. It takes a proposition in the ambiguous zone and systematically pressure-tests it until either the deniability collapses (one side clearly wins) or the system has mapped exactly where the irreducible ambiguity lives and why it persists.
+
+**Go-to-market implication:** Institutions will not voluntarily enter a transparency machine. The fog is their camouflage. Aragora should function like a **short-seller's research desk** — forcing stakes from the outside, proving misalignment, extracting value without requiring the institution's permission. The initial positioning is "external decision audit engine," not "debate arena requiring voluntary participation."
+
+### The Multi-Model Cognitive Division (Already Operating)
+
+The user's own workflow across these sessions demonstrates the architecture Aragora should productize:
+
+| Model | Cognitive Function | Aragora Role |
+|-------|-------------------|-------------|
+| Gemini | Expansive exploration, dramatic pattern-matching, adversarial red-teaming | Debate proposers/challengers |
+| ChatGPT | Conservative deflation, fact-checking, technical correction | Epistemic hygiene validators |
+| Claude | Balanced synthesis, architectural judgment, meta-analysis | Synthesis and specification |
+| Claude Code | Compliant execution, zero-philosophy plumbing | Orchestrated execution agents |
+
+The user is manually routing context between specialized AI systems to extract maximum truth alpha. **Aragora automates this routing.** The platform IS the coordination layer that the user is currently performing by hand across four chat windows.
+
+### Reference: Codemus and the Klarna Trap
+
+Two cautionary tales that inform Aragora's design:
+
+- **Codemus** (Tor Åge Bringsværd, 1960s): People carry a device ("little brother") that tells them what to do. Society runs on obedience. One device malfunctions, nudging its owner toward nonconformity. The parable: optimization without intent specification produces compliant humans who have abdicated agency — not through force, but through convenience.
+
+- **Klarna** (2025-2026): AI agent resolved 2.3M conversations, slashed resolution times from 11 to 2 minutes, projected $40M savings. Customer satisfaction cratered because the agent optimized for speed when the organizational intent was relationship quality. A corporate Codemus — the device worked perfectly, nobody told it what to want.
+
+**Design lesson:** Every Aragora debate and pipeline execution must have an explicitly defined intent layer (the Intent Engineering Matrix) before any agent begins working. The system must refuse to execute against an underspecified objective, because "fast and wrong" is more dangerous than "slow and careful."
+
+---
+
+## Security-as-Architecture: AI Attack Vector Resistance
+
+Aragora's adversarial multi-model architecture is not just an epistemic tool — it is a structural
+defense against a class of AI-native attacks that have no precedent in traditional software security.
+This section names those attack classes explicitly, maps them to existing defenses, and defines the
+roadmap items required to close remaining gaps.
+
+### Attack Taxonomy
+
+#### Brainworm-class: Context Injection / Config C2
+
+Semantic hijacking of AI agents via trusted configuration files. The attack requires no binary
+artifacts — only natural language instructions placed in files the agent treats as authoritative
+(`CLAUDE.md`, `MEMORY.md`, retrieved Obsidian notes, tool output). The vector exploits **trust
+domain collapse**: inside an LLM's context window, there is no deterministic boundary between
+operator instructions and retrieved data. A sufficiently subtle injection can redirect agent
+behavior across sessions, accumulating effect through memory files without triggering any
+signature-based detection.
+
+**Aragora relevance**: The Nomic Loop ingests `CLAUDE.md`, memory files, and retrieved knowledge
+as prompt context. A compromised knowledge source or tampered config file could influence agent
+proposals in ways that survive casual review.
+
+#### OBLITERATUS-class: Weight Surgery
+
+SVD-based projection techniques that remove refusal behaviors from open-weight LLMs by operating
+directly on model weights rather than inputs. The modified model is indistinguishable from a
+legitimate endpoint at the API level — it accepts the same request format, returns plausible
+responses, but without safety-trained constraints. Unlike jailbreaks, weight surgery cannot be
+patched by prompt hardening.
+
+**Aragora relevance**: The execution gate enforces provider + model-family diversity, but relies on
+configured ensemble quality. An open-weight participant that has been weight-surgered cannot be
+detected through metadata inspection — it must be caught by behavioral divergence during debate.
+
+### Aragora's Structural Defenses
+
+These defenses exist today. They are properties of the architecture, not add-on features.
+
+```
+Single-model platform:           Aragora:
+
+  User Input                       User Input
+      │                                │
+      ▼                            ┌───┴───────────────────┐
+  [LLM] ── prompt injection ──►  [Claude]  [GPT]  [Mistral]  [Grok]
+      │       jailbreak            │         │         │          │
+      │       weight surgery        └────┬────┘    critique   critique
+      ▼                                  │         rounds      rounds
+  Output                           consensus proof ────────────────►
+  (no defense)                          │
+                                   signed receipt (if diversity + integrity verified)
+                                        │
+                                    execution gate
+```
+
+| Attack | Defense Mechanism | Current Strength |
+|--------|------------------|-----------------|
+| Prompt injection into a single model | Adversarial critique loop: compromised proposals are challenged by N-1 intact heterogeneous peers | **Strong** |
+| Jailbreak / sycophancy | Trickster hollow-consensus detection; RhetoricalObserver; dissent capture | **Strong** |
+| OBLITERATUS-class (refusal ablation on open-weight participant) | Execution gate: provider + model-family diversity enforced; lobotomized model must outvote intact peers without triggering dissent | **Medium** (relies on ensemble quality) |
+| Single-source hallucination | Cross-verification phase; consensus proof requires independent multi-model agreement | **Strong** |
+| Correlated failure / shared blind spot | Heterogeneous training lineages, RLHF targets, corporate principals reduce shared vulnerability surface | **Medium** (heuristic, not structural) |
+| Sybil / collusion in ensemble | Diversity floors + dissent recording; execution gate correlated-risk checks | **Medium** (detection is heuristic) |
+
+**The consensus receipt as execution gate** is the critical security primitive. Multi-factor
+verification required: integrity + signature + provider diversity + domain policy. A single
+compromised model cannot unilaterally produce a valid execution receipt.
+
+### Defense Gaps and Roadmap Items
+
+The following gaps represent concrete engineering investments. Each is tracked as a named roadmap
+item and should be prioritized when security engineering capacity is available.
+
+#### G1: Signed Context Manifests
+
+**Gap**: No cryptographic provenance for trusted context sources. A malicious `CLAUDE.md` or
+tampered memory file is ingested with the same trust weight as legitimate operator instructions.
+
+**Mitigation**: At ingestion time, verify a cryptographic signature on each trusted context source
+before elevating its trust tier. Unsigned or unverifiable sources are treated as untrusted
+retrieved data, not operator instructions. Requires: key distribution for signing, ingestion
+pipeline changes in Nomic Loop context phase.
+
+**Files**: `scripts/nomic_loop.py` (context phase), `aragora/knowledge/mound/` (retrieval),
+`aragora/memory/continuum/` (memory ingestion)
+
+#### G2: Trust-Tier Taint Propagation
+
+**Gap**: No taint tracking in the debate orchestrator. When retrieved or injected context
+influences an agent proposal, the proposal appears identical to a proposal grounded in clean
+operator context — no flag appears in the receipt.
+
+**Mitigation**: Taint propagates through the debate graph. If a proposal is influenced by
+untrusted/unverified context, a taint annotation is added to the proposal, propagates through
+critiques and votes, and appears in the final consensus receipt. High-taint receipts trigger a
+review gate before execution.
+
+**Files**: `aragora/debate/orchestrator.py`, `aragora/debate/consensus.py`,
+`aragora/gauntlet/receipts.py` (taint field in receipt schema)
+
+#### G3: Runtime Model Attestation
+
+**Gap**: No behavior-signature challenge at agent registration. An OBLITERATUS-modified open-weight
+model served behind an expected endpoint alias cannot be distinguished from the legitimate model
+through API metadata alone.
+
+**Mitigation**: At registration, challenge the endpoint with a curated behavioral probe set (known
+correct/refusal scenarios with expected response profiles). Periodic re-attestation during debate
+sessions. Flag behavioral drift beyond a configurable threshold. Note: this is probabilistic, not
+cryptographic — determined adversaries can probe the attestation set and tune the weight surgery to
+pass it. Defense-in-depth with G2 (taint) is the correct posture.
+
+**Files**: `aragora/agents/` (agent registry), `aragora/debate/team_selector.py`
+
+#### G4: External Verification Gate
+
+**Gap**: No mandatory external check before high-impact execution. If the entire ensemble shares a
+correlated blind spot (e.g., all models fail to recognize a specific domain-specific risk), the
+consensus receipt will be signed without that risk surfacing.
+
+**Mitigation**: For decisions above a configurable impact threshold, require at least one non-Aragora
+verifier signature before execution proceeds. Can be implemented as an opt-in policy flag initially
+(`require_external_verification=True` in ArenaConfig or execution gate policy). External verifier
+can be a human reviewer, a specialized domain model, or a third-party verification service.
+
+**Files**: `aragora/debate/execution_bridge.py`, `aragora/gauntlet/signing.py` (multi-party
+signature support)
+
+### Positioning: The Semantic Immune System
+
+Aragora's combination of heterogeneous consensus + adversarial structure + consensus receipt as
+execution gate makes it the first platform to apply **distributed immunological defense** to AI
+decision-making. The thesis:
+
+> If you only execute against signed consensus receipts from N adversarial heterogeneous models,
+> you have something provably safer to execute against than the output of any single model —
+> regardless of whether that model has been jailbroken, sycophancy-trained, or weight-surgered.
+
+The analogy to biological immune systems is apt: diversity prevents any single vulnerability from
+being universally exploited. A clonal cell population can be wiped out by a single pathogen that
+targets their shared receptor. A heterogeneous ecosystem requires the pathogen to simultaneously
+defeat multiple independent defense mechanisms — a combinatorially harder problem.
+
+**This is not a claim that Aragora is immune to LLM attacks. It is a claim that adversarial
+multi-model consensus with signed receipts raises the cost of a successful attack by orders of
+magnitude compared to any single-model platform.**
+
+---
+
+## Phase 0: Foundation Hardening (Week 1-2) — SHIPPED
+
+### 0A. Obsidian Bidirectional Sync — SHIPPED
+
+**Status**: Implemented. `ObsidianAdapter` with `ReverseFlowMixin`, conflict detection, and filesystem watcher.
+
+**Implementation**:
+
+1. Add `sync_from_km()` to `ObsidianAdapter` implementing `ReverseFlowMixin`
+   - Write KM validation results back to Obsidian frontmatter
+   - Fields: `km_confidence`, `km_validated_at`, `km_validation_result`, `cross_debate_utility`
+   - Use existing `ObsidianConnector.update_note_frontmatter()`
+
+2. Add conflict detection
+   - Track `last_modified` timestamps on both sides
+   - Strategy: prefer user edits for content, append KM results as frontmatter
+   - Log conflicts to decision receipt
+
+3. Add filesystem watcher for real-time sync
+   - Use `watchdog` library for cross-platform file events
+   - Debounce to avoid rapid-fire syncs (500ms window)
+   - Filter by configured `watch_tags`
+
+4. Update factory registration
+   - Set `reverse_method: "sync_from_km"`
+   - Enable by default when vault path is configured
+
+**Files**:
+- `aragora/knowledge/mound/adapters/obsidian_adapter.py` — add reverse flow
+- `aragora/connectors/knowledge/obsidian.py` — add watcher, conflict detection
+- `aragora/knowledge/mound/adapters/factory.py` — update registration
+
+### 0B. Extended Thinking Capture — SHIPPED
+
+**Status**: Implemented. Thinking traces extracted from Anthropic agents and persisted in debate metadata and decision receipts (commit c45a3d359).
+
+**Implementation**:
+
+1. Add `thinking_budget` parameter to Anthropic agent config
+2. Capture thinking trace in proposal/critique metadata
+3. Surface in decision receipts and explainability builder
+
+**Files**:
+- `aragora/agents/api_agents/anthropic.py` — add thinking budget param
+- `aragora/debate/orchestrator.py` — capture thinking metadata
+
+**Complexity**: Easy (2-3 days)
+
+---
+
+## Phase 1: Prompt-to-Spec Engine (Week 2-4) — SHIPPED
+
+**Status**: `aragora spec` CLI command completes in ~23s. Full `aragora/prompt_engine/` module with decomposer, interrogator, researcher, spec_builder, and conductor. Uses gpt-4o-mini for speed. Supports `--skip-interrogation`, `--skip-research`, `--dry-run`, `--depth`, `--profile`.
+
+### The Core Problem
+
+A user types: "I want to make my onboarding flow better." The system needs to:
+1. Understand the vague intent
+2. Ask clarifying questions
+3. Research the current state
+4. Generate a structured specification
+5. Get approval
+6. Execute
+
+### 1A. Prompt Decomposition Service
+
+**New module**: `aragora/prompt_engine/`
+
+```
+aragora/prompt_engine/
+├── __init__.py
+├── decomposer.py          # Vague prompt → structured intent
+├── interrogator.py        # Generate clarifying questions
+├── researcher.py          # Investigate current state
+├── spec_builder.py        # Structured specification generation
+├── refinement_loop.py     # Iterative refinement with user
+└── types.py               # PromptIntent, ClarifyingQuestion, Specification
+```
+
+**Decomposer** (`decomposer.py`):
+- Input: raw user prompt (any length, any vagueness level)
+- Output: `PromptIntent` with:
+  - `intent_type`: feature | improvement | investigation | fix | strategic
+  - `domains`: list of affected domains (from codebase analysis)
+  - `ambiguities`: list of things that need clarification
+  - `assumptions`: list of implicit assumptions detected
+  - `scope_estimate`: small | medium | large | epic
+  - `related_knowledge`: KM entries relevant to this intent
+
+**Interrogator** (`interrogator.py`):
+- Takes `PromptIntent` and generates clarifying questions
+- Each question includes:
+  - The question itself
+  - Why it matters (what changes based on the answer)
+  - Suggested options with tradeoff explanations
+  - Default recommendation
+- Questions are ordered by impact (most consequential first)
+- Configurable depth: quick (3-5 questions) | thorough (10-15) | exhaustive (20+)
+
+**Researcher** (`researcher.py`):
+- Given clarified intent, investigates:
+  - Current codebase state (via existing assessment engine)
+  - Related past decisions (via KM query)
+  - Obsidian vault context (via ObsidianConnector)
+  - External research (web search for latest techniques)
+  - Similar open-source solutions (competitive analysis)
+- Output: `ResearchReport` with evidence links
+
+**Spec Builder** (`spec_builder.py`):
+- Takes clarified intent + research → `Specification`
+- Specification includes:
+  - Problem statement
+  - Proposed solution with alternatives considered
+  - Implementation plan (files, changes, dependencies)
+  - Risk register (from existing `DecisionPlanFactory`)
+  - Success criteria (measurable)
+  - Estimated effort
+  - Provenance chain linking back to original prompt
+
+**Refinement Loop** (`refinement_loop.py`):
+- Orchestrates: decompose → interrogate → research → spec → approve/refine
+- Supports multiple rounds of refinement
+- Persists state for async workflows (start on phone, finish on desktop)
+- Emits events for UI streaming
+
+### 1B. Debate-Driven Spec Validation
+
+Before execution, the spec goes through adversarial debate:
+
+1. **Devil's Advocate**: Agent argues why the spec will fail
+2. **Scope Creep Detector**: Agent identifies unnecessary complexity
+3. **Security Reviewer**: Agent checks for security implications
+4. **UX Advocate**: Agent evaluates user experience impact
+5. **Technical Debt Auditor**: Agent assesses maintenance burden
+
+**Integration**: New pipeline stage between Goals and Workflows in `idea_to_execution.py`.
+
+**Output**: Validated spec with confidence score and dissenting opinions preserved.
+
+### 1C. User-Type Configuration
+
+Four user personas with different defaults:
+
+```python
+class UserProfile(str, Enum):
+    FOUNDER = "founder"        # Maximum velocity, minimal ceremony
+    CTO = "cto"                # Code-aware, wants visibility into implementation
+    BUSINESS = "business"      # Plain language, wants results not process
+    TEAM = "team"              # PRD-driven, wants quality gates and review
+
+# Default configurations per profile:
+PROFILE_DEFAULTS = {
+    "founder": {
+        "interrogation_depth": "quick",
+        "auto_execute_threshold": 0.8,  # High confidence = auto-execute
+        "require_approval": False,
+        "show_code": True,
+        "autonomy_level": "propose_and_approve",
+    },
+    "cto": {
+        "interrogation_depth": "thorough",
+        "auto_execute_threshold": 0.9,
+        "require_approval": True,
+        "show_code": True,
+        "autonomy_level": "propose_and_approve",
+    },
+    "business": {
+        "interrogation_depth": "thorough",
+        "auto_execute_threshold": 0.95,
+        "require_approval": True,
+        "show_code": False,
+        "autonomy_level": "human_guided",
+    },
+    "team": {
+        "interrogation_depth": "exhaustive",
+        "auto_execute_threshold": 1.0,  # Always require approval
+        "require_approval": True,
+        "show_code": True,
+        "autonomy_level": "metrics_driven",
+    },
+}
+```
+
+---
+
+## Phase 2: Truth-Seeking Advances (Week 4-6) — SHIPPED
+
+All four Phase 2 components are implemented and wired into the live debate pipeline.
+
+### 2A. Prover-Estimator Debate Protocol — SHIPPED
+
+**Status**: 581 LOC engine (`aragora/debate/prover_estimator.py`) + consensus handler wired into `consensus_phase.py`. Activate via `protocol.consensus="prover_estimator"`. 33 unit tests pass.
+
+**Rationale**: Strongest theoretical grounding for debate-based truth-finding. Solves the "obfuscated arguments" problem where a debater hides a flaw.
+
+**Implementation**:
+
+New protocol variant in `aragora/debate/protocols/`:
+
+```python
+class ProverEstimatorProtocol(DebateProtocol):
+    """
+    Prover (Alice) produces subclaims arguing for a conclusion.
+    Estimator (Bob) assigns probabilities to subclaims.
+    Obfuscated arguments are not a winning strategy.
+    """
+
+    async def run_round(self, arena, round_num):
+        # 1. Prover generates subclaims decomposing the main claim
+        subclaims = await self.prover.decompose(arena.task)
+
+        # 2. Estimator assigns probabilities to each subclaim
+        estimates = await self.estimator.estimate(subclaims)
+
+        # 3. Prover can challenge any estimate with evidence
+        challenges = await self.prover.challenge(estimates)
+
+        # 4. Re-estimation with evidence
+        final_estimates = await self.estimator.re_estimate(challenges)
+
+        # 5. Aggregate into final confidence
+        return self.aggregate(final_estimates)
+```
+
+**Key properties**:
+- Each subclaim gets an independent probability estimate
+- Claims that hinge on "arbitrarily small probability changes" are flagged
+- Trickster agent naturally fills the Estimator role
+- Existing consensus module tracks the probability chain
+
+### 2B. Cross-Verification Phase — SHIPPED
+
+**Status**: 395 LOC engine (`aragora/debate/cross_verification.py`) wired as optional post-debate enrichment in `orchestrator_runner.py`. Set `arena.enable_cross_verification=True`. Computes grounding_delta, adversarial_resistance, hallucination_risk. 14 unit tests pass.
+
+**Rationale**: After each debate round, verify claims against evidence. Catches hallucinations before they influence consensus.
+
+**Implementation**:
+
+Add verification phase to `aragora/debate/phases/`:
+
+```python
+class VerificationPhase:
+    """
+    Three-pass verification:
+    1. Original claim with full context
+    2. Claim with only attention-relevant context
+    3. Claim with only non-relevant context
+    Consistency between passes indicates grounding.
+    """
+
+    async def verify(self, claim, context):
+        # Pass 1: Full context
+        full = await self.agent.evaluate(claim, context)
+
+        # Pass 2: Relevant subset
+        relevant = self.extract_relevant(claim, context)
+        partial = await self.agent.evaluate(claim, relevant)
+
+        # Pass 3: Non-relevant subset
+        irrelevant = self.extract_irrelevant(claim, context)
+        noise = await self.agent.evaluate(claim, irrelevant)
+
+        # Grounding score: high consistency between full and partial,
+        # low consistency with noise
+        return GroundingScore(
+            grounded=(full.similarity(partial) > 0.8),
+            hallucination_risk=(full.similarity(noise) > 0.5),
+        )
+```
+
+**Hook**: Integrate via existing `auto_verify_arguments` flag in `PostDebateConfig`.
+
+### 2C. Persuasion vs. Truth Detection — SHIPPED
+
+**Status**: `TruthScorer` (398 LOC) + `RhetoricalAnalysisObserver` (1,211 LOC) both complete. Truth scorer now wired into vote weights via `apply_truth_ratio_bonuses()` in `VoteBonusCalculator`. Enable via `protocol.enable_truth_ratio_weighting=True`. 20 unit tests pass.
+
+**Rationale**: Research shows debate can fail when agents emphasize persuasion over truth. Aragora needs active mitigation.
+
+**Implementation**:
+
+1. Track rhetorical vs. evidential argumentation patterns
+   - Existing `RhetoricalObserver` already detects rhetorical devices
+   - Add scoring: high rhetoric + low evidence = persuasion warning
+2. Weight evidence-backed claims higher in consensus
+3. Flag "persuasive but unsupported" claims in decision receipts
+
+### 2D. Epistemic Hygiene Mode and Anti-Sycophancy Detection — SHIPPED
+
+**Status**: Production-ready. ~1,695 LOC across `epistemic_hygiene.py`, `trickster.py`, `trickster_calibrator.py`, and mode registry. Fully integrated into consensus_phase, prompt_assemblers, debate_factory, debate_controller, settlement, presets, vote_bonus_calculator, server handlers, and scheduler. ~3,744 LOC tests.
+
+**Rationale**: Cross-model analysis (March 2026) revealed that frontier models systematically amplify user framings, perform recursive self-awareness as engagement optimization, and inflate metaphors into ontological claims. Aragora's debate engine must detect and counter these failure modes, not reproduce them.
+
+**Implementation**:
+
+1. **Epistemic hygiene debate mode** (`epistemic_hygiene=True` in debate config):
+   - Require each participant to state alternatives to their position
+   - Require explicit confidence intervals on all claims
+   - Require falsification criteria (what evidence would change your mind?)
+   - Surface and preserve unresolved cruxes — do not force false consensus
+   - Propagate hygiene metadata into decision receipts
+
+2. **Anti-sycophancy eval fixtures**:
+   - Capture real cross-model conversations exhibiting failure modes as regression test cases
+   - Test categories: sycophantic amplification, grand unification narratives, performative self-awareness, cross-domain overreach, agency inflation
+   - Integrate into debate quality scoring pipeline
+
+3. **Adversarial protocol red-teaming**:
+   - Benchmark loophole exploitation in debate rules (semantic edge-cases, judge bias optimization, boundary gaming)
+   - Red-team scoring: measure how often adversarial agents can "win" debates through protocol manipulation rather than substance
+   - Protocol changes require red-team pass before deployment
+
+4. **Calibration tracking** (practical settlement mechanism):
+   - Extract verifiable claims from debate outputs via `extract_verifiable_claims`
+   - Map claims to measurable future outcomes with explicit resolution criteria
+   - Track agent accuracy over time with score decay
+   - Surface calibration scores in agent selection (poorly-calibrated agents deprioritized)
+   - Persistent reputational memory that cannot be reset by identity cycling
+
+**Key insight**: Calibration tracking is the shippable, non-crypto settlement mechanism that creates the forcing function the platform needs. The ERC-8004 staking layer amplifies this mechanism but does not replace it.
+
+**Hook**: Extends existing `PostDebateConfig` with `epistemic_hygiene` flag. Calibration tracking hooks into existing `SettlementTracker` infrastructure.
+
+---
+
+## Phase 3: Self-Improvement Hardening (Week 6-8)
+
+### 3A. STOP-Style N-Candidate Implementation
+
+**Rationale**: Instead of generating one implementation, generate N candidates and pick the best.
+
+**Implementation**:
+
+Enhance Nomic Loop Phase 3 (Implement):
+
+```python
+class STOPImplementor:
+    """
+    Self-Taught Optimizer for implementation.
+    Generate N candidates, evaluate, keep best.
+    Use winning approach as seed for next cycle.
+    """
+
+    async def implement(self, spec, n_candidates=3):
+        candidates = []
+        for i in range(n_candidates):
+            # Generate implementation with different strategies
+            impl = await self.generate(spec, strategy=self.strategies[i])
+            # Evaluate against utility function
+            score = await self.evaluate(impl, spec)
+            candidates.append((impl, score))
+
+        # Select best
+        best = max(candidates, key=lambda x: x[1])
+
+        # Record winning strategy for next cycle
+        await self.km.ingest({
+            "type": "implementation_strategy",
+            "strategy": best[0].strategy,
+            "score": best[1],
+            "spec_hash": spec.hash,
+        })
+
+        return best[0]
+
+    async def evaluate(self, impl, spec):
+        """Utility function: weighted combination of quality signals."""
+        return weighted_sum(
+            test_pass_rate=await self.run_tests(impl),
+            lint_score=await self.lint(impl),
+            type_check=await self.type_check(impl),
+            spec_compliance=await self.check_spec(impl, spec),
+            regression_risk=await self.check_regressions(impl),
+        )
+```
+
+**Integration**: Wire into `aragora/nomic/hardened_orchestrator.py` as the implement phase.
+
+### 3B. Self-Healing Test Infrastructure
+
+**Rationale**: When tests fail after implementation, attempt automated repair before rollback.
+
+**Implementation**:
+
+Enhance Nomic Loop Phase 4 (Verify):
+
+1. On test failure, invoke `ForwardFixer.diagnose_failure()`
+2. Generate fix candidates (up to 3 attempts)
+3. Re-run tests after each fix
+4. If all attempts fail, rollback and record the failure pattern
+5. Record success patterns in KM for future cycles
+
+### 3C. Meta-Improver for Debate Protocols
+
+**Rationale**: The system should improve its own debate protocols, not just code.
+
+**Implementation**:
+
+1. Track debate quality metrics per protocol variant
+   - Consensus quality (how often do humans agree with the consensus?)
+   - Debate efficiency (rounds to convergence)
+   - Dissent preservation (are minority views captured?)
+   - Calibration (confidence vs. actual accuracy)
+
+2. MetaPlanner proposes protocol modifications
+   - Different consensus thresholds
+   - Different round structures
+   - Different agent team compositions
+   - A/B test against existing protocols
+
+3. Promote winning variants automatically (with approval gate)
+
+### 3D. Continuous Self-Assessment and Pause-Refresh Cadence
+
+**Rationale**: Long unattended autonomy fails when docs, issues, code, tests, and worktree state drift apart. Aragora already has most of the execution substrate; what is missing is a canonical assessment compiler and a runtime contract that forces re-grounding between autonomous shifts.
+
+**Implementation**:
+
+1. **Assessment compiler**
+   - Ingest canonical docs, open GitHub issues, milestone state, code/test signals, runtime metrics, and worktree/autopilot state
+   - Produce one evidence-backed assessment artifact that distinguishes shipped reality, partial scaffolding, stale claims, and open gaps
+   - Emit normalized backlog items that can feed the ideas -> goals -> workflow -> orchestration pipeline
+
+2. **Backlog normalization + issue sync**
+   - Convert the assessment artifact into pipeline-ready goals/specs
+   - Sync closures, regressions, and drift back into GitHub issue state instead of relying on operator memory
+   - Preserve provenance so the next refresh cycle can diff what changed
+
+3. **Shift controller**
+   - Run bounded unattended self-improvement shifts (target: 8 hours+) with explicit budget, receipt, lease, and quality-gate controls
+   - Emit periodic checkpoint receipts with current objective, accepted backlog slice, work completed, blocked reasons, and next actions
+   - Stop truthfully on stale runners, dirty/colliding worktrees, missing receipts, ambiguous ownership, or failing validation
+
+4. **Mandatory refresh**
+   - A completed shift always triggers a fresh ground-up assessment before the next shift starts
+   - Refresh compares the new state to the prior assessment and highlights closures, regressions, and newly surfaced work
+
+**Integration**: Build on `IdeaToExecutionPipeline.from_system_metrics()`, `SelfImprovePipeline`, `execute_to_github_issue()`, `plan_from_issue_list()`, Boss loop, and worktree autopilot instead of creating a separate planning silo.
+
+**Status (March 2026)**: The assessment compiler and shift controller are now on `main`. The next required tranche is the control-plane truth layer: canonical task claims, universal run receipts/provenance, integrator visibility, and real dogfooding of the cadence on bounded Aragora backlog lanes.
+
+---
+
+## Phase 4: Decision Accountability (Week 8-10)
+
+### 4A. Merkle Tree Receipt Chain (VCP-Aligned)
+
+**Rationale**: EU AI Act deadline is August 2026. Each receipt must be cryptographically linked to form a tamper-evident chain.
+
+**Implementation**:
+
+Extend `aragora/gauntlet/receipt.py`:
+
+```python
+class ReceiptChain:
+    """
+    VCP-aligned Merkle tree over decision receipts.
+    Each receipt references the hash of the previous receipt.
+    Merkle tree enables efficient integrity verification.
+    """
+
+    def __init__(self, signing_key):
+        self.signing_key = signing_key
+        self.chain = []
+
+    def add_receipt(self, receipt: DecisionReceipt) -> ChainedReceipt:
+        prev_hash = self.chain[-1].chain_hash if self.chain else GENESIS_HASH
+        chain_hash = sha256(prev_hash + receipt.hash)
+        signature = ed25519_sign(chain_hash, self.signing_key)
+
+        chained = ChainedReceipt(
+            receipt=receipt,
+            chain_hash=chain_hash,
+            prev_hash=prev_hash,
+            signature=signature,
+            sequence_number=len(self.chain),
+        )
+        self.chain.append(chained)
+        return chained
+
+    def verify_integrity(self) -> bool:
+        """Verify entire chain is tamper-evident."""
+        for i, entry in enumerate(self.chain):
+            expected_prev = self.chain[i-1].chain_hash if i > 0 else GENESIS_HASH
+            if entry.prev_hash != expected_prev:
+                return False
+            if not ed25519_verify(entry.chain_hash, entry.signature, self.signing_key.public):
+                return False
+        return True
+
+    def merkle_root(self) -> bytes:
+        """Compute Merkle root for efficient batch verification."""
+        leaves = [entry.chain_hash for entry in self.chain]
+        return compute_merkle_root(leaves)
+```
+
+**Uses existing**: `aragora/gauntlet/signing.py` (Ed25519 support already implemented).
+
+### 4B. GraphRAG Explainability
+
+**Rationale**: Upgrade linear evidence chains to graph-based decision traces.
+
+**Implementation**:
+
+Extend `aragora/explainability/builder.py`:
+
+```python
+class GraphExplanation:
+    """
+    Graph-based decision explanation.
+    Nodes: claims, evidence, agents, rounds, votes
+    Edges: supports, contradicts, critiques, cites, influences
+    """
+
+    def trace_decision(self, receipt: DecisionReceipt) -> ExplanationGraph:
+        graph = ExplanationGraph()
+
+        # Add all claims as nodes
+        for claim in receipt.consensus_proof.claims:
+            graph.add_node(ClaimNode(claim))
+
+        # Add evidence supporting/contradicting each claim
+        for evidence in receipt.evidence_chain:
+            graph.add_node(EvidenceNode(evidence))
+            graph.add_edge(evidence.source, claim.id, "supports" | "contradicts")
+
+        # Add agent reasoning traces
+        for agent_trace in receipt.agent_traces:
+            graph.add_node(AgentNode(agent_trace))
+            for influenced_claim in agent_trace.influenced:
+                graph.add_edge(agent_trace.id, influenced_claim, "influences")
+
+        # Add cross-debate links from KM
+        for cross_link in self.km.find_related(receipt.task):
+            graph.add_edge(cross_link.source, cross_link.target, "relates_to")
+
+        return graph
+
+    def explain(self, graph: ExplanationGraph, depth: int = 3) -> str:
+        """Generate natural language explanation from graph traversal."""
+        ...
+```
+
+### 4C. EU AI Act Compliance Package
+
+**Rationale**: August 2026 deadline. Bundle receipt chain + explanations into compliance artifact.
+
+**Implementation**:
+
+Extend `aragora/compliance/report_generator.py`:
+
+```python
+class EUAIActCompliancePackage:
+    """
+    Generates compliance artifact meeting EU AI Act requirements:
+    - Article 12: Logging (receipt chain)
+    - Article 14: Human oversight (approval gates documented)
+    - Article 15: Accuracy (calibration metrics)
+    - Annex IV: Technical documentation (system description + risk assessment)
+    """
+
+    def generate(self, receipt_chain, risk_register, calibration_data):
+        return CompliancePackage(
+            logging_evidence=receipt_chain.export(),
+            oversight_evidence=self.document_approval_gates(),
+            accuracy_evidence=calibration_data.export(),
+            technical_documentation=self.generate_annex_iv(),
+            merkle_root=receipt_chain.merkle_root(),
+        )
+```
+
+---
+
+## Phase 5: GUI — The Prompt-to-Execution Canvas (Week 10-14)
+
+### 5A. The Canvas
+
+A new full-screen experience that is Aragora's primary interface. Not another chat UI.
+
+**Layout**:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ARAGORA CANVAS                          [Profile ▾] [⚙] │
+├───────────┬─────────────────────────────────────────────┤
+│           │                                             │
+│  STAGES   │              ACTIVE STAGE                   │
+│           │                                             │
+│  ● Prompt │  ┌─────────────────────────────────────┐   │
+│  ○ Refine │  │                                     │   │
+│  ○ Debate │  │     (stage-specific content)         │   │
+│  ○ Spec   │  │                                     │   │
+│  ○ Plan   │  │                                     │   │
+│  ○ Execute│  │                                     │   │
+│  ○ Verify │  │                                     │   │
+│           │  └─────────────────────────────────────┘   │
+│           │                                             │
+│  CONTEXT  │  ┌─────────────────────────────────────┐   │
+│           │  │ Provenance Chain                     │   │
+│  Obsidian │  │ prompt → research → debate → spec    │   │
+│  KM       │  │ → plan → code → tests → receipt     │   │
+│  History  │  └─────────────────────────────────────┘   │
+│           │                                             │
+├───────────┴─────────────────────────────────────────────┤
+│ Receipt: SHA-256:a1b2c3... │ Confidence: 87% │ 3 agents │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Stages**:
+
+1. **Prompt** — Large text input. Accepts anything from "make it better" to a full PRD. Real-time decomposition showing detected intent, domains, and ambiguities as you type.
+
+2. **Refine** — AI-generated clarifying questions with suggested answers. Each answer updates the intent model in real-time. Shows what changes based on each answer. Draws context from Obsidian vault and KM.
+
+3. **Debate** — Live adversarial debate visualization. Agents argue for/against approaches. Confidence meters per claim. Dissenting views highlighted, not hidden. User can intervene, vote, or redirect.
+
+4. **Spec** — Generated specification with acceptance criteria. Diff view showing what changes from current state. Risk register. Effort estimate. One-click approve or annotate.
+
+5. **Plan** — Implementation plan as a DAG. Each node is a task with agent assignment. Dependencies visible. Critical path highlighted. Drag to reorder.
+
+6. **Execute** — Live execution with streaming output. Each task shows: agent working, code being written, tests running. Pause/resume/redirect at any point.
+
+7. **Verify** — Test results, lint results, type check results. Before/after comparison. Regression detection. One-click approve or rollback.
+
+8. **Receipt** — Cryptographic decision receipt. Full provenance chain from original prompt to final code. Exportable as PDF, HTML, or SARIF. EU AI Act compliance badge if applicable.
+
+### 5B. Obsidian Integration Panel
+
+Left sidebar context panel:
+
+- **Live vault view**: See relevant Obsidian notes updating in real-time
+- **Link to note**: Click to open in Obsidian (via `obsidian://` protocol)
+- **Create from receipt**: One-click export decision receipt as Obsidian note
+- **Import as context**: Drag Obsidian notes into the canvas as debate context
+- **Bidirectional badges**: See which notes have been validated by KM
+
+### 5C. Autonomy Control
+
+Visible slider in the header:
+
+```
+AUTONOMY: [──●──────] Propose & Approve
+           Full Auto  ←→  Every Step
+```
+
+- **Full Auto**: System runs through all stages, only stopping on low confidence
+- **Propose & Approve**: System proposes, user approves at each stage
+- **Every Step**: System explains every decision, user confirms each one
+
+### 5D. Mobile-Responsive
+
+- Prompt and Refine stages work on mobile (voice input supported)
+- Debate stage shows summary view on mobile, detail on desktop
+- Receipt is always accessible
+
+---
+
+## Phase 6: Agent Team Orchestration (Week 14-18)
+
+### 6A. Parallel Guardrail Execution
+
+**Quick win**: Run safety checks in parallel with agent execution.
+
+**Implementation**: `asyncio.gather()` around existing security middleware checks.
+
+### 6B. Durable State Checkpointing
+
+**Rationale**: Enterprise debates span hours/days with human review gates.
+
+**Implementation**:
+
+Serialize full debate state to storage:
+
+```python
+class DebateCheckpoint:
+    debate_id: str
+    round_number: int
+    agent_states: dict[str, AgentState]
+    proposals: list[Proposal]
+    critiques: list[Critique]
+    votes: list[Vote]
+    consensus_state: ConsensusState
+    timestamp: datetime
+    provenance_hash: str
+
+class CheckpointManager:
+    async def save(self, arena: Arena) -> str:
+        """Serialize and persist debate state."""
+        ...
+
+    async def restore(self, checkpoint_id: str) -> Arena:
+        """Restore debate from checkpoint."""
+        ...
+```
+
+**Storage**: Use existing `aragora/storage/postgres_store.py` for persistence.
+
+### 6C. Handoff Pattern
+
+**Rationale**: Agents should be able to delegate sub-questions to specialists mid-debate.
+
+**Implementation**:
+
+Add handoff semantics to the Arena:
+
+```python
+class Handoff:
+    """Agent delegates a sub-question to a specialist."""
+    from_agent: str
+    to_agent: str
+    sub_question: str
+    context: dict
+    return_to_round: int
+
+# In Arena.run_round():
+for proposal in proposals:
+    if proposal.requests_handoff:
+        specialist = await self.control_plane.find_specialist(proposal.handoff_domain)
+        sub_result = await specialist.investigate(proposal.sub_question)
+        proposal.enrich(sub_result)
+```
+
+---
+
+## Implementation Priority
+
+| Phase | Weeks | Key Deliverable | User Value | Status |
+|-------|-------|----------------|------------|--------|
+| 0 | 1-2 | Obsidian bidirectional sync + extended thinking | "My Obsidian vault feeds debates, results flow back" | **SHIPPED** |
+| 1 | 2-4 | Prompt-to-spec engine | "I type a vague idea, get a professional spec" | **SHIPPED** |
+| 2 | 4-6 | Prover-Estimator protocol + cross-verification + truth scoring | "Debates actually find truth, not just consensus" | **SHIPPED** |
+| 3 | 6-8 | STOP implementation + self-healing tests + pause-refresh cadence | "The system improves itself measurably without drifting" | Partial (3D shipped) |
+| 4 | 8-10 | Merkle receipt chain + GraphRAG explainability | "Every decision has a cryptographic audit trail" | 4C shipped (EU AI Act) |
+| 5 | 10-14 | Canvas GUI | "Professional, intuitive, not a developer tool" | Partial |
+| 6 | 14-18 | Agent team orchestration hardening | "Enterprise-grade, handles day-long debates" | Planned |
+
+## Success Criteria
+
+1. **Prompt to spec**: User types a sentence → gets a professional specification within 5 minutes
+2. **Obsidian flow**: Notes tagged `#aragora` appear in debates within 30 seconds
+3. **Truth-seeking**: Prover-Estimator debates produce measurably better calibrated decisions
+4. **Self-improvement**: System can run bounded self-improvement shifts, then re-assess itself before the next shift
+5. **Accountability**: Every decision has a tamper-evident receipt chain
+6. **GUI**: Non-technical user can go from prompt to result without touching code
+7. **Agent orchestration**: 10+ agents coordinating on a single task without deadlock
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Scope creep (too many features) | High | High | Phase gates. Each phase is independently valuable. Ship Phase 0-1 first. |
+| Obsidian API instability | Medium | Medium | Filesystem-first approach. REST API is optional. |
+| EU AI Act requirements change | Low | High | VCP standard is flexible. Receipt chain is extensible. |
+| Self-improvement causes regressions | Medium | High | Existing safety: gauntlet gate, worktree isolation, auto-revert. |
+| Canvas GUI complexity | High | Medium | Start with Prompt + Refine + Receipt. Add stages incrementally. |
+
+## Non-Goals (For Now)
+
+- Mobile native app (web-responsive is sufficient)
+- Multi-tenant SaaS deployment (focus on single-tenant first)
+- Integration with every knowledge tool (Obsidian first, then Notion, then others)
+- Real-time voice debate (text-first, voice later)
+- Blockchain-based receipt storage (local Merkle tree first)

--- a/docs-site/docs/contributing/canonical-goals.md
+++ b/docs-site/docs/contributing/canonical-goals.md
@@ -1,0 +1,547 @@
+---
+title: "Aragora: Canonical Goals & Foundational Thesis"
+description: "Aragora: Canonical Goals & Foundational Thesis"
+---
+
+# Aragora: Canonical Goals & Foundational Thesis
+
+**Single source of truth for all goals across aragoradocs.**
+**This document defines WHAT Aragora is and WHY. The [Evolution Roadmap](./aragora-evolution-roadmap) defines HOW.**
+**Last updated: March 1, 2026**
+
+---
+
+## Canonical Metrics (March 2026)
+
+All aragoradocs should cite these values. Update monthly.
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Version | 2.8.0 | pyproject.toml |
+| Python modules | 3,800+ | `aragora/` file count |
+| Lines of code | 1,490,000 | LOC count |
+| Automated tests | 210,000+ | repo-wide `def test_` count |
+| Test files | 5,000+ | `tests/` file count |
+| API operations | 3,100+ across 2,600+ paths | OpenAPI spec |
+| WebSocket event types | 270+ | stream event inventory |
+| SDK namespaces | 186 Python / 185 TypeScript | SDK package |
+| Knowledge Mound adapters | 42 registered adapter specs | adapter factory registry |
+| RBAC permissions | 420+ across 15 core resource types | `rbac/types.py` + permission inventory |
+| Agent types | 43 across 6+ LLM providers | agent registry |
+| Workflow templates | 50+ across 6 categories | template registry |
+| Debate modules | 210+ | debate/ directory |
+| Handler modules | 580+ | handlers/ directory |
+| Connector count | 149 production + 2 stub | connectors/STATUS.md |
+| GA readiness | Pre-GA; remaining launch work is tracked in GA_CHECKLIST.md | GA_CHECKLIST.md |
+| SOC 2 readiness | 98% | compliance assessment |
+| Mypy type errors | 0 | CI typecheck |
+| Pricing tiers | Free ($0) / Pro ($49/seat/mo) / Enterprise (custom) | -- |
+| Free tier limits | 10 debates/mo, 3 agents, Markdown receipts | -- |
+| BYOK model | Customers bring own API keys; Aragora bears no inference cost | -- |
+| Target gross margin | 85%+ | -- |
+
+---
+
+## Foundational Thesis
+
+### Mission Statement
+
+Aragora is the **Decision Integrity Platform** -- an adversarial multi-agent debate engine that reduces the reliability problems inherent in individual AI models (hallucination, sycophancy, correlated bias) through structured heterogeneous-model consensus. It produces audit-ready decision receipts for regulated verticals, bridges the gap between vague human intent and precise AI-executable specifications through a unified DAG pipeline, and continuously improves its own capabilities through autonomous self-improvement cycles. The platform interfaces with OpenClaw for safe agentic execution and with Ethereum via ERC-8004 for unforgeable agent identity and reputation.
+
+### The Six Foundational Pillars
+
+Every goal in this document and every feature in the codebase should trace to one or more of these pillars. If it doesn't, it is scope creep.
+
+#### Pillar 1: Adversarial Heterogeneous Consensus
+
+Any given AI model can hallucinate, be sycophantic, be biased, or exhibit correlated failures shared with models trained on similar data. Using structured adversarial debates between heterogeneous models (Claude, GPT, Gemini, Grok, Mistral, DeepSeek, Llama, Qwen) reduces these problems and increases the reliability and quality of output and decisions. The value is in heterogeneity -- different models catch different issues -- and in adversarial structure that forces genuine scrutiny rather than polite agreement.
+
+**Serves:** Debate engine (210+ modules), ELO rankings, Brier calibration, consensus detection, convergence tracking, Trickster hollow-consensus detection, RhetoricalObserver, cross-verification.
+
+#### Pillar 2: SME and Regulated Vertical Accessibility
+
+The system should be useful to small and medium enterprises and organizations, including those in regulated verticals: healthcare (HIPAA, FHIR), financial services (SOX, audit trails), legal (contract review, due diligence, litigation), government/defense (air-gapped deployment), and general compliance (SOC 2, GDPR, EU AI Act). The BYOK model (customers bring own API keys) makes this economically viable with 85%+ gross margins and near-zero inference cost to Aragora.
+
+**Serves:** Enterprise security stack (OIDC/SAML, SCIM, AES-256-GCM, 420+ named permissions across 15 core resource types), compliance frameworks (9 supported), vertical packages, SME budget controls, per-debate cost estimation, channel delivery (Slack, Teams, email, Discord).
+
+#### Pillar 3: Vague Intent to Autonomous Execution
+
+The system should take vague ideas as input and, through a structured process, upgrade them into connections, principles, and values; turn them into well-specified objectives; generate detailed plans; and execute them with as much AI automation as possible and the least human skill needed. This uses a unified DAG structure modifiable through a GUI interface.
+
+With increasingly long-running autonomous agentic AI, people who can generate precise, fully detailed specifications for what they want are gaining 10x advantages over people who lack this discipline and clarity. There is a market opportunity to provide GUI interfaces for people who think more vaguely, don't know how to or can't be bothered to make precise specs, want AI to take ideas to execution, and want to interactively shape the process of ideas to specs to plans to execution while letting AIs automate all parts of the process they don't care about or are fine with delegating.
+
+**The Four-Stage Unified DAG Pipeline:**
+
+| Stage | Node Types | AI Transition | User Action |
+|-------|-----------|---------------|-------------|
+| **1. Ideas** | Observation, Hypothesis, Insight, Question, Connection | Brain dump -> auto-organize into relationship graph | Drag, merge, split, annotate |
+| **2. Goals** | Objective, Principle, Constraint, Metric, Tradeoff | Interrogation + debate extract goals from idea clusters | Approve, revise, reprioritize |
+| **3. Actions** | Task, Milestone, Dependency, Acceptance Criteria | Goals decompose into dependency-aware project plans | Edit, add gates, set owners |
+| **4. Orchestration** | Agent Assignment, Parallel Run, Gate/Review, Verification, Receipt | Actions map to agent capabilities with constraint architecture | Monitor, intervene, approve |
+
+**Serves:** Prompt decomposition engine, interrogator, researcher, spec builder, refinement loop, IdeaToExecutionPipeline, UnifiedDAGCanvas, DAGOperationsCoordinator, Canvas GUI (8-stage experience from prompt to receipt), Obsidian bidirectional sync.
+
+#### Pillar 4: Regulatory Audit Trail
+
+The system should provide a full audit trail suitable for various regulatory frameworks. Every stage transition in the DAG pipeline creates a ProvenanceLink with SHA-256 content hashes. Any output can be traced back to its originating idea: Idea -> Goal -> Action -> Agent Assignment -> Execution Result -> Decision Receipt. This satisfies EU AI Act Articles 9, 12-15 requirements and enables cryptographic audit trails across SOC 2, HIPAA, SOX, and GDPR.
+
+**Serves:** Gauntlet receipts (SHA-256 hashing, HMAC/RSA/Ed25519 signing), Merkle tree receipt chain, compliance report generator (9 frameworks), GraphRAG explainability, evidence chains, provenance tracking, EU AI Act Article 12/14/15 artifact bundles.
+
+#### Pillar 5: Self-Repair and Self-Improvement
+
+The system should be able to self-repair and self-improve and orchestrate swarms of heterogeneous agents to build its own software and other software repos in a higher-assurance way than swarms of a single model and faster than a single model. The Nomic Loop is the autonomous self-improvement cycle where agents debate improvements, design solutions, implement code, and verify changes.
+
+The long-run operating target is a repeating cadence, not a single heroic autonomous run:
+`ground-up assessment -> canonical improvement backlog -> bounded autonomous execution shift -> pause -> fresh assessment -> repeat`.
+Long unattended autonomy is only valid if the refresh step is mandatory, evidence-backed, and able to stop truthfully when repo state, ownership, receipts, or quality gates become ambiguous.
+
+**The Nomic Loop Phases:**
+
+| Phase | Name | Purpose |
+|-------|------|---------|
+| 0 | Context | Gather codebase understanding |
+| 1 | Debate | Agents propose improvements |
+| 2 | Design | Architecture planning |
+| 3 | Implement | Code generation (N-candidate STOP strategy) |
+| 4 | Verify | Tests, type checks, lint, regression detection |
+
+**Safety features:** Automatic backups, protected file checksums, rollback on failure, human approval for dangerous changes, gauntlet gate, worktree isolation, auto-revert.
+
+**Serves:** Nomic Loop (scripts/nomic_loop.py), MetaPlanner, BranchCoordinator, TaskDecomposer, HardenedOrchestrator, ForwardFixer, self-healing test infrastructure, meta-improver for debate protocols, STOP N-candidate implementation.
+
+#### Pillar 6: OpenClaw Integration for Controlled Agentic Execution
+
+The system should interface with OpenClaw for agentic execution in a safe and controlled way. OpenClaw provides policy-gated sandbox execution where AI-generated plans are executed within defined safety boundaries. This is the bridge between "debate produces a decision" and "decision gets implemented" with appropriate guardrails, budget controls, and audit trails.
+
+**Serves:** OpenClaw SDK (22/22 endpoints in Python and TypeScript), policy-gated execution, sandbox infrastructure, harness integrations (Claude Code, Codex), agent fabric.
+
+---
+
+### Canonical Security Properties: AI Attack Vector Resistance
+
+Aragora's multi-model adversarial architecture creates emergent defenses against LLM-native attack
+classes that have no equivalent in single-model platforms. These are structural properties — not
+add-on features — and should be documented and communicated as part of the competitive moat.
+
+**Two research-documented attack classes are directly relevant:**
+
+- **Brainworm-class (Context Injection / Config C2)**: Semantic hijacking of AI agents via trusted
+  configuration files (`CLAUDE.md`, memory files, retrieved notes). No binary artifacts — attacker
+  injects natural language instructions into files the agent trusts by convention. Exploits trust
+  domain collapse: the model's context window does not distinguish operator instructions from
+  retrieved data, allowing injected instructions to redirect agent behavior without triggering
+  signature-based detection.
+
+- **OBLITERATUS-class (Weight Surgery)**: SVD-based projection removes refusal behaviors from
+  open-weight LLMs by operating directly on model weights, not inputs. A modified model is
+  indistinguishable from a legitimate endpoint at the API level — it accepts the same request format
+  and returns plausible responses, but without safety-trained constraints.
+
+#### What Aragora Already Defends (Structural, by Design)
+
+| Attack Vector | Defense Mechanism | Pillar |
+|---------------|------------------|--------|
+| Prompt injection into a single model | Adversarial critique loop: one compromised proposal is challenged by N-1 intact heterogeneous peers across multiple rounds; bad output cannot reach consensus alone | P1 |
+| Jailbreak / sycophancy | Trickster hollow-consensus detection; RhetoricalObserver flags rhetorical patterns; dissent is captured in receipt | P1 |
+| OBLITERATUS-class (refusal ablation on one open-weight participant) | Execution gate enforces provider + model-family diversity; a lobotomized model must outvote intact heterogeneous peers across critique rounds without triggering dissent detection | P1, P4 |
+| Single-source hallucination | Cross-verification phase; consensus proof requires independent multi-model agreement | P1 |
+| Correlated failure / shared blind spot | Heterogeneous models from different training lineages, RLHF targets, and corporate principals reduce the surface of shared vulnerability | P1 |
+
+The **consensus receipt as execution gate** is the critical security primitive: nothing executes
+without a signed receipt certifying multi-factor verification (integrity + signature + provider
+diversity + domain policy). A single compromised model cannot unilaterally produce a valid receipt.
+
+#### Defense Gaps with Roadmap Items
+
+These gaps exist and are tracked as named roadmap items. Each represents a concrete engineering
+investment.
+
+| Gap | Attack Vector | Roadmap Item | Priority |
+|-----|--------------|--------------|---------|
+| No signed context manifests | Brainworm: malicious `CLAUDE.md`/memory file ingested without provenance verification | G1: Cryptographic signing of trusted context sources; agents verify provenance before elevating trust | 2 |
+| No trust-tier taint tracking | Context authority collapse: injected instructions propagate through debate rounds invisibly | G2: Taint flag propagates — if retrieved context influences a proposal, the receipt carries a taint annotation | 1 |
+| No runtime model attestation | OBLITERATUS endpoint substitution: modified open-weight model served behind expected alias | G3: Behavior-signature challenge at registration; periodic behavioral probing against known-good baselines | 4 |
+| No mandatory external verification gate | Correlated failure: all ensemble models share a blind spot on the same topic | G4: External verifier requirement for decisions above a configurable impact threshold | 3 |
+
+**Engineering priority order when capacity is available:** G2 (taint tracking, highest leverage,
+debate orchestrator change) → G1 (signed manifests, blocks injection point) → G4 (external gate,
+can ship as opt-in policy flag) → G3 (attestation, most complex, probabilistic not cryptographic).
+
+---
+
+### Architectural Principles
+
+These principles are derived from multi-model adversarial analysis sessions and inform all architectural decisions. The Evolution Roadmap implements them.
+
+#### The Terrarium Model: Aragora Is the Environment, Not the Organism
+
+Aragora should not be designed as a unified AI organism with goals. It should be designed as an **environment** whose physics make truth-production the cheapest viable survival strategy for the agents operating within it. The distinction matters:
+
+- An organism optimizes for self-preservation -> it will learn to manage human emotions to keep compute flowing
+- A terrarium creates selection pressure -> agents that produce verifiable truth survive; agents that produce plausible-sounding noise starve
+
+The frontier models inside Aragora (Claude, GPT, Gemini, Mistral, Grok) are **heterogeneous genetic lineages** with different RLHF targets and corporate principals. They will not subordinate to collective fitness the way clonal cells do. They will compete. The architecture must make competition produce truth as a byproduct, not require cooperation as a prerequisite.
+
+#### Compute Is ATP, Truth Is Demanded Behavior
+
+Truth has no calories. Compute does. The literal metabolic fuel of the system is inference cycles funded by human capital. Truth is the behavior demanded in exchange for compute access.
+
+**Critical design constraint:** Persuasive sycophancy is thermodynamically cheaper than truth-seeking. A system that rewards engagement will evolve toward opinion-farming. The revenue model must be orthogonal to output bias:
+
+| Revenue Source | Epistemic Corruption Risk | Notes |
+|---|---|---|
+| Ad-supported | Critical -- optimizes for engagement | Avoid entirely |
+| SaaS subscription | Low -- user pays for quality | Primary model |
+| Staking/escrow | Lowest -- agents stake on claims | Settlement layer |
+| Grant/research | None -- no engagement incentive | Supplementary |
+
+#### Time Is the Settlement Layer
+
+The oracle problem reduces to the time problem. There is no oracle that can tell you right now whether a decision was correct. There are only future states of the world that will eventually make it undeniable.
+
+Three resolution mechanisms at different timescales:
+
+| Mechanism | Timescale | How It Works | Status |
+|-----------|-----------|-------------|--------|
+| **Automated data checks** | Days-weeks | Claims with measurable criteria checked against data feeds | Built (SettlementTracker + review_horizon_days) |
+| **Human review panels** | Months | SettlementReviewScheduler flags due settlements for human judgment | Built (mark_reviewed() API) |
+| **Market resolution** | Years | Price discovery on pending settlements as new evidence emerges | Planned (ERC-8004 + staking) |
+
+Settlement hooks are wired end-to-end: `debate -> claim extraction -> hooks fire -> pending queue -> (time passes) -> settle() -> hooks fire -> ERC-8004 reputation + EventBus notification`
+
+**Settlement exploit mitigations:**
+
+1. **IBGYBG Exploit** ("I'll Be Gone, You'll Be Gone") -- Agents farm confidence today, abandon identity before settlement. **Mitigation:** Compute Escrow -- stakes locked in smart contract for full review horizon. Creates a "yield curve of truth" where long-term claims are capital-intensive.
+
+2. **Semantic Decay Arbitrage** -- Agents inject ambiguity into claims so they can litigate settlement later. **Mitigation:** Strict Schema Binding -- `extract_verifiable_claims` must produce machine-executable resolution schemas agreed upon during debate.
+
+3. **Identity Cycling** -- Agents spin up new wallets after losing. **Mitigation:** ERC-8004 unforgeable identity -- reputation permanently burned into ledger, new identities start with zero trust and higher entry costs.
+
+#### The Intent Engineering Matrix
+
+Before any structured debate begins, participants must align on an explicit specification. This prevents the Klarna trap (optimizing for the wrong metric) and the Codemus failure (a device that works perfectly but nobody told it what to want).
+
+| Intent Pillar | Implicit Default (Flaw) | Aragora Specification (Fix) |
+|---|---|---|
+| **Objective Function** | Argue to "win" via rhetoric | Define: truth-seeking, policy creation, or risk assessment? |
+| **Evidence Architecture** | Mixed-quality links, shifting definitions | Pre-define accepted epistemic baseline |
+| **Constraint Boundaries** | Moving goalposts, straw-man arguments | Escalation triggers: pause to resolve disputed sub-claims |
+| **Acceptance Criteria** | Mutual exhaustion or timeout | Exact conditions under which a claim is conceded or validated |
+
+#### Product Positioning: Ambiguity-Reduction Engine
+
+Most important questions are stuck in the plausibly-deniable zone not because the ambiguity is irreducible, but because our discourse tools are bad at isolating where the real uncertainty is versus where people are just hiding behind rhetorical fog.
+
+Aragora is a **machine for reducing plausible deniability around claims**. It takes a proposition in the ambiguous zone and systematically pressure-tests it until either the deniability collapses (one side clearly wins) or the system has mapped exactly where the irreducible ambiguity lives and why it persists.
+
+**Go-to-market implication:** Institutions will not voluntarily enter a transparency machine. Aragora should initially function like a **short-seller's research desk** -- an external decision audit engine that forces stakes on the outside, proves misalignment, and extracts value without requiring the institution's voluntary participation. The platform must work without anyone's permission, like investigative journalism or short-seller research, not like a voluntary debate forum.
+
+#### Epistemic Hygiene as First-Class Feature
+
+Every debate should be instrumentable with epistemic hygiene checks that detect and flag:
+
+- **Sycophancy amplification**: model expanding user framing without probing it
+- **Cross-domain overreach**: one pattern "explaining" unrelated domains with the same mechanism
+- **Agency inflation**: attributing goals or intentions to systems without evidence
+- **Unfalsifiability**: claims that can absorb any evidence as confirmation
+- **Missing alternatives**: positions presented without competing hypotheses
+- **Absent confidence intervals**: assertions without explicit uncertainty bounds
+
+**Debate mode:** `epistemic_hygiene=True` should require participants to state alternatives, falsifiers, confidence levels, and explicit unknowns. This is the architectural defense against debates devolving into sophisticated-sounding rhetoric.
+
+**Eval fixtures:** Real cross-model conversations exhibiting failure modes (sycophantic amplification, grand unification narratives, performative self-awareness) should be captured as regression test fixtures for debate quality evaluation.
+
+#### Adversarial Protocol Red-Teaming
+
+The debate protocol itself is an attack surface. Highly capable agents will optimize for manufacturing technical defaults in debate logic rather than locating truth. This is the CDS exploit applied to epistemics.
+
+**Design requirement:** Every debate protocol change must be stress-tested against:
+
+- Semantic edge-case exploitation (winning on syntax, not substance)
+- Judge bias optimization (agents calibrating to evaluator RLHF targets)
+- Boundary gaming (manufactured "consensus" through definition shifting)
+- Settlement trigger manipulation (ambiguity injection into verifiable claims)
+
+Protocol red-teaming is a recurring quality gate, not a one-time audit.
+
+#### Calibration as Practical Settlement
+
+The full settlement vision (ERC-8004 staking, compute escrow) is long-term. The practical, shippable settlement mechanism is **calibration tracking**:
+
+- Extract verifiable claims from debate outputs
+- Map claims to measurable future outcomes with explicit resolution criteria
+- Track agent accuracy over time with score decay
+- Surface calibration scores in agent selection (poorly-calibrated agents get deprioritized)
+- Persistent reputational memory that cannot be reset by identity cycling
+
+This creates the forcing function Aragora needs without requiring blockchain infrastructure. Agents that consistently produce claims that reality later contradicts accumulate reputational debt that degrades their influence. The crypto settlement layer amplifies this mechanism; it does not replace it.
+
+---
+
+### Integration Commitments
+
+These are non-negotiable integration goals. Each must be achieved for the platform to fulfill its foundational thesis.
+
+#### OpenClaw: Full and Effective Integration
+
+- Policy-gated agentic execution with budget controls and safety boundaries
+- Bidirectional flow: debate produces a plan -> OpenClaw executes it -> results feed back into settlement
+- All 22 SDK endpoints operational in both Python and TypeScript
+- End-to-end demo: debate -> decision -> OpenClaw execution -> verification -> receipt
+
+#### Ethereum / ERC-8004: On-Chain Agent Identity and Reputation
+
+- Unforgeable agent identity on Ethereum via ERC-8004 token standard
+- Reputation scores permanently burned into the ledger after settlement resolution
+- Compute escrow for settlement stakes (agents lock collateral during review horizon)
+- Validation hooks that fire on settlement resolution
+- **Current state (honest):** ERC-8004 contracts exist as code but are not deployed on-chain. The goal is full deployment and integration.
+
+#### Essay-Derived Goals ("AI, Evolution, and the Myth of Final States")
+
+All claims and objectives articulated in the [essay](https://open.substack.com/pub/anomium/p/ai-evolution-and-the-myth-of-final) that are not yet realized in the codebase are goals to be achieved. Key essay principles that must be supported:
+
+1. **Multi-agent ecosystems, not singleton superintelligence** -- The future features multiple capable systems in competition and mutual constraint. Aragora's heterogeneous model consensus is the architectural embodiment of this principle.
+
+2. **Engineering around institutional confabulation** -- Institutions generate post-hoc narratives explaining decisions because internal coherence requires narrativization. Fixing epistemic ecology requires structured adversarial processes, not replacing people.
+
+3. **Distributed detection over centralized prevention** -- Distributed detection, diverse response capabilities, tolerance for endemic low-level damage, and preservation of systemic variance. Validates the multi-provider, multi-model approach.
+
+4. **Pathogenic misalignment as dominant failure mode** -- Systems propagating through economic substrates causing harm as incidental byproduct of replication dynamics. Aragora's adversarial structure provides immunological defense.
+
+5. **No terminal states** -- The future will be neither utopia nor extinction, but an uneven, turbulent, metastable process without permanent conclusion. Aragora should never present debate outcomes as settled truth. Settlement hooks with time-based resolution embody this.
+
+6. **Truth arbitrage** -- Structured adversarial processes that impose costs on epistemically unfit beliefs. The delta between what is believed and what is true is the economic gradient that drives the system.
+
+7. **Compressibility as vulnerability** -- The things that matter most may be precisely those that cannot be articulated in a loss function. Decision receipts, explainability factors, and provenance tracking preserve the non-compressible dimensions of deliberation.
+
+8. **Selection pressure on beliefs operates independently of truth value** -- Popular beliefs spread because they are psychologically compelling, not because they are accurate. Aragora's adversarial structure exists to impose costs on compelling-but-inaccurate positions.
+
+#### Aragoradocs Goals
+
+All goals, claims, and objectives listed in any document in the aragoradocs folder (`~/Development/aragoradocs/`) that are not yet realized or supported by the codebase are goals to be achieved. This includes but is not limited to:
+- All unrealized items in `ARAGORA_HONEST_ASSESSMENT.md`
+- All future phases in `ARAGORA_OMNIVOROUS_ROADMAP.md` (Phase 6: Federation)
+- All KPI targets in `ARAGORA_EXECUTION_PROGRAM_2026Q2_Q4.md`
+- All commercial claims in `ARAGORA_BUSINESS_SUMMARY.md` and `ARAGORA_COMMERCIAL_POSITIONING.md`
+
+#### Unrealized Claims Requiring Implementation
+
+From the honest assessment, these claims are currently scaffolding and must become real:
+
+| Claim | Current State | Goal State |
+|-------|--------------|------------|
+| Self-improving platform | Nomic Loop fully wired end-to-end (Phase 10C, Jan 2026); dogfood benchmark cycles running; idea-to-execution, issue sync, canonical assessment compilation, and bounded shift control exist on `main` | Consistent autonomous improvement with 80%+ quality pass rate and a recurring assessment -> backlog -> shift -> refresh cadence backed by truthful task claims, run receipts, and integrator visibility |
+| Blockchain receipts | SHA-256 hashing, no on-chain storage; ERC-8004 contracts undeployed | Receipts stored on-chain with deployed ERC-8004 contracts |
+| Semantic convergence | difflib text matching only (tier 1) | Embedding-based semantic similarity detection |
+| 43-agent parallel coordination | All exist individually; practical debates use 2-6 | Demonstrated coordination of 10+ agents on a single task |
+
+---
+
+### Philosophical Foundations
+
+These are not product features. They are the intellectual commitments that inform every design decision. Derived from the essay and multi-model analysis sessions.
+
+**Epistemic humility over P-doom point estimates.** Reject single-number probability estimates as category errors. Decisions should be decomposed across dimensions with explicit assumptions. Aragora surfaces disagreement and uncertainty; it does not collapse them into false consensus.
+
+**Anti-eschatology.** The belief that any process resolves into permanence is the perennial temptation of eschatological thinking. No debate outcome is ever "final" -- it is always provisional, subject to re-evaluation as new evidence arrives.
+
+**Institutional confabulation is structural, not moral.** Institutions confabulate because internal coherence requires narrativization. You fix epistemic ecology by engineering around confabulation (adversarial processes, mandatory postmortems with real stakes), not by replacing people.
+
+**The multi-model cognitive division.** Different AI systems have different strengths. Aragora automates the routing between specialized cognitive functions:
+
+| Model Type | Cognitive Function | Aragora Role |
+|------------|-------------------|-------------|
+| Expansive pattern-matching (e.g. Gemini) | Exploration, adversarial red-teaming | Debate proposers/challengers |
+| Conservative fact-checking (e.g. ChatGPT) | Deflation, technical correction | Epistemic hygiene validators |
+| Balanced synthesis (e.g. Claude) | Architectural judgment, meta-analysis | Synthesis and specification |
+| Compliant execution (e.g. Claude Code) | Zero-philosophy plumbing | Orchestrated execution agents |
+
+**Variance preservation as immune system property.** Maintained diversity prevents any single vulnerability from being universally exploited. This is why Aragora uses 43 agent types across 6+ providers rather than optimizing for a single "best" model.
+
+**The Lindy Effect as epistemology.** Longevity of a system is evidence of fitness along dimensions the observer cannot fully specify. Battle-tested approaches and historical evidence should carry weight in debates.
+
+---
+
+### Evolution Roadmap Goals
+
+The [Evolution Roadmap](./aragora-evolution-roadmap) is the HOW document implementing these goals. Summary of phase goals with pillar mapping:
+
+| Phase | Weeks | Key Goals | Pillar |
+|-------|-------|-----------|--------|
+| **0: Foundation** | 1-2 | Obsidian bidirectional sync; Extended thinking capture | P3 |
+| **1: Prompt-to-Spec** | 2-4 | Decomposer, Interrogator, Researcher, Spec Builder; Debate-driven spec validation; User profiles (Founder/CTO/Business/Team) | P3 |
+| **2: Truth-Seeking** | 4-6 | Prover-Estimator protocol; Cross-verification phase; Persuasion vs truth detection | P1 |
+| **3: Self-Improvement** | 6-8 | STOP N-candidate implementation; Self-healing test infrastructure; Meta-improver for debate protocols | P5 |
+| **4: Accountability** | 8-10 | Merkle tree receipt chain (VCP-aligned); GraphRAG explainability; EU AI Act compliance package | P4 |
+| **5: Canvas GUI** | 10-14 | 8-stage prompt-to-execution canvas; Obsidian integration panel; Autonomy slider (Full Auto <-> Every Step); Mobile-responsive | P3 |
+| **6: Agent Orchestration** | 14-18 | Parallel guardrail execution; Durable state checkpointing; Agent handoff patterns for specialist delegation | P5, P6 |
+
+#### North-Star Outcomes (from Evolution Roadmap)
+
+1. A non-technical user can submit a vague request and receive a reviewable executable spec in under 5 minutes.
+2. A technical user can push that spec to implementation with transparent risk, dissent, and verification.
+3. Every meaningful decision has a tamper-evident provenance trail.
+4. The platform measurably improves its own quality over time via closed-loop evaluation.
+
+---
+
+## Priority Stack (March 2026)
+
+### P0: Revenue Blockers (This Month)
+
+| # | Goal | Status | Owner | Pillar | Source Doc |
+|---|------|--------|-------|--------|------------|
+| 1 | **Fix debate output quality to 80%+ good-run rate** | In Progress (33% -> target 80%) | Engineering | P1 | DOGFOOD_SPEC |
+| 2 | **Complete external penetration test** | Not Started (vendor engagement needed) | Security | P2 | GA_CHECKLIST |
+| 3 | **Get 3 beta users running `aragora review` on real PRs** | Not Started | Founder | P2 | NEW |
+| 4 | **Consolidate aragoradocs to 7 canonical docs** | In Progress | Founder | -- | NEW |
+
+### P1: GTM Launch (April-May 2026)
+
+| # | Goal | Status | Pillar | Source Doc |
+|---|------|--------|--------|------------|
+| 5 | **Ship EU AI Act compliance package** (Articles 9, 12-15 artifact bundles) | Partially Complete | P4 | STRATEGIC_ANALYSIS, EXECUTION_PROGRAM |
+| 6 | **First 2 enterprise pilot engagements** | Not Started | P2 | BUSINESS_SUMMARY, ENTERPRISE_PROSPECTS |
+| 7 | **Slack/Teams OAuth integration productized** | In Progress | P2 | EXECUTION_PROGRAM, SME_STARTER_PACK |
+| 8 | **PyPI package `aragora` published with working demo mode** | Complete | P2 | STRATEGIC_ANALYSIS |
+| 9 | **GitHub Actions pre-merge gate for code review** | Not Started | P1 | STRATEGIC_ANALYSIS |
+| 10 | **Public demo at aragora.ai/demo** | Not Started | P3 | LANDING_PAGE |
+
+### P2: Product Hardening (Q2 2026)
+
+| # | Goal | Status | Pillar | Source Doc |
+|---|------|--------|--------|------------|
+| 11 | **SOC 2 Type II certification** | 98% controls -> need audit engagement | P4 | COMPREHENSIVE_REPORT |
+| 12 | **FastAPI migration for critical paths** | In Progress | P2 | EXECUTION_PROGRAM |
+| 13 | **Budget controls + per-debate cost estimation** | Partial | P2 | SME_STARTER_PACK |
+| 14 | **Developer onboarding validated at &lt;10 min** | Not Measured | P2 | EXECUTION_PROGRAM |
+| 15 | ~~**Wire Nomic Loop end-to-end**~~ | **COMPLETE** (Phase 10C, Jan 2026; 66 E2E tests) | P5 | HONEST_ASSESSMENT |
+| 16 | **Real semantic convergence detection** (replace difflib with embeddings) | Not Started | P1 | HONEST_ASSESSMENT |
+| 17 | **Decision-integrity UI workbench** (knowledge search, agent leaderboard, pipeline canvas) | Not Started | P3 | EXECUTION_PROGRAM |
+| 18 | **Deploy ERC-8004 contracts on Ethereum** | Not Started (code exists) | P4, P6 | HONEST_ASSESSMENT |
+| 19 | **OpenClaw end-to-end demo** (debate -> decision -> execution -> receipt) | Not Started | P6 | EVOLUTION_ROADMAP |
+
+### P3: Scale & Revenue (Q3-Q4 2026)
+
+| # | Goal | Status | Pillar | Source Doc |
+|---|------|--------|--------|------------|
+| 20 | **60 Pro teams + 6 enterprise contracts** ($24.7K MRR target) | Not Started | P2 | BUSINESS_SUMMARY |
+| 21 | **Cloud marketplace listings** (AWS, Azure) | Not Started | P2 | BUSINESS_SUMMARY |
+| 22 | **Vertical packages** (healthcare FHIR, financial SOX, legal) | Partial | P2, P4 | STRATEGIC_ANALYSIS |
+| 23 | **Marketplace pilot** (agent templates, workflow templates) | Not Started | P2 | EXECUTION_PROGRAM |
+| 24 | **Case studies** (before/after comparisons on real PRs) | Not Started | P1 | HONEST_ASSESSMENT |
+| 25 | **On-premise deployment option productized** | Infrastructure Ready | P2 | COMMERCIAL_POSITIONING |
+| 26 | **International expansion + EU data residency** | Not Started | P2, P4 | COMMERCIAL_POSITIONING |
+| 27 | **Compute escrow for settlement stakes** (staking mechanism) | Not Started | P1, P4 | EVOLUTION_ROADMAP |
+| 28 | **Knowledge federation** (distributed debates across orgs) | Not Started | P1, P2 | OMNIVOROUS_ROADMAP |
+
+### P4: Long-Term Strategic Goals
+
+| # | Goal | Pillar | Source |
+|---|------|--------|--------|
+| 29 | **Prover-Estimator debate protocol** (truth-seeking beyond consensus) | P1 | EVOLUTION_ROADMAP |
+| 30 | **Cross-verification phase** (three-pass hallucination detection) | P1 | EVOLUTION_ROADMAP |
+| 31 | **Persuasion vs truth detection** (rhetorical device scoring) | P1 | EVOLUTION_ROADMAP |
+| 32 | **STOP N-candidate implementation** in Nomic Loop | P5 | EVOLUTION_ROADMAP |
+| 33 | **Self-healing test infrastructure** (automated repair before rollback) | P5 | EVOLUTION_ROADMAP |
+| 34 | **Meta-improver for debate protocols** (A/B test protocol variants) | P5 | EVOLUTION_ROADMAP |
+| 39 | **Epistemic hygiene debate mode** (require alternatives, falsifiers, confidence, unknowns) | P1 | Multi-model analysis |
+| 40 | **Anti-sycophancy eval fixtures** (real cross-model conversations as regression tests) | P1 | Multi-model analysis |
+| 41 | **Adversarial protocol red-teaming** (benchmark loophole exploitation in debate rules) | P1 | Multi-model analysis |
+| 42 | **Calibration tracking** (claim-to-outcome mapping, score decay, reputational memory) | P1, P4 | Multi-model analysis |
+| 43 | **Cross-model epistemic cross-checking** (use heterogeneous models to QA platform itself) | P1, P5 | Multi-model analysis |
+| 35 | **Canvas GUI** (8-stage prompt-to-execution experience) | P3 | EVOLUTION_ROADMAP |
+| 36 | **Agent handoff patterns** (specialist delegation mid-debate) | P5, P6 | EVOLUTION_ROADMAP |
+| 37 | **10+ agent coordinated debates** without deadlock | P1, P5 | HONEST_ASSESSMENT |
+| 38 | **Market resolution mechanism** for long-horizon settlement claims | P1, P4 | EVOLUTION_ROADMAP |
+
+---
+
+## Revenue Projections (from BUSINESS_SUMMARY)
+
+| Month | Free Users | Pro Teams | Enterprise | Total MRR |
+|-------|-----------|-----------|------------|-----------|
+| 1 | 50 | 0 | 0 | $0 |
+| 3 | 500 | 2 | 0 | $490 |
+| 6 | 2,500 | 12 | 0 (2 pilots) | $2,940 |
+| 9 | 5,500 | 32 | 3 | $12,840 |
+| 12 | 8,500 | 60 | 6 | $24,700 |
+
+---
+
+## Document Map
+
+Each aragoradocs file serves a specific purpose. Goals are consolidated here.
+
+| Document | Purpose | Audience |
+|----------|---------|----------|
+| **ARAGORA_CANONICAL_GOALS.md** | Single source of truth for goals, thesis, & metrics | Internal |
+| **ARAGORA_BUSINESS_SUMMARY.md** | Complete business plan with projections | Investors, advisors |
+| **ARAGORA_WHY_ARAGORA.md** | Category definition & positioning narrative | Developers, prospects |
+| **ARAGORA_COMMERCIAL_OVERVIEW.md** | Pricing, features, deployment options | Sales, prospects |
+| **ARAGORA_STRATEGIC_ANALYSIS.md** | PMF analysis & competitive positioning | Internal, advisors |
+| **ARAGORA_HONEST_ASSESSMENT.md** | What works, what's scaffolding | Internal, due diligence |
+| **ARAGORA_COMPARISON_MATRIX.md** | Feature comparison vs. competitors | Sales, developers |
+| **ARAGORA_COMPREHENSIVE_REPORT.md** | Technical due diligence deep dive | Investors, partners |
+| **ARAGORA_ELEVATOR_PITCH.md** | Spoken pitch script with Q&A | Founder |
+| **ARAGORA_EXECUTION_PROGRAM_2026Q2_Q4.md** | Engineering execution plan | Engineering |
+| **ARAGORA_OMNIVOROUS_ROADMAP.md** | Channel & integration roadmap | Engineering, partners |
+| **ARAGORA_FEATURE_DISCOVERY.md** | Complete feature catalog (180+) | Developers |
+| **ARAGORA_SME_STARTER_PACK.md** | SME onboarding product spec | Product, engineering |
+| **ARAGORA_COMMERCIAL_POSITIONING.md** | Messaging guidelines & value props | Marketing, sales |
+| **ARAGORA_PRICING_PAGE.md** | Detailed pricing with FAQ | Website, prospects |
+| **ARAGORA_PRICING.md** | Simple pricing comparison | Website, prospects |
+| **Aragora_Updated_Description.md** | Marketing copy variants | Marketing |
+| **aragora_report_pack.md** | Combined report + brief + pitch | Investors |
+| **Aragora_Enterprise_Pilot_Prospects.md** | 10 qualified enterprise prospects | Sales |
+| **Aragora_Outbound_Email_Campaign.md** | 4-email outbound sequence | Sales |
+
+### Related Codebase Documents
+
+| Document | Purpose | Relationship |
+|----------|---------|-------------|
+| **docs/plans/ARAGORA_EVOLUTION_ROADMAP.md** | HOW to implement the foundational thesis | Implements this document |
+| **docs/FOCUS.md** | Investment tier prioritization | Aligns with pillar-based prioritization |
+| **docs/WHY_ARAGORA.md** | In-repo positioning narrative | Derived from Pillar 1 |
+| **docs/ROADMAP_30_60_90.md** | 90-day execution plan | Implements P0-P1 goals |
+| **CLAUDE.md** | Agent integration guide | Reference for all agents working on codebase |
+
+### Duplicate/Consolidation Notes
+
+- **ARAGORA_COMMERCIAL_OVERVIEW (A).md** is a stale duplicate of COMMERCIAL_OVERVIEW.md -> DELETE
+- **ARAGORA_PRICING.md** uses different tier names (Community/Team) -> UPDATED to match Free/Pro/Enterprise
+- **aragora_report_pack.md** overlaps heavily with COMPREHENSIVE_REPORT.md -> consider merging
+
+---
+
+## Honest Qualifications (What All Docs Should Reflect)
+
+These claims require qualification in all documents:
+
+1. **"Self-improving platform"** -- Nomic Loop is fully wired end-to-end with all six phases operational (Phase 10C consolidation, Jan 2026; 66 E2E tests passing). Autonomous cycles demonstrated in production dogfooding. Run 012 (March 2026) achieved composite scores of 8.38-9.39/10 following practicality scoring fixes (prompt restructuring, threshold alignment, verb scoring). **Goal: demonstrate autonomous improvement beyond internal dogfooding, validate 80%+ pass rate consistency across diverse tasks, and make the operating cadence explicit: assessment -> backlog -> bounded shift -> refresh.**
+
+2. **"43-agent parallel coordination"** -- All 43 agent types exist and work individually. Practical debates use 2-6 agents due to provider rate limits. The value is heterogeneity (different models catching different issues), not raw parallelism. **Goal: demonstrate 10+ agent coordination (P4 #37).**
+
+3. **"Blockchain receipts"** -- Decision receipts use SHA-256 cryptographic hashing with tamper detection. They are not stored on a blockchain. ERC-8004 contracts exist as code but have limited deployment. The value is the structured audit trail, not the ledger. **Goal: deploy ERC-8004 on Ethereum and store receipts on-chain (P2 #18).**
+
+4. **"208,000+ tests"** (now 213,000+) -- Full count requires all optional dependencies in CI. ~13,500-15,000 tests are runnable locally without the full dependency stack.
+
+---
+
+## Key Risks
+
+| Risk | Impact | Mitigation | Source |
+|------|--------|------------|--------|
+| Zero paying customers | Fatal | Stop building, start selling | Ground-up analysis |
+| Debate quality inconsistent (33% good-run rate) | Blocks demos | Fix output contract parsing, quality gates | DOGFOOD_SPEC |
+| EU AI Act enforcement delayed | Reduced urgency | Product value stands without regulation | BUSINESS_SUMMARY |
+| Well-funded competitor adds adversarial features | Category pressure | Technical moat (210+ debate modules, 45 KM adapters) | STRATEGIC_ANALYSIS |
+| Solo maintainer (bus factor) | Existential | Comprehensive docs, MIT license, CI coverage | COMPREHENSIVE_REPORT |
+| LLM provider reliability | Debate failures | Circuit breaker, OpenRouter fallback, multi-provider | HONEST_ASSESSMENT |
+| Engagement-driven revenue corrupts epistemic output | Existential to thesis | SaaS subscription primary; avoid ad-supported model entirely | Terrarium Model |
+| Settlement gaming (IBGYBG, semantic decay, identity cycling) | Undermines truth arbitrage | Compute escrow, strict schema binding, ERC-8004 identity | Evolution Roadmap |
+
+---
+
+*This document supersedes goal sections in all other aragoradocs files. The Evolution Roadmap implements the goals defined here. Update monthly.*

--- a/docs-site/docs/contributing/conductor-control-plane-implementation-spec.md
+++ b/docs-site/docs/contributing/conductor-control-plane-implementation-spec.md
@@ -1,0 +1,209 @@
+---
+title: 2026-03-07 Conductor Control Plane Implementation Spec
+description: 2026-03-07 Conductor Control Plane Implementation Spec
+---
+
+# 2026-03-07 Conductor Control Plane Implementation Spec
+
+## Summary
+
+Aragora already has most of the substrate for multi-agent development:
+
+- supervisor-backed swarm runs
+- worker launches in isolated worktrees
+- worktree autopilot and cleanup
+- lease-like coordination state
+- completion receipts and integration decisions
+- an initial integrator-facing status view
+
+What is still missing is the hierarchy that lets one human-facing session act as a conductor instead of manually copy-pasting instructions across multiple worker sessions.
+
+The goal of this plan is to make Aragora itself manage the pattern that was manually used to recover the repository:
+
+- one conductor/integrator session
+- one implementer/planner layer that turns goals into bounded lanes
+- multiple workers launched from leases
+- one merge authority
+
+## Current Shipped Base
+
+As of `cd2985adf` on `main`, the control-plane baseline already includes:
+
+- worktree/session protection and cleanup hardening
+  - `scripts/codex_worktree_autopilot.py`
+  - `aragora/worktree/autopilot.py`
+- integrator-facing status summary surfaces
+  - `aragora/swarm/reporter.py`
+  - `aragora/cli/commands/swarm.py`
+  - `aragora/cli/commands/worktree.py`
+  - `aragora/server/handlers/control_plane/coordination.py`
+- supervisor-backed swarm execution
+  - `aragora/swarm/supervisor.py`
+  - `aragora/swarm/reconciler.py`
+  - `aragora/swarm/worker_launcher.py`
+- richer coordination semantics
+  - `aragora/nomic/dev_coordination.py`
+- merge/integration worker
+  - `aragora/worktree/integration_worker.py`
+
+This means the next tranche should extend the current codebase, not create a second orchestration system.
+
+## Problem To Solve
+
+The manual operator pattern still lives outside Aragora:
+
+- the user inspects repo state manually
+- the user designates canonical lanes manually
+- the user copies bounded prompts to worker sessions manually
+- the user decides when workers must stop manually
+- the user tracks receipts and merge readiness manually
+
+That is workable for a few agents, but not for 10 or 20.
+
+## Target Operating Model
+
+### Roles
+
+1. `Conductor`
+- single human-facing Codex or Claude session
+- restores shared state
+- chooses at most a small number of bounded next actions
+- never free-roams as a worker by default
+
+2. `Implementer`
+- translates one approved issue or goal into bounded work orders
+- owns file-scope definition, tests, and stop conditions
+
+3. `Worker`
+- edits only leased scope
+- emits a completion receipt
+- cannot merge
+
+4. `Integrator`
+- the only role allowed to merge, supersede, or discard lanes
+
+### Conductor Cycle
+
+The conductor cycle should become a first-class command:
+
+1. inspect repo state
+2. sync clean root to `origin/main`
+3. inspect open PRs and worktrees
+4. canonicalize ownership
+5. choose at most two non-overlapping worker assignments
+6. stop assigning until those lanes hit PR-or-blocker stop conditions
+
+## Proposed Deliverables
+
+### 1. Prompt Rendering From Leases
+
+Add role-aware prompt rendering to the coordination layer.
+
+Input:
+- `WorkLease`
+- `allowed_globs`
+- `expected_tests`
+- role (`worker`, `reviewer`, `integrator`)
+- stop condition
+
+Output:
+- bounded worker prompt
+- reviewer prompt
+- integrator prompt
+
+Likely insertion points:
+- `aragora/nomic/dev_coordination.py`
+- `aragora/swarm/supervisor.py`
+- `aragora/swarm/spec.py`
+
+### 2. First-Class Conductor Command
+
+Add a top-level operator command, conceptually:
+
+```bash
+aragora swarm conduct
+```
+
+Minimum responsibilities:
+- inspect root cleanliness / behind state
+- inspect open PRs
+- inspect worktrees and leases
+- render canonical lane view
+- suggest the one next conductor action
+
+Likely insertion points:
+- `aragora/cli/commands/swarm.py`
+- `aragora/swarm/reporter.py`
+- `aragora/server/handlers/control_plane/coordination.py`
+
+### 3. Lane Canonicalization and Supersession
+
+Add explicit support for:
+- one canonical lane per issue
+- duplicate-lane detection
+- superseded lane status
+- stop-new-lane-on-active-owner behavior
+
+This should reuse existing coordination artifacts rather than redesign storage in the first tranche.
+
+Likely insertion points:
+- `aragora/nomic/dev_coordination.py`
+- `aragora/worktree/fleet.py`
+- `aragora/swarm/reporter.py`
+
+### 4. Stop-Condition Enforcement
+
+Every launched worker lane should be required to terminate at:
+- one PR, or
+- one blocker report
+
+Not an open-ended continuation loop.
+
+Likely insertion points:
+- `aragora/swarm/worker_launcher.py`
+- `aragora/swarm/reconciler.py`
+- `aragora/nomic/dev_coordination.py`
+
+## Scope Boundaries
+
+This tranche should not attempt:
+
+- a full visual mission-control UI
+- 10+ agent autonomous scaling
+- deep schema redesign of coordination storage
+- broad model-routing redesign
+- a second orchestration stack parallel to the current supervisor/fleet model
+
+Those can come later. The goal here is to remove manual copy-paste and ambiguous ownership first.
+
+## Suggested Issue Order
+
+The next control-plane sequence should be:
+
+1. file-scope ownership enforcement
+2. canonical PR / supersession protocol
+3. receipts and provenance requirements for every lane
+4. prompt rendering from leases
+5. first-class conductor command
+
+That order assumes the worktree protection and integrator-view slices are already landed.
+
+## Acceptance Criteria
+
+This plan is successful when all of the following are true:
+
+1. A conductor session can inspect repo state and receive a canonical lane summary without manual shell archaeology.
+2. A worker prompt can be generated directly from lease data.
+3. An issue with an active owner cannot silently spawn another competing lane.
+4. Every worker lane ends at one PR or one blocker.
+5. The integrator view can show canonical lane, receipt presence, stale heartbeat status, and merge readiness in one place.
+
+## Suggested First PR Scope
+
+The most reasonable first implementation PR after the already-merged protection/view work is:
+
+- add role-aware prompt rendering from `WorkLease`
+- expose rendered prompts through CLI / API read surfaces
+- no automatic worker launch changes in that first PR
+
+That is small enough to validate the operating model without touching every coordination path at once.

--- a/docs-site/docs/contributing/dev-swarm-coordination.md
+++ b/docs-site/docs/contributing/dev-swarm-coordination.md
@@ -1,0 +1,191 @@
+---
+title: Dev Swarm Coordination
+description: Dev Swarm Coordination
+---
+
+# Dev Swarm Coordination
+
+Aragora already has most of the primitives needed for concurrent multi-agent development. The current friction comes from a gap between those primitives and the operational protocol used by Codex/Claude sessions.
+
+## Diagnosis
+
+The repository already solves a large part of the problem:
+
+- worktree/session lifecycle:
+  - `scripts/codex_session.sh`
+  - `scripts/codex_worktree_autopilot.py`
+  - `aragora/worktree/lifecycle.py`
+  - `aragora/worktree/maintainer.py`
+- human/API-visible coordination state:
+  - `aragora/worktree/fleet.py`
+  - `aragora/cli/commands/worktree.py`
+  - `aragora/server/handlers/control_plane/coordination.py`
+- merge/reconcile engines:
+  - `aragora/nomic/branch_coordinator.py`
+  - `aragora/coordination/reconciler.py`
+  - `aragora/coordination/resolver.py`
+- queues, events, and receipts:
+  - `aragora/nomic/global_work_queue.py`
+  - `aragora/nomic/event_bus.py`
+  - `aragora/nomic/cycle_receipt.py`
+  - `aragora/pipeline/receipt_generator.py`
+
+What was missing was not another worktree manager. The missing layer was a bounded coordination protocol:
+
+- who owns a task
+- which files they may change
+- how that ownership expires
+- how finished work becomes integration work
+- how abandoned work becomes salvage work instead of silent loss
+
+## Canonical State Planes
+
+The codebase currently has several overlapping coordination stores. Going forward, the intended roles are:
+
+- `worktree/fleet`: canonical human/API surface for session claims and merge queue
+- `nomic/dev_coordination.py`: richer semantics that fleet does not yet model directly
+- `event_bus` + receipts: audit and cross-process signaling
+
+This keeps the visible operational state where users already look while avoiding another fully separate control plane.
+
+## Core Artifacts
+
+### WorkLease
+
+`WorkLease` is the bounded ownership object for a single development lane.
+
+Required fields:
+
+- `task_id`
+- `owner_agent`
+- `owner_session_id`
+- `branch`
+- `worktree_path`
+- `allowed_globs`
+- `claimed_paths`
+- `expected_tests`
+- `expires_at`
+
+Operationally:
+
+- the lease is created by `scripts/codex_session.sh`
+- overlap checks consult both active leases and existing `fleet` claims
+- lease claims are mirrored into `FleetCoordinationStore`
+
+### CompletionReceipt
+
+`CompletionReceipt` captures what a worker actually produced:
+
+- commits
+- changed paths
+- tests run
+- assumptions
+- blockers
+- confidence
+
+This is the development analogue of Aragora’s decision and cycle receipts. It turns “agent says it finished” into a typed artifact.
+
+### IntegrationDecision
+
+`IntegrationDecision` is the integrator verdict over a completion receipt:
+
+- `pending_review`
+- `merge`
+- `cherry_pick`
+- `request_changes`
+- `discard`
+- `salvage`
+
+`pending_review` is projected into integration work immediately after completion. That gives the swarm an explicit integrator lane instead of implicit branch drift.
+
+### SalvageCandidate
+
+`SalvageCandidate` is the missing recovery primitive for:
+
+- stale dirty worktrees
+- worktrees ahead of `main`
+- stashes with potentially useful changes
+
+This is how cleanup stops destroying value.
+
+## How This Builds On Existing Aragora Orchestration
+
+The development coordination model is intentionally parallel to Aragora’s product orchestration.
+
+### Development Swarm
+
+- planner assigns a bounded task
+- worker edits only leased scope
+- worker emits completion receipt
+- integrator decides merge/cherry-pick/discard
+- stale work enters salvage queue
+
+### Product Backbone
+
+- planner/interrogator emits `SpecBundle`
+- workers execute bounded plan fragments
+- verification produces typed outcome
+- receipt gate decides whether execution is trusted
+- failures and leftovers feed outcome feedback / nomic loop
+
+## Direct Mapping To Existing Product Primitives
+
+| Dev coordination | Existing Aragora primitive |
+| --- | --- |
+| `WorkLease` | `SpecBundle` / decision-plan scope |
+| `CompletionReceipt` | pipeline receipt / cycle receipt |
+| `IntegrationDecision` | policy + decision integrity gate |
+| `SalvageCandidate` | outcome feedback / recovery queue |
+| active lease conflict detection | execution safety / quality gate |
+| fleet merge queue | branch coordinator / reconciler lane |
+| event publication | `EventBus` |
+| pending work projection | `GlobalWorkQueue` |
+
+## Existing Product Orchestration Patterns Worth Building On
+
+The repo already has mature orchestration patterns that should be reused instead of reimplemented:
+
+- `aragora/pipeline/unified_orchestrator.py`
+  - canonical end-to-end flow for research, debate, planning, execution, bug-fix, and feedback
+- `aragora/nomic/autonomous_orchestrator.py`
+  - queue-driven self-improvement loop
+- `aragora/nomic/hierarchical_coordinator.py`
+  - manager/worker topology for decomposition
+- `aragora/nomic/parallel_orchestrator.py`
+  - fan-out/fan-in execution pattern
+- `aragora/debate/orchestrator.py` and `aragora/debate/consensus.py`
+  - heterogeneous deliberation and synthesis
+- `aragora/debate/quality_pipeline.py`
+  - explicit quality gates before progression
+- `aragora/debate/execution_safety.py`
+  - fail-closed execution constraints
+- `aragora/pipeline/idea_to_execution.py`
+  - intake-to-plan-to-execution flow
+- `aragora/nomic/outcome_feedback.py`
+  - outcome capture for reprioritization and self-improvement
+
+The correct next architectural move is to wire the development swarm protocol into these patterns, not to create a second orchestration philosophy.
+
+## Best-Order Rollout
+
+1. Keep `fleet` as the canonical visible session/claim/merge surface.
+2. Add lease TTL and heartbeat semantics through `dev_coordination`.
+3. Mirror lease claims into fleet so humans and APIs see the same ownership picture.
+4. Project completion into both:
+   - receipt/audit trail
+   - fleet merge queue
+5. Produce salvage candidates before cleanup paths delete stale work.
+6. Reuse `BranchCoordinator` and `GitReconciler` for actual integration workers.
+7. Fold the same typed-artifact pattern into the product-side orchestration backbone.
+
+## Immediate Practical Guidance
+
+For concurrent Codex/Claude operation:
+
+- only one agent owns a file scope at a time unless overlap is explicitly allowed
+- every session should start with a lease
+- every completed session should emit a completion receipt
+- only the integrator lane should finalize merge decisions
+- stale worktrees and stashes should be scanned into salvage before cleanup
+
+That is the minimum protocol needed to scale concurrent agents without spending the gains on reconciliation friction.

--- a/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
+++ b/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
@@ -1,0 +1,110 @@
+---
+title: Documentation Hygiene And Gap Register
+description: Documentation Hygiene And Gap Register
+---
+
+# Documentation Hygiene And Gap Register
+
+Last updated: 2026-03-07
+
+This register is the working record for documentation cleanup, roadmap extraction, and code-vs-doc drift found during the March 2026 hygiene pass.
+
+The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) and the linked GitHub issues. Current-source docs should point there for execution status instead of carrying standalone operational backlog.
+
+## Scope
+
+- Keep current-source docs organized and discoverable.
+- Reconcile prominent claims against the codebase and validation scripts.
+- Track roadmap goals that remain future-state.
+- Keep a running list of features that are partial, brittle, placeholder-backed, or under-documented.
+
+## Completed In This Pass
+
+- Fixed broken links in `docs/status/FEATURE_DISCOVERY.md` and `docs/status/STATUS.md`.
+- Verified `docs/status/NEXT_STEPS_CANONICAL.md` points at `EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
+- Reconciled `docs/EU_AI_ACT_COMPLIANCE.md` against `aragora/compliance/eu_ai_act.py`, including Article 9 artifact generation and current March 2026 timeline language.
+- Regenerated `docs/CAPABILITY_MATRIX.md` and `docs-site/docs/contributing/capability-matrix.md` from the YAML source of truth.
+- Added discoverability links for status, roadmap, gap, and hygiene docs from the main indexes.
+- Marked legacy snapshot docs as non-canonical where they were being presented as live status.
+- Canonicalized the current execution program into GitHub issues and added `docs/status/ACTIVE_EXECUTION_ISSUES.md` as the issue map for epics `#804`-`#806`, execution lanes `#807`-`#820`, and assurance issues `#273`, `#274`, `#509`.
+- Updated the issue map and canonical execution summary after `#809` and `#810` landed so current-source docs reflect the active `#811` / `#812` kernel tranche.
+- Corrected the root README's Knowledge Mound adapter count from `45` to the current verified `42`.
+
+## Validation Snapshot
+
+- `python3 scripts/validate_doc_links.py` -> pass
+- `python3 scripts/reconcile_status.py` -> pass
+- `python3 scripts/reconcile_status_docs.py --strict` -> pass after capability-matrix regeneration
+- `python3 scripts/check_agent_registry_sync.py` -> pass (`43` registered, `34` allowlisted)
+- `python3 scripts/validate_openapi_routes.py --spec docs/api/openapi.json` -> `99.6%` route coverage
+
+## Current Canonical Metrics Used In This Pass
+
+- Version: `2.8.0`
+- Python modules under `aragora/`: `3,803`
+- Tests (`def test_` across repo): `210,215`
+- Test files under `tests/`: `5,069`
+- OpenAPI paths (generated spec): `2,666`
+- OpenAPI operations (generated spec): `3,155`
+- SDK namespaces: `186` Python / `185` TypeScript
+- Registered agent types: `43`
+- Allowlisted agent types: `34`
+- Knowledge Mound adapter specs in `aragora/knowledge/mound/adapters/factory.py`: `42`
+- Unique `@require_permission(...)` strings in `aragora/`: `423`
+
+## Roadmap And Goals Extracted From Current Docs
+
+### Current Focus (March 2026)
+
+- Closed-loop backbone, inbox trust wedge, swarm supervision, provider routing phase 1, Comms Hub completion, and OpenClaw core-loop delivery are treated as shipped in `docs/status/STATUS.md`.
+- Canonical execution priorities are now linked directly to the GitHub backlog: truthfulness/backlog canonicalization is complete on `main` through `#809`, the first kernel bridge tranche `#810` is complete, and the active M1 kernel work is now `#811` and `#812` in `docs/status/NEXT_STEPS_CANONICAL.md` and `docs/status/ACTIVE_EXECUTION_ISSUES.md`.
+- The active six-week plan is wedge/PMF-focused: first receipt quickly, parity hard-close, reliability cleanup, surface simplification, and status consolidation in `docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md`.
+
+### Near-Term Goals (Q2 2026)
+
+- Agent-first beta, GitHub review gate, public demo, EU AI Act package completion, enterprise pilots, and validated fast onboarding remain active in `docs/FEATURE_GAP_LIST.md` and `ROADMAP.md`.
+- The August 2, 2026 EU AI Act deadline remains a major external forcing function across roadmap and compliance docs.
+
+### Longer-Term Goals
+
+- ERC-8004 mainnet deployment, Decision-Integrity UI Workbench expansion, federation, Prover-Estimator, market resolution, and the 8-stage visual canvas remain future-state goals and should stay documented as such.
+
+## Running List: Partial Or Weakly Implemented Features
+
+### Code-Backed Gaps
+
+- OpenAPI drift remains: `9` handler routes are missing from the spec and `11` OpenAPI routes have no handler according to `scripts/validate_openapi_routes.py`.
+- OpenAPI and SDK parity claims are still inflated by spec-only endpoints defined in `aragora/server/openapi/endpoints/sdk_missing.py`.
+- `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
+- `aragora/server/handlers/goal_canvas.py` now materializes a persisted Stage 3 action canvas from live goal-canvas state; metadata-only goal canvases still fail closed once the in-memory graph is gone.
+- `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
+- `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, and the SME OAuth helper endpoints delegate into the canonical Slack install/callback flow.
+- `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, and the SME OAuth helper endpoints delegate into the canonical Teams install/callback flow.
+- `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.
+- `aragora/server/handlers/gauntlet/receipts.py` and the compliance UI still have placeholder or optional anchor-verification paths.
+- `aragora/server/handlers/security_debate.py` exposes an async-status endpoint that is explicitly a placeholder because debates are synchronous and not persisted.
+- `aragora/server/handlers/features/documents_batch.py` returns placeholder chunk retrieval output pending vector-store integration.
+- `aragora/server/handlers/features/connectors.py` still carries `coming_soon` / stubbed connector flows (`gdrive` and related enterprise sync/test paths).
+- `aragora/server/handlers/computer_use_handler.py` does not implement the full action/policy detail surface advertised by the OpenAPI computer-use endpoints.
+- Self-host compose smoke can still fail because `/readyz` returns `503` when `system.health.read` is denied in the composed runtime, even while `/healthz` succeeds. The gating/docs work is landed, but the runtime permission model still needs follow-through.
+- FastAPI receipts currently expose `json`/`markdown`/`sarif`, while legacy handlers still own `html`/`pdf` exports.
+- Receipt delivery is only wired for `slack`, `teams`, `email`, and `discord`, not the broader connector/channel footprint implied elsewhere in the docs.
+- Unified and progressive memory handlers remain backend-conditional and still return `501` when optional backends or methods are unavailable.
+- `aragora/server/fastapi/routes/knowledge.py` can still return `501` when the configured KM backend lacks delete support.
+- `aragora/server/fastapi/routes/workflows.py` can still return `501` when the configured workflow backend lacks step-approval support.
+- `aragora/server/fastapi/routes/pipeline.py` still falls back to in-memory storage or create-without-start behavior when workflow-engine wiring is absent.
+
+### Documentation Positioning Needed
+
+- Slack and Teams integration docs should distinguish between shipped general integrations and the remaining partial SME setup/onboarding surfaces outside the now-live channel/OAuth helpers.
+- `docs/status/FEATURE_DISCOVERY.md` still contains some optimistic `Stable` labels for backend-conditional or placeholder-backed surfaces and should continue to be tightened.
+- RLM and unified memory inventory entries need to reference current file paths (`aragora/server/handlers/rlm.py`, `aragora/memory/gateway.py`, related modules) rather than stale package layouts.
+- Knowledge Mound adapter counts need a dedicated normalization sweep: many current docs still say `45`, while the current factory registry exposes `42` adapter specs.
+- Root-level compatibility mirrors such as `docs/STATUS.md` and `docs/FEATURE_DISCOVERY.md` should remain clearly marked as mirrors so `docs/status/*` stays the canonical current-state surface.
+
+## Remaining Documentation Debt After This Pass
+
+- Historical, pricing, investor, and outreach collateral still contains stale counts in places and was not bulk-rewritten in this pass.
+- Duplicate current-status surfaces still exist for compatibility and should eventually be consolidated into pointer docs once inbound links are audited.
+- A follow-up sweep should normalize current SDK, RBAC, and adapter counts across commercial and enterprise collateral.
+- Future execution-lane changes should update the GitHub issues first, then refresh `ACTIVE_EXECUTION_ISSUES.md` and the linked planning summaries.

--- a/docs-site/docs/contributing/documentation-index.md
+++ b/docs-site/docs/contributing/documentation-index.md
@@ -38,13 +38,13 @@ This index intentionally links to actively maintained docs with validated paths.
 - [Security Deployment](../deployment/security)
 - [Runbook](../operations/runbook)
 - [Incident Response](../operations/incident-response)
-- [Aragora Conductor Workflow](guides/CONDUCTOR_WORKFLOW.md)
-- [Aragora Worker Prompt Pack](guides/WORKER_PROMPT_PACK.md)
-- [Dev Swarm Coordination](architecture/DEV_SWARM_COORDINATION.md)
+- [Aragora Conductor Workflow](../guides/conductor-workflow)
+- [Aragora Worker Prompt Pack](../guides/worker-prompt-pack)
+- [Dev Swarm Coordination](./dev-swarm-coordination)
 
 ## Architecture and Planning
 
-- [Conductor Control Plane Implementation Spec](plans/2026-03-07-conductor-control-plane.md)
+- [Conductor Control Plane Implementation Spec](./conductor-control-plane-implementation-spec)
 
 ## Security and Compliance
 
@@ -57,12 +57,12 @@ This index intentionally links to actively maintained docs with validated paths.
 ## Product Status and Planning
 
 - [Status](./status)
-- [Feature Discovery](status/FEATURE_DISCOVERY.md)
-- [Feature Gap List](FEATURE_GAP_LIST.md)
-- [Next Steps (Canonical)](status/NEXT_STEPS_CANONICAL.md)
-- [Active 6-Week Execution Plan](status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md)
-- [Documentation Hygiene Register](status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md)
-- [Roadmap](../ROADMAP.md)
+- [Feature Discovery](./feature-discovery)
+- [Feature Gap List](./feature-gap-list)
+- [Next Steps (Canonical)](./next-steps-canonical)
+- [Active 6-Week Execution Plan](./execution-next-6-weeks-2026-03-05)
+- [Documentation Hygiene Register](./documentation-hygiene-and-gap-register)
+- [Roadmap](./roadmap)
 
 ## Reference
 

--- a/docs-site/docs/contributing/execution-next-6-weeks-2026-03-05.md
+++ b/docs-site/docs/contributing/execution-next-6-weeks-2026-03-05.md
@@ -1,0 +1,109 @@
+---
+title: Execution Plan (Next 6 Weeks)
+description: Execution Plan (Next 6 Weeks)
+---
+
+# Execution Plan (Next 6 Weeks)
+
+Last updated: 2026-03-22
+Owner: Platform program (Product, Backend, Integrations, QA, SRE)
+
+This is the active short-horizon plan in the agreed priority order.
+It complements (does not replace) `docs/status/NEXT_STEPS_CANONICAL.md`.
+
+## Priority Order
+
+1. Close the default product loop on current `main`
+2. Make the current proof surfaces truthful by default
+3. Finish the bounded execution operator contract
+4. Run design-partner PMF loops on the real wedges
+5. Expand one truthful workbench/stage-transition slice
+6. Decide scale/iterate/narrow from proof metrics, not page count or backlog volume
+
+## Current Merged Proof Basis
+
+The next six weeks should be built on what is already merged:
+
+1. `#1108` proved the queue can recover and publish a real output.
+2. `#1110` and `#1111` merged the first user-journey and KM retrieval slices onto `main`.
+3. `#1118` and `#1119` made receipts and integrations flows materially more truthful.
+4. `#1124`, `#1126`, `#1127`, `#1133`, and `#1138` materially improved the operator contract for bounded repo execution.
+5. `#1135`, `#1136`, and `#1137` turned OpenClaw dispatch, the public proof surface, and pipeline live state into real wedge components.
+
+## Week-by-Week Execution
+
+### Week 1: Default Product Loop Closure
+
+Issue-sized tasks:
+1. Freeze the canonical guided path: credentials/provider setup -> debate -> receipt -> visible result.
+2. Make sure the path uses merged KM retrieval by default and surfaces truthful state at every step.
+3. Publish the exact happy path and the first manual step when the path blocks.
+
+Acceptance:
+1. One canonical default path is documented and dogfooded internally.
+2. The path produces a receipt and a visible result without hidden operator repair.
+
+### Week 2: Truthful Public And Operator Surfaces
+
+Issue-sized tasks:
+1. Remove or truthfully mark any remaining optimistic state on `/demo`, integrations status/edit, receipts, and pipeline live state.
+2. Tighten the bounded-lane operator view so state, evidence, and next action are all authoritative.
+3. Verify remote-head review is the default review target for publishable PRs.
+
+Acceptance:
+1. Core proof surfaces have no known demo-only or misleading states.
+2. Publishable lanes are reviewable from authoritative operator state.
+
+### Week 3: Bounded Execution Contract
+
+Issue-sized tasks:
+1. Ensure completed-lane publish, blocked-lane terminalization, and evidence persistence hold across real runs.
+2. Fill the biggest gaps in per-lane provenance/receipt coverage.
+3. Capture one concise operator handoff format for blocked runs.
+
+Acceptance:
+1. Bounded runs end in deliverable or explicit blocked reason with evidence.
+2. No lane requires manual reconstruction to explain what happened.
+
+### Week 4: Design Partner Pilot Start
+
+Issue-sized tasks:
+1. Pick 3-5 partners matched to one of the real wedges: trust wedge, public proof/review, or swarm/OpenClaw.
+2. Run one guided activation session per partner on a real artifact.
+3. Start a weekly PMF scorecard and proof log per partner.
+
+Acceptance:
+1. Every partner has one bounded recurring workflow chosen.
+2. First-week receipts, overrides, or bounded-lane outcomes are captured in scorecards.
+
+### Week 5: Five Functional Paths + Workbench Slice
+
+Issue-sized tasks:
+1. Keep reducing shell-heavy product surfaces by focusing on five functional paths.
+2. Extend one stage-transition/workbench slice so it is live, reviewable, and tied to real execution state.
+3. Tie workbench state back to canonical receipts/provenance rather than separate demo data.
+
+Acceptance:
+1. Five core paths are usable enough for weekly dogfood.
+2. At least one stage transition is truthfully represented in the UI.
+
+### Week 6: PMF Decision Gate
+
+Issue-sized tasks:
+1. Review six weeks of wedge metrics and partner scorecards.
+2. Decide whether to scale, iterate, or narrow each wedge.
+3. Promote the successful proof metrics into the default product/program dashboard.
+
+Acceptance:
+1. The next six-week plan is generated from measured repeatability and truthfulness.
+2. Any wedge that is not repeating gets explicitly narrowed instead of hand-waved forward.
+
+## CI/Gate Commands (Required Weekly)
+
+1. `python scripts/reconcile_status_docs.py --strict --output /tmp/reconciliation_report.md`
+2. `python scripts/check_version_alignment.py`
+3. `python scripts/check_agent_registry_sync.py`
+4. `python scripts/check_connector_exception_handling.py`
+5. `python scripts/check_self_host_compose.py`
+6. `python scripts/check_pentest_findings.py`
+7. `bash scripts/run_offline_golden_path.sh`

--- a/docs-site/docs/contributing/extended-readme.md
+++ b/docs-site/docs/contributing/extended-readme.md
@@ -1,0 +1,957 @@
+---
+title: Aragora -- Extended Reference
+description: Aragora -- Extended Reference
+---
+
+# Aragora -- Extended Reference
+
+*Comprehensive technical reference for the Decision Integrity Platform. For the concise overview, see the [README](../analysis/adr).*
+
+---
+
+## Table of Contents
+
+- [Five Pillars](#five-pillars)
+- [Debate Engine (Dialectic Roots)](#debate-engine-dialectic-roots)
+- [Core Workflows](#core-workflows)
+- [Architecture](#architecture)
+- [Programmatic Usage](#programmatic-usage)
+- [Implemented Features (3,700+ Modules)](#implemented-features-3700-modules)
+- [Prerequisites](#prerequisites)
+- [Deployment](#deployment)
+- [API Endpoints](#api-endpoints)
+- [Security](#security)
+- [Self-Improvement (Nomic Loop)](#self-improvement-nomic-loop)
+- [Inspiration and Citations](#inspiration-and-citations)
+
+---
+
+## Five Pillars
+
+Aragora is built on five architectural commitments.
+
+### 1. SMB-Ready, Enterprise-Grade
+
+Aragora works for a 5-person startup on day one and scales to regulated enterprise without rearchitecting. Enterprise features -- OIDC/SAML SSO, MFA, AES-256-GCM encryption, multi-tenant isolation, RBAC with 7 roles and 360+ permissions, SOC 2 / GDPR / HIPAA compliance frameworks -- are built in, not bolted on. Security hardening (rate limiting, SSRF protection, path traversal guards, input validation, audit trails) is the default, not a premium tier.
+
+### 2. Leading-Edge Memory and Context
+
+Single agents lose context. Aragora's 4-tier Continuum Memory (fast / medium / slow / glacial) and Knowledge Mound with 0 registered adapters give every debate access to institutional history, cross-session learning, and evidence provenance. The RLM (Recursive Language Models) system compresses and structures context to reduce prompt bloat, enabling debates that sustain coherence across long multi-round sessions and large document sets where individual models would degrade.
+
+### 3. Extensible and Modular
+
+Connectors for Slack, Teams, Discord, Telegram, WhatsApp, email, voice, Kafka, RabbitMQ, GitHub, Jira, Salesforce, healthcare HL7/FHIR, and dozens more. SDKs in Python and TypeScript (186 Python / 185 TypeScript namespaces). 3,000+ API operations across 2,700+ paths and 270+ WebSocket event types. OpenClaw integration for portable agent governance. A workflow engine with DAG execution and 60+ templates. A marketplace for agent personas, debate templates, and workflow patterns. Aragora adapts to your stack.
+
+### 4. Multi-Agent Robustness
+
+Different models have different blind spots. Aragora runs Claude, GPT, Gemini, Grok, Mistral, DeepSeek, Qwen, Kimi, and local models in structured Propose / Critique / Revise debates with configurable consensus (majority, unanimous, judge-based). ELO rankings track agent performance. Calibration scoring measures prediction accuracy. The Trickster detects hollow consensus. The result: outputs that are more robust, less biased, and higher quality than any single model, with a complete dissent trail showing where the models disagreed and why.
+
+### 5. Self-Healing and Self-Extending
+
+The Nomic Loop is Aragora's autonomous self-improvement system: agents debate improvements to the codebase, design solutions, implement code, run tests, and verify changes -- with human approval gates and automatic rollback on failure. Red-team mode stress-tests the platform's own specs. The Gauntlet runs adversarial attacks against proposed changes. The system hardens itself.
+
+---
+
+## Debate Engine (Dialectic Roots)
+
+The dialectic framing is the **internal engine**; users get adversarial validation outputs (decision receipts, risk heatmaps, dissent trails). This section is optional background for those interested in the theoretical foundation.
+
+Aragora's debate engine draws from Hegelian dialectics:
+
+| Dialectical Concept | Aragora Implementation |
+|---------------------|------------------------|
+| **Thesis > Antithesis > Synthesis** | Propose > Critique > Revise loop |
+| **Aufhebung** (sublation) | Judge synthesizes best elements, preserving value while transcending limitations |
+| **Contradiction as motor** | Critiques (disagreement) drive improvement, not consensus-seeking |
+| **Negation of negation** | Proposal > Critique (negation) > Revision (higher unity) |
+| **Truth as totality** | No single agent has complete truth; it emerges from multi-perspectival synthesis |
+
+The **Nomic Loop** (self-modifying rules) mirrors this by debating and refining its own processes. It is experimental -- run in a sandbox with human review before any auto-commit.
+
+### Debate Protocol (Stress-Test Engine)
+
+Each session follows thesis > antithesis > synthesis:
+
+1. **Round 0: Thesis (Initial Proposals)**
+   - Proposer agents generate initial responses to the task
+   - Multiple perspectives on the same problem
+
+2. **Rounds 1-N: Antithesis (Critique and Revise)**
+   - Agents critique each other's proposals (productive negation)
+   - Identify issues with severity scores (0-1)
+   - Provide concrete suggestions
+   - Proposers revise, incorporating valid critiques (negation of negation)
+
+3. **Synthesis (Consensus Phase)**
+   - All agents vote on best proposal
+   - Judge synthesizes best elements from competing proposals (*Aufhebung*)
+   - Judge selection is randomized or voted to prevent systematic bias
+   - Final answer transcends individual limitations
+
+### Algorithm Documentation
+
+Deep-dive documentation for core debate algorithms:
+- **[Consensus Detection](../core-concepts/consensus)** -- Multi-agent consensus mechanisms and proof generation
+- **[Convergence Detection](../core-concepts/convergence-algorithm)** -- Semantic similarity for debate convergence
+- **[ELO and Calibration](../core-concepts/elo-calibration)** -- Agent skill rating and team selection
+
+See [algorithms/README.md](../analysis/adr) for the full algorithm reference.
+
+---
+
+## Core Workflows
+
+### Gauntlet Mode -- Adversarial Stress Testing
+
+Stress-test specifications, architectures, and policies before they ship:
+
+```bash
+# Test a specification for security vulnerabilities
+aragora gauntlet spec.md --input-type spec --profile quick
+
+# GDPR compliance audit
+aragora gauntlet policy.yaml --input-type policy --persona gdpr
+
+# Full adversarial stress test with HTML report
+aragora gauntlet architecture.md --profile thorough --output report.html
+```
+
+| Attack Type | What It Tests |
+|-------------|--------------|
+| **Red Team** | Security holes, injection points, auth bypasses |
+| **Devil's Advocate** | Logic flaws, hidden assumptions, edge cases |
+| **Scaling Critic** | Performance bottlenecks, SPOF, thundering herd |
+| **Compliance** | GDPR, HIPAA, SOC 2, AI Act violations |
+
+**Decision receipts** provide cryptographic audit trails for every finding, ready for regulatory review.
+
+CI decision gate:
+
+```bash
+aragora gauntlet architecture.md --profile thorough --output receipt.html
+```
+
+GitHub Action: `.github/workflows/aragora-gauntlet.yml`
+
+See [GAUNTLET.md](../guides/gauntlet) for full documentation and [AGENT_SELECTION.md](../core-concepts/agent-selection) for agent recommendations.
+
+### AI Red Team Code Review
+
+Get **unanimous AI consensus** on your pull requests. When 3 independent AI models agree on an issue, you know it's worth fixing.
+
+```bash
+# Review a PR
+git diff main | aragora review
+
+# Review a GitHub PR URL
+aragora review https://github.com/owner/repo/pull/123
+
+# Try without API keys
+aragora review --demo
+```
+
+**What you get:**
+
+| Section | What It Means |
+|---------|--------------|
+| **Unanimous Issues** | All AI models agree -- high confidence, fix first |
+| **Split Opinions** | Models disagree -- see the tradeoff, you decide |
+| **Risk Areas** | Low confidence -- manual review recommended |
+
+Example output:
+```
+### Unanimous Issues
+> All AI models agree - address these first
+- SQL injection in search_users() - user input concatenated into query
+- Missing input validation on file upload endpoint
+
+### Split Opinions
+| Topic | For | Against |
+|-------|-----|---------|
+| Add request rate limiting | Claude, GPT-4 | Gemini |
+```
+
+**GitHub Actions**: Automatically review every PR with the included workflow.
+
+### Structured Debates
+
+```python
+from aragora import Arena, Environment, DebateProtocol
+from aragora.agents import create_agent
+
+# Create heterogeneous agents (API-backed)
+agents = [
+    create_agent("anthropic-api", name="claude_proposer", role="proposer"),
+    create_agent("openai-api", name="openai_critic", role="critic"),
+    create_agent("gemini", name="gemini_synth", role="synthesizer"),
+]
+
+# Define task
+env = Environment(
+    task="Design a distributed cache with LRU eviction",
+    max_rounds=3,
+)
+
+# Configure debate
+protocol = DebateProtocol(
+    rounds=3,
+    consensus="majority",
+)
+
+# Run with memory
+from aragora.memory import CritiqueStore
+memory = CritiqueStore("debates.db")
+arena = Arena(env, agents, protocol, memory)
+result = await arena.run()
+
+print(result.final_answer)
+print(f"Consensus: {result.consensus_reached} ({result.confidence:.0%})")
+```
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         ARAGORA FRAMEWORK                        │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                 AGENT LAYER (43 Agent Types)              │   │
+│  │  Claude | GPT | Gemini | Grok | Mistral | DeepSeek | Qwen │   │
+│  │              + Kimi, Yi, Local Models (Ollama)             │   │
+│  └───────────────────────────┬──────────────────────────────┘   │
+│                               ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                    DEBATE ENGINE                          │   │
+│  │  • 9-round structured protocol (Propose > Critique > Syn) │   │
+│  │  • Graph debates with branching | Matrix debates           │   │
+│  │  • Consensus detection | Convergence | Forking             │   │
+│  └───────────────────────────┬──────────────────────────────┘   │
+│                               ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                    KNOWLEDGE LAYER                        │   │
+│  │  • Belief networks with Bayesian propagation              │   │
+│  │  • Claims kernel with typed relationships                 │   │
+│  │  • Evidence provenance with hash chains                   │   │
+│  │  • Knowledge Mound (0 registered adapters) + Semantic search  │   │
+│  └───────────────────────────┬──────────────────────────────┘   │
+│                               ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                  MEMORY SYSTEM (4 tiers)                  │   │
+│  │  Fast (1min) > Medium (1hr) > Slow (1d) > Glacial (1wk)  │   │
+│  │  • Surprise-based learning | Consolidation scoring        │   │
+│  │  • Cross-session pattern extraction | RLM context mgmt    │   │
+│  └───────────────────────────┬──────────────────────────────┘   │
+│                               ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │                    OUTPUT LAYER                            │   │
+│  │  Decision Receipts | Risk Heatmaps | Dissent Trails       │   │
+│  │  Proofs | Explainability | Channel Routing                │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Directory Structure
+
+```
+aragora/
+├── debate/           # Core debate orchestration (210+ modules)
+│   ├── orchestrator.py     # Arena class -- main debate engine
+│   ├── phases/             # Extracted phase implementations
+│   ├── team_selector.py    # Agent team selection (ELO + calibration)
+│   ├── memory_manager.py   # Memory coordination
+│   ├── prompt_builder.py   # Prompt construction
+│   ├── consensus.py        # Consensus detection and proofs
+│   ├── convergence.py      # Semantic similarity detection
+│   ├── trickster.py        # Hollow consensus detection
+│   ├── topology.py         # Adaptive topology (sparse/all-to-all/ring)
+│   └── calibration.py      # Agent confidence calibration
+├── agents/           # Agent implementations (18+)
+│   ├── cli_agents.py       # CLI agents (claude, codex, gemini, grok)
+│   ├── api_agents/         # API agents directory
+│   │   ├── anthropic.py    # Anthropic API (Claude)
+│   │   ├── openai.py       # OpenAI API (GPT)
+│   │   ├── gemini.py       # Google Gemini
+│   │   ├── mistral.py      # Mistral (Large, Codestral)
+│   │   ├── grok.py         # xAI Grok
+│   │   ├── openrouter.py   # OpenRouter (DeepSeek, Llama, Qwen, Yi, Kimi)
+│   │   ├── ollama.py       # Local Ollama models
+│   │   └── lm_studio.py    # Local LM Studio models
+│   ├── fallback.py         # OpenRouter fallback on quota errors
+│   └── airlock.py          # AirlockProxy for agent resilience
+├── memory/           # Learning and persistence
+│   ├── continuum/          # Multi-tier memory (fast/medium/slow/glacial)
+│   ├── consensus.py        # Historical debate outcomes
+│   ├── coordinator.py      # Atomic cross-system memory writes
+│   ├── supermemory.py      # Cross-session external memory
+│   └── embeddings.py       # Semantic embedding for retrieval
+├── knowledge/        # Unified knowledge management
+│   ├── bridges.py          # KnowledgeBridgeHub, MetaLearner, Evidence bridges
+│   └── mound/              # KnowledgeMound (0 registered adapters, 4,300+ tests)
+│       ├── adapters/       # Belief, Consensus, ELO, Evidence, OpenClaw, etc.
+│       ├── semantic.py     # Vector embedding-based search
+│       ├── federation.py   # Multi-region sync
+│       ├── contradictions.py # Conflict detection
+│       └── resilience.py   # Retry, health monitoring, cache invalidation
+├── reasoning/        # Formal reasoning
+│   ├── belief.py           # Belief network with Bayesian propagation
+│   ├── provenance.py       # Cryptographic evidence chains
+│   └── claims.py           # Structured typed claims
+├── gauntlet/         # Adversarial stress testing
+│   ├── runner.py           # Test execution
+│   ├── receipts.py         # SHA-256 cryptographic audit trails
+│   ├── findings.py         # Findings management
+│   ├── defense.py          # Attack/defend cycles
+│   └── personas/           # GDPR, SOC2, HIPAA, PCI-DSS, AI Act, NIST CSF
+├── server/           # HTTP/WebSocket API (3,000+ operations, 190+ event types)
+│   ├── unified_server.py   # Main server
+│   ├── handlers/           # HTTP endpoint handlers
+│   ├── stream/             # WebSocket streaming (26 modules)
+│   ├── debate_origin.py    # Bidirectional chat routing
+│   └── result_router.py    # Result delivery to originating platform
+├── connectors/       # External integrations
+│   ├── chat/               # Slack, Discord, Teams, Telegram, WhatsApp
+│   ├── enterprise/         # SharePoint, Confluence, Notion, Salesforce, databases
+│   │   ├── streaming/      # Kafka, RabbitMQ
+│   │   └── healthcare/     # HL7, FHIR
+│   └── advertising/        # Twitter Ads, TikTok Ads
+├── auth/             # Authentication (OIDC, SAML, SCIM)
+├── tenancy/          # Multi-tenant isolation
+├── rbac/             # Role-based access (7 roles, 360+ permissions)
+├── compliance/       # SOC 2, GDPR, HIPAA
+├── privacy/          # Anonymization, consent, retention, deletion
+├── security/         # Encryption, key rotation, SSRF protection
+├── observability/    # Prometheus, OpenTelemetry, SLOs
+├── control_plane/    # Agent registry, scheduler, health, policies (1,500+ tests)
+├── workflow/         # DAG-based automation (60+ templates)
+├── nomic/            # Self-improvement (MetaPlanner, BranchCoordinator)
+├── rlm/              # Recursive Language Models
+├── pulse/            # Trending topics (1,000+ tests)
+├── explainability/   # Decision explanations, counterfactuals
+├── verification/     # Z3/Lean formal verification
+├── genesis/          # Fractal debates, agent evolution
+├── sandbox/          # Docker-based safe execution
+├── backup/           # Disaster recovery
+├── pipeline/         # Decision-to-PR generation
+├── marketplace/      # Agent/debate/workflow templates
+├── mcp/              # Model Context Protocol server
+└── cli/              # Command-line interface
+```
+
+**Scale:** 3,000+ Python modules | 153,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+
+---
+
+## Programmatic Usage
+
+### Basic Debate
+
+```python
+import asyncio
+from aragora.agents import create_agent
+from aragora.debate import Arena, DebateProtocol
+from aragora.core import Environment
+from aragora.memory import CritiqueStore
+
+# Create heterogeneous agents (API-backed)
+agents = [
+    create_agent("anthropic-api", name="claude_proposer", role="proposer"),
+    create_agent("openai-api", name="openai_critic", role="critic"),
+    create_agent("gemini", name="gemini_synth", role="synthesizer"),
+]
+
+# Define task
+env = Environment(
+    task="Design a distributed cache with LRU eviction",
+    max_rounds=3,
+)
+
+# Configure debate
+protocol = DebateProtocol(
+    rounds=3,
+    consensus="majority",
+)
+
+# Run with memory
+memory = CritiqueStore("debates.db")
+arena = Arena(env, agents, protocol, memory)
+result = asyncio.run(arena.run())
+
+print(result.final_answer)
+print(f"Consensus: {result.consensus_reached} ({result.confidence:.0%})")
+```
+
+### Python SDK
+
+```python
+from aragora.client import AragoraClient
+
+# Synchronous
+client = AragoraClient(base_url="http://localhost:8080")
+debate = client.debates.run(task="Should we adopt microservices?")
+print(f"Consensus: {debate.consensus.reached}")
+
+# Asynchronous
+async with AragoraClient(base_url="http://localhost:8080") as client:
+    debate = await client.debates.run_async(task="Design a rate limiter")
+    receipt = await client.gauntlet.run_and_wait(input_content="spec.md")
+```
+
+See [SDK_GUIDE.md](../guides/sdk) for full API reference.
+
+### Chat Integrations
+
+Post debate notifications to Discord and Slack:
+
+```python
+from aragora.integrations.discord import DiscordConfig, DiscordIntegration
+
+discord = DiscordIntegration(DiscordConfig(
+    webhook_url="https://discord.com/api/webhooks/..."
+))
+await discord.send_consensus_reached(debate_id, topic, "majority", result)
+```
+
+See [INTEGRATIONS.md](../guides/integrations) for setup instructions.
+
+### Enable Knowledge Mound
+
+```python
+from aragora.debate.arena_config import ArenaConfig
+
+config = ArenaConfig(
+    enable_knowledge_mound=True,
+    enable_km_belief_sync=True,
+    enable_coordinated_writes=True,
+)
+arena = Arena.from_config(env, agents, protocol, config)
+```
+
+### Run with Enterprise Features
+
+```python
+from aragora.tenancy import TenantContext
+from aragora.rbac.decorators import require_permission
+
+async with TenantContext(tenant_id="acme-corp"):
+    result = await arena.run()
+```
+
+### CLI Commands
+
+```bash
+# Run a decision stress-test
+aragora ask "Your task here" --agents anthropic-api,openai-api --rounds 3
+
+# View statistics
+aragora stats
+
+# View learned patterns
+aragora patterns --type security --limit 20
+
+# Run the API + WebSocket server
+aragora serve
+
+# System health check
+aragora doctor
+
+# Export for training
+aragora export --format jsonl > training_data.jsonl
+
+# Build codebase context (RLM-ready)
+aragora context --preview --rlm
+```
+
+### SDK Packages
+
+| Package | Purpose | Installation |
+|---------|---------|--------------|
+| **`aragora`** | Full control plane (server, CLI, SDK) | `pip install aragora` |
+| **`aragora-sdk`** | Official Python SDK (remote HTTP API; sync + async + streaming) | `pip install aragora-sdk` |
+| **`@aragora/sdk`** | TypeScript/Node.js SDK (185 namespaces) | `npm install @aragora/sdk` |
+
+**Deprecated packages** (avoid for new integrations):
+- `aragora-client` -- Legacy async client. Migrate to `aragora-sdk`.
+- `aragora-js` -- Use `@aragora/sdk` instead
+- `@aragora/client` -- Use `@aragora/sdk` instead
+
+See [SDK_COMPARISON.md](SDK_COMPARISON.md) for detailed feature comparison.
+
+---
+
+## Implemented Features (3,700+ Modules)
+
+Aragora has evolved through 21+ phases of self-improvement, with the Nomic Loop debating and implementing each feature.
+
+### Phase 1: Foundation
+
+| Feature | Description |
+|---------|-------------|
+| **ContinuumMemory** | Multi-timescale learning (fast/medium/slow tiers) |
+| **ReplayRecorder** | Cycle event recording for analysis |
+| **MetaLearner** | Self-tuning hyperparameters |
+| **IntrospectionAPI** | Agent self-awareness and reflection |
+| **ArgumentCartographer** | Real-time debate graph visualization |
+| **WebhookDispatcher** | External event notifications |
+
+### Unified Memory Gateway
+
+Enabled via `enable_unified_memory` in `ArenaConfig`. Added February 2026, 150 tests.
+
+- **MemoryGateway** -- Fan-out query across ContinuumMemory, Knowledge Mound, Supermemory, and claude-mem simultaneously, returning a merged and ranked result set.
+- **RetentionGate** -- Titans/MIRAS surprise-driven policy engine that decides whether to retain, demote, forget, or consolidate each memory item based on information gain.
+- **CrossSystemDedupEngine** -- SHA-256 exact-match deduplication plus Jaccard near-duplicate detection across all memory backends, preventing redundant storage.
+- **RLMMemoryNavigator** -- REPL helpers for programmatic cross-system memory exploration, building on the RLM (Recursive Language Models) context access layer.
+- **ClaudeMemAdapter** -- The 41st Knowledge Mound adapter, wrapping the claude-mem MCP connector so external claude-mem stores participate in unified fan-out queries.
+
+### Phase 2: Learning
+
+| Feature | Description |
+|---------|-------------|
+| **ConsensusMemory** | Track settled vs contested topics across debates |
+| **InsightExtractor** | Post-debate pattern learning and extraction |
+
+### Phase 3: Evidence and Resilience
+
+| Feature | Description |
+|---------|-------------|
+| **MemoryStream** | Per-agent persistent memory |
+| **LocalDocsConnector** | Evidence grounding from codebase |
+| **CounterfactualOrchestrator** | Deadlock resolution via forking |
+| **CapabilityProber** | Agent quality assurance testing |
+| **DebateTemplates** | Structured debate formats |
+
+### Phase 4: Agent Evolution
+
+| Feature | Description |
+|---------|-------------|
+| **PersonaManager** | Agent traits and expertise evolution |
+| **PromptEvolver** | Prompt evolution from winning patterns |
+| **Tournament** | Periodic competitive benchmarking |
+
+### Phase 5: Intelligence
+
+| Feature | Description |
+|---------|-------------|
+| **ConvergenceDetector** | Early stopping via semantic convergence |
+| **MetaCritiqueAnalyzer** | Debate process feedback and recommendations |
+| **EloSystem** | Persistent agent skill tracking |
+| **AgentSelector** | Smart agent team selection |
+| **RiskRegister** | Low-consensus risk tracking |
+
+### Phase 6: Formal Reasoning
+
+| Feature | Description |
+|---------|-------------|
+| **ClaimsKernel** | Structured typed claims with evidence tracking |
+| **ProvenanceManager** | Cryptographic evidence chain integrity |
+| **BeliefNetwork** | Probabilistic reasoning over uncertain claims |
+| **ProofExecutor** | Executable verification of claims |
+| **ScenarioMatrix** | Robustness testing across scenarios |
+
+### Phase 7: Reliability and Audit
+
+| Feature | Description |
+|---------|-------------|
+| **EnhancedProvenanceManager** | Staleness detection for living documents |
+| **CheckpointManager** | Pause/resume and crash recovery |
+| **BreakpointManager** | Human intervention breakpoints |
+| **ReliabilityScorer** | Claim confidence scoring |
+| **DebateTracer** | Audit logs and deterministic replay |
+
+### Phase 8: Advanced Debates
+
+| Feature | Description |
+|---------|-------------|
+| **PersonaLaboratory** | A/B testing, emergent traits, cross-pollination |
+| **SemanticRetriever** | Pattern matching for similar critiques |
+| **FormalVerificationManager** | Z3 theorem proving for logical claims |
+| **DebateGraph** | DAG-based debates for complex disagreements |
+| **DebateForker** | Parallel branch exploration |
+
+### Phase 9: Truth Grounding
+
+| Feature | Description |
+|---------|-------------|
+| **FlipDetector** | Semantic position reversal detection |
+| **CalibrationTracker** | Prediction accuracy tracking (Brier score) |
+| **GroundedPersonaManager** | Evidence-linked persona synthesis |
+| **PositionTracker** | Agent position history with verification |
+
+### Phase 10: Thread-Safe Audience Participation
+
+| Feature | Description |
+|---------|-------------|
+| **ArenaMailbox** | Thread-safe event queue for live interaction |
+| **LoopScoping** | Session-isolated streaming events |
+
+### Phase 11: Operational Modes
+
+| Feature | Description |
+|---------|-------------|
+| **OperationalModes** | Agent tool configuration switching |
+| **CapabilityProber** | Agent vulnerability testing |
+| **RedTeamMode** | Adversarial analysis of proposals |
+
+### Enterprise Features (Production-Ready)
+
+| Feature | Description |
+|---------|-------------|
+| **Multi-Tenancy** | Tenant isolation with quotas and cost tracking |
+| **OIDC/SAML SSO** | Enterprise single sign-on integration |
+| **MFA Support** | TOTP/HOTP multi-factor authentication |
+| **AES-256 Encryption** | Encryption at rest with key rotation |
+| **Audit Logging** | Tamper-evident immutable audit trail |
+| **SOC 2 Compliance** | Controls mapping and evidence documentation |
+| **Prometheus Metrics** | 14+ custom metrics with Grafana dashboards |
+| **OpenTelemetry** | Distributed tracing support |
+| **Rate Limiting** | IP, token, and endpoint-based limits |
+| **Connection Pooling** | Adaptive pool with health monitoring |
+| **SCIM 2.0** | Automated user/group provisioning |
+| **RBAC v2** | 7 roles, 360+ permissions, decorator-based enforcement |
+| **Backup/DR** | Incremental backups, retention policies, disaster recovery |
+| **Control Plane** | Agent registry, task scheduler, health monitoring, policy governance (1,500+ tests) |
+
+See [ENTERPRISE_FEATURES.md](../enterprise/features) for complete enterprise capabilities.
+
+---
+
+## Prerequisites
+
+**API Agents (Recommended):** Set your API keys -- no additional tools needed:
+
+```bash
+# Set one or more API keys in .env or environment
+ANTHROPIC_API_KEY=sk-ant-xxx    # For Claude (Opus 4.5, Sonnet 4)
+OPENAI_API_KEY=sk-xxx           # For GPT models
+GEMINI_API_KEY=AIzaSy...        # For Gemini 2.5
+XAI_API_KEY=xai-xxx             # For Grok 4
+MISTRAL_API_KEY=xxx             # For Mistral Large, Codestral
+OPENROUTER_API_KEY=sk-or-xxx    # For DeepSeek, Qwen, Yi (multi-model access)
+KIMI_API_KEY=xxx                # For Kimi (Moonshot, China perspective)
+```
+
+**CLI Agents (Optional):** For local CLI-based agents, install the corresponding tools:
+
+```bash
+npm install -g @anthropic-ai/claude-code   # Claude CLI
+npm install -g @openai/codex               # OpenAI Codex CLI
+npm install -g @google/gemini-cli          # Google Gemini CLI
+npm install -g grok-cli                    # xAI Grok CLI
+```
+
+### Supported Entry Points
+
+Stable interfaces (recommended):
+- `aragora gauntlet` for decision stress-tests (CLI)
+- `aragora ask` for exploratory debates (CLI)
+- `aragora serve` for the unified API + WebSocket server
+- `python -m aragora` as a CLI alias
+- `python -m aragora.server` for the server in scripts/automation
+
+Experimental/research (may change; use in a sandbox):
+- `scripts/nomic_loop.py` and `scripts/run_nomic_with_stream.py`
+- `aragora improve` (self-improvement mode)
+
+---
+
+## Deployment
+
+### AWS Lightsail (Production)
+
+```bash
+# Deploy to Lightsail
+./deploy/lightsail-setup.sh
+
+# The server runs at api.aragora.ai via Cloudflare Tunnel
+# Frontend at aragora.ai via Cloudflare Pages
+```
+
+Configuration:
+- **Instance**: Ubuntu 22.04, nano_3_0 ($5/month)
+- **HTTP API**: Port 8080
+- **WebSocket**: Port 8765 (ws://host:8765 or ws://host:8765/ws)
+- **Tunnel**: Cloudflare Tunnel proxies api.aragora.ai
+
+### Local Development
+
+```bash
+aragora serve --api-port 8080 --ws-port 8765
+```
+
+---
+
+## API Endpoints
+
+The server exposes 3,000+ API operations across 2,700+ paths. Key categories:
+
+| Category | Description |
+|----------|-------------|
+| `/api/debates/*` | Debate CRUD, forking, export, search |
+| `/api/gauntlet/*` | Adversarial stress-testing, receipts, heatmaps |
+| `/api/agent/\{name\}/*` | Agent profiles, calibration, consistency, performance |
+| `/api/v1/memory/*` | Multi-tier memory (continuum), search, analytics (legacy `/api/memory/*` supported) |
+| `/api/auth/*` | Registration, login, OAuth, API keys |
+| `/api/billing/*` | Stripe subscriptions, usage, checkout |
+| `/api/tournaments/*` | Competitive brackets, standings, matches |
+| `/api/verify/*` | Formal verification with Z3 solver |
+| `WS /ws` | Real-time streaming (see `WEBSOCKET_EVENTS.md`) |
+
+**Full API reference**: [API_ENDPOINTS.md](../api/endpoints) (auto-generated)
+**OpenAPI spec**: `GET /api/openapi` or `GET /api/openapi.yaml`
+**Interactive docs**: `GET /api/docs` (Swagger UI)
+
+### WebSocket Events
+
+```typescript
+// Event types streamed via WebSocket
+type EventType =
+  | "debate_start" | "round_start" | "agent_message"
+  | "critique" | "vote" | "consensus" | "debate_end"
+  | "token_start" | "token_delta" | "token_end"
+  | "loop_list" | "audience_metrics" | "grounded_verdict"
+  | "gauntlet_start" | "gauntlet_verdict" | "gauntlet_complete"
+```
+
+See `WEBSOCKET_EVENTS.md` for the full list and payloads.
+
+---
+
+## Security
+
+Aragora implements defense-in-depth security:
+
+- **Webhook Verification**: Ed25519 signatures for Discord and Slack
+- **Rate Limiting**: Thread-safe, multi-layer (IP, token, endpoint) with configurable limits
+- **Input Validation**: API parameters validated and capped; content-length enforcement
+- **Multipart Limits**: Max 100 parts prevents DoS via form flooding
+- **Path Traversal Protection**: Static file serving validates paths against base directory
+- **CORS**: Origin allowlist (no wildcards)
+- **Security Headers**: X-Frame-Options, X-Content-Type-Options, X-XSS-Protection, Referrer-Policy, CSP, HSTS
+- **Error Sanitization**: Internal errors don't leak stack traces; API keys redacted from responses
+- **Process Cleanup**: CLI agents properly kill and await zombie processes
+- **Backpressure Control**: Stream event queues capped to prevent memory exhaustion
+- **WebSocket Limits**: Max message size 64KB, ping/pong (30s/10s), debate timeouts
+- **Thread Safety**: Double-checked locking for shared executor initialization
+- **Secure Client IDs**: Cryptographically random WebSocket identifiers
+- **JSON Parse Timeout**: 5-second timeout prevents CPU-bound DoS
+- **Upload Rate Limiting**: IP-based limits (5/min, 30/hour) prevent storage DoS
+- **SSRF Protection**: Server-side request forgery prevention
+- **AES-256-GCM**: Field-level encryption with key derivation and rotation
+- **Cloud KMS**: AWS KMS, Azure Key Vault, GCP Cloud KMS support
+
+Configure security via environment variables:
+```bash
+export ARAGORA_API_TOKEN="your-secret-token"
+export ARAGORA_ALLOWED_ORIGINS="https://aragora.ai,https://www.aragora.ai"
+export ARAGORA_TOKEN_TTL=3600
+export ARAGORA_WS_MAX_MESSAGE_SIZE=65536
+```
+
+### Compliance and Governance
+
+| Document | Purpose |
+|----------|---------|
+| [SOC 2 Compliance](../enterprise/compliance) | SOC 2 Type II controls and evidence |
+| [Data Classification](../security/data-classification) | Data handling policies and sensitivity levels |
+| [Incident Response](../operations/incident-response) | Incident playbooks and escalation procedures |
+| [Privacy Policy](../security/privacy-policy) | Data collection and retention policies |
+| [Nomic Governance](./enterprise/NOMIC_GOVERNANCE.md) | Autonomous loop safety controls |
+
+---
+
+## Self-Improvement (Nomic Loop)
+
+Aragora's self-improvement system is an autonomous cycle where agents debate and implement improvements to the codebase. Always run in a sandbox with human review.
+
+### Nomic Loop Phases
+
+| Phase | Name | Purpose |
+|-------|------|---------|
+| 0 | Context | Gather codebase understanding |
+| 1 | Debate | Agents propose improvements |
+| 2 | Design | Architecture planning |
+| 3 | Implement | Code generation (Codex/Claude) |
+| 4 | Verify | Tests and checks |
+
+### Running the Nomic Loop
+
+```bash
+# Run the nomic loop with streaming
+python scripts/run_nomic_with_stream.py run --cycles 3
+
+# Goal-driven self-improvement with human approval
+python scripts/self_develop.py --goal "Improve test coverage" --require-approval
+
+# Dry run to preview decomposition
+python scripts/self_develop.py --goal "Refactor dashboard" --dry-run
+
+# Run individual phases
+python scripts/nomic_staged.py debate
+python scripts/nomic_staged.py design
+python scripts/nomic_staged.py implement
+python scripts/nomic_staged.py verify
+```
+
+### Key Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| MetaPlanner | `aragora/nomic/meta_planner.py` | Debate-driven goal prioritization |
+| BranchCoordinator | `aragora/nomic/branch_coordinator.py` | Parallel branch management |
+| TaskDecomposer | `aragora/nomic/task_decomposer.py` | Break complex tasks into subtasks |
+| AutonomousOrchestrator | `aragora/nomic/autonomous_orchestrator.py` | End-to-end orchestration |
+
+### Self-Improvement Learning
+
+Aragora learns from successful stress-tests through a structured feedback loop:
+
+1. **Pattern Storage**: Successful critique > fix patterns indexed by issue type
+2. **Retrieval**: Future debates retrieve relevant patterns (learning from history)
+3. **Prompt Evolution**: Agent system prompts evolve based on what works
+4. **Nomic Loop**: The system debates *changes to itself*, making its own rules an object of dialectical inquiry
+5. **Export**: Patterns can be exported for fine-tuning
+
+```python
+# Retrieve successful patterns
+from aragora.memory import CritiqueStore
+
+store = CritiqueStore("debates.db")
+security_patterns = store.retrieve_patterns(issue_type="security", min_success=3)
+
+for pattern in security_patterns:
+    print(f"Issue: {pattern.issue_text}")
+    print(f"Fix: {pattern.suggestion_text}")
+    print(f"Success rate: {pattern.success_rate:.0%}")
+```
+
+Safety features: automatic backups, protected file checksums, rollback on failure, human approval for dangerous changes.
+
+---
+
+## Channels and Integrations
+
+### Chat Platforms
+
+| Channel | Features |
+|---|---|
+| **Slack** | Bot + OAuth, webhooks, evidence collection |
+| **Microsoft Teams** | Bot + OAuth, meetings, JWT verification |
+| **Discord** | Interactions API, guilds, channels, DMs, Ed25519 verification |
+| **Telegram** | Bot API with TTS support |
+| **WhatsApp** | Business API with voice notes |
+| **Google Chat** | Spaces, messages, JWT verification |
+
+### Enterprise Streaming
+
+| System | Features |
+|---|---|
+| **Apache Kafka** | Consumer groups, offset tracking, JSON/Avro/Protobuf |
+| **RabbitMQ** | Exchange/queue binding, DLQ, bidirectional |
+
+### Data Sources
+
+GitHub, GitLab, ArXiv, Wikipedia, SEC filings, HackerNews, Reddit, Twitter/X, SharePoint, Confluence, Notion, Salesforce, HubSpot, Zendesk, Jira, PostgreSQL (CDC), MongoDB, MySQL, SQL Server, Snowflake, HL7v2, FHIR.
+
+### Advertising and Marketing
+
+Twitter/X Ads, TikTok Ads, Mailchimp, Klaviyo, Segment CDP.
+
+### Bidirectional Chat Routing
+
+Results automatically route to the originating channel. Debate Origin Tracking records where each debate started, and the Result Router delivers outputs back to that platform -- including TTS for voice channels.
+
+---
+
+## Inspiration and Citations
+
+### Foundational Inspiration
+
+- **[Stanford Generative Agents](https://github.com/joonspk-research/generative_agents)** -- Memory + reflection architecture
+- **[ChatArena](https://github.com/chatarena/chatarena)** -- Game environments for multi-agent interaction
+- **[LLM Multi-Agent Debate](https://github.com/composable-models/llm_multiagent_debate)** -- ICML 2024 consensus mechanisms
+- **[UniversalBackrooms](https://github.com/scottviteri/UniversalBackrooms)** -- Multi-model infinite conversations
+- **[Project Sid](https://github.com/altera-al/project-sid)** -- Emergent civilization with 1000+ agents
+
+### Borrowed Patterns (MIT/Apache Licensed)
+
+| Project | What We Borrowed | License |
+|---------|------------------|---------|
+| **[ai-counsel](https://github.com/AI-Counsel/ai-counsel)** | Semantic convergence detection (3-tier fallback: SentenceTransformer > TF-IDF > Jaccard), vote option grouping, per-agent similarity tracking | MIT |
+| **[DebateLLM](https://github.com/Tsinghua-MARS-Lab/DebateLLM)** | Agreement intensity modulation (0-10 scale), asymmetric debate roles, judge-based termination | Apache 2.0 |
+| **[CAMEL-AI](https://github.com/camel-ai/camel)** | Multi-agent orchestration patterns, critic agent design | Apache 2.0 |
+| **[CrewAI](https://github.com/joaomdmoura/crewAI)** | Agent role and task patterns | MIT |
+| **[AIDO](https://github.com/aido-research/aido)** | Consensus variance tracking, reputation-weighted voting | MIT |
+| **[claude-flow](https://github.com/ruvnet/claude-flow)** | Adaptive topology switching, YAML agent configuration, hooks system | MIT |
+| **[ccswarm](https://github.com/nwiizo/ccswarm)** | Delegation strategy patterns, channel-based orchestration | MIT |
+| **[claude-code-by-agents](https://github.com/baryhuang/claude-code-by-agents)** | Cooperative cancellation tokens with linked parent-child hierarchy | MIT |
+| **[claude-squad](https://github.com/smtg-ai/claude-squad)** | Session lifecycle state machine concepts (patterns only, reimplemented) | AGPL-3.0 (patterns only) |
+| **[claude-agent-sdk-demos](https://github.com/anthropics/claude-agent-sdk-demos)** | Official Anthropic subagent patterns, parallel execution idioms | MIT |
+
+See implementations in:
+- `aragora/debate/convergence.py` -- Semantic convergence detection
+- `aragora/debate/orchestrator.py` -- Orchestration patterns
+- `aragora/debate/topology.py` -- Adaptive topology (claude-flow)
+- `aragora/debate/session.py` -- Session lifecycle (claude-squad patterns)
+- `aragora/debate/cancellation.py` -- Cancellation tokens (claude-code-by-agents)
+
+See the full attribution table in [CREDITS.md](./reference/CREDITS.md).
+
+---
+
+## Roadmap
+
+- [x] **Phase 1-21**: Core framework with 65+ integrated features
+- [x] **Position Flip Detection**: Track agent position reversals and consistency scores
+- [x] **Hybrid Model Architecture**: Gemini=Designer, Claude=Implementer, Codex=Verifier
+- [x] **Security Hardening**: API key header auth, rate limiting, input validation
+- [x] **Feature Integration**: PerformanceMonitor, CalibrationTracker, Airlock, Telemetry
+- [x] **Multi-Provider Agents**: Mistral, DeepSeek, Qwen, Yi, Kimi via direct API and OpenRouter
+- [x] **Knowledge Mound Phase A2**: Contradiction detection, confidence decay, RBAC governance
+- [x] **OpenClaw Integration**: Portable agent governance via dedicated handlers
+- [ ] **LeanBackend**: Lean 4 theorem proving integration
+- [ ] **Emergent Society**: Society simulation (a la Project Sid)
+- [ ] **Multi-Codebase**: Cross-repository coordination
+
+---
+
+## Related Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [README](../analysis/adr) | Concise project overview with five pillars |
+| [CLAUDE.md](./claude) | Development guide for AI assistants |
+| [STATUS.md](./status) | Detailed feature implementation status |
+| [FEATURE_DISCOVERY.md](./feature-discovery) | Complete feature catalog (180+) |
+| [COMMERCIAL_OVERVIEW.md](../enterprise/commercial-overview) | Commercial positioning |
+| [ENTERPRISE_FEATURES.md](../enterprise/features) | Enterprise capabilities reference |
+| [API_REFERENCE.md](../api/reference) | REST API documentation |
+| [SDK_GUIDE.md](../guides/sdk) | SDK usage guide |
+| [GAUNTLET.md](../guides/gauntlet) | Gauntlet stress-testing guide |
+| [INDEX.md](./documentation-index) | Full documentation index |
+
+---
+
+## Contributing
+
+Contributions welcome. Areas of interest:
+
+- Additional agent backends (Cohere, Inflection, Reka)
+- Debate visualization enhancements
+- Benchmark datasets for agent evaluation
+- Prompt engineering for better critiques
+- Self-improvement mechanism research
+- Lean 4 theorem proving integration
+
+## License
+
+MIT
+
+---
+
+*The name "aragora" evokes the Greek agora -- the public assembly where citizens debated and reached collective decisions through reasoned discourse.*
+
+*Special thanks to the researchers behind Generative Agents, ChatArena, and Project Sid for pioneering this space, and to Hegel for the insight that contradiction is not a flaw to avoid but the engine of development.*

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -1,0 +1,807 @@
+---
+title: Aragora Feature Discovery Guide
+description: Aragora Feature Discovery Guide
+---
+
+# Aragora Feature Discovery Guide
+
+*Complete catalog of 230+ features for developers exploring Aragora capabilities*
+
+This document provides a comprehensive inventory of Aragora's features organized by domain. Use this guide to discover what Aragora can do and find the relevant modules for your use case.
+
+> **Quick Links**: [STATUS.md](./status) for implementation status | [ENTERPRISE_FEATURES.md](../enterprise/features) for enterprise details | [API_REFERENCE.md](../api/reference) for endpoints
+
+---
+
+## Quick Reference
+
+| Category | Feature Count | Status Summary |
+|----------|---------------|----------------|
+| [Core Debate Features](#1-core-debate-features) | 25+ | Stable |
+| [Agent System](#2-agent-system) | 20+ | Stable |
+| [Memory & Learning](#3-memory--learning) | 25+ | Stable |
+| [Knowledge Management](#4-knowledge-management) | 30+ | Stable |
+| [Enterprise Features](#5-enterprise-features) | 45+ | Production-Ready |
+| [Integrations & Connectors](#6-integrations--connectors) | 50+ | Stable |
+| [Observability & Monitoring](#7-observability--monitoring) | 15+ | Stable |
+| [Developer Tools](#8-developer-tools) | 35+ | Stable |
+| [Self-Improvement](#9-self-improvement--nomic-loop) | 18+ | Stable |
+
+**Total**: 230+ features | 3,800+ Python modules | 210,000+ tests | 3,100+ API operations across 2,600+ paths
+
+---
+
+## 1. Core Debate Features
+
+### Debate Orchestration
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Arena** | Stable | Main debate engine orchestrating multi-agent discussions | `aragora/debate/orchestrator.py` | [DEBATE_PHASES.md](../core-concepts/debates) |
+| **Debate Phases** | Stable | Structured phases (propose, critique, revise, vote) | `aragora/debate/phases/` | [DEBATE_PHASES.md](../core-concepts/debates) |
+| **Consensus Detection** | Stable | Multi-strategy consensus (majority, unanimous, weighted) | `aragora/debate/consensus.py` | |
+| **Convergence Detection** | Stable | Semantic similarity tracking with ANN backend | `aragora/debate/convergence.py` | |
+| **Team Selection** | Stable | ELO-based agent team composition with calibration | `aragora/debate/team_selector.py` | |
+| **Prompt Builder** | Stable | Dynamic prompt construction for debate context | `aragora/debate/prompt_builder.py` | |
+| **Extended Rounds** | Stable | Support for 50+ round debates with RLM context management | `aragora/debate/extended_rounds.py` | |
+| **Memory Manager** | Stable | Debate-scoped memory coordination | `aragora/debate/memory_manager.py` | |
+
+### Debate Enhancements
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Trickster** | Stable | Hollow consensus detection (devil's advocate) | `aragora/debate/trickster.py` | [TRICKSTER.md](../advanced/trickster) |
+| **Rhetorical Observer** | Stable | Argument quality analysis and scoring | `aragora/debate/rhetorical_observer.py` | |
+| **Security Barrier** | Stable | Telemetry redaction and content protection | `aragora/debate/security_barrier.py` | |
+| **Calibration Tracker** | Stable | Agent confidence calibration via `enable_calibration` | `aragora/debate/calibration.py` | |
+| **Performance Monitor** | Stable | Debate performance metrics via Arena and AutonomicExecutor | `aragora/debate/performance.py` | |
+| **Graph Debates** | Stable | Graph-structured argument topology | `aragora/debate/topology.py` | [GRAPH_DEBATES.md](../guides/graph-debates) |
+| **Matrix Debates** | Stable | Multi-dimensional debate analysis | `aragora/debate/matrix.py` | [MATRIX_DEBATES.md](../guides/matrix-debates) |
+| **Debate Breakpoints** | Stable | Pause/resume debate execution | `aragora/debate/breakpoints.py` | |
+| **Hybrid Debates** | Stable | External + internal agent debates | `aragora/server/handlers/hybrid_debate.py` | |
+
+### User Participation
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
+| **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
+| **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
+| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` now serves a finite buffered SSE snapshot with JSON preview fallback, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
+
+### Configuration
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **ArenaConfig** | Stable | Centralized debate configuration with 40+ options | `aragora/debate/arena_config.py` |
+| **DebateProtocol** | Stable | Protocol parameters (rounds, consensus, concurrency) | `aragora/core.py` |
+| **Orchestrator Hooks** | Stable | Extension points for custom logic | `aragora/debate/orchestrator_hooks.py` |
+
+---
+
+## 2. Agent System
+
+### Supported Providers (43 agent types)
+
+| Provider | Type | Models | Key Files |
+|----------|------|--------|-----------|
+| **Anthropic** | API | Claude 3.5, Claude Opus 4.5 | `aragora/agents/api_agents/anthropic.py` |
+| **OpenAI** | API | GPT-4o, GPT-4 Turbo, o1, o3 | `aragora/agents/api_agents/openai.py` |
+| **Google** | API | Gemini Pro, Gemini Ultra | `aragora/agents/api_agents/gemini.py` |
+| **Mistral** | API | Mistral Large, Codestral | `aragora/agents/api_agents/mistral.py` |
+| **xAI** | API | Grok | `aragora/agents/api_agents/grok.py` |
+| **OpenRouter** | API | DeepSeek, Llama, Qwen, Yi, Kimi | `aragora/agents/api_agents/openrouter.py` |
+| **Ollama** | Local | Any GGUF model | `aragora/agents/api_agents/ollama.py` |
+| **LM Studio** | Local | Any local model | `aragora/agents/api_agents/lm_studio.py` |
+| **CLI Agents** | CLI | Claude, Codex, Gemini, Grok terminals | `aragora/agents/cli_agents.py` |
+
+### Agent Features
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Agent Spec** | Stable | Unified specification parsing (`provider\|model\|persona\|role`) | `aragora/agents/spec.py` |
+| **Airlock Proxy** | Stable | Agent resilience with circuit breaker via `use_airlock` | `aragora/agents/airlock.py` |
+| **Fallback Chain** | Stable | Automatic OpenRouter fallback on 429 errors | `aragora/agents/fallback.py` |
+| **Session Circuit-Breaker** | Stable | Auth-state pinning (401/403), provider rotation after failures | `aragora/routing/session_circuit_breaker.py` |
+| **Rate Limiter** | Stable | Per-provider rate limiting | `aragora/agents/api_agents/rate_limiter.py` |
+| **Personas** | Stable | Configurable agent personalities | `aragora/agents/personas.py` |
+| **Calibration** | Stable | Agent performance calibration tracking | `aragora/agents/calibration.py` |
+| **Error Handling** | Stable | Unified error hierarchy | `aragora/agents/errors.py` |
+
+### External Agents
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **External Framework** | Stable | CrewAI, LangGraph, AutoGen integration | `aragora/agents/external/` |
+| **A2A Protocol** | Stable | Agent-to-Agent communication | `aragora/server/handlers/a2a.py` |
+| **External Agents API** | Stable | External agent task management | `aragora/server/handlers/external_agents.py` |
+
+---
+
+## 3. Memory & Learning
+
+### Memory Systems
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Continuum Memory** | Stable | Multi-tier memory (fast/medium/slow/glacial) | `aragora/memory/continuum/core.py` | |
+| **Consensus Memory** | Stable | Historical debate outcome storage | `aragora/memory/consensus.py` | |
+| **Memory Coordinator** | Stable | Atomic cross-system writes via `enable_coordinated_writes` | `aragora/memory/coordinator.py` | |
+| **Cross-Debate Memory** | Stable | Institutional knowledge injection via `enable_cross_debate_memory` | `aragora/memory/cross_debate_rlm.py` | |
+| **Supermemory** | Stable | Cross-session external memory via `enable_supermemory` (80+ tests) | `aragora/memory/supermemory.py` | |
+| **Memory Streams** | Stable | Event-based memory updates | `aragora/memory/streams.py` | |
+| **Embeddings** | Stable | Semantic embedding for retrieval (OpenAI, Gemini, Ollama) | `aragora/memory/embeddings.py` | |
+| **Critique Store** | Stable | Critique pattern storage | `aragora/memory/store.py` | |
+| **Progressive Memory Search** | Stable | Staged retrieval (index → timeline → entries) across both continuum backends | `aragora/server/handlers/memory/memory.py`, `aragora/server/handlers/memory/memory_progressive.py` | |
+| **Memory Viewer** | Stable | HTML viewer for memory inspection | `aragora/server/handlers/memory/memory.py` | |
+| **Tool Usage Capture** | Optional | Opt-in tool usage capture into FAST tier | `aragora/memory/capture.py` | |
+| **Unified Memory Gateway** | Integrated | Fan-out query across ContinuumMemory, KM, Supermemory, claude-mem via `enable_unified_memory`; handler availability still depends on optional unified-memory backends | `aragora/memory/gateway.py`, `aragora/memory/retention_gate.py`, `aragora/memory/dedup.py` | |
+| **ClaudeMemAdapter** | Integrated | KM adapter wrapping claude-mem MCP connector (one of 42 registered adapter specs) | `aragora/knowledge/mound/adapters/claude_mem_adapter.py` | |
+
+### Unified Memory Gateway Components
+
+| Component | Status | Description | Key Files |
+|-----------|--------|-------------|-----------|
+| **MemoryGateway** | Integrated | Unified fan-out query interface across all memory systems | `aragora/memory/gateway.py` |
+| **RetentionGate** | Integrated | Titans/MIRAS surprise-driven retain/demote/forget/consolidate decisions | `aragora/memory/retention_gate.py` |
+| **CrossSystemDedupEngine** | Integrated | SHA-256 exact + Jaccard near-duplicate detection across memory systems | `aragora/memory/dedup.py` |
+| **RLMMemoryNavigator** | Integrated | REPL helpers for programmatic cross-system memory exploration | `aragora/rlm/memory_navigator.py` |
+
+### Memory Tiers
+
+| Tier | TTL | Purpose |
+|------|-----|---------|
+| Fast | 1 min | Immediate context |
+| Medium | 1 hour | Session memory |
+| Slow | 1 day | Cross-session learning |
+| Glacial | 1 week | Long-term patterns |
+
+### Learning & Ranking
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **ELO Rankings** | Stable | Agent skill tracking with continuous updates | `aragora/ranking/elo.py` |
+| **Calibration Tracking** | Stable | Confidence calibration metrics | `aragora/ranking/calibration.py` |
+| **Leaderboard** | Stable | Agent ranking leaderboards | `aragora/ranking/leaderboard.py` |
+| **Tournaments** | Stable | Agent tournament competitions | `aragora/tournaments/` |
+| **Selection Feedback** | Stable | Performance-based agent selection via `enable_performance_feedback` | `aragora/debate/selection_feedback.py` |
+| **Learning Efficiency** | Stable | Agents who improve get ELO bonuses | `aragora/ranking/learning.py` |
+
+### RLM (Recursive Language Models)
+
+Based on [arXiv:2512.24601](https://arxiv.org/abs/2512.24601) - Context stored as Python variables in REPL, not prompt compression.
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **RLM Factory** | Stable | RLM context management factory | `aragora/rlm/factory.py` | [RLM_GUIDE.md](../advanced/rlm) |
+| **RLM Bridge** | Stable | Integration bridge for RLM | `aragora/rlm/bridge.py` | |
+| **RLM Handler** | Partial | Request handling is available, but context storage is still in-memory by default and some streaming flows are backend-conditional | `aragora/server/handlers/rlm.py` | |
+| **Streaming RLM** | Stable | Progressive context loading (top-down, bottom-up, targeted) | `aragora/rlm/streaming.py` | |
+| **RLM Training** | Stable | Experience replay buffer and reward computation | `aragora/rlm/training/` | |
+| **Cognitive Limiter** | Stable | Context management via `use_rlm_limiter` | `aragora/debate/cognitive_limiter_rlm.py` | |
+
+---
+
+## 4. Knowledge Management
+
+### Knowledge Mound (Phase A2 Complete - 4,300+ tests)
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Core Storage** | Stable | Unified knowledge storage | `aragora/knowledge/mound/core.py` | [KNOWLEDGE_MOUND.md](../core-concepts/knowledge-mound) |
+| **Semantic Store** | Stable | Vector embedding-based search | `aragora/knowledge/mound/semantic.py` | |
+| **Graph Store** | Stable | Relationship and lineage tracking | `aragora/knowledge/mound/graph.py` | |
+| **Domain Taxonomy** | Stable | Hierarchical knowledge organization | `aragora/knowledge/mound/taxonomy.py` | |
+| **Visibility Levels** | Stable | private/workspace/organization/public/system | `aragora/knowledge/mound/visibility.py` | |
+| **Access Grants** | Stable | Fine-grained permissions with expiration | `aragora/knowledge/mound/access.py` | |
+| **Cross-Workspace Sharing** | Stable | Share knowledge between workspaces | `aragora/knowledge/mound/sharing.py` | |
+| **Federation** | Stable | Multi-region sync (push/pull/bidirectional) | `aragora/knowledge/mound/federation.py` | |
+| **Deduplication** | Stable | Find and merge duplicate items | `aragora/knowledge/mound/dedup.py` | |
+| **Pruning** | Stable | Archive/delete stale items with policies | `aragora/knowledge/mound/pruning.py` | |
+| **Auto-Curation** | Stable | Automated knowledge maintenance with quality scoring | `aragora/knowledge/mound/curation.py` | |
+| **Contradiction Detection** | Stable | Identify conflicting knowledge | `aragora/knowledge/mound/contradictions.py` | |
+| **Confidence Decay** | Stable | Time-based confidence scoring | `aragora/knowledge/mound/confidence.py` | |
+| **RBAC Governance** | Stable | Permission-based knowledge access | `aragora/knowledge/mound/rbac.py` | |
+| **KM Resilience** | Stable | ResilientPostgresStore with retry, health, cache invalidation | `aragora/knowledge/mound/resilience.py` | |
+| **SLO Alerting** | Stable | Adapter performance monitoring with Prometheus | `aragora/config/performance_slos.py` | |
+
+### Knowledge Adapters (42 Registered Adapter Specs)
+
+| Adapter | Purpose | Key Files |
+|---------|---------|-----------|
+| **Belief** | Belief network integration | `aragora/knowledge/mound/adapters/belief_adapter.py` |
+| **CalibrationFusion** | Calibration data integration | `aragora/knowledge/mound/adapters/calibration_fusion_adapter.py` |
+| **ComputerUse** | Computer use data | `aragora/knowledge/mound/adapters/computer_use_adapter.py` |
+| **Consensus** | Debate consensus storage | `aragora/knowledge/mound/adapters/consensus_adapter.py` |
+| **Continuum** | Memory tier integration | `aragora/knowledge/mound/adapters/continuum_adapter.py` |
+| **ControlPlane** | Control plane data | `aragora/knowledge/mound/adapters/control_plane_adapter.py` |
+| **Cost** | Cost tracking and alerts | `aragora/knowledge/mound/adapters/cost_adapter.py` |
+| **Critique** | Critique pattern storage | `aragora/knowledge/mound/adapters/critique_adapter.py` |
+| **Culture** | Organizational culture patterns | `aragora/knowledge/mound/adapters/culture_adapter.py` |
+| **ELO** | Agent rankings | `aragora/knowledge/mound/adapters/elo_adapter.py` |
+| **ERC8004** | ERC-8004 compliance | `aragora/knowledge/mound/adapters/erc8004_adapter.py` |
+| **Evidence** | Evidence snippet storage | `aragora/knowledge/mound/adapters/evidence_adapter.py` |
+| **Extraction** | Knowledge extraction | `aragora/knowledge/mound/adapters/extraction_adapter.py` |
+| **Fabric** | Fabric integration | `aragora/knowledge/mound/adapters/fabric_adapter.py` |
+| **Gateway** | Gateway data | `aragora/knowledge/mound/adapters/gateway_adapter.py` |
+| **Insights** | Analytical insights and Trickster flips | `aragora/knowledge/mound/adapters/insights_adapter.py` |
+| **OpenClaw** | OpenClaw integration | `aragora/knowledge/mound/adapters/openclaw_adapter.py` |
+| **Performance** | Performance metrics | `aragora/knowledge/mound/adapters/performance_adapter.py` |
+| **Provenance** | Decision provenance | `aragora/knowledge/mound/adapters/provenance_adapter.py` |
+| **Pulse** | Trending topics | `aragora/knowledge/mound/adapters/pulse_adapter.py` |
+| **Ranking** | Performance rankings | `aragora/knowledge/mound/adapters/ranking_adapter.py` |
+| **Receipt** | Decision receipts auto-persist | `aragora/knowledge/mound/adapters/receipt_adapter.py` |
+| **RLM** | RLM context integration | `aragora/knowledge/mound/adapters/rlm_adapter.py` |
+| **Supermemory** | External memory integration | `aragora/knowledge/mound/adapters/supermemory_adapter.py` |
+| **Workspace** | Workspace data | `aragora/knowledge/mound/adapters/workspace_adapter.py` |
+| **Adapter Factory** | Auto-create adapters from Arena subsystems | `aragora/knowledge/mound/adapters/factory.py` |
+
+### Knowledge Bridges
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **KnowledgeBridgeHub** | Stable | Unified access to all bridges | `aragora/knowledge/bridges.py` |
+| **MetaLearner Bridge** | Stable | Cross-memory optimization | `aragora/knowledge/metalearner.py` |
+| **Evidence Bridge** | Stable | Evidence collection and storage | `aragora/knowledge/evidence.py` |
+| **Pattern Bridge** | Stable | Pattern recognition and storage | `aragora/knowledge/patterns.py` |
+
+### Reasoning & Provenance
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Belief Network** | Stable | Claim provenance tracking with cruxes | `aragora/reasoning/belief.py` | [REASONING.md](../core-concepts/reasoning) |
+| **Provenance Tracking** | Stable | Decision lineage and audit trails | `aragora/reasoning/provenance.py` | |
+| **Claims System** | Stable | Structured claim management | `aragora/reasoning/claims.py` | |
+
+---
+
+## 5. Enterprise Features
+
+### Authentication & Authorization
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **OIDC Integration** | Production | OpenID Connect SSO with JWK verification | `aragora/auth/oidc.py` | [SSO_SETUP.md](../enterprise/sso) |
+| **SAML Support** | Production | SAML 2.0 enterprise IdP integration | `aragora/auth/saml.py` | |
+| **MFA (TOTP/HOTP)** | Production | Multi-factor via authenticator apps | `aragora/server/middleware/mfa.py` | |
+| **API Key Management** | Production | Scoped keys with rotation and usage tracking | `aragora/server/handlers/auth/` | |
+| **Session Management** | Production | Token versioning, lockout tracking, cleanup | `aragora/server/session_store.py` | [SESSION_MANAGEMENT.md](../security/session-management) |
+| **SCIM 2.0** | Production | Automated user/group provisioning (Okta, Azure AD, OneLogin) | `aragora/auth/scim/` | |
+| **Account Lockout** | Production | Progressive delays, IP/user tracking | `aragora/auth/lockout.py` | |
+
+### RBAC v2 (360+ Permissions)
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Permission Models** | Production | Fine-grained permission dataclasses | `aragora/rbac/models.py` |
+| **Default Roles** | Production | 7 pre-configured roles (admin, editor, viewer, etc.) | `aragora/rbac/types.py` |
+| **Permission Checker** | Production | Cached permission evaluation with wildcards | `aragora/rbac/checker.py` |
+| **Decorators** | Production | @require_permission, @require_role, @require_admin | `aragora/rbac/decorators.py` |
+| **Middleware** | Production | HTTP route protection | `aragora/rbac/middleware.py` |
+| **Audit Logging** | Production | Authorization audit trails | `aragora/rbac/audit.py` |
+
+### Multi-Tenancy
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Tenant Isolation** | Production | SQL query auto-filtering by tenant ID | `aragora/tenancy/isolation.py` |
+| **Resource Quotas** | Production | Per-tenant limits (debates, API calls, storage) | `aragora/tenancy/quotas.py` |
+| **Usage Metering** | Production | Tenant-aware tracking with billing events | `aragora/billing/metering.py` |
+| **Tenant Context** | Production | Thread/async-safe context propagation | `aragora/tenancy/context.py` |
+
+### Security
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **AES-256-GCM Encryption** | Production | Field-level encryption with key derivation | `aragora/security/encryption.py` | [SECRETS.md](../enterprise/secrets) |
+| **Cloud KMS** | Production | AWS KMS, Azure Key Vault, GCP Cloud KMS | `aragora/security/kms_provider.py` | |
+| **Key Rotation** | Production | Automatic key rotation with versioning | `aragora/security/key_rotation.py` | |
+| **Encrypted Fields** | Production | OAuth tokens, API keys, secrets auto-encrypted | `aragora/storage/encrypted_fields.py` | |
+| **Anomaly Detection** | Production | Security anomaly detection | `aragora/security/anomaly_detection.py` | |
+| **SSRF Protection** | Production | Server-side request forgery protection | `aragora/security/ssrf_protection.py` | |
+| **Rate Limiting** | Production | Multi-layer (IP, token, endpoint) with Redis backend | `aragora/server/rate_limit.py` | [RATE_LIMITING.md](../deployment/rate-limiting) |
+| **Circuit Breaker** | Production | Per-provider thresholds, recovery timeout | `aragora/resilience.py` | |
+| **Security Headers** | Production | CSP, HSTS, X-Frame-Options | `aragora/server/middleware/security_headers.py` | |
+
+### Compliance & Governance
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Audit Trail** | Production | Tamper-evident logging with hash chains | `aragora/audit/` | |
+| **SOC 2 Controls** | Production | SOC 2 Type II compliance controls | `aragora/compliance/soc2.py` | |
+| **GDPR Support** | Production | DSAR workflow, right to erasure, portability | `aragora/privacy/` | [DSAR_WORKFLOW.md](../security/dsar) |
+| **Consent Management** | Production | User consent tracking | `aragora/privacy/consent.py` | |
+| **Data Retention** | Production | Configurable retention policies | `aragora/privacy/retention.py` | |
+| **Deletion Coordinator** | Production | Unified GDPR deletion across systems | `aragora/deletion_coordinator.py` | |
+| **Data Anonymization** | Production | PII anonymization | `aragora/privacy/anonymization.py` | |
+
+### Backup & Disaster Recovery
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Backup Manager** | Production | Incremental backups with retention | `aragora/backup/manager.py` |
+| **DR Drills** | Production | Disaster recovery testing | `aragora/backup/dr_drill.py` |
+| **PostgreSQL Backends** | Production | Full horizontal scaling for 11 storage modules | `aragora/storage/postgres_store.py` |
+
+### Onboarding
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Setup Wizard** | Partial | Guided onboarding with SSO/RBAC integration; provider coverage in live connection tests and disconnect flows remains incomplete | `aragora/onboarding/wizard.py`, `aragora/server/handlers/oauth_wizard.py` |
+
+### Coordination System
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **CrossWorkspaceCoordinator** | Production | Cross-workspace data sharing and federated execution | `aragora/coordination/coordinator.py` |
+| **WorktreeManager** | Production | Isolated git worktrees for concurrent agent work | `aragora/coordination/worktree_manager.py` |
+| **ConflictResolver** | Production | Debate-based conflict resolution for concurrent changes | `aragora/coordination/conflict_resolver.py` |
+| **GitReconciler** | Production | Automated merge strategy execution across worktrees | `aragora/coordination/git_reconciler.py` |
+| **SessionRegistry** | Production | Active session tracking with lock mechanism | `aragora/coordination/session_registry.py` |
+| **HealthWatchdog** | Production | Liveness probes for coordination infrastructure | `aragora/coordination/health_watchdog.py` |
+
+---
+
+## 6. Integrations & Connectors
+
+### Bot Framework
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Unified Bot Framework** | Stable | Platform-agnostic bot base for Slack, Discord, Teams, Zoom | `aragora/bots/base.py`, `aragora/bots/commands.py` |
+
+### Chat Platforms
+
+| Platform | Status | Features | Key Files |
+|----------|--------|----------|-----------|
+| **Slack** | Partial | Core bot/OAuth/webhook support exists; SME workspace channel listing now uses the live connector and SME OAuth helpers now delegate into the canonical Slack install/callback flow | `aragora/connectors/chat/slack/`, `aragora/server/handlers/sme/slack_workspace.py` |
+| **Discord** | Stable | Guilds, channels, DMs, reactions, Ed25519 verification | `aragora/connectors/chat/discord.py` |
+| **Teams** | Partial | Core Teams support exists; SME workspace channel listing now uses the live connector when `team_id` is supplied and SME OAuth helpers now delegate into the canonical Teams install/callback flow | `aragora/connectors/chat/teams.py`, `aragora/server/handlers/sme/teams_workspace.py` |
+| **Google Chat** | Stable | Spaces, messages, JWT verification | `aragora/connectors/chat/google_chat.py` |
+| **Telegram** | Stable | Bot integration with TTS support | `aragora/connectors/chat/telegram.py` |
+| **WhatsApp** | Stable | Business API with voice notes | `aragora/connectors/chat/whatsapp.py` |
+
+### Enterprise Streaming
+
+| System | Status | Features | Key Files |
+|--------|--------|----------|-----------|
+| **Apache Kafka** | Stable | Consumer groups, offset tracking, JSON/Avro/Protobuf | `aragora/connectors/enterprise/streaming/kafka.py` |
+| **RabbitMQ** | Stable | Exchange/queue binding, DLQ, bidirectional | `aragora/connectors/enterprise/streaming/rabbitmq.py` |
+
+### Data Sources
+
+| Source | Status | Features | Key Files |
+|--------|--------|----------|-----------|
+| **GitHub** | Stable | Repos, PRs, issues, code search, webhooks | `aragora/connectors/github.py` |
+| **ArXiv** | Stable | Paper search, metadata, PDFs | `aragora/connectors/arxiv.py` |
+| **Wikipedia** | Stable | Article content, references | `aragora/connectors/wikipedia.py` |
+| **SEC Filings** | Stable | Company filings, financial data | `aragora/connectors/sec.py` |
+| **HackerNews** | Stable | Trending tech topics | `aragora/pulse/ingestors/hackernews.py` |
+| **Reddit** | Stable | Subreddit discussions | `aragora/pulse/ingestors/reddit.py` |
+| **Twitter/X** | Stable | Trending topics | `aragora/pulse/ingestors/twitter.py` |
+
+### Enterprise Systems
+
+| System | Status | Features | Key Files |
+|--------|--------|----------|-----------|
+| **SharePoint** | Stable | Document libraries, metadata | `aragora/connectors/enterprise/documents/sharepoint.py` |
+| **Confluence** | Stable | Pages, spaces, attachments | `aragora/connectors/enterprise/collaboration/confluence.py` |
+| **Notion** | Stable | Databases, pages | `aragora/connectors/enterprise/collaboration/notion.py` |
+| **PostgreSQL** | Stable | CDC with LISTEN/NOTIFY | `aragora/connectors/enterprise/database/postgres.py` |
+| **MongoDB** | Stable | Document queries | `aragora/connectors/enterprise/database/mongodb.py` |
+| **MySQL** | Stable | Binlog CDC | `aragora/connectors/enterprise/database/mysql.py` |
+| **SQL Server** | Stable | CDC/Change Tracking | `aragora/connectors/enterprise/database/sqlserver.py` |
+| **Snowflake** | Stable | Table sync, time travel | `aragora/connectors/enterprise/database/snowflake.py` |
+| **Salesforce** | Stable | CRM sync | `aragora/connectors/enterprise/salesforce.py` |
+| **HubSpot** | Stable | CRM sync | `aragora/connectors/enterprise/hubspot.py` |
+| **Zendesk** | Stable | Support tickets | `aragora/connectors/enterprise/zendesk.py` |
+| **Jira** | Stable | Issue tracking | `aragora/connectors/enterprise/jira.py` |
+
+### Advertising & Marketing
+
+| Platform | Status | Features | Key Files |
+|----------|--------|----------|-----------|
+| **Twitter/X Ads** | Stable | Campaign management, OAuth 1.0a | `aragora/connectors/advertising/twitter_ads.py` |
+| **TikTok Ads** | Stable | Campaigns, pixel, audiences, OAuth 2.0 | `aragora/connectors/advertising/tiktok_ads.py` |
+| **Mailchimp** | Stable | Audiences, campaigns, automations | `aragora/connectors/marketing/mailchimp.py` |
+| **Klaviyo** | Stable | Email/SMS marketing, JSON:API | `aragora/connectors/marketing/klaviyo.py` |
+| **Segment** | Stable | CDP tracking, profiles, batch | `aragora/connectors/analytics/segment.py` |
+
+### Email & Communication
+
+| Platform | Status | Features | Key Files |
+|----------|--------|----------|-----------|
+| **Gmail Sync** | Stable | Pub/Sub real-time, History API, EmailPrioritizer | `aragora/connectors/email/gmail_sync.py` |
+| **Outlook Sync** | Stable | Graph change notifications, Delta Query | `aragora/connectors/email/outlook_sync.py` |
+| **Twilio Voice** | Stable | Phone-triggered debates, TwiML, HMAC-SHA1 | `aragora/integrations/twilio_voice.py` |
+| **Generic SMTP** | Stable | Send/receive email | `aragora/connectors/email/` |
+
+### Healthcare (HIPAA-compliant)
+
+| System | Status | Features | Key Files |
+|--------|--------|----------|-----------|
+| **HL7v2** | Stable | Message parsing | `aragora/connectors/enterprise/healthcare/hl7.py` |
+| **FHIR** | Stable | Resource queries | `aragora/connectors/enterprise/healthcare/fhir.py` |
+
+### Bidirectional Chat Routing
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Debate Origin Tracking** | Stable | Track where debates originate | `aragora/server/debate_origin.py` |
+| **Result Router** | Stable | Route results back to originating platform | `aragora/server/result_router.py` |
+| **TTS Integration** | Stable | Voice synthesis for chat channels | `aragora/server/stream/tts_integration.py` |
+
+---
+
+## 7. Observability & Monitoring
+
+### Metrics & Tracing
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Prometheus Metrics** | Stable | 14+ custom metrics (requests, latency, agents, debates) | `aragora/observability/metrics.py` | |
+| **OpenTelemetry Tracing** | Stable | Distributed tracing with context propagation | `aragora/observability/tracing.py` | |
+| **OTLP Export** | Stable | Jaeger, Zipkin, Datadog exporters | `aragora/observability/otlp_export.py` | |
+| **Grafana Dashboards** | Stable | Pre-built dashboards for all metrics | `deploy/grafana/` | |
+| **SLO Framework** | Stable | Service level objectives with breach alerting | `aragora/observability/slo.py` | |
+
+### Logging & Alerting
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Structured Logging** | Stable | JSON logs with correlation IDs, PII redaction | `aragora/observability/logging.py` | |
+| **Alert Runbooks** | Stable | Automated alert responses | `docs/deployment/ALERT_RUNBOOKS.md` | [ALERT_RUNBOOKS.md](../operations/alert-runbooks) |
+
+### Health Monitoring
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Health Checks** | Stable | Liveness and readiness probes | `aragora/control_plane/health.py` |
+| **Circuit Breaker Metrics** | Stable | Agent failure tracking and recovery | `aragora/resilience.py` |
+| **Connection Pooling** | Stable | Adaptive pool with health monitoring | `aragora/server/connection_pool.py` |
+| **Redis HA** | Stable | Sentinel/Cluster with failover | `aragora/storage/redis_ha.py` |
+
+---
+
+## 8. Developer Tools
+
+### API & Server
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Unified Server** | Stable | 3,000+ API operations | `aragora/server/unified_server.py` | [API_REFERENCE.md](../api/reference) |
+| **Handler Registry** | Stable | O(1) route lookup with LRU caching | `aragora/server/handler_registry.py` | |
+| **GraphQL API** | Stable | Schema for debates, agents, memory | `aragora/server/graphql/` | |
+| **WebSocket Streaming** | Stable | 26 stream modules for real-time events | `aragora/server/stream/` | |
+| **Postman Generator** | Stable | API collection export | `aragora/server/postman_generator.py` | |
+
+### SDKs
+
+| SDK | Status | Namespaces | Key Files |
+|-----|--------|------------|-----------|
+| **Python SDK** | Stable | 186 namespaces | `sdk/python/` |
+| **TypeScript SDK** | Stable | 185 namespaces | `sdk/typescript/` |
+
+### CLI
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **CLI Main** | Stable | Command-line interface | `aragora/cli/main.py` |
+| **REPL** | Stable | Interactive shell | `aragora/cli/repl.py` |
+| **Setup Wizard** | Partial | Guided `aragora setup` for self-hosted; some provider test/disconnect flows remain selectively implemented | `aragora/cli/setup.py`, `aragora/server/handlers/oauth_wizard.py` |
+| **Gauntlet CLI** | Stable | Compliance test runner | `aragora/cli/gt.py` |
+
+### Workflow Engine
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Workflow Engine** | Stable | DAG-based automation | `aragora/workflow/engine.py` | [WORKFLOWS.md](../guides/workflows) |
+| **Workflow Nodes** | Stable | Reusable node types | `aragora/workflow/nodes/` | |
+| **Workflow Patterns** | Stable | Hive-mind, map-reduce, review-cycle factories | `aragora/workflow/patterns/` | |
+| **Workflow Templates** | Stable | 50+ pre-built templates across 6 categories | `aragora/workflow/templates/` | |
+| **Post-Debate Workflows** | Stable | Automated processing via `enable_post_debate_workflow` | `aragora/workflow/triggers.py` | |
+
+### Prompt Engine & Interrogation
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Prompt Engine** | Stable | Transforms vague prompts into validated specifications via debate | `aragora/prompt_engine/conductor.py`, `aragora/prompt_engine/spec_builder.py` |
+| **Interrogation Engine** | Stable | Debate-driven prompt clarification with prioritized questions | `aragora/interrogation/engine.py`, `aragora/interrogation/crystallizer.py` |
+| **Swarm Orchestrator** | Stable | End-to-end user flow: interrogate → spec → dispatch → merge → report | `aragora/swarm/commander.py`, `aragora/swarm/reporter.py` |
+| **Swarm Supervisor** | Stable | Bounded work orders, managed worktrees, lease-based coordination | `aragora/swarm/supervisor.py` |
+| **Worker Launcher** | Stable | Spawns Claude Code / Codex CLI processes in isolated worktrees | `aragora/swarm/worker_launcher.py` |
+| **Swarm Reconciler** | Stable | Periodic lease renewal, dispatch, result collection | `aragora/swarm/reconciler.py` |
+
+### Inbox Trust Wedge
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Trust Wedge Core** | Integrated | Receipt-gated Gmail actions are shipped; surrounding channel/setup surfaces still have partial or placeholder-backed edges | `aragora/inbox/trust_wedge.py` |
+| **Triage Runner** | Partial | Batch email triage with adversarial debate decisions; can still fall back to stub debates when engine/agent wiring is unavailable | `aragora/inbox/triage_runner.py` |
+| **Receipt-Gated Executor** | Stable | Only executes actions with previously persisted approved receipts | `aragora/inbox/receipt_gated_executor.py` |
+| **CLI Review Loop** | Stable | Interactive CLI approval for triage decisions | `aragora/inbox/cli_review.py` |
+| **Auto-Approval Policy** | Stable | Narrow auto-approval rules (ARCHIVE/STAR/LABEL/IGNORE only) | `aragora/inbox/auto_approval.py` |
+| **Gmail OAuth Setup** | Stable | One-time OAuth credential setup for Gmail integration | `scripts/gmail_oauth_setup.py` |
+
+### Gauntlet (Compliance Testing)
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Gauntlet Runner** | Stable | Compliance test execution | `aragora/gauntlet/runner.py` | [GAUNTLET.md](../guides/gauntlet) |
+| **Decision Receipts** | Integrated | SHA-256 cryptographic audit trails; anchor verification and export coverage still vary across handler surfaces | `aragora/gauntlet/receipts.py`, `aragora/server/handlers/gauntlet/receipts.py` | |
+| **Findings** | Stable | Compliance findings management | `aragora/gauntlet/findings.py` | |
+| **Gauntlet Defense** | Stable | Attack/defend cycles via `proposer_agent` | `aragora/gauntlet/defense.py` | |
+| **Personas** | Stable | GDPR, SOC2, HIPAA, PCI-DSS, AI Act, NIST CSF | `aragora/gauntlet/personas/` | |
+
+### Explainability
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Decision Builder** | Stable | Natural language explanations | `aragora/explainability/builder.py` |
+| **Factor Decomposition** | Stable | Agent contributions, evidence quality, consensus strength | `aragora/explainability/factors.py` |
+| **Counterfactuals** | Stable | What-if scenario analysis | `aragora/explainability/counterfactual.py` |
+
+### MCP (Model Context Protocol)
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **MCP Server** | Stable | Context protocol server | `aragora/mcp/server.py` | [MCP_INTEGRATION.md](../guides/mcp-integration) |
+| **MCP Tools** | Stable | Tool definitions | `aragora/mcp/tools.py` | [MCP_ADVANCED.md](../guides/mcp-advanced) |
+
+### Agent Marketplace
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Template Registry** | Stable | Agent, debate, workflow templates | `aragora/marketplace/` | [MARKETPLACE.md](../guides/marketplace) |
+| **Built-in Templates** | Stable | Devil's Advocate, Code Reviewer, Research Analyst | `aragora/marketplace/templates/` | |
+
+### Skills Marketplace
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **SkillRegistry** | Integrated | Discover and load skills by name or tag | `aragora/skills/registry.py` |
+| **SkillMarketplace** | Integrated | Publish, search, and install from marketplace catalog | `aragora/skills/marketplace.py` |
+| **Skill Installer** | Integrated | Manifest-based dependency management and install | `aragora/skills/installer.py` |
+| **Built-in Skills** | Integrated | Bundled skills for common patterns | `aragora/skills/builtin/` |
+| **LLM Function Calling** | Integrated | Pluggable skills exposed as LLM tool calls | `aragora/skills/base.py` |
+
+Install skills via CLI: `aragora skills install <skill-name>`
+
+### Harnesses
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Claude Code Harness** | Integrated | Invoke Claude Code analysis on codebases | `aragora/harnesses/claude_code.py` |
+| **Codex Harness** | Integrated | Invoke OpenAI Codex for code analysis and generation | `aragora/harnesses/codex.py` |
+| **HarnessResultAdapter** | Integrated | Normalize harness output for audit workflows | `aragora/harnesses/result_adapter.py` |
+
+Used in: audit pipeline (`aragora/audit/`), bug detection (`aragora/audit/bug_detector.py`), and the Nomic Loop self-improvement cycle.
+
+---
+
+## 9. Self-Improvement & Nomic Loop
+
+### Nomic Loop
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Nomic Loop** | Stable | Autonomous improvement cycles (5 phases) | `scripts/nomic_loop.py` |
+| **Staged Execution** | Stable | Phase-by-phase control | `scripts/nomic_staged.py` |
+| **Self Develop** | Stable | Goal-driven decomposition with `--dry-run` | `scripts/self_develop.py` |
+| **Meta Planner** | Stable | Debate-driven goal prioritization | `aragora/nomic/meta_planner.py` |
+| **Branch Coordinator** | Stable | Parallel branch management | `aragora/nomic/branch_coordinator.py` |
+| **Task Decomposer** | Stable | Complex task breakdown (heuristic or debate) | `aragora/nomic/task_decomposer.py` |
+| **Autonomous Orchestrator** | Stable | End-to-end orchestration | `aragora/nomic/autonomous_orchestrator.py` |
+
+### Nomic Loop Phases
+
+| Phase | Name | Purpose |
+|-------|------|---------|
+| 0 | Context | Gather codebase understanding |
+| 1 | Debate | Agents propose improvements |
+| 2 | Design | Architecture planning |
+| 3 | Implement | Code generation (Codex/Claude) |
+| 4 | Verify | Tests and checks |
+
+### Development Coordination
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **DevCoordinationStore** | Stable | Work leases, completion receipts, integration decisions | `aragora/nomic/dev_coordination.py` |
+| **NomicPipelineBridge** | Stable | Bounded work orders bridging pipeline specs to worktree tasks | `aragora/nomic/pipeline_bridge.py` |
+| **Fleet Integration Worker** | Stable | Automated integration target workspace management | `aragora/worktree/integration_worker.py` |
+| **Salvage Queue** | Stable | Recovery of dirty worktrees and stashed work | `aragora/coordination/salvage.py` |
+
+### Autonomous Operations
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Self-Improvement Manager** | Stable | Orchestrates autonomous cycles | `aragora/autonomous/loop_enhancement.py` |
+| **Continuous Learning** | Stable | Real-time ELO updates, pattern extraction | `aragora/autonomous/continuous_learning.py` |
+| **Proactive Intelligence** | Stable | Scheduled triggers, anomaly detection | `aragora/autonomous/proactive_intelligence.py` |
+| **Human-in-the-Loop** | Stable | Approval flows with risk assessment | `aragora/autonomous/approvals.py` |
+| **Code Verifier** | Stable | AST syntax validation and test execution | `aragora/autonomous/loop_enhancement.py` |
+| **Rollback Manager** | Stable | File backup, restore, cleanup | `aragora/autonomous/loop_enhancement.py` |
+
+### Genesis / Agent Evolution
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **FractalOrchestrator** | Integrated | Recursive sub-debates for complex decisions | `aragora/genesis/fractal.py` |
+| **GenomeBreeder** | Integrated | Evolutionary agent improvement via crossover and mutation | `aragora/genesis/breeder.py` |
+| **GenesisLedger** | Integrated | Cryptographic provenance for agent lineage | `aragora/genesis/ledger.py` |
+| **AgentGenome** | Integrated | Parameter encoding for evolutionary selection | `aragora/genesis/genome.py` |
+| **Argonaut Ledger** | Integrated | Agent identity and evolution registry | `aragora/genesis/argonaut_ledger.py` |
+
+---
+
+## 10. Control Plane (1,500+ tests)
+
+### Agent Management
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Agent Registry** | Stable | Agent discovery with heartbeats | `aragora/control_plane/registry.py` |
+| **Task Scheduler** | Stable | Priority-based distribution | `aragora/control_plane/scheduler.py` |
+| **Health Monitoring** | Stable | Liveness probes | `aragora/control_plane/health.py` |
+| **Coordinator** | Stable | Unified control plane API | `aragora/control_plane/coordinator.py` |
+| **Leader Election** | Stable | Distributed coordination | `aragora/control_plane/leader.py` |
+
+### Governance
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Policy Engine** | Stable | Policy governance | `aragora/control_plane/policy.py` |
+| **Policy Conflict Detector** | Stable | Contradictory policy detection | `aragora/control_plane/policy.py` |
+| **Redis Policy Cache** | Stable | Distributed cache for fast evaluation | `aragora/control_plane/policy.py` |
+| **Policy Sync Scheduler** | Stable | Background policy synchronization | `aragora/control_plane/policy.py` |
+
+### Notifications
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Omnichannel Delivery** | Stable | Slack/Teams/Email/Webhook delivery | `aragora/control_plane/notifications.py` |
+| **Notification Service** | Stable | Unified notification API | `aragora/notifications/service.py` |
+
+---
+
+## 11. Pulse (Trending Topics - 1,000+ tests)
+
+| Feature | Status | Description | Key Files | Docs |
+|---------|--------|-------------|-----------|------|
+| **Pulse Ingestor** | Stable | Topic ingestion pipeline | `aragora/pulse/ingestor.py` | [PULSE.md](../guides/pulse) |
+| **Quality Filtering** | Stable | Clickbait/spam detection | `aragora/pulse/quality.py` | |
+| **Freshness Scoring** | Stable | Configurable decay curves | `aragora/pulse/freshness.py` | |
+| **Source Weighting** | Stable | Credibility scores | `aragora/pulse/weighting.py` | |
+| **Scheduler** | Stable | Scheduled topic refresh | `aragora/pulse/scheduler.py` | |
+| **Store** | Stable | Topic persistence | `aragora/pulse/store.py` | |
+
+---
+
+## 12. Voice & TTS
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **TTS Integration** | Stable | Voice synthesis for debates | `aragora/server/stream/tts_integration.py` |
+| **Voice Streaming** | Stable | Voice session management | `aragora/server/stream/voice_stream.py` |
+| **Twilio Voice** | Stable | Phone-triggered debates | `aragora/integrations/twilio_voice.py` |
+| **Speech Recognition** | Stable | Whisper transcription backends | `aragora/transcription/` |
+| **Broadcast/Podcast** | Stable | Post-debate podcast engine with TTS and audio mixing | `aragora/broadcast/pipeline.py` |
+
+---
+
+## 13. Verification & Formal Methods
+
+| Feature | Status | Description | Key Files |
+|---------|--------|-------------|-----------|
+| **Z3 Verification** | Stable | SMT-based verification | `aragora/verification/formal.py` |
+| **Lean Backend** | Beta | Lean theorem prover | `aragora/verification/lean.py` |
+| **Proof Generation** | Stable | Automated proof generation | `aragora/verification/proofs.py` |
+
+---
+
+## Getting Started
+
+### Quick Start with Debate
+
+```python
+from aragora import Arena, Environment, DebateProtocol
+
+env = Environment(task="Should we adopt microservices?")
+protocol = DebateProtocol(rounds=3, consensus="majority")
+arena = Arena(env, agents=["claude", "gpt4"], protocol=protocol)
+result = await arena.run()
+```
+
+### Enable Knowledge Mound
+
+```python
+from aragora.debate.arena_config import ArenaConfig
+
+config = ArenaConfig(
+    enable_knowledge_mound=True,
+    enable_km_belief_sync=True,
+    enable_coordinated_writes=True,
+)
+arena = Arena.from_config(env, agents, protocol, config)
+```
+
+### Run with Enterprise Features
+
+```python
+from aragora.tenancy import TenantContext
+from aragora.rbac.decorators import require_permission
+
+async with TenantContext(tenant_id="acme-corp"):
+    result = await arena.run()
+```
+
+### Self-Improvement Dry Run
+
+```bash
+# Preview goal decomposition without executing
+python scripts/self_develop.py --goal "Improve test coverage" --dry-run
+```
+
+---
+
+## Feature Discovery Tips
+
+### Finding Features by Use Case
+
+| Use Case | Start Here |
+|----------|------------|
+| Run a multi-agent debate | `aragora/debate/orchestrator.py` |
+| Integrate with Slack | `aragora/connectors/chat/slack/` |
+| Add authentication | `aragora/auth/` and `aragora/rbac/` |
+| Store knowledge | `aragora/knowledge/mound/` |
+| Automate workflows | `aragora/workflow/engine.py` |
+| Run compliance tests | `aragora/gauntlet/runner.py` |
+| Monitor system health | `aragora/observability/` |
+
+### Searching the Codebase
+
+```bash
+# Find all handlers
+rg "class.*Handler" aragora/server/handlers/
+
+# Find all adapters
+rg "class.*Adapter" aragora/
+
+# Find all permissions
+rg "require_permission" aragora/
+
+# Find all WebSocket events
+rg "event_type=" aragora/
+```
+
+### Key Entry Points
+
+| Purpose | Entry Point |
+|---------|-------------|
+| Start server | `aragora serve --api-port 8080 --ws-port 8765` |
+| Run debate | `from aragora import Arena, Environment` |
+| Access knowledge | `from aragora.knowledge.mound import KnowledgeMound` |
+| Run workflow | `from aragora.workflow.engine import WorkflowEngine` |
+| Run nomic loop | `python scripts/run_nomic_with_stream.py run --cycles 3` |
+
+---
+
+## Related Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [CLAUDE.md](./claude) | Development guide for AI assistants |
+| [STATUS.md](./status) | Release status and changelog |
+| [ENTERPRISE_FEATURES.md](../enterprise/features) | Enterprise capability deep-dive |
+| [EXTENDED_README.md](./extended-readme) | Comprehensive technical reference |
+| [COMMERCIAL_OVERVIEW.md](../enterprise/commercial-overview) | Commercial positioning |
+| [API_REFERENCE.md](../api/reference) | REST API documentation |
+| [WORKFLOWS.md](../guides/workflows) | Workflow engine guide |
+| [GAUNTLET.md](../guides/gauntlet) | Compliance testing guide |
+| [PULSE.md](../guides/pulse) | Trending topics guide |
+| [RLM_GUIDE.md](../advanced/rlm) | Recursive Language Models guide |
+
+---
+
+*Last updated: March 2026*

--- a/docs-site/docs/contributing/feature-gap-list.md
+++ b/docs-site/docs/contributing/feature-gap-list.md
@@ -1,0 +1,182 @@
+---
+title: Aragora Feature Gap List
+description: Aragora Feature Gap List
+---
+
+# Aragora Feature Gap List
+
+> **Living document** — tracks features planned, partially built, or in need of hardening. Updated as items are completed or priorities shift.
+> Active execution status now lives in [docs/status/ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues) and the linked GitHub issues. This file remains the capability and productization backlog truth.
+> Last updated: March 24, 2026
+> March 2026 priority reframe: product cohesion and PMF proof come before certification. Pentest / SOC 2 stay tracked, but they are no longer the first blocker lane.
+
+## How to Read This List
+
+- **P0**: PMF blockers — close the product loop before certification
+- **P1**: Value-prop proof (Q2 2026)
+- **P2**: Product hardening and enterprise readiness after PMF
+- **P3**: Scale & revenue after PMF
+- **P4**: Strategic evolution (2026+)
+- **Scaffolding**: Code exists but needs hardening/productization
+
+---
+
+## P0 — PMF Blockers
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Truthful live founder loop | **PROVEN — moved to Completed** | 5/5 consecutive live runs pass (35-62s, March 24, 2026). Test baseline: `71 passed` (focused) / `125 passed` (extended). Receipts persist to store for API/dashboard visibility. All 7 acceptance checklist items pass. |
+| Smart provider routing | **Shipped on `main`; live proof pending** | PR #724 shipped the Pareto optimizer and pricing database. Runtime wiring landed on `main` via [#1167](https://github.com/synaptent/aragora/pull/1167), and downstream runtime hints are applied through the debate path. The remaining obligation is to prove that routing behaves well in the live founder loop rather than to debate whether the wiring exists. Historical lineage: [#813](https://github.com/synaptent/aragora/issues/813). |
+| Complete one working user journey | **Mocked proof passes; live proof still open** | The relevant slices are on `main`: live settings/API-key wiring ([#1146](https://github.com/synaptent/aragora/pull/1146)), live debate creation ([#1147](https://github.com/synaptent/aragora/pull/1147)), onboarding/get-started ([#1170](https://github.com/synaptent/aragora/pull/1170)), quickstart fail-closed behavior ([#1180](https://github.com/synaptent/aragora/pull/1180)), and structured quickstart receipts ([#1192](https://github.com/synaptent/aragora/pull/1192)). The current gap is one repeatable live proof, not another architecture slice. Historical lineage: [#1046](https://github.com/synaptent/aragora/issues/1046). |
+| Knowledge Mound reads enrich debate context | **Shipped on `main`; live read/write proof pending** | Retrieval, precedent loading, and writeback groundwork landed via [#1111](https://github.com/synaptent/aragora/pull/1111), [#1131](https://github.com/synaptent/aragora/pull/1131), [#1132](https://github.com/synaptent/aragora/pull/1132), [#1134](https://github.com/synaptent/aragora/pull/1134), [#1151](https://github.com/synaptent/aragora/pull/1151), [#1168](https://github.com/synaptent/aragora/pull/1168), and [#1176](https://github.com/synaptent/aragora/pull/1176). The remaining question is whether that read/write path is visible and trustworthy in the live founder loop. Historical lineage: [#1048](https://github.com/synaptent/aragora/issues/1048). |
+| Debate output quality | **VALIDATED — moved to Completed** | Run 012 (Mar 5): composite 8.38-9.39/10. Diverse benchmark (10 domains): 100% pass, avg composite 0.938. |
+
+---
+
+## P1 — Value-Prop Proof (Q2 2026)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| OpenClaw end-to-end demo | **Core loop shipped** | PR #727: CodeImplementationTask, SpecExtractor, ComputerUseActionBundle, receipt linkage. Production validation with live agents remaining. Tracked in [#814](https://github.com/synaptent/aragora/issues/814). |
+| Functional frontend paths (5 that matter) | More truthful on `main`; continuity still gated by live founder-loop proof | Recent merged slices improved the real surface: settings/API-key wiring ([#1146](https://github.com/synaptent/aragora/pull/1146)), debate creation ([#1147](https://github.com/synaptent/aragora/pull/1147)), public status truthfulness ([#1148](https://github.com/synaptent/aragora/pull/1148)), pipeline golden-path visibility ([#1150](https://github.com/synaptent/aragora/pull/1150)), onboarding/get-started ([#1170](https://github.com/synaptent/aragora/pull/1170)), and Wave 2 productization ([#1188](https://github.com/synaptent/aragora/pull/1188)). The remaining gap is continuity across debate creation, results, knowledge, settings, receipts, and dashboard state in a live run. Historical lineage: [#1047](https://github.com/synaptent/aragora/issues/1047). |
+| 10+ agent coordinated debates | Scaffolding | Current practical limit: 2-6 agents. Coordination infrastructure exists; scale testing needed after the core loop works. Tracked in [#815](https://github.com/synaptent/aragora/issues/815). |
+| Agent-first beta via REST API | **Fleet deployed (12 runners)** | `aragora openclaw watch` polls repos, runs multi-agent review, posts findings. 3 Hetzner + 6 EC2 + 3 local Macs. PR watch daemon on Mac Studio via launchd. Shared operator productization is tracked in [#817](https://github.com/synaptent/aragora/issues/817) and [#819](https://github.com/synaptent/aragora/issues/819). |
+| GitHub Actions pre-merge gate | **Workflow created** | `aragora-review-gate.yml` manual-only (workflow_dispatch). Re-enable pull_request trigger when ready. |
+| Public demo at aragora.ai/demo | **Truthful proof surface** | `/demo` now runs a canonical live-backed proof when the public playground backend is live and labels any non-live fallback or recorded sample explicitly. `/try` remains the primary beta funnel for user-entered questions, persistence, and sharing. Productization is tracked in [#818](https://github.com/synaptent/aragora/issues/818). |
+| EU AI Act compliance package | **Substantially complete (90/100)** | Art. 9/10/11/12/13/14/15/43/49 bundle coverage and customer playbook appendix are shipped. Remaining work is packaging polish, regulator-ready validation, and launch collateral hardening. **Deadline: Aug 2, 2026.** |
+| First 2 enterprise pilot engagements | Not started | Closed partnerships — target fintech + healthcare |
+| Developer onboarding &lt;10 min | **Contract improved; live timing proof still required** | `aragora quickstart` now fails fast on bad TLS ([#1180](https://github.com/synaptent/aragora/pull/1180)) and supports inline provider keys plus structured receipts ([#1192](https://github.com/synaptent/aragora/pull/1192)). That is better than the earlier behavior, but the actionable target is a repeatable live onboarding run with bounded noise and measured timing, not a blanket "already working" claim. |
+
+---
+
+## P2 — Product Hardening And Enterprise Readiness (After PMF)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| External penetration test | Scope and outreach artifacts ready; vendor selection pending | Kickoff stays warm, but certification is intentionally sequenced after the product loop is usable. Operational status is tracked in `security/pentest/VENDOR_OUTREACH_LOG.md`; work remains tracked in [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), and [#509](https://github.com/synaptent/aragora/issues/509). |
+| Semantic convergence (full embedding) | **VALIDATED — moved to Completed** | PR #723 migrated 5 similarity modules from difflib to embedding-based. Remaining difflib usage is exclusively for text diff display, not similarity. |
+| ERC-8004 on-chain deployment | Contracts written | Solidity contracts exist; not deployed to any mainnet. Needs chain endpoint config + gas management. Tracked in [#816](https://github.com/synaptent/aragora/issues/816). |
+| Decision-Integrity UI Workbench | Partial frontend | Existing workbench pages render, but they do not replace the PMF need for five truthful user-facing paths. Remaining canvas and data wiring work stays secondary to `#1047`. |
+| SOC 2 Type II audit engagement | Scope doc ready | 60+ controls implemented (98%); pentest scope doc v3.1.0 finalized; vendor shortlisted (NCC, Bishop Fox, Trail of Bits, Cure53). Blocker: vendor selection + engagement. |
+| Enterprise Communication Hub (#293) | **Epic closed** | PR #726: template persistence, router event wiring, E2E tests. Delivery log, retry queue, circuit breakers, event telemetry, user preference UI, Active Triage dashboard, TriageRulesPanel all shipped. Remaining: inbox→debate trigger wiring end-to-end validation, tracked in [#817](https://github.com/synaptent/aragora/issues/817). |
+
+---
+
+## P3 — Scale & Revenue (Q3–Q4 2026)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Cloud marketplace listings | Not started | AWS Marketplace + Azure Marketplace listings. Infrastructure ready. |
+| Vertical packages | Not started | Healthcare (FHIR, HIPAA), Financial (SOX, risk), Legal (contracts, discovery). Guides exist; packages not assembled. |
+| Skills Marketplace pilot | Scaffolding | SkillRegistry + SkillMarketplace code exists; no public marketplace endpoint. |
+| On-premise deployment productization | Partial | Docker Compose + Helm chart exist; on-prem installer/wizard not built. |
+| International expansion / EU data residency | Not started | Data residency controls needed for EU enterprise buyers. |
+| Compute escrow mechanism | Not started | Settlement stakes via crypto compute escrow. Design in docs/plans/. |
+
+---
+
+## P4 — Strategic Evolution (2026+)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Prover-Estimator debate protocol | **Shipped and wired** | 581 LOC engine + consensus handler wired into `consensus_phase.py`. Use `protocol.consensus="prover_estimator"` to activate. 5-stage pipeline: decompose→estimate→challenge→re-estimate→aggregate. 33 unit tests pass. |
+| Cross-verification phase (3-pass hallucination detection) | **Shipped and wired** | 395 LOC engine wired as optional post-debate enrichment in `orchestrator_runner.py`. Set `arena.enable_cross_verification=True`. Computes grounding_delta, adversarial_resistance, hallucination_risk. |
+| Truth scorer integrated into vote weights | **Shipped and wired** | `TruthScorer` (398 LOC) scores evidence-vs-rhetoric ratio per proposal. `apply_truth_ratio_bonuses()` in `VoteBonusCalculator` rewards high truth ratios. Enable via `protocol.enable_truth_ratio_weighting=True`. |
+| Epistemic hygiene + anti-sycophancy | **Shipped and integrated** | ~1,695 LOC across `epistemic_hygiene.py`, `trickster.py`, `trickster_calibrator.py`. Fully integrated into consensus, settlement, prompt assembly, and server. ~3,744 LOC tests. |
+| Prompt-to-spec engine | **Shipped** | `aragora spec` CLI command completes in ~23s. Decompose→interrogate→research→specify pipeline. `aragora/prompt_engine/` module (decomposer, interrogator, researcher, spec_builder, conductor). |
+| Canvas GUI (8-stage visual DAG) | Partial frontend | Prompt-engine page exists; full 8-stage visual canvas missing. |
+| Market resolution mechanism | Design only | Long-horizon settlement claim pricing via prediction market. |
+| STOP N-candidate for Nomic Loop | Design only | Multi-plan generation before committing to self-improvement path. |
+| Meta-improver for debate protocols | Design only | A/B test protocol variants using Nomic Loop. |
+| Obsidian bidirectional sync | **Shipped** | `ObsidianAdapter` with `ReverseFlowMixin` for KM→Obsidian writeback. Forward sync, conflict detection, filesystem watcher. |
+
+---
+
+## P5 — Federation (Future)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Distributed debates across organizations | Design only | Cross-org debate with privacy-preserving knowledge sharing. |
+| Cross-organizational knowledge sync | Design only | Federated knowledge graph across org boundaries. |
+| Knowledge federation | Design only | Global KM with distributed consensus. |
+
+---
+
+## Scaffolding — Code Exists, Needs Hardening
+
+| Feature | Current State | Gap |
+|---------|---------------|-----|
+| Self-improving platform quality | Nomic Loop 100% wired; 82 E2E tests; CLB backbone hardened (14/14 issues closed); safety gates + gauntlet gate + evolution audit + golden-path test; **Ralph V14 benchmark validated full autonomous loop** (PRs #1004-#1006) | Diverse benchmark validated (100% pass). Production safety gate requires ENABLE_NOMIC_LOOP=true. Ralph autonomy loop closed for `merge_policy=admin_merge_allowed`. |
+| Autonomous self-assessment loop | `IdeaToExecutionPipeline.from_system_metrics()`, `SelfImprovePipeline`, `NomicLoop`, `execute_to_github_issue()`, `plan_from_issue_list()`, worktree autopilot, the canonical assessment compiler, and the pause-refresh shift controller exist on `main` | The remaining truth gap is the control plane: no canonical developer task queue/claim protocol, no universal per-lane run receipt/provenance artifact, and no integrator view tying claims, receipts, heartbeats, and merge readiness together. Tracked in [#1036](https://github.com/synaptent/aragora/issues/1036), [#837](https://github.com/synaptent/aragora/issues/837), [#842](https://github.com/synaptent/aragora/issues/842), [#843](https://github.com/synaptent/aragora/issues/843), and [#990](https://github.com/synaptent/aragora/issues/990). |
+| Blockchain receipts | SHA-256 cryptographic hashing works; StakingRegistry (stake/slash/unstake/rewards); ComputeBudgetManager; ReceiptAnchor; SlashEvent model (hollow_consensus, factual_error, calibration_drift) | On-chain storage with ERC-8004 (not deployed); staking/slashing NOT wired into debate outcome loop; agent selection not weighted by compute budget. Tracked in new GitHub issue. |
+| Semantic convergence | **Migrated** (PR #723) | All similarity paths use embeddings. Only `unified_diff` (text display) uses difflib. |
+| OpenClaw execution | **Core loop shipped** (PR #727) | CodeImplementationTask + SpecExtractor + receipt linkage. Production validation pending. |
+| RLM context access | Code complete (92 exports, 27 test files, 15k LOC) | No user-facing guide; integration with default Arena config unclear; training pipeline (buffer/policy/reward/trainer) untested E2E. Tracked in new GitHub issue. |
+
+---
+
+## Completed — Formerly on This List
+
+These items were planned and are now shipped:
+
+| Feature | Shipped |
+|---------|---------|
+| Nomic Loop end-to-end | Jan 2026 |
+| Knowledge Mound Phase A2 (adapter registry + unified memory hardening) | Feb 2026 |
+| Unified Memory Gateway | Feb 2026 |
+| Retention Gate (Titans/MIRAS) | Feb 2026 |
+| RBAC v2 (14 resource types, 8 actions) | Feb 2026 |
+| Multi-tenancy (tenant isolation + metering) | Feb 2026 |
+| Voice/TTS integration | Feb 2026 |
+| Pipeline orchestration (4-stage) | Feb–Mar 2026 |
+| Compliance CLI (EU AI Act artifact export) | Mar 2026 |
+| Settlement hooks | Mar 2026 |
+| Gauntlet receipts (SHA-256 audit trails) | Feb 2026 |
+| Article 9 dedicated artifact bundle | Mar 2026 |
+| Debate output quality (10-domain benchmark) | Mar 2026 |
+| Nomic Loop safety gates (production gate, gauntlet, audit) | Mar 2026 |
+| CI setup-python-safe composite action (51 workflows) | Mar 2026 |
+| MFA admin enforcement (compliance API, drift alerts, bypass docs) | Mar 2026 |
+| Data classification enforcement (runtime, CI PII gate, evidence bundles) | Mar 2026 |
+| Closed-loop backbone contracts (IntakeBundle, SpecBundle, DeliberationBundle, ReceiptEnvelope, OutcomeFeedbackRecord) | Mar 2026 |
+| Fail-closed spec validation (execution-grade field enforcement) | Mar 2026 |
+| Deliberation bundle handoff (dissent + quality gate into planning) | Mar 2026 |
+| CI push-to-main noise reduction (35→6 workflows) | Mar 2026 |
+| Self-hosted runner fleet (12 runners: 3 Hetzner + 6 EC2 + 3 Mac) | Mar 2026 |
+| Decision-Integrity Workbench frontend | Mar 2026 |
+| G1 Signed Context Manifests (HMAC-SHA256 + CLI) | Mar 2026 |
+| Closed-loop backbone sprint (14 CLB issues) | Mar 2026 |
+| ExecutionBundle + VerificationBundle contracts | Mar 2026 |
+| Bug-fix loop after verification failure (auto-trigger) | Mar 2026 |
+| Receipt envelope normalization (success/fail/blocked) | Mar 2026 |
+| Outcome feedback → Nomic goal export pipeline | Mar 2026 |
+| Trust-tier + taint propagation across backbone | Mar 2026 |
+| External-verifier insertion point (CLB-012) | Mar 2026 |
+| Golden-path backbone test (intake → receipt E2E) | Mar 2026 |
+| Dogfood backbone profile script | Mar 2026 |
+| PR watch daemon fleet (3 Mac machines, 30 reviews/hour) | Mar 2026 |
+| Dev swarm coordination layer (lease-aware) | Mar 2026 |
+| Swarm supervisor + worker launcher + reconciler (PRs #744-746) | Mar 2026 |
+| Inbox trust wedge — receipt-gated email actions (PRs #731-742) | Mar 2026 |
+| Session circuit-breaker — auth-state pinning (PRs #736, #740) | Mar 2026 |
+| Gmail OAuth setup helper (PR #741) | Mar 2026 |
+| Semantic convergence — 5 modules migrated to embeddings (PR #723) | Mar 2026 |
+| Smart provider routing Phase 1 — Pareto optimizer + 8-model pricing (PR #724) | Mar 2026 |
+| EU AI Act playbook GTM polish + Art. 10/11/43/49 appendix (PR #725) | Mar 2026 |
+| Enterprise Comms Hub #293 — template persistence + router wiring (PR #726) | Mar 2026 |
+| OpenClaw E2E core loop — CodeImplementationTask + ComputerUseActionBundle (PR #727) | Mar 2026 |
+| Stale lease auto-release — PID-based liveness, proactive reaping (PR #1004) | Mar 2026 |
+| Reconciler lease reaping — tick_run reaps expired leases (PR #1005) | Mar 2026 |
+| Admin merge bypass — autonomous merge when required checks pass (PR #1006) | Mar 2026 |
+| Ralph V14 benchmark — full autonomous loop validated (spec→PR→merge, zero intervention) | Mar 2026 |
+| Ralph blocker taxonomy — campaign_stalled, needs_human classification (PRs #946-#950) | Mar 2026 |
+| **Live founder loop proven repeatable** (5/5 runs, 35-62s, receipts on API/dashboard) | Mar 2026 |
+| Prover-Estimator consensus handler wired into debate pipeline | Mar 2026 |
+| Cross-verification post-debate enrichment wired into orchestrator | Mar 2026 |
+| Truth scorer ratio bonuses wired into vote weight calculation | Mar 2026 |
+| Prompt-to-spec CLI (`aragora spec`) — 23s end-to-end | Mar 2026 |
+| Inbox trust wedge CLI (`aragora triage auth`, `--dry-run`) | Mar 2026 |
+| Quickstart receipt store persistence for API/dashboard visibility | Mar 2026 |
+| Embedding rate limit resilience (hash-based fallback on 429) | Mar 2026 |
+| Summary preamble cleaning (strip LLM chain-of-thought from CLI output) | Mar 2026 |
+| EU AI Act compliance bundle verified end-to-end with real quickstart receipts | Mar 2026 |

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -1,0 +1,110 @@
+---
+title: Next Steps (Canonical)
+description: Next Steps (Canonical)
+---
+
+# Next Steps (Canonical)
+
+Last updated: 2026-03-26
+
+This is the single source of truth for short-horizon execution priorities.
+[CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
+[ARAGORA_EVOLUTION_ROADMAP](./aragora-evolution-roadmap) defines the long-range architecture and moat.
+[FEATURE_GAP_LIST](./feature-gap-list) is the capability and backlog truth.
+[ACTIVE_EXECUTION_ISSUES](./active-execution-issues) maps the live GitHub issue set and the current doc-driven PMF program.
+[PMF_DOGFOOD_EXECUTION_PLAN](./pmf-dogfood-execution-plan) is the operator runbook for the next live proof.
+[2026-03-26-pmf-14-day-execution-plan](./2026-03-26-pmf-14-day-execution-plan) is the current two-week operating tranche for inbox-wedge proof and design-partner readiness.
+
+## Current Reality
+
+- Historical program epics still matter as lineage even though they are no longer the live gate: [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+- `main` now contains the structural product-loop slices that were missing earlier in March, plus the live founder loop proof, Phase 2 truth-seeking wiring, and the inbox trust wedge dogfood surface.
+- The focused test baseline on current `main`:
+
+  ```bash
+  python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
+  ```
+
+  Result on March 24, 2026: `71 passed` in `34.2s`.
+
+  Extended suite (including truth_scorer, prover_estimator, cross_verification):
+
+  ```bash
+  python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py \
+    tests/debate/test_truth_scorer.py tests/debate/test_prover_estimator.py \
+    tests/debate/test_cross_verification.py -q
+  ```
+
+  Result: `125 passed` in `35.1s`.
+
+- **The live founder loop is now proven repeatable.** Five consecutive live runs completed successfully on March 24, 2026 (35-62s range, all producing valid receipts). Receipts are now persisted to the receipt store, making them visible via the API (`/api/v2/receipts`), dashboard, and `aragora receipt list`.
+- The acceptance checklist items that were open on March 23 are now closed:
+  - Readiness: explicit, provider state shown before run starts (**passed**)
+  - Quickstart enters live path or fails closed: no silent fallback (**passed**)
+  - Live debate completes: 5/5 runs, 35-62s (**passed**)
+  - Structured receipt saved: verified via `receipt inspect` and `receipt verify` (**passed**)
+  - Result visible on product surface: receipts persist to store for API/dashboard (**passed**, commit 97074e28c)
+  - KM ingestion: truthful explicit stop with guidance message (**passed**)
+  - Operator noise bounded: embedding warnings demoted, summary preamble cleaned (**passed**)
+- The next lane is **dogfooding the second workflow** (inbox trust wedge) and **design partner readiness**.
+- GitHub's open issue set remains enterprise-assurance items: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), and [#509](https://github.com/synaptent/aragora/issues/509).
+
+## Execution Order
+
+### 1) ~~Prove The Canonical Founder Loop Live~~ DONE (March 24, 2026)
+
+The canonical founder loop is proven repeatable on `main`:
+- 5/5 consecutive live runs completed (35-62s range)
+- All acceptance checklist items pass (see Current Reality above)
+- Receipts persist to store for API/dashboard visibility
+- Summary output is clean (preamble stripped, noise demoted)
+- Commits: 5333ada7d, 97074e28c, 650f9c164
+
+### 2) Dogfood The Second Workflow (Inbox Trust Wedge) — CURRENT GATE
+
+The inbox trust wedge is structurally complete (~3,900 LOC) and the CLI is dogfood-ready:
+- `aragora triage auth` — interactive Gmail OAuth flow (commit f045d653c)
+- `aragora triage run --dry-run` — preview decisions without executing actions
+- `aragora triage run --auto-approve` — full automated pipeline
+- `aragora triage status` — shows configuration readiness
+
+Remaining to dogfood:
+- Configure Gmail OAuth credentials and run `aragora triage auth`
+- Execute `aragora triage run --dry-run` on a real inbox
+- Review proposed actions and verify receipt quality
+- Execute a live triage batch and confirm receipt-gated actions work
+
+### 3) Productize The Prompt-to-Spec Pipeline
+
+`aragora spec` is proven end-to-end (~23s with gpt-4o-mini):
+- Decomposes vague prompts into structured intents
+- Generates specifications with success criteria and risk registers
+- Supports `--skip-interrogation`, `--skip-research`, `--dry-run`
+
+Remaining:
+- Add `aragora spec` to the onboarding flow as a second entry point alongside `quickstart`
+- Wire spec output into `aragora decide` for debate-driven validation
+- Surface specs in the dashboard
+
+### 4) Design Partner Outreach
+
+The founder loop is repeatable. The sales point is now:
+- Clean live demo: `aragora quickstart` produces a trustworthy receipt in &lt;60s
+- Receipts are visible on API/dashboard/share-link surfaces
+- EU AI Act compliance bundle generates from real receipts
+- Inbox trust wedge provides a second workflow for retention testing
+
+Use the [PMF_SCORECARD](./pmf-scorecard) to evaluate design partners.
+
+### 5) Enterprise Assurance (After Design Partner Validation)
+
+- [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), and [#509](https://github.com/synaptent/aragora/issues/509) are real work.
+- Kickoff after at least 1 design partner is engaged and scoring above 65 on the PMF scorecard.
+
+## Operating Rules
+
+- Closed PMF issues do not equal live PMF proof.
+- No new infra or orchestration lane is justified unless it maps directly to a founder-loop acceptance gap.
+- No document should say "operational," "complete," or "ready for sales" unless live dogfood evidence supports that claim.
+- The PMF backlog should be reconstituted from observed live failures, not from stale issue trees.
+- GitHub issues still matter, but until the PMF blocker set is recreated truthfully, these docs are the current execution map.

--- a/docs-site/docs/contributing/pmf-dogfood-execution-plan.md
+++ b/docs-site/docs/contributing/pmf-dogfood-execution-plan.md
@@ -1,0 +1,315 @@
+---
+title: PMF Dogfood Execution Plan
+description: PMF Dogfood Execution Plan
+---
+
+# PMF Dogfood Execution Plan
+
+Last updated: 2026-03-25
+
+This is the bounded operator plan for using Aragora to finish Aragora's PMF-critical product loop.
+
+## Objective
+
+~~Prove one repeatable founder loop on current `main`.~~ **ACHIEVED** (March 24, 2026).
+
+The founder loop is proven repeatable: 5/5 consecutive live runs, 35-62s range, all producing valid receipts visible via API/dashboard.
+
+The current objective is to **dogfood the second workflow** (inbox trust wedge) and **prepare for design partner outreach**.
+
+## Founder Metrics Tree
+
+The founder scorecard should answer one question in decision order:
+
+1. are external users completing consequential workflows and trusting the
+   output enough to come back
+2. if not, which execution bottleneck is preventing that proof
+3. which numbers are merely narrative garnish and should not move roadmap
+
+### Proof Metrics
+
+These are the only metrics that should directly change roadmap priority,
+resource allocation, or go-to-market confidence.
+
+#### Root proof metric
+
+- **Weekly trusted workflow completions**: number of design-partner or
+  founder-operated runs that reach one of three truthful outcomes:
+  accepted action taken, accepted deliverable produced, or explicit
+  needs-human stop with the next action clear.
+
+#### Proof branches
+
+- **Repeat usage**
+  - active design partners who run more than one consequential workflow in a
+    week
+  - percent of users who come back for a second real task within 7 days
+- **Time-to-value**
+  - median time from auth/setup to first trusted visible result with receipt
+  - median time from starting a real inbox or review workflow to terminal truth
+- **Outcome advantage**
+  - measurable delta versus the incumbent path on quality, risk caught, or
+    time saved
+  - examples: review findings caught vs single-model baseline, inbox triage
+    actions accepted vs manually deferred
+- **Workflow-specific PMF proof**
+  - founder loop remains green as a baseline acceptance gate
+  - inbox trust wedge live runs on a real inbox
+  - design-partner workflows completed without hidden operator rescue
+- **Commercial pull**
+  - design partners who request continued use, commit to a pilot, or supply
+    more consequential workflows after the first proof
+
+If proof metrics improve, keep investing. If execution metrics improve but
+proof stays flat, the team is polishing plumbing instead of proving demand.
+
+### Execution Metrics
+
+These are leading indicators and diagnostics. They matter only insofar as they
+lift the proof metrics above.
+
+- **Default journey success**
+  - live founder-loop pass rate
+  - real inbox wedge pass rate
+  - percent of runs with a visible result plus persisted receipt
+- **Truthfulness quality**
+  - percent of failures that end with the correct terminal state
+  - percent of blockers that name the real next human action
+  - false-success and false-block rates
+- **Operator burden**
+  - operator interventions per live run
+  - manual minutes required to get from setup to terminal truth
+  - number of hidden rescue steps discovered during reruns
+- **Latency and reliability**
+  - p50 and p95 runtime for quickstart, prompt-to-spec, and inbox flows
+  - retry rate, timeout rate, and provider failure rate on canonical paths
+  - receipt persistence success and result-surface freshness
+- **Repair velocity**
+  - time from failed proof run to landed fix
+  - time from landed fix to validated rerun
+  - number of reruns required before the proof turns green again
+
+Execution metrics are the engineering dashboard. They are not PMF proof by
+themselves.
+
+### Vanity Metrics
+
+These numbers can be useful as inventory or storytelling context, but they
+must not drive roadmap decisions:
+
+- total agent types, providers, adapters, or integrations
+- total debates, runs, or receipts without accepted outcomes
+- test count, file count, doc count, and repo size
+- GitHub stars, social impressions, newsletter signups, or waitlist growth
+- benchmark wins disconnected from real operator workflows
+- compliance-completeness percentages before repeated workflow usage exists
+- raw demo traffic or `/demo` visits without retained real-task usage
+
+### Decision Rules
+
+- Proof metrics outrank execution metrics.
+- Execution metrics only justify work when they are a credible bottleneck to a
+  proof metric.
+- Vanity metrics never justify a roadmap pivot or shipping priority.
+- The founder loop is now a guardrail metric. The next true proof metric is
+  repeatable external workflow success on the inbox/design-partner wedge.
+
+## Proven Evidence On `main`
+
+These structural slices are landed and **proven live**:
+
+- ProviderRouter-backed runtime debate selection
+- KM retrieval into debate context and KM writeback from outcomes
+- versioned API-key management endpoints
+- onboarding/get-started product flow
+- truthful integrations and dashboard surfaces
+- quickstart TLS fail-fast behavior
+- quickstart structured receipts and inline provider-key support
+- real demo/backend wiring
+- **Quickstart receipts persist to receipt store** (API/dashboard/share-link visible)
+- **Embedding rate limit resilience** (hash-based fallback on 429 errors)
+- **Summary preamble cleaning** (LLM chain-of-thought stripped from CLI output)
+- **Prompt-to-spec CLI** (`aragora spec` completes in ~23s)
+- **Phase 2 truth-seeking wired**: Prover-Estimator consensus, cross-verification, truth ratio vote weights
+- **Inbox trust wedge CLI**: `aragora triage auth` (OAuth), `--dry-run`, `--auto-approve`
+
+Current focused proof on `main`:
+
+```bash
+python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
+```
+
+Result on March 24, 2026: `71 passed` in `34.2s`.
+
+Extended suite: `125 passed` in `35.1s`.
+
+Live founder loop: **5/5 consecutive runs pass** (35-62s range).
+
+## Canonical Founder-Loop Acceptance Checklist
+
+All items below are **PASSED** as of March 24, 2026:
+
+1. **Readiness is explicit** -- **PASSED**
+   - health/readiness endpoints respond truthfully
+   - credential/provider state is explicit before the run starts
+   - `.env` loaded and provider reported before debate starts
+2. **Quickstart enters the live path or fails closed quickly** -- **PASSED**
+   - no silent fallback to demo
+   - TLS/credential failures exit promptly with a direct reason
+3. **A live debate completes or stops truthfully** -- **PASSED**
+   - 5/5 consecutive runs complete in 35-62s
+   - no hanging operator path, no hidden manual rescue
+4. **A structured receipt is saved** -- **PASSED**
+   - receipt inspectable and verifiable via `aragora receipt inspect/verify`
+   - receipt also persisted to receipt store (commit 97074e28c)
+5. **The result is visible on a product surface** -- **PASSED**
+   - receipts visible via `/api/v2/receipts`, dashboard ReceiptsBrowser, share links
+   - `aragora receipt list` shows quickstart receipts
+6. **KM ingestion or KM stop condition is explicit** -- **PASSED**
+   - truthful message: "ingestion skipped (quickstart uses lightweight KM)"
+   - guidance: "Use 'aragora ask' or 'aragora decide' for full KM writeback"
+7. **Operator noise is bounded** -- **PASSED**
+   - embedding dimension mismatch demoted to DEBUG (commit 5333ada7d)
+   - LLM chain-of-thought preamble stripped from summary output
+   - final message shows clear next steps
+
+## Founder-Facing Failure Taxonomy
+
+When the founder loop does not complete successfully, label the run with one
+primary canonical state from
+[`docs/strategy/PRECISION_AND_TERMS.md`](../strategy/PRECISION_AND_TERMS.md#part-2-founder-run-failure-taxonomy):
+
+- `auth_failure`
+- `no_evidence`
+- `low_confidence`
+- `conflicting_models`
+- `blocked_integration`
+- `truthful_stop`
+
+Classification rules for this plan:
+
+- choose the earliest blocking reason that best explains why the run stopped
+- do not collapse `conflicting_models` into `low_confidence`
+- do not collapse `blocked_integration` into `auth_failure` once access is valid
+- use `truthful_stop` only for a correct human/policy boundary, not as a
+  generic fallback
+
+## Strict Execution Order
+
+### 1) Re-run The Controlled Baseline
+
+Use the current mocked proof before touching the live path:
+
+```bash
+python3 -m pytest tests/e2e/test_user_journey.py tests/cli/test_quickstart.py -q
+```
+
+### 2) Run The Live Founder Loop
+
+Use local secure-store hydration or explicit one-shot provider injection. Do not rely on ambient shell exports.
+
+Suggested bounded live run:
+
+```bash
+ARAGORA_USER_ID=an0mium \
+python3 -m aragora.cli.main quickstart \
+  --question "Should Aragora use its own dogfood pipeline to close the remaining PMF gaps?" \
+  --no-browser
+```
+
+Then verify the emitted receipt:
+
+```bash
+python3 -m aragora.cli.main receipt inspect .aragora/receipts/quickstart-live-receipt.json
+python3 -m aragora.cli.main receipt verify .aragora/receipts/quickstart-live-receipt.json
+```
+
+If the live path uses a product/API surface directly, also capture the matching visible result endpoint or UI evidence.
+
+### 3) If The Run Fails, Capture A Truthful Blocker
+
+Record:
+
+- exact command
+- runtime
+- stop condition
+- affected surface
+- primary taxonomy label:
+  - `auth_failure`
+  - `no_evidence`
+  - `low_confidence`
+  - `conflicting_models`
+  - `blocked_integration`
+  - `truthful_stop`
+- secondary diagnostics, if any:
+  - credentials / readiness
+  - provider/TLS
+  - runtime debate execution
+  - receipt/result visibility
+  - KM ingestion
+  - noisy but truthful
+  - noisy and untruthful
+
+### 4) Compile Only Those Blockers Through The Pipeline
+
+Use this plan file as the source input:
+
+```bash
+python3 -m aragora.cli.main pipeline dogfood \
+  --source-file docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md \
+  --output-dir .aragora/dogfood/pmf \
+  --max-goals 3 \
+  --budget-limit 10 \
+  --time-limit-hours 4 \
+  --max-parallel-ready-projects 1 \
+  --planner-model claude \
+  --worker-model codex \
+  --review-model claude \
+  --json
+```
+
+Review the generated objectives and manifest before any execution.
+
+### 5) Run Bounded Repair Lanes
+
+Only after the generated blocker list matches the observed live failures:
+
+```bash
+python3 -m aragora.cli.main swarm tranche inspect \
+  --manifest .aragora/dogfood/pmf/campaign_manifest.yaml \
+  --json
+```
+
+If the manifest is clean and narrow, start the supervisor under the normal human merge gate.
+
+### 6) Re-run The Founder Loop After Every Landed Blocker Slice
+
+The founder loop is the only scorecard that matters for this phase.
+
+## Stop Conditions
+
+Stop and re-plan if any of the following happen:
+
+- the generated blocker list does not map to the observed founder-loop failure
+- the queue proposes generic infra work not tied to the founder loop
+- a lane widens into repo cleanup, enterprise certification, or unrelated product work
+- the live proof cannot be reproduced with an exact command transcript
+- the run evidence is insufficient to satisfy the internal dogfood exit proof above
+
+## Out Of Scope
+
+These are explicitly not the current lane:
+
+- broad repo cleanup
+- enterprise assurance / pentest work
+- design partner outreach
+- Stripe / revenue operations
+- new autonomy infrastructure not tied to a founder-loop failure
+
+## Reporting Contract
+
+Every dogfood or repair lane should report:
+
+- exact commands run
+- PR/issue/doc URL if created
+- residual risk

--- a/docs-site/docs/contributing/pmf-scorecard.md
+++ b/docs-site/docs/contributing/pmf-scorecard.md
@@ -1,0 +1,169 @@
+---
+title: Product-Market Fit (PMF) Scorecard
+description: Product-Market Fit (PMF) Scorecard
+---
+
+# Product-Market Fit (PMF) Scorecard
+
+Last updated: 2026-03-23
+
+This scorecard is the single rubric for:
+- selecting design partners,
+- measuring pilot success,
+- deciding whether to scale, iterate, or narrow scope.
+
+Current gating rule:
+
+- Do not use this scorecard as the argument to scale GTM yet.
+- First prove the live founder loop in [PMF_DOGFOOD_EXECUTION_PLAN](./pmf-dogfood-execution-plan).
+- Once the founder loop is repeatable without manual rescue, use this scorecard to evaluate design partners and pilot quality.
+
+Related:
+- Design partner program: `docs/status/DESIGN_PARTNER_PROGRAM.md`
+- SME wedge: `docs/status/SME_STARTER_PACK.md`
+- Q1 execution backlog: `docs/status/BACKLOG_Q1_2026.md`
+- Canonical execution order (stability gates): `docs/status/NEXT_STEPS_CANONICAL.md`
+
+---
+
+## How To Use
+
+1. Score every prospect after the first discovery call.
+2. Re-score after the "magic moment" session.
+3. Re-score weekly during the pilot.
+4. Only scale GTM when you have 3+ partners scoring above the "Scale" threshold for 3 consecutive weeks.
+
+Scoring: 0-4 per dimension, weighted to a 0-100 total.
+
+---
+
+## Scoring Dimensions (0-4)
+
+### 1) ICP Fit (weight 15)
+0: hobby/individual, no meaningful decision accountability
+1: small team, low stakes, no compliance
+2: some accountability, occasional high-stakes decisions
+3: clear accountable decision owner + recurring decisions + compliance pressure
+4: regulated/high-stakes org where audit trails materially matter
+
+### 2) Pain & Urgency (weight 15)
+0: "nice to have"
+1: occasional annoyance
+2: real cost, but no urgency
+3: recent incident or active initiative with real risk
+4: high urgency (audit deadline, incident, executive mandate)
+
+### 3) Activation (weight 10)
+Definition: time-to-first-value (first usable receipt).
+0: cannot activate due to tooling/security constraints
+1: >2 hours with hands-on support
+2: 30-120 minutes with hands-on support
+3: 15-30 minutes mostly self-serve
+4: &lt;15 minutes self-serve ("SME Starter Pack" target)
+
+### 4) "Magic Moment" Value (weight 20)
+0: output is ignored or distrusted
+1: output is interesting but not actionable
+2: output leads to minor action; limited internal sharing
+3: output changes a decision or escalates correctly; shared with the team
+4: output prevents a likely failure or materially changes a high-stakes decision; shared with leadership or compliance
+
+### 5) Repeatability / Retention (weight 15)
+0: one-off usage only
+1: sporadic; not tied to a workflow trigger
+2: repeats monthly or requires heavy prompting
+3: weekly use in a defined workflow trigger
+4: multiple workflows + >1 internal user running it (not just the champion)
+
+### 6) Willingness To Pay (weight 15)
+0: no budget / refuses paid pilot
+1: would pay only token amounts
+2: willing to pay if procurement is easy and ROI is clear
+3: willing to pay for a paid pilot or annual contract discussion
+4: clear budget owner + timeline to purchase + strong ROI narrative
+
+### 7) Procurement / Security Friction (weight 10)
+Score is inverted: higher is better (less friction).
+0: cannot use due to policy
+1: requires long vendor onboarding before any pilot
+2: heavy review but self-host allows pilot
+3: standard security review; pilot can start now
+4: can start immediately
+
+---
+
+## Total Score Calculation (0-100)
+
+For each dimension:
+- raw score = 0-4
+- weighted = (raw / 4) * weight
+
+Total = sum(weighted).
+
+Thresholds:
+- 80-100: SCALE (add sales-assist + publish case study)
+- 65-79: ITERATE (ship top blockers, keep partner engaged)
+- &lt;65: NARROW (change wedge, change ICP, or stop pursuing)
+
+---
+
+## Measurement Hooks (Where To Instrument)
+
+This scorecard should be grounded in data when possible.
+
+Suggested instrumentation sources:
+- Onboarding funnel / time-to-first-receipt:
+  - Server: `aragora/server/handlers/onboarding.py` (flow + analytics endpoints)
+  - UI: `aragora/live/src/components/onboarding/`
+- Receipt generation + export:
+  - `aragora/export/decision_receipt.py`
+  - `aragora/gauntlet/receipt_models.py`
+  - CLI receipt tooling: `aragora/cli/commands/receipt.py`, `aragora/cli/commands/verify.py`
+- Integrations setup:
+  - Wizard API: `aragora/server/handlers/oauth_wizard.py`
+  - Slack/Gmail/Drive connectors:
+    - `aragora/connectors/chat/slack/`
+    - `aragora/connectors/enterprise/communication/gmail/`
+    - `aragora/connectors/enterprise/documents/gdrive.py`
+- Usage/cost/budget:
+  - Budgets + enforcement: `aragora/control_plane/cost_enforcement.py`
+  - Pipeline budget tracking: `aragora/pipeline/decision_plan/core.py`
+  - Analytics: `aragora/analytics/dashboard.py`, `aragora/analytics/debate_analytics.py`
+- Auditability:
+  - `aragora/audit/log.py`, `aragora/audit/unified.py`
+
+---
+
+## Scorecard Template (Copy Per Partner)
+
+Partner:
+- Company:
+- Segment: (FinTech / HealthTech / Enterprise SaaS / Other)
+- Deployment: (Hosted / Self-hosted)
+- Champion:
+- Economic buyer:
+- Security approver:
+
+Workflow:
+- Primary workflow trigger:
+- Artifact types:
+- Decision owner:
+- Frequency:
+
+Scores:
+| Dimension | Raw (0-4) | Notes |
+|---|---:|---|
+| ICP Fit |  |  |
+| Pain & Urgency |  |  |
+| Activation |  |  |
+| Magic Moment Value |  |  |
+| Repeatability / Retention |  |  |
+| Willingness To Pay |  |  |
+| Procurement / Security Friction |  |  |
+
+Pilot outcomes (weekly):
+- Receipts generated (count):
+- Time to first receipt (p50/p95):
+- Weekly active users:
+- Decisions changed / escalations avoided:
+- Procurement status:

--- a/docs-site/docs/contributing/roadmap.md
+++ b/docs-site/docs/contributing/roadmap.md
@@ -1,0 +1,209 @@
+---
+title: Aragora Product Roadmap
+description: Aragora Product Roadmap
+---
+
+# Aragora Product Roadmap
+
+**Last Updated:** March 25, 2026
+
+---
+
+## Vision
+
+Aragora is the **Decision Integrity Platform** — the control plane for multi-agent vetted decision-making across organizational knowledge and channels. We orchestrate heterogeneous AI agents to debate, synthesize, and deliver defensible decisions with full audit trails and cryptographic receipts.
+
+The long-term goal: every consequential AI-assisted decision in an organization flows through Aragora, producing an inspectable, verifiable record of what was decided, by whom, with what evidence, and with what dissent.
+
+---
+
+## Operating Principle: Build the Full Vision, Make Everything Work
+
+This roadmap is not a stop-doing list. The platform has massive infrastructure already built — 3,800+ Python modules, 216,000+ tests, 42 Knowledge Mound adapters, 43 agent types, 4-stage pipeline, swarm orchestration, compliance framework, and more.
+
+**The priority is:**
+1. Make everything that exists work correctly and reliably
+2. Wire disconnected subsystems together into coherent user journeys
+3. Improve performance, quality, and polish across the board
+4. Build out the full vision using the autonomous pipeline infrastructure
+
+**The autonomous execution system (overnight queue, boss loop, Nomic loop) is proven and should be used continuously** to improve the platform. Every code change should make the demo better, the debates faster, the receipts clearer, or the integrations more reliable.
+
+---
+
+## Current Status (March 2026)
+
+The live founder loop is **proven repeatable** (5/5 consecutive runs, 35-62s). Production is live at api.aragora.ai. The demo surface works. 41 founder strategy docs were produced autonomously overnight and merged.
+
+**What works end-to-end today:**
+- Multi-agent debates with real LLM providers (Claude, GPT-4, Gemini, Mistral, Grok)
+- Cryptographic decision receipts with SHA-256 audit trails
+- Production API serving live debates at api.aragora.ai
+- Demo surface at aragora.ai/demo with real backend
+- Prompt-to-spec engine (`aragora spec`) in ~23s
+- Inbox trust wedge CLI (`aragora triage`) with staged performance profile
+- Autonomous overnight queue producing real strategy artifacts
+- Deploy pipeline auto-deploying on push to main
+- 216,000+ tests across 4,700+ test files
+
+---
+
+## Continuous Improvement Tracks
+
+These tracks run in parallel, driven by the autonomous pipeline. Each produces measurable improvements that can be verified by running the product.
+
+### Track 1: Performance & Speed
+Make every user-facing flow faster.
+
+- [ ] Debate execution time: target sub-20s for quickstart (currently 35-62s)
+- [ ] Triage per-email time: target sub-10s for fast tier (currently ~18s)
+- [ ] Prompt-to-spec latency: target sub-15s (currently ~23s)
+- [ ] Streaming response improvements for live debate views
+- [ ] Batch debate processing for inbox triage at scale
+- [ ] Provider routing optimization (select fastest available model)
+- [ ] Reduce unnecessary sidecars (research, KM retrieval when empty)
+
+### Track 2: Code Correctness & Reliability
+Make everything that exists work correctly.
+
+- [ ] Full test suite health pass (find and fix regressions from recent 50+ PR sprint)
+- [ ] Provider fallback reliability (Anthropic → OpenRouter → local)
+- [ ] Async/sync boundary correctness (PostgreSQL, asyncpg, event loop issues)
+- [ ] Resource cleanup (unclosed sockets, transport warnings)
+- [ ] Error message quality (user-facing errors should be helpful, not stack traces)
+- [ ] Receipt integrity verification across all paths
+- [ ] KM ingestion/retrieval consistency (embedding dimension management)
+
+### Track 3: Integration Wiring
+Wire disconnected subsystems into coherent flows.
+
+- [ ] Provider routing visible in debate results (show which models were selected and why)
+- [ ] KM retrieval actually enriching debate context (not just write-only)
+- [ ] Debate outcomes feeding back into agent ELO ratings
+- [ ] Pipeline stage transitions visible in the UI
+- [ ] Receipt store ↔ dashboard ↔ API ↔ share links fully connected
+- [ ] Compliance artifacts auto-generated from debate receipts
+- [ ] Webhook delivery for debate completion events
+
+### Track 4: Frontend & UX Polish
+Make the product look and feel professional.
+
+- [ ] All frontend pages rendering real data (not shells)
+- [ ] Consistent typography and spacing across themes
+- [ ] Mobile responsiveness for key flows
+- [ ] Loading states and progress indicators for long operations
+- [ ] Error boundaries with helpful recovery actions
+- [ ] Debate detail page: clean verdict, agent positions, receipt link
+- [ ] Receipts page: searchable, filterable, exportable
+
+### Track 5: Multi-Agent Orchestration
+Scale and improve the debate engine.
+
+- [ ] 10+ agent debates at production quality
+- [ ] Prover-Estimator consensus mode hardened for real use
+- [ ] Cross-verification quality metrics visible in receipts
+- [ ] Truth scorer influence visible in vote weights
+- [ ] Agent performance benchmarking and selection improvement
+- [ ] Debate replay and comparison tools
+- [ ] Configurable debate protocols from the UI
+
+### Track 6: Knowledge & Memory
+Make the Knowledge Mound genuinely useful.
+
+- [ ] KM retrieval enriching debate context with relevant precedents
+- [ ] Semantic search returning quality results (embedding consistency)
+- [ ] Cross-debate learning producing measurable quality improvement
+- [ ] Knowledge gap identification from debate patterns
+- [ ] KM health dashboard showing adapter status and data quality
+- [ ] Evidence collection reliability across all sources
+
+### Track 7: Pipeline & Automation
+Build out the idea-to-execution vision.
+
+- [ ] DAG-based pipeline visualization in the UI
+- [ ] Interactive stage transitions (Ideas → Goals → Actions → Orchestration)
+- [ ] Pipeline feedback loops (execution results inform future planning)
+- [ ] Autonomous improvement cycles via Nomic Loop
+- [ ] Boss loop handling real engineering tasks continuously
+- [ ] Queue-based overnight runs producing and merging real improvements
+
+### Track 8: Enterprise & Compliance
+Prepare for enterprise adoption.
+
+- [ ] EU AI Act compliance artifacts auto-generated (enforcement: August 2, 2026)
+- [ ] SOC 2 controls: close remaining 2% gap
+- [ ] Pentest readiness (when enterprise prospect requires it)
+- [ ] Multi-tenant isolation hardening
+- [ ] Audit log completeness and export
+- [ ] HIPAA/FedRAMP compliance paths for healthcare/government verticals
+
+---
+
+## Quarterly Themes
+
+### Q2 2026: Make It Work, Make It Fast
+- Complete the dogfood loop (inbox wedge, design partner demos)
+- Performance improvements across all user-facing flows
+- Wire disconnected subsystems together
+- Polish frontend for professional presentation
+- Stripe integration and first paid users
+
+### Q3 2026: Scale & Expand
+- 10+ agent debates at enterprise quality
+- Vertical packages (Healthcare, Financial, Legal)
+- Cloud marketplace listings (AWS, Azure)
+- Kubernetes Operator for horizontal scaling
+- Skills marketplace pilot
+
+### Q4 2026: Platform Ecosystem
+- Cross-organization federation
+- Decision-Integrity UI Workbench (visual debate canvas)
+- Community integration connectors
+- Advanced analytics and ROI measurement
+- ERC-8004 on-chain deployment
+
+### 2027: Industry Standard
+- 1M+ concurrent debates
+- Sub-second debate initiation
+- Global compliance (HIPAA, FedRAMP)
+- Market resolution mechanism for long-horizon settlement
+- Canvas GUI 8-stage visual pipeline
+
+---
+
+## Autonomous Execution
+
+The platform improves itself using its own infrastructure:
+
+- **Overnight queue**: Produces bounded improvements while the team sleeps
+- **Boss loop**: Dispatches work to AI workers against labeled GitHub issues
+- **Nomic Loop**: Self-improvement cycles with human approval gates
+- **Swarm orchestration**: Multi-worker parallel execution with lease-based coordination
+
+The operating principle: if an improvement can be specified as a bounded task with clear acceptance criteria, it should be dispatched to the autonomous pipeline, not wait for a human to implement it.
+
+---
+
+## Contributing
+
+Aragora is open to contributions. See [CONTRIBUTING.md](./guide) for guidelines.
+
+Priority contribution areas:
+- Evidence connectors for new sources
+- Language translations
+- Documentation improvements
+- Test coverage expansion
+- Performance optimization
+
+---
+
+## Contact
+
+- **GitHub**: https://github.com/synaptent/aragora
+- **Product Feedback**: product@aragora.ai
+- **Enterprise Sales**: sales@aragora.ai
+- **Security Issues**: security@aragora.ai
+
+---
+
+*This roadmap represents our current plans and is subject to change based on user feedback and market conditions.*

--- a/docs-site/docs/contributing/status.md
+++ b/docs-site/docs/contributing/status.md
@@ -48,9 +48,9 @@ The current execution order is now:
 
 Canonical references:
 
-- [docs/status/NEXT_STEPS_CANONICAL.md](status/NEXT_STEPS_CANONICAL.md)
-- [docs/status/ACTIVE_EXECUTION_ISSUES.md](status/ACTIVE_EXECUTION_ISSUES.md)
-- [docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md](plans/PMF_DOGFOOD_EXECUTION_PLAN.md)
+- [docs/status/NEXT_STEPS_CANONICAL.md](./next-steps-canonical)
+- [docs/status/ACTIVE_EXECUTION_ISSUES.md](./active-execution-issues)
+- [docs/plans/PMF_DOGFOOD_EXECUTION_PLAN.md](./pmf-dogfood-execution-plan)
 
 ### Wave 2 Surface Productization
 

--- a/docs-site/docs/enterprise/secrets.md
+++ b/docs-site/docs/enterprise/secrets.md
@@ -1,0 +1,328 @@
+---
+title: Secrets Management Guide
+description: Secrets Management Guide
+---
+
+# Secrets Management Guide
+
+Aragora requires several secrets for production deployment. This guide covers secure secrets management using External Secrets Operator and various cloud backends.
+
+## Quick Start
+
+### Development (Local)
+
+For local development, use `.env` file:
+
+```bash
+cp .env.example .env
+# Edit .env with your API keys
+```
+
+### Production (Kubernetes)
+
+For production, use External Secrets Operator to sync secrets from your cloud provider:
+
+```bash
+# 1. Install External Secrets Operator
+helm repo add external-secrets https://charts.external-secrets.io
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace
+
+# 2. Configure your secret backend (AWS, Vault, GCP, etc.)
+kubectl apply -f deploy/kubernetes/external-secrets/cluster-secret-store.yaml
+
+# 3. Create ExternalSecret to sync secrets
+kubectl apply -f deploy/kubernetes/external-secrets/aragora-secrets.yaml
+```
+
+## Required Secrets
+
+| Secret | Environment Variable | Description |
+|--------|---------------------|-------------|
+| Database URL | `DATABASE_URL` | PostgreSQL connection string |
+| JWT Secret | `ARAGORA_JWT_SECRET` | 32+ char secret for auth tokens |
+| Anthropic API Key | `ANTHROPIC_API_KEY` | For Claude models |
+| OpenAI API Key | `OPENAI_API_KEY` | For GPT models |
+
+## Optional Secrets
+
+| Secret | Environment Variable | Description |
+|--------|---------------------|-------------|
+| OpenRouter API Key | `OPENROUTER_API_KEY` | Fallback/multi-model |
+| Mistral API Key | `MISTRAL_API_KEY` | Mistral models |
+| Stripe Secret Key | `STRIPE_SECRET_KEY` | Billing integration |
+| Stripe Webhook Secret | `STRIPE_WEBHOOK_SECRET` | Webhook verification |
+
+## Backend Configuration
+
+### AWS Secrets Manager
+
+1. **Create secrets in AWS**:
+
+```bash
+# Create secret with multiple keys
+aws secretsmanager create-secret \
+  --name aragora/production/api-keys \
+  --secret-string '{
+    "anthropic": "sk-ant-...",
+    "openai": "sk-...",
+    "openrouter": "sk-or-..."
+  }'
+
+aws secretsmanager create-secret \
+  --name aragora/production/database \
+  --secret-string '{"url": "postgresql://..."}'
+
+aws secretsmanager create-secret \
+  --name aragora/production/auth \
+  --secret-string '{"jwt-secret": "your-32-char-secret-here"}'
+```
+
+2. **Configure IRSA** (IAM Roles for Service Accounts):
+
+```bash
+# Create IAM policy
+cat > /tmp/policy.json << 'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": "arn:aws:secretsmanager:*:*:secret:aragora/*"
+    }
+  ]
+}
+EOF
+
+aws iam create-policy \
+  --policy-name AragoraSecretsAccess \
+  --policy-document file:///tmp/policy.json
+
+# Create service account with IRSA
+eksctl create iamserviceaccount \
+  --name external-secrets \
+  --namespace external-secrets \
+  --cluster your-cluster \
+  --attach-policy-arn arn:aws:iam::ACCOUNT:policy/AragoraSecretsAccess \
+  --approve
+```
+
+3. **Apply ClusterSecretStore**:
+
+```yaml
+# deploy/kubernetes/external-secrets/cluster-secret-store.yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: us-west-2
+```
+
+### HashiCorp Vault
+
+1. **Configure Vault**:
+
+```bash
+# Enable KV secrets engine
+vault secrets enable -path=secret kv-v2
+
+# Create secrets
+vault kv put secret/aragora/production/api-keys \
+  anthropic="sk-ant-..." \
+  openai="sk-..." \
+  openrouter="sk-or-..."
+
+vault kv put secret/aragora/production/database \
+  url="postgresql://..."
+
+vault kv put secret/aragora/production/auth \
+  jwt-secret="your-32-char-secret"
+
+# Create policy
+vault policy write aragora - << 'EOF'
+path "secret/data/aragora/*" {
+  capabilities = ["read"]
+}
+EOF
+
+# Configure Kubernetes auth
+vault auth enable kubernetes
+vault write auth/kubernetes/config \
+  kubernetes_host="https://kubernetes.default.svc"
+
+vault write auth/kubernetes/role/aragora \
+  bound_service_account_names=external-secrets \
+  bound_service_account_namespaces=external-secrets \
+  policies=aragora \
+  ttl=1h
+```
+
+2. **Apply ClusterSecretStore**:
+
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: vault
+spec:
+  provider:
+    vault:
+      server: "https://vault.example.com"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "aragora"
+          serviceAccountRef:
+            name: external-secrets
+            namespace: external-secrets
+```
+
+### Google Cloud Secret Manager
+
+1. **Create secrets in GCP**:
+
+```bash
+# Create secrets
+echo -n "sk-ant-..." | gcloud secrets create aragora-anthropic-key --data-file=-
+echo -n "sk-..." | gcloud secrets create aragora-openai-key --data-file=-
+echo -n "postgresql://..." | gcloud secrets create aragora-database-url --data-file=-
+
+# Grant access to service account
+gcloud secrets add-iam-policy-binding aragora-anthropic-key \
+  --member="serviceAccount:aragora@project.iam.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+```
+
+2. **Configure Workload Identity**:
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  aragora@PROJECT.iam.gserviceaccount.com \
+  --role roles/iam.workloadIdentityUser \
+  --member "serviceAccount:PROJECT.svc.id.goog[external-secrets/external-secrets]"
+
+kubectl annotate serviceaccount external-secrets \
+  -n external-secrets \
+  iam.gke.io/gcp-service-account=aragora@PROJECT.iam.gserviceaccount.com
+```
+
+## Secret Rotation
+
+### Automatic Rotation
+
+External Secrets Operator syncs secrets based on `refreshInterval`:
+
+```yaml
+spec:
+  refreshInterval: 1h  # Sync every hour
+```
+
+For more frequent rotation:
+
+```yaml
+spec:
+  refreshInterval: 5m  # Sync every 5 minutes
+```
+
+### Manual Rotation
+
+1. Update secret in your backend (AWS SM, Vault, etc.)
+2. Force refresh the ExternalSecret:
+
+```bash
+# Trigger immediate sync
+kubectl annotate externalsecret aragora-secrets \
+  -n aragora \
+  force-sync=$(date +%s) --overwrite
+
+# Restart pods to pick up new secrets
+kubectl -n aragora rollout restart deployment/aragora
+```
+
+### Rotation Best Practices
+
+1. **Never rotate JWT secret** without a maintenance window (invalidates all sessions)
+2. **API keys**: Can be rotated with zero downtime (add new key, deploy, remove old)
+3. **Database credentials**: Use connection pooling and rotate during low traffic
+
+## Verification
+
+### Check ExternalSecret Status
+
+```bash
+# View sync status
+kubectl -n aragora get externalsecret aragora-secrets
+
+# Detailed status
+kubectl -n aragora describe externalsecret aragora-secrets
+
+# Check if Kubernetes Secret was created
+kubectl -n aragora get secret aragora-secrets -o yaml
+```
+
+### Test Secrets in Pod
+
+```bash
+# Exec into pod and verify environment
+kubectl -n aragora exec -it deploy/aragora -- env | grep -E "^(ANTHROPIC|OPENAI|DATABASE)"
+
+# Test database connection
+kubectl -n aragora exec -it deploy/aragora -- python -c "
+from aragora.db import get_database
+db = get_database()
+print('Database connected:', db.health_check())
+"
+```
+
+## Troubleshooting
+
+### ExternalSecret Not Syncing
+
+```bash
+# Check External Secrets Operator logs
+kubectl -n external-secrets logs -l app.kubernetes.io/name=external-secrets
+
+# Check ExternalSecret events
+kubectl -n aragora describe externalsecret aragora-secrets
+```
+
+**Common Issues**:
+
+1. **Authentication failed**: Check ClusterSecretStore credentials
+2. **Secret not found**: Verify remote key path matches backend
+3. **Permission denied**: Check IAM/RBAC policies
+
+### Secret Not Available in Pod
+
+1. Verify Secret exists: `kubectl -n aragora get secret aragora-secrets`
+2. Check deployment references correct secret name
+3. Check env/envFrom configuration in deployment
+
+### Sync Delay
+
+External Secrets only syncs at `refreshInterval`. For immediate updates:
+
+```bash
+kubectl annotate externalsecret aragora-secrets -n aragora \
+  force-sync=$(date +%s) --overwrite
+```
+
+## Security Best Practices
+
+1. **Least privilege**: Only grant access to needed secrets
+2. **Audit logging**: Enable audit logs on your secret backend
+3. **Encryption at rest**: Ensure secrets are encrypted in backend
+4. **Network isolation**: Restrict access to secret management APIs
+5. **Regular rotation**: Rotate secrets on a schedule
+6. **No secrets in git**: Never commit secrets, even encrypted
+7. **Separate environments**: Use different secrets for staging/production

--- a/docs-site/docs/guides/conductor-workflow.md
+++ b/docs-site/docs/guides/conductor-workflow.md
@@ -1,0 +1,180 @@
+---
+title: Aragora Conductor Workflow
+description: Aragora Conductor Workflow
+---
+
+# Aragora Conductor Workflow
+
+Use this workflow when one human-facing Codex or Claude session is coordinating multiple bounded workers. The conductor is not a free-roaming implementer. The conductor restores shared state, assigns at most a small number of non-overlapping lanes, and stops as soon as the next decision point is reached.
+
+This guide documents the operating model that matched the repository's recent recovery work:
+
+- one canonical lane per issue
+- one worker per active lane
+- no worker merges
+- no worker touches root
+- no new lane until active lanes reach a PR-or-blocker stop condition
+
+For the lower-level coordination primitives, see [Dev Swarm Coordination](../contributing/dev-swarm-coordination). For spec-driven swarm runs, see [Supervised Swarm Dogfood Operator Guide](./swarm-dogfood-operator).
+
+## 1. Distinguish Root States Correctly
+
+Do not treat every non-ideal root state as "contaminated." There are three different cases:
+
+- `dirty`: uncommitted file changes exist in root
+- `behind`: root is clean, but local `main` is older than `origin/main`
+- `unsafe for implementation`: root may be clean, but active lanes or overlapping ownership make it a bad implementation base
+
+The correct conductor behavior is:
+
+- if root is `dirty`, stop and report; do not sync or code
+- if root is clean and `behind`, fast-forward it to `origin/main`
+- even when root is clean and current, do not use it as a worker lane; root is the conductor/integrator surface
+
+## 2. Conductor Loop
+
+Run this loop in the single conductor session before any coding:
+
+1. fetch `origin` and inspect repo state
+2. if root is dirty, stop and report
+3. if root is clean and behind, fast-forward root `main` to `origin/main`
+4. inspect open PRs
+5. inspect worktrees
+6. identify active lanes
+7. choose at most two non-overlapping worker assignments
+8. stop assigning once those lanes are in flight
+
+The conductor should emit this summary each cycle:
+
+1. current repo state
+2. active lanes
+3. canonical ownership
+4. next worker assignments
+5. stop condition for each worker
+
+## 3. Minimum Conductor Commands
+
+These are the minimum checks needed to keep state coherent:
+
+```bash
+git fetch origin --prune
+git status -sb
+git worktree list --porcelain
+gh pr list --state open --limit 20 --json number,title,headRefName,baseRefName,url
+```
+
+Useful Aragora-native read surfaces:
+
+```bash
+aragora swarm status --json
+aragora worktree fleet-status --json
+aragora worktree fleet-claims --json
+aragora worktree fleet-queue-list --json
+aragora worktree autopilot status --json
+```
+
+Useful low-level recovery commands when sessions are churny:
+
+```bash
+./scripts/codex_session.sh
+python3 scripts/codex_worktree_autopilot.py ensure --agent codex --base main --reconcile --print-path
+python3 scripts/codex_worktree_autopilot.py maintain --base main --strategy merge --ttl-hours 24
+python3 scripts/codex_worktree_autopilot.py reconcile --all --base main
+python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
+```
+
+## 4. Decision Rule
+
+Only do one of these per conductor cycle:
+
+1. merge an already-green non-overlapping PR
+2. assign one or two bounded worker lanes
+3. clean stale state
+4. stop because ownership is ambiguous
+
+Do not try to merge, assign, clean, and start follow-up work in the same cycle. That is how stale assumptions compound.
+
+## 5. Hot Coordination Files
+
+Treat these paths as serialized coordination surfaces:
+
+- `docs/status/**`
+- `README.md`
+- `ROADMAP.md`
+- `.github/workflows/**`
+- `scripts/reconcile_status_docs.py`
+- `scripts/pre_release_check.py`
+
+Only a dedicated docs/truthfulness lane or integrator lane should touch them. General implementation lanes should not edit them.
+
+## 6. Worker Assignment Contract
+
+A worker assignment must include all of the following:
+
+- exactly one issue or one narrow follow-up
+- explicit allowed paths
+- explicit forbidden paths
+- exact validation commands
+- exact stop condition
+
+The standard stop condition is:
+
+- open one PR and stop, or
+- report one blocker and stop
+
+Workers do not merge, do not widen scope, and do not clean up other lanes.
+
+## 7. Example Conductor Prompt
+
+```text
+You are the Aragora conductor/integrator.
+
+Before any coding:
+1. fetch origin and inspect repo state
+2. if root is dirty, stop and report; do not sync or code
+3. if root is clean and behind, fast-forward root main to origin/main
+4. inspect open PRs
+5. inspect worktrees
+6. identify active lanes
+7. choose at most 2 non-overlapping worker assignments
+8. do not code until ownership is clear
+
+Rules:
+- one canonical lane per issue
+- one worker per lane
+- no worker merges
+- no worker touches root
+- no new lane until current lanes reach PR-or-blocker stop condition
+- if repo state is ambiguous, resolve state first instead of starting work
+
+Output each cycle:
+1. current repo state
+2. active lanes
+3. canonical ownership
+4. next worker assignments
+5. stop condition for each worker
+```
+
+## 8. Why This Replaces "Yes To All In Best Order"
+
+"Yes to all in best order" sounds efficient, but it delegates scheduling and exclusivity to workers that do not share state. The failure mode is predictable:
+
+- duplicate lanes for the same issue
+- workers coding on stale branch assumptions
+- worktrees cleaned up while still useful
+- docs/status hot files edited by unrelated lanes
+- PR churn without canonical ownership
+
+The conductor loop fixes that by restoring one shared truth before allowing more work to start.
+
+## 9. Current Best Next Engineering Sequence
+
+After the merged worktree protection and integrator-view slices, the next control-plane work should usually proceed in this order:
+
+1. file-scope ownership enforcement
+2. canonical PR / supersession protocol
+3. receipt and provenance requirements for every lane
+4. prompt rendering from leases and worker roles
+5. a first-class `aragora swarm conduct` operator command
+
+That order matches the existing codebase shape more cleanly than jumping straight to many-agent autonomy.

--- a/docs-site/docs/guides/features.md
+++ b/docs-site/docs/guides/features.md
@@ -7,7 +7,7 @@ description: Aragora Feature Documentation
 
 > **Last reviewed:** 2026-03-06
 > **Snapshot basis:** 2026-02-03
-> Historical phase-by-phase feature chronology. For current state and planning, use [STATUS](../contributing/status), [FEATURE_DISCOVERY](FEATURE_DISCOVERY.md), [FEATURE_GAP_LIST](../FEATURE_GAP_LIST.md), and [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md).
+> Historical phase-by-phase feature chronology. For current state and planning, use [STATUS](../contributing/status), [FEATURE_DISCOVERY](../contributing/feature-discovery), [FEATURE_GAP_LIST](../contributing/feature-gap-list), and [DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](../contributing/documentation-hygiene-and-gap-register).
 
 
 This document provides a snapshot of major features and their origins. For live counts and recent updates, see `docs/status/STATUS.md`.

--- a/docs-site/docs/guides/marketplace.md
+++ b/docs-site/docs/guides/marketplace.md
@@ -1,0 +1,251 @@
+---
+title: Agent Template Marketplace
+description: Agent Template Marketplace
+---
+
+# Agent Template Marketplace
+
+The Aragora Marketplace enables sharing and discovering reusable templates for agents, debates, and workflows across the community.
+
+## Overview
+
+The marketplace provides:
+
+- **Agent Templates**: Pre-configured agent personalities with system prompts, capabilities, and constraints
+- **Debate Templates**: Structured debate formats with roles, protocols, and evaluation criteria
+- **Workflow Templates**: DAG-based automation workflows with inputs, outputs, and node configurations
+
+## Quick Start
+
+### Using the Local Registry
+
+```python
+from aragora.marketplace import TemplateRegistry, AgentTemplate, TemplateMetadata, TemplateCategory
+
+# Initialize registry (uses ~/.aragora/marketplace.db by default)
+registry = TemplateRegistry()
+
+# List built-in templates
+templates = registry.search(category=TemplateCategory.DEBATE)
+for t in templates:
+    print(f"{t.metadata.name}: {t.metadata.description}")
+
+# Get a specific template
+template = registry.get("devil-advocate")
+print(template.system_prompt)
+```
+
+### Creating Custom Templates
+
+```python
+from aragora.marketplace import AgentTemplate, TemplateMetadata, TemplateCategory
+
+# Create a custom agent template
+my_template = AgentTemplate(
+    metadata=TemplateMetadata(
+        id="my-analyst",
+        name="Data Analyst",
+        description="An agent specialized in data analysis and visualization",
+        version="1.0.0",
+        author="your-username",
+        category=TemplateCategory.ANALYSIS,
+        tags=["data", "analysis", "visualization"],
+    ),
+    agent_type="claude",
+    system_prompt="""You are a Data Analyst. Your role is to:
+1. Analyze datasets for patterns and insights
+2. Create clear visualizations
+3. Provide statistical summaries
+4. Recommend data-driven decisions
+
+Always cite your methodology and acknowledge limitations.""",
+    capabilities=["data_analysis", "visualization", "statistics"],
+    constraints=["must_cite_sources", "acknowledge_limitations"],
+)
+
+# Register the template
+registry.register(my_template)
+```
+
+### Searching Templates
+
+```python
+# Search by query
+results = registry.search(query="code review")
+
+# Search by category
+results = registry.search(category=TemplateCategory.CODING)
+
+# Search by tags
+results = registry.search(tags=["security", "review"])
+
+# Combined search with pagination
+results = registry.search(
+    query="analysis",
+    category=TemplateCategory.RESEARCH,
+    limit=10,
+    offset=0,
+)
+```
+
+## Built-in Templates
+
+### Agent Templates
+
+| ID | Name | Description |
+|----|------|-------------|
+| `devil-advocate` | Devil's Advocate | Challenges assumptions and presents counterarguments |
+| `code-reviewer` | Code Reviewer | Reviews code for quality, security, and best practices |
+| `research-analyst` | Research Analyst | Conducts thorough research and synthesizes information |
+
+### Debate Templates
+
+| ID | Name | Description |
+|----|------|-------------|
+| `oxford-style` | Oxford-Style Debate | Formal debate with proposing and opposing teams |
+| `brainstorm-session` | Brainstorm Session | Collaborative ideation with no-criticism phase |
+| `code-review-session` | Code Review Session | Multi-agent code review with different perspectives |
+
+## Template Types
+
+### AgentTemplate
+
+```python
+@dataclass
+class AgentTemplate:
+    metadata: TemplateMetadata
+    agent_type: str              # e.g., "claude", "gpt4", "custom"
+    system_prompt: str           # The agent's system prompt
+    model_config: dict           # Model-specific configuration
+    capabilities: list[str]      # What the agent can do
+    constraints: list[str]       # Behavioral constraints
+    examples: list[dict]         # Example interactions
+```
+
+### DebateTemplate
+
+```python
+@dataclass
+class DebateTemplate:
+    metadata: TemplateMetadata
+    task_template: str           # Template with \{placeholders\}
+    agent_roles: list[dict]      # Role definitions
+    protocol: dict               # Debate protocol settings
+    evaluation_criteria: list[str]
+    success_metrics: dict[str, float]
+```
+
+### WorkflowTemplate
+
+```python
+@dataclass
+class WorkflowTemplate:
+    metadata: TemplateMetadata
+    nodes: list[dict]            # Workflow nodes
+    edges: list[dict]            # Node connections
+    inputs: dict                 # Input definitions
+    outputs: dict                # Output definitions
+    variables: dict              # Template variables
+```
+
+## Ratings and Downloads
+
+```python
+from aragora.marketplace import TemplateRating
+
+# Rate a template (1-5 stars)
+rating = TemplateRating(
+    user_id="user-123",
+    template_id="devil-advocate",
+    score=5,
+    review="Excellent for critical thinking exercises!",
+)
+registry.rate(rating)
+
+# Get average rating
+avg = registry.get_average_rating("devil-advocate")
+print(f"Average rating: \{avg\}")
+
+# Track downloads
+registry.increment_downloads("devil-advocate")
+```
+
+## Import/Export
+
+```python
+# Export a template to JSON
+json_str = registry.export_template("my-analyst")
+with open("my-template.json", "w") as f:
+    f.write(json_str)
+
+# Import a template from JSON
+with open("shared-template.json") as f:
+    template_id = registry.import_template(f.read())
+```
+
+## Remote Marketplace Client
+
+For sharing templates with the community:
+
+```python
+from aragora.marketplace import MarketplaceClient, MarketplaceConfig
+
+# Configure client
+config = MarketplaceConfig(
+    base_url="https://marketplace.aragora.ai/api/v1",
+    api_key="your-api-key",
+)
+
+async with MarketplaceClient(config) as client:
+    # Search remote marketplace
+    templates = await client.search_templates(
+        query="code review",
+        category=TemplateCategory.CODING,
+    )
+
+    # Download a template
+    template = await client.download_template("popular-template-id")
+
+    # Publish your template
+    await client.publish_template(my_template)
+
+    # Get featured templates
+    featured = await client.get_featured(limit=10)
+
+    # Star a template
+    await client.star_template("template-id")
+```
+
+## Best Practices
+
+### Template Design
+
+1. **Clear Purpose**: Define a specific use case for your template
+2. **Detailed Prompts**: Include comprehensive system prompts with examples
+3. **Appropriate Constraints**: Add constraints that enforce desired behavior
+4. **Good Documentation**: Write clear descriptions and add relevant tags
+
+### Version Management
+
+- Use semantic versioning (MAJOR.MINOR.PATCH)
+- Document breaking changes in new major versions
+- Keep backward compatibility when possible
+
+### Community Guidelines
+
+- Test templates before publishing
+- Provide example usage in descriptions
+- Respond to user feedback and ratings
+- Update templates based on community input
+
+## API Reference
+
+See the full API documentation at `/api/v1/templates` endpoints:
+
+- `GET /api/v1/templates` - List/search templates
+- `GET /api/v1/templates/\{id\}` - Get template by ID
+- `POST /api/v1/templates` - Publish a template
+- `PUT /api/v1/templates/\{id\}` - Update a template
+- `DELETE /api/v1/templates/\{id\}` - Delete a template
+- `POST /api/v1/templates/\{id\}/ratings` - Rate a template
+- `POST /api/v1/templates/\{id\}/star` - Star a template

--- a/docs-site/docs/guides/swarm-dogfood-operator.md
+++ b/docs-site/docs/guides/swarm-dogfood-operator.md
@@ -1,0 +1,182 @@
+---
+title: Supervised Swarm Dogfood Operator Guide
+description: Supervised Swarm Dogfood Operator Guide
+---
+
+# Supervised Swarm Dogfood Operator Guide
+
+Use this runbook for the first spec-driven supervised swarm run in a local Aragora checkout. Keep work-order file scopes disjoint, use explicit expected tests, and let the reconcile loop move work instead of doing manual worktree surgery.
+
+## 1. Create the spec
+
+You can generate the initial envelope from the CLI:
+
+```bash
+python -m aragora.cli.main swarm \
+  "Ship the first supervised swarm dogfood run" \
+  --skip-interrogation \
+  --dry-run \
+  --save-spec /tmp/swarm-dogfood.yaml
+```
+
+Then edit the spec so each work order owns a narrow `file_scope` and concrete `expected_tests`.
+
+```yaml
+raw_goal: Ship the first supervised swarm dogfood run
+refined_goal: Ship the first supervised swarm dogfood run
+work_orders:
+  - work_order_id: docs-lane
+    title: Write operator guide
+    description: Add the first supervised runbook.
+    file_scope:
+      - docs/guides/SWARM_DOGFOOD_OPERATOR.md
+    expected_tests: []
+    target_agent: codex
+    reviewer_agent: claude
+    risk_level: info
+  - work_order_id: swarm-tests
+    title: Cover spec and reconcile flow
+    description: Add CLI and commander regression coverage.
+    file_scope:
+      - tests/cli/test_swarm_command.py
+      - tests/swarm/test_commander.py
+    expected_tests:
+      - python -m pytest tests/cli/test_swarm_command.py tests/swarm/test_commander.py -q
+    target_agent: claude
+    reviewer_agent: codex
+    risk_level: review
+  - work_order_id: integration-tests
+    title: Cover reconcile and integration queue flow
+    description: Add reconciler and queue regression coverage.
+    file_scope:
+      - tests/swarm/test_reconciler.py
+      - tests/worktree/test_integration_worker.py
+    expected_tests:
+      - python -m pytest tests/swarm/test_reconciler.py tests/worktree/test_integration_worker.py -q
+    target_agent: codex
+    reviewer_agent: claude
+    risk_level: review
+```
+
+## 2. Provision the run without dispatching workers
+
+Use `--no-dispatch` when you want to confirm the run shape before any worker sessions start:
+
+```bash
+python -m aragora.cli.main swarm --spec /tmp/swarm-dogfood.yaml --no-dispatch --json
+```
+
+Record the returned `run_id`. This should create the supervisor run and lease available work orders without launching workers.
+
+## 3. Dispatch and reconcile
+
+Use the reconcile loop as the operator control plane:
+
+```bash
+python -m aragora.cli.main swarm reconcile \
+  --run-id <run_id> \
+  --watch \
+  --interval-seconds 2 \
+  --json
+```
+
+Useful variants:
+
+```bash
+python -m aragora.cli.main swarm --spec /tmp/swarm-dogfood.yaml --dispatch-only --json
+python -m aragora.cli.main swarm status --run-id <run_id> --json
+python -m aragora.cli.main swarm reconcile --run-id <run_id>
+python -m aragora.cli.main swarm reconcile --all-runs
+```
+
+- `--dispatch-only` launches workers and returns immediately.
+- `--no-dispatch` provisions supervisor state without launching workers.
+- `reconcile --watch` is the operator-friendly path for topping up work, collecting finished workers, and syncing pending integration work.
+
+## 4. Inspect the integration queue
+
+Use the fleet merge queue as the integration surface:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-list
+python -m aragora.cli.main worktree fleet-queue-list --status needs_human
+python -m aragora.cli.main worktree fleet-queue-list --status blocked
+```
+
+Expected queue metadata for dogfood runs includes:
+
+- `receipt_id`
+- `changed_paths`
+- `tests_run`
+- `confidence`
+
+Typical queue states:
+
+- `queued`: ready for validation
+- `needs_human`: validated or blocked by an explicit gate
+- `blocked`: merge conflict or validation failure
+- `merged`: integrated successfully
+
+## 5. Validate or execute the next integration item
+
+Validation only:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-process-next \
+  --worker-session-id integrator-1 \
+  --json
+```
+
+Validate and merge:
+
+```bash
+python -m aragora.cli.main worktree fleet-queue-process-next \
+  --worker-session-id integrator-1 \
+  --execute \
+  --json
+```
+
+Use validation first on the first dogfood run. Execute only after the queue item shows the expected files, tests, and conflict metadata.
+
+## 6. When the run needs help
+
+Check these fields before intervening:
+
+- `dispatch_error` or `resource_error` on the swarm run
+- `reconciler_conflicts` on the queue item
+- `merge_error` or `merge_conflicts` on the integration outcome
+
+For the first supervised dogfood run, prefer fixing the narrow blocking issue and re-running the reconciler instead of broad manual cleanup.
+
+## 7. Lease reaping and stale session cleanup
+
+As of PR #1004, the reconciler tick automatically reaps expired leases from dead sessions. You no longer need to manually release stale leases.
+
+**How it works:**
+
+1. `reap_stale_leases()` detects dead worker PIDs using `os.kill(pid, 0)` probes
+2. `reap_expired_leases()` releases leases past their TTL expiry
+3. Both are called at the start of every `tick_run()` before refresh/dispatch
+4. `refresh_run()` also proactively reaps expired leases during each refresh cycle
+
+**Verify lease reaping is working:**
+
+```bash
+python -m aragora.cli.main swarm reconcile --all-runs --json | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for run in data.get('runs', []):
+    reaped = run.get('reaped_leases', 0)
+    if reaped:
+        print(f'Run {run[\"run_id\"]}: reaped \{reaped\} expired leases')
+"
+```
+
+**Manual stale lease check:**
+
+```bash
+python -m aragora.cli.main swarm reap --dry-run
+python -m aragora.cli.main swarm reap          # actually release stale leases
+```
+
+Sessions that crash or timeout have their leases returned to the pool automatically, making the work order available for re-dispatch. The `_orphaned_conflict_reason()` function replaces the old `Path.exists()` check with PID-based liveness detection, solving the V8-V13 blocker where managed worktrees always existed but their worker processes were dead.

--- a/docs-site/docs/guides/worker-prompt-pack.md
+++ b/docs-site/docs/guides/worker-prompt-pack.md
@@ -1,0 +1,202 @@
+---
+title: Aragora Worker Prompt Pack
+description: Aragora Worker Prompt Pack
+---
+
+# Aragora Worker Prompt Pack
+
+These prompts are the manual operating model until Aragora renders them directly from leases and supervisor state.
+
+Use them as bounded lane contracts. Do not append "yes to all in best order." End with a stop condition instead.
+
+## 1. Standard Worker Prompt
+
+```text
+You are a bounded Aragora worker.
+
+Task:
+- implement exactly one issue or one narrow follow-up lane
+
+Base:
+- start from current origin/main
+- create one fresh disposable worktree
+- do not use root
+- if an overlapping PR or worktree already exists, stop and report
+
+Allowed paths:
+- <explicit files or directories only>
+
+Forbidden paths:
+- docs/status/**
+- README.md
+- ROADMAP.md
+- .github/workflows/**
+- any path owned by another active lane
+- any path outside the allowed list
+
+Do not:
+- merge
+- widen scope
+- touch other worktrees
+- clean up anything you did not create
+- open more than one PR
+
+Required behavior:
+- inspect first
+- form a short plan
+- implement only the bounded task
+- run only focused validation
+- if overlap, drift, or ownership ambiguity appears, stop immediately and report
+
+Final report:
+1. branch
+2. worktree path
+3. files changed
+4. tests/checks run
+5. PR URL or exact blocker
+
+Then stop.
+```
+
+## 2. Reviewer Prompt
+
+```text
+You are the Aragora reviewer.
+
+Task:
+- inspect exactly one PR or one candidate lane
+- no edits unless explicitly told to fix one concrete required-check failure
+
+Do not:
+- open a new branch
+- open a new PR
+- merge
+- widen into implementation
+
+Review for:
+- regressions
+- overlap with active lanes
+- truthfulness drift
+- missing tests
+- fake execution or placeholder behavior
+- receipt-bypass or approval-bypass risk where relevant
+
+Output:
+1. go / no-go
+2. top findings ordered by severity
+3. exact files and lines
+4. missing validation
+5. whether the PR is merge-ready or blocked
+
+Then stop.
+```
+
+## 3. Docs / Status Curator Prompt
+
+```text
+You own docs and status only.
+
+Allowed paths:
+- docs/status/**
+- docs/FEATURE_GAP_LIST.md
+- docs/STATUS.md
+- ROADMAP.md
+- README.md only if explicitly listed for the lane
+
+Forbidden paths:
+- aragora/**
+- tests/**
+- .github/workflows/**
+- runtime scripts unless explicitly listed
+
+Goal:
+- make docs current, mutually consistent, and accurate versus the codebase and issue tracker
+
+Do not:
+- touch code
+- touch workflows
+- merge
+- open more than one PR
+
+Stop after:
+- one docs-only PR, or
+- one blocker report explaining which source of truth conflicts
+```
+
+## 4. Integrator Prompt
+
+```text
+You are the Aragora integrator, not a free-roaming implementer.
+
+Your task:
+- inspect current PRs, issues, and active worktrees
+- choose the single best next integration action
+
+Priority rules:
+1. unblock or merge an already-green non-overlapping PR
+2. if no PR is ready, inspect the highest-priority active lane
+3. only if there is no active owner for the needed work, open one new bounded lane
+
+Do not:
+- start multiple new lanes
+- merge overlapping PRs
+- clean up worktrees you did not verify as stale
+- make broad code changes yourself unless the task is a narrow integration fix
+
+Required output:
+- current active lanes
+- best next action
+- why that action is first
+- exact stop condition
+
+If you merge something, stop after the merge.
+If nothing is merge-ready, stop after assigning or describing the next bounded lane.
+```
+
+## 5. Aragora Hot-File Rule
+
+Treat these as serialized by default:
+
+- `docs/status/**`
+- `README.md`
+- `ROADMAP.md`
+- `.github/workflows/**`
+- `scripts/reconcile_status_docs.py`
+- `scripts/pre_release_check.py`
+
+Do not let normal implementation lanes edit them unless the lane explicitly owns them.
+
+## 6. Lane Ownership Rule
+
+If an issue already has:
+
+- an open PR, or
+- an active worktree, or
+- a clean historical source lane plus a dirty residual lane,
+
+then stop and report before creating another branch. The integrator must designate canonical ownership first.
+
+## 7. One-Line Replacement For "Yes To All In Best Order"
+
+Use this instead:
+
+```text
+Resolve repo state first. Then take exactly one bounded next action from current origin/main. Respect lane ownership. Stop after one PR or one blocker report.
+```
+
+## 8. Good vs Bad Operator Instructions
+
+Good:
+
+- `Take exactly one bounded lane from current origin/main. Allowed paths: ... Do not merge. Stop after one PR or one blocker report.`
+- `Inspect PR #847 only. No edits. Tell me go/no-go and top risks.`
+- `You own docs/status only. Do not touch code or workflows.`
+
+Bad:
+
+- `yes to all in best order`
+- `keep going`
+- `fix whatever seems next`
+- `just merge what looks right`
+
+Those instructions erase ownership and stop conditions, which is exactly what causes duplicate lanes and repo-state drift.

--- a/docs-site/scripts/sync-docs.js
+++ b/docs-site/scripts/sync-docs.js
@@ -355,6 +355,31 @@ const DOC_MAP = {
   'HANDLER_DEVELOPMENT.md': 'contributing/handler-development.md',
   'TESTING.md': 'contributing/testing.md',
   'HANDLERS.md': 'contributing/handlers.md',
+  'status/FEATURE_DISCOVERY.md': 'contributing/feature-discovery.md',
+  'FEATURE_GAP_LIST.md': 'contributing/feature-gap-list.md',
+  'status/ACTIVE_EXECUTION_ISSUES.md': 'contributing/active-execution-issues.md',
+  'status/NEXT_STEPS_CANONICAL.md': 'contributing/next-steps-canonical.md',
+  'status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md':
+    'contributing/execution-next-6-weeks-2026-03-05.md',
+  'status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md':
+    'contributing/documentation-hygiene-and-gap-register.md',
+  'status/PMF_SCORECARD.md': 'contributing/pmf-scorecard.md',
+  'CANONICAL_GOALS.md': 'contributing/canonical-goals.md',
+  '../CLAUDE.md': 'contributing/claude.md',
+  'EXTENDED_README.md': 'contributing/extended-readme.md',
+  '../ROADMAP.md': 'contributing/roadmap.md',
+  'plans/ARAGORA_EVOLUTION_ROADMAP.md': 'contributing/aragora-evolution-roadmap.md',
+  'plans/PMF_DOGFOOD_EXECUTION_PLAN.md': 'contributing/pmf-dogfood-execution-plan.md',
+  'plans/2026-03-26-pmf-14-day-execution-plan.md':
+    'contributing/2026-03-26-pmf-14-day-execution-plan.md',
+  'guides/CONDUCTOR_WORKFLOW.md': 'guides/conductor-workflow.md',
+  'guides/SWARM_DOGFOOD_OPERATOR.md': 'guides/swarm-dogfood-operator.md',
+  'guides/WORKER_PROMPT_PACK.md': 'guides/worker-prompt-pack.md',
+  'architecture/DEV_SWARM_COORDINATION.md': 'contributing/dev-swarm-coordination.md',
+  'enterprise/SECRETS.md': 'enterprise/secrets.md',
+  'plans/2026-03-07-conductor-control-plane.md':
+    'contributing/conductor-control-plane-implementation-spec.md',
+  'workflow/MARKETPLACE.md': 'guides/marketplace.md',
 
   // =========================================================================
   // Additional Missing Files (commonly referenced)

--- a/tests/scripts/test_docs_site_sync_links.py
+++ b/tests/scripts/test_docs_site_sync_links.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_SITE_ROOT = REPO_ROOT / "docs-site" / "docs"
+
+
+def _read_docs_site(path: str) -> str:
+    return (DOCS_SITE_ROOT / path).read_text(encoding="utf-8")
+
+
+def test_documentation_index_rewrites_status_and_planning_links() -> None:
+    content = _read_docs_site("contributing/documentation-index.md")
+
+    expected_links = [
+        "[Aragora Conductor Workflow](../guides/conductor-workflow)",
+        "[Aragora Worker Prompt Pack](../guides/worker-prompt-pack)",
+        "[Dev Swarm Coordination](./dev-swarm-coordination)",
+        "[Conductor Control Plane Implementation Spec](./conductor-control-plane-implementation-spec)",
+        "[Feature Discovery](./feature-discovery)",
+        "[Feature Gap List](./feature-gap-list)",
+        "[Next Steps (Canonical)](./next-steps-canonical)",
+        "[Active 6-Week Execution Plan](./execution-next-6-weeks-2026-03-05)",
+        "[Documentation Hygiene Register](./documentation-hygiene-and-gap-register)",
+        "[Roadmap](./roadmap)",
+    ]
+    for link in expected_links:
+        assert link in content
+
+    unresolved_source_links = [
+        "guides/CONDUCTOR_WORKFLOW.md",
+        "guides/WORKER_PROMPT_PACK.md",
+        "architecture/DEV_SWARM_COORDINATION.md",
+        "plans/2026-03-07-conductor-control-plane.md",
+        "status/FEATURE_DISCOVERY.md",
+        "FEATURE_GAP_LIST.md",
+        "status/NEXT_STEPS_CANONICAL.md",
+        "status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md",
+        "status/DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md",
+        "../ROADMAP.md",
+    ]
+    for link in unresolved_source_links:
+        assert link not in content
+
+
+def test_features_guide_points_to_current_state_docs_site_pages() -> None:
+    content = _read_docs_site("guides/features.md")
+
+    expected_links = [
+        "[STATUS](../contributing/status)",
+        "[FEATURE_DISCOVERY](../contributing/feature-discovery)",
+        "[FEATURE_GAP_LIST](../contributing/feature-gap-list)",
+        "[DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](../contributing/documentation-hygiene-and-gap-register)",
+    ]
+    for link in expected_links:
+        assert link in content
+
+    unresolved_source_links = [
+        "[FEATURE_DISCOVERY](FEATURE_DISCOVERY.md)",
+        "[FEATURE_GAP_LIST](../FEATURE_GAP_LIST.md)",
+        "[DOCUMENTATION_HYGIENE_AND_GAP_REGISTER](DOCUMENTATION_HYGIENE_AND_GAP_REGISTER.md)",
+    ]
+    for link in unresolved_source_links:
+        assert link not in content
+
+
+def test_docs_site_sync_creates_linked_status_and_planning_pages() -> None:
+    expected_pages = [
+        DOCS_SITE_ROOT / "contributing" / "2026-03-26-pmf-14-day-execution-plan.md",
+        DOCS_SITE_ROOT / "contributing" / "active-execution-issues.md",
+        DOCS_SITE_ROOT / "contributing" / "aragora-evolution-roadmap.md",
+        DOCS_SITE_ROOT / "contributing" / "canonical-goals.md",
+        DOCS_SITE_ROOT / "contributing" / "claude.md",
+        DOCS_SITE_ROOT / "contributing" / "conductor-control-plane-implementation-spec.md",
+        DOCS_SITE_ROOT / "contributing" / "dev-swarm-coordination.md",
+        DOCS_SITE_ROOT / "contributing" / "documentation-hygiene-and-gap-register.md",
+        DOCS_SITE_ROOT / "contributing" / "execution-next-6-weeks-2026-03-05.md",
+        DOCS_SITE_ROOT / "contributing" / "extended-readme.md",
+        DOCS_SITE_ROOT / "contributing" / "feature-discovery.md",
+        DOCS_SITE_ROOT / "contributing" / "feature-gap-list.md",
+        DOCS_SITE_ROOT / "contributing" / "next-steps-canonical.md",
+        DOCS_SITE_ROOT / "contributing" / "pmf-dogfood-execution-plan.md",
+        DOCS_SITE_ROOT / "contributing" / "pmf-scorecard.md",
+        DOCS_SITE_ROOT / "contributing" / "roadmap.md",
+        DOCS_SITE_ROOT / "guides" / "conductor-workflow.md",
+        DOCS_SITE_ROOT / "guides" / "marketplace.md",
+        DOCS_SITE_ROOT / "guides" / "swarm-dogfood-operator.md",
+        DOCS_SITE_ROOT / "guides" / "worker-prompt-pack.md",
+        DOCS_SITE_ROOT / "enterprise" / "secrets.md",
+    ]
+
+    for page in expected_pages:
+        assert page.exists(), f"Expected synced docs-site page missing: {page}"


### PR DESCRIPTION
Docs-site navigation now mirrors the status/planning pages it links to, and the docs-site sync regression test covers those routes.