### PR TITLE
Harden stream replay JSON shape handling

### DIFF
--- a/aragora/server/stream/stream_handlers.py
+++ b/aragora/server/stream/stream_handlers.py
@@ -41,6 +41,36 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _load_json_object(path: Path, *, context: str) -> dict[str, Any]:
+    """Load a JSON object from disk, degrading malformed shapes to {}."""
+    try:
+        data = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse %s %s: %s", context, path, e)
+        return {}
+
+    if not isinstance(data, dict):
+        logger.warning("Ignoring non-object %s %s", context, path)
+        return {}
+
+    return data
+
+
+def _parse_json_object_line(line: str, *, source: Path) -> dict[str, Any] | None:
+    """Parse one JSONL line, returning only object-shaped entries."""
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError as e:
+        logger.warning("Failed to parse event line from %s: %s", source, e)
+        return None
+
+    if not isinstance(data, dict):
+        logger.warning("Skipping non-object replay event in %s", source)
+        return None
+
+    return data
+
+
 class StreamAPIHandlersMixin:
     """
     Mixin class providing HTTP API handlers for the streaming server.
@@ -886,11 +916,7 @@ class StreamAPIHandlersMixin:
                 if replay_path.is_dir():
                     meta_file = replay_path / "meta.json"
                     if meta_file.exists():
-                        try:
-                            meta = json.loads(meta_file.read_text())
-                        except json.JSONDecodeError as e:
-                            logger.warning("Failed to parse replay meta %s: %s", meta_file, e)
-                            meta = {}
+                        meta = _load_json_object(meta_file, context="replay meta")
                         replays.append(
                             {
                                 "id": replay_path.name,
@@ -976,27 +1002,23 @@ class StreamAPIHandlersMixin:
             with events_file.open() as f:
                 for line in f:
                     if line.strip():
-                        try:
-                            events.append(json.loads(line))
-                        except json.JSONDecodeError as e:
-                            logger.warning("Failed to parse event line: %s", e)
-                            continue
+                        event = _parse_json_object_line(line, source=events_file)
+                        if event is not None:
+                            events.append(event)
 
             # Create artifact from events
-            meta = {}
-            if meta_file.exists():
-                try:
-                    meta = json.loads(meta_file.read_text())
-                except json.JSONDecodeError as e:
-                    logger.warning("Failed to parse replay meta %s: %s", meta_file, e)
+            meta = _load_json_object(meta_file, context="replay meta") if meta_file.exists() else {}
             generator = ReplayGenerator()
+            verdict = meta.get("verdict", {})
+            if not isinstance(verdict, dict):
+                verdict = {}
 
             # Simple HTML generation from events
             artifact = ReplayArtifact(
                 debate_id=replay_id,
                 task=meta.get("topic", "Unknown"),
                 scenes=[],
-                verdict=meta.get("verdict", {}),
+                verdict=verdict,
                 metadata=meta,
             )
 
@@ -1004,17 +1026,22 @@ class StreamAPIHandlersMixin:
             round_events: dict[int, list] = {}
             for event in events:
                 round_num = event.get("round", 0)
+                if isinstance(round_num, bool) or not isinstance(round_num, int):
+                    round_num = 0
                 round_events.setdefault(round_num, []).append(event)
 
             for round_num in sorted(round_events.keys()):
                 messages = []
                 for event in round_events[round_num]:
+                    event_data = event.get("data", {})
+                    if not isinstance(event_data, dict):
+                        event_data = {}
                     if event.get("type") in ("agent_message", "propose", "critique"):
                         messages.append(
                             Message(
-                                role=event.get("data", {}).get("role", "unknown"),
+                                role=event_data.get("role", "unknown"),
                                 agent=event.get("agent", "unknown"),
-                                content=event.get("data", {}).get("content", ""),
+                                content=event_data.get("content", ""),
                                 round=round_num,
                             )
                         )

--- a/tests/server/stream/test_stream_handlers.py
+++ b/tests/server/stream/test_stream_handlers.py
@@ -856,6 +856,25 @@ class TestReplaysHandler:
             call_args = mock_response.call_args[0][0]
             assert len(call_args["replays"]) <= 2
 
+    @pytest.mark.asyncio
+    async def test_treats_non_object_meta_as_empty(self, request_factory, tmp_path):
+        """Valid JSON that is not an object degrades to default replay metadata."""
+        replays_dir = tmp_path / "replays"
+        replay_dir = replays_dir / "replay-non-object-meta"
+        replay_dir.mkdir(parents=True)
+        (replay_dir / "meta.json").write_text("[]")
+
+        handler = ConcreteStreamAPIHandlers(nomic_dir=tmp_path)
+        request = request_factory()
+
+        with patch("aiohttp.web.json_response") as mock_response:
+            mock_response.return_value = MagicMock()
+            await handler._handle_replays(request)
+            call_args = mock_response.call_args[0][0]
+            assert call_args["count"] == 1
+            assert call_args["replays"][0]["id"] == "replay-non-object-meta"
+            assert call_args["replays"][0]["topic"] == "replay-non-object-meta"
+
 
 class TestReplayHtmlHandler:
     """Tests for _handle_replay_html endpoint."""
@@ -912,6 +931,53 @@ class TestReplayHtmlHandler:
             call_kwargs = mock_response.call_args[1]
             assert call_kwargs.get("content_type") == "text/html"
             assert "<html>" in call_kwargs.get("text", "")
+
+    @pytest.mark.asyncio
+    async def test_tolerates_non_object_meta_and_malformed_event_shapes(
+        self, request_factory, tmp_path
+    ):
+        """Replay HTML generation skips malformed JSON shapes instead of returning 500."""
+        replays_dir = tmp_path / "replays"
+        replay_dir = replays_dir / "test-replay"
+        replay_dir.mkdir(parents=True)
+        (replay_dir / "meta.json").write_text("[]")
+        (replay_dir / "events.jsonl").write_text(
+            "\n".join(
+                [
+                    json.dumps("not-an-event"),
+                    json.dumps(
+                        {
+                            "type": "agent_message",
+                            "agent": "claude",
+                            "data": "bad-payload",
+                            "round": [],
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "type": "critique",
+                            "agent": "gemini",
+                            "data": {"role": "critic", "content": "Hello"},
+                            "round": 1,
+                        }
+                    ),
+                ]
+            )
+        )
+
+        handler = ConcreteStreamAPIHandlers(nomic_dir=tmp_path)
+        request = request_factory(match_info={"replay_id": "test-replay"})
+
+        with (
+            patch("aiohttp.web.Response") as mock_response,
+            patch("aiohttp.web.json_response") as mock_json_response,
+        ):
+            mock_response.return_value = MagicMock()
+            await handler._handle_replay_html(request)
+            mock_json_response.assert_not_called()
+            call_kwargs = mock_response.call_args[1]
+            assert call_kwargs.get("content_type") == "text/html"
+            assert "Hello" in call_kwargs.get("text", "")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- treat replay meta files as empty unless they decode to JSON objects
- skip non-object replay event lines and normalize malformed event payload fields
- add regressions for replay listing and HTML generation with malformed JSON shapes

## Testing
- python -m ruff check aragora/server/stream/stream_handlers.py tests/server/stream/test_stream_handlers.py
- python -m pytest tests/server/stream/test_stream_handlers.py -q -k "non_object_meta or malformed_event_shapes or replay_html or _handle_replays"
- python -m pytest tests/server/stream/test_stream_handlers.py -q