### PR TITLE
Reject malformed Slack token fields

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -197,6 +197,22 @@ def _parse_slack_ok(raw_value: Any) -> bool:
     raise ValueError("ok must be a boolean")
 
 
+def _parse_token_string(raw_value: Any, *, required: bool) -> str | None:
+    """Parse Slack token fields while rejecting malformed non-string values."""
+    if raw_value is None:
+        if required:
+            raise ValueError("token must be a non-empty string")
+        return None
+    if not isinstance(raw_value, str):
+        raise ValueError("token must be a string")
+    value = raw_value.strip()
+    if not value:
+        if required:
+            raise ValueError("token must be a non-empty string")
+        return None
+    return value
+
+
 def _get_oauth_audit_logger() -> Any:
     """Get or create Slack audit logger for OAuth (lazy initialization)."""
     global _slack_oauth_audit
@@ -1198,7 +1214,12 @@ class SlackOAuthHandler(SecureHandler):
             return error_response(f"Slack OAuth failed: {error_msg}", 400)
 
         # Extract workspace info
-        access_token = data.get("access_token")
+        try:
+            access_token = _parse_token_string(data.get("access_token"), required=True)
+            refresh_token = _parse_token_string(data.get("refresh_token"), required=False)
+        except ValueError:
+            logger.error("[%s] Slack token exchange returned malformed token fields", request_id)
+            return error_response("Invalid response from Slack", 500)
         team_payload = data.get("team")
         team = team_payload if isinstance(team_payload, dict) else {}
         bot_user_id = data.get("bot_user_id", "")
@@ -1212,8 +1233,6 @@ class SlackOAuthHandler(SecureHandler):
         else:
             scope = str(raw_scope or "").strip()
 
-        # Extract token refresh data (if available)
-        refresh_token = data.get("refresh_token")
         try:
             expires_in = _parse_expires_in(data.get("expires_in"))
         except ValueError:
@@ -1817,7 +1836,20 @@ class SlackOAuthHandler(SecureHandler):
                 return error_response("Invalid token refresh response", 502)
 
             # Update stored tokens
-            new_access_token = data.get("access_token")
+            try:
+                new_access_token = _parse_token_string(data.get("access_token"), required=True)
+                new_refresh_token = _parse_token_string(data.get("refresh_token"), required=False)
+            except ValueError:
+                logger.error("Token refresh returned malformed token fields for %s", workspace_id)
+                audit = _get_oauth_audit_logger()
+                if audit:
+                    audit.log_oauth(
+                        workspace_id=workspace_id,
+                        action="token_refresh",
+                        success=False,
+                        error="Invalid refresh response: malformed token field",
+                    )
+                return error_response("Invalid token refresh response", 502)
             if not str(new_access_token or "").strip():
                 logger.error("Token refresh returned no access token for %s", workspace_id)
                 audit = _get_oauth_audit_logger()
@@ -1829,7 +1861,6 @@ class SlackOAuthHandler(SecureHandler):
                         error="Invalid refresh response: missing access token",
                     )
                 return error_response("Invalid token refresh response", 502)
-            new_refresh_token = data.get("refresh_token")
             if not str(new_refresh_token or "").strip():
                 new_refresh_token = workspace.refresh_token
             try:

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1294,6 +1294,33 @@ class TestCallback:
         assert _status(result) == 500
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_nonstring_access_token(self, handler):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": {"token": "xoxb-token"},
+                "team": {"id": "W123", "name": "Bad Token"},
+                "bot_user_id": "B789",
+                "authed_user": {"id": "U456"},
+                "scope": "channels:history",
+            }
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_callback_no_credentials_returns_503(self, handler, handler_module, monkeypatch):
         monkeypatch.setattr(handler_module, "SLACK_CLIENT_ID", None)
         result = await handler.handle(
@@ -2892,6 +2919,38 @@ class TestRefreshToken:
             {
                 "ok": True,
                 "access_token": "",
+                "expires_in": 43200,
+                "team": {"id": "W123"},
+            }
+        )
+
+        with (
+            patch("httpx.AsyncClient", return_value=mock_client),
+            patch(
+                "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+                return_value=mock_workspace_store,
+            ),
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/workspaces/W123/refresh",
+                {},
+                {},
+                {},
+                None,
+            )
+
+        assert _status(result) == 502
+        body = _body(result)
+        assert "invalid token refresh response" in body.get("error", "").lower()
+        mock_workspace_store.save.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refresh_rejects_nonstring_access_token(self, handler, mock_workspace_store):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": {"token": "xoxb-new"},
                 "expires_in": 43200,
                 "team": {"id": "W123"},
             }


### PR DESCRIPTION
## Summary
- require Slack callback and refresh token fields to be real strings before persisting them
- reject malformed non-string access tokens instead of storing arbitrary objects as credentials
- cover the callback and manual refresh paths with focused token-shape regressions

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'callback_rejects_nonstring_access_token or refresh_rejects_nonstring_access_token'
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q