### PR TITLE
test(infra): share FastAPI and admin handler fixtures

### DIFF
--- a/tests/server/fastapi/conftest.py
+++ b/tests/server/fastapi/conftest.py
@@ -1,0 +1,170 @@
+"""Shared fixtures for FastAPI route tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aragora.rbac.models import AuthorizationContext
+from aragora.server.fastapi import create_app
+from aragora.server.fastapi.dependencies.auth import require_authenticated
+
+
+@pytest.fixture
+def fastapi_context_builder():
+    """Build common FastAPI app context dictionaries for route tests."""
+
+    def _build(**overrides: Any) -> dict[str, Any]:
+        context = {
+            "storage": MagicMock(),
+            "elo_system": MagicMock(),
+            "user_store": None,
+            "rbac_checker": MagicMock(),
+            "decision_service": MagicMock(),
+        }
+        context.update(overrides)
+        return context
+
+    return _build
+
+
+@pytest.fixture
+def fastapi_context(fastapi_context_builder):
+    """Default FastAPI app context used by shared client/request fixtures."""
+    return fastapi_context_builder()
+
+
+@pytest.fixture
+def fastapi_app(fastapi_context):
+    """Create a FastAPI app with a lightweight mocked context."""
+    app = create_app()
+    app.state.context = fastapi_context
+    return app
+
+
+@pytest.fixture
+def app(fastapi_app):
+    """Compatibility alias for tests that expect an ``app`` fixture."""
+    return fastapi_app
+
+
+@pytest.fixture
+def fastapi_client(fastapi_app):
+    """Create a test client that always clears dependency overrides on teardown."""
+    client = TestClient(fastapi_app, raise_server_exceptions=False)
+    try:
+        yield client
+    finally:
+        fastapi_app.dependency_overrides.clear()
+        client.close()
+
+
+@pytest.fixture
+def client(fastapi_client):
+    """Compatibility alias for tests that expect a ``client`` fixture."""
+    return fastapi_client
+
+
+@pytest.fixture
+def mock_app_client(fastapi_client):
+    """Explicit alias used by route tests that want a mocked app client."""
+    return fastapi_client
+
+
+@pytest.fixture
+def fastapi_request_factory(fastapi_context_builder):
+    """Create lightweight request mocks for calling route functions directly."""
+
+    def _build(
+        *,
+        context: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        method: str = "GET",
+        path: str = "/",
+        body: bytes = b"",
+    ) -> MagicMock:
+        request = MagicMock()
+        request.app.state.context = context if context is not None else fastapi_context_builder()
+        request.headers = headers or {}
+        request.method = method
+        request.url = SimpleNamespace(path=path)
+        request.state = SimpleNamespace()
+        request.body = AsyncMock(return_value=body)
+        return request
+
+    return _build
+
+
+@pytest.fixture
+def route_request_factory(fastapi_request_factory):
+    """Short alias for direct route-request helper creation."""
+    return fastapi_request_factory
+
+
+@pytest.fixture
+def fastapi_route_auth_factory():
+    """Build lightweight auth objects for direct route-function tests."""
+
+    def _build(
+        *,
+        user_id: str = "user-1",
+        email: str = "user@example.com",
+        org_id: str = "org-1",
+        workspace_id: str = "ws-1",
+        roles: set[str] | None = None,
+        permissions: set[str] | None = None,
+        **extra: Any,
+    ) -> SimpleNamespace:
+        return SimpleNamespace(
+            user_id=user_id,
+            email=email,
+            org_id=org_id,
+            workspace_id=workspace_id,
+            roles=set(roles or {"admin"}),
+            permissions=set(permissions or {"*"}),
+            **extra,
+        )
+
+    return _build
+
+
+@pytest.fixture
+def route_auth_factory(fastapi_route_auth_factory):
+    """Short alias for direct route-auth helper creation."""
+    return fastapi_route_auth_factory
+
+
+@pytest.fixture
+def override_fastapi_auth():
+    """Override ``require_authenticated`` with a configurable auth context."""
+
+    def _override(
+        client: TestClient,
+        *,
+        user_id: str = "user-1",
+        org_id: str = "org-1",
+        workspace_id: str = "ws-1",
+        roles: set[str] | None = None,
+        permissions: set[str] | None = None,
+    ) -> AuthorizationContext:
+        auth_ctx = AuthorizationContext(
+            user_id=user_id,
+            org_id=org_id,
+            workspace_id=workspace_id,
+            roles=set(roles or {"admin"}),
+            permissions=set(permissions or {"*"}),
+        )
+        client.app.dependency_overrides[require_authenticated] = lambda: auth_ctx
+        return auth_ctx
+
+    return _override
+
+
+@pytest.fixture
+def override_auth(override_fastapi_auth):
+    """Short alias for common auth override helper usage."""
+    return override_fastapi_auth

--- a/tests/server/fastapi/test_admin_routes.py
+++ b/tests/server/fastapi/test_admin_routes.py
@@ -7,17 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from aragora.server.fastapi.routes import admin as admin_routes
 
 
-def _request() -> MagicMock:
-    request = MagicMock()
-    request.app.state.context = {}
-    return request
-
-
-def _auth(user_id: str = "admin-1") -> SimpleNamespace:
-    return SimpleNamespace(user_id=user_id)
-
-
-def test_list_users_prefers_async_store_methods() -> None:
+def test_list_users_prefers_async_store_methods(route_request_factory, route_auth_factory) -> None:
     user = MagicMock()
     user.to_dict.return_value = {
         "id": "user-1",
@@ -34,13 +24,13 @@ def test_list_users_prefers_async_store_methods() -> None:
 
     response = asyncio.run(
         admin_routes.list_users(
-            request=_request(),
+            request=route_request_factory(context={}),
             limit=50,
             offset=0,
             org_id=None,
             role=None,
             active_only=False,
-            auth=_auth(),
+            auth=route_auth_factory(user_id="admin-1"),
             user_store=store,
         )
     )
@@ -56,7 +46,9 @@ def test_list_users_prefers_async_store_methods() -> None:
     )
 
 
-def test_create_user_hashes_password_and_prefers_async_store_methods() -> None:
+def test_create_user_hashes_password_and_prefers_async_store_methods(
+    route_request_factory, route_auth_factory
+) -> None:
     store = MagicMock()
     store.get_user_by_email.side_effect = AssertionError(
         "sync get_user_by_email should not be used"
@@ -77,8 +69,8 @@ def test_create_user_hashes_password_and_prefers_async_store_methods() -> None:
                     role="member",
                     password="super-secret-1",
                 ),
-                request=_request(),
-                auth=_auth(),
+                request=route_request_factory(context={}),
+                auth=route_auth_factory(user_id="admin-1"),
                 user_store=store,
             )
         )
@@ -95,7 +87,9 @@ def test_create_user_hashes_password_and_prefers_async_store_methods() -> None:
     )
 
 
-def test_deactivate_user_prefers_async_store_methods() -> None:
+def test_deactivate_user_prefers_async_store_methods(
+    route_request_factory, route_auth_factory
+) -> None:
     target_user = SimpleNamespace(email="user@example.com")
     store = MagicMock()
     store.get_user_by_id.side_effect = AssertionError("sync get_user_by_id should not be used")
@@ -107,8 +101,8 @@ def test_deactivate_user_prefers_async_store_methods() -> None:
         response = asyncio.run(
             admin_routes.deactivate_user(
                 user_id="user-1",
-                request=_request(),
-                auth=_auth(),
+                request=route_request_factory(context={}),
+                auth=route_auth_factory(user_id="admin-1"),
                 user_store=store,
             )
         )
@@ -118,7 +112,9 @@ def test_deactivate_user_prefers_async_store_methods() -> None:
     store.update_user_async.assert_awaited_once_with("user-1", is_active=False)
 
 
-def test_get_revenue_stats_prefers_async_store_methods() -> None:
+def test_get_revenue_stats_prefers_async_store_methods(
+    route_request_factory, route_auth_factory
+) -> None:
     store = MagicMock()
     store.get_admin_stats.side_effect = AssertionError("sync get_admin_stats should not be used")
     store.get_admin_stats_async = AsyncMock(
@@ -130,8 +126,8 @@ def test_get_revenue_stats_prefers_async_store_methods() -> None:
 
     response = asyncio.run(
         admin_routes.get_revenue_stats(
-            request=_request(),
-            auth=_auth(),
+            request=route_request_factory(context={}),
+            auth=route_auth_factory(user_id="admin-1"),
             user_store=store,
         )
     )
@@ -140,10 +136,9 @@ def test_get_revenue_stats_prefers_async_store_methods() -> None:
     store.get_admin_stats_async.assert_awaited_once_with()
 
 
-def test_get_user_store_falls_back_to_storage_singleton() -> None:
+def test_get_user_store_falls_back_to_storage_singleton(route_request_factory) -> None:
     store = object()
-    request = _request()
-    request.app.state.context = {}
+    request = route_request_factory(context={})
 
     with patch("aragora.storage.user_store.get_user_store", return_value=store):
         result = admin_routes._get_user_store(request)

--- a/tests/server/handlers/admin/conftest.py
+++ b/tests/server/handlers/admin/conftest.py
@@ -1,0 +1,135 @@
+"""Shared fixtures for admin handler tests."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _coerce_request_body(body: dict[str, Any] | list[Any] | bytes | str | None) -> bytes:
+    if body is None:
+        return b"{}"
+    if isinstance(body, bytes):
+        return body
+    if isinstance(body, str):
+        return body.encode("utf-8")
+    return json.dumps(body).encode("utf-8")
+
+
+@pytest.fixture(autouse=True)
+def reset_admin_rate_limiter():
+    """Reset the admin rate limiter before and after each test."""
+    from aragora.server.handlers.admin.handler import _admin_limiter
+
+    _admin_limiter._buckets.clear()
+    yield
+    _admin_limiter._buckets.clear()
+
+
+@pytest.fixture
+def admin_context_builder():
+    """Build common server context dictionaries for admin handler tests."""
+
+    def _build(**overrides: Any) -> dict[str, Any]:
+        context = {
+            "user_store": MagicMock(),
+            "storage": MagicMock(),
+            "elo_system": MagicMock(),
+            "decision_service": MagicMock(),
+        }
+        context.update(overrides)
+        return context
+
+    return _build
+
+
+@pytest.fixture
+def admin_server_context(admin_context_builder):
+    """Default admin server context with mocked dependencies."""
+    return admin_context_builder()
+
+
+@pytest.fixture
+def mock_server_context(admin_server_context):
+    """Compatibility alias for tests that expect ``mock_server_context``."""
+    return admin_server_context
+
+
+@pytest.fixture
+def admin_auth_context() -> MagicMock:
+    """Create a reusable authenticated admin auth context."""
+    auth_ctx = MagicMock()
+    auth_ctx.user_id = "admin-1"
+    auth_ctx.user_email = "admin@example.com"
+    auth_ctx.org_id = "org-1"
+    auth_ctx.workspace_id = "ws-1"
+    auth_ctx.roles = ["admin", "owner"]
+    auth_ctx.permissions = {"*"}
+    return auth_ctx
+
+
+@pytest.fixture
+def admin_request_factory(admin_auth_context):
+    """Create request-handler doubles for admin handler unit tests."""
+
+    def _build(
+        *,
+        method: str = "GET",
+        path: str = "/api/v1/admin",
+        headers: dict[str, str] | None = None,
+        body: dict[str, Any] | list[Any] | bytes | str | None = None,
+        user_id: str | None = None,
+        roles: list[str] | None = None,
+    ) -> MagicMock:
+        body_bytes = _coerce_request_body(body)
+        role_list = list(roles or admin_auth_context.roles)
+        current_user_id = user_id or admin_auth_context.user_id
+
+        handler = MagicMock()
+        handler.headers = {"Content-Type": "application/json", **(headers or {})}
+        handler.headers.setdefault("Content-Length", str(len(body_bytes)))
+        handler.request_body = body_bytes
+        handler._body = body_bytes
+        handler.rfile = MagicMock()
+        handler.rfile.read = MagicMock(return_value=body_bytes)
+        handler.path = path
+        handler.command = method
+        handler.client_address = ("127.0.0.1", 12345)
+        handler._context = {"user": {"id": current_user_id, "roles": role_list}}
+
+        request_auth_context = MagicMock()
+        request_auth_context.user_id = current_user_id
+        request_auth_context.user_email = admin_auth_context.user_email
+        request_auth_context.org_id = admin_auth_context.org_id
+        request_auth_context.workspace_id = admin_auth_context.workspace_id
+        request_auth_context.roles = role_list
+        request_auth_context.permissions = admin_auth_context.permissions
+        handler._auth_context = request_auth_context
+        return handler
+
+    return _build
+
+
+@pytest.fixture
+def admin_request_handler(admin_request_factory):
+    """Default admin request handler double."""
+    return admin_request_factory()
+
+
+@pytest.fixture
+def mock_handler(admin_request_handler):
+    """Compatibility alias for tests that expect ``mock_handler``."""
+    return admin_request_handler
+
+
+@pytest.fixture
+def admin_handler_factory(admin_server_context):
+    """Instantiate admin handlers with the shared server context."""
+
+    def _build(handler_cls, *args: Any, **kwargs: Any):
+        return handler_cls(admin_server_context, *args, **kwargs)
+
+    return _build

