### PR TITLE
fix(swarm): block boss loop on active coordination claims

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -26,6 +26,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any
 
+from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.terminal_truth import (
     extract_run_deliverable,
@@ -558,13 +559,47 @@ class BossLoop:
     def _blocked_issue_scopes(self) -> set[str]:
         if not self.config.avoid_open_pr_scope_conflicts:
             return set()
+        blocked = self._coordination_blocked_scopes()
         repo = str(self.config.repo).strip() if isinstance(self.config.repo, str) else ""
         if not repo:
             feed_repo = getattr(self._feed, "repo", None)
             repo = str(feed_repo).strip() if isinstance(feed_repo, str) else ""
         if not repo:
-            return set()
-        return fetch_open_pr_changed_paths(repo=repo)
+            return blocked
+        blocked.update(fetch_open_pr_changed_paths(repo=repo))
+        return blocked
+
+    def _coordination_blocked_scopes(self) -> set[str]:
+        blocked: set[str] = set()
+        try:
+            store = DevCoordinationStore(repo_root=Path.cwd().resolve())
+        except Exception:
+            logger.debug(
+                "Failed to open coordination store for boss-loop scope blocking", exc_info=True
+            )
+            return blocked
+
+        try:
+            for lease in store.list_active_leases():
+                blocked.update(
+                    str(path).strip()
+                    for path in [*lease.claimed_paths, *lease.allowed_globs]
+                    if str(path).strip()
+                )
+        except Exception:
+            logger.debug("Failed to collect active lease scope claims", exc_info=True)
+
+        try:
+            store.fleet_store.reap_stale_claims()
+            blocked.update(
+                str(claim.get("path", "")).strip()
+                for claim in store.fleet_store.list_claims()
+                if isinstance(claim, dict) and str(claim.get("path", "")).strip()
+            )
+        except Exception:
+            logger.debug("Failed to collect active fleet claim scopes", exc_info=True)
+
+        return blocked
 
     def _extract_iteration_metrics(self, worker_result: dict[str, Any]) -> tuple[int, int, int]:
         """Summarize changed files and test verification from a worker run."""

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -255,8 +255,81 @@ class TestBatchIssueSelection:
             raise AssertionError("open PR scope lookup should be skipped without an explicit repo")
 
         monkeypatch.setattr("aragora.swarm.boss_loop.fetch_open_pr_changed_paths", _unexpected)
+        monkeypatch.setattr(loop, "_coordination_blocked_scopes", lambda: set())
 
         assert loop._blocked_issue_scopes() == set()
+
+    def test_blocked_issue_scopes_without_repo_keeps_coordination_claims(self, monkeypatch):
+        loop = BossLoop(_boss_config(repo=None))
+
+        def _unexpected(**kwargs):
+            raise AssertionError("open PR scope lookup should be skipped without an explicit repo")
+
+        monkeypatch.setattr("aragora.swarm.boss_loop.fetch_open_pr_changed_paths", _unexpected)
+        monkeypatch.setattr(
+            loop,
+            "_coordination_blocked_scopes",
+            lambda: {"aragora/swarm/supervisor.py", "tests/swarm/test_supervisor.py"},
+        )
+
+        assert loop._blocked_issue_scopes() == {
+            "aragora/swarm/supervisor.py",
+            "tests/swarm/test_supervisor.py",
+        }
+
+    def test_blocked_issue_scopes_unions_open_pr_and_coordination_claims(self, monkeypatch):
+        loop = BossLoop(_boss_config(repo="synaptent/aragora"))
+        monkeypatch.setattr(
+            loop,
+            "_coordination_blocked_scopes",
+            lambda: {"aragora/swarm/supervisor.py"},
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.boss_loop.fetch_open_pr_changed_paths",
+            lambda **kwargs: {"tests/memory/test_tier_ttl_expiration.py"},
+        )
+
+        assert loop._blocked_issue_scopes() == {
+            "aragora/swarm/supervisor.py",
+            "tests/memory/test_tier_ttl_expiration.py",
+        }
+
+    def test_coordination_blocked_scopes_collects_active_leases_and_claims(self, monkeypatch):
+        loop = BossLoop(_boss_config(repo="synaptent/aragora"))
+
+        class _FakeFleetStore:
+            def __init__(self) -> None:
+                self.reaped = False
+
+            def reap_stale_claims(self) -> dict[str, int]:
+                self.reaped = True
+                return {"released": 1}
+
+            def list_claims(self) -> list[dict[str, str]]:
+                return [
+                    {"path": "tests/memory/test_tier_ttl_expiration.py"},
+                    {"path": "aragora/swarm"},
+                ]
+
+        class _FakeStore:
+            def __init__(self, repo_root) -> None:
+                self.repo_root = repo_root
+                self.fleet_store = _FakeFleetStore()
+
+            def list_active_leases(self):
+                lease = MagicMock()
+                lease.claimed_paths = ["aragora/swarm/boss_loop.py"]
+                lease.allowed_globs = ["tests/swarm/**"]
+                return [lease]
+
+        monkeypatch.setattr("aragora.swarm.boss_loop.DevCoordinationStore", _FakeStore)
+
+        assert loop._coordination_blocked_scopes() == {
+            "aragora/swarm/boss_loop.py",
+            "tests/swarm/**",
+            "tests/memory/test_tier_ttl_expiration.py",
+            "aragora/swarm",
+        }
 
     def test_parallel_selection_skips_conflicting_issue_scopes(self):
         loop = BossLoop(_boss_config(max_parallel_dispatches=3))


### PR DESCRIPTION
## Summary
- block boss-loop issue selection on active coordination lease scopes and live fleet claims
- keep the existing open-PR scope guard and union it with coordination-backed blocked scopes
- add targeted boss-loop tests for repo-less coordination blocking, unioned blocked scopes, and active-claim harvesting

## Validation
- python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m pytest tests/swarm/test_boss_loop.py -q
- post-merge stabilization on main: hotspot ruff, pytest, jest, and tsc all passed