### PR TITLE
fix(supervisor): reject malformed boolean metadata

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -98,6 +98,10 @@ def _is_concrete_repo_path(path: str) -> bool:
     return "." in name
 
 
+def _strict_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
 def _docs_only_scope_supports_hint(path: str, original_scope: list[str]) -> bool:
     if any(_path_in_scope(path, scope) or _path_in_scope(scope, path) for scope in original_scope):
         return True
@@ -394,9 +398,15 @@ class SwarmApprovalPolicy:
     def from_dict(cls, data: dict[str, Any] | None) -> SwarmApprovalPolicy:
         payload = dict(data or {})
         return cls(
-            require_merge_approval=bool(payload.get("require_merge_approval", True)),
-            require_external_action_approval=bool(
-                payload.get("require_external_action_approval", True)
+            require_merge_approval=(
+                _strict_bool(payload.get("require_merge_approval"))
+                if _strict_bool(payload.get("require_merge_approval")) is not None
+                else True
+            ),
+            require_external_action_approval=(
+                _strict_bool(payload.get("require_external_action_approval"))
+                if _strict_bool(payload.get("require_external_action_approval")) is not None
+                else True
             ),
             protected_patterns=[
                 str(item) for item in payload.get("protected_patterns", []) if str(item).strip()
@@ -545,22 +555,30 @@ class SwarmSupervisor:
             config.claude_profile_script = self._optional_snapshot_text(
                 snapshot["claude_profile_script"]
             )
-        if "auto_commit" in snapshot:
-            config.auto_commit = bool(snapshot["auto_commit"])
-        if "use_managed_session_script" in snapshot:
-            config.use_managed_session_script = bool(snapshot["use_managed_session_script"])
+        auto_commit = _strict_bool(snapshot.get("auto_commit"))
+        if auto_commit is not None:
+            config.auto_commit = auto_commit
+        use_managed_session_script = _strict_bool(snapshot.get("use_managed_session_script"))
+        if use_managed_session_script is not None:
+            config.use_managed_session_script = use_managed_session_script
         if "base_branch" in snapshot:
             config.base_branch = str(snapshot["base_branch"]).strip() or config.base_branch
-        if "detach" in snapshot:
-            config.detach = bool(snapshot["detach"])
-        if "require_explicit_approval" in snapshot:
-            config.require_explicit_approval = bool(snapshot["require_explicit_approval"])
-        if "allow_claude_dangerously_skip_permissions" in snapshot:
-            config.allow_claude_dangerously_skip_permissions = bool(
-                snapshot["allow_claude_dangerously_skip_permissions"]
+        detach = _strict_bool(snapshot.get("detach"))
+        if detach is not None:
+            config.detach = detach
+        require_explicit_approval = _strict_bool(snapshot.get("require_explicit_approval"))
+        if require_explicit_approval is not None:
+            config.require_explicit_approval = require_explicit_approval
+        allow_claude_dangerously_skip_permissions = _strict_bool(
+            snapshot.get("allow_claude_dangerously_skip_permissions")
+        )
+        if allow_claude_dangerously_skip_permissions is not None:
+            config.allow_claude_dangerously_skip_permissions = (
+                allow_claude_dangerously_skip_permissions
             )
-        if "allow_codex_full_auto" in snapshot:
-            config.allow_codex_full_auto = bool(snapshot["allow_codex_full_auto"])
+        allow_codex_full_auto = _strict_bool(snapshot.get("allow_codex_full_auto"))
+        if allow_codex_full_auto is not None:
+            config.allow_codex_full_auto = allow_codex_full_auto
         if "execution_mode" in snapshot:
             try:
                 config.execution_mode = ExecutionMode(str(snapshot["execution_mode"]).strip())
@@ -4855,7 +4873,7 @@ class SwarmSupervisor:
                 cls._verification_command_covers_expected(entry.get("command", ""), command)
                 for command in expected_checks
             )
-            and not bool(entry.get("passed", False))
+            and entry.get("passed") is not True
         ]
         deferred_dependency_ids = [
             str(dep).strip()

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -19,6 +19,7 @@ from aragora.swarm.supervisor import (
     LAUNCHER_CONFIG_METADATA_KEY,
     WORKER_TYPE_CIRCUIT_BREAKERS_KEY,
     WORKER_TYPE_CIRCUIT_BREAKER_POLICY_KEY,
+    SwarmApprovalPolicy,
     SwarmSupervisor,
 )
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
@@ -242,6 +243,48 @@ def test_apply_launcher_snapshot_preserves_null_optional_fields(repo: Path) -> N
     assert supervisor.launcher.config.codex_model is None
     assert supervisor.launcher.config.claude_profile is None
     assert supervisor.launcher.config.claude_profile_script is None
+
+
+def test_apply_launcher_snapshot_rejects_malformed_boolean_fields(repo: Path) -> None:
+    supervisor = SwarmSupervisor(repo_root=repo)
+    supervisor.launcher.config = LaunchConfig(
+        auto_commit=False,
+        use_managed_session_script=False,
+        detach=False,
+        require_explicit_approval=True,
+        allow_claude_dangerously_skip_permissions=False,
+        allow_codex_full_auto=False,
+    )
+
+    supervisor._apply_launcher_config_snapshot(
+        {
+            "auto_commit": "false",
+            "use_managed_session_script": 1,
+            "detach": "false",
+            "require_explicit_approval": 0,
+            "allow_claude_dangerously_skip_permissions": "false",
+            "allow_codex_full_auto": "false",
+        }
+    )
+
+    assert supervisor.launcher.config.auto_commit is False
+    assert supervisor.launcher.config.use_managed_session_script is False
+    assert supervisor.launcher.config.detach is False
+    assert supervisor.launcher.config.require_explicit_approval is True
+    assert supervisor.launcher.config.allow_claude_dangerously_skip_permissions is False
+    assert supervisor.launcher.config.allow_codex_full_auto is False
+
+
+def test_swarm_approval_policy_from_dict_rejects_malformed_booleans() -> None:
+    policy = SwarmApprovalPolicy.from_dict(
+        {
+            "require_merge_approval": 0,
+            "require_external_action_approval": "false",
+        }
+    )
+
+    assert policy.require_merge_approval is True
+    assert policy.require_external_action_approval is True
 
 
 def test_start_run_discards_duplicate_open_non_deliverable_lane(
@@ -4281,6 +4324,28 @@ def test_merge_gate_state_normalizes_python_command_equivalence() -> None:
     assert state["checks_passed"] is True
     assert state["merge_eligible"] is True
     assert state["blocked_reasons"] == []
+
+
+def test_merge_gate_state_rejects_nonboolean_passed_field() -> None:
+    state = SwarmSupervisor._merge_gate_state(
+        {
+            "expected_tests": ["python -m pytest tests/swarm/test_supervisor.py -q"],
+            "verification_results": [
+                {
+                    "command": "python -m pytest tests/swarm/test_supervisor.py -q",
+                    "passed": "true",
+                    "exit_code": 0,
+                    "stdout": "",
+                    "stderr": "",
+                    "duration_seconds": 1.0,
+                }
+            ],
+        }
+    )
+
+    assert state["checks_passed"] is False
+    assert state["merge_eligible"] is False
+    assert "verification failed" in state["blocked_reasons"][0]
 
 
 def test_merge_gate_state_rejects_broader_pytest_with_k_selector() -> None:


### PR DESCRIPTION
## Summary
- reject malformed boolean values when rehydrating persisted supervisor approval and launcher config state
- fail closed in merge-gate evaluation unless verification entries carry a real boolean `passed` flag
- add regressions for malformed launcher snapshots, approval policy payloads, and merge-gate metadata

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k "malformed_boolean_fields or swarm_approval_policy_from_dict_rejects_malformed_booleans or merge_gate_state_rejects_nonboolean_passed_field"
- python -m pytest tests/swarm/test_supervisor.py -q