### PR TITLE
Return durable rows from Postgres webhook updates

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -1330,7 +1330,10 @@ class PostgresWebhookConfigStore(WebhookConfigStoreBackend):
                 )
             if result == "UPDATE 0":
                 return None
-            webhook.updated_at = updated_at
+            durable = await self.get_async(webhook_id)
+            if durable is None:
+                return None
+            return durable
 
         return webhook
 

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1799,6 +1799,7 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
     async def test_update_async_returns_durable_revision_timestamp(self) -> None:
         """Returned updated_at should match the durable revision written to Postgres."""
         conn = AsyncMock()
+        conn.execute.return_value = "UPDATE 1"
         acquire_cm = AsyncMock()
         acquire_cm.__aenter__.return_value = conn
         acquire_cm.__aexit__.return_value = False
@@ -1814,22 +1815,73 @@ class TestPostgresWebhookConfigStoreSyncWrappers:
             updated_at=100.0,
         )
         revised_at = 200.0
+        durable = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/new",
+            events=["debate_end"],
+            secret="secret",
+            updated_at=revised_at,
+        )
+        get_async = AsyncMock(side_effect=[original, durable])
 
         with (
-            patch.object(store, "get_async", AsyncMock(return_value=original)),
-            patch(
-                "aragora.storage.webhook_config_store.time.time",
-                side_effect=[revised_at, revised_at + 1],
-            ),
+            patch.object(store, "get_async", get_async),
+            patch("aragora.storage.webhook_config_store.time.time", return_value=revised_at),
         ):
             updated = await store.update_async("webhook-123", url="https://example.com/new")
 
         assert updated is not None
         assert updated.url == "https://example.com/new"
         assert updated.updated_at == revised_at
+        assert get_async.await_count == 2
         query, *params = conn.execute.await_args.args
         assert "updated_at = to_timestamp($2)" in query
         assert params == ["https://example.com/new", revised_at, "webhook-123"]
+
+    @pytest.mark.asyncio
+    async def test_update_async_returns_durable_boolean_state_after_postgres_coercion(self) -> None:
+        """Returned active flag should reflect durable Postgres truth, not the input payload type."""
+        conn = AsyncMock()
+        conn.execute.return_value = "UPDATE 1"
+        acquire_cm = AsyncMock()
+        acquire_cm.__aenter__.return_value = conn
+        acquire_cm.__aexit__.return_value = False
+        pool = MagicMock()
+        pool.acquire.return_value = acquire_cm
+        store = PostgresWebhookConfigStore(pool)
+
+        original = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/hook",
+            events=["debate_end"],
+            secret="secret",
+            active=True,
+            updated_at=100.0,
+        )
+        revised_at = 200.0
+        durable = WebhookConfig(
+            id="webhook-123",
+            url="https://example.com/hook",
+            events=["debate_end"],
+            secret="secret",
+            active=False,
+            updated_at=revised_at,
+        )
+        get_async = AsyncMock(side_effect=[original, durable])
+
+        with (
+            patch.object(store, "get_async", get_async),
+            patch("aragora.storage.webhook_config_store.time.time", return_value=revised_at),
+        ):
+            updated = await store.update_async("webhook-123", active="false")
+
+        assert updated is not None
+        assert updated.active is False
+        assert updated.updated_at == revised_at
+        assert get_async.await_count == 2
+        query, *params = conn.execute.await_args.args
+        assert "active = $1" in query
+        assert params == ["false", revised_at, "webhook-123"]
 
     @pytest.mark.asyncio
     async def test_update_async_returns_none_when_row_is_deleted_before_write(self) -> None:


### PR DESCRIPTION
## Summary\n- return the authoritative Postgres row after a successful webhook update\n- keep returned fields like active and updated_at aligned with durable truth\n- add regressions for durable revision and Postgres boolean coercion\n\n## Testing\n- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py\n- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'durable_boolean_state_after_postgres_coercion or durable_revision_timestamp'\n- python -m pytest tests/storage/test_webhook_config_store.py -q