### PR TITLE
test: add comprehensive receipt signature lifecycle tests

### DIFF
--- a/tests/inbox/test_receipt_signature.py
+++ b/tests/inbox/test_receipt_signature.py
@@ -129,3 +129,68 @@ class TestReceiptSignatureLifecycle:
 
         signed = s1.sign(sample_receipt)
         assert not s2.verify(signed)
+
+    def test_verify_dict_roundtrip(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        """verify_dict should accept the dict form of a signed receipt."""
+        signed = signer.sign(sample_receipt)
+        assert signer.verify_dict(signed.to_dict())
+
+    def test_verify_dict_tamper_detected(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        d = signer.sign(sample_receipt).to_dict()
+        d["receipt"]["decision"] = "reject"
+        assert not signer.verify_dict(d)
+
+    def test_nested_receipt_data(self, signer: ReceiptSigner) -> None:
+        """Deeply nested data should still be signed deterministically."""
+        nested = {
+            "id": "rcpt-nested",
+            "meta": {"tags": ["a", "b"], "scores": {"quality": 0.9}},
+        }
+        signed = signer.sign(nested)
+        assert signer.verify(signed)
+        signed.receipt_data["meta"]["scores"]["quality"] = 0.1
+        assert not signer.verify(signed)
+
+    def test_empty_receipt(self, signer: ReceiptSigner) -> None:
+        signed = signer.sign({})
+        assert signer.verify(signed)
+
+    def test_signature_metadata_timestamp(
+        self, signer: ReceiptSigner, sample_receipt: dict
+    ) -> None:
+        signed = signer.sign(sample_receipt)
+        # Metadata should carry a valid ISO timestamp
+        ts = signed.signature_metadata.timestamp
+        from datetime import datetime
+
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+    def test_sign_shares_reference(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        """sign() stores a reference; callers must not mutate after signing."""
+        data = copy.deepcopy(sample_receipt)
+        signed = signer.sign(data)
+        assert signer.verify(signed)
+        # Mutating the dict invalidates the signature (shared reference)
+        data["decision"] = "reject"
+        assert not signer.verify(signed)
+
+    def test_full_lifecycle_end_to_end(self, tmp_path: object) -> None:
+        """Complete lifecycle: create key, sign, serialise, reload key, verify, tamper, detect."""
+        key_path = os.path.join(str(tmp_path), "lifecycle.key")
+
+        # Phase 1: sign and serialise
+        signer1 = ReceiptSigner(backend=DurableFileSigner(key_path=key_path))
+        receipt = {"id": "e2e", "action": "deploy", "risk": 0.3}
+        signed = signer1.sign(
+            receipt, signatory=SignatoryInfo(name="Bot", email="bot@a.io", role="CI")
+        )
+        json_blob = signed.to_json()
+
+        # Phase 2: new process loads same key, verifies
+        signer2 = ReceiptSigner(backend=DurableFileSigner(key_path=key_path))
+        restored = SignedReceipt.from_json(json_blob)
+        assert signer2.verify(restored)
+
+        # Phase 3: tamper with serialised form
+        restored.receipt_data["risk"] = 0.0
+        assert not signer2.verify(restored)


### PR DESCRIPTION
Add 7 new tests covering verify_dict roundtrip, nested data tampering,
empty receipts, metadata timestamps, shared-reference semantics, and a
full end-to-end lifecycle (create key → sign → serialise → reload →
verify → tamper → detect).

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 7f998ebf293b4c19afc81abecff3d017018d4877)
