### PR TITLE
test(playground): cover public assess route handling

### DIFF
--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -149,6 +149,9 @@ class TestCanHandle:
     def test_cost_estimate_path(self, handler):
         assert handler.can_handle("/api/v1/playground/debate/live/cost-estimate")
 
+    def test_assess_path(self, handler):
+        assert handler.can_handle("/api/v1/playground/assess")
+
     def test_status_path(self, handler):
         assert handler.can_handle("/api/v1/playground/status")
 


### PR DESCRIPTION
## Summary
- preserve explicit coverage for the public /api/v1/playground/assess handler path
- keep the landing telemetry and assess endpoints covered together with the budget-gate exemptions

## Validation
- python3 -m pytest tests/handlers/test_playground.py -q -k 'assess_path or routes_attribute'
- python3 -m pytest tests/server/test_live_streaming_budget_gate.py -q -k 'assess_still_exempt or landing_events_still_exempt or landing_feedback_still_exempt'