### PR TITLE
Fail closed on SQLite webhook update races

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -718,11 +718,13 @@ class SQLiteWebhookConfigStore(WebhookConfigStoreBackend):
             params.append(webhook_id)
 
             conn = self._get_conn()
-            conn.execute(
+            cursor = conn.execute(
                 f"UPDATE webhook_configs SET {', '.join(updates)} WHERE id = ?",  # noqa: S608 -- dynamic clause from internal state
                 params,
             )
             conn.commit()
+            if cursor.rowcount <= 0:
+                return None
             webhook.updated_at = now
 
         return webhook

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1094,6 +1094,32 @@ class TestSQLiteWebhookConfigStore:
         assert updated.updated_at == revised_at
         assert sqlite_store.get_cache_revision(webhook.id) == revised_at
 
+    def test_update_returns_none_when_row_is_deleted_before_write(self, sqlite_store):
+        """A concurrent delete must not surface a phantom successful SQLite update."""
+        original = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/hook",
+            events=["debate_end"],
+            secret="secret",
+            updated_at=100.0,
+        )
+        cursor = MagicMock()
+        cursor.rowcount = 0
+        conn = MagicMock()
+        conn.execute.return_value = cursor
+
+        with (
+            patch.object(sqlite_store, "get", return_value=original),
+            patch.object(sqlite_store, "_get_conn", return_value=conn),
+            patch("aragora.storage.webhook_config_store.time.time", return_value=200.0),
+        ):
+            updated = sqlite_store.update("webhook-123", url="https://example.com/new")
+
+        assert updated is None
+        query, params = conn.execute.call_args.args
+        assert "updated_at = ?" in query
+        assert params == ["https://example.com/new", 200.0, "webhook-123"]
+
     def test_record_delivery_success(self, sqlite_store):
         """Test recording successful delivery."""
         webhook = sqlite_store.register(url="https://a.com", events=["debate_end"])


### PR DESCRIPTION
## Summary
- fail closed when SQLite update affects no rows after a successful prefetch
- add a regression for the delete-between-read-and-write race in the SQLite store
- keep returned webhook revisions aligned with durable truth instead of fabricating a successful update

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'update_returns_none_when_row_is_deleted_before_write or update_async_returns_none_when_row_is_deleted_before_write or update_keeps_returned_revision_in_sync_with_durable_row or update_async_returns_durable_revision_timestamp'
- python -m pytest tests/storage/test_webhook_config_store.py -q