### PR TITLE
fix: require string webhook register urls

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -693,9 +693,12 @@ The webhook secret is only returned once on creation - save it securely.""",
         if rbac_error:
             return rbac_error
 
-        url = body.get("url", "").strip()
+        raw_url = body.get("url", "")
+        if not isinstance(raw_url, str):
+            return error_response("URL must be a non-empty string", 400)
+        url = raw_url.strip()
         if not url:
-            return error_response("URL is required", 400)
+            return error_response("URL must be a non-empty string", 400)
 
         # Validate URL format and check for SSRF
         is_valid, error_msg = validate_webhook_url(url, allow_localhost=False)

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -458,7 +458,21 @@ class TestWebhookHandlerRegister:
         result = await webhook_handler.handle_post("/api/v1/webhooks", {}, handler)
 
         assert result.status_code == 400
-        assert b"URL is required" in result.body
+        assert b"url must be a non-empty string" in result.body.lower()
+
+    @pytest.mark.asyncio
+    async def test_register_webhook_rejects_nonstring_url(self, webhook_handler):
+        """Registration must reject malformed non-string callback URLs."""
+        body = json.dumps({"url": False, "events": ["debate_start"]}).encode()
+        handler = MockHandler(
+            headers={"Content-Length": str(len(body)), "Content-Type": "application/json"},
+            body=body,
+        )
+
+        result = await webhook_handler.handle_post("/api/v1/webhooks", {}, handler)
+
+        assert result.status_code == 400
+        assert b"url must be a non-empty string" in result.body.lower()
 
     @pytest.mark.asyncio
     async def test_register_webhook_invalid_url(self, webhook_handler):


### PR DESCRIPTION
## Summary
- require webhook registration URL payloads to be real strings
- return 400 for malformed non-string register URLs instead of crashing the handler
- add registration regressions for missing and malformed URL payloads

## Testing
- python -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/test_webhooks_handler.py
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q -k 'register_webhook_missing_url or register_webhook_rejects_nonstring_url or register_webhook_invalid_url or register_webhook_rejects_string_events_payload'
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q