### PR TITLE
Persist waiting-resource blocker details

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -765,9 +765,7 @@ class SwarmSupervisor:
                     self._mark_waiting_conflict(item, exc.conflicts)
                 except RuntimeError as exc:
                     if self._is_resource_constraint_error(exc):
-                        self._clear_waiting_state(item)
-                        item["status"] = "waiting_resource"
-                        item["resource_error"] = str(exc)
+                        self._mark_waiting_resource(item, str(exc))
                         break
                     else:
                         self._clear_stale_prelaunch_deliverable_state(item)
@@ -5043,6 +5041,9 @@ class SwarmSupervisor:
             "waiting_conflict": (
                 "Which overlapping lane should finish, be discarded, or be split before this task can proceed?"
             ),
+            "waiting_resource": (
+                "Which capacity or environment constraint must be resolved before this lane can proceed?"
+            ),
             "clean_exit_no_deliverable": (
                 "What concrete branch, commit, or PR should this lane produce before rerunning?"
             ),
@@ -5187,6 +5188,21 @@ class SwarmSupervisor:
         if not blockers:
             blockers.append("waiting_conflict")
         item["blockers"] = blockers
+
+    @classmethod
+    def _mark_waiting_resource(cls, item: dict[str, Any], resource_error: str) -> None:
+        """Persist a resource-blocked wait state with explicit blocker metadata."""
+        cls._clear_waiting_state(item)
+        normalized_error = str(resource_error).strip() or "waiting_resource"
+        item["status"] = "waiting_resource"
+        item["resource_error"] = normalized_error
+        item["failure_reason"] = "waiting_resource"
+        item["blocking_question"] = cls._default_blocking_question("waiting_resource")
+        item["blocker"] = {
+            "reason": "waiting_resource",
+            "question": item["blocking_question"],
+        }
+        item["blockers"] = [normalized_error]
 
     @staticmethod
     def _clear_waiting_state(item: dict[str, Any]) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -2637,6 +2637,10 @@ def test_refresh_run_marks_resource_wait_on_disk_full(
     work_order = run.work_orders[0]
     assert work_order["status"] == "waiting_resource"
     assert "No space left on device" in work_order["resource_error"]
+    assert work_order["failure_reason"] == "waiting_resource"
+    assert "capacity or environment constraint" in work_order["blocking_question"]
+    assert work_order["blocker"]["reason"] == "waiting_resource"
+    assert work_order["blockers"] == ["No space left on device"]
 
 
 def test_start_run_prefers_explicit_spec_work_orders(
@@ -7150,6 +7154,10 @@ def test_refresh_run_waiting_resource_clears_stale_terminal_state(
     assert work_order["status"] == "waiting_resource"
     assert work_order["review_status"] == "pending"
     assert work_order["resource_error"] == "No space left on device"
+    assert work_order["failure_reason"] == "waiting_resource"
+    assert "capacity or environment constraint" in work_order["blocking_question"]
+    assert work_order["blocker"]["reason"] == "waiting_resource"
+    assert work_order["blockers"] == ["No space left on device"]
     for cleared_key in (
         "lease_id",
         "owner_session_id",
@@ -7164,10 +7172,6 @@ def test_refresh_run_waiting_resource_clears_stale_terminal_state(
         "changed_paths",
         "merge_gate",
         "dispatch_error",
-        "failure_reason",
-        "blocking_question",
-        "blocker",
-        "blockers",
     ):
         assert cleared_key not in work_order
 


### PR DESCRIPTION
## Summary
- treat waiting_resource as a first-class wait state with blocker metadata
- preserve resource-blocked lanes as explainable blockers instead of bare status plus resource_error
- tighten supervisor regressions for waiting_resource transitions

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q