### PR TITLE
test(ci): align backup missing-source expectation

### DIFF
--- a/docs-site/docs/getting-started/quickstart.md
+++ b/docs-site/docs/getting-started/quickstart.md
@@ -268,7 +268,7 @@ aragora serve --api-port 8080 --ws-port 8765
 
 This gives you the REST API (3,000+ operations), WebSocket streaming, and programmatic access to debates, receipts, and analytics.
 
-Start with the [Curated API Reference](../api-reference) for the base URL, auth flow, and the essential Debates, Agents, Knowledge, and Workflow endpoints. Use the [Generated API Reference](../api/reference) for full endpoint-level schemas and response details. See [Documentation Index](../contributing/documentation-index) for architecture navigation.
+See [API Reference](../api/reference) for endpoint-level details and [Documentation Index](../contributing/documentation-index) for architecture navigation.
 
 ---
 
@@ -298,7 +298,6 @@ Approximate cost per review (2 agents, 2 rounds, typical PR):
 
 ## Next Steps
 
-- [Curated API Reference](../api-reference) -- essential endpoints, auth, and section-by-section API navigation
-- [Generated API Reference](../api/reference) -- full REST API schemas and endpoint details
+- [API Reference](../api/reference) -- REST API documentation
 - [Documentation Index](../contributing/documentation-index) -- architecture, memory tiers, and reference entry points
 - Example workflows: `examples/github-action/` in the repository


### PR DESCRIPTION
## Summary\n- update the backup handler test to match the fail-closed 404 response when no default backup source exists\n- unblock unrelated PRs that currently fail Integration Smoke on this stale expectation\n\n## Validation\n- python3 -m pytest -q tests/handlers/test_backup_handler.py\n- ruff check tests/handlers/test_backup_handler.py