### PR TITLE
Fail closed on malformed Slack uninstall payloads

### DIFF
--- a/aragora/server/handlers/social/slack_oauth.py
+++ b/aragora/server/handlers/social/slack_oauth.py
@@ -1559,11 +1559,41 @@ class SlackOAuthHandler(SecureHandler):
                 logger.warning("Invalid Slack signature")
                 return error_response("Invalid signature", 401)
 
-        event = body.get("event", {})
-        event_type = event.get("type")
+        event_payload = body.get("event")
+        event = event_payload if isinstance(event_payload, dict) else {}
+        try:
+            event_type = (
+                _parse_slack_string_field(
+                    event.get("type"),
+                    field_name="event.type",
+                    required=False,
+                )
+                or ""
+            )
+        except ValueError:
+            logger.warning("Ignoring malformed Slack uninstall event type")
+            event_type = ""
 
         if event_type == "app_uninstalled":
-            workspace_id = body.get("team_id") or event.get("team_id")
+            workspace_id = ""
+            for raw_value, field_name in (
+                (body.get("team_id"), "team_id"),
+                (event.get("team_id"), "event.team_id"),
+            ):
+                try:
+                    candidate_workspace_id = _parse_slack_string_field(
+                        raw_value,
+                        field_name=field_name,
+                        required=False,
+                    )
+                except ValueError:
+                    logger.warning(
+                        "Ignoring malformed Slack uninstall workspace id in %s", field_name
+                    )
+                    continue
+                if candidate_workspace_id:
+                    workspace_id = candidate_workspace_id
+                    break
 
             if workspace_id:
                 try:
@@ -1588,9 +1618,26 @@ class SlackOAuthHandler(SecureHandler):
                     logger.warning("Could not deactivate workspace - store unavailable")
 
         elif event_type == "tokens_revoked":
-            workspace_id = body.get("team_id")
-            tokens = event.get("tokens", {})
-            bot_tokens = tokens.get("bot", [])
+            try:
+                workspace_id = (
+                    _parse_slack_string_field(
+                        body.get("team_id"),
+                        field_name="team_id",
+                        required=False,
+                    )
+                    or ""
+                )
+            except ValueError:
+                logger.warning("Ignoring malformed Slack tokens_revoked workspace id")
+                workspace_id = ""
+            tokens_payload = event.get("tokens")
+            tokens = tokens_payload if isinstance(tokens_payload, dict) else {}
+            bot_payload = tokens.get("bot", [])
+            bot_tokens = (
+                [token.strip() for token in bot_payload if isinstance(token, str) and token.strip()]
+                if isinstance(bot_payload, (list, tuple, set))
+                else []
+            )
 
             if workspace_id and bot_tokens:
                 try:

--- a/tests/handlers/social/test_slack_oauth.py
+++ b/tests/handlers/social/test_slack_oauth.py
@@ -2118,6 +2118,60 @@ class TestUninstall:
         mock_workspace_store.deactivate.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_uninstall_malformed_event_payload_still_acks(
+        self, handler, mock_workspace_store, monkeypatch
+    ):
+        monkeypatch.setenv("ARAGORA_ENV", "test")
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "")
+        body = {
+            "team_id": "W123",
+            "event": True,
+        }
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/uninstall",
+                body,
+                {},
+                {},
+                None,
+            )
+        assert _status(result) == 200
+        assert _body(result).get("ok") is True
+        mock_workspace_store.deactivate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tokens_revoked_malformed_bot_tokens_no_deactivation(
+        self, handler, mock_workspace_store, monkeypatch
+    ):
+        monkeypatch.setenv("ARAGORA_ENV", "test")
+        monkeypatch.setenv("SLACK_SIGNING_SECRET", "")
+        body = {
+            "team_id": "W123",
+            "event": {
+                "type": "tokens_revoked",
+                "tokens": {"bot": "xoxb-old"},
+            },
+        }
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_workspace_store,
+        ):
+            result = await handler.handle(
+                "POST",
+                "/api/integrations/slack/uninstall",
+                body,
+                {},
+                {},
+                None,
+            )
+        assert _status(result) == 200
+        mock_workspace_store.deactivate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unknown_event_still_acks(self, handler, monkeypatch):
         monkeypatch.setenv("ARAGORA_ENV", "test")
         monkeypatch.setenv("SLACK_SIGNING_SECRET", "")

--- a/tests/server/handlers/social/test_slack_oauth_handler.py
+++ b/tests/server/handlers/social/test_slack_oauth_handler.py
@@ -658,6 +658,32 @@ class TestSlackOAuthUninstall:
         mock_store.deactivate.assert_called_once_with("T12345678")
 
     @pytest.mark.asyncio
+    async def test_uninstall_tokens_revoked_malformed_bot_tokens_does_not_deactivate(
+        self, oauth_handler
+    ):
+        """Malformed bot token payloads should ack without deactivating."""
+        mock_store = MagicMock()
+
+        with patch(
+            "aragora.storage.slack_workspace_store.get_slack_workspace_store",
+            return_value=mock_store,
+        ):
+            result = await oauth_handler.handle(
+                "POST",
+                "/api/integrations/slack/uninstall",
+                body={
+                    "team_id": "T12345678",
+                    "event": {
+                        "type": "tokens_revoked",
+                        "tokens": {"bot": "xoxb-token"},
+                    },
+                },
+            )
+
+        assert result.status_code == 200
+        mock_store.deactivate.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_uninstall_uses_secret_backed_signing_secret(self, oauth_handler):
         """Uninstall should verify signatures with secret-backed config in production."""
         body = {


### PR DESCRIPTION
## Summary
- validate Slack uninstall event payload shapes before reading event type, workspace id, or revoked bot tokens
- ignore malformed event and token shapes instead of crashing or deactivating a workspace on truthy junk
- add regression coverage in both Slack OAuth suites

## Testing
- python -m ruff check aragora/server/handlers/social/slack_oauth.py tests/handlers/social/test_slack_oauth.py tests/server/handlers/social/test_slack_oauth_handler.py
- python -m pytest tests/handlers/social/test_slack_oauth.py -q
- python -m pytest tests/server/handlers/social/test_slack_oauth_handler.py -q