### PR TITLE
Harden worker launcher terminal marker parsing

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1386,7 +1386,10 @@ class WorkerLauncher:
 
     @staticmethod
     def _terminal_session_result(session_meta: dict[str, Any]) -> tuple[int | None, str | None]:
-        ended_at = str(session_meta.get("ended_at", "")).strip()
+        raw_ended_at = session_meta.get("ended_at")
+        if not isinstance(raw_ended_at, str):
+            return None, None
+        ended_at = raw_ended_at.strip()
         if not ended_at:
             return None, None
         raw_exit_code = session_meta.get("exit_code")

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1812,6 +1812,56 @@ class TestCollectFinishedSync:
         mock_wait_pid.assert_called_once_with(919)
         assert worker.work_order_id not in launcher._processes
 
+    def test_collect_finished_sync_rejects_nonstring_session_ended_at(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        worker = WorkerProcess(
+            work_order_id="wo-sync-bad-ended-at",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-bad-ended-at",
+            branch="main",
+            pid=919,
+            initial_head="def456",
+            expected_tests=[expected_test],
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        session_meta = {
+            "pid": 919,
+            "exit_code": 0,
+            "ended_at": {"when": "2026-03-31T12:34:56+00:00"},
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push_sync") as mock_push,
+            patch.object(WorkerLauncher, "_run_verification_commands_sync") as mock_verify,
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync") as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.completed_at is not None
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_called()
+        mock_verify.assert_not_called()
+        mock_wait_pid.assert_called_once_with(919)
+        assert worker.work_order_id not in launcher._processes
+
 
 class TestCollectDetachedResult:
     @pytest.mark.asyncio
@@ -1984,6 +2034,53 @@ class TestCollectDetachedResult:
         assert result is not None
         assert result.exit_code == 1
         assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_awaited()
+        mock_verify.assert_not_awaited()
+        mock_wait.assert_awaited_once_with(24680)
+
+    @pytest.mark.asyncio
+    async def test_collect_detached_result_rejects_nonstring_session_ended_at(self):
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        session_meta = {
+            "pid": 24680,
+            "exit_code": 0,
+            "ended_at": {"when": "2026-03-31T12:34:56+00:00"},
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push", new_callable=AsyncMock) as mock_push,
+            patch.object(
+                WorkerLauncher,
+                "_run_verification_commands",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new_callable=AsyncMock) as mock_wait,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-detached-bad-ended-at",
+                agent="codex",
+                worktree_path="/tmp/wt-detached-bad-ended-at",
+                branch="main",
+                pid=24680,
+                initial_head="def456",
+                expected_tests=[expected_test],
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert result.completed_at is not None
         assert result.commit_shas == ["abc123"]
         assert result.changed_paths == ["file.py"]
         assert result.tests_run == []


### PR DESCRIPTION
## Summary
- require terminal session ended_at markers to be real non-empty strings
- treat malformed ended_at markers as missing terminal markers in sync and detached collection
- add regressions covering malformed ended_at session metadata in both paths

## Testing
- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py
- python -m pytest tests/swarm/test_worker_launcher.py -q -k nonstring_session_ended_at
- python -m pytest tests/swarm/test_worker_launcher.py -q
- python -m pytest tests/swarm/test_supervisor.py -q