### PR TITLE
Require strict runner availability on heartbeat refresh

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -88,6 +88,10 @@ _ALREADY_DONE_MARKERS = (
 _BOSS_PUBLISH_COMMENT_MARKER = "<!-- aragora-boss-loop-publish -->"
 
 
+def _strict_bool(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
 # ---------------------------------------------------------------------------
 # Boss Loop Status & Stop Conditions
 # ---------------------------------------------------------------------------
@@ -858,7 +862,7 @@ class BossLoop:
                 runner_id=runner_id,
                 runner_type=str(reg.get("runner_type", "codex")).strip(),
                 availability=str(reg.get("availability", "unknown")).strip(),
-                available=bool(reg.get("available", False)),
+                available=_strict_bool(reg.get("available")) is True,
                 auth_mode=str(reg.get("auth_mode", "unknown")).strip(),
                 command_path=reg.get("command_path"),
                 profile=reg.get("profile"),

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3710,6 +3710,50 @@ class TestRunnerHeartbeatRefresh:
         assert reg["updated_at"] != old_ts, "updated_at should be refreshed"
         assert reg["heartbeat_at"] != old_ts, "heartbeat_at should be refreshed"
 
+    def test_heartbeat_refresh_requires_real_boolean_available(self, tmp_path):
+        """Malformed availability values fail closed during heartbeat refresh."""
+        import json as _json
+
+        registry_path = str(tmp_path / "runners.json")
+        old_ts = "2025-01-01T00:00:00+00:00"
+        _json.dump(
+            {
+                "registrations": [
+                    {
+                        "runner_id": "codex-runner-1",
+                        "runner_type": "codex",
+                        "availability": "ready",
+                        "available": "false",
+                        "auth_mode": "api_key",
+                        "registered": True,
+                        "registered_at": old_ts,
+                        "updated_at": old_ts,
+                        "heartbeat_at": old_ts,
+                        "owner_binding": {
+                            "user_id": "u1",
+                            "workspace_id": "w1",
+                        },
+                    }
+                ]
+            },
+            open(registry_path, "w"),
+        )
+
+        config = _boss_config(registry_path=registry_path)
+        loop = BossLoop(
+            config=config,
+            env={"ARAGORA_USER_ID": "u1", "ARAGORA_WORKSPACE_ID": "w1"},
+        )
+
+        loop._refresh_runner_heartbeats()
+
+        with open(registry_path) as f:
+            data = _json.load(f)
+
+        reg = data["registrations"][0]
+        assert reg["available"] is False
+        assert reg["freshness_status"] == "unavailable"
+
     def test_heartbeat_refresh_called_during_run(self, tmp_path):
         """The main run() loop calls _refresh_runner_heartbeats each iteration."""
         feed = MagicMock()


### PR DESCRIPTION
## Summary
- require registered runner `available` state to be a real boolean during boss heartbeat refresh
- stop malformed values like "false" from being rewritten into fresh available runners
- add a regression around `_refresh_runner_heartbeats()` and keep the full boss-loop suite green

## Testing
- python -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python -m pytest tests/swarm/test_boss_loop.py -q -k "heartbeat_refresh_requires_real_boolean_available or heartbeat_refresh"
- python -m pytest tests/swarm/test_boss_loop.py -q