### PR TITLE
fix(pipeline): narrow receipt gate exception handling

### DIFF
--- a/aragora/pipeline/receipt_gate.py
+++ b/aragora/pipeline/receipt_gate.py
@@ -140,13 +140,13 @@ def _resolve_backbone_run(plan: Any, plan_store: Any | None = None) -> Any | Non
             from aragora.pipeline.plan_store import get_plan_store
 
             store = get_plan_store()
-        except Exception:  # noqa: BLE001 - gating must degrade safely
-            logger.debug("Backbone run store unavailable during execution gate lookup")
+        except (ImportError, RuntimeError, OSError, TypeError, ValueError) as exc:
+            logger.warning("Backbone run store unavailable during execution gate lookup: %s", exc)
             return None
     try:
         return store.get_run(run_id)
-    except Exception:  # noqa: BLE001 - treat missing run as absent evidence
-        logger.debug("Backbone run lookup failed for %s", run_id, exc_info=True)
+    except (RuntimeError, OSError, TypeError, ValueError) as exc:
+        logger.warning("Backbone run lookup failed for %s: %s", run_id, exc)
         return None
 
 

--- a/tests/pipeline/test_receipt_gate.py
+++ b/tests/pipeline/test_receipt_gate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,6 +21,7 @@ from aragora.pipeline.plan_store import PlanStore
 from aragora.pipeline.receipt_gate import (
     PlanExecutionGateError,
     PlanReceiptGateError,
+    _resolve_backbone_run,
     ensure_plan_receipt,
 )
 
@@ -91,6 +93,39 @@ def test_existing_tampered_receipt_fails_closed() -> None:
 
     with pytest.raises(PlanReceiptGateError, match="signature verification"):
         ensure_plan_receipt(plan)
+
+
+def test_resolve_backbone_run_logs_warning_when_store_import_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plan = _plan(metadata={"backbone_run_id": "run-missing-store"})
+
+    with (
+        patch(
+            "aragora.pipeline.plan_store.get_plan_store",
+            side_effect=RuntimeError("store unavailable"),
+        ),
+        caplog.at_level(logging.WARNING),
+    ):
+        assert _resolve_backbone_run(plan) is None
+
+    assert (
+        "Backbone run store unavailable during execution gate lookup: store unavailable"
+        in caplog.text
+    )
+
+
+def test_resolve_backbone_run_logs_warning_when_lookup_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    plan = _plan(metadata={"backbone_run_id": "run-lookup-fail"})
+    store = MagicMock()
+    store.get_run.side_effect = RuntimeError("lookup unavailable")
+
+    with caplog.at_level(logging.WARNING):
+        assert _resolve_backbone_run(plan, plan_store=store) is None
+
+    assert "Backbone run lookup failed for run-lookup-fail: lookup unavailable" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace the two broad receipt_gate exception catches with specific degradation-safe tuples
- emit structured warning logs for store import and run lookup failures
- add focused receipt-gate tests that pin the warning paths

Closes #2505