### PR TITLE
fix: reject malformed cached webhook activity flags

### DIFF
--- a/aragora/storage/webhook_config_store.py
+++ b/aragora/storage/webhook_config_store.py
@@ -839,6 +839,8 @@ class RedisWebhookConfigStore(WebhookConfigStoreBackend):
     def _deserialize_from_cache(payload: str) -> WebhookConfig:
         """Deserialize cache entries, decrypting cached secrets when present."""
         data = json.loads(payload)
+        if data.get("active") is not True and data.get("active") is not False:
+            raise ValueError("cached webhook active flag must be boolean")
         secret = str(data.get("secret") or "").strip()
         if secret:
             data["secret"] = _decrypt_secret(secret)

--- a/tests/storage/test_webhook_config_store.py
+++ b/tests/storage/test_webhook_config_store.py
@@ -1435,6 +1435,32 @@ class TestRedisWebhookConfigStore:
         mock_redis.setex.assert_called_once()
         store.close()
 
+    def test_with_mocked_redis_get_rejects_nonboolean_cached_active_flag(self, tmp_path):
+        """Malformed cached activity flags must not override SQLite truth."""
+        db_path = tmp_path / "test.db"
+        store = RedisWebhookConfigStore(db_path)
+
+        mock_redis = MagicMock()
+        mock_redis.ping.return_value = True
+        store._redis = mock_redis
+        store._redis_checked = True
+
+        webhook = store._sqlite.register(url="https://example.com", events=["debate_end"])
+        inactive = store._sqlite.update(webhook.id, active=False)
+        assert inactive is not None
+
+        cached_payload = inactive.to_dict(include_secret=True)
+        cached_payload["active"] = "false"
+        mock_redis.get.return_value = json.dumps(cached_payload)
+
+        retrieved = store.get(webhook.id)
+
+        assert retrieved is not None
+        assert retrieved.active is False
+        mock_redis.get.assert_called_once_with(f"aragora:webhook_configs:{webhook.id}")
+        mock_redis.setex.assert_called_once()
+        store.close()
+
     def test_with_mocked_redis_get_cache_miss(self, tmp_path):
         """Test get falls back to SQLite on cache miss and populates cache."""
         db_path = tmp_path / "test.db"


### PR DESCRIPTION
## Summary
- require Redis-cached webhook activity flags to be real booleans
- treat malformed cached active values as invalid cache entries and repair from SQLite truth
- add a regression for inactive webhooks cached with a string activity flag

## Testing
- python -m ruff check aragora/storage/webhook_config_store.py tests/storage/test_webhook_config_store.py
- python -m pytest tests/storage/test_webhook_config_store.py -q -k 'nonboolean_cached_active_flag'
- python -m pytest tests/storage/test_webhook_config_store.py -q