### PR TITLE
Recover playground server hardening salvage

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -2820,6 +2820,10 @@ class PlaygroundHandler(BaseHandler):
         # Client-provided debate ID — allows the frontend to subscribe to
         # spectate WebSocket events *before* the HTTP POST returns.
         client_debate_id = str(body.get("debate_id", "") or "").strip() or None
+        if client_debate_id and (
+            len(str(client_debate_id)) > 64 or not str(client_debate_id).isascii()
+        ):
+            client_debate_id = None
 
         try:
             rounds = int(body.get("rounds", _DEFAULT_ROUNDS))
@@ -2992,11 +2996,16 @@ class PlaygroundHandler(BaseHandler):
         if not question:
             return json_response({"type": "ready", "option": self._build_ready_option("")})
 
-        # Rate limit: reuse the existing per-IP check (10 per 60s for assess)
+        if len(question) > _MAX_TOPIC_LENGTH:
+            return json_response(
+                {"type": "ready", "option": self._build_ready_option(question[:200])}
+            )
+
+        # Rate limit: reuse the existing per-IP check (5 per 60s for assess)
         client_ip = _extract_client_ip(handler)
         allowed, retry_after = _check_rate_limit(
             f"assess:{client_ip}",
-            limit=10,
+            limit=5,
             window=60.0,
         )
         if not allowed:
@@ -3723,6 +3732,7 @@ class PlaygroundHandler(BaseHandler):
                 agent_count=agent_count,
                 max_rounds=rounds,
                 timeout=_LIVE_TIMEOUT,
