### PR TITLE
Reject malformed Slack expiry values

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -175,6 +175,21 @@ def _cleanup_oauth_states_fallback(now: float | None = None) -> None:
         _oauth_states_fallback.pop(state, None)
 
 
+def _parse_expires_in(raw_value: Any) -> int | None:
+    """Parse Slack expires_in while rejecting malformed values."""
+    if raw_value is None or raw_value == "":
+        return None
+    if isinstance(raw_value, bool):
+        raise ValueError("expires_in must be an integer number of seconds")
+    try:
+        expires_in = int(raw_value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("expires_in must be an integer number of seconds") from exc
+    if expires_in < 0:
+        raise ValueError("expires_in must be non-negative")
+    return expires_in
+
+
 def _get_oauth_audit_logger() -> Any:
     """Get or create Slack audit logger for OAuth (lazy initialization)."""
     global _slack_oauth_audit
@@ -1180,10 +1195,12 @@ class SlackOAuthHandler(SecureHandler):
 
         # Extract token refresh data (if available)
         refresh_token = data.get("refresh_token")
-        expires_in = data.get("expires_in")  # Seconds until expiration
-        token_expires_at = None
-        if expires_in:
-            token_expires_at = time.time() + expires_in
+        try:
+            expires_in = _parse_expires_in(data.get("expires_in"))
+        except ValueError:
+            logger.error("[%s] Slack token exchange returned invalid expires_in", request_id)
+            return error_response("Invalid response from Slack", 500)
+        token_expires_at = time.time() + expires_in if expires_in is not None else None
 
         workspace_id = str(
             team.get("id")
@@ -1782,8 +1799,20 @@ class SlackOAuthHandler(SecureHandler):
             new_refresh_token = data.get("refresh_token")
             if not str(new_refresh_token or "").strip():
                 new_refresh_token = workspace.refresh_token
-            expires_in = data.get("expires_in")
-            new_expires_at = time.time() + expires_in if expires_in else None
+            try:
+                expires_in = _parse_expires_in(data.get("expires_in"))
+            except ValueError:
+                logger.error("Token refresh returned invalid expires_in for %s", workspace_id)
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: malformed expires_in",
+                    )
+                return error_response("Invalid token refresh response", 502)
+            new_expires_at = time.time() + expires_in if expires_in is not None else None
 
             workspace.access_token = new_access_token
             workspace.refresh_token = new_refresh_token

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1397,6 +1397,41 @@ class TestCallback:
         assert _status(result) == 200
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_invalid_expires_in(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-token",
+                "team": {"id": "W123", "name": "Bad Expiry"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history",
+                "expires_in": "soon",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_callback_uses_redirect_uri_from_state_metadata_when_config_missing(
         self, handler, handler_module, mock_state_store, mock_workspace_store, monkeypatch
     ):
@@ -2992,6 +3027,38 @@ class TestRefreshToken:
         body = _body(result)
         assert body["token_expires_at"] is None
         assert body["expires_in_seconds"] is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_invalid_expires_in(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "expires_in": "soon",
+                "team": {"id": "W123"},
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_refresh_updates_workspace_tokens(


### PR DESCRIPTION
## Summary
- parse Slack `expires_in` defensively in both OAuth callback and manual refresh paths
- accept clean integer values but fail closed on malformed expiry payloads instead of crashing mid-handler
- add regressions for malformed callback and refresh expiry values

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'callback_rejects_invalid_expires_in or refresh_rejects_invalid_expires_in or callback_with_refresh_token or refresh_without_expires_in'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q
