### PR TITLE
fix(boss-loop): preserve handoff on malformed failed dispatch

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -524,6 +524,25 @@ def _backbone_dispatch_status(result: dict[str, Any]) -> str:
     return status or "failed"
 
 
+def _dispatch_result_started(result: Any) -> bool:
+    if not isinstance(result, dict):
+        return False
+    run_id = result.get("run_id")
+    if isinstance(run_id, str) and run_id.strip():
+        return True
+    run = result.get("run")
+    if not isinstance(run, dict):
+        return False
+    embedded_run_id = run.get("run_id")
+    if isinstance(embedded_run_id, str) and embedded_run_id.strip():
+        return True
+    work_orders = run.get("work_orders")
+    if isinstance(work_orders, list):
+        return True
+    run_status = run.get("status")
+    return isinstance(run_status, str) and bool(run_status.strip())
+
+
 class BossLoop:
     """Long-running Boss loop: pull issues, check freshness, dispatch, report.
 
@@ -3356,7 +3375,7 @@ class BossLoop:
             except Exception:
                 pass  # Never block autonomous dispatch
         if pending_handoff is not None:
-            dispatch_started = bool(result.get("run") or result.get("run_id"))
+            dispatch_started = _dispatch_result_started(result)
             if result.get("status") != "failed" or dispatch_started:
                 self._pending_handoff_prompts.pop(issue.number, None)
         result["receipt_metadata"] = self._receipt_metadata_for_result(

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2675,6 +2675,50 @@ async def test_dispatch_issue_preserves_pending_handoff_on_pre_run_failure() -> 
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_preserves_pending_handoff_on_failed_result_with_malformed_run_id() -> (
+    None
+):
+    issue = _make_issue(1705, "Retry handoff should ignore malformed run id")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="claude"))
+    loop._pending_handoff_prompts[issue.number] = (
+        "## Goal\nRetry with preserved context\n\n## Context (from claude, round 1)\nStill relevant.",
+        "codex",
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": requested_target_agent or "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(
+                return_value={
+                    "status": "failed",
+                    "run_id": {"id": "junk"},
+                    "outcome": "crash",
+                    "error": "boom",
+                }
+            ),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    dispatch_kwargs = dispatch_mock.await_args.kwargs
+    assert result["status"] == "failed"
+    assert dispatch_kwargs["default_target_agent"] == "codex"
+    assert loop._pending_handoff_prompts[issue.number] == (
+        "## Goal\nRetry with preserved context\n\n## Context (from claude, round 1)\nStill relevant.",
+        "codex",
+    )
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_uses_configured_dispatch_max_ticks() -> None:
     issue = _make_issue(1706, "Use configured max ticks")
     loop = BossLoop(config=_boss_config(max_iterations=1, dispatch_max_ticks=777))


### PR DESCRIPTION
## Summary
- only treat a dispatch result as started when it carries a real run id or run payload
- preserve pending handoff prompts when a failed dispatch returns malformed truthy junk instead of a real started run
- add regression coverage for the malformed failed-dispatch path

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k "preserves_pending_handoff_on_pre_run_failure or malformed_run_id"
- python -m pytest tests/swarm/test_boss_loop.py -q