### PR TITLE
test: add fallback quota test with mocked primary agent

### DIFF
--- a/tests/agents/test_fallback_quota.py
+++ b/tests/agents/test_fallback_quota.py
@@ -1,0 +1,67 @@
+"""Tests that quota/rate-limit errors on a primary agent trigger fallback."""
+
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock
+
+from aragora.agents.fallback import (
+    AgentFallbackChain,
+    AllProvidersExhaustedError,
+)
+
+
+def _make_agent(name: str, side_effect=None, return_value=None):
+    """Create a mock agent with a generate method."""
+    agent = AsyncMock()
+    agent.name = name
+    if side_effect is not None:
+        agent.generate.side_effect = side_effect
+    elif return_value is not None:
+        agent.generate.return_value = return_value
+    return agent
+
+
+class TestFallbackOnQuotaError:
+    """Verify that AgentFallbackChain routes to fallback on quota errors."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_rate_limit(self):
+        """Primary raises 429-style error; fallback returns successfully."""
+        primary = _make_agent("primary", side_effect=Exception("429 Too Many Requests"))
+        fallback = _make_agent("fallback", return_value="fallback response")
+
+        chain = AgentFallbackChain(providers=[primary, fallback])
+        result = await chain.generate("test prompt")
+
+        assert result == "fallback response"
+        primary.generate.assert_called_once()
+        fallback.generate.assert_called_once()
+        assert chain.metrics.primary_attempts == 1
+        assert chain.metrics.primary_successes == 0
+        assert chain.metrics.fallback_attempts == 1
+        assert chain.metrics.fallback_successes == 1
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_quota_exceeded(self):
+        """Primary raises quota-exceeded error; fallback handles it."""
+        primary = _make_agent("primary", side_effect=Exception("quota exceeded"))
+        fallback = _make_agent("fallback", return_value="ok")
+
+        chain = AgentFallbackChain(providers=[primary, fallback])
+        result = await chain.generate("prompt")
+
+        assert result == "ok"
+        assert chain.metrics.fallback_rate > 0
+
+    @pytest.mark.asyncio
+    async def test_all_providers_exhausted(self):
+        """Both primary and fallback fail; AllProvidersExhaustedError raised."""
+        primary = _make_agent("primary", side_effect=Exception("rate limit"))
+        fallback = _make_agent("fallback", side_effect=Exception("also rate limited"))
+
+        chain = AgentFallbackChain(providers=[primary, fallback])
+        with pytest.raises(AllProvidersExhaustedError):
+            await chain.generate("prompt")
+
+        assert chain.metrics.total_failures == 2


### PR DESCRIPTION
Create tests/agents/test_fallback_quota.py verifying that
AgentFallbackChain routes requests to fallback agents when the
primary agent raises quota/rate-limit errors. Covers three
scenarios: 429 rate limit, quota exceeded, and all providers
exhausted.

Closes #2395

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c6deffef45c9632d44f3ca8b378902479ef7c521)