--- a/tests/server/handlers/admin/test_security_handler.py
+++ b/tests/server/handlers/admin/test_security_handler.py
@@ -127,26 +127,9 @@ class MockRotationResult:
 
 
 @pytest.fixture
-def mock_server_context() -> MagicMock:
-    """Create mock server context."""
-    return MagicMock()
-
-
-@pytest.fixture
-def security_handler(mock_server_context: MagicMock) -> SecurityHandler:
+def security_handler(mock_server_context: dict[str, Any]) -> SecurityHandler:
     """Create security handler for tests."""
     return SecurityHandler(mock_server_context)
-
-
-@pytest.fixture
-def mock_handler() -> MagicMock:
-    """Create mock request handler with auth context."""
-    handler = MagicMock()
-    handler._context = {"user": {"id": "admin-1", "roles": ["admin"]}}
-    handler._auth_context = MagicMock()
-    handler._auth_context.user_id = "admin-1"
-    handler._auth_context.roles = ["admin"]
-    return handler
 
 
 class TestCanHandle:


### PR DESCRIPTION
## Summary
- add shared FastAPI route-test fixtures for app, client, request, and auth setup
- add shared admin handler fixtures for mocked server context, request handlers, and rate limiter reset
- migrate admin route and security handler tests to the shared scaffold to reduce duplication and unblock follow-on handler fixes

## Validation
- python3 -m ruff check tests/server/fastapi/conftest.py tests/server/fastapi/test_admin_routes.py tests/server/handlers/admin/conftest.py tests/server/handlers/admin/test_security_handler.py
- python3 -m pytest tests/server/fastapi tests/server/handlers/admin -q