### PR TITLE
Reject malformed Slack workspace fields

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1238,7 +1238,6 @@ class SlackOAuthHandler(SecureHandler):
             return error_response("Invalid response from Slack", 500)
         team_payload = data.get("team")
         team = team_payload if isinstance(team_payload, dict) else {}
-        bot_user_id = data.get("bot_user_id", "")
         authed_user_payload = data.get("authed_user")
         authed_user = authed_user_payload if isinstance(authed_user_payload, dict) else {}
         raw_scope = data.get("scope", "")

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -1014,6 +1014,34 @@ class TestCallback:
         assert "invalid response from slack" in body.get("error", "").lower()
 
     @pytest.mark.asyncio
+    async def test_callback_rejects_nonstring_top_level_workspace_identity(self, handler):
+        mock_client, _ = _make_httpx_mock(
+            {
+                "ok": True,
+                "access_token": "xoxb-new-token",
+                "team": "not-a-dict",
+                "workspace_id": {"id": "W123"},
+                "workspace_name": "Top Level Team",
+                "bot_user_id": "B789",
+                "scope": "channels:history,chat:write",
+            }
+        )
+
+        with patch("httpx.AsyncClient", return_value=mock_client):
+            result = await handler.handle(
+                "GET",
+                "/api/integrations/slack/callback",
+                {},
+                {"code": "test-code", "state": "test-state-token-abc123"},
+                {},
+                None,
+            )
+
+        assert _status(result) == 500
+        body = _body(result)
+        assert "invalid response from slack" in body.get("error", "").lower()
+
+    @pytest.mark.asyncio
     async def test_callback_rejects_nonstring_bot_user_id(self, handler):
         mock_client, _ = _make_httpx_mock(
             {


### PR DESCRIPTION
## Summary\n- reject non-string callback workspace identity fields instead of stringifying them\n- reject malformed bot_user_id values before persisting workspace credentials\n- add focused callback regressions for non-string workspace_id and bot_user_id\n\n## Testing\n- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q -k 'nonstring_top_level_workspace_identity or nonstring_bot_user_id'\n- python -m pytest tests/handlers/social/test_slack_oauth.py -q\n- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q