### PR TITLE
docs: flesh out curated API reference page

### DIFF
--- a/docs-site/docs/api-reference/index.md
+++ b/docs-site/docs/api-reference/index.md
@@ -1,12 +1,13 @@
----
-title: API Reference
-description: Complete API reference for the Aragora platform
+title: Curated API Reference
+description: Quickstart-focused reference for the most important Aragora endpoints
 sidebar_position: 1
 ---
 
-# API Reference
+# Curated API Reference
 
-This section contains the complete API reference for the Aragora platform.
+Use this page when you need the endpoints most teams touch first. It keeps the
+quickstart-critical routes in one place and points to the generated reference
+when you need full schemas or less common operations.
 
 ## Base URL
 
@@ -28,82 +29,99 @@ curl -H "Authorization: Bearer YOUR_API_KEY" \
 
 See the [Authentication Guide](/docs/security/authentication) for details on obtaining API keys.
 
-## API Sections
+## Essential Endpoints
 
-### Core APIs
+### Debates
 
-| Section | Description |
-|---------|-------------|
-| [Debates](/docs/api-reference/debates/overview) | Create, manage, and query debates |
-| [Agents](/docs/api-reference/agents/overview) | Agent configuration and management |
-| [Knowledge](/docs/api-reference/knowledge/overview) | Knowledge Mound operations |
-| [Workflows](/docs/api-reference/workflows/overview) | Automated workflow execution |
-| [Control Plane](/docs/enterprise/control-plane) | Orchestrate agents, tasks, and deliberations |
-| [Decisions](/docs/api/reference) | Unified decision routing (full generated reference) |
+| Method | Endpoint | Use it for |
+|--------|----------|------------|
+| POST | `/api/v1/debates` | Start a new multi-agent debate |
+| GET | `/api/v1/debates` | List recent or filtered debates |
+| GET | `/api/v1/debates/:id` | Read one debate with status and metadata |
+| GET | `/api/v1/debates/:id/messages` | Inspect the round-by-round transcript |
+| GET | `/api/v1/debates/:id/consensus` | Pull the final synthesis and voting outcome |
 
-### Full Reference
+### Agents
 
-For the complete endpoint list, see the generated API docs:
+| Method | Endpoint | Use it for |
+|--------|----------|------------|
+| GET | `/api/v1/agents` | List available agent types and providers |
+| GET | `/api/v1/agents/:name` | Inspect one agent configuration |
+| GET | `/api/v1/agents/:name/stats` | Check performance and usage stats |
+| GET | `/api/v1/leaderboard` | Compare agents by current ranking |
 
