### PR TITLE
fix: require boolean webhook active updates

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -830,11 +830,18 @@ The webhook secret is only returned once on creation - save it securely.""",
             if invalid_events:
                 return error_response(f"Invalid event types: {', '.join(invalid_events)}", 400)
 
+        active = None
+        if "active" in body:
+            raw_active = body.get("active")
+            if not isinstance(raw_active, bool):
+                return error_response("Active must be a boolean", 400)
+            active = raw_active
+
         updated = store.update(
             webhook_id=webhook_id,
             url=new_url,
             events=events,
-            active=body.get("active"),
+            active=active,
             name=body.get("name"),
             description=body.get("description"),
         )

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -917,6 +917,24 @@ class TestWebhookHandlerUpdate:
         assert result.status_code == 400
         assert b"at least one event type is required" in result.body.lower()
 
+    def test_update_webhook_rejects_nonboolean_active(self, webhook_handler, server_context):
+        """PATCH must not persist malformed activation flags."""
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com", events=["debate_start"], user_id="test-user-001"
+        )
+
+        body = json.dumps({"active": "false"}).encode()
+        handler = MockHandler(
+            headers={"Content-Length": str(len(body)), "Content-Type": "application/json"},
+            body=body,
+        )
+
+        result = webhook_handler.handle_patch(f"/api/v1/webhooks/{webhook.id}", {}, handler)
+
+        assert result.status_code == 400
+        assert b"active must be a boolean" in result.body.lower()
+
     def test_update_webhook_hides_workspace_mismatch(self, server_context):
         from aragora.server.handlers.webhooks import WebhookHandler
 


### PR DESCRIPTION
## Summary
- require PATCH webhook active payloads to be real booleans
- prevent stringly activation flags from persisting as truthy active state
- add handler regressions for malformed active payloads

## Testing
- python -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/test_webhooks_handler.py
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q -k 'update_webhook_success or nonboolean_active or empty_url or empty_events_payload or string_events_payload'
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q