### PR TITLE
fix: restore truthful crash salvage terminal outcome

### DIFF
--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -47,7 +47,7 @@ _WORKER_OUTCOME_TO_TERMINAL: dict[str, str] = {
     "completed": "deliverable_created",
     "clean_exit_no_effect": "clean_exit_no_deliverable",
     "crash": "crash",
-    "crash_with_salvage": "deliverable_created",  # salvaged commits are real deliverables
+    "crash_with_salvage": "crash",  # salvage preserves artifacts but not the terminal truth
     "timeout_no_progress": "timeout",
     "timeout_with_salvage": "deliverable_created",  # salvaged commits are real deliverables
     "scope_violation": "blocked",


### PR DESCRIPTION
## Summary\n- restore  terminal truth to \n- preserve salvage artifacts while keeping supervisor telemetry truthful\n- fix the regression now present on  after #2606 merged\n\n## Validation\n- python3 -m pytest -q tests/swarm/test_lane_telemetry.py\n- python3 -m pytest -q tests/swarm/test_lane_telemetry.py -k 'terminal_work_order_records_supervisor_event or preview_only_outcome_is_excluded_from_human_intervention or missing_outcome_falls_back_to_deliverable_created'\n- python3 -m ruff check aragora/swarm/terminal_truth.py tests/swarm/test_lane_telemetry.py\n- python3 -m ruff format --check aragora/swarm/terminal_truth.py tests/swarm/test_lane_telemetry.py\n- git diff --check