### PR TITLE
fix: restore approvals fallback on checker failure

### DIFF
--- a/aragora/rbac/approvals.py
+++ b/aragora/rbac/approvals.py
@@ -717,6 +717,9 @@ class ApprovalWorkflow:
         ) as e:
             logger.warning("Error finding default approvers: %s", e)
             return []
+        except Exception as e:  # noqa: BLE001 - avoid breaking approval flow on unexpected checker failures
+            logger.warning("Unexpected error finding default approvers: %s", e)
+            return []
 
     async def _grant_temporary_permission(self, request: ApprovalRequest) -> None:
         """


### PR DESCRIPTION
## Summary
- restore the non-fatal fallback in `ApprovalWorkflow._get_default_approvers()`
- preserve the approvals flow when the permission checker raises an unexpected exception
- follow up on the regression introduced by #2624

## Validation
- `python3 -m pytest -q tests/rbac/test_approvals.py`
- `python3 -m ruff check aragora/rbac/approvals.py tests/rbac/test_approvals.py`
- `git diff --check`