### PR TITLE
test(infra): share social, chat, and channel fixtures

### DIFF
--- a/tests/channels/conftest.py
+++ b/tests/channels/conftest.py
@@ -1,0 +1,171 @@
+"""Shared fixtures for channel dock tests."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aragora.channels.dock import ChannelCapability, ChannelDock, SendResult
+from aragora.channels.normalized import MessageFormat, NormalizedMessage
+from aragora.channels.registry import DockRegistry
+
+
+class MockDock(ChannelDock):
+    """Mock dock for registry tests."""
+
+    PLATFORM = "mock"
+    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.BUTTONS
+
+    def __init__(self, config=None):
+        self.config = config or {}
+        self._initialized = False
+
+    @property
+    def is_initialized(self):
+        return self._initialized
+
+    async def initialize(self):
+        self._initialized = True
+
+    async def send_message(self, channel_id, message):
+        return None
+
+    async def send_result(self, channel_id, result, **kwargs):
+        return None
+
+    async def send_error(self, channel_id, error, **kwargs):
+        return None
+
+
+class VoiceDock(ChannelDock):
+    """Mock dock with voice capability for registry tests."""
+
+    PLATFORM = "voice_platform"
+    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.VOICE
+
+    def __init__(self, config=None):
+        self.config = config or {}
+        self._initialized = False
+
+    @property
+    def is_initialized(self):
+        return self._initialized
+
+    async def initialize(self):
+        self._initialized = True
+
+    async def send_message(self, channel_id, message):
+        return None
+
+    async def send_result(self, channel_id, result, **kwargs):
+        return None
+
+    async def send_error(self, channel_id, error, **kwargs):
+        return None
+
+
+class FakeSlackDock(ChannelDock):
+    PLATFORM = "slack"
+    CAPABILITIES = (
+        ChannelCapability.RICH_TEXT | ChannelCapability.BUTTONS | ChannelCapability.THREADS
+    )
+
+    async def send_message(self, channel_id, message, **kwargs):
+        return SendResult.ok(message_id="msg-1", platform=self.PLATFORM, channel_id=channel_id)
+
+
+class FakeTelegramDock(ChannelDock):
+    PLATFORM = "telegram"
+    CAPABILITIES = (
+        ChannelCapability.RICH_TEXT
+        | ChannelCapability.BUTTONS
+        | ChannelCapability.VOICE
+        | ChannelCapability.FILES
+    )
+
+    async def send_message(self, channel_id, message, **kwargs):
+        return SendResult.ok(message_id="msg-2", platform=self.PLATFORM, channel_id=channel_id)
+
+
+class FakeEmailDock(ChannelDock):
+    PLATFORM = "email"
+    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.FILES
+
+    async def send_message(self, channel_id, message, **kwargs):
+        return SendResult.ok(platform=self.PLATFORM, channel_id=channel_id)
+
+
+class FakeSimpleDock(ChannelDock):
+    PLATFORM = "simple"
+    CAPABILITIES = ChannelCapability.NONE
+
+    async def send_message(self, channel_id, message, **kwargs):
+        return SendResult.ok(platform=self.PLATFORM, channel_id=channel_id)
+
+
+def _make_message(**kwargs):
+    """Create a NormalizedMessage for testing."""
+    return NormalizedMessage(
+        content=kwargs.get("content", "Test message"),
+        message_type=kwargs.get("message_type", "notification"),
+        format=kwargs.get("format", MessageFormat.MARKDOWN),
+        title=kwargs.get("title"),
+        thread_id=kwargs.get("thread_id"),
+        reply_to=kwargs.get("reply_to"),
+        metadata=kwargs.get("metadata", {}),
+    )
+
+
+def _make_httpx_response(status_code=200, json_data=None, text="OK"):
+    """Create a mock httpx response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.content = text.encode() if text else b""
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+@pytest.fixture
+def dock_registry():
+    """Create a fresh dock registry."""
+    return DockRegistry()
+
+
+@pytest.fixture
+def dock_registry_factory():
+    """Create fresh dock registries on demand."""
+
+    def _build() -> DockRegistry:
+        return DockRegistry()
+
+    return _build
+
+
+@pytest.fixture
+def normalized_message_factory():
+    """Expose the shared normalized message helper as a fixture."""
+    return _make_message
+
+
+@pytest.fixture
+def httpx_response_factory():
+    """Expose the shared httpx response helper as a fixture."""
+    return _make_httpx_response
+
+
+@pytest.fixture
+def registered_mock_dock(dock_registry):
+    """Register and return a mock dock for router tests."""
+    mock_dock = MagicMock(spec=ChannelDock)
+    mock_dock.is_initialized = True
+    mock_dock.supports.return_value = False
+    mock_dock.send_result = AsyncMock(
+        return_value=SendResult.ok(platform="test", channel_id="123", message_id="msg-1")
+    )
+    mock_dock.send_error = AsyncMock(return_value=SendResult.ok(platform="test", channel_id="123"))
+    dock_registry._dock_classes["test"] = lambda config=None: mock_dock
+    dock_registry._dock_instances["test"] = mock_dock
+    return dock_registry, mock_dock

--- a/tests/channels/test_dock_registry.py
+++ b/tests/channels/test_dock_registry.py
@@ -13,62 +13,9 @@ from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
+from .conftest import MockDock, VoiceDock
 from aragora.channels.registry import DockRegistry, get_dock_registry
 from aragora.channels.dock import ChannelDock, ChannelCapability
-
-
-class MockDock(ChannelDock):
-    """Mock dock for testing."""
-
-    PLATFORM = "mock"
-    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.BUTTONS
-
-    def __init__(self, config=None):
-        self.config = config or {}
-        self._initialized = False
-
-    @property
-    def is_initialized(self):
-        return self._initialized
-
-    async def initialize(self):
-        self._initialized = True
-
-    async def send_message(self, channel_id, message):
-        return None
-
-    async def send_result(self, channel_id, result, **kwargs):
-        return None
-
-    async def send_error(self, channel_id, error, **kwargs):
-        return None
-
-
-class VoiceDock(ChannelDock):
-    """Mock dock with voice support."""
-
-    PLATFORM = "voice_platform"
-    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.VOICE
-
-    def __init__(self, config=None):
-        self.config = config or {}
-        self._initialized = False
-
-    @property
-    def is_initialized(self):
-        return self._initialized
-
-    async def initialize(self):
-        self._initialized = True
-
-    async def send_message(self, channel_id, message):
-        return None
-
-    async def send_result(self, channel_id, result, **kwargs):
-        return None
-
-    async def send_error(self, channel_id, error, **kwargs):
-        return None
 
 
 class TestDockRegistry:

