### PR TITLE
[codex] fix(live): honor runtime backend in EU AI Act classifier

### DIFF
--- a/aragora/live/src/app/(standalone)/eu-ai-act/page.tsx
+++ b/aragora/live/src/app/(standalone)/eu-ai-act/page.tsx
@@ -29,6 +29,12 @@ interface RiskClassification {
   confidence: number;
 }
 
+type ClassificationResponse =
+  | RiskClassification
+  | {
+      classification?: RiskClassification | null;
+    };
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -98,6 +104,15 @@ function getDemoClassification(description: string): RiskClassification {
   return { risk_level: 'minimal', annex_iii_categories: [], applicable_articles: ['Article 52'], matched_keywords: [], confidence: 0.85 };
 }
 
+function normalizeClassificationResponse(
+  data: ClassificationResponse,
+): RiskClassification | null {
+  if ('risk_level' in data) {
+    return data;
+  }
+  return data.classification ?? null;
+}
+
 // ---------------------------------------------------------------------------
 // Deadline countdown
 // ---------------------------------------------------------------------------
@@ -130,11 +145,11 @@ export default function CompliancePage() {
     setClassification(null);
 
     try {
-      const data = await apiPost<{ classification?: RiskClassification }>(
+      const data = await apiPost<ClassificationResponse>(
         '/api/v2/compliance/eu-ai-act/classify',
         { description: useCase },
       );
-      setClassification(data.classification || data);
+      setClassification(normalizeClassificationResponse(data));
     } catch {
       setClassification(getDemoClassification(useCase));
     } finally {

--- a/tests/live/test_standalone_compliance_page.py
+++ b/tests/live/test_standalone_compliance_page.py
@@ -8,6 +8,6 @@ def test_standalone_classifier_uses_shared_api_helper() -> None:
     source = EU_AI_ACT_PAGE.read_text(encoding="utf-8")
 
     assert "import { apiPost } from '@/lib/api';" in source
-    assert "apiPost<{ classification?: RiskClassification }>(" in source
+    assert "apiPost<ClassificationResponse>(" in source
     assert "'/api/v2/compliance/eu-ai-act/classify'" in source
     assert "fetch('/api/v2/compliance/eu-ai-act/classify'" not in source


### PR DESCRIPTION
## Summary
- switch the standalone EU AI Act classifier to the shared runtime-aware API helper instead of a same-origin relative fetch
- keep the existing demo fallback behavior when the compliance backend is unavailable
- add a focused regression test that guards against reintroducing the relative fetch path in this page

## Repro
- `aragora/live/src/app/(standalone)/eu-ai-act/page.tsx` posted classification requests to `'/api/v2/compliance/eu-ai-act/classify'`
- that bypassed the shared runtime backend resolver used elsewhere in the live app, so the public compliance surface ignored the selected backend and localhost fallback path

## Validation
- `pytest -q tests/live/test_standalone_compliance_page.py`
- `git diff --check`

## Notes
- JS unit tests are not runnable in this automation worktree because `aragora/live` dependencies are not installed (`npm test` currently fails with `jest: command not found`)
