### PR TITLE
Log boss loop configured and effective parallelism

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -1566,8 +1566,14 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 else "none"
             )
             stop = status_dict.get("stop_reason")
+            configured_parallel = status_dict.get("configured_max_parallel_dispatches")
+            effective_parallel = status_dict.get("effective_parallel_dispatches")
+            parallel_text = ""
+            if configured_parallel is not None:
+                effective_text = str(effective_parallel) if effective_parallel is not None else "?"
+                parallel_text = f" parallel={configured_parallel}/{effective_text}"
             print(
-                f"[iter {iteration}] worker={worker} issue={issue_text}"
+                f"[iter {iteration}] worker={worker} issue={issue_text}{parallel_text}"
                 + (f" stop={stop}" if stop else "")
             )
             for action_text in status_dict.get("next_actions", [])[:2]:
@@ -1583,7 +1589,9 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 f"attempted={len(result.issues_attempted)} "
                 f"completed={len(result.issues_completed)} "
                 f"failed={len(result.issues_failed)} "
-                f"elapsed={result.total_elapsed_seconds:.1f}s"
+                f"elapsed={result.total_elapsed_seconds:.1f}s "
+                f"parallel={result.configured_max_parallel_dispatches}/"
+                f"{result.effective_parallel_dispatches_observed if result.effective_parallel_dispatches_observed is not None else '?'}"
             )
             for reason in result.needs_human_reasons[:3]:
                 print(f"  needs_human: {reason}")

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -108,6 +108,8 @@ class BossIterationStatus:
     elapsed_seconds: float = 0.0
     error: str | None = None
     worker_outcome: str | None = None
+    configured_max_parallel_dispatches: int | None = None
+    effective_parallel_dispatches: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         result: dict[str, Any] = {
@@ -122,6 +124,8 @@ class BossIterationStatus:
             "next_actions": list(self.next_actions),
             "elapsed_seconds": self.elapsed_seconds,
             "error": self.error,
+            "configured_max_parallel_dispatches": self.configured_max_parallel_dispatches,
+            "effective_parallel_dispatches": self.effective_parallel_dispatches,
         }
         if self.worker_outcome is not None:
             result["worker_outcome"] = self.worker_outcome
@@ -142,6 +146,8 @@ class BossLoopResult:
     iteration_statuses: list[dict[str, Any]]
     needs_human_reasons: list[str]
     next_actions: list[str]
+    configured_max_parallel_dispatches: int = 1
+    effective_parallel_dispatches_observed: int | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -156,6 +162,8 @@ class BossLoopResult:
             "iteration_statuses": list(self.iteration_statuses),
             "needs_human_reasons": list(self.needs_human_reasons),
             "next_actions": list(self.next_actions),
+            "configured_max_parallel_dispatches": self.configured_max_parallel_dispatches,
+            "effective_parallel_dispatches_observed": self.effective_parallel_dispatches_observed,
         }
 
 
@@ -539,6 +547,9 @@ class BossLoop:
     ) -> None:
         self.config = config or BossLoopConfig()
         self.run_id = f"boss-{uuid.uuid4().hex[:12]}"
+        self._configured_parallel_dispatches = max(1, int(self.config.max_parallel_dispatches or 1))
+        self._current_effective_parallel_dispatches: int | None = None
+        self._max_effective_parallel_dispatches_observed: int | None = None
         self._feed = issue_feed or GitHubIssueFeed(
             repo=self.config.repo,
             label_filter=self.config.label_filter,
@@ -555,6 +566,26 @@ class BossLoop:
         self._issue_attempt_counts: dict[int | str, int] = {}
         self._pending_handoff_prompts: dict[int, tuple[str, str | None]] = {}
         self._stop_reason: str | None = None
+
+    def _decorate_iteration_status(
+        self,
+        status: BossIterationStatus,
+        *,
+        effective_parallel_dispatches: int | None = None,
+    ) -> BossIterationStatus:
+        if status.configured_max_parallel_dispatches is None:
+            status.configured_max_parallel_dispatches = self._configured_parallel_dispatches
+        effective = effective_parallel_dispatches
+        if effective is None:
+            effective = self._current_effective_parallel_dispatches
+        if status.effective_parallel_dispatches is None:
+            status.effective_parallel_dispatches = effective
+        if status.effective_parallel_dispatches is not None:
+            self._max_effective_parallel_dispatches_observed = max(
+                int(status.effective_parallel_dispatches),
+                int(self._max_effective_parallel_dispatches_observed or 0),
+            )
+        return status
 
     def _blocked_issue_scopes(self) -> set[str]:
         if not self.config.avoid_open_pr_scope_conflicts:
@@ -965,6 +996,7 @@ class BossLoop:
                     "max_retries_per_issue": self.config.max_retries_per_issue,
                     "max_consecutive_failures": self.config.max_consecutive_failures,
                     "budget_limit_usd": self.config.budget_limit_usd,
+                    "configured_max_parallel_dispatches": result.configured_max_parallel_dispatches,
                 },
                 outputs={
                     "iterations_completed": result.iterations_completed,
@@ -972,6 +1004,9 @@ class BossLoop:
                     "issues_attempted": attempted,
                     "issues_completed": completed,
                     "issues_failed": failed,
+                    "effective_parallel_dispatches_observed": (
+                        result.effective_parallel_dispatches_observed
+                    ),
                     "needs_human_reasons": list(result.needs_human_reasons),
                     "next_actions": list(result.next_actions),
                 },
