### PR TITLE
test: add comprehensive receipt signature lifecycle tests (#2351)

### DIFF
--- a/tests/inbox/test_receipt_signature.py
+++ b/tests/inbox/test_receipt_signature.py
@@ -129,3 +129,73 @@ class TestReceiptSignatureLifecycle:
 
         signed = s1.sign(sample_receipt)
         assert not s2.verify(signed)
+
+    def test_full_lifecycle(self, tmp_path: object) -> None:
+        """End-to-end: create receipt, sign, verify, serialize, tamper, detect."""
+        key_path = os.path.join(str(tmp_path), "lifecycle.key")
+        backend = DurableFileSigner(key_path=key_path)
+        signer = ReceiptSigner(backend=backend)
+
+        receipt = {
+            "receipt_id": "rcpt-lifecycle",
+            "decision": "approve",
+            "score": 0.95,
+            "participants": ["a1", "a2"],
+        }
+
+        # Step 1: sign
+        signatory = SignatoryInfo(name="Bot", email="bot@test.com", role="System")
+        signed = signer.sign(receipt, signatory=signatory)
+
+        # Step 2: verify original
+        assert signer.verify(signed)
+        assert signed.signature_metadata.algorithm == "HMAC-SHA256"
+        assert signed.signature_metadata.signatory.name == "Bot"
+
+        # Step 3: roundtrip via JSON
+        restored = SignedReceipt.from_json(signed.to_json())
+        assert signer.verify(restored)
+
+        # Step 4: verify with fresh instance (same key file)
+        signer2 = ReceiptSigner(backend=DurableFileSigner(key_path=key_path))
+        assert signer2.verify(restored)
+
+        # Step 5: tamper and detect
+        restored.receipt_data["decision"] = "reject"
+        assert not signer2.verify(restored)
+
+    def test_verify_dict_roundtrip(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        signed = signer.sign(sample_receipt)
+        assert signer.verify_dict(signed.to_dict())
+
+        # Tampered dict should fail
+        d = signed.to_dict()
+        d["receipt"]["decision"] = "tampered"
+        assert not signer.verify_dict(d)
+
+    def test_deep_copy_independence(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        """Signing a deep copy produces a valid, independent receipt."""
+        original_signed = signer.sign(sample_receipt)
+        cloned = copy.deepcopy(original_signed)
+
+        assert signer.verify(cloned)
+
+        # Mutating clone doesn't affect original verification
+        cloned.receipt_data["decision"] = "tampered"
+        assert not signer.verify(cloned)
+        assert signer.verify(original_signed)
+
+    def test_empty_receipt(self, signer: ReceiptSigner) -> None:
+        signed = signer.sign({})
+        assert signer.verify(signed)
+        signed.receipt_data["new_key"] = "value"
+        assert not signer.verify(signed)
+
+    def test_timestamp_present(self, signer: ReceiptSigner, sample_receipt: dict) -> None:
+        signed = signer.sign(sample_receipt)
+        ts = signed.signature_metadata.timestamp
+        assert ts  # non-empty
+        # Should be a valid ISO timestamp
+        from datetime import datetime
+
+        datetime.fromisoformat(ts.replace("Z", "+00:00"))


### PR DESCRIPTION
Add end-to-end lifecycle test covering create, sign, verify, serialize,
key persistence, tamper detection in a single flow. Also add tests for
verify_dict roundtrip, deep copy independence, empty receipt edge case,
and timestamp metadata validation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit eda9657a091c9583892d4633d4946937441ede29)
