### PR TITLE
Add comprehensive tests for ContinuumMemory tier TTL expiration

### DIFF
--- a/tests/memory/test_tier_ttl_expiration.py
+++ b/tests/memory/test_tier_ttl_expiration.py
@@ -5,9 +5,18 @@ from unittest.mock import patch
 
 import pytest
 
-from aragora.memory.continuum import ContinuumMemory, reset_continuum_memory
+from aragora.memory.continuum import (
+    DEFAULT_RETENTION_MULTIPLIER,
+    ContinuumMemory,
+    reset_continuum_memory,
+)
 from aragora.memory.continuum_stats import cleanup_expired_memories
-from aragora.memory.tier_manager import MemoryTier, TierManager, reset_tier_manager
+from aragora.memory.tier_manager import (
+    DEFAULT_TIER_CONFIGS,
+    MemoryTier,
+    TierManager,
+    reset_tier_manager,
+)
 
 
 @pytest.fixture
@@ -154,3 +163,25 @@ class TestCrosssTierExpiration:
             mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
             result = cleanup_expired_memories(memory)
         assert result["archived"] == 4
+
+
+@pytest.mark.parametrize(
+    ("tier", "future"),
+    [
+        (MemoryTier.FAST, timedelta(hours=3)),
+        (MemoryTier.MEDIUM, timedelta(hours=49)),
+        (MemoryTier.SLOW, timedelta(days=15)),
+    ],
+)
+def test_delete_mode_reports_expected_cutoff_hours(memory, tier, future):
+    _add_entries(memory)
+    with patch("aragora.memory.continuum_stats.datetime") as mock_dt:
+        mock_dt.now.return_value = datetime.now() + future
+        mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+        result = cleanup_expired_memories(memory, tier=tier, archive=False)
+
+    expected_cutoff_hours = (
+        DEFAULT_TIER_CONFIGS[tier].half_life_hours * DEFAULT_RETENTION_MULTIPLIER
+    )
+    assert result["deleted"] == 1
+    assert result["by_tier"][tier.value]["cutoff_hours"] == expected_cutoff_hours


### PR DESCRIPTION
Tests verify that entries expire correctly based on tier-specific TTL
settings (half_life * retention_multiplier=2x) using mocked datetime.
Covers fast (2h), medium (48h), slow (14d), and glacial (60d) tiers
with both before-TTL and after-TTL assertions, plus cross-tier ordering.

Closes #2438

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 2bc302705dd6576dbc027164d5826034460443e5)
