### PR TITLE
Reject malformed Slack OAuth payloads

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1154,6 +1154,10 @@ class SlackOAuthHandler(SecureHandler):
             logger.error("[%s] Slack token exchange failed: %s", request_id, e)
             return error_response("Token exchange failed", 500)
 
+        if not isinstance(data, dict):
+            logger.error("[%s] Slack token exchange returned non-dict payload", request_id)
+            return error_response("Invalid response from Slack", 500)
+
         if not data.get("ok"):
             error_msg = data.get("error", "Unknown error")
             logger.error("Slack OAuth failed: %s", error_msg)
@@ -1692,6 +1696,21 @@ class SlackOAuthHandler(SecureHandler):
                     )
                 logger.warning("Handler error: %s", e)
                 return error_response("Token refresh failed", 502)
+
+            if not isinstance(data, dict):
+                logger.error(
+                    "Token refresh returned non-dict payload for %s",
+                    workspace_id,
+                )
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: malformed payload",
+                    )
+                return error_response("Invalid token refresh response", 502)
 
             if not data.get("ok"):
                 error_msg = data.get("error", "Unknown error")

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -987,6 +987,31 @@ class TestCallback:
         assert mock_workspace_cls.call_args.kwargs["scopes"] == ["channels:history", "chat:write"]
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_nondict_token_payload(self, handler):
+        mock_client, _ = _make_httpx_mock(
+            [
+                {
+                    "ok": True,
+                    "access_token": "xoxb-new-token",
+                }
+            ]
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_callback_rejects_cross_tenant_workspace_rebind(
         self, handler, mock_workspace, mock_workspace_store, mock_state_store
     ):
@@ -2856,6 +2881,39 @@ class TestRefreshToken:
                 "refresh_token": "xoxr-new-refresh",
                 "expires_in": 43200,
             }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_nondict_payload(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            [
+                {
+                    "ok": True,
+                    "access_token": "xoxb-new-token",
+                    "team": {"id": "W123"},
+                }
+            ]
         )
 
         with (


### PR DESCRIPTION
## Summary
- fail closed when Slack OAuth callback returns a non-dict JSON payload
- fail closed when manual token refresh returns a non-dict JSON payload
- add regressions for both malformed upstream payload shapes

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'callback_rejects_nondict_token_payload or refresh_rejects_nondict_payload'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q