### PR TITLE
fix(boss-loop): cap auto-published boss harvest PRs

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -277,6 +277,7 @@ class BossLoopConfig:
     # Autonomous post-processing: publish verified branch deliverables and
     # optionally close already-resolved no-op issues.
     auto_publish_deliverables: bool = False
+    max_open_auto_publish_prs: int = 1
     auto_close_already_done_issues: bool = False
 
     # Reporting
@@ -1518,6 +1519,38 @@ class BossLoop:
         ]
         if not branch or not commit_shas:
             return None
+        max_open_prs = max(int(self.config.max_open_auto_publish_prs or 0), 0)
+        if max_open_prs <= 0:
+            logger.info(
+                "Boss publish deferred for issue #%s branch %s: max_open_auto_publish_prs=%d",
+                issue.number,
+                branch,
+                max_open_prs,
+            )
+            return {
+                "action": "deferred_due_to_open_boss_prs",
+                "reason": "max_open_auto_publish_prs_zero",
+                "branch": branch,
+                "max_open_prs": max_open_prs,
+                "open_prs": [],
+            }
+        open_boss_prs = self._list_open_boss_harvest_prs()
+        if len(open_boss_prs) >= max_open_prs:
+            logger.info(
+                "Boss publish deferred for issue #%s branch %s: %d open boss-harvest PR(s) "
+                "already exist (limit=%d)",
+                issue.number,
+                branch,
+                len(open_boss_prs),
+                max_open_prs,
+            )
+            return {
+                "action": "deferred_due_to_open_boss_prs",
+                "reason": "open_boss_harvest_pr_limit",
+                "branch": branch,
+                "max_open_prs": max_open_prs,
+                "open_prs": open_boss_prs,
+            }
         try:
             from aragora.ralph.github_control import GitHubControl
             from aragora.swarm.pr_registry import PullRequestRegistry
@@ -1581,6 +1614,60 @@ class BossLoop:
             worker_result["pr_url"] = pr_url
             worker_result["pr_number"] = self._pr_number_from_url(pr_url)
         return dict(publish_result)
+
+    def _list_open_boss_harvest_prs(self) -> list[dict[str, Any]]:
+        """List open boss-harvest PRs so auto-publish can avoid queue fan-out."""
+        repo = str(self.config.repo or "").strip()
+        if not repo:
+            return []
+        cmd: list[str] = [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,isDraft,url",
+            "--limit",
+            "100",
+            "-R",
+            repo,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if proc.returncode != 0:
+                logger.debug(
+                    "Failed to list open boss-harvest PRs: %s",
+                    (proc.stderr or proc.stdout or "").strip(),
+                )
+                return []
+            entries = json.loads(proc.stdout or "[]")
+        except Exception as exc:
+            logger.debug("Exception listing open boss-harvest PRs: %s", exc)
+            return []
+
+        open_boss_prs: list[dict[str, Any]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            head_ref = str(entry.get("headRefName", "")).strip()
+            if not head_ref.startswith("aragora/boss-harvest/issue-"):
+                continue
+            open_boss_prs.append(
+                {
+                    "number": entry.get("number"),
+                    "headRefName": head_ref,
+                    "isDraft": bool(entry.get("isDraft")),
+                    "url": str(entry.get("url", "")).strip() or None,
+                }
+            )
+        return open_boss_prs
 
     def _harvest_worker_commits_for_publish(
         self,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -4300,6 +4300,105 @@ class TestPromoteReadyDrafts:
         assert result == []
 
 
+class TestListOpenBossHarvestPrs:
+    """Tests for boss-harvest queue-cap inspection."""
+
+    def test_filters_to_open_boss_harvest_prs(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        pr_list_json = json.dumps(
+            [
+                {
+                    "number": 10,
+                    "headRefName": "aragora/boss-harvest/issue-10-boss-aaa",
+                    "isDraft": True,
+                    "url": "https://github.com/synaptent/aragora/pull/10",
+                },
+                {
+                    "number": 11,
+                    "headRefName": "codex/ordinary-branch",
+                    "isDraft": True,
+                    "url": "https://github.com/synaptent/aragora/pull/11",
+                },
+            ]
+        )
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=0, stdout=pr_list_json, stderr="")
+            result = loop._list_open_boss_harvest_prs()
+
+        assert result == [
+            {
+                "number": 10,
+                "headRefName": "aragora/boss-harvest/issue-10-boss-aaa",
+                "isDraft": True,
+                "url": "https://github.com/synaptent/aragora/pull/10",
+            }
+        ]
+
+    def test_returns_empty_when_listing_fails(self) -> None:
+        loop = BossLoop(config=BossLoopConfig(repo="synaptent/aragora"))
+        with patch("aragora.swarm.boss_loop.subprocess.run") as mock_run:
+            mock_run.return_value = SimpleNamespace(returncode=1, stdout="", stderr="error")
+            result = loop._list_open_boss_harvest_prs()
+        assert result == []
+
+
+class TestMaybePublishDeliverable:
+    """Tests for auto-publish queue capping."""
+
+    def test_defers_when_open_boss_harvest_pr_already_exists(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+                max_open_auto_publish_prs=1,
+            )
+        )
+        issue = _make_issue(number=123)
+        worker_result = {
+            "status": "needs_human",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/issue-123",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(
+                loop,
+                "_list_open_boss_harvest_prs",
+                return_value=[
+                    {
+                        "number": 2045,
+                        "headRefName": "aragora/boss-harvest/issue-45-boss-aaa",
+                        "isDraft": True,
+                        "url": "https://github.com/synaptent/aragora/pull/2045",
+                    }
+                ],
+            ),
+            patch.object(loop, "_harvest_worker_commits_for_publish") as mock_harvest,
+            patch("aragora.swarm.tranche_integrate.publish_lane_deliverable") as mock_publish,
+        ):
+            result = loop._maybe_publish_deliverable(issue, worker_result)
+
+        assert result == {
+            "action": "deferred_due_to_open_boss_prs",
+            "reason": "open_boss_harvest_pr_limit",
+            "branch": "codex/issue-123",
+            "max_open_prs": 1,
+            "open_prs": [
+                {
+                    "number": 2045,
+                    "headRefName": "aragora/boss-harvest/issue-45-boss-aaa",
+                    "isDraft": True,
+                    "url": "https://github.com/synaptent/aragora/pull/2045",
+                }
+            ],
+        }
+        mock_harvest.assert_not_called()
+        mock_publish.assert_not_called()
+
+
 class TestPostprocessConvertsToDraft:
     """Verify _postprocess_issue_result calls _convert_pr_to_draft."""
 


### PR DESCRIPTION
## Summary
- cap boss-loop auto-publish to one open boss-harvest PR at a time
- defer new auto-publish attempts while an existing boss-harvest PR is still open
- add regression coverage for the queue-cap inspection and deferred publish path

## Validation
- python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m pytest -q tests/swarm/test_boss_loop.py -k "MaybePublishDeliverable or ListOpenBossHarvestPrs or PromoteReadyDrafts or ConvertPrToDraft or dispatch_auto_publish"