### PR TITLE
Reject non-boolean Slack ok flags

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -190,6 +190,13 @@ def _parse_expires_in(raw_value: Any) -> int | None:
     return expires_in
 
 
+def _parse_slack_ok(raw_value: Any) -> bool:
+    """Parse Slack ok while rejecting malformed truthy values."""
+    if isinstance(raw_value, bool):
+        return raw_value
+    raise ValueError("ok must be a boolean")
+
+
 def _get_oauth_audit_logger() -> Any:
     """Get or create Slack audit logger for OAuth (lazy initialization)."""
     global _slack_oauth_audit
@@ -1173,7 +1180,13 @@ class SlackOAuthHandler(SecureHandler):
             logger.error("[%s] Slack token exchange returned non-dict payload", request_id)
             return error_response("Invalid response from Slack", 500)
 
-        if not data.get("ok"):
+        try:
+            slack_ok = _parse_slack_ok(data.get("ok"))
+        except ValueError:
+            logger.error("[%s] Slack token exchange returned invalid ok flag", request_id)
+            return error_response("Invalid response from Slack", 500)
+
+        if not slack_ok:
             error_msg = data.get("error", "Unknown error")
             logger.error("Slack OAuth failed: %s", error_msg)
             return error_response(f"Slack OAuth failed: {error_msg}", 400)
@@ -1729,7 +1742,21 @@ class SlackOAuthHandler(SecureHandler):
                     )
                 return error_response("Invalid token refresh response", 502)
 
-            if not data.get("ok"):
+            try:
+                slack_ok = _parse_slack_ok(data.get("ok"))
+            except ValueError:
+                logger.error("Token refresh returned invalid ok flag for %s", workspace_id)
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: malformed ok flag",
+                    )
+                return error_response("Invalid token refresh response", 502)
+
+            if not slack_ok:
                 error_msg = data.get("error", "Unknown error")
                 logger.error("Token refresh failed for %s: %s", workspace_id, error_msg)
                 audit = _get_oauth_audit_logger()

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1188,6 +1188,40 @@ class TestCallback:
         assert "invalid_code" in body.get("error", "")
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_non_boolean_ok(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": "false",
+                "access_token": "xoxb-token",
+                "team": {"id": "W123", "name": "Malformed"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history",
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_callback_http_status_error_returns_500(self, handler):
         mock_client, mock_response = _make_httpx_mock({"ok": False, "error": "invalid_code"}, 400)
         request = httpx.Request("POST", "https://slack.com/api/oauth.v2.access")
@@ -3035,6 +3069,37 @@ class TestRefreshToken:
                 "ok": True,
                 "access_token": "xoxb-new-token",
                 "expires_in": "soon",
+                "team": {"id": "W123"},
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_non_boolean_ok(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": "false",
+                "access_token": "xoxb-new-token",
                 "team": {"id": "W123"},
             }
         )


### PR DESCRIPTION
## Summary
- require Slack callback and refresh responses to use a real boolean ok flag
- reject malformed truthy ok values instead of treating them as successful token responses
- add regressions for callback and refresh with non-boolean ok payloads

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q