### PR TITLE
style: format boss_loop.py with ruff

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1099,14 +1099,31 @@ class BossLoop:
         # Check if a PR was already merged for this issue — if so, close it
         try:
             pr_check = subprocess.run(
-                ["gh", "pr", "list", "--repo", repo, "--state", "merged",
-                 "--search", f"#{issue.number}", "--limit", "1",
-                 "--json", "number", "--jq", ".[0].number"],
-                capture_output=True, text=True, timeout=15,
+                [
+                    "gh",
+                    "pr",
+                    "list",
+                    "--repo",
+                    repo,
+                    "--state",
+                    "merged",
+                    "--search",
+                    f"#{issue.number}",
+                    "--limit",
+                    "1",
+                    "--json",
+                    "number",
+                    "--jq",
+                    ".[0].number",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
             )
             if pr_check.returncode == 0 and pr_check.stdout.strip():
                 self._label_boss_stuck(
-                    issue_number, repo,
+                    issue_number,
+                    repo,
                     f"PR #{pr_check.stdout.strip()} already merged for this issue.",
                 )
                 return


### PR DESCRIPTION
## Summary

- Format `aragora/swarm/boss_loop.py` with ruff to unblock lint CI across multiple PRs (#2246, #2291, #2273)

## Test plan

- [ ] `ruff format --check aragora/swarm/boss_loop.py` — passes
- [ ] Lint CI gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)