--- a/tests/channels/test_docks_all.py
+++ b/tests/channels/test_docks_all.py
@@ -8,6 +8,7 @@ for message delivery, payload building, and error handling.
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
+from .conftest import _make_httpx_response, _make_message
 from aragora.channels.dock import ChannelDock, ChannelCapability, SendResult, MessageType
 from aragora.channels.normalized import (
     NormalizedMessage,
@@ -15,34 +16,6 @@ from aragora.channels.normalized import (
     MessageButton,
     MessageAttachment,
 )
-
-
-# =============================================================================
-# Shared helpers
-# =============================================================================
-
-
-def _make_message(**kwargs):
-    """Create a NormalizedMessage for testing."""
-    return NormalizedMessage(
-        content=kwargs.get("content", "Test message"),
-        message_type=kwargs.get("message_type", "notification"),
-        format=kwargs.get("format", MessageFormat.MARKDOWN),
-        title=kwargs.get("title"),
-        thread_id=kwargs.get("thread_id"),
-        reply_to=kwargs.get("reply_to"),
-        metadata=kwargs.get("metadata", {}),
-    )
-
-
-def _make_httpx_response(status_code=200, json_data=None, text="OK"):
-    """Create a mock httpx response."""
-    resp = MagicMock()
-    resp.status_code = status_code
-    resp.text = text
-    resp.content = text.encode() if text else b""
-    resp.json.return_value = json_data or {}
-    return resp
 
 
 # =============================================================================

--- a/tests/channels/test_registry.py
+++ b/tests/channels/test_registry.py
@@ -7,53 +7,10 @@ Tests registration, lookup, capability queries, and the global singleton.
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 
+from .conftest import FakeEmailDock, FakeSimpleDock, FakeSlackDock, FakeTelegramDock
 from aragora.channels.dock import ChannelDock, ChannelCapability, SendResult
 from aragora.channels.normalized import NormalizedMessage
 from aragora.channels.registry import DockRegistry, get_dock_registry
-
-
-# =============================================================================
-# Helper docks for testing
-# =============================================================================
-
-
-class FakeSlackDock(ChannelDock):
-    PLATFORM = "slack"
-    CAPABILITIES = (
-        ChannelCapability.RICH_TEXT | ChannelCapability.BUTTONS | ChannelCapability.THREADS
-    )
-
-    async def send_message(self, channel_id, message, **kwargs):
-        return SendResult.ok(message_id="msg-1", platform=self.PLATFORM, channel_id=channel_id)
-
-
-class FakeTelegramDock(ChannelDock):
-    PLATFORM = "telegram"
-    CAPABILITIES = (
-        ChannelCapability.RICH_TEXT
-        | ChannelCapability.BUTTONS
-        | ChannelCapability.VOICE
-        | ChannelCapability.FILES
-    )
-
-    async def send_message(self, channel_id, message, **kwargs):
-        return SendResult.ok(message_id="msg-2", platform=self.PLATFORM, channel_id=channel_id)
-
-
-class FakeEmailDock(ChannelDock):
-    PLATFORM = "email"
-    CAPABILITIES = ChannelCapability.RICH_TEXT | ChannelCapability.FILES
-
-    async def send_message(self, channel_id, message, **kwargs):
-        return SendResult.ok(platform=self.PLATFORM, channel_id=channel_id)
-
-
-class FakeSimpleDock(ChannelDock):
-    PLATFORM = "simple"
-    CAPABILITIES = ChannelCapability.NONE
-
-    async def send_message(self, channel_id, message, **kwargs):
-        return SendResult.ok(platform=self.PLATFORM, channel_id=channel_id)
 
 
 # =============================================================================

--- a/tests/channels/test_router.py
+++ b/tests/channels/test_router.py
@@ -50,27 +50,9 @@ class TestChannelRouter:
         assert "not available" in result.error
 
     @pytest.mark.asyncio
-    async def test_route_result_with_mock_dock(self):
+    async def test_route_result_with_mock_dock(self, registered_mock_dock):
         """Test routing result through mocked dock."""
-        from aragora.channels.registry import DockRegistry
-        from aragora.channels.dock import ChannelDock
-
-        # Create mock dock
-        mock_dock = MagicMock(spec=ChannelDock)
-        mock_dock.is_initialized = True
-        mock_dock.send_result = AsyncMock(
-            return_value=SendResult.ok(
-                platform="test",
-                channel_id="123",
-                message_id="msg-1",
-            )
-        )
-        mock_dock.supports.return_value = False
-
-        # Create registry with mock dock
-        registry = DockRegistry()
-        registry._dock_classes["test"] = lambda config: mock_dock
-        registry._dock_instances["test"] = mock_dock
+        registry, mock_dock = registered_mock_dock
 
         router = ChannelRouter(registry=registry)
 
@@ -84,22 +66,9 @@ class TestChannelRouter:
         mock_dock.send_result.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_route_error_with_mock_dock(self):
+    async def test_route_error_with_mock_dock(self, registered_mock_dock):
         """Test routing error through mocked dock."""
-        from aragora.channels.registry import DockRegistry
-        from aragora.channels.dock import ChannelDock
-
-        mock_dock = MagicMock(spec=ChannelDock)
-        mock_dock.is_initialized = True
-        mock_dock.send_error = AsyncMock(
-            return_value=SendResult.ok(
-                platform="test",
-                channel_id="123",
-            )
-        )
-
-        registry = DockRegistry()
-        registry._dock_instances["test"] = mock_dock
+        registry, mock_dock = registered_mock_dock
 
         router = ChannelRouter(registry=registry)
 
@@ -113,17 +82,9 @@ class TestChannelRouter:
         assert result.success is True
 
     @pytest.mark.asyncio
-    async def test_route_voice_unsupported(self):
+    async def test_route_voice_unsupported(self, registered_mock_dock):
         """Test voice routing to dock without voice support."""
-        from aragora.channels.registry import DockRegistry
-        from aragora.channels.dock import ChannelDock
-
-        mock_dock = MagicMock(spec=ChannelDock)
-        mock_dock.is_initialized = True
-        mock_dock.supports.return_value = False  # No voice support
-
-        registry = DockRegistry()
-        registry._dock_instances["test"] = mock_dock
+        registry, _ = registered_mock_dock
 
         router = ChannelRouter(registry=registry)
 

--- a/tests/connectors/chat/conftest.py
+++ b/tests/connectors/chat/conftest.py
@@ -1,0 +1,149 @@
+"""Shared fixtures for chat connector tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from aragora.connectors.chat.base import ChatPlatformConnector
+from aragora.connectors.chat.models import (
+    FileAttachment,
+    SendMessageResponse,
+    WebhookEvent,
+)
+
+
+class StubConnector(ChatPlatformConnector):
+    """Minimal concrete implementation for testing base connector behaviour."""
+
+    @property
+    def platform_name(self) -> str:
+        return "stub"
+
+    @property
+    def platform_display_name(self) -> str:
+        return "Stub Platform"
+
+    async def send_message(self, channel_id, text, blocks=None, thread_id=None, **kw):
+        return SendMessageResponse(success=True, message_id="msg-1")
+
+    async def update_message(self, channel_id, message_id, text, blocks=None, **kw):
+        return SendMessageResponse(success=True, message_id=message_id)
+
+    async def delete_message(self, channel_id, message_id, **kw):
+        return True
+
+    async def respond_to_command(self, command, text, blocks=None, ephemeral=True, **kw):
+        return SendMessageResponse(success=True)
+
+    async def respond_to_interaction(
+        self, interaction, text, blocks=None, replace_original=False, **kw
+    ):
+        return SendMessageResponse(success=True)
+
+    async def upload_file(
+        self,
+        channel_id,
+        content,
+        filename,
+        content_type="application/octet-stream",
+        title=None,
+        thread_id=None,
+        **kw,
+    ):
+        return FileAttachment(
+            id="file-1", filename=filename, content_type=content_type, size=len(content)
+        )
+
+    async def download_file(self, file_id, **kw):
+        return FileAttachment(id=file_id, filename="test.txt", content_type="text/plain", size=0)
+
+    def format_blocks(self, title=None, body=None, fields=None, actions=None, **kw):
+        return [{"type": "section", "text": body}]
+
+    def format_button(self, text, action_id, value=None, style="default", url=None):
+        return {"type": "button", "text": text, "action_id": action_id}
+
+    def verify_webhook(self, headers, body):
+        return True
+
+    def parse_webhook_event(self, headers, body):
+        return WebhookEvent(platform="stub", event_type="message")
+
+
+@pytest.fixture(autouse=True)
+def reset_circuit_breakers():
+    """Clear circuit breakers before and after each chat connector test."""
+    from aragora.resilience import _circuit_breakers, _circuit_breakers_lock
+
+    with _circuit_breakers_lock:
+        _circuit_breakers.clear()
+    yield
+    with _circuit_breakers_lock:
+        _circuit_breakers.clear()
+
+
+@pytest.fixture
+def connector():
+    """Create a default stub connector with circuit breaker enabled."""
+    return StubConnector(bot_token="tok-123", signing_secret="sec-456")
+
+
+@pytest.fixture
+def connector_no_cb():
+    """Create a stub connector with circuit breaker disabled."""
+    return StubConnector(bot_token="tok-123", enable_circuit_breaker=False)
+
+
+@pytest.fixture
+def rsa_key_pair():
+    """Generate an RSA key pair for JWT verification tests."""
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend(),
+    )
+    public_key = private_key.public_key()
+
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    return private_key, public_key, private_pem, public_pem
+
+
+@pytest.fixture
+def mock_jwks_client():
+    """Create a controllable mock PyJWKClient pair."""
+    mock_client = MagicMock()
+    mock_signing_key = MagicMock()
+    mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
+    return mock_client, mock_signing_key
+
+
+@pytest.fixture
+def mock_httpx_response():
+    """Create a reusable mock httpx response factory."""
+
+    def _create_response(json_data: dict, status_code: int = 200, text: str | None = None):
+        mock = MagicMock()
+        mock.json.return_value = json_data
+        mock.status_code = status_code
+        payload_text = text if text is not None else json.dumps(json_data)
+        mock.text = payload_text
+        mock.content = payload_text.encode()
+        return mock
+
+    return _create_response

--- a/tests/connectors/chat/test_base.py
+++ b/tests/connectors/chat/test_base.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aragora.connectors.chat.base import ChatPlatformConnector
+from .conftest import StubConnector
 from aragora.connectors.chat.models import (
     BotCommand,
     FileAttachment,
@@ -22,98 +22,6 @@ from aragora.connectors.chat.models import (
     UserInteraction,
     WebhookEvent,
 )
-
-
-# ============================================================================
-# Concrete Test Subclass
-# ============================================================================
-
-
-class StubConnector(ChatPlatformConnector):
-    """Minimal concrete implementation for testing base class behaviour."""
-
-    @property
-    def platform_name(self) -> str:
-        return "stub"
-
-    @property
-    def platform_display_name(self) -> str:
-        return "Stub Platform"
-
-    async def send_message(self, channel_id, text, blocks=None, thread_id=None, **kw):
-        return SendMessageResponse(success=True, message_id="msg-1")
-
-    async def update_message(self, channel_id, message_id, text, blocks=None, **kw):
-        return SendMessageResponse(success=True, message_id=message_id)
-
-    async def delete_message(self, channel_id, message_id, **kw):
-        return True
-
-    async def respond_to_command(self, command, text, blocks=None, ephemeral=True, **kw):
-        return SendMessageResponse(success=True)
-
-    async def respond_to_interaction(
-        self, interaction, text, blocks=None, replace_original=False, **kw
-    ):
-        return SendMessageResponse(success=True)
-
-    async def upload_file(
-        self,
-        channel_id,
-        content,
-        filename,
-        content_type="application/octet-stream",
-        title=None,
-        thread_id=None,
-        **kw,
-    ):
-        return FileAttachment(
-            id="file-1", filename=filename, content_type=content_type, size=len(content)
-        )
-
-    async def download_file(self, file_id, **kw):
-        return FileAttachment(id=file_id, filename="test.txt", content_type="text/plain", size=0)
-
-    def format_blocks(self, title=None, body=None, fields=None, actions=None, **kw):
-        return [{"type": "section", "text": body}]
-
-    def format_button(self, text, action_id, value=None, style="default", url=None):
-        return {"type": "button", "text": text, "action_id": action_id}
-
-    def verify_webhook(self, headers, body):
-        return True
-
-    def parse_webhook_event(self, headers, body):
-        return WebhookEvent(platform="stub", event_type="message")
-
-
-# ============================================================================
-# Fixtures
-# ============================================================================
-
-
-@pytest.fixture(autouse=True)
-def reset_circuit_breakers():
-    """Clear all circuit breakers before each test to ensure isolation."""
-    from aragora.resilience import _circuit_breakers, _circuit_breakers_lock
-
-    with _circuit_breakers_lock:
-        _circuit_breakers.clear()
-    yield
-    with _circuit_breakers_lock:
-        _circuit_breakers.clear()
-
-
-@pytest.fixture
-def connector():
-    """Create a default StubConnector with circuit breaker enabled."""
-    return StubConnector(bot_token="tok-123", signing_secret="sec-456")
-
-
-@pytest.fixture
-def connector_no_cb():
-    """Create a StubConnector with circuit breaker disabled."""
-    return StubConnector(bot_token="tok-123", enable_circuit_breaker=False)
 
 
 # ============================================================================

--- a/tests/connectors/chat/test_chat_base.py
+++ b/tests/connectors/chat/test_chat_base.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aragora.connectors.chat.base import ChatPlatformConnector
+from .conftest import StubConnector
 from aragora.connectors.chat.models import (
     BotCommand,
     FileAttachment,
@@ -22,98 +22,6 @@ from aragora.connectors.chat.models import (
     UserInteraction,
     WebhookEvent,
 )
-
-
-# ============================================================================
-# Concrete Test Subclass
-# ============================================================================
-
-
-class StubConnector(ChatPlatformConnector):
-    """Minimal concrete implementation for testing base class behaviour."""
-
-    @property
-    def platform_name(self) -> str:
-        return "stub"
-
-    @property
-    def platform_display_name(self) -> str:
-        return "Stub Platform"
-
-    async def send_message(self, channel_id, text, blocks=None, thread_id=None, **kw):
-        return SendMessageResponse(success=True, message_id="msg-1")
-
-    async def update_message(self, channel_id, message_id, text, blocks=None, **kw):
-        return SendMessageResponse(success=True, message_id=message_id)
-
-    async def delete_message(self, channel_id, message_id, **kw):
-        return True
-
-    async def respond_to_command(self, command, text, blocks=None, ephemeral=True, **kw):
-        return SendMessageResponse(success=True)
-
-    async def respond_to_interaction(
-        self, interaction, text, blocks=None, replace_original=False, **kw
-    ):
-        return SendMessageResponse(success=True)
-
-    async def upload_file(
-        self,
-        channel_id,
-        content,
-        filename,
-        content_type="application/octet-stream",
-        title=None,
-        thread_id=None,
-        **kw,
-    ):
-        return FileAttachment(
-            id="file-1", filename=filename, content_type=content_type, size=len(content)
-        )
-
-    async def download_file(self, file_id, **kw):
-        return FileAttachment(id=file_id, filename="test.txt", content_type="text/plain", size=0)
-
-    def format_blocks(self, title=None, body=None, fields=None, actions=None, **kw):
-        return [{"type": "section", "text": body}]
-
-    def format_button(self, text, action_id, value=None, style="default", url=None):
-        return {"type": "button", "text": text, "action_id": action_id}
-
-    def verify_webhook(self, headers, body):
-        return True
-
-    def parse_webhook_event(self, headers, body):
-        return WebhookEvent(platform="stub", event_type="message")
-
-
-# ============================================================================
-# Fixtures
-# ============================================================================
-
-
-@pytest.fixture(autouse=True)
-def reset_circuit_breakers():
-    """Clear all circuit breakers before each test to ensure isolation."""
-    from aragora.resilience import _circuit_breakers, _circuit_breakers_lock
-
-    with _circuit_breakers_lock:
-        _circuit_breakers.clear()
-    yield
-    with _circuit_breakers_lock:
-        _circuit_breakers.clear()
-
-
-@pytest.fixture
-def connector():
-    """Create a default StubConnector with circuit breaker enabled."""
-    return StubConnector(bot_token="tok-123", signing_secret="sec-456")
-
-
-@pytest.fixture
-def connector_no_cb():
-    """Create a StubConnector with circuit breaker disabled."""
-    return StubConnector(bot_token="tok-123", enable_circuit_breaker=False)
 
 
 # ============================================================================

--- a/tests/connectors/chat/test_chat_integration.py
+++ b/tests/connectors/chat/test_chat_integration.py
@@ -498,26 +498,48 @@ class TestCrossPlatformConsistency:
         }
 
         for name, connector in test_connectors.items():
-            # Mock the HTTP call to fail gracefully
-            with patch("httpx.AsyncClient") as mock_client:
-                mock_client.return_value.__aenter__.return_value.request = AsyncMock(
-                    side_effect=Exception("Network error")
-                )
-                mock_client.return_value.__aenter__.return_value.post = AsyncMock(
-                    side_effect=Exception("Network error")
-                )
+            if name == "slack":
+                with patch.object(
+                    connector, "_slack_api_request", new_callable=AsyncMock
+                ) as mock_request:
+                    mock_request.return_value = (False, None, "Network error")
+                    result = await connector.send_message(
+                        channel_id="test-channel",
+                        text="Test message",
+                    )
+            elif name == "teams":
+                with (
+                    patch.object(
+                        connector,
+                        "_get_access_token",
+                        new_callable=AsyncMock,
+                        return_value="test-token",
+                    ),
+                    patch.object(
+                        connector, "_http_request", new_callable=AsyncMock
+                    ) as mock_request,
+                ):
+                    mock_request.return_value = (False, None, "Network error")
+                    result = await connector.send_message(
+                        channel_id="test-channel",
+                        text="Test message",
+                    )
+            else:
+                with patch.object(
+                    connector, "_http_request", new_callable=AsyncMock
+                ) as mock_request:
+                    mock_request.return_value = (False, None, "Network error")
+                    result = await connector.send_message(
+                        channel_id="test-channel",
+                        text="Test message",
+                    )
 
-                result = await connector.send_message(
-                    channel_id="test-channel",
-                    text="Test message",
-                )
-
-                # Must return SendMessageResponse even on failure
-                assert isinstance(result, SendMessageResponse), (
-                    f"{name} should return SendMessageResponse"
-                )
-                assert result.success is False, f"{name} should return success=False on error"
-                assert result.error is not None, f"{name} should include error message"
+            # Must return SendMessageResponse even on failure
+            assert isinstance(result, SendMessageResponse), (
+                f"{name} should return SendMessageResponse"
+            )
+            assert result.success is False, f"{name} should return success=False on error"
+            assert result.error is not None, f"{name} should include error message"
 
 
 # =============================================================================

--- a/tests/connectors/chat/test_discord_connector.py
+++ b/tests/connectors/chat/test_discord_connector.py
@@ -176,12 +176,8 @@ class TestDiscordSendMessage:
 
         connector = DiscordConnector(bot_token="test-token")
 
-        mock_client_instance = MagicMock()
-        mock_client_instance.request = AsyncMock(side_effect=Exception("Rate limited"))
-        mock_client_instance.__aenter__ = AsyncMock(return_value=mock_client_instance)
-        mock_client_instance.__aexit__ = AsyncMock(return_value=None)
-
-        with patch("httpx.AsyncClient", return_value=mock_client_instance):
+        with patch.object(connector, "_http_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = (False, None, "Rate limited")
             result = await connector.send_message(
                 channel_id="invalid",
                 text="Test",
@@ -267,11 +263,8 @@ class TestDiscordDeleteMessage:
 
         connector = DiscordConnector(bot_token="test-token")
 
-        with patch("httpx.AsyncClient") as mock_client:
-            mock_instance = mock_client.return_value.__aenter__.return_value
-            # Now uses request() method instead of delete()
-            mock_instance.request = AsyncMock(side_effect=Exception("Not found"))
-
+        with patch.object(connector, "_http_request", new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = (False, None, "Not found")
             result = await connector.delete_message(
                 channel_id="456",
                 message_id="invalid",

--- a/tests/connectors/chat/test_jwt_verify.py
+++ b/tests/connectors/chat/test_jwt_verify.py
@@ -66,30 +66,6 @@ from aragora.connectors.chat.jwt_verify import (
 
 
 @pytest.fixture
-def rsa_key_pair():
-    """Generate an RSA key pair for testing JWT signatures."""
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-        backend=default_backend(),
-    )
-    public_key = private_key.public_key()
-
-    private_pem = private_key.private_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PrivateFormat.PKCS8,
-        encryption_algorithm=serialization.NoEncryption(),
-    )
-
-    public_pem = public_key.public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-
-    return private_key, public_key, private_pem, public_pem
-
-
-@pytest.fixture
 def second_rsa_key_pair():
     """Generate a second RSA key pair for key rotation testing."""
     private_key = rsa.generate_private_key(
@@ -140,15 +116,6 @@ def valid_google_claims():
         "sub": "google-user-id",
         "email": "bot@example.iam.gserviceaccount.com",
     }
-
-
-@pytest.fixture
-def mock_jwks_client():
-    """Create a mock PyJWKClient that returns a controllable signing key."""
-    mock_client = MagicMock()
-    mock_signing_key = MagicMock()
-    mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
-    return mock_client, mock_signing_key
 
 
 @pytest.fixture

--- a/tests/connectors/chat/test_jwt_verify_cache.py
+++ b/tests/connectors/chat/test_jwt_verify_cache.py
@@ -26,29 +26,6 @@ from cryptography.hazmat.backends import default_backend
 # ===========================================================================
 
 
-@pytest.fixture
-def rsa_key_pair():
-    """Generate an RSA key pair for testing JWT signatures."""
-
-    private_key = rsa.generate_private_key(
-        public_exponent=65537,
-        key_size=2048,
-        backend=default_backend(),
-    )
-    public_key = private_key.public_key()
-
-    return private_key, public_key
-
-
-@pytest.fixture
-def mock_jwks_client():
-    """Create a mock PyJWKClient that returns a controllable signing key."""
-    mock_client = MagicMock()
-    mock_signing_key = MagicMock()
-    mock_client.get_signing_key_from_jwt.return_value = mock_signing_key
-    return mock_client, mock_signing_key
-
-
 # ===========================================================================
 # Default Cache TTL Tests
 # ===========================================================================
@@ -274,7 +251,7 @@ class TestCacheInvalidationOnSignatureFailure:
             MICROSOFT_VALID_ISSUERS,
         )
 
-        private_key, public_key = rsa_key_pair
+        private_key, public_key, *_ = rsa_key_pair
         mock_client, mock_signing_key = mock_jwks_client
         mock_signing_key.key = public_key
 
@@ -321,7 +298,7 @@ class TestCacheInvalidationOnSignatureFailure:
             GOOGLE_VALID_ISSUERS,
         )
 
-        private_key, public_key = rsa_key_pair
+        private_key, public_key, *_ = rsa_key_pair
         mock_client, mock_signing_key = mock_jwks_client
         mock_signing_key.key = public_key
 
@@ -406,7 +383,7 @@ class TestCacheInvalidationOnSignatureFailure:
         )
         from jwt.exceptions import ExpiredSignatureError
 
-        private_key, public_key = rsa_key_pair
+        private_key, public_key, *_ = rsa_key_pair
         mock_client, mock_signing_key = mock_jwks_client
         mock_signing_key.key = public_key
 
@@ -566,7 +543,7 @@ class TestCacheHardeningIntegration:
         )
         from jwt.exceptions import InvalidSignatureError
 
-        private_key, public_key = rsa_key_pair
+        private_key, public_key, *_ = rsa_key_pair
         mock_client, mock_signing_key = mock_jwks_client
         mock_signing_key.key = public_key
 

--- a/tests/connectors/chat/test_telegram_connector.py
+++ b/tests/connectors/chat/test_telegram_connector.py
@@ -28,20 +28,6 @@ def connector():
     )
 
 
-@pytest.fixture
-def mock_httpx_response():
-    """Create a mock httpx response."""
-
-    def _create_response(json_data, status_code=200):
-        mock = MagicMock()
-        mock.json.return_value = json_data
-        mock.status_code = status_code
-        mock.content = b"test content"
-        return mock
-
-    return _create_response
-
-
 class TestTelegramConnectorInit:
     """Test connector initialization."""
 

--- a/tests/connectors/chat/test_whatsapp_connector.py
+++ b/tests/connectors/chat/test_whatsapp_connector.py
@@ -32,20 +32,6 @@ def connector():
     )
 
 
-@pytest.fixture
-def mock_httpx_response():
-    """Create a mock httpx response."""
-
-    def _create_response(json_data, status_code=200):
-        mock = MagicMock()
-        mock.json.return_value = json_data
-        mock.status_code = status_code
-        mock.content = b"test content"
-        return mock
-
-    return _create_response
-
-
 class TestWhatsAppConnectorInit:
     """Test connector initialization."""
 

--- a/tests/server/handlers/social/conftest.py
+++ b/tests/server/handlers/social/conftest.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import sys
 import time
+import types as _types_mod
 from dataclasses import dataclass, field
 from io import BytesIO
 from typing import Any, Optional
@@ -19,6 +21,41 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aragora.server.handlers.base import HandlerResult
+
+
+def install_social_slack_stubs() -> None:
+    """Pre-stub Slack modules so social handler imports stay lightweight in tests."""
+
+    slack_attrs = [
+        "SlackHandler",
+        "get_slack_handler",
+        "get_slack_integration",
+        "get_workspace_store",
+        "resolve_workspace",
+        "create_tracked_task",
+        "_validate_slack_url",
+        "SLACK_SIGNING_SECRET",
+        "SLACK_BOT_TOKEN",
+        "SLACK_WEBHOOK_URL",
+        "SLACK_ALLOWED_DOMAINS",
+        "SignatureVerifierMixin",
+        "CommandsMixin",
+        "EventsMixin",
+        "init_slack_handler",
+    ]
+    for module_name in (
+        "aragora.server.handlers.social.slack.handler",
+        "aragora.server.handlers.social.slack",
+        "aragora.server.handlers.social._slack_impl",
+    ):
+        if module_name not in sys.modules:
+            module = _types_mod.ModuleType(module_name)
+            for attr in slack_attrs:
+                setattr(module, attr, None)
+            sys.modules[module_name] = module
+
+
+install_social_slack_stubs()
 
 
 # ===========================================================================
@@ -53,6 +90,7 @@ class MockHandler:
     ):
         self.headers = headers or {}
         self._body = body
+        self.request_body = body
         self.path = path
         self.command = method
         self.rfile = BytesIO(body)
@@ -68,6 +106,9 @@ class MockHandler:
 
     def end_headers(self) -> None:
         pass
+
+    def get_argument(self, name: str, default: str | None = None) -> str | None:
+        return default
 
     @classmethod
     def with_json_body(
@@ -397,11 +438,16 @@ class MockUser:
     """Mock authenticated user for testing secure handlers."""
 
     user_id: str = "test-user-id"
+    id: str | None = None
     org_id: str = "test-org-id"
     email: str = "test@example.com"
     name: str = "Test User"
     roles: list[str] = field(default_factory=lambda: ["member"])
     permissions: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.id is None:
+            self.id = self.user_id
 
 
 @pytest.fixture
@@ -418,6 +464,37 @@ def mock_admin_user():
         roles=["admin"],
         permissions=["notifications.read", "notifications.write", "admin.system"],
     )
+
+
+@pytest.fixture
+def mock_user_store(mock_user):
+    """Create a default user store that resolves the shared mock user."""
+    store = MagicMock()
+    store.get_user_by_id.return_value = mock_user
+    return store
+
+
+@pytest.fixture
+def social_handler_context_builder():
+    """Build common context dictionaries for social handler tests."""
+
+    def _build(**overrides: Any) -> dict[str, Any]:
+        context = {
+            "storage": MagicMock(),
+            "elo_system": MagicMock(),
+            "arena": MagicMock(),
+            "user_store": MagicMock(),
+        }
+        context.update(overrides)
+        return context
+
+    return _build
+
+
+@pytest.fixture
+def handler_context(social_handler_context_builder, mock_user_store):
+    """Default handler context shared across social handler tests."""
+    return social_handler_context_builder(user_store=mock_user_store)
 
 
 # ===========================================================================

--- a/tests/server/handlers/social/test_channel_health.py
+++ b/tests/server/handlers/social/test_channel_health.py
@@ -1,93 +1,15 @@
 """Tests for aragora.server.handlers.social.channel_health - Channel Health Handler."""
 
-import sys
-import types as _types_mod
-
-# Pre-stub Slack modules to prevent import chain failures
-_SLACK_ATTRS = [
-    "SlackHandler",
-    "get_slack_handler",
-    "get_slack_integration",
-    "get_workspace_store",
-    "resolve_workspace",
-    "create_tracked_task",
-    "_validate_slack_url",
-    "SLACK_SIGNING_SECRET",
-    "SLACK_BOT_TOKEN",
-    "SLACK_WEBHOOK_URL",
-    "SLACK_ALLOWED_DOMAINS",
-    "SignatureVerifierMixin",
-    "CommandsMixin",
-    "EventsMixin",
-    "init_slack_handler",
-]
-for _mod_name in (
-    "aragora.server.handlers.social.slack.handler",
-    "aragora.server.handlers.social.slack",
-    "aragora.server.handlers.social._slack_impl",
-):
-    if _mod_name not in sys.modules:
-        _m = _types_mod.ModuleType(_mod_name)
-        for _a in _SLACK_ATTRS:
-            setattr(_m, _a, None)
-        sys.modules[_mod_name] = _m
-
-import json
 import time
-from dataclasses import dataclass
-from io import BytesIO
-from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from .conftest import MockHandler, install_social_slack_stubs
+
+install_social_slack_stubs()
+
 from aragora.server.handlers.social.channel_health import ChannelHealthHandler
-
-
-# ===========================================================================
-# Mock Classes
-# ===========================================================================
-
-
-@dataclass
-class MockUser:
-    """Mock authenticated user."""
-
-    user_id: str = "user-123"
-    id: str = "user-123"
-    org_id: str = "org-123"
-    email: str = "test@example.com"
-    name: str = "Test User"
-
-
-class MockHandler:
-    """Mock HTTP request handler."""
-
-    def __init__(
-        self,
-        body: bytes = b"",
-        headers: dict[str, str] | None = None,
-        path: str = "/",
-        method: str = "GET",
-    ):
-        self._body = body
-        self.headers = headers or {"Content-Length": str(len(body))}
-        self.path = path
-        self.command = method
-        self.rfile = BytesIO(body)
-        self.client_address = ("127.0.0.1", 12345)
-
-    @classmethod
-    def with_json_body(cls, data: dict[str, Any], **kwargs) -> "MockHandler":
-        body = json.dumps(data).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": str(len(body)),
-        }
-        return cls(body=body, headers=headers, **kwargs)
-
-    def get_argument(self, name: str, default: str = None) -> str | None:
-        return default
 
 
 # ===========================================================================
@@ -105,18 +27,6 @@ def reset_module_state():
     except Exception:
         pass
     yield
-
-
-@pytest.fixture
-def mock_user():
-    return MockUser()
-
-
-@pytest.fixture
-def mock_user_store(mock_user):
-    store = MagicMock()
-    store.get_user_by_id.return_value = mock_user
-    return store
 
 
 @pytest.fixture
@@ -142,11 +52,6 @@ def mock_channel_monitor():
         "unhealthy": 0,
     }
     return monitor
-
-
-@pytest.fixture
-def handler_context(mock_user_store):
-    return {"user_store": mock_user_store}
 
 
 @pytest.fixture

--- a/tests/server/handlers/social/test_collaboration.py
+++ b/tests/server/handlers/social/test_collaboration.py
@@ -1,45 +1,14 @@
 """Tests for aragora.server.handlers.social.collaboration - Collaboration Handler."""
 
-import sys
-import types as _types_mod
-
-# Pre-stub Slack modules to prevent import chain failures
-_SLACK_ATTRS = [
-    "SlackHandler",
-    "get_slack_handler",
-    "get_slack_integration",
-    "get_workspace_store",
-    "resolve_workspace",
-    "create_tracked_task",
-    "_validate_slack_url",
-    "SLACK_SIGNING_SECRET",
-    "SLACK_BOT_TOKEN",
-    "SLACK_WEBHOOK_URL",
-    "SLACK_ALLOWED_DOMAINS",
-    "SignatureVerifierMixin",
-    "CommandsMixin",
-    "EventsMixin",
-    "init_slack_handler",
-]
-for _mod_name in (
-    "aragora.server.handlers.social.slack.handler",
-    "aragora.server.handlers.social.slack",
-    "aragora.server.handlers.social._slack_impl",
-):
-    if _mod_name not in sys.modules:
-        _m = _types_mod.ModuleType(_mod_name)
-        for _a in _SLACK_ATTRS:
-            setattr(_m, _a, None)
-        sys.modules[_mod_name] = _m
-
-import json
-import time
 from dataclasses import dataclass, field
-from io import BytesIO
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from .conftest import MockHandler, install_social_slack_stubs
+
+install_social_slack_stubs()
 
 from aragora.server.handlers.social.collaboration import CollaborationHandler
 
@@ -47,17 +16,6 @@ from aragora.server.handlers.social.collaboration import CollaborationHandler
 # ===========================================================================
 # Mock Classes
 # ===========================================================================
-
-
-@dataclass
-class MockUser:
-    """Mock authenticated user."""
-
-    user_id: str = "user-123"
-    id: str = "user-123"
-    org_id: str = "org-123"
-    email: str = "test@example.com"
-    name: str = "Test User"
 
 
 @dataclass
@@ -90,36 +48,6 @@ class MockSession:
         }
 
 
-class MockHandler:
-    """Mock HTTP request handler."""
-
-    def __init__(
-        self,
-        body: bytes = b"",
-        headers: dict[str, str] | None = None,
-        path: str = "/",
-        method: str = "GET",
-    ):
-        self._body = body
-        self.headers = headers or {"Content-Length": str(len(body))}
-        self.path = path
-        self.command = method
-        self.rfile = BytesIO(body)
-        self.client_address = ("127.0.0.1", 12345)
-
-    @classmethod
-    def with_json_body(cls, data: dict[str, Any], **kwargs) -> "MockHandler":
-        body = json.dumps(data).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": str(len(body)),
-        }
-        return cls(body=body, headers=headers, **kwargs)
-
-    def get_argument(self, name: str, default: str = None) -> str | None:
-        return default
-
-
 # ===========================================================================
 # Fixtures
 # ===========================================================================
@@ -138,18 +66,6 @@ def reset_module_state():
 
 
 @pytest.fixture
-def mock_user():
-    return MockUser()
-
-
-@pytest.fixture
-def mock_user_store(mock_user):
-    store = MagicMock()
-    store.get_user_by_id.return_value = mock_user
-    return store
-
-
-@pytest.fixture
 def mock_session_store():
     store = MagicMock()
     store.get_by_org.return_value = [MockSession()]
@@ -160,11 +76,6 @@ def mock_session_store():
     store.add_participant.return_value = True
     store.remove_participant.return_value = True
     return store
-
-
-@pytest.fixture
-def handler_context(mock_user_store):
-    return {"user_store": mock_user_store}
 
 
 @pytest.fixture

--- a/tests/server/handlers/social/test_sharing.py
+++ b/tests/server/handlers/social/test_sharing.py
@@ -1,44 +1,14 @@
 """Tests for aragora.server.handlers.social.sharing - Sharing Handler."""
 
-import sys
-import types as _types_mod
-
-# Pre-stub Slack modules to prevent import chain failures
-_SLACK_ATTRS = [
-    "SlackHandler",
-    "get_slack_handler",
-    "get_slack_integration",
-    "get_workspace_store",
-    "resolve_workspace",
-    "create_tracked_task",
-    "_validate_slack_url",
-    "SLACK_SIGNING_SECRET",
-    "SLACK_BOT_TOKEN",
-    "SLACK_WEBHOOK_URL",
-    "SLACK_ALLOWED_DOMAINS",
-    "SignatureVerifierMixin",
-    "CommandsMixin",
-    "EventsMixin",
-    "init_slack_handler",
-]
-for _mod_name in (
-    "aragora.server.handlers.social.slack.handler",
-    "aragora.server.handlers.social.slack",
-    "aragora.server.handlers.social._slack_impl",
-):
-    if _mod_name not in sys.modules:
-        _m = _types_mod.ModuleType(_mod_name)
-        for _a in _SLACK_ATTRS:
-            setattr(_m, _a, None)
-        sys.modules[_mod_name] = _m
-
-import json
 from dataclasses import dataclass, field
-from io import BytesIO
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from .conftest import MockHandler, install_social_slack_stubs
+
+install_social_slack_stubs()
 
 from aragora.server.handlers.social.sharing import SharingHandler
 
@@ -46,17 +16,6 @@ from aragora.server.handlers.social.sharing import SharingHandler
 # ===========================================================================
 # Mock Classes
 # ===========================================================================
-
-
-@dataclass
-class MockUser:
-    """Mock authenticated user."""
-
-    user_id: str = "user-123"
-    id: str = "user-123"
-    org_id: str = "org-123"
-    email: str = "test@example.com"
-    name: str = "Test User"
 
 
 @dataclass
@@ -89,36 +48,6 @@ class MockShare:
         }
 
 
-class MockHandler:
-    """Mock HTTP request handler."""
-
-    def __init__(
-        self,
-        body: bytes = b"",
-        headers: dict[str, str] | None = None,
-        path: str = "/",
-        method: str = "GET",
-    ):
-        self._body = body
-        self.headers = headers or {"Content-Length": str(len(body))}
-        self.path = path
-        self.command = method
-        self.rfile = BytesIO(body)
-        self.client_address = ("127.0.0.1", 12345)
-
-    @classmethod
-    def with_json_body(cls, data: dict[str, Any], **kwargs) -> "MockHandler":
-        body = json.dumps(data).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": str(len(body)),
-        }
-        return cls(body=body, headers=headers, **kwargs)
-
-    def get_argument(self, name: str, default: str = None) -> str | None:
-        return default
-
-
 # ===========================================================================
 # Fixtures
 # ===========================================================================
@@ -137,18 +66,6 @@ def reset_module_state():
 
 
 @pytest.fixture
-def mock_user():
-    return MockUser()
-
-
-@pytest.fixture
-def mock_user_store(mock_user):
-    store = MagicMock()
-    store.get_user_by_id.return_value = mock_user
-    return store
-
-
-@pytest.fixture
 def mock_share_store():
     store = MagicMock()
     store.get_by_org.return_value = [MockShare()]
@@ -156,11 +73,6 @@ def mock_share_store():
     store.create.return_value = MockShare()
     store.delete.return_value = True
     return store
-
-
-@pytest.fixture
-def handler_context(mock_user_store):
-    return {"user_store": mock_user_store}
 
 
 @pytest.fixture

--- a/tests/server/handlers/social/test_social_media.py
+++ b/tests/server/handlers/social/test_social_media.py
@@ -1,93 +1,16 @@
 """Tests for aragora.server.handlers.social.social_media - Social Media Handler."""
 
-import sys
-import types as _types_mod
-
-# Pre-stub Slack modules to prevent import chain failures
-_SLACK_ATTRS = [
-    "SlackHandler",
-    "get_slack_handler",
-    "get_slack_integration",
-    "get_workspace_store",
-    "resolve_workspace",
-    "create_tracked_task",
-    "_validate_slack_url",
-    "SLACK_SIGNING_SECRET",
-    "SLACK_BOT_TOKEN",
-    "SLACK_WEBHOOK_URL",
-    "SLACK_ALLOWED_DOMAINS",
-    "SignatureVerifierMixin",
-    "CommandsMixin",
-    "EventsMixin",
-    "init_slack_handler",
-]
-for _mod_name in (
-    "aragora.server.handlers.social.slack.handler",
-    "aragora.server.handlers.social.slack",
-    "aragora.server.handlers.social._slack_impl",
-):
-    if _mod_name not in sys.modules:
-        _m = _types_mod.ModuleType(_mod_name)
-        for _a in _SLACK_ATTRS:
-            setattr(_m, _a, None)
-        sys.modules[_mod_name] = _m
-
-import json
-from dataclasses import dataclass
-from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from .conftest import MockHandler, install_social_slack_stubs
+
+install_social_slack_stubs()
+
 from aragora.server.handlers.social.social_media import SocialMediaHandler
-
-
-# ===========================================================================
-# Mock Classes
-# ===========================================================================
-
-
-@dataclass
-class MockUser:
-    """Mock authenticated user."""
-
-    user_id: str = "user-123"
-    id: str = "user-123"
-    org_id: str = "org-123"
-    email: str = "test@example.com"
-    name: str = "Test User"
-
-
-class MockHandler:
-    """Mock HTTP request handler."""
-
-    def __init__(
-        self,
-        body: bytes = b"",
-        headers: dict[str, str] | None = None,
-        path: str = "/",
-        method: str = "GET",
-    ):
-        self._body = body
-        self.headers = headers or {"Content-Length": str(len(body))}
-        self.path = path
-        self.command = method
-        self.rfile = BytesIO(body)
-        self.client_address = ("127.0.0.1", 12345)
-
-    @classmethod
-    def with_json_body(cls, data: dict[str, Any], **kwargs) -> "MockHandler":
-        body = json.dumps(data).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Content-Length": str(len(body)),
-        }
-        return cls(body=body, headers=headers, **kwargs)
-
-    def get_argument(self, name: str, default: str = None) -> str | None:
-        return default
 
 
 # ===========================================================================
@@ -105,18 +28,6 @@ def reset_oauth_state():
     except Exception:
         pass
     yield
-
-
-@pytest.fixture
-def mock_user():
-    return MockUser()
-
-
-@pytest.fixture
-def mock_user_store(mock_user):
-    store = MagicMock()
-    store.get_user_by_id.return_value = mock_user
-    return store
 
 
 @pytest.fixture
@@ -181,15 +92,20 @@ def mock_audio_store():
 
 @pytest.fixture
 def handler_context(
-    mock_user_store, mock_youtube_connector, mock_twitter_connector, mock_storage, mock_audio_store
+    social_handler_context_builder,
+    mock_user_store,
+    mock_youtube_connector,
+    mock_twitter_connector,
+    mock_storage,
+    mock_audio_store,
 ):
-    return {
-        "user_store": mock_user_store,
-        "youtube_connector": mock_youtube_connector,
-        "twitter_connector": mock_twitter_connector,
-        "storage": mock_storage,
-        "audio_store": mock_audio_store,
-    }
+    return social_handler_context_builder(
+        user_store=mock_user_store,
+        youtube_connector=mock_youtube_connector,
+        twitter_connector=mock_twitter_connector,
+        storage=mock_storage,
+        audio_store=mock_audio_store,
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- extend `tests/server/handlers/social/conftest.py` with reusable Slack stub installation, handler context builders, and shared mock user/http helpers, then refactor the duplicated social handler tests to consume them
- add `tests/connectors/chat/conftest.py` with shared stub connector, JWT, and HTTP response fixtures and refactor the duplicated chat base/JWT/connector tests around that scaffold
- add `tests/channels/conftest.py` for the dock-focused tests that currently live under `tests/channels/` and move the repeated dock/router helper setup there
- update a few chat error-handling assertions to target the shared transport abstractions used by the current connector implementations

## Validation
- `python3 -m ruff check tests/channels/conftest.py tests/channels/test_dock_registry.py tests/channels/test_docks_all.py tests/channels/test_registry.py tests/channels/test_router.py tests/connectors/chat/conftest.py tests/connectors/chat/test_base.py tests/connectors/chat/test_chat_base.py tests/connectors/chat/test_chat_integration.py tests/connectors/chat/test_discord_connector.py tests/connectors/chat/test_jwt_verify.py tests/connectors/chat/test_jwt_verify_cache.py tests/connectors/chat/test_telegram_connector.py tests/connectors/chat/test_whatsapp_connector.py tests/server/handlers/social/conftest.py tests/server/handlers/social/test_channel_health.py tests/server/handlers/social/test_collaboration.py tests/server/handlers/social/test_sharing.py tests/server/handlers/social/test_social_media.py`
- `python3 -m pytest tests/server/handlers/social -q`
- `python3 -m pytest tests/channels -q`
- `python3 -m pytest tests/connectors/chat/test_base.py tests/connectors/chat/test_chat_base.py tests/connectors/chat/test_jwt_verify.py tests/connectors/chat/test_jwt_verify_cache.py tests/connectors/chat/test_discord_connector.py tests/connectors/chat/test_chat_integration.py tests/connectors/chat/test_telegram_connector.py tests/connectors/chat/test_whatsapp_connector.py -q`