### PR TITLE
Require string webhook text metadata

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -313,6 +313,15 @@ class WebhookHandler(SecureHandler):
             events.append(event)
         return events
 
+    @staticmethod
+    def _parse_optional_text_field(raw_value: Any, field_name: str) -> str | None:
+        """Normalize optional text fields while rejecting malformed non-string payloads."""
+        if raw_value is None:
+            return None
+        if not isinstance(raw_value, str):
+            raise ValueError(f"{field_name} must be a string")
+        return raw_value.strip()
+
     @api_endpoint(
         path="/api/v1/webhooks",
         method="GET",
@@ -723,13 +732,18 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Get user context
         user = self.get_current_user(handler)
         user_id = user.user_id if user else None
+        try:
+            name = self._parse_optional_text_field(body.get("name"), "Name")
+            description = self._parse_optional_text_field(body.get("description"), "Description")
+        except ValueError as exc:
+            return error_response(str(exc), 400)
 
         store = self._get_webhook_store()
         webhook = store.register(
             url=url,
             events=events,
-            name=body.get("name"),
-            description=body.get("description"),
+            name=name,
+            description=description,
             user_id=user_id,
             workspace_id=getattr(user, "org_id", None),
         )
@@ -839,14 +853,19 @@ The webhook secret is only returned once on creation - save it securely.""",
             if not isinstance(raw_active, bool):
                 return error_response("Active must be a boolean", 400)
             active = raw_active
+        try:
+            name = self._parse_optional_text_field(body.get("name"), "Name")
+            description = self._parse_optional_text_field(body.get("description"), "Description")
+        except ValueError as exc:
+            return error_response(str(exc), 400)
 
         updated = store.update(
             webhook_id=webhook_id,
             url=new_url,
             events=events,
             active=active,
-            name=body.get("name"),
-            description=body.get("description"),
+            name=name,
+            description=description,
         )
 
         # Audit log: webhook updated

--- a/tests/server/handlers/test_webhooks_handler.py
+++ b/tests/server/handlers/test_webhooks_handler.py
@@ -545,6 +545,26 @@ class TestWebhookHandlerRegister:
         assert result.status_code == 400
         assert b"list of strings" in result.body.lower()
 
+    @pytest.mark.asyncio
+    async def test_register_webhook_rejects_nonstring_name(self, webhook_handler):
+        """Registration must reject malformed non-string webhook names."""
+        body = json.dumps(
+            {
+                "url": "https://example.com",
+                "events": ["debate_start"],
+                "name": False,
+            }
+        ).encode()
+        handler = MockHandler(
+            headers={"Content-Length": str(len(body)), "Content-Type": "application/json"},
+            body=body,
+        )
+
+        result = await webhook_handler.handle_post("/api/v1/webhooks", {}, handler)
+
+        assert result.status_code == 400
+        assert b"name must be a string" in result.body.lower()
+
 
 class TestWebhookHandlerList:
     """Tests for GET /api/webhooks endpoint."""
@@ -948,6 +968,24 @@ class TestWebhookHandlerUpdate:
 
         assert result.status_code == 400
         assert b"active must be a boolean" in result.body.lower()
+
+    def test_update_webhook_rejects_nonstring_description(self, webhook_handler, server_context):
+        """PATCH must not persist malformed non-string descriptions."""
+        store = server_context["webhook_store"]
+        webhook = store.register(
+            url="https://example.com", events=["debate_start"], user_id="test-user-001"
+        )
+
+        body = json.dumps({"description": {"nested": "value"}}).encode()
+        handler = MockHandler(
+            headers={"Content-Length": str(len(body)), "Content-Type": "application/json"},
+            body=body,
+        )
+
+        result = webhook_handler.handle_patch(f"/api/v1/webhooks/{webhook.id}", {}, handler)
+
+        assert result.status_code == 400
+        assert b"description must be a string" in result.body.lower()
 
     def test_update_webhook_hides_workspace_mismatch(self, server_context):
         from aragora.server.handlers.webhooks import WebhookHandler


### PR DESCRIPTION
## Summary
- require webhook name and description payloads to be real strings when present
- reject malformed non-string metadata instead of passing it through to storage
- add regressions for register and update malformed text metadata

## Testing
- python -m ruff check aragora/server/handlers/webhooks.py tests/server/handlers/test_webhooks_handler.py
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q -k "nonstring_name or nonstring_description or register_webhook_success or update_webhook_success"
- python -m pytest tests/server/handlers/test_webhooks_handler.py -q