### PR TITLE
Clear stale wait state on dependency-base conflicts

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2403,6 +2403,12 @@ class SwarmSupervisor:
     ) -> bool:
         def _clear_stale_deliverable_state() -> None:
             for key in (
+                "dispatch_error",
+                "failure_reason",
+                "blocking_question",
+                "blocker",
+                "resource_error",
+                "conflicts",
                 "receipt_id",
                 "confidence",
                 "worker_outcome",
@@ -2424,6 +2430,7 @@ class SwarmSupervisor:
                 "scope_violation",
             ):
                 work_order.pop(key, None)
+            work_order.pop("blockers", None)
 
         if not self._is_safe_dependency_ref(str(session.path), dependency_ref):
             _clear_stale_deliverable_state()

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -7066,6 +7066,11 @@ def test_refresh_run_marks_invalid_dependency_ref_needs_human(
                 "pr_url": "https://github.com/synaptent/aragora/pull/9999",
                 "merge_gate": {"checks_passed": True},
                 "verification_missing_reason": "missing_verification_plan",
+                "resource_error": "old disk pressure",
+                "conflicts": [{"source": "lease", "lease_id": "lease-stale"}],
+                "blockers": ["old blocker"],
+                "blocker": {"reason": "waiting_conflict", "question": "old question"},
+                "blocking_question": "old question",
             },
         ],
         status="active",
@@ -7081,6 +7086,24 @@ def test_refresh_run_marks_invalid_dependency_ref_needs_human(
     assert dependent["dependency_base_ref"] == "-bad-ref"
     assert dependent["dependency_base_source"] == "micro-task-1"
     assert "unsafe dependency base reference" in dependent["dispatch_error"]
+    for cleared_key in (
+        "resource_error",
+        "conflicts",
+        "receipt_id",
+        "confidence",
+        "worker_outcome",
+        "commit_shas",
+        "changed_paths",
+        "head_sha",
+        "pr_url",
+        "merge_gate",
+        "verification_missing_reason",
+        "scope_violation",
+    ):
+        assert cleared_key not in dependent
+    assert dependent["blockers"] == [
+        "Dependent lane received an invalid prerequisite branch reference; reconcile the dependency chain before rerunning."
+    ]
 
 
 def test_refresh_run_rehabilitates_validation_marker_crash_lane(


### PR DESCRIPTION
## Summary
- clear stale wait/blocker metadata before dependency-base conflicts are persisted as needs_human
- extend the invalid dependency reference regression to cover inherited wait state
- keep dependency-base blockers fail-closed instead of mixing old wait metadata with the new prelaunch error

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k 'refresh_run_marks_invalid_dependency_ref_needs_human or refresh_run_waiting_resource_clears_stale_terminal_state or dispatch_workers_dispatch_failed_clears_stale_deliverable_state'
- python -m pytest tests/swarm/test_supervisor.py -q