### PR TITLE
Recover playground TL;DR fallback hardening

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -38,6 +38,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Literal
 
+from aragora.agents.errors import AgentError
 from aragora.server.handlers.base import (
     BaseHandler,
     HandlerResult,
@@ -3180,7 +3181,14 @@ class PlaygroundHandler(BaseHandler):
 
         try:
             return self._call_frontier_model(prompt, timeout=5.0)
-        except (TimeoutError, OSError, RuntimeError, ConnectionError, ValueError) as exc:
+        except (
+            AgentError,
+            TimeoutError,
+            OSError,
+            RuntimeError,
+            ConnectionError,
+            ValueError,
+        ) as exc:
             logger.debug("TL;DR synthesis failed, using fallback: %s", exc)
 
         # Fallback: extract first sentence from fallback_text

--- a/tests/server/handlers/test_playground_tldr.py
+++ b/tests/server/handlers/test_playground_tldr.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aragora.agents.errors import AgentCircuitOpenError
 from aragora.server.handlers.playground import PlaygroundHandler
 
 
@@ -95,6 +96,20 @@ class TestSynthesizeTldr:
                 fallback_text="First sentence here. Second sentence.",
             )
         assert result == "First sentence here."
+
+    def test_falls_back_on_agent_circuit_open_error(self, handler: PlaygroundHandler) -> None:
+        """Agent circuit breaker failures should not break the public fallback path."""
+        with patch.object(
+            handler,
+            "_call_frontier_model",
+            side_effect=AgentCircuitOpenError("Circuit open", agent_name="tldr-synth"),
+        ):
+            result = handler._synthesize_tldr(
+                question="Test?",
+                proposals={"a": "Text"},
+                fallback_text="Fallback sentence here. More text follows.",
+            )
+        assert result == "Fallback sentence here."
 
     def test_empty_fallback_text_returns_empty_string(self, handler: PlaygroundHandler) -> None:
         """When fallback_text is empty and model fails, return empty string."""


### PR DESCRIPTION
## Summary
- recover the local playground TL;DR fallback hardening patch onto current main
- degrade gracefully when TL;DR synthesis hits agent-level circuit breaker errors
- keep the public playground response path on the fallback sentence instead of surfacing model failures

## Testing
- python -m ruff check aragora/server/handlers/playground.py tests/server/handlers/test_playground_tldr.py
- python -m pytest tests/server/handlers/test_playground_tldr.py -q
- python -m pytest tests/handlers/test_playground.py -q -k "successful_live_debate or invalid_client_debate_id_is_dropped"