### PR TITLE
boss-loop: allow explicitly declared new validation targets

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -52,6 +52,7 @@ from aragora.swarm.boss_validation import (  # noqa: F401
     sanitize_issue_body_for_dispatch,
     extract_issue_validation_contract,
     extract_pre_dispatch_validation_commands,
+    extract_declared_new_file_paths,
     find_missing_pre_dispatch_validation_targets,
     run_pre_dispatch_validation_commands,
     discover_focused_tests,
@@ -3249,18 +3250,29 @@ class BossLoop:
             repo_root=Path.cwd(),
         )
         if missing_validation_targets:
-            targets_text = ", ".join(missing_validation_targets)
-            return {
-                "status": "needs_human",
-                "outcome": "verification_target_missing",
-                "reasons": [
-                    f"Issue #{issue.number} references missing validation targets: {targets_text}"
-                ],
-                "next_actions": [
-                    "Refresh the issue's Acceptance Criteria or Test Plan so pytest points at current repo paths.",
-                    "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
-                ],
-            }
+            declared_new_paths = set(extract_declared_new_file_paths(issue.body or ""))
+            unresolved_missing_targets = [
+                target for target in missing_validation_targets if target not in declared_new_paths
+            ]
+            if not unresolved_missing_targets:
+                logger.info(
+                    "boss_loop_missing_validation_targets_allowed issue=#%s targets=%s",
+                    issue.number,
+                    ", ".join(missing_validation_targets),
+                )
+            else:
+                targets_text = ", ".join(unresolved_missing_targets)
+                return {
+                    "status": "needs_human",
+                    "outcome": "verification_target_missing",
+                    "reasons": [
+                        f"Issue #{issue.number} references missing validation targets: {targets_text}"
+                    ],
+                    "next_actions": [
+                        "Refresh the issue's Acceptance Criteria or Test Plan so pytest points at current repo paths.",
+                        "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
+                    ],
+                }
 
         if not spec.is_dispatch_bounded():
             return {

--- a/aragora/swarm/boss_validation.py
+++ b/aragora/swarm/boss_validation.py
@@ -69,6 +69,8 @@ _PRE_DISPATCH_SAFE_COMMAND_PREFIXES = (
 )
 _BACKTICK_COMMAND_RE = re.compile(r"`(?P<command>[^`]+)`")
 _EXPLICIT_PYTEST_TARGET_RE = re.compile(r"(?<!\S)(?P<path>tests/\S+?\.py)(?:::\S+)?(?!\S)")
+_DECLARED_NEW_FILE_RE = re.compile(r"\(\s*new(?:\s+file)?\s*\)", re.IGNORECASE)
+_BACKTICK_PATH_RE = re.compile(r"`(?P<path>[^`\n]+/[^`\n]+)`")
 
 
 def _ordered_unique_strings(items: list[str]) -> list[str]:
@@ -269,6 +271,26 @@ def find_missing_pre_dispatch_validation_targets(
             if path and not (repo_root / path).exists():
                 missing.append(path)
     return _ordered_unique_strings(missing)
+
+
+def extract_declared_new_file_paths(issue_body: str) -> list[str]:
+    """Return file paths explicitly marked as new in the issue body.
+
+    This keeps the missing-target gate strict for stale contracts while
+    allowing lanes whose acceptance criteria intentionally point at a file the
+    worker is expected to create.
+    """
+
+    declared: list[str] = []
+    for raw_line in str(issue_body or "").splitlines():
+        line = str(raw_line).strip()
+        if not line or not _DECLARED_NEW_FILE_RE.search(line):
+            continue
+        for match in _BACKTICK_PATH_RE.finditer(line):
+            path = str(match.group("path") or "").strip()
+            if path:
+                declared.append(path)
+    return _ordered_unique_strings(declared)
 
 
 def run_pre_dispatch_validation_commands(

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -41,6 +41,7 @@ from aragora.swarm.boss_loop import (
     check_runner_freshness,
     discover_focused_tests,
     dispatch_bounded_spec,
+    extract_declared_new_file_paths,
     extract_pre_dispatch_validation_commands,
     extract_issue_validation_contract,
     find_missing_pre_dispatch_validation_targets,
@@ -510,6 +511,19 @@ Acceptance Criteria:
 
         assert find_missing_pre_dispatch_validation_targets(commands, repo_root=tmp_path) == [
             "tests/webhooks/test_delivery_retry.py"
+        ]
+
+    def test_extract_declared_new_file_paths_only_accepts_explicit_new_markers(self):
+        body = (
+            "## Files\n"
+            "- `tests/test_openapi_regeneration.py` (new)\n"
+            "- `tests/webhooks/test_delivery_retry.py` (new or extend)\n"
+            "- `tests/pipeline/test_run_ledger_ordering.py` (new file)\n"
+        )
+
+        assert extract_declared_new_file_paths(body) == [
+            "tests/test_openapi_regeneration.py",
+            "tests/pipeline/test_run_ledger_ordering.py",
         ]
 
     def test_run_pre_dispatch_validation_commands_stops_on_failure(self, monkeypatch):
@@ -2598,6 +2612,57 @@ async def test_dispatch_issue_blocks_on_missing_validation_target_before_dispatc
     assert "missing validation targets" in result["reasons"][0]
     assert "tests/webhooks/test_delivery_retry.py" in result["reasons"][0]
     mock_commander_cls.return_value.run_supervised_from_spec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_allows_missing_validation_target_for_explicit_new_file() -> None:
+    issue = _make_issue(
+        2459,
+        "Add OpenAPI spec regeneration test to prevent drift",
+        body=(
+            "The generated OpenAPI artifacts drift when handlers change. Add a test that regenerates and diffs.\n\n"
+            "## Files\n"
+            "- `tests/test_openapi_regeneration.py` (new)\n\n"
+            "## Acceptance\n"
+            "`pytest tests/test_openapi_regeneration.py -x -q` passes\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "status": "completed",
+        "run_id": "run-2459",
+        "work_orders": [
+            {"status": "completed", "branch": "codex/openapi-regen-test", "commit_shas": ["abc123"]}
+        ],
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(return_value=fake_run)
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    mock_commander_cls.return_value.run_supervised_from_spec.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow pre-dispatch validation to skip missing pytest file targets when the issue body explicitly marks them as  or 
- keep blocking ambiguous stale contracts such as 
- add focused boss-loop coverage for the explicit-new path and the parser

## Validation
- python3 -m ruff check aragora/swarm/boss_validation.py aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m pytest -q tests/swarm/test_boss_loop.py -k 'declared_new_file_paths or missing_validation_target'