+                debate_id=debate_id,
             )
         except TimeoutError:
             return json_response(
@@ -3894,6 +3904,7 @@ def start_playground_debate(
     agent_count: int = 3,
     max_rounds: int = 2,
     timeout: int = 60,
+    debate_id: str | None = None,
 ) -> dict[str, Any]:
     """Run a simplified live debate for the playground.
 
@@ -3905,6 +3916,8 @@ def start_playground_debate(
         agent_count: Number of agents (2-5)
         max_rounds: Maximum rounds (1-2)
         timeout: Timeout in seconds
+        debate_id: Optional debate ID to bind spectate context before the HTTP
+            response returns.
 
     Returns:
         Dict with debate result fields
@@ -3937,8 +3950,14 @@ def start_playground_debate(
 
             arena = factory.create_arena(config)
 
+            try:
+                from aragora.spectate.ws_bridge import bind_spectate_context
+            except ImportError:
+                from contextlib import nullcontext as bind_spectate_context  # type: ignore[assignment]
+
             async def _run_arena():
-                return await asyncio.wait_for(arena.run(), timeout=timeout)
+                with bind_spectate_context(debate_id=debate_id):
+                    return await asyncio.wait_for(arena.run(), timeout=timeout)
 
             result = asyncio.run(_run_arena())
 

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -1739,6 +1739,37 @@ class TestRunLiveDebate:
             assert "upgrade_cta" in body
             assert body["topic"] == "test topic"
 
+    def test_successful_live_debate_passes_generated_debate_id(self, handler):
+        mock_result = {
+            "status": "completed",
+            "rounds_used": 2,
+            "consensus_reached": True,
+            "confidence": 0.8,
+            "verdict": "approved",
+            "duration_seconds": 5.0,
+            "participants": ["anthropic", "openai"],
+            "proposals": {"anthropic": "A says...", "openai": "B says..."},
+            "critiques": [],
+            "votes": [],
+            "dissenting_views": [],
+            "final_answer": "Conclusion",
+        }
+        fake_uuid = MagicMock(hex="0123456789abcdef")
+        with (
+            patch("importlib.util.find_spec", return_value=True),
+            patch("aragora.server.handlers.playground.uuid.uuid4", return_value=fake_uuid),
+            patch(
+                "aragora.server.handlers.playground.start_playground_debate",
+                return_value=mock_result,
+            ) as mock_start,
+        ):
+            result = handler._run_live_debate("test topic", 2, 3)
+
+        assert _status(result) == 200
+        body = _body(result)
+        assert body["id"] == "playground_01234567"
+        assert mock_start.call_args.kwargs["debate_id"] == "playground_01234567"
+
 
 # ============================================================================
 # POST dispatch routing
@@ -1756,6 +1787,27 @@ class TestPostDispatch:
             mock_h = _MockHTTPHandler("POST", body={})
             result = handler.handle_post("/api/v1/playground/debate", {}, mock_h)
             assert _status(result) == 200
+
+    def test_invalid_client_debate_id_is_dropped(self, handler):
+        from aragora.server.handlers.utils.responses import HandlerResult
+
+        invalid_id = "naïve-debate-id"
+        with patch.object(
+            handler,
+            "_run_debate",
+            return_value=HandlerResult(
+                status_code=200,
+                content_type="application/json",
+                body=json.dumps({"ok": True}).encode(),
+            ),
+        ) as mock_run:
+            mock_h = _MockHTTPHandler(
+                "POST",
+                body={"topic": "AI Safety", "debate_id": invalid_id},
+            )
+            handler.handle_post("/api/v1/playground/debate", {}, mock_h)
+
+        assert mock_run.call_args.kwargs["client_debate_id"] is None
 
     def test_cost_estimate_path_dispatches(self, handler):
         mock_h = _MockHTTPHandler("POST", body={})

--- a/tests/server/handlers/test_playground_assess.py
+++ b/tests/server/handlers/test_playground_assess.py
@@ -17,7 +17,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aragora.server.handlers.playground import PlaygroundHandler, _reset_rate_limits
+from aragora.server.handlers.playground import (
+    PlaygroundHandler,
+    _MAX_TOPIC_LENGTH,
+    _reset_rate_limits,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -135,6 +139,21 @@ class TestHandleAssess:
         assert body["type"] == "ready"
         mock_call.assert_not_called()
 
+    def test_long_question_short_circuits_to_ready_without_model(
+        self, handler: PlaygroundHandler
+    ) -> None:
+        """Oversized assess prompts should not hit the frontier model."""
+        question = "x" * (_MAX_TOPIC_LENGTH + 20)
+        http_handler = _make_http_handler({"question": question})
+
+        with patch.object(handler, "_call_frontier_model") as mock_call:
+            result = handler._handle_assess(http_handler)
+
+        body = json.loads(result.body)
+        assert body["type"] == "ready"
+        assert body["option"]["debatePrompt"] == question[:200]
+        mock_call.assert_not_called()
+
     def test_malformed_model_json_returns_ready(self, handler: PlaygroundHandler) -> None:
         """When the model returns unparseable garbage, gracefully return type=ready."""
         http_handler = _make_http_handler({"question": "Some question"})
@@ -182,6 +201,23 @@ class TestHandleAssess:
 
         body = json.loads(result.body)
         assert body["type"] == "ready"
+
+    def test_rate_limit_blocks_sixth_request(self, handler: PlaygroundHandler) -> None:
+        """Assess is capped at five requests per IP per minute."""
+        model_response = json.dumps({"clear": True, "topic": "Should we delay the launch?"})
+
+        with patch.object(handler, "_call_frontier_model", return_value=model_response):
+            for _ in range(5):
+                http_handler = _make_http_handler({"question": "Should we delay the launch?"})
+                result = handler._handle_assess(http_handler)
+                assert json.loads(result.body)["type"] == "ready"
+
+            http_handler = _make_http_handler({"question": "Should we delay the launch?"})
+            limited = handler._handle_assess(http_handler)
+
+        body = json.loads(limited.body)
+        assert limited.status_code == 429
+        assert body["code"] == "rate_limit_exceeded"
 
     def test_interpretations_capped_at_four(self, handler: PlaygroundHandler) -> None:
         """At most 4 interpretation options (plus the original) are returned."""


### PR DESCRIPTION
## Summary
- recover the local playground hardening commit from the salvage branch onto current main
- sanitize client debate ids before wiring them into spectate flows
- cap assess abuse and preserve generated debate ids through live spectate startup

## Testing
- python -m ruff check aragora/server/handlers/playground.py tests/handlers/test_playground.py tests/server/handlers/test_playground_assess.py
- python -m pytest tests/server/handlers/test_playground_assess.py -q
- python -m pytest tests/handlers/test_playground.py -q