### PR TITLE
fix(sveltekit): use dynamic public env for browser client

### DIFF
--- a/examples/sveltekit/src/lib/aragora.ts
+++ b/examples/sveltekit/src/lib/aragora.ts
@@ -5,7 +5,7 @@
  */
 
 import { createClient, type AragoraClient } from '@aragora/sdk';
-import { PUBLIC_ARAGORA_API_URL } from '$env/static/public';
+import { env } from '$env/dynamic/public';
 
 // Browser client (singleton)
 let browserClient: AragoraClient | null = null;
@@ -17,7 +17,7 @@ export function getBrowserClient(): AragoraClient {
 
   if (!browserClient) {
     browserClient = createClient({
-      baseUrl: PUBLIC_ARAGORA_API_URL || 'http://localhost:8080',
+      baseUrl: env.PUBLIC_ARAGORA_API_URL || 'http://localhost:8080',
     });
   }
 


### PR DESCRIPTION
## Summary
- switch the browser client to use SvelteKit's dynamic public env object
- avoid compile-time failure when PUBLIC_ARAGORA_API_URL is not defined
- preserve the existing localhost fallback

## Validation
- cd examples/sveltekit && npm ci && npm run build