-- [API Reference (generated)](/docs/api/reference)
-- [API Endpoints (generated)](/docs/api/endpoints)
+### Knowledge
+
+| Method | Endpoint | Use it for |
+|--------|----------|------------|
+| POST | `/api/v1/knowledge/mound/query` | Search the Knowledge Mound |
+| POST | `/api/v1/knowledge/mound/nodes` | Store a new knowledge node |
+| PUT | `/api/v1/knowledge/mound/nodes/:id` | Update a node in place |
+| DELETE | `/api/v1/knowledge/mound/nodes/:id` | Remove stale or incorrect knowledge |
+
+### Workflows
+
+| Method | Endpoint | Use it for |
+|--------|----------|------------|
+| GET | `/api/v1/workflows` | List saved workflows |
+| POST | `/api/v1/workflows` | Create a reusable workflow |
+| POST | `/api/v1/workflows/:id/execute` | Launch a workflow run |
+| GET | `/api/v1/workflows/executions/:id` | Poll execution progress and result |
+
+### Platform Essentials
+
+| Method | Endpoint | Use it for |
+|--------|----------|------------|
+| POST | `/api/v1/decisions` | Submit one decision request without building a workflow |
+| GET | `/api/v1/decisions/:id/status` | Poll an async decision request |
+| GET | `/api/v1/receipts/:receipt_id` | Retrieve the audit receipt for a completed action |
+| POST | `/api/v1/github/pr/review` | Trigger a GitHub PR review from Aragora |
+| GET | `/api/features/discover` | Discover deployed capabilities before deeper integration |
+
+## Example Calls
+
+### Start a debate and read consensus
+
+```bash
+curl -X POST https://api.aragora.ai/api/v1/debates \
+  -H "Authorization: Bearer $ARAGORA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"topic":"Should we gate deploys on two-model review?","agents":["claude","gpt4"],"rounds":2}'
+
+curl -H "Authorization: Bearer $ARAGORA_API_KEY" \
+  https://api.aragora.ai/api/v1/debates/debate_abc123/consensus
+```
+
+### Store and query knowledge
+
+```bash
+curl -X POST https://api.aragora.ai/api/v1/knowledge/mound/nodes \
+  -H "Authorization: Bearer $ARAGORA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Merge gate policy","content":"Require passing receipts before merge."}'
+
+curl -X POST https://api.aragora.ai/api/v1/knowledge/mound/query \
+  -H "Authorization: Bearer $ARAGORA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query":"merge gate receipts","limit":5}'
+```
+
+### Execute a workflow or one-off decision
+
+```bash
+curl -X POST https://api.aragora.ai/api/v1/workflows/workflow_123/execute \
+  -H "Authorization: Bearer $ARAGORA_API_KEY"
+
+curl -X POST https://api.aragora.ai/api/v1/decisions \
+  -H "Authorization: Bearer $ARAGORA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"question":"Ship the retry-queue change today?","mode":"judge"}'
+```
+
+## Need Full Schemas?
+
+- [Generated API Reference](/docs/api/reference)
+- [Generated Endpoint Catalog](/docs/api/endpoints)
 - [OpenAPI JSON](https://api.aragora.ai/api/v1/openapi.json)
-
-## Rate Limits
-
-| Tier | Requests/min | Debates/hour |
-|------|--------------|--------------|
-| Free | 60 | 10 |
-| Pro | 300 | 100 |
-| Enterprise | Custom | Custom |
-
-Rate limit headers are included in all responses:
-
-```
-X-RateLimit-Limit: 60
-X-RateLimit-Remaining: 45
-X-RateLimit-Reset: 1703185200
-```
-
-## Error Handling
-
-All errors follow a consistent format:
-
-```json
-{
-  "error": {
-    "code": "RATE_LIMIT_EXCEEDED",
-    "message": "Too many requests. Please retry after 60 seconds.",
-    "details": {
-      "retry_after": 60
-    }
-  }
-}
-```
-
-### Common Error Codes
-
-| Code | HTTP Status | Description |
-|------|-------------|-------------|
-| `UNAUTHORIZED` | 401 | Invalid or missing API key |
-| `FORBIDDEN` | 403 | Insufficient permissions |
-| `NOT_FOUND` | 404 | Resource not found |
-| `RATE_LIMIT_EXCEEDED` | 429 | Too many requests |
-| `INTERNAL_ERROR` | 500 | Server error |
-
-## SDKs
-
-Official SDKs are available for:
-
-- [TypeScript/JavaScript](/docs/guides/sdk-typescript)
-- [Python](/docs/guides/sdk)
-
-## OpenAPI Specification
-
-The complete OpenAPI specification is available at:
-
-```
-https://api.aragora.ai/api/v1/openapi.json
-```
-
-You can import this into tools like Postman or use it to generate clients.
+- [TypeScript SDK Guide](/docs/guides/sdk-typescript)
+- [Python SDK Guide](/docs/guides/sdk)


### PR DESCRIPTION
## Summary
- turn `/docs/api-reference` into a real curated quickstart reference instead of a generic landing page
- list the essential debate, agent, knowledge, workflow, and platform endpoints with brief descriptions
- add concrete curl examples and keep links to the generated reference for full schemas

## Validation
- `python3 -m pytest -x -q tests/handlers/test_api_docs.py tests/test_handlers_docs.py tests/server/handlers/test_docs.py`
- `git diff --check`

Closes #2253