### PR TITLE
fix(boss-loop): use configured parallel limit when runners lack capacity data

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -2566,12 +2566,19 @@ class BossLoop:
         if not isinstance(selected_runners, list):
             return configured_limit
         available_capacity = 0
+        any_capacity_reported = False
         for item in selected_runners:
             if not isinstance(item, dict):
                 continue
-            available_capacity += max(0, int(item.get("available_capacity", 0) or 0))
-        if available_capacity <= 0:
-            return 1
+            cap = max(0, int(item.get("available_capacity", 0) or 0))
+            if cap > 0:
+                any_capacity_reported = True
+            available_capacity += cap
+        if not any_capacity_reported:
+            # Runners are selected (passed eligibility) but none report explicit
+            # capacity — trust the configured parallel limit instead of degrading
+            # to serial dispatch.
+            return configured_limit
         return max(1, min(configured_limit, available_capacity))
 
     @staticmethod

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3082,6 +3082,45 @@ def test_boss_loop_batch_reports_effective_parallel_dispatches() -> None:
     assert {status["effective_parallel_dispatches"] for status in result.iteration_statuses} == {2}
 
 
+def test_boss_loop_batch_uses_configured_limit_when_no_capacity_reported() -> None:
+    """When selected runners don't report available_capacity, the configured
+    max_parallel_dispatches should be used instead of falling back to serial."""
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [
+        _make_issue(401, "Batch issue X"),
+        _make_issue(402, "Batch issue Y"),
+        _make_issue(403, "Batch issue Z"),
+        _make_issue(404, "Batch issue W"),
+    ]
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_parallel_dispatches=4),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: RunnerFreshnessResult(
+            fresh=True,
+            runner_ids=["max-01", "max-02", "max-03", "max-04"],
+            checked_at=datetime.now(UTC).isoformat(),
+            details={
+                "routing": {
+                    "selected_runners": [
+                        {"runner_id": "max-01", "available_capacity": 0},
+                        {"runner_id": "max-02", "available_capacity": 0},
+                        {"runner_id": "max-03"},
+                        {"runner_id": "max-04"},
+                    ]
+                }
+            },
+        ),
+    )
+    loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+    statuses: list[BossIterationStatus] = []
+    result = asyncio.run(loop.run(on_status=statuses.append))
+
+    assert result.configured_max_parallel_dispatches == 4
+    assert result.effective_parallel_dispatches_observed == 4
+    assert {status.effective_parallel_dispatches for status in statuses} == {4}
+
+
 # ---------------------------------------------------------------------------
 # _classify_terminal_run_outcome regression tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_parallel_dispatch_limit` in `boss_loop.py` was falling back to serial dispatch (1) when selected runners didn't report `available_capacity` or all reported 0 (because `max_parallel_lanes` wasn't configured in their capabilities)
- Since runners in `selected_runners` already passed eligibility checks in the registry, the configured `max_parallel_dispatches` is the correct governing constraint when capacity data is absent
- Adds a regression test with runners that have zero/missing `available_capacity` to verify the configured limit is used

## Test plan
- [x] New test `test_boss_loop_batch_uses_configured_limit_when_no_capacity_reported` passes
- [x] Existing test `test_boss_loop_batch_reports_effective_parallel_dispatches` still passes (capacity IS reported)
- [x] Full boss loop test suite (126 tests) passes
- [x] Pre-existing failure in `test_boss_loop_autonomy.py` confirmed unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)