### PR TITLE
fix(swarm): clear stale lease metadata for blocked workers

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -4442,6 +4442,8 @@ class SwarmSupervisor:
             failure_reason="worker_type_blocked",
         )
         self._release_terminal_lease(item)
+        item.pop("lease_id", None)
+        item.pop("owner_session_id", None)
 
     @staticmethod
     def _mark_dispatch_failed(item: dict[str, Any], reason: str) -> None:

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -5116,6 +5116,8 @@ async def test_dispatch_workers_marks_needs_human_when_all_worker_types_blocked(
     assert work_order["failure_reason"] == "worker_type_blocked"
     assert "worker type or capacity issue" in work_order["blocking_question"]
     for key in (
+        "lease_id",
+        "owner_session_id",
         "receipt_id",
         "confidence",
         "worker_outcome",


### PR DESCRIPTION
## Summary
- clear stale lease and owner-session metadata after worker-type-blocked transitions
- preserve store-side lease release before removing the work-order metadata
- extend the blocked-worker supervisor test to assert stale lease cleanup

## Validation
- python3 -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python3 -m pytest tests/swarm/test_supervisor.py -q -k worker_types_blocked
- python3 -m pytest tests/swarm/test_supervisor.py -q -k 'worker_types_blocked or dispatch_failed_clears_stale_deliverable_state'