### PR TITLE
fix(swarm): preserve serialized approval booleans

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -71,6 +71,8 @@ SESSION_LOCK_FILES = (
     ".codex_session_active",
     ".nomic-session-active",
 )
+_TRUTHY_BOOL_STRINGS = {"1", "true", "yes", "y", "on"}
+_FALSY_BOOL_STRINGS = {"0", "false", "no", "n", "off"}
 
 
 def _path_in_scope(path: str, scope_pattern: str) -> bool:
@@ -100,6 +102,18 @@ def _is_concrete_repo_path(path: str) -> bool:
 
 def _strict_bool(value: Any) -> bool | None:
     return value if isinstance(value, bool) else None
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUTHY_BOOL_STRINGS:
+            return True
+        if normalized in _FALSY_BOOL_STRINGS:
+            return False
+    return default
 
 
 def _docs_only_scope_supports_hint(path: str, original_scope: list[str]) -> bool:
@@ -3077,7 +3091,10 @@ class SwarmSupervisor:
                     risk_level=risk_level,
                     target_agent=target_agent,
                     reviewer_agent=reviewer_agent,
-                    approval_required=bool(payload.get("approval_required", False)),
+                    approval_required=_coerce_bool(
+                        payload.get("approval_required"),
+                        default=True,
+                    ),
                     metadata={
                         **dict(payload.get("metadata") or {}),
                         "source": "explicit_spec_work_order",
@@ -3113,7 +3130,6 @@ class SwarmSupervisor:
             item.risk_level = str(item.risk_level).strip() or self._risk_level_for_scope(
                 item.file_scope
             )
-            item.approval_required = True
             item.metadata = {
                 **dict(item.metadata),
                 "acceptance_criteria": list(spec.acceptance_criteria),

--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -19,6 +19,8 @@ DEFAULT_TRANCHE_ARTIFACT_ROOT = ".aragora/tranche_artifacts"
 DEFAULT_TRANCHE_MANIFEST_DIR = ".aragora/tranches"
 _GITHUB_REF_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/(pull|issues)/(\d+)$")
 _REUSABLE_PREPARED_STATUSES = {"prepared", "running"}
+_TRUTHY_BOOL_STRINGS = {"1", "true", "yes", "y", "on"}
+_FALSY_BOOL_STRINGS = {"0", "false", "no", "n", "off"}
 
 
 def _utcnow() -> datetime:
@@ -46,6 +48,18 @@ def _dict_value(value: Any, *, field_name: str) -> dict[str, Any]:
     if not isinstance(value, dict):
         raise ValueError(f"{field_name} must be an object.")
     return dict(value)
+
+
+def _coerce_bool(value: Any, *, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUTHY_BOOL_STRINGS:
+            return True
+        if normalized in _FALSY_BOOL_STRINGS:
+            return False
+    return default
 
 
 def _normalize_scope(value: str) -> str:
@@ -823,7 +837,10 @@ class TrancheExecutor:
             project=project,
             worker_model=worker_model,
             review_model=review_model,
-            enforce_cross_model_review=bool(lane.metadata.get("enforce_cross_model_review", True)),
+            enforce_cross_model_review=_coerce_bool(
+                lane.metadata.get("enforce_cross_model_review"),
+                default=True,
+            ),
             run_dict=dict(run_dict),
             budget_context={"project_estimated_cost_usd": _lane_budget_limit_usd(lane)},
             repo_root=self.repo_root,
@@ -1498,7 +1515,10 @@ def _lane_spec_from_manifest(manifest: TrancheManifest, lane: TrancheLane) -> An
         },
         "estimated_complexity": str(lane.metadata.get("estimated_complexity", "medium")).strip()
         or "medium",
-        "approval_required": bool(lane.metadata.get("requires_approval", True)),
+        "approval_required": _coerce_bool(
+            lane.metadata.get("requires_approval"),
+            default=True,
+        ),
         "metadata": {
             "tranche_manifest_id": manifest.manifest_id,
             "tranche_lane_id": lane.lane_id,
@@ -1512,7 +1532,10 @@ def _lane_spec_from_manifest(manifest: TrancheManifest, lane: TrancheLane) -> An
         budget_limit_usd=_lane_budget_limit_usd(lane),
         file_scope_hints=list(dict.fromkeys(file_scope_hints)),
         work_orders=[explicit_work_order],
-        requires_approval=bool(lane.metadata.get("requires_approval", True)),
+        requires_approval=_coerce_bool(
+            lane.metadata.get("requires_approval"),
+            default=True,
+        ),
         user_expertise="developer",
         estimated_complexity=str(lane.metadata.get("estimated_complexity", "medium")).strip()
         or "medium",
@@ -1584,7 +1607,7 @@ def _lane_review_model(lane: TrancheLane, *, target_agent: str) -> str:
     requested = _optional_text(lane.metadata.get("review_model"))
     if requested:
         if (
-            bool(lane.metadata.get("enforce_cross_model_review", True))
+            _coerce_bool(lane.metadata.get("enforce_cross_model_review"), default=True)
             and requested == target_agent
         ):
             return "claude" if target_agent == "codex" else "codex"

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -490,6 +490,31 @@ def test_start_run_discards_duplicate_explicit_lane_by_tranche_lane_id(
     assert work_order["metadata"]["canonical_task_key"].endswith(":existing")
 
 
+def test_start_run_coerces_string_approval_required_for_explicit_work_orders(repo: Path) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+    spec = SwarmSpec(
+        raw_goal="Run the explicit work order without a human gate.",
+        refined_goal="Run the explicit work order without a human gate.",
+        work_orders=[
+            {
+                "work_order_id": "explicit-1",
+                "title": "Explicit lane",
+                "description": "Verify malformed booleans do not force approval.",
+                "file_scope": ["README.md"],
+                "approval_required": "false",
+            }
+        ],
+    )
+
+    run = supervisor.start_run(spec=spec, refresh_scaling=False)
+
+    assert run.work_orders[0]["approval_required"] is False
+
+
 def test_start_run_discards_duplicate_scope_less_open_lane(
     repo: Path, store: DevCoordinationStore
 ) -> None:

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -13,8 +13,11 @@ from aragora.swarm.tranche import (
     TrancheExecutor,
     TrancheInspector,
     TrancheLaneArtifact,
+    TrancheLane,
     TrancheManifest,
     TranchePlanner,
+    _lane_review_model,
+    _lane_spec_from_manifest,
     load_tranche_manifest,
     parse_github_reference_url,
 )
@@ -1077,3 +1080,33 @@ async def test_run_allows_explicit_managed_session_script_override(tmp_path: Pat
         await executor.run(manifest, lane_id="pmf_impl", skip_review=True)
 
     assert captured_kwargs.get("use_managed_session_script") is True
+
+
+def test_lane_spec_coerces_string_boolean_metadata() -> None:
+    manifest = TrancheManifest(
+        manifest_id="m1",
+        repo={"name": "synaptent/aragora", "root": "/tmp/repo", "base_ref": "origin/main"},
+        references={},
+        gates={},
+        lanes=[],
+        terminal_outcomes={"success": {"definition": "done"}},
+    )
+    lane = TrancheLane(
+        lane_id="lane-a",
+        owner_role="engineer",
+        allowed_write_scope=["aragora/swarm/**"],
+        verification_commands=[],
+        metadata={
+            "prompt": "Ship the fix.",
+            "target_agent": "codex",
+            "review_model": "codex",
+            "requires_approval": "false",
+            "enforce_cross_model_review": "false",
+        },
+    )
+
+    spec = _lane_spec_from_manifest(manifest, lane)
+
+    assert spec.work_orders[0]["approval_required"] is False
+    assert spec.requires_approval is False
+    assert _lane_review_model(lane, target_agent="codex") == "codex"


### PR DESCRIPTION
Preserve explicit supervisor/tranche approval booleans from serialized metadata and add focused regressions.