### PR TITLE
fix(receipts): restore raw export mode

### DIFF
--- a/aragora/live/__tests__/ReceiptsPage.test.tsx
+++ b/aragora/live/__tests__/ReceiptsPage.test.tsx
@@ -329,7 +329,7 @@ describe('ReceiptsPage', () => {
       );
       expect(global.fetch).toHaveBeenNthCalledWith(
         2,
-        'http://localhost:8080/api/v2/receipts/receipt-456/export?format=json',
+        'http://localhost:8080/api/v2/receipts/receipt-456/export?format=json&raw=true',
         expect.any(Object)
       );
       expect(URL.createObjectURL).toHaveBeenCalled();

--- a/aragora/live/src/app/(app)/receipts/page.tsx
+++ b/aragora/live/src/app/(app)/receipts/page.tsx
@@ -685,11 +685,15 @@ function buildExportUrls(
   const urls = new Set<string>();
 
   if (item.receiptId) {
-    urls.add(`${backendUrl}/api/v2/receipts/${item.receiptId}/export?format=${exportFormat}`);
+    urls.add(
+      `${backendUrl}/api/v2/receipts/${item.receiptId}/export?format=${exportFormat}&raw=true`
+    );
   }
 
   if (!item.receiptId && item.id) {
-    urls.add(`${backendUrl}/api/v2/receipts/${item.id}/export?format=${exportFormat}`);
+    urls.add(
+      `${backendUrl}/api/v2/receipts/${item.id}/export?format=${exportFormat}&raw=true`
+    );
   }
 
   if (item.gauntletId) {

--- a/aragora/live/src/components/onboarding/CompletionStep.tsx
+++ b/aragora/live/src/components/onboarding/CompletionStep.tsx
@@ -68,7 +68,7 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
             description="See your decision summary"
             href={
               firstReceiptId
-                ? `${API_BASE_URL}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html`
+                ? `${API_BASE_URL}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html&raw=true`
                 : (firstDebateId ? `/debate/${firstDebateId}` : '/debates')
             }
           />

--- a/aragora/live/src/components/onboarding/FirstDebateStep.tsx
+++ b/aragora/live/src/components/onboarding/FirstDebateStep.tsx
@@ -184,7 +184,7 @@ export function FirstDebateStep() {
     setReceiptError(null);
 
     const response = await fetch(
-      `${apiBase}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=${format}`
+      `${apiBase}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=${format}&raw=true`
     );
     if (!response.ok) {
       throw new Error(`Export failed (HTTP ${response.status})`);
@@ -392,7 +392,7 @@ export function FirstDebateStep() {
                   </button>
                   {firstReceiptId && (
                     <a
-                      href={`${apiBase}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html`}
+                      href={`${apiBase}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html&raw=true`}
                       target="_blank"
                       rel="noreferrer"
                       className="px-3 py-1.5 text-xs font-theme-data border border-border text-text-muted hover:border-[var(--accent)]/40 hover:text-text transition-colors"

--- a/aragora/server/fastapi/routes/receipts.py
+++ b/aragora/server/fastapi/routes/receipts.py
@@ -49,6 +49,7 @@ class ExportFormat(str, Enum):
     html = "html"
     markdown = "markdown"
     md = "md"
+    pdf = "pdf"
     sarif = "sarif"
 
 
@@ -1310,9 +1311,13 @@ async def verify_receipt(
 async def export_receipt(
     receipt_id: str,
     format: ExportFormat = Query(ExportFormat.json, description="Export format"),
+    raw: bool = Query(
+        False,
+        description="Return the exported bytes directly instead of a JSON wrapper.",
+    ),
     store=Depends(get_receipt_store),
-) -> ExportResponse:
-    """Export receipt in the specified format (json, html, markdown, sarif)."""
+) -> ExportResponse | Response:
+    """Export receipt in the specified format."""
     try:
         receipt_data = None
 
@@ -1333,18 +1338,61 @@ async def export_receipt(
             else:
                 raise ValueError("Cannot reconstruct receipt for export")
 
+            if format == ExportFormat.pdf:
+                try:
+                    return Response(
+                        content=receipt.to_pdf(),
+                        media_type="application/pdf",
+                    )
+                except ImportError:
+                    logger.info("PDF export unavailable, falling back to printable HTML")
+                    printable_html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Receipt {receipt_id}</title>
+    <style>
+        @media print {{
+            body {{ font-size: 12pt; }}
+            .no-print {{ display: none; }}
+        }}
+        body {{ font-family: system-ui, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }}
+        .print-notice {{ background: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin-bottom: 20px; border-radius: 4px; }}
+    </style>
+</head>
+<body>
+    <div class="print-notice no-print">
+        <strong>Note:</strong> PDF export is unavailable. Use your browser's Print function (Ctrl+P / Cmd+P) to save as PDF.
+    </div>
+    {receipt.to_html()}
+</body>
+</html>"""
+                    return Response(
+                        content=printable_html.encode("utf-8"),
+                        media_type="text/html",
+                        headers={"X-PDF-Fallback": "true"},
+                    )
+
             if format in (ExportFormat.markdown, ExportFormat.md):
                 content = receipt.to_markdown()
                 response_format = "markdown"
+                media_type = "text/markdown"
             elif format == ExportFormat.html:
                 content = receipt.to_html()
                 response_format = "html"
+                media_type = "text/html"
             elif format == ExportFormat.sarif:
                 content = receipt.to_sarif_json()
                 response_format = "sarif"
+                media_type = "application/sarif+json"
             else:
                 content = receipt.to_json()
                 response_format = "json"
+                media_type = "application/json"
+
+            if raw:
+                body = content if isinstance(content, bytes) else content.encode("utf-8")
+                return Response(content=body, media_type=media_type)
 
             return ExportResponse(
                 receipt_id=receipt_id,

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -401,6 +401,15 @@ class TestExportReceipt:
         assert data["format"] == "markdown"
         assert "Decision Receipt" in data["content"]
 
+    def test_export_receipt_markdown_raw_mode(self, client, mock_receipt_store, sample_receipt_dict):
+        """Raw mode returns markdown bytes for the live download surfaces."""
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        response = client.get("/api/v2/receipts/rcpt_test123/export?format=md&raw=true")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/markdown")
+        assert "Decision Receipt" in response.text
+
     def test_export_receipt_md_alias_format(self, client, mock_receipt_store, sample_receipt_dict):
         """Export receipt accepts the legacy md alias used by the live UI."""
         mock_receipt_store.get.return_value = sample_receipt_dict
@@ -422,6 +431,16 @@ class TestExportReceipt:
         assert "<!DOCTYPE html>" in data["content"]
         assert "Decision Receipt" in data["content"]
 
+    def test_export_receipt_html_raw_mode(self, client, mock_receipt_store, sample_receipt_dict):
+        """Raw HTML mode returns an inline document for onboarding receipt links."""
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        response = client.get("/api/v2/receipts/rcpt_test123/export?format=html&raw=true")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert "<!DOCTYPE html>" in response.text
+        assert "Decision Receipt" in response.text
+
     def test_export_receipt_sarif_format(self, client, mock_receipt_store, sample_receipt_dict):
         """Export receipt in SARIF format."""
         mock_receipt_store.get.return_value = sample_receipt_dict
@@ -434,6 +453,50 @@ class TestExportReceipt:
 
         sarif = json.loads(data["content"])
         assert sarif["version"] == "2.1.0"
+
+    def test_export_receipt_json_raw_mode(self, client, mock_receipt_store, sample_receipt_dict):
+        """Raw JSON mode serves the receipt body directly for file downloads."""
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        response = client.get("/api/v2/receipts/rcpt_test123/export?format=json&raw=true")
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.json()["receipt_id"] == "rcpt_test123"
+
+    def test_export_receipt_pdf_format_returns_pdf_bytes(
+        self, client, mock_receipt_store, sample_receipt_dict
+    ):
+        """PDF export should return raw bytes for browser/download flows."""
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        mock_receipt = MagicMock()
+        mock_receipt.to_pdf.return_value = b"%PDF-1.4..."
+
+        with patch("aragora.export.decision_receipt.DecisionReceipt.from_dict", return_value=mock_receipt):
+            response = client.get("/api/v2/receipts/rcpt_test123/export?format=pdf")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("application/pdf")
+        assert response.content == b"%PDF-1.4..."
+
+    def test_export_receipt_pdf_fallback_returns_printable_html(
+        self, client, mock_receipt_store, sample_receipt_dict
+    ):
+        """When PDF generation is unavailable, export falls back to printable HTML."""
+        mock_receipt_store.get.return_value = sample_receipt_dict
+
+        mock_receipt = MagicMock()
+        mock_receipt.to_pdf.side_effect = ImportError("weasyprint not found")
+        mock_receipt.to_html.return_value = "<div>Receipt Content</div>"
+
+        with patch("aragora.export.decision_receipt.DecisionReceipt.from_dict", return_value=mock_receipt):
+            response = client.get("/api/v2/receipts/rcpt_test123/export?format=pdf")
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/html")
+        assert response.headers["x-pdf-fallback"] == "true"
+        assert "PDF export is unavailable" in response.text
+        assert "Receipt Content" in response.text
 
     def test_export_receipt_from_stored_receipt_uses_full_payload(
         self, client, mock_receipt_store, sample_stored_receipt


### PR DESCRIPTION
## Summary
- restore the raw receipt export mode on the receipts page
- cover the raw-mode export path in the FastAPI receipts route tests
- keep the receipts page expectations aligned with the restored export behavior

## Validation
- python3 -m pytest tests/server/fastapi/test_receipts_routes.py -q
- cd aragora/live && npx jest --runTestsByPath __tests__/ReceiptsPage.test.tsx --runInBand