### PR TITLE
fix: require strict boss-loop freshness flag

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -326,6 +326,13 @@ def _freshness_to_dict(freshness: Any) -> dict[str, Any]:
     return {}
 
 
+def _freshness_is_fresh(freshness: Any, freshness_dict: dict[str, Any]) -> bool:
+    """Require a real boolean freshness signal before dispatching work."""
+    if hasattr(freshness, "fresh"):
+        return getattr(freshness, "fresh") is True
+    return freshness_dict.get("fresh") is True
+
+
 async def dispatch_bounded_spec(
     spec: Any,
     *,
@@ -2278,7 +2285,7 @@ class BossLoop:
         )
         freshness_dict = _freshness_to_dict(freshness)
 
-        if not (freshness.fresh if hasattr(freshness, "fresh") else freshness_dict.get("fresh")):
+        if not _freshness_is_fresh(freshness, freshness_dict):
             blocked_reason = (
                 freshness.blocked_reason
                 if hasattr(freshness, "blocked_reason")

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1266,6 +1266,32 @@ class TestBossLoop:
         assert len(result.needs_human_reasons) > 0
         assert "No fresh runner" in result.needs_human_reasons[0]
 
+    def test_malformed_truthy_freshness_flag_blocks_dispatch(self):
+        config = _boss_config()
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(1, "Malformed freshness issue")]
+
+        freshness = SimpleNamespace(
+            fresh="false",
+            blocked_reason="malformed_fresh_flag",
+            details={},
+            to_dict=lambda: {"fresh": "false", "blocked_reason": "malformed_fresh_flag"},
+        )
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: freshness,
+        )
+
+        with patch.object(BossLoop, "_dispatch_issue", new_callable=AsyncMock) as mock_dispatch:
+            result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_FRESH_RUNNER.value
+        assert len(result.issues_attempted) == 0
+        assert "No fresh runner" in result.needs_human_reasons[0]
+        mock_dispatch.assert_not_awaited()
+
     def test_no_suitable_issue_stops(self):
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = []


### PR DESCRIPTION
## Summary
- require a real boolean freshness signal before boss-loop dispatch
- prevent malformed truthy freshness payloads from dispatching on stale runners
- add a regression for malformed freshness checker output

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k 'malformed_truthy_freshness_flag_blocks_dispatch or no_fresh_runner_stops_immediately'
- python -m pytest tests/swarm/test_boss_loop.py -q