### PR TITLE
Fail closed on supervisor scope violations

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3111,8 +3111,7 @@ class SwarmSupervisor:
             scope_violations = self._llm_adjudicate_scope(item, scope_violations)
         if scope_violations:
             self._mark_scope_violation(item, scope_violations)
-            if not _pre_outcome:
-                item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
+            item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
             lease_id = str(item.get("lease_id", "")).strip()
             if lease_id:
                 self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
@@ -4852,6 +4851,29 @@ class SwarmSupervisor:
         reason = "worker edited files outside permitted scope: " + ", ".join(out_of_scope_paths[:5])
         if extra_reason:
             reason = f"{extra_reason}; {reason}"
+        changed_paths = [
+            str(path).strip() for path in item.get("changed_paths", []) if str(path).strip()
+        ]
+        for key in (
+            "receipt_id",
+            "confidence",
+            "worker_outcome",
+            "completed_at",
+            "exit_code",
+            "head_sha",
+            "commit_shas",
+            "diff",
+            "diff_lines",
+            "tests_run",
+            "verification_results",
+            "resource_error",
+            "conflicts",
+            "pr_url",
+            "adopted_pr",
+            "merge_gate",
+            "verification_missing_reason",
+        ):
+            item.pop(key, None)
         item["status"] = "scope_violation"
         item["dispatch_error"] = reason
         item["failure_reason"] = "scope_violation"
@@ -4865,23 +4887,11 @@ class SwarmSupervisor:
         item["review_status"] = "changes_requested"
         scope_violation_detail = {
             "violations": violations,
-            "changed_paths": list(item.get("changed_paths", [])),
+            "changed_paths": changed_paths,
             "detected_at": datetime.now(UTC).isoformat(),
         }
         item["scope_violation"] = scope_violation_detail
-        blockers = [str(v).strip() for v in item.get("blockers", []) if str(v).strip()]
-        if reason not in blockers:
-            blockers.append(reason)
-        item["blockers"] = blockers
-        item.pop("receipt_id", None)
-        item.pop("confidence", None)
-        for key in (
-            "pr_url",
-            "adopted_pr",
-            "merge_gate",
-            "verification_missing_reason",
-        ):
-            item.pop(key, None)
+        item["blockers"] = [reason]
         item.pop("pid", None)
 
         # Write violation metadata into the lease so status_summary() surfaces

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4052,12 +4052,20 @@ async def test_collect_results_marks_scope_violation_needs_human(
                 "lease_id": lease.lease_id,
                 "file_scope": ["aragora/server/auth_checks.py"],
                 "review_status": "pending",
+                "worker_outcome": "completed",
                 "receipt_id": "receipt-stale",
                 "confidence": 0.88,
+                "head_sha": "deadbeef",
                 "pr_url": "https://github.com/synaptent/aragora/pull/9999",
                 "adopted_pr": "https://github.com/synaptent/aragora/pull/9999",
                 "merge_gate": {"checks_passed": True},
                 "verification_missing_reason": "missing_verification_plan",
+                "commit_shas": ["deadbeef"],
+                "tests_run": ["python -m pytest tests/old_scope.py -q"],
+                "verification_results": [{"command": "pytest", "passed": True}],
+                "resource_error": "old disk pressure",
+                "conflicts": [{"source": "lease", "lease_id": "stale-lease"}],
+                "blockers": ["old blocker"],
             }
         ],
         status="active",
@@ -4103,11 +4111,19 @@ async def test_collect_results_marks_scope_violation_needs_human(
     assert "stay in scope" in wo["blocking_question"]
     assert wo.get("receipt_id") is None
     assert "confidence" not in wo
+    assert wo["scope_violation"]["changed_paths"] == ["aragora/server/handlers/playground.py"]
+    assert wo["blockers"] == [wo["dispatch_error"]]
     for cleared_key in (
+        "head_sha",
+        "commit_shas",
+        "tests_run",
+        "verification_results",
         "pr_url",
         "adopted_pr",
         "merge_gate",
         "verification_missing_reason",
+        "resource_error",
+        "conflicts",
     ):
         assert cleared_key not in wo
     assert wo["lease_id"] == lease.lease_id


### PR DESCRIPTION
## Summary
- clear stale deliverable and blocker metadata when a lane is marked scope_violation
- make scope_violation override any stale worker_outcome from earlier attempts
- lock the behavior in the supervisor scope-violation regression

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'collect_results_marks_scope_violation_needs_human'
- python -m pytest tests/swarm/test_supervisor.py -q