### PR TITLE
fix: clear stale wait state on clean exit

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3611,8 +3611,11 @@ class SwarmSupervisor:
                     "merge_gate",
                     "verification_missing_reason",
                     "scope_violation",
+                    "resource_error",
+                    "conflicts",
                 ):
                     item.pop(key, None)
+                item.pop("blockers", None)
                 item["commit_shas"] = []
                 self._mark_needs_human(
                     item,
@@ -3635,8 +3638,11 @@ class SwarmSupervisor:
                     "merge_gate",
                     "verification_missing_reason",
                     "scope_violation",
+                    "resource_error",
+                    "conflicts",
                 ):
                     item.pop(key, None)
+                item.pop("blockers", None)
                 if not _pre_outcome:
                     item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
                 logger.warning(

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5042,6 +5042,9 @@ def test_apply_worker_result_clean_exit_no_deliverable_clears_stale_deliverable_
         "merge_gate": {"checks_passed": True},
         "verification_missing_reason": "stale",
         "scope_violation": {"violations": [{"path": "README.md"}]},
+        "resource_error": "old disk pressure",
+        "conflicts": [{"source": "lease", "lease_id": "lease-stale"}],
+        "blockers": ["old blocker"],
         "lease_id": "lease-123",
     }
     result = WorkerProcess(
@@ -5073,8 +5076,13 @@ def test_apply_worker_result_clean_exit_no_deliverable_clears_stale_deliverable_
         "merge_gate",
         "verification_missing_reason",
         "scope_violation",
+        "resource_error",
+        "conflicts",
     ):
         assert cleared_key not in work_order
+    assert work_order["blockers"] == [
+        "worker produced only session artifacts, no real deliverables"
+    ]
     mock_release.assert_called_once_with(work_order)
 
 


### PR DESCRIPTION
Clear stale wait-state metadata when a worker exits cleanly without any real deliverable, so old resource conflicts and blocker strings do not survive into the new `clean_exit_no_deliverable` outcome.

Testing:
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q
