### PR TITLE
ci(openapi): use standard project installer

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -183,8 +183,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .
-          python -m pip install pyyaml "datamodel-code-generator==0.54.0"
+          bash scripts/ci_install_project.sh --extras dev
           USER_BASE="$(python -m site --user-base)"
           echo "${USER_BASE}/bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
## Summary
- switch the OpenAPI workflow from ad hoc pip installs to `scripts/ci_install_project.sh --extras dev`
- pick up the repo's standard control-plane dependency set, including `pydantic-settings`
- keep the diff limited to the workflow install stanza

## Why
OpenAPI generation jobs that actually import handlers can degrade on runners that only install `-e .`, because this repo's standalone package metadata keeps runtime dependencies empty and relies on the standard CI installer to restore the control-plane dependency set. That leaves `pydantic_settings` unavailable in the workflow and causes degraded spec generation plus downstream validation failures.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(.github/workflows/openapi.yml) ... PY`
- `git diff --check HEAD^ HEAD`
- local OpenAPI generation on the same fix path confirmed `pydantic_settings` imports cleanly and the generator produces the full route set instead of the degraded fallback