### PR TITLE
Prefer session pid over ppid in worker lockfiles

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1271,7 +1271,8 @@ class WorkerLauncher:
             raw = active_lock.read_text(encoding="utf-8")
         except OSError:
             return []
-        pids: list[int] = []
+        session_pids: list[int] = []
+        parent_pids: list[int] = []
         for line in raw.splitlines():
             entry = line.strip()
             if not entry:
@@ -1279,12 +1280,20 @@ class WorkerLauncher:
             if "=" not in entry:
                 continue
             key, value = entry.split("=", 1)
-            if key.strip() not in {"pid", "ppid"}:
+            normalized_key = key.strip()
+            if normalized_key not in {"pid", "ppid"}:
                 continue
             pid = cls._normalized_pid(value.strip())
-            if pid is not None and pid not in pids:
-                pids.append(pid)
-        return pids
+            if pid is None:
+                continue
+            target = session_pids if normalized_key == "pid" else parent_pids
+            if pid not in target:
+                target.append(pid)
+        # Prefer the harness session PID over any optional parent PID entries.
+        # The parent may outlive the managed session briefly and must not
+        # become the authoritative liveness/cleanup target just because it was
+        # listed first in the lock file.
+        return session_pids + [pid for pid in parent_pids if pid not in session_pids]
 
     @classmethod
     def _session_owned_pid(

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -2058,6 +2058,41 @@ class TestCollectDetachedResult:
         mock_cleanup.assert_called_once_with(str(tmp_path))
 
     @pytest.mark.asyncio
+    async def test_collect_detached_result_prefers_pid_entry_when_lock_lists_ppid_first(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("ppid=13579\npid=24680\n", encoding="utf-8")
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new=AsyncMock()) as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts") as mock_cleanup,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-ppid-first",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=11111,
+                initial_head="def456",
+                auto_commit=False,
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        mock_wait_pid.assert_awaited_once_with(24680)
+        mock_cleanup.assert_called_once_with(str(tmp_path))
+
+    @pytest.mark.asyncio
     async def test_skips_session_meta_pid_fallback_when_disabled(self, tmp_path: Path):
         (tmp_path / ".codex_session_active").write_text("1\n", encoding="utf-8")
 
@@ -2287,6 +2322,31 @@ class TestSnapshotProgress:
         assert snapshot["pid_alive"] is False
         assert mock_running.call_args_list
         assert all(call.args[0] in {24680, 13579} for call in mock_running.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_prefers_pid_entry_when_lock_lists_ppid_first(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("ppid=13579\npid=24680\n", encoding="utf-8")
+        work_order = {
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        assert mock_running.call_args_list
+        assert mock_running.call_args_list[0].args == (24680,)
 
     @pytest.mark.asyncio
     async def test_includes_log_tails(self, tmp_path: Path):


### PR DESCRIPTION
## Summary
- prefer the managed session  over any optional  entry when parsing 
- keep parent PIDs as secondary evidence for lock liveness, but stop treating them as the authoritative cleanup/progress target
- add regressions for detached collection and progress snapshots when the lockfile lists  before 

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'ppid_first or active_lock_pid_is_dead_even_if_worker_pid_was_reused_without_session_meta or snapshot_progress_uses_active_lock_pid_when_session_meta_missing_and_worker_pid_is_stale'
- python -m pytest tests/swarm/test_worker_launcher.py -q