### PR TITLE
Clear stale lease metadata on dispatch failure

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -4450,6 +4450,8 @@ class SwarmSupervisor:
         item["review_status"] = "pending"
         item["dispatch_error"] = str(reason)
         for key in (
+            "lease_id",
+            "owner_session_id",
             "resource_error",
             "conflicts",
             "receipt_id",

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5119,6 +5119,22 @@ async def test_dispatch_workers_dispatch_failed_clears_stale_deliverable_state(
         ],
         status="active",
     )
+    lease = store.claim_lease(
+        task_id="wo-dispatch-failed-cleanup",
+        title="dispatch failure clears stale deliverable state",
+        owner_agent="codex",
+        owner_session_id="stale-session",
+        branch="main",
+        worktree_path=str(repo),
+        claimed_paths=["aragora/swarm/supervisor.py"],
+    )
+    run_record["work_orders"][0]["lease_id"] = lease.lease_id
+    run_record["work_orders"][0]["owner_session_id"] = lease.owner_session_id
+    store.update_supervisor_run(
+        run_record["run_id"],
+        work_orders=run_record["work_orders"],
+        status="active",
+    )
 
     mock_launcher = MagicMock(spec=WorkerLauncher)
     mock_launcher.launch = AsyncMock(side_effect=FileNotFoundError("fatal: boom"))
@@ -5149,6 +5165,8 @@ async def test_dispatch_workers_dispatch_failed_clears_stale_deliverable_state(
         "pid",
         "initial_head",
         "dispatched_at",
+        "lease_id",
+        "owner_session_id",
         "failure_reason",
         "blocking_question",
         "blocker",


### PR DESCRIPTION
## Summary
- clear stale lease ownership metadata when a leased work order fails before launch
- keep dispatch_failed lanes from looking like they still own an active lease from an older attempt
- add regression coverage for the pre-launch dispatch failure path with a real lease record

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k dispatch_failed_clears_stale_deliverable_state
- python -m pytest tests/swarm/test_supervisor.py -q