### PR TITLE
fix(automation): limit codex publisher fanout

### DIFF
--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -20,6 +20,8 @@ from typing import Any
 
 UTC = timezone.utc
 DEFAULT_SINCE_HOURS = 72
+DEFAULT_PUBLISH_LIMIT = 1
+DEFAULT_MAX_OPEN_PRS = 1
 CODEX_BRANCH_PREFIX = "codex/"
 ACTIVE_SESSION_FILES = (
     ".claude-session-active",
@@ -454,13 +456,13 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--limit",
         type=int,
-        default=5,
+        default=DEFAULT_PUBLISH_LIMIT,
         help="Maximum number of eligible branches to publish in one apply run",
     )
     parser.add_argument(
         "--max-open-prs",
         type=int,
-        default=3,
+        default=DEFAULT_MAX_OPEN_PRS,
         help="Maximum number of open codex PRs allowed before publishing pauses",
     )
     parser.add_argument(

--- a/scripts/run_codex_automation_publisher.sh
+++ b/scripts/run_codex_automation_publisher.sh
@@ -31,5 +31,5 @@ if ! gh auth status >/dev/null 2>&1; then
 fi
 
 echo "$(STAMP) [codex-automation-publisher] starting publish pass"
-python3 scripts/publish_codex_automation_branches.py --apply --limit 3 --json
+python3 scripts/publish_codex_automation_branches.py --apply --limit 1 --max-open-prs 1 --json
 echo "$(STAMP) [codex-automation-publisher] publish pass complete"

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -10,6 +10,7 @@ from scripts.publish_codex_automation_branches import (
     BranchSnapshot,
     WorktreeSnapshot,
     _worktree_is_dirty,
+    _build_parser,
     select_publishable_branches,
 )
 
@@ -62,6 +63,13 @@ def test_select_publishable_branches_marks_recent_clean_branch_eligible() -> Non
     assert len(decisions) == 1
     assert decisions[0].eligible is True
     assert decisions[0].reason == "eligible"
+
+
+def test_parser_defaults_to_single_branch_publish_budget() -> None:
+    args = _build_parser().parse_args([])
+
+    assert args.limit == 1
+    assert args.max_open_prs == 1
 
 
 def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() -> None:


### PR DESCRIPTION
## Summary
- reduce the codex automation publisher default budget to one branch per pass and one open codex PR at a time
- make the wrapper script pass the same one-at-a-time budget explicitly
- add a parser default regression test so the publish budget cannot drift back silently

## Validation
- python3 -m ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- python3 -m ruff format --check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py
- python3 -m pytest -q tests/scripts/test_publish_codex_automation_branches.py