### PR TITLE
fix: fail closed on Slack callback state consume errors

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1053,7 +1053,13 @@ class SlackOAuthHandler(SecureHandler):
             return error_response("Invalid or expired state token", 400)
 
         # Consume only after verifying this state was actually minted for Slack.
-        state_data = state_store.validate_and_consume(state) if store_state_is_slack else None
+        try:
+            state_data = state_store.validate_and_consume(state) if store_state_is_slack else None
+        except Exception:
+            if fallback_state_is_slack:
+                _oauth_states_fallback.pop(state, None)
+            logger.debug("Failed to consume Slack OAuth state", exc_info=True)
+            return error_response("Invalid or expired state token", 400)
         fallback_state_data = (
             _oauth_states_fallback.pop(state, None) if fallback_state_is_slack else None
         )

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1736,6 +1736,50 @@ class TestCallback:
         mock_client.post.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_and_burns_fallback_when_state_consume_raises(
+        self, handler, handler_module, mock_state_store
+    ):
+        """Consume failures must fail closed and clear the fallback copy."""
+        handler_module._oauth_states_fallback["test-state-token-abc123"] = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_state_store.peek.return_value = {
+            "tenant_id": "tenant-1",
+            "provider": "slack",
+            "created_at": time.time(),
+        }
+        mock_state_store.validate_and_consume.side_effect = RuntimeError("state store unavailable")
+
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-token",
+                "team": {"id": "W111", "name": "Consume Error"},
+                "bot_user_id": "B1",
+                "authed_user": {"id": "U1"},
+                "scope": "channels:history",
+            }
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 400
+        body = _body(result)
+        assert "invalid or expired state token" in body.get("error", "").lower()
+        assert "test-state-token-abc123" not in handler_module._oauth_states_fallback
+        mock_client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_callback_state_from_oauth_state_object(
         self, handler, mock_state_store, mock_workspace_store
     ):


### PR DESCRIPTION
Fail closed when Slack OAuth callback cannot consume centralized state after a successful peek, and burn the fallback copy so the state cannot be replayed through the legacy cache path.

Testing:
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k callback_rejects_and_burns_fallback_when_state_consume_raises
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q