### PR TITLE
fix: harden landing live debate preview

### DIFF
--- a/aragora/live/src/components/landing/Header.tsx
+++ b/aragora/live/src/components/landing/Header.tsx
@@ -7,13 +7,19 @@ import { useTheme } from '@/context/ThemeContext';
 import { Logo } from '@/components/Logo';
 import { ThemeSelector } from './ThemeSelector';
 
+interface NavLinkConfig {
+  href: string;
+  label: string;
+  anchor: boolean;
+}
+
 const NAV_LINKS = [
   { href: '#how-it-works', label: 'How it works', anchor: true },
   { href: '/quickstart', label: 'Quickstart', anchor: false },
   { href: '/docs', label: 'Docs', anchor: false },
   { href: '/pricing', label: 'Pricing', anchor: false },
   { href: '/login', label: 'Log in', anchor: false },
-];
+] satisfies NavLinkConfig[];
 
 export interface HeaderProps {
   /** Optional callback for the "Log in" link. When provided the click triggers
@@ -21,6 +27,108 @@ export interface HeaderProps {
    *  landing page is rendered inline (e.g. HomePage for unauthenticated visitors)
    *  and needs to store a return URL before redirecting to the login route. */
   onLoginClick?: () => void;
+}
+
+function isLoginLink(link: NavLinkConfig): boolean {
+  return link.label === 'Log in';
+}
+
+function DesktopNavItem({
+  link,
+  onLoginClick,
+}: {
+  link: NavLinkConfig;
+  onLoginClick?: () => void;
+}) {
+  const style = { color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' } as const;
+
+  if (link.anchor) {
+    return (
+      <a
+        href={link.href}
+        className="text-sm transition-colors hover:opacity-80"
+        style={style}
+      >
+        {link.label}
+      </a>
+    );
+  }
+
+  if (isLoginLink(link) && onLoginClick) {
+    return (
+      <button
+        type="button"
+        onClick={onLoginClick}
+        className="text-sm transition-colors hover:opacity-80 bg-transparent border-none cursor-pointer p-0"
+        style={style}
+      >
+        {link.label}
+      </button>
+    );
+  }
+
+  return (
+    <Link
+      href={link.href}
+      className="text-sm transition-colors hover:opacity-80"
+      style={style}
+    >
+      {link.label}
+    </Link>
+  );
+}
+
+function MobileNavItem({
+  link,
+  isActive,
+  onClose,
+  onLoginClick,
+}: {
+  link: NavLinkConfig;
+  isActive: boolean;
+  onClose: () => void;
+  onLoginClick?: () => void;
+}) {
+  const linkStyle = {
+    color: isActive ? 'var(--accent)' : 'var(--text-muted)',
+    fontFamily: 'var(--font-landing)',
+    fontSize: '15px',
+    padding: '12px 8px',
+    borderRadius: 'var(--radius-card)',
+    backgroundColor: isActive ? 'var(--surface)' : 'transparent',
+    display: 'block',
+    transition: 'background-color 0.15s, color 0.15s',
+  } as const;
+
+  if (link.anchor) {
+    return (
+      <a href={link.href} onClick={onClose} style={linkStyle}>
+        {link.label}
+      </a>
+    );
+  }
+
+  if (isLoginLink(link) && onLoginClick) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          onClose();
+          onLoginClick();
+        }}
+        className="bg-transparent border-none cursor-pointer text-left w-full"
+        style={linkStyle}
+      >
+        {link.label}
+      </button>
+    );
+  }
+
+  return (
+    <Link href={link.href} onClick={onClose} style={linkStyle}>
+      {link.label}
+    </Link>
+  );
 }
 
 export function Header({ onLoginClick }: HeaderProps = {}) {
@@ -93,45 +201,13 @@ export function Header({ onLoginClick }: HeaderProps = {}) {
           {/* Desktop nav + Theme selector */}
           <div className="flex items-center gap-6">
             <nav className="hidden sm:flex items-center gap-5">
-              {NAV_LINKS.map((link) => {
-                if (link.anchor) {
-                  return (
-                    <a
-                      key={link.href}
-                      href={link.href}
-                      className="text-sm transition-colors hover:opacity-80"
-                      style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-                    >
-                      {link.label}
-                    </a>
-                  );
-                }
-
-                if (link.label === 'Log in' && onLoginClick) {
-                  return (
-                    <button
-                      key={link.href}
-                      type="button"
-                      onClick={onLoginClick}
-                      className="text-sm transition-colors hover:opacity-80 bg-transparent border-none cursor-pointer p-0"
-                      style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-                    >
-                      {link.label}
-                    </button>
-                  );
-                }
-
-                return (
-                  <Link
-                    key={link.href}
-                    href={link.href}
-                    className="text-sm transition-colors hover:opacity-80"
-                    style={{ color: 'var(--text-muted)', fontFamily: 'var(--font-landing)' }}
-                  >
-                    {link.label}
-                  </Link>
-                );
-              })}
+              {NAV_LINKS.map((link) => (
+                <DesktopNavItem
+                  key={link.href}
+                  link={link}
+                  onLoginClick={onLoginClick}
+                />
+              ))}
             </nav>
             <ThemeSelector />
 
@@ -192,53 +268,14 @@ export function Header({ onLoginClick }: HeaderProps = {}) {
         >
           {NAV_LINKS.map((link) => {
             const isActive = !link.anchor && pathname === link.href;
-            const linkStyle = {
-              color: isActive ? 'var(--accent)' : 'var(--text-muted)',
-              fontFamily: 'var(--font-landing)',
-              fontSize: '15px',
-              padding: '12px 8px',
-              borderRadius: 'var(--radius-card)',
-              backgroundColor: isActive ? 'var(--surface)' : 'transparent',
-              display: 'block',
-              transition: 'background-color 0.15s, color 0.15s',
-            };
-
-            if (link.anchor) {
-              return (
-                <a
-                  key={link.href}
-                  href={link.href}
-                  onClick={() => setMobileOpen(false)}
-                  style={linkStyle}
-                >
-                  {link.label}
-                </a>
-              );
-            }
-
-            if (link.label === 'Log in' && onLoginClick) {
-              return (
-                <button
-                  key={link.href}
-                  type="button"
-                  onClick={() => { setMobileOpen(false); onLoginClick(); }}
-                  className="bg-transparent border-none cursor-pointer text-left w-full"
-                  style={linkStyle}
-                >
-                  {link.label}
-                </button>
-              );
-            }
-
             return (
-              <Link
+              <MobileNavItem
                 key={link.href}
-                href={link.href}
-                onClick={() => setMobileOpen(false)}
-                style={linkStyle}
-              >
-                {link.label}
-              </Link>
+                link={link}
+                isActive={isActive}
+                onClose={() => setMobileOpen(false)}
+                onLoginClick={onLoginClick}
+              />
             );
           })}
 

--- a/aragora/live/src/components/landing/LiveDebatePanel.tsx
+++ b/aragora/live/src/components/landing/LiveDebatePanel.tsx
@@ -64,8 +64,9 @@ export interface LiveDebatePanelProps {
 /*  Helpers                                                            */
 /* ------------------------------------------------------------------ */
 
-const LIVE_PREVIEW_POLL_MS = 4000;
+const LIVE_PREVIEW_POLL_MS = 12000;
 const LIVE_PREVIEW_EVENT_LIMIT = 12;
+const SAFE_DEBATE_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 function toEpochMs(value: string | null | undefined): number | null {
   if (!value) return null;
@@ -80,6 +81,20 @@ function formatClockTime(timestampMs: number): string {
     second: '2-digit',
     hour12: false,
   });
+}
+
+function sanitizeDebateId(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return SAFE_DEBATE_ID_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+function buildSpectateSocketUrl(wsBase: string, debateId: string): string {
+  const normalizedBase = wsBase.endsWith('/') ? wsBase : `${wsBase}/`;
+  const url = new URL(normalizedBase);
+  const basePath = url.pathname.replace(/\/+$/, '');
+  url.pathname = `${basePath}/spectate/${encodeURIComponent(debateId)}`.replace(/\/{2,}/g, '/');
+  return url.toString();
 }
 
 function readDetails(data: Record<string, unknown>): string | null {
@@ -193,6 +208,19 @@ function normalizeSocketEvent(message: SpectateSocketMessage): LivePreviewEvent 
   };
 }
 
+function mergePreviewEvents(...eventGroups: LivePreviewEvent[][]): LivePreviewEvent[] {
+  const merged = new Map<string, LivePreviewEvent>();
+  for (const group of eventGroups) {
+    for (const event of group) {
+      merged.set(event.id, event);
+    }
+  }
+
+  return Array.from(merged.values())
+    .sort((left, right) => left.timestampMs - right.timestampMs)
+    .slice(-LIVE_PREVIEW_EVENT_LIMIT);
+}
+
 function summarizeLiveDebates(
   events: PublicSpectateEvent[],
   activityWindowSeconds: number,
@@ -204,15 +232,16 @@ function summarizeLiveDebates(
     const timestampMs = toEpochMs(event.timestamp);
     if (timestampMs === null) continue;
     if (now - timestampMs > activityWindowSeconds * 1000) continue;
-    if (!event.debate_id) continue;
+    const debateId = sanitizeDebateId(event.debate_id);
+    if (!debateId) continue;
 
-    const existing = debates.get(event.debate_id);
+    const existing = debates.get(debateId);
     const task = readTask(event.data);
     const agents = readAgents(event.data);
 
     if (!existing) {
-      debates.set(event.debate_id, {
-        debateId: event.debate_id,
+      debates.set(debateId, {
+        debateId,
         task,
         agents,
         lastEventAt: event.timestamp,
@@ -258,6 +287,7 @@ export function LiveDebatePanel({
   const [socketTask, setSocketTask] = useState<string | null>(null);
   const [socketAgents, setSocketAgents] = useState<string[]>([]);
   const [socketEvents, setSocketEvents] = useState<LivePreviewEvent[]>([]);
+  const [mergedEvents, setMergedEvents] = useState<LivePreviewEvent[]>([]);
 
   const refreshPreview = useCallback(async () => {
     try {
@@ -297,14 +327,26 @@ export function LiveDebatePanel({
     () => summarizeLiveDebates(recentEvents, activityWindowSeconds),
     [activityWindowSeconds, recentEvents],
   );
+  const safeSelectedDebateId = useMemo(
+    () => sanitizeDebateId(selectedDebateId),
+    [selectedDebateId],
+  );
+
+  useEffect(() => {
+    if (selectedDebateId && !safeSelectedDebateId) {
+      setSelectedDebateId(null);
+    }
+  }, [safeSelectedDebateId, selectedDebateId]);
 
   useEffect(() => {
     const hottestDebateId = liveDebates[0]?.debateId ?? null;
-    setSelectedDebateId(hottestDebateId);
+    setSelectedDebateId((currentDebateId) =>
+      currentDebateId === hottestDebateId ? currentDebateId : hottestDebateId,
+    );
   }, [liveDebates]);
 
   useEffect(() => {
-    if (!selectedDebateId) {
+    if (!safeSelectedDebateId) {
       setSocketStatus('idle');
       setSocketTask(null);
       setSocketAgents([]);
@@ -317,7 +359,7 @@ export function LiveDebatePanel({
     setSocketAgents([]);
     setSocketEvents([]);
 
-    const socket = new WebSocket(`${resolvedWsBase}/spectate/${selectedDebateId}`);
+    const socket = new WebSocket(buildSpectateSocketUrl(resolvedWsBase, safeSelectedDebateId));
     wsRef.current = socket;
 
     socket.onopen = () => {
@@ -344,15 +386,7 @@ export function LiveDebatePanel({
         }
 
         const normalizedEvent = normalizeSocketEvent(message);
-        setSocketEvents((currentEvents) => {
-          const nextEvents = new Map(
-            currentEvents.map((previewEvent) => [previewEvent.id, previewEvent]),
-          );
-          nextEvents.set(normalizedEvent.id, normalizedEvent);
-          return Array.from(nextEvents.values())
-            .sort((left, right) => left.timestampMs - right.timestampMs)
-            .slice(-LIVE_PREVIEW_EVENT_LIMIT);
-        });
+        setSocketEvents((currentEvents) => mergePreviewEvents(currentEvents, [normalizedEvent]));
       } catch {
         setSocketStatus('error');
       }
@@ -374,29 +408,22 @@ export function LiveDebatePanel({
         wsRef.current = null;
       }
     };
-  }, [resolvedWsBase, selectedDebateId]);
+  }, [resolvedWsBase, safeSelectedDebateId]);
 
   const selectedDebate = useMemo(
-    () => liveDebates.find((debate) => debate.debateId === selectedDebateId) ?? null,
-    [liveDebates, selectedDebateId],
+    () => liveDebates.find((debate) => debate.debateId === safeSelectedDebateId) ?? null,
+    [liveDebates, safeSelectedDebateId],
   );
 
   const recentDebateEvents = useMemo(() => {
-    if (!selectedDebateId) return [];
+    if (!safeSelectedDebateId) return [];
     return recentEvents
-      .filter((event) => event.debate_id === selectedDebateId)
+      .filter((event) => sanitizeDebateId(event.debate_id) === safeSelectedDebateId)
       .map(normalizeRecentEvent);
-  }, [recentEvents, selectedDebateId]);
+  }, [recentEvents, safeSelectedDebateId]);
 
-  const mergedEvents = useMemo(() => {
-    const merged = new Map<string, LivePreviewEvent>();
-    for (const event of [...recentDebateEvents, ...socketEvents]) {
-      merged.set(event.id, event);
-    }
-
-    return Array.from(merged.values())
-      .sort((left, right) => left.timestampMs - right.timestampMs)
-      .slice(-LIVE_PREVIEW_EVENT_LIMIT);
+  useEffect(() => {
+    setMergedEvents(mergePreviewEvents(recentDebateEvents, socketEvents));
   }, [recentDebateEvents, socketEvents]);
 
   const bridgeTone = socketStatus === 'connected'
@@ -423,6 +450,9 @@ export function LiveDebatePanel({
     ?? selectedDebate?.task
     ?? 'Waiting for a public debate to surface in the live bridge.';
   const activeAgents = socketAgents.length > 0 ? socketAgents : (selectedDebate?.agents ?? []);
+  const spectatorHref = safeSelectedDebateId
+    ? `/spectate/${encodeURIComponent(safeSelectedDebateId)}`
+    : '/spectate';
 
   return (
     <section className="px-4 pb-20">
@@ -476,9 +506,9 @@ export function LiveDebatePanel({
               <span className="font-theme-data text-xs text-text-muted">
                 {(status?.recent_event_count ?? recentEvents.length).toString()} recent bridge events
               </span>
-              {selectedDebateId && (
+              {safeSelectedDebateId && (
                 <span className="font-theme-data text-xs text-text-muted">
-                  Debate {selectedDebateId.slice(-8).toUpperCase()}
+                  Debate {safeSelectedDebateId.slice(-8).toUpperCase()}
                 </span>
               )}
               {activeAgents.length > 0 && (
@@ -490,7 +520,7 @@ export function LiveDebatePanel({
 
             <div className="flex flex-wrap gap-3">
               <Link
-                href={selectedDebateId ? `/spectate/${selectedDebateId}` : '/spectate'}
+                href={spectatorHref}
                 className="font-theme-data text-xs px-4 py-2 bg-[var(--accent)] text-bg font-bold hover:opacity-90 transition-opacity"
               >
                 Open spectator view

--- a/aragora/live/src/components/landing/__tests__/Header.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/Header.test.tsx
@@ -59,6 +59,16 @@ describe('Header', () => {
         '/login',
       );
     });
+
+    it('uses the login callback when provided', async () => {
+      const user = userEvent.setup();
+      const onLoginClick = jest.fn();
+      renderWithProviders(<Header onLoginClick={onLoginClick} />);
+
+      await user.click(screen.getAllByRole('button', { name: /log in/i })[0]);
+
+      expect(onLoginClick).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('mobile menu', () => {

--- a/aragora/live/src/components/landing/__tests__/LiveDebatePanel.test.tsx
+++ b/aragora/live/src/components/landing/__tests__/LiveDebatePanel.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { LiveDebatePanel } from '../LiveDebatePanel';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as typeof fetch;
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  url: string;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  close = jest.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe('LiveDebatePanel', () => {
+  const originalSetInterval = window.setInterval;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockWebSocket.instances = [];
+    mockFetch.mockReset();
+    (global as typeof globalThis & { WebSocket: typeof WebSocket }).WebSocket =
+      MockWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    window.setInterval = originalSetInterval;
+  });
+
+  it('ignores invalid debate ids from recent events before opening a socket', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          events: [
+            {
+              event_type: 'proposal',
+              timestamp: new Date().toISOString(),
+              data: { task: 'bad debate id' },
+              debate_id: '../escape',
+              pipeline_id: null,
+              agent_name: 'agent-1',
+              round_number: 1,
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          active: true,
+          recent_activity_window_seconds: 120,
+          recent_event_count: 1,
+        }),
+      });
+
+    render(<LiveDebatePanel apiBase="https://api.example.test" wsUrl="wss://api.example.test/ws" />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    expect(MockWebSocket.instances).toHaveLength(0);
+    expect(screen.getByRole('link', { name: /open spectator view/i })).toHaveAttribute(
+      'href',
+      '/spectate',
+    );
+  });
+
+  it('uses the slower refresh cadence for the live preview poll loop', () => {
+    const setIntervalSpy = jest.spyOn(window, 'setInterval');
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ events: [] }),
+    });
+
+    render(<LiveDebatePanel apiBase="https://api.example.test" wsUrl="wss://api.example.test/ws" />);
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 12000);
+    setIntervalSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Follow-up to #2291. The original landing preview restore merged, but this hardening work landed after that merge and needs its own clean PR.

## What changed
- validate and encode public debate IDs before building landing-page spectate URLs
- slow landing preview polling to a less aggressive 12s cadence
- move live-event dedupe/merge work out of the render path
- simplify header navigation rendering into dedicated desktop/mobile helpers
- add focused landing tests for login callback behavior and invalid debate ID handling

## Validation
- npx jest --runInBand src/components/landing/__tests__/LandingPage.test.tsx src/components/landing/__tests__/Header.test.tsx src/components/landing/__tests__/LiveDebatePanel.test.tsx src/app/__tests__/HomePageLandingSelection.test.ts
- npx tsc --noEmit -p tsconfig.json
- npx eslint src/components/landing/LiveDebatePanel.tsx src/components/landing/Header.tsx src/components/landing/__tests__/Header.test.tsx src/components/landing/__tests__/LiveDebatePanel.test.tsx
- git diff --check