### PR TITLE
fix(ci): honor explicit v1 scope expansion marker

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -680,6 +680,15 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Derive V1 scope expansion override
+        shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "${PR_BODY:-}" | grep -q 'ARAGORA_ALLOW_SCOPE_EXPANSION=1'; then
+            echo "ARAGORA_ALLOW_SCOPE_EXPANSION=1" >> "$GITHUB_ENV"
+          fi
+
       - name: Enforce V1 scope lock
         run: |
           python scripts/check_v1_scope_lock.py \

--- a/scripts/check_v1_scope_lock.py
+++ b/scripts/check_v1_scope_lock.py
@@ -26,6 +26,7 @@ BLOCKED_PREFIXES = (
     "aragora/server/handlers/features/plugins.py",
     "aragora/blockchain/contracts/staking.py",
 )
+SCOPE_EXPANSION_MARKER = "ARAGORA_ALLOW_SCOPE_EXPANSION=1"
 
 
 def _is_truthy(value: str | None) -> bool:
@@ -94,7 +95,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if _is_truthy(os.environ.get("ARAGORA_ALLOW_SCOPE_EXPANSION")):
-        print("V1 scope lock gate bypassed via ARAGORA_ALLOW_SCOPE_EXPANSION")
+        print(f"V1 scope lock gate bypassed via {SCOPE_EXPANSION_MARKER}")
         return 0
 
     lock_file = Path(args.lock_file)
@@ -121,8 +122,9 @@ def main(argv: list[str] | None = None) -> int:
         for path in violations:
             print(f"  - {path}", file=sys.stderr)
         print(
-            "If scope expansion is intentional, set ARAGORA_ALLOW_SCOPE_EXPANSION=1 "
-            "and document rationale in PR description.",
+            f"If scope expansion is intentional, add `{SCOPE_EXPANSION_MARKER}` "
+            "and rationale to the PR description, or set the same environment variable "
+            "when running the gate intentionally.",
             file=sys.stderr,
         )
         return 1

--- a/tests/scripts/test_check_v1_scope_lock.py
+++ b/tests/scripts/test_check_v1_scope_lock.py
@@ -41,6 +41,7 @@ def test_scope_lock_fails_for_blocked_prefix() -> None:
     assert result.returncode == 1
     assert "violation" in result.stderr.lower()
     assert "social/slack.py" in result.stderr
+    assert "ARAGORA_ALLOW_SCOPE_EXPANSION=1" in result.stderr
 
 
 def test_scope_lock_can_be_overridden_by_env() -> None:


### PR DESCRIPTION
## Summary
- honor an explicit `ARAGORA_ALLOW_SCOPE_EXPANSION=1` marker in pull request bodies during the V1 scope lock workflow
- make the scope-lock script error message point at the exact marker reviewers should use
- keep the override opt-in and explicit rather than silently widening blocked prefixes

## Testing
- python3 -m ruff check scripts/check_v1_scope_lock.py tests/scripts/test_check_v1_scope_lock.py
- python3 -m ruff format --check scripts/check_v1_scope_lock.py tests/scripts/test_check_v1_scope_lock.py
- python3 -m pytest -q tests/scripts/test_check_v1_scope_lock.py