### PR TITLE
fix: parse legacy session lock pids

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1286,6 +1286,12 @@ class WorkerLauncher:
             if not entry:
                 continue
             if "=" not in entry:
+                pid = cls._normalized_pid(entry)
+                # Older lockfiles sometimes used a bare "1" sentinel to mean
+                # "lock exists" without recording a usable PID. Only trust
+                # bare numeric lines when they look like real session PIDs.
+                if pid is not None and pid > 1 and pid not in session_pids:
+                    session_pids.append(pid)
                 continue
             key, value = entry.split("=", 1)
             normalized_key = key.strip()

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -2201,6 +2201,48 @@ class TestCollectDetachedResult:
         mock_cleanup.assert_called_once_with(str(tmp_path))
 
     @pytest.mark.asyncio
+    async def test_collect_detached_result_uses_legacy_lock_pid_when_worker_pid_is_stale(
+        self, tmp_path: Path
+    ):
+        (tmp_path / ".codex_session_active").write_text("24680\n", encoding="utf-8")
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(
+                WorkerLauncher, "_has_working_tree_changes", new=AsyncMock(return_value=False)
+            ),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value=""),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new=AsyncMock()) as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts") as mock_cleanup,
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-active-lock-legacy-pid",
+                agent="codex",
+                worktree_path=str(tmp_path),
+                branch="main",
+                pid=11111,
+                initial_head="def456",
+                auto_commit=False,
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert mock_running.call_args_list
+        assert all(call.args == (24680,) for call in mock_running.call_args_list)
+        mock_wait_pid.assert_awaited_once_with(24680)
+        mock_cleanup.assert_called_once_with(str(tmp_path))
+
+    @pytest.mark.asyncio
     async def test_collect_detached_result_prefers_pid_entry_when_lock_lists_ppid_first(
         self, tmp_path: Path
     ):
@@ -2507,6 +2549,36 @@ class TestSnapshotProgress:
         assert snapshot["pid_alive"] is False
         assert mock_running.call_args_list
         assert all(call.args[0] in {24680, 13579} for call in mock_running.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_uses_legacy_lock_pid_when_worker_pid_is_stale(
+        self, tmp_path: Path
+    ):
+        launcher = WorkerLauncher()
+        (tmp_path / ".codex_session_active").write_text("24680\n", encoding="utf-8")
+        work_order = {
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        def _pid_running(pid: int | None) -> bool:
+            return pid == 11111
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={}),
+            patch.object(
+                WorkerLauncher, "_is_pid_running", side_effect=_pid_running
+            ) as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        assert mock_running.call_args_list
+        assert all(call.args == (24680,) for call in mock_running.call_args_list)
 
     @pytest.mark.asyncio
     async def test_snapshot_progress_prefers_pid_entry_when_lock_lists_ppid_first(


### PR DESCRIPTION
Teach worker launcher to treat legacy bare-PID `.codex_session_active` lines as session-owned PIDs when they look like real process IDs, while preserving the old bare `1` sentinel behavior.

Testing:
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k legacy_lock_pid_when_worker_pid_is_stale
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q