### PR TITLE
test: add comprehensive receipt signature lifecycle tests (#2326)

### DIFF
--- a/tests/inbox/test_receipt_signature.py
+++ b/tests/inbox/test_receipt_signature.py
@@ -129,3 +129,62 @@ class TestReceiptSignatureLifecycle:
 
         signed = s1.sign(sample_receipt)
         assert not s2.verify(signed)
+
+    def test_full_lifecycle_end_to_end(self, tmp_path: object) -> None:
+        """Complete lifecycle: create receipt, sign, verify, tamper, detect."""
+        key_path = os.path.join(str(tmp_path), "lifecycle.key")
+        backend = DurableFileSigner(key_path=key_path)
+        signer = ReceiptSigner(backend=backend)
+
+        # Step 1: Create receipt data
+        receipt = {
+            "receipt_id": "rcpt-lifecycle-001",
+            "decision": "approve",
+            "topic": "Security audit findings",
+            "consensus_score": 0.92,
+            "agents": ["claude", "gpt-4", "gemini"],
+            "timestamp": "2026-04-05T12:00:00Z",
+        }
+
+        # Step 2: Sign with DurableFileSigner
+        signatory = SignatoryInfo(name="TestBot", email="bot@test.com", role="Auditor")
+        signed = signer.sign(receipt, signatory=signatory)
+        assert isinstance(signed, SignedReceipt)
+        assert signed.signature_metadata.algorithm == "HMAC-SHA256"
+        assert signed.signature_metadata.signatory.name == "TestBot"
+
+        # Step 3: Verify valid signature
+        assert signer.verify(signed)
+
+        # Step 4: Roundtrip through JSON serialization and re-verify
+        json_str = signed.to_json()
+        restored = SignedReceipt.from_json(json_str)
+        assert signer.verify(restored)
+
+        # Step 5: Verify with a fresh signer instance (same key file)
+        signer2 = ReceiptSigner(backend=DurableFileSigner(key_path=key_path))
+        assert signer2.verify(restored)
+
+        # Step 6: Tamper with data and confirm detection
+        tampered = copy.deepcopy(restored)
+        tampered.receipt_data["decision"] = "reject"
+        assert not signer.verify(tampered)
+
+        # Step 7: Ensure original is still valid after tampering a copy
+        assert signer.verify(restored)
+
+    def test_verify_dict_roundtrip(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        """verify_dict accepts the dict form of a signed receipt."""
+        signed = signer.sign(sample_receipt)
+        assert signer.verify_dict(signed.to_dict())
+
+        # Tamper via dict path
+        d = signed.to_dict()
+        d["receipt"]["decision"] = "reject"
+        assert not signer.verify_dict(d)
+
+    def test_metadata_timestamp_present(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        signed = signer.sign(sample_receipt)
+        ts = signed.signature_metadata.timestamp
+        assert ts  # non-empty
+        assert "T" in ts  # ISO format contains T separator


### PR DESCRIPTION
Add end-to-end lifecycle test covering create → sign → verify → JSON
roundtrip → key persistence → tamper detection in a single flow.
Also add verify_dict roundtrip and metadata timestamp tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit be95bba745f594013f711dff4f2362762c75318b)
