### PR TITLE
fix(landing): keep latest debate progress event only

### DIFF
--- a/aragora/live/src/components/landing/__tests__/HeroSection.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/HeroSection.test.tsx
@@ -444,6 +444,8 @@ describe('HeroSection', () => {
       await user.click(screen.getByRole('button', { name: /start debate/i }));
 
       await waitFor(() => {
+        expect(screen.getByTestId('debate-result-preview')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /view full debate/i })).toBeInTheDocument();
         expect(screen.getByRole('button', { name: /log in to save/i })).toBeInTheDocument();
       });
 
@@ -464,6 +466,7 @@ describe('HeroSection', () => {
       );
       expect(setItemSpy).toHaveBeenCalledWith('return_url', '/debates/debate-123');
       expect(mockPush).toHaveBeenLastCalledWith('/signup');
+      expect(screen.getByRole('button', { name: /try another/i })).toBeInTheDocument();
 
       setItemSpy.mockRestore();
     });

--- a/aragora/live/src/hooks/useLandingDebateProgress.ts
+++ b/aragora/live/src/hooks/useLandingDebateProgress.ts
@@ -15,7 +15,8 @@ interface UseLandingDebateProgressOptions {
 }
 
 export function useLandingDebateProgress({ debateId, wsUrl, enabled }: UseLandingDebateProgressOptions) {
-  const [events, setEvents] = useState<DebateProgressEvent[]>([]);
+  const [latestEvent, setLatestEvent] = useState<DebateProgressEvent | null>(null);
+  const [eventCount, setEventCount] = useState(0);
   const [connected, setConnected] = useState(false);
   const [elapsed, setElapsed] = useState(0);
   const wsRef = useRef<WebSocket | null>(null);
@@ -49,7 +50,8 @@ export function useLandingDebateProgress({ debateId, wsUrl, enabled }: UseLandin
           const data = JSON.parse(event.data);
           const mapped = mapEventToProgress(data);
           if (mapped) {
-            setEvents((prev) => [...prev, mapped]);
+            setLatestEvent(mapped);
+            setEventCount(c => c + 1);
           }
         } catch { /* ignore parse errors */ }
       };
@@ -61,14 +63,13 @@ export function useLandingDebateProgress({ debateId, wsUrl, enabled }: UseLandin
   }, [enabled, debateId, wsUrl]);
 
   const reset = useCallback(() => {
-    setEvents([]);
+    setLatestEvent(null);
+    setEventCount(0);
     setConnected(false);
     setElapsed(0);
   }, []);
 
-  const latestEvent = events.length > 0 ? events[events.length - 1] : null;
-
-  return { events, latestEvent, connected, elapsed, reset };
+  return { latestEvent, eventCount, connected, elapsed, reset };
 }
 
 function mapEventToProgress(data: Record<string, unknown>): DebateProgressEvent | null {


### PR DESCRIPTION
## Summary
- keep only the latest landing debate progress event instead of retaining the full event array
- preserve the existing landing auth/save flow assertions while restoring the preview assertions
- recover the remaining valuable frontend-only content from the stale assess branch on top of current main

## Validation
- python3 -m pytest tests/server/handlers/test_playground_assess.py -q
- python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check
- cd aragora/live && npm ci
- cd aragora/live && npx jest src/components/landing/__tests__/HeroSection.test.tsx --runInBand
- cd aragora/live && npx tsc --noEmit