@@ -1994,10 +2029,10 @@ class BossLoop:
         except Exception:
             logger.debug("Boss lane telemetry emission skipped", exc_info=True)
 
-    @staticmethod
-    def _emit_live_status(on_status: Any | None, status: BossIterationStatus) -> None:
+    def _emit_live_status(self, on_status: Any | None, status: BossIterationStatus) -> None:
         if on_status is None:
             return
+        status = self._decorate_iteration_status(status)
         try:
             on_status(status)
         except Exception:
@@ -2019,6 +2054,10 @@ class BossLoop:
         """
         start_time = time.monotonic()
         iteration = 0
+        logger.info(
+            "Boss loop starting: configured_max_parallel_dispatches=%d",
+            self._configured_parallel_dispatches,
+        )
 
         # Clean stale supervisor runs that would block dispatch via
         # duplicate_open_work_order detection.  Previous runs with
@@ -2050,6 +2089,7 @@ class BossLoop:
             self._refresh_runner_heartbeats()
 
             statuses = await self._run_iteration_statuses(iteration, on_status=on_status)
+            statuses = [self._decorate_iteration_status(status) for status in statuses]
             self._iteration_statuses.extend(statuses)
 
             for status in statuses:
@@ -2100,6 +2140,8 @@ class BossLoop:
             iteration_statuses=[s.to_dict() for s in self._iteration_statuses],
             needs_human_reasons=self._collect_needs_human_reasons(),
             next_actions=self._derive_next_actions(),
+            configured_max_parallel_dispatches=self._configured_parallel_dispatches,
+            effective_parallel_dispatches_observed=self._max_effective_parallel_dispatches_observed,
         )
         self._emit_terminal_receipt(result)
         return result
@@ -2124,6 +2166,7 @@ class BossLoop:
         now = datetime.now(UTC).isoformat()
         iter_start = time.monotonic()
         freshness_dict: dict[str, Any] = {}
+        self._current_effective_parallel_dispatches = 1
         # Step 1: Fetch issues from GitHub
         try:
             issues = self._feed.fetch()
@@ -2299,6 +2342,7 @@ class BossLoop:
         now = datetime.now(UTC).isoformat()
         iter_start = time.monotonic()
         freshness_dict: dict[str, Any] = {}
+        self._current_effective_parallel_dispatches = None
 
         try:
             issues = self._feed.fetch()
@@ -2405,6 +2449,13 @@ class BossLoop:
             ]
 
         parallel_limit = self._parallel_dispatch_limit(freshness)
+        self._current_effective_parallel_dispatches = parallel_limit
+        logger.info(
+            "Boss loop iteration %d parallel dispatches: configured=%d effective=%d",
+            iteration,
+            self._configured_parallel_dispatches,
+            parallel_limit,
+        )
         pending_issues = list(selected_issues)
         active_tasks: dict[
             asyncio.Task[dict[str, Any]], tuple[GitHubIssue, dict[str, Any], float]

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1630,6 +1630,8 @@ class TestBossLoop:
         assert len(statuses) == 1
         assert isinstance(statuses[0], BossIterationStatus)
         assert statuses[0].iteration == 1
+        assert statuses[0].configured_max_parallel_dispatches == 1
+        assert statuses[0].effective_parallel_dispatches == 1
 
     @pytest.mark.asyncio
     async def test_on_status_callback_emits_dispatching_before_final_status(self):
@@ -1650,7 +1652,12 @@ class TestBossLoop:
         assert statuses[0].selected_issue["number"] == 1749
         assert statuses[1].selected_issue["number"] == 1749
         assert statuses[0].next_actions == ["Dispatching issue #1749 with codex."]
+        assert statuses[0].configured_max_parallel_dispatches == 1
+        assert statuses[0].effective_parallel_dispatches == 1
+        assert statuses[1].effective_parallel_dispatches == 1
         assert [status["worker_status"] for status in result.iteration_statuses] == ["completed"]
+        assert result.configured_max_parallel_dispatches == 1
+        assert result.effective_parallel_dispatches_observed == 1
 
     def test_successful_completion_resets_consecutive_failures(self):
         feed = MagicMock(spec=GitHubIssueFeed)
@@ -1875,6 +1882,8 @@ class TestStatusPayloadShape:
         assert "needs_human_reasons" in payload
         assert "next_actions" in payload
         assert "elapsed_seconds" in payload
+        assert "configured_max_parallel_dispatches" in payload
+        assert "effective_parallel_dispatches" in payload
 
     def test_loop_result_has_required_fields(self):
         result = BossLoopResult(
@@ -1902,6 +1911,8 @@ class TestStatusPayloadShape:
         assert "iteration_statuses" in payload
         assert "needs_human_reasons" in payload
         assert "next_actions" in payload
+        assert "configured_max_parallel_dispatches" in payload
+        assert "effective_parallel_dispatches_observed" in payload
 
     def test_loop_result_is_json_serializable(self):
         result = BossLoopResult(
@@ -1926,6 +1937,8 @@ class TestStatusPayloadShape:
         parsed = json.loads(serialized)
         assert parsed["mode"] == "boss-loop"
         assert parsed["run_id"] == "boss-test-789"
+        assert parsed["configured_max_parallel_dispatches"] == 1
+        assert parsed["effective_parallel_dispatches_observed"] is None
 
     def test_freshness_result_serializable(self):
         result = _fresh_result(fresh=True)
@@ -2145,6 +2158,7 @@ class TestBossLoopCLI:
         assert "Boss loop finished" in out
         assert "no_fresh_runner" in out
         assert "iterations=1" in out
+        assert "parallel=1/1" in out
 
     def test_boss_loop_parser_accepts_action(self):
         from aragora.cli.parser import build_parser
@@ -2979,6 +2993,8 @@ class TestBossLoopFixtureInvocation:
         assert payload["iterations_completed"] == 1
         assert payload["stop_reason"] == "max_iterations"
         assert len(payload["issues_completed"]) == 1
+        assert payload["configured_max_parallel_dispatches"] == 1
+        assert payload["effective_parallel_dispatches_observed"] == 1
         assert payload["issues_completed"][0]["number"] in {100, 200}
         assert payload["issues_completed"][0]["title"] in {
             "Add retry to aragora/resilience/retry.py",
@@ -3011,6 +3027,8 @@ class TestBossLoopFixtureInvocation:
         assert "run_id" in payload2
         assert isinstance(payload2["next_actions"], list)
         assert len(payload2["next_actions"]) > 0
+        assert payload2["configured_max_parallel_dispatches"] == 1
+        assert payload2["effective_parallel_dispatches_observed"] == 1
 
 
 def test_boss_loop_batch_no_issue_skips_runner_freshness_check() -> None:
@@ -3028,6 +3046,40 @@ def test_boss_loop_batch_no_issue_skips_runner_freshness_check() -> None:
 
     assert result.stop_reason == "no_suitable_issue"
     assert result.iterations_completed == 1
+
+
+def test_boss_loop_batch_reports_effective_parallel_dispatches() -> None:
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [
+        _make_issue(301, "Batch issue A"),
+        _make_issue(302, "Batch issue B"),
+    ]
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_parallel_dispatches=2),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: RunnerFreshnessResult(
+            fresh=True,
+            runner_ids=["codex-runner-1", "codex-runner-2"],
+            checked_at=datetime.now(UTC).isoformat(),
+            details={
+                "routing": {
+                    "selected_runners": [
+                        {"runner_id": "codex-runner-1", "available_capacity": 1},
+                        {"runner_id": "codex-runner-2", "available_capacity": 1},
+                    ]
+                }
+            },
+        ),
+    )
+    loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+    statuses: list[BossIterationStatus] = []
+    result = asyncio.run(loop.run(on_status=statuses.append))
+
+    assert result.configured_max_parallel_dispatches == 2
+    assert result.effective_parallel_dispatches_observed == 2
+    assert {status.effective_parallel_dispatches for status in statuses} == {2}
+    assert {status["effective_parallel_dispatches"] for status in result.iteration_statuses} == {2}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add configured/effective parallel dispatch fields to boss-loop status and result payloads
- include parallelism in CLI text output and operational receipts
- add focused tests for single-lane and batch observability

## Validation
- python3 -m ruff check aragora/swarm/boss_loop.py aragora/cli/commands/swarm.py tests/swarm/test_boss_loop.py
- python3 -m pytest -q tests/swarm/test_boss_loop.py -k "status_payload_shape or on_status_callback or boss_loop_text_output or fixture_boss_loop_selects_task_or_blocks or batch_reports_effective_parallel_dispatches or batch_no_issue_skips_runner_freshness_check"