### PR TITLE
Prefer lock PID over stale worker PID

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -427,7 +427,7 @@ class WorkerLauncher:
         if not worktree_path:
             return snapshot
         session_meta = self._read_session_meta(worktree_path)
-        pid = self._authoritative_session_pid(pid, session_meta)
+        pid = self._session_owned_pid(worktree_path, pid, session_meta)
         snapshot["pid_alive"] = self._is_pid_running(pid) if pid is not None else False
         lock_pid = self._pid_for_active_lock(worktree_path, pid, session_meta)
         if self._active_session_lock_blocks_collection(worktree_path, lock_pid):
@@ -1120,7 +1120,7 @@ class WorkerLauncher:
         session_exit_code, session_completed_at = cls._terminal_session_result(session_meta)
         observed_pid = cls._normalized_pid(pid)
         if allow_session_meta_pid_fallback:
-            observed_pid = cls._authoritative_session_pid(observed_pid, session_meta)
+            observed_pid = cls._session_owned_pid(worktree_path, observed_pid, session_meta)
         lock_pid = (
             cls._pid_for_active_lock(worktree_path, observed_pid, session_meta)
             if allow_session_meta_pid_fallback
@@ -1265,10 +1265,50 @@ class WorkerLauncher:
         return pid
 
     @classmethod
+    def _session_lock_pids(cls, worktree_path: str) -> list[int]:
+        active_lock = Path(worktree_path) / ".codex_session_active"
+        try:
+            raw = active_lock.read_text(encoding="utf-8")
+        except OSError:
+            return []
+        pids: list[int] = []
+        for line in raw.splitlines():
+            entry = line.strip()
+            if not entry:
+                continue
+            if "=" not in entry:
+                continue
+            key, value = entry.split("=", 1)
+            if key.strip() not in {"pid", "ppid"}:
+                continue
+            pid = cls._normalized_pid(value.strip())
+            if pid is not None and pid not in pids:
+                pids.append(pid)
+        return pids
+
+    @classmethod
+    def _session_owned_pid(
+        cls,
+        worktree_path: str,
+        pid: int | None,
+        session_meta: dict[str, Any],
+    ) -> int | None:
+        meta_pid = cls._normalized_pid(session_meta.get("pid"))
+        if meta_pid is not None:
+            return meta_pid
+        lock_pids = cls._session_lock_pids(worktree_path)
+        if lock_pids:
+            return lock_pids[0]
+        return pid
+
+    @classmethod
     def _active_session_lock_blocks_collection(cls, worktree_path: str, pid: int | None) -> bool:
         active_lock = Path(worktree_path) / ".codex_session_active"
         if not active_lock.exists():
             return False
+        lock_pids = cls._session_lock_pids(worktree_path)
+        if lock_pids:
+            return any(cls._is_pid_running(lock_pid) for lock_pid in lock_pids)
         # codex_session.sh writes ended_at/exit_code before it removes the
         # active lock in its EXIT trap. Treat the lock as authoritative while
         # it still exists unless the session PID is clearly gone.
@@ -1287,7 +1327,7 @@ class WorkerLauncher:
         active_lock = Path(worktree_path) / ".codex_session_active"
         if not active_lock.exists():
             return pid
-        return cls._authoritative_session_pid(pid, session_meta)
+        return cls._session_owned_pid(worktree_path, pid, session_meta)
 
     @staticmethod
     def _cleanup_session_artifacts(worktree_path: str) -> None:
@@ -2162,7 +2202,7 @@ class WorkerLauncher:
                     if str(item.get("command", "")).strip()
                 ]
         finally:
-            cleanup_pid = self._authoritative_session_pid(worker.pid, session_meta)
+            cleanup_pid = self._session_owned_pid(worker.worktree_path, worker.pid, session_meta)
             if cleanup_pid is not None:
                 self._wait_for_pid_exit_sync(cleanup_pid)
             self._cleanup_session_artifacts(worker.worktree_path)

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -2014,6 +2014,50 @@ class TestCollectDetachedResult:
         mock_cleanup.assert_called_once_with(str(tmp_path))
 
     @pytest.mark.asyncio
+    async def test_collects_when_active_lock_pid_is_dead_even_if_worker_pid_was_reused_without_session_meta(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("pid=24680\nppid=13579\n", encoding="utf-8")
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new=AsyncMock()) as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts") as mock_cleanup,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-stale-worker-pid-no-meta",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=11111,
+                initial_head="def456",
+                auto_commit=False,
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert mock_running.call_args_list
+        assert all(call.args[0] in {24680, 13579} for call in mock_running.call_args_list)
+        mock_wait_pid.assert_awaited_once_with(24680)
+        mock_cleanup.assert_called_once_with(str(tmp_path))
+
+    @pytest.mark.asyncio
     async def test_skips_session_meta_pid_fallback_when_disabled(self, tmp_path: Path):
         (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
 
@@ -2213,6 +2257,36 @@ class TestSnapshotProgress:
         assert snapshot["pid_alive"] is False
         assert mock_running.call_args_list
         assert all(call.args == (24680,) for call in mock_running.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_uses_active_lock_pid_when_session_meta_missing_and_worker_pid_is_stale(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("pid=24680\nppid=13579\n", encoding="utf-8")
+        work_order = {
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        assert mock_running.call_args_list
+        assert all(call.args[0] in {24680, 13579} for call in mock_running.call_args_list)
 
     @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- use the managed-session lock file PID record when session metadata is missing
- stop detached collection and progress snapshots from trusting a reused stale worker pid
- lock the behavior in worker launcher regressions for detached collection and progress snapshots

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'active_lock_pid_is_dead_even_if_worker_pid_was_reused_without_session_meta or snapshot_progress_uses_active_lock_pid_when_session_meta_missing_and_worker_pid_is_stale'
- python -m pytest tests/swarm/test_worker_launcher.py -q