### PR TITLE
fix(playground): harden assess and spectate ids

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1254,8 +1254,18 @@ class BossLoop:
             )
             # Add boss-stuck AND remove boss-ready — an issue should never be both
             subprocess.run(
-                ["gh", "issue", "edit", str(issue_number), "--repo", repo,
-                 "--add-label", "boss-stuck", "--remove-label", "boss-ready"],
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--repo",
+                    repo,
+                    "--add-label",
+                    "boss-stuck",
+                    "--remove-label",
+                    "boss-ready",
+                ],
                 capture_output=True,
                 timeout=15,
             )


### PR DESCRIPTION
## Summary
- sanitize client-provided playground debate ids before they reach execution
- bind live playground spectate context to the generated debate id
- short-circuit oversized assess prompts and tighten assess rate limiting

## Validation
- python3 -m pytest -q tests/server/handlers/test_playground_assess.py
- python3 -m pytest -q tests/handlers/test_playground.py -k 'test_successful_live_debate_passes_generated_debate_id or test_invalid_client_debate_id_is_dropped or test_successful_live_debate or test_debate_path_dispatches'
- ruff check aragora/server/handlers/playground.py tests/server/handlers/test_playground_assess.py tests/handlers/test_playground.py