### PR TITLE
feat(boss-loop): draft-first PRs with auto-promotion on required checks

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -63,6 +63,19 @@ UTC = timezone.utc
 _LANE_TELEMETRY = LaneTelemetryCollector()
 _GITHUB_ISSUE_URL_RE = re.compile(r"github\.com/(?P<repo>[^/]+/[^/]+)/issues/(?P<number>\d+)")
 _GITHUB_PR_URL_RE = re.compile(r"github\.com/[^/]+/[^/]+/pull/(?P<number>\d+)")
+
+# The 5 CI checks required for merge.  Draft PRs run only these;
+# ready PRs run the full 32-workflow suite.  The boss loop creates
+# PRs as drafts and auto-promotes them once these 5 pass.
+_REQUIRED_CHECK_NAMES: frozenset[str] = frozenset(
+    {
+        "lint",
+        "typecheck",
+        "sdk-parity",
+        "Generate & Validate",
+        "TypeScript SDK Type Check",
+    }
+)
 _ALREADY_DONE_MARKERS = (
     "already implemented",
     "already exists",
@@ -1841,6 +1854,175 @@ class BossLoop:
             return f"Auto-continuing: published PR {pr_url} for human review."
         return f"Auto-continuing: deliverable is available at {pr_url} for human review."
 
+    def _convert_pr_to_draft(self, worker_result: dict[str, Any]) -> None:
+        """Convert a newly-created PR to draft so only the 5 required checks run.
+
+        The boss loop later promotes draft PRs to ready once those checks pass
+        (see ``_promote_ready_drafts``).  This avoids triggering all 32 CI
+        workflows on every PR while 35+ PRs compete for runner time.
+        """
+        pr_url = self._published_pr_url(worker_result)
+        if not pr_url:
+            return
+        pr_number = self._pr_number_from_url(pr_url)
+        if pr_number is None:
+            return
+        repo = str(self.config.repo or "").strip()
+        cmd: list[str] = ["gh", "pr", "ready", "--undo", str(pr_number)]
+        if repo:
+            cmd.extend(["-R", repo])
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if proc.returncode == 0:
+                logger.info(
+                    "Converted PR #%d to draft to limit CI to required checks only",
+                    pr_number,
+                )
+                worker_result["draft_converted"] = True
+            else:
+                detail = (proc.stderr or proc.stdout or "").strip()
+                # If already a draft, treat as success
+                if "already a draft" in detail.lower():
+                    logger.debug("PR #%d already a draft", pr_number)
+                    worker_result["draft_converted"] = True
+                else:
+                    logger.warning(
+                        "Failed to convert PR #%d to draft: %s",
+                        pr_number,
+                        detail or "gh pr ready --undo failed",
+                    )
+        except Exception as exc:
+            logger.warning("Exception converting PR #%d to draft: %s", pr_number, exc)
+
+    def _promote_ready_drafts(self) -> list[int]:
+        """Promote draft PRs whose 5 required checks have all passed.
+
+        Returns the list of PR numbers that were promoted.
+        """
+        repo = str(self.config.repo or "").strip()
+        if not repo:
+            return []
+
+        # List open draft PRs authored by the current user (or any, if no filter)
+        list_cmd: list[str] = [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--draft",
+            "--json",
+            "number",
+            "--limit",
+            "100",
+            "-R",
+            repo,
+        ]
+        try:
+            list_proc = subprocess.run(
+                list_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if list_proc.returncode != 0:
+                logger.debug(
+                    "Failed to list draft PRs for promotion: %s",
+                    (list_proc.stderr or "").strip(),
+                )
+                return []
+            draft_prs = json.loads(list_proc.stdout or "[]")
+        except Exception as exc:
+            logger.debug("Exception listing draft PRs for promotion: %s", exc)
+            return []
+
+        promoted: list[int] = []
+        for pr_entry in draft_prs:
+            pr_num = pr_entry.get("number")
+            if not isinstance(pr_num, int):
+                continue
+            if self._all_required_checks_passed(pr_num, repo):
+                ready_cmd: list[str] = [
+                    "gh",
+                    "pr",
+                    "ready",
+                    str(pr_num),
+                    "-R",
+                    repo,
+                ]
+                try:
+                    ready_proc = subprocess.run(
+                        ready_cmd,
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        check=False,
+                    )
+                    if ready_proc.returncode == 0:
+                        logger.info(
+                            "Promoted draft PR #%d to ready — all %d required checks passed",
+                            pr_num,
+                            len(_REQUIRED_CHECK_NAMES),
+                        )
+                        promoted.append(pr_num)
+                    else:
+                        logger.debug(
+                            "Failed to promote PR #%d: %s",
+                            pr_num,
+                            (ready_proc.stderr or "").strip(),
+                        )
+                except Exception as exc:
+                    logger.debug("Exception promoting PR #%d: %s", pr_num, exc)
+        return promoted
+
+    @staticmethod
+    def _all_required_checks_passed(pr_number: int, repo: str) -> bool:
+        """Return True if all 5 required CI checks have conclusion==success."""
+        checks_cmd: list[str] = [
+            "gh",
+            "pr",
+            "checks",
+            str(pr_number),
+            "--json",
+            "name,state,conclusion",
+            "-R",
+            repo,
+        ]
+        try:
+            proc = subprocess.run(
+                checks_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if proc.returncode != 0:
+                return False
+            checks = json.loads(proc.stdout or "[]")
+        except Exception:
+            return False
+
+        # Build a map of check name -> conclusion
+        check_conclusions: dict[str, str] = {}
+        for check in checks:
+            name = str(check.get("name", "")).strip()
+            conclusion = str(check.get("conclusion", "")).strip().upper()
+            if name in _REQUIRED_CHECK_NAMES:
+                check_conclusions[name] = conclusion
+
+        # All 5 must be present and successful
+        for required in _REQUIRED_CHECK_NAMES:
+            if check_conclusions.get(required) != "SUCCESS":
+                return False
+        return True
+
     def _postprocess_issue_result(
         self,
         issue: GitHubIssue,
@@ -1857,6 +2039,10 @@ class BossLoop:
             worker_result["issue_resolution"] = issue_resolution
         self._apply_postprocess_metadata(worker_result)
         self._promote_published_deliverable(worker_result)
+        # Convert newly-published PRs to draft so only the 5 required CI
+        # checks run.  They will be promoted to ready by _promote_ready_drafts
+        # once those checks pass.
+        self._convert_pr_to_draft(worker_result)
         return worker_result
 
     def _log_value_outcome(
@@ -2129,6 +2315,20 @@ class BossLoop:
                     len(self._completed_issues),
                     len(self._failed_issues),
                 )
+
+            # Promote draft PRs whose required checks have passed.
+            # This converts them to ready-for-review, triggering the
+            # full CI suite only when the 5 fast required checks pass.
+            try:
+                promoted = self._promote_ready_drafts()
+                if promoted:
+                    logger.info(
+                        "Promoted %d draft PR(s) to ready: %s",
+                        len(promoted),
+                        promoted,
+                    )
+            except Exception:
+                logger.debug("Draft PR promotion check skipped", exc_info=True)
 
             # Inter-iteration sleep (skipped after last iteration)
             if iteration < self.config.max_iterations:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3838,3 +3838,209 @@ async def test_dispatch_backbone_failure_does_not_block():
         result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
 
     assert result["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Draft PR promotion tests
+# ---------------------------------------------------------------------------
+
+
+class TestConvertPrToDraft:
+    """Tests for _convert_pr_to_draft."""
+
+    def test_converts_pr_to_draft_on_success(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        worker_result: dict[str, Any] = {
+            "pr_url": "https://github.com/synaptent/aragora/pull/42",
+        }
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="", stderr="")
+            loop._convert_pr_to_draft(worker_result)
+        mock_run.assert_called_once()
+        cmd = mock_run.call_args[0][0]
+        assert cmd == ["gh", "pr", "ready", "--undo", "42", "-R", "synaptent/aragora"]
+        assert worker_result.get("draft_converted") is True
+
+    def test_no_op_when_no_pr_url(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        worker_result: dict[str, Any] = {"status": "completed"}
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            loop._convert_pr_to_draft(worker_result)
+        mock_run.assert_not_called()
+        assert "draft_converted" not in worker_result
+
+    def test_handles_already_draft(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        worker_result: dict[str, Any] = {
+            "pr_url": "https://github.com/synaptent/aragora/pull/7",
+        }
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(
+                returncode=1, stdout="", stderr="already a draft"
+            )
+            loop._convert_pr_to_draft(worker_result)
+        assert worker_result.get("draft_converted") is True
+
+    def test_handles_gh_failure_gracefully(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        worker_result: dict[str, Any] = {
+            "pr_url": "https://github.com/synaptent/aragora/pull/7",
+        }
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=1, stdout="", stderr="network error")
+            loop._convert_pr_to_draft(worker_result)
+        assert "draft_converted" not in worker_result
+
+    def test_handles_subprocess_exception(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        worker_result: dict[str, Any] = {
+            "pr_url": "https://github.com/synaptent/aragora/pull/7",
+        }
+        with patch("aragora.swarm.boss_loop.subprocess.run", side_effect=OSError("fail")):
+            loop._convert_pr_to_draft(worker_result)
+        assert "draft_converted" not in worker_result
+
+
+class TestAllRequiredChecksPassed:
+    """Tests for _all_required_checks_passed."""
+
+    def test_all_checks_pass(self) -> None:
+        checks_json = json.dumps(
+            [
+                {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "Generate & Validate", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "TypeScript SDK Type Check",
+                    "state": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                },
+                {"name": "other-check", "state": "COMPLETED", "conclusion": "FAILURE"},
+            ]
+        )
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout=checks_json, stderr="")
+            assert BossLoop._all_required_checks_passed(42, "synaptent/aragora") is True
+
+    def test_missing_check_fails(self) -> None:
+        checks_json = json.dumps(
+            [
+                {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "Generate & Validate", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                # TypeScript SDK Type Check is missing
+            ]
+        )
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout=checks_json, stderr="")
+            assert BossLoop._all_required_checks_passed(42, "synaptent/aragora") is False
+
+    def test_failed_check_fails(self) -> None:
+        checks_json = json.dumps(
+            [
+                {"name": "lint", "state": "COMPLETED", "conclusion": "FAILURE"},
+                {"name": "typecheck", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "Generate & Validate", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "TypeScript SDK Type Check",
+                    "state": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                },
+            ]
+        )
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout=checks_json, stderr="")
+            assert BossLoop._all_required_checks_passed(42, "synaptent/aragora") is False
+
+    def test_gh_command_failure(self) -> None:
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=1, stdout="", stderr="error")
+            assert BossLoop._all_required_checks_passed(42, "synaptent/aragora") is False
+
+    def test_subprocess_exception(self) -> None:
+        with patch("aragora.swarm.boss_loop.subprocess.run", side_effect=OSError("fail")):
+            assert BossLoop._all_required_checks_passed(42, "synaptent/aragora") is False
+
+
+class TestPromoteReadyDrafts:
+    """Tests for _promote_ready_drafts."""
+
+    def test_promotes_draft_with_all_checks_passing(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        draft_list_json = json.dumps([{"number": 10}, {"number": 20}])
+        checks_10 = json.dumps(
+            [
+                {"name": "lint", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "typecheck", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "sdk-parity", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {"name": "Generate & Validate", "state": "COMPLETED", "conclusion": "SUCCESS"},
+                {
+                    "name": "TypeScript SDK Type Check",
+                    "state": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                },
+            ]
+        )
+        checks_20 = json.dumps(
+            [
+                {"name": "lint", "state": "COMPLETED", "conclusion": "FAILURE"},
+            ]
+        )
+
+        def fake_run(cmd, **kw):
+            if "list" in cmd:
+                return SimpleNamespace(returncode=0, stdout=draft_list_json, stderr="")
+            if "checks" in cmd:
+                if "10" in cmd:
+                    return SimpleNamespace(returncode=0, stdout=checks_10, stderr="")
+                return SimpleNamespace(returncode=0, stdout=checks_20, stderr="")
+            # gh pr ready (promote)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        with patch("aragora.swarm.boss_loop.subprocess.run", side_effect=fake_run):
+            promoted = loop._promote_ready_drafts()
+
+        assert promoted == [10]
+
+    def test_no_repo_returns_empty(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo=None))
+        result = loop._promote_ready_drafts()
+        assert result == []
+
+    def test_gh_list_failure_returns_empty(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=1, stdout="", stderr="error")
+            result = loop._promote_ready_drafts()
+        assert result == []
+
+    def test_empty_draft_list(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout="[]", stderr="")
+            result = loop._promote_ready_drafts()
+        assert result == []
+
+
+class TestPostprocessConvertsToDraft:
+    """Verify _postprocess_issue_result calls _convert_pr_to_draft."""
+
+    def test_postprocess_calls_convert(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        issue = _make_issue(number=99)
+        worker_result: dict[str, Any] = {
+            "status": "completed",
+            "pr_url": "https://github.com/synaptent/aragora/pull/99",
+        }
+        with (
+            patch.object(loop, "_maybe_publish_deliverable", return_value=None),
+            patch.object(loop, "_maybe_comment_published_deliverable", return_value=None),
+            patch.object(loop, "_maybe_auto_close_already_done_issue", return_value=None),
+            patch.object(loop, "_promote_published_deliverable"),
+            patch.object(loop, "_convert_pr_to_draft") as mock_convert,
+        ):
+            loop._postprocess_issue_result(issue, worker_result)
+        mock_convert.assert_called_once_with(worker_result)


### PR DESCRIPTION
## Summary

- Boss loop now converts newly-created PRs to **draft** immediately after publishing, so only the 5 required CI checks run (lint, typecheck, sdk-parity, Generate & Validate, TypeScript SDK Type Check)
- New `_promote_ready_drafts()` method runs at the end of each boss loop iteration, scanning open drafts and marking them ready-for-review once all 5 required checks pass
- This prevents **1,100+ CI runs** competing for runner time when 35+ open PRs each trigger all 32 workflows

### Key changes

- **`_convert_pr_to_draft(worker_result)`** -- called in `_postprocess_issue_result` after PR URL is harvested; runs `gh pr ready --undo` to convert to draft
- **`_promote_ready_drafts()`** -- lists open draft PRs, checks if all 5 required checks passed via `gh pr checks`, promotes via `gh pr ready`
- **`_all_required_checks_passed(pr_number, repo)`** -- static helper that parses `gh pr checks` JSON output
- **`_REQUIRED_CHECK_NAMES`** -- frozenset constant defining the 5 required check names
- All operations are best-effort with graceful error handling (warnings on failure, never blocks the loop)

## Test plan

- [x] `TestConvertPrToDraft` -- 5 tests covering success, no-op, already-draft, gh failure, subprocess exception
- [x] `TestAllRequiredChecksPassed` -- 5 tests covering all-pass, missing check, failed check, gh failure, exception
- [x] `TestPromoteReadyDrafts` -- 4 tests covering selective promotion, no repo, gh list failure, empty list
- [x] `TestPostprocessConvertsToDraft` -- 1 test verifying postprocess integration
- [x] Full test suite: 144/144 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)