### PR TITLE
Fail closed on malformed boss-loop deliverables

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -3077,7 +3077,10 @@ class BossLoop:
             )
 
         if worker_result.get("status") == "needs_human":
-            has_deliverable = bool(worker_result.get("deliverable"))
+            _terminal_outcome, normalized_deliverable_type = _qualify_worker_result_terminal_state(
+                worker_result
+            )
+            has_deliverable = bool(normalized_deliverable_type)
             self._emit_lane_receipt(worker_result, issue_dict, elapsed_seconds)
             if self.config.auto_continue_on_needs_human and has_deliverable:
                 self._failed_issues.append(issue_dict)

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1569,6 +1569,34 @@ class TestBossLoop:
         assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
         assert "Approval required for merge." in result.needs_human_reasons
 
+    def test_needs_human_truthy_junk_deliverable_does_not_auto_continue(self):
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(1, "Needs human review")]
+
+        config = _boss_config(auto_continue_on_needs_human=True)
+
+        async def _needs_human_dispatch(issue, freshness):
+            return {
+                "status": "needs_human",
+                "reasons": ["Approval required for merge."],
+                "deliverable": "branch-ready",
+            }
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _needs_human_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NO_SUITABLE_ISSUE.value
+        assert result.iteration_statuses[0]["next_actions"] == [
+            "Skipping to next issue (auto-continue mode)."
+        ]
+        assert "Approval required for merge." in result.iteration_statuses[0]["needs_human_reasons"]
+
     def test_retry_rotation_switches_target_agent_after_needs_human(self):
         feed = MagicMock(spec=GitHubIssueFeed)
         feed.fetch.return_value = [_make_issue(42, "Retry with rotated agent")]


### PR DESCRIPTION
## Summary
- require a normalized concrete deliverable type before boss-loop auto-continue treats a needs-human result as recoverable
- keep truthy junk deliverable payloads on the plain skip path instead of the recovered-deliverable fast path
- add regression coverage for malformed deliverable payloads in auto-continue mode

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k 'truthy_junk_deliverable or needs_human_stops or retry_rotation_switches_target_agent_after_needs_human'
- python -m pytest tests/swarm/test_boss_loop.py -q