### PR TITLE
Reject float session metadata in worker launcher

### DIFF
--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -1261,9 +1261,17 @@ class WorkerLauncher:
     def _normalized_pid(raw_pid: Any) -> int | None:
         if isinstance(raw_pid, bool):
             return None
-        try:
-            pid = int(raw_pid)
-        except (TypeError, ValueError):
+        if isinstance(raw_pid, int):
+            pid = raw_pid
+        elif isinstance(raw_pid, str):
+            text = raw_pid.strip()
+            if not text or not re.fullmatch(r"[0-9]+", text):
+                return None
+            try:
+                pid = int(text)
+            except ValueError:
+                return None
+        else:
             return None
         return pid if pid > 0 else None
 
@@ -1395,9 +1403,17 @@ class WorkerLauncher:
         raw_exit_code = session_meta.get("exit_code")
         if isinstance(raw_exit_code, bool):
             return None, ended_at
-        try:
-            exit_code = int(raw_exit_code)
-        except (TypeError, ValueError):
+        if isinstance(raw_exit_code, int):
+            exit_code = raw_exit_code
+        elif isinstance(raw_exit_code, str):
+            text = raw_exit_code.strip()
+            if not text or not re.fullmatch(r"-?[0-9]+", text):
+                return None, ended_at
+            try:
+                exit_code = int(text)
+            except ValueError:
+                return None, ended_at
+        else:
             return None, ended_at
         return exit_code, ended_at
 

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -1812,6 +1812,56 @@ class TestCollectFinishedSync:
         mock_wait_pid.assert_called_once_with(919)
         assert worker.work_order_id not in launcher._processes
 
+    def test_collect_finished_sync_rejects_float_session_exit_code(self):
+        launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        worker = WorkerProcess(
+            work_order_id="wo-sync-float-exit-code",
+            agent="codex",
+            worktree_path="/tmp/wt-sync-float-exit-code",
+            branch="main",
+            pid=919,
+            initial_head="def456",
+            expected_tests=[expected_test],
+        )
+        launcher._workers[worker.work_order_id] = worker
+        proc = MagicMock()
+        proc.returncode = 0
+        launcher._processes[worker.work_order_id] = proc
+
+        session_meta = {
+            "pid": 919,
+            "exit_code": 0.0,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_collect_diff_sync", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output_sync", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas_sync", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths_sync", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push_sync") as mock_push,
+            patch.object(WorkerLauncher, "_run_verification_commands_sync") as mock_verify,
+            patch.object(WorkerLauncher, "_wait_for_pid_exit_sync") as mock_wait_pid,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            completed = launcher.collect_finished_sync(work_order_ids=[worker.work_order_id])
+
+        assert len(completed) == 1
+        result = completed[0]
+        assert result.exit_code == 1
+        assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_called()
+        mock_verify.assert_not_called()
+        mock_wait_pid.assert_called_once_with(919)
+        assert worker.work_order_id not in launcher._processes
+
     def test_collect_finished_sync_rejects_nonstring_session_ended_at(self):
         launcher = WorkerLauncher(LaunchConfig(auto_commit=False))
         expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
@@ -2025,6 +2075,53 @@ class TestCollectDetachedResult:
                 work_order_id="wo-detached-bool-exit-code",
                 agent="codex",
                 worktree_path="/tmp/wt-detached-bool-exit-code",
+                branch="main",
+                pid=24680,
+                initial_head="def456",
+                expected_tests=[expected_test],
+            )
+
+        assert result is not None
+        assert result.exit_code == 1
+        assert result.completed_at == "2026-03-31T12:34:56+00:00"
+        assert result.commit_shas == ["abc123"]
+        assert result.changed_paths == ["file.py"]
+        assert result.tests_run == []
+        assert result.verification_results == []
+        mock_push.assert_not_awaited()
+        mock_verify.assert_not_awaited()
+        mock_wait.assert_awaited_once_with(24680)
+
+    @pytest.mark.asyncio
+    async def test_collect_detached_result_rejects_float_session_exit_code(self):
+        expected_test = "python -m pytest tests/swarm/test_worker_launcher.py -q"
+        session_meta = {
+            "pid": 24680,
+            "exit_code": 0.0,
+            "ended_at": "2026-03-31T12:34:56+00:00",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value=session_meta),
+            patch.object(WorkerLauncher, "_is_pid_running", return_value=False),
+            patch.object(WorkerLauncher, "_collect_diff", return_value="diff --git a/x"),
+            patch.object(WorkerLauncher, "_git_output", return_value="abc123"),
+            patch.object(WorkerLauncher, "_read_log_file", return_value="some output"),
+            patch.object(WorkerLauncher, "_collect_commit_shas", return_value=["abc123"]),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=["file.py"]),
+            patch.object(WorkerLauncher, "_auto_push", new_callable=AsyncMock) as mock_push,
+            patch.object(
+                WorkerLauncher,
+                "_run_verification_commands",
+                new_callable=AsyncMock,
+            ) as mock_verify,
+            patch.object(WorkerLauncher, "_wait_for_pid_exit", new_callable=AsyncMock) as mock_wait,
+            patch.object(WorkerLauncher, "_cleanup_session_artifacts"),
+        ):
+            result = await WorkerLauncher.collect_detached_result(
+                work_order_id="wo-detached-float-exit-code",
+                agent="codex",
+                worktree_path="/tmp/wt-detached-float-exit-code",
                 branch="main",
                 pid=24680,
                 initial_head="def456",
@@ -2661,6 +2758,27 @@ class TestSnapshotProgress:
 
         with (
             patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": True}),
+            patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
+            patch.object(WorkerLauncher, "_git_output", return_value="def456"),
+            patch.object(WorkerLauncher, "_collect_diff", return_value=""),
+            patch.object(WorkerLauncher, "_collect_changed_paths", return_value=[]),
+        ):
+            snapshot = await launcher.snapshot_progress(work_order)
+
+        assert snapshot["pid_alive"] is False
+        mock_running.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_snapshot_progress_ignores_float_session_meta_pid(self, tmp_path: Path):
+        launcher = WorkerLauncher()
+        work_order = {
+            "pid": "oops",
+            "worktree_path": str(tmp_path),
+            "initial_head": "abc123",
+        }
+
+        with (
+            patch.object(WorkerLauncher, "_read_session_meta", return_value={"pid": 24680.0}),
             patch.object(WorkerLauncher, "_is_pid_running") as mock_running,
             patch.object(WorkerLauncher, "_git_output", return_value="def456"),
             patch.object(WorkerLauncher, "_collect_diff", return_value=""),


### PR DESCRIPTION
## Summary\n- reject float PID metadata instead of coercing it through int()\n- reject float session exit codes before they can qualify a terminal marker\n- add regressions for sync, detached, and snapshot-progress paths\n\n## Testing\n- python -m ruff check aragora/swarm/worker_launcher.py tests/swarm/test_worker_launcher.py\n- python -m pytest tests/swarm/test_worker_launcher.py -q -k 'float_session_exit_code or float_session_meta_pid'\n- python -m pytest tests/swarm/test_worker_launcher.py -q\n- python -m pytest tests/swarm/test_supervisor.py -q