### PR TITLE
Reject malformed webhook cache revisions

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -844,6 +844,20 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
             data["secret"] = _decrypt_secret(secret)
         return WebhookConfig(**data)
 
+    @staticmethod
+    def _trusted_cache_revision(value: Any) -> float | None:
+        """Return a revision usable for cache trust decisions.
+
+        Cache payloads are untyped JSON. Reject booleans explicitly because
+        `True == 1.0` and `False == 0.0`, which can accidentally satisfy the
+        durable revision equality check.
+        """
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)):
+            return float(value)
+        return None
+
     def register(
         self,
         url: str,
@@ -885,9 +899,11 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
                 if data:
                     cached_webhook = self._deserialize_from_cache(data)
                     durable_revision = self._sqlite.get_cache_revision(webhook_id)
+                    cached_revision = self._trusted_cache_revision(cached_webhook.updated_at)
                     if (
                         durable_revision is not None
-                        and cached_webhook.updated_at == durable_revision
+                        and cached_revision is not None
+                        and cached_revision == durable_revision
                     ):
                         return cached_webhook
             except (

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1409,6 +1409,32 @@ class TestRedisWebhookConfigStore:
         mock_redis.setex.assert_called_once()
         store.close()
 
+    def test_with_mocked_redis_get_rejects_boolean_cached_revision(self, tmp_path):
+        """Boolean cache revisions must not satisfy the durable revision trust gate."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store._sqlite.register(url="https://example.com", events=["debate_end"])
+
+        cached_payload = webhook.to_dict(include_secret=True)
+        cached_payload["url"] = "https://stale.example.com"
+        cached_payload["updated_at"] = True
+        mock_redis.get.return_value = json.dumps(cached_payload)
+
+        with patch.object(store._sqlite, "get_cache_revision", return_value=1.0):
+            retrieved = store.get(webhook.id)
+
+        assert retrieved is not None
+        assert retrieved.url == "https://example.com"
+        mock_redis.get.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        mock_redis.setex.assert_called_once()
+        store.close()
+
     def test_with_mocked_redis_get_cache_miss(self, tmp_path):
         """Test get falls back to SQLite on cache miss and populates cache."""
         db_path = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- reject boolean Redis cache revision values before trusting a cached webhook payload
- route malformed cache revisions back through SQLite truth and cache repair
- add a regression that proves a cached payload cannot bypass durable truth via `updated_at: true`

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k boolean_cached_revision
- python -m pytest tests/storage/test_webhook_config_store.py -q