### PR TITLE
feat(spectate): theme-aware spectate pages

### DIFF
--- a/aragora/live/src/app/(app)/spectate/[debateId]/SpectateClient.tsx
+++ b/aragora/live/src/app/(app)/spectate/[debateId]/SpectateClient.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useCallback, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { WS_URL } from '@/config';
-import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { ThemeEffects } from '@/components/ThemeEffects';
 import { useRightSidebar } from '@/context/RightSidebarContext';
 import { TimelineView } from '@/components/spectate/TimelineView';
 import { SummaryView } from '@/components/spectate/SummaryView';
@@ -157,10 +157,10 @@ export default function SpectateClient() {
             <span
               className={`text-sm font-theme-data ${
                 connectionStatus === 'connected'
-                  ? 'text-green-400'
+                  ? 'text-success'
                   : connectionStatus === 'error'
-                    ? 'text-red-400'
-                    : 'text-yellow-400'
+                    ? 'text-crimson'
+                    : 'text-warning'
               }`}
             >
               {connectionStatus.toUpperCase()}
@@ -172,7 +172,7 @@ export default function SpectateClient() {
         <div className="space-y-2">
           <Link
             href="/spectate"
-            className="block w-full px-3 py-2 text-xs font-theme-data text-center bg-[var(--surface)] text-[var(--text-muted)] border border-[var(--border)] hover:border-[var(--acid-green)]/30 transition-colors"
+            className="block w-full px-3 py-2 text-xs font-theme-data text-center btn-theme-secondary"
           >
             ← BACK TO LIST
           </Link>
@@ -180,8 +180,8 @@ export default function SpectateClient() {
             onClick={() => setAutoScroll(!autoScroll)}
             className={`block w-full px-3 py-2 text-xs font-theme-data text-center border transition-colors ${
               autoScroll
-                ? 'bg-[var(--acid-green)]/10 text-[var(--acid-green)] border-[var(--acid-green)]/30'
-                : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)]'
+                ? 'bg-accent/10 text-accent border-accent/30'
+                : 'bg-surface text-text-muted border-border'
             }`}
           >
             AUTO-SCROLL {autoScroll ? 'ON' : 'OFF'}
@@ -190,8 +190,8 @@ export default function SpectateClient() {
             onClick={() => setShowTimestamps(!showTimestamps)}
             className={`block w-full px-3 py-2 text-xs font-theme-data text-center border transition-colors ${
               showTimestamps
-                ? 'bg-[var(--acid-cyan)]/10 text-[var(--acid-cyan)] border-[var(--acid-cyan)]/30'
-                : 'bg-[var(--surface)] text-[var(--text-muted)] border-[var(--border)]'
+                ? 'bg-acid-cyan/10 text-acid-cyan border-acid-cyan/30'
+                : 'bg-surface text-text-muted border-border'
             }`}
           >
             TIMESTAMPS {showTimestamps ? 'ON' : 'OFF'}
@@ -228,8 +228,7 @@ export default function SpectateClient() {
 
   return (
     <>
-      <Scanlines opacity={0.02} />
-      <CRTVignette />
+      <ThemeEffects opacity={0.02} />
 
       <main className="min-h-screen bg-bg text-text relative z-10">
         <div className="max-w-6xl mx-auto px-4 py-8">
@@ -242,7 +241,7 @@ export default function SpectateClient() {
                 </Link>
                 <div className="flex items-center gap-2">
                   {connectionStatus === 'connected' && (
-                    <div className="w-3 h-3 bg-red-500 rounded-full animate-pulse" />
+                    <div className="w-3 h-3 bg-crimson rounded-full animate-pulse" />
                   )}
                   <h1 className="text-xl font-theme-data text-[var(--accent)]">SPECTATING</h1>
                 </div>
@@ -250,12 +249,12 @@ export default function SpectateClient() {
 
               {/* Connection Status Badge */}
               <div
-                className={`px-3 py-1 text-xs font-theme-data border ${
+                className={`px-3 py-1 text-xs font-theme-data border badge-theme ${
                   connectionStatus === 'connected'
-                    ? 'bg-green-500/10 text-green-400 border-green-500/30'
+                    ? 'bg-success/10 text-success border-success/30'
                     : connectionStatus === 'connecting'
-                      ? 'bg-yellow-500/10 text-yellow-400 border-yellow-500/30'
-                      : 'bg-red-500/10 text-red-400 border-red-500/30'
+                      ? 'bg-warning/10 text-warning border-warning/30'
+                      : 'bg-crimson/10 text-crimson border-crimson/30'
                 }`}
               >
                 {connectionStatus.toUpperCase()}
@@ -291,8 +290,8 @@ export default function SpectateClient() {
           )}
 
           {/* View Mode Tabs */}
-          <div className="border border-[var(--accent)]/30 bg-surface/50">
-            <div className="flex items-center border-b border-[var(--accent)]/20 bg-surface/80">
+          <div className="card-theme overflow-hidden">
+            <div className="flex items-center border-b border-border bg-surface-elevated/80">
               {/* Tab buttons */}
               <div className="flex">
                 {([
@@ -343,7 +342,7 @@ export default function SpectateClient() {
                 {filteredEvents.length === 0 ? (
                   <div className="flex items-center justify-center h-full">
                     <div className="text-center text-text-muted">
-                      <div className="w-8 h-8 border-2 border-[var(--accent)]/30 border-t-acid-green rounded-full animate-spin mx-auto mb-4" />
+                      <div className="w-8 h-8 border-2 border-accent/30 border-t-accent rounded-full animate-spin mx-auto mb-4" />
                       <p>Waiting for events...</p>
                     </div>
                   </div>
@@ -376,7 +375,7 @@ export default function SpectateClient() {
           </div>
 
           {/* Legend */}
-          <div className="mt-4 border border-[var(--accent)]/20 bg-surface/30 p-4">
+          <div className="mt-4 card-theme-info p-4">
             <h3 className="text-xs font-theme-data text-[var(--acid-cyan)] mb-3">EVENT TYPES</h3>
             <div className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 gap-2">
               {Object.entries(EVENT_STYLES).map(([type, style]) => (
@@ -403,7 +402,7 @@ function EventLine({
   showTimestamp: boolean;
   formatTimestamp: (ts: number) => string;
 }) {
-  const style = EVENT_STYLES[event.type] || { icon: '•', color: 'text-gray-400', label: 'UNKNOWN' };
+  const style = EVENT_STYLES[event.type] || { icon: '•', color: 'text-text-muted', label: 'UNKNOWN' };
 
   return (
     <div className="flex items-start gap-2 py-1 hover:bg-[var(--accent)]/5 px-2 -mx-2 rounded">

--- a/aragora/live/src/app/(app)/spectate/page.tsx
+++ b/aragora/live/src/app/(app)/spectate/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo } from 'react';
 import Link from 'next/link';
-import { Scanlines, CRTVignette } from '@/components/MatrixRain';
+import { ThemeEffects } from '@/components/ThemeEffects';
 import { useRightSidebar } from '@/context/RightSidebarContext';
 import {
   useSpectate,
@@ -339,11 +339,7 @@ export default function SpectatePage() {
 
   return (
     <>
-      {/* CRT effects only render in dark theme via CSS */}
-      <div className="crt-effect">
-        <Scanlines opacity={0.02} />
-        <CRTVignette />
-      </div>
+      <ThemeEffects opacity={0.02} />
 
       <main className="min-h-screen bg-[var(--bg)] text-[var(--text)] relative z-10">
         <div className="max-w-6xl mx-auto px-4 py-8">

--- a/aragora/live/src/components/spectate/SummaryView.tsx
+++ b/aragora/live/src/components/spectate/SummaryView.tsx
@@ -23,7 +23,7 @@ export function SummaryView() {
     return (
       <div className="flex items-center justify-center h-[500px]">
         <div className="text-center text-text-muted">
-          <div className="w-8 h-8 border-2 border-[var(--accent)]/30 border-t-acid-green rounded-full animate-spin mx-auto mb-4" />
+          <div className="w-8 h-8 border-2 border-accent/30 border-t-accent rounded-full animate-spin mx-auto mb-4" />
           <p className="font-theme-data text-sm">Waiting for events...</p>
         </div>
       </div>
@@ -34,7 +34,7 @@ export function SummaryView() {
     <div className="p-4 space-y-6">
       {/* Debate Topic */}
       {task && (
-        <div className="border border-[var(--accent)]/20 bg-surface/50 p-4">
+        <div className="card-theme p-4">
           <div className="text-[10px] font-theme-data text-text-muted uppercase mb-1">
             Topic
           </div>
@@ -44,24 +44,24 @@ export function SummaryView() {
 
       {/* Progress Overview */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-        <StatCard label="Round" value={`${currentRound}`} color="acid-green" />
+        <StatCard label="Round" value={`${currentRound}`} color="accent" />
         <StatCard label="Agents" value={`${agents.length}`} color="acid-cyan" />
-        <StatCard label="Proposals" value={`${stats.proposalCount}`} color="blue-400" />
-        <StatCard label="Critiques" value={`${stats.critiqueCount}`} color="red-400" />
+        <StatCard label="Proposals" value={`${stats.proposalCount}`} color="acid-cyan" />
+        <StatCard label="Critiques" value={`${stats.critiqueCount}`} color="crimson" />
       </div>
 
       {/* Consensus Indicator */}
-      <div className="border border-border bg-surface/50 p-4">
+      <div className="card-theme p-4">
         <div className="flex items-center justify-between mb-3">
           <h3 className="text-xs font-theme-data text-[var(--accent)] uppercase">
             Consensus Progress
           </h3>
           <span
-            className={`text-xs font-theme-data px-2 py-0.5 border ${
+            className={`text-xs font-theme-data px-2 py-0.5 border badge-theme ${
               stats.hasConsensus
-                ? 'text-green-400 border-green-400/30 bg-green-400/10'
+                ? 'text-success border-success/30 bg-success/10'
                 : stats.latestConvergence !== null && stats.latestConvergence > 0.7
-                ? 'text-yellow-400 border-yellow-400/30 bg-yellow-400/10'
+                ? 'text-warning border-warning/30 bg-warning/10'
                 : 'text-text-muted border-border bg-surface'
             }`}
           >
@@ -79,10 +79,10 @@ export function SummaryView() {
             <div
               className={`h-full transition-all duration-500 ${
                 stats.hasConsensus
-                  ? 'bg-green-400'
+                  ? 'bg-success'
                   : stats.latestConvergence > 0.7
-                  ? 'bg-yellow-400'
-                  : 'bg-[var(--accent)]'
+                  ? 'bg-warning'
+                  : 'bg-accent'
               }`}
               style={{ width: `${Math.min(stats.latestConvergence * 100, 100)}%` }}
             />
@@ -105,7 +105,7 @@ export function SummaryView() {
       </div>
 
       {/* Agent Activity Summary */}
-      <div className="border border-border bg-surface/50">
+      <div className="card-theme overflow-hidden">
         <div className="px-4 py-3 border-b border-border">
           <h3 className="text-xs font-theme-data text-[var(--accent)] uppercase">
             Agent Activity
@@ -119,25 +119,25 @@ export function SummaryView() {
             return (
               <div key={agent} className="px-4 py-3 flex items-center justify-between gap-4">
                 <div className="flex items-center gap-2 min-w-0">
-                  <span className="text-xs font-theme-data text-[var(--acid-cyan)] font-bold truncate">
+                  <span className="text-xs font-theme-data text-acid-cyan font-bold truncate">
                     {agent}
                   </span>
                 </div>
                 <div className="flex items-center gap-3 text-[10px] font-theme-data text-text-muted shrink-0">
                   {agentStats.proposals > 0 && (
-                    <span className="text-blue-400">{agentStats.proposals}P</span>
+                    <span className="text-acid-cyan">{agentStats.proposals}P</span>
                   )}
                   {agentStats.critiques > 0 && (
-                    <span className="text-red-400">{agentStats.critiques}C</span>
+                    <span className="text-crimson">{agentStats.critiques}C</span>
                   )}
                   {agentStats.votes > 0 && (
-                    <span className="text-yellow-400">{agentStats.votes}V</span>
+                    <span className="text-warning">{agentStats.votes}V</span>
                   )}
                   {agentStats.refines > 0 && (
-                    <span className="text-blue-300">{agentStats.refines}R</span>
+                    <span className="text-accent">{agentStats.refines}R</span>
                   )}
                   {agentStats.lastMetric !== null && (
-                    <span className="text-[var(--accent)]">
+                    <span className="text-accent">
                       ({agentStats.lastMetric.toFixed(2)})
                     </span>
                   )}
@@ -149,7 +149,7 @@ export function SummaryView() {
       </div>
 
       {/* Latest Key Events */}
-      <div className="border border-border bg-surface/50">
+      <div className="card-theme overflow-hidden">
         <div className="px-4 py-3 border-b border-border">
           <h3 className="text-xs font-theme-data text-[var(--accent)] uppercase">
             Key Events
@@ -162,10 +162,10 @@ export function SummaryView() {
             stats.keyEvents.map((ev, i) => (
               <div key={i} className="flex items-start gap-2 text-xs font-theme-data">
                 <span className="text-text-muted shrink-0">R{ev.round ?? 0}</span>
-                <span className={ev.type === 'consensus' ? 'text-green-400' : ev.type === 'vote' ? 'text-yellow-400' : 'text-[var(--acid-cyan)]'}>
+                <span className={ev.type === 'consensus' ? 'text-success' : ev.type === 'vote' ? 'text-warning' : 'text-acid-cyan'}>
                   [{ev.type.toUpperCase()}]
                 </span>
-                {ev.agent && <span className="text-[var(--acid-cyan)]">{ev.agent}</span>}
+                {ev.agent && <span className="text-acid-cyan">{ev.agent}</span>}
                 {ev.details && <span className="text-text truncate">{ev.details}</span>}
               </div>
             ))
@@ -186,7 +186,7 @@ function StatCard({
   color: string;
 }) {
   return (
-    <div className="border border-border bg-surface/50 p-3">
+    <div className="card-theme p-3">
       <div className="text-[10px] font-theme-data text-text-muted uppercase">
         {label}
       </div>

--- a/aragora/live/src/components/spectate/TimelineView.tsx
+++ b/aragora/live/src/components/spectate/TimelineView.tsx
@@ -30,7 +30,7 @@ export function TimelineView() {
     return (
       <div className="flex items-center justify-center h-[500px]">
         <div className="text-center text-text-muted">
-          <div className="w-8 h-8 border-2 border-[var(--accent)]/30 border-t-acid-green rounded-full animate-spin mx-auto mb-4" />
+          <div className="w-8 h-8 border-2 border-accent/30 border-t-accent rounded-full animate-spin mx-auto mb-4" />
           <p className="font-theme-data text-sm">Waiting for events...</p>
         </div>
       </div>
@@ -41,7 +41,7 @@ export function TimelineView() {
     <div className="space-y-6 p-4">
       {/* Agent Legend */}
       {agents.length > 0 && (
-        <div className="flex flex-wrap gap-2 pb-4 border-b border-[var(--accent)]/20">
+        <div className="flex flex-wrap gap-2 pb-4 border-b border-border">
           {agents.map((agent) => (
             <span
               key={agent}
@@ -100,7 +100,7 @@ export function TimelineView() {
                 .map((ev, i) => {
                   const style = EVENT_STYLES[ev.type] || {
                     icon: '.',
-                    color: 'text-gray-400',
+                    color: 'text-text-muted',
                     label: 'UNKNOWN',
                   };
                   return (
@@ -130,13 +130,13 @@ export function TimelineView() {
                     {agentEvents.map((ev, i) => {
                       const style = EVENT_STYLES[ev.type] || {
                         icon: '.',
-                        color: 'text-gray-400',
+                        color: 'text-text-muted',
                         label: 'UNKNOWN',
                       };
                       return (
                         <div
                           key={i}
-                          className="group relative flex items-center gap-1 px-2 py-1 bg-surface border border-border hover:border-[var(--accent)]/30 transition-colors"
+                          className="group relative flex items-center gap-1 px-2 py-1 card-theme hover:border-accent/30 transition-colors"
                           title={ev.details || style.label}
                         >
                           <span className="text-xs">{style.icon}</span>

--- a/aragora/live/src/store/spectateStore.ts
+++ b/aragora/live/src/store/spectateStore.ts
@@ -38,24 +38,26 @@ export interface SpectatorEvent {
 export type SpectateConnectionStatus = 'idle' | 'connecting' | 'connected' | 'disconnected' | 'error';
 
 // Event styles for UI - maps to EVENT_STYLES in events.py
+// Uses theme-aware Tailwind color classes (see tailwind.config.js) so colors
+// adapt to warm/dark/professional themes via CSS variables.
 export const EVENT_STYLES: Record<SpectatorEventType, { icon: string; color: string; label: string }> = {
-  debate_start: { icon: '🎬', color: 'text-fuchsia-400', label: 'DEBATE START' },
-  debate_end: { icon: '🏁', color: 'text-fuchsia-400', label: 'DEBATE END' },
-  round_start: { icon: '⏱️', color: 'text-cyan-400', label: 'ROUND START' },
-  round_end: { icon: '✓', color: 'text-cyan-400', label: 'ROUND END' },
-  proposal: { icon: '💡', color: 'text-blue-400', label: 'PROPOSAL' },
-  critique: { icon: '🔍', color: 'text-red-400', label: 'CRITIQUE' },
-  refine: { icon: '✨', color: 'text-blue-400', label: 'REFINE' },
-  vote: { icon: '🗳️', color: 'text-yellow-400', label: 'VOTE' },
-  judge: { icon: '⚖️', color: 'text-yellow-400', label: 'JUDGE' },
-  consensus: { icon: '🤝', color: 'text-green-400', label: 'CONSENSUS' },
-  convergence: { icon: '📊', color: 'text-green-400', label: 'CONVERGENCE' },
-  converged: { icon: '🎉', color: 'text-green-400', label: 'CONVERGED' },
-  memory_recall: { icon: '🧠', color: 'text-blue-400', label: 'MEMORY' },
-  breakpoint: { icon: '⚠️', color: 'text-amber-400', label: 'BREAKPOINT' },
-  breakpoint_resolved: { icon: '✅', color: 'text-green-400', label: 'RESOLVED' },
-  system: { icon: '⚙️', color: 'text-gray-400', label: 'SYSTEM' },
-  error: { icon: '❌', color: 'text-red-400', label: 'ERROR' },
+  debate_start: { icon: '🎬', color: 'text-purple', label: 'DEBATE START' },
+  debate_end: { icon: '🏁', color: 'text-purple', label: 'DEBATE END' },
+  round_start: { icon: '⏱️', color: 'text-acid-cyan', label: 'ROUND START' },
+  round_end: { icon: '✓', color: 'text-acid-cyan', label: 'ROUND END' },
+  proposal: { icon: '💡', color: 'text-acid-cyan', label: 'PROPOSAL' },
+  critique: { icon: '🔍', color: 'text-crimson', label: 'CRITIQUE' },
+  refine: { icon: '✨', color: 'text-acid-cyan', label: 'REFINE' },
+  vote: { icon: '🗳️', color: 'text-warning', label: 'VOTE' },
+  judge: { icon: '⚖️', color: 'text-warning', label: 'JUDGE' },
+  consensus: { icon: '🤝', color: 'text-success', label: 'CONSENSUS' },
+  convergence: { icon: '📊', color: 'text-success', label: 'CONVERGENCE' },
+  converged: { icon: '🎉', color: 'text-success', label: 'CONVERGED' },
+  memory_recall: { icon: '🧠', color: 'text-acid-cyan', label: 'MEMORY' },
+  breakpoint: { icon: '⚠️', color: 'text-warning', label: 'BREAKPOINT' },
+  breakpoint_resolved: { icon: '✅', color: 'text-success', label: 'RESOLVED' },
+  system: { icon: '⚙️', color: 'text-text-muted', label: 'SYSTEM' },
+  error: { icon: '❌', color: 'text-crimson', label: 'ERROR' },
 };
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replace all hardcoded Tailwind color classes (`text-green-400`, `text-red-400`, `text-blue-400`, `bg-green-500`, etc.) with theme-mapped Tailwind aliases (`text-success`, `text-crimson`, `text-acid-cyan`, `text-warning`, `text-text-muted`) that resolve to CSS variables and adapt across all three themes (warm/dark/professional)
- Switch raw `Scanlines`/`CRTVignette` imports to `ThemeEffects` component so CRT effects only render in dark theme (auto-hidden in warm/professional)
- Update all cards, containers, and badges to use `card-theme`, `card-theme-info`, `badge-theme`, `btn-theme-secondary` utility classes for consistent border-radius and shadow behavior across themes

## Files changed
- `spectateStore.ts` -- all 17 `EVENT_STYLES` color entries updated
- `SpectateClient.tsx` -- connection badge, live dot, sidebar buttons, view tabs, legend, spinner
- `SummaryView.tsx` -- stat cards, consensus bar, agent activity, key events
- `TimelineView.tsx` -- spinner, agent legend border, event chips
- `spectate/page.tsx` -- CRT effects replaced with ThemeEffects

## Test plan
- [ ] Visit `/spectate` in dark theme -- verify CRT scanlines render, neon green accent colors, sharp card borders
- [ ] Switch to warm theme -- verify scanlines disappear, warm cream background, rounded cards with shadows, forest green accents
- [ ] Switch to professional theme -- verify clean layout, subtle shadows, green-700 accents, rounded corners
- [ ] Visit `/spectate/{debateId}` -- verify connection badge, agent tags, event feed, and legend all adapt
- [ ] Check timeline and summary sub-views render correctly in all three themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)