### PR TITLE
Backfill fresh receipts for salvaged deliverables

### DIFF
--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -3765,7 +3765,9 @@ class SwarmSupervisor:
             # Salvaged deliverables proceed to completion — the recovery was
             # intentional and the deliverable (commits/PR) is real. Clear any
             # stale blocker metadata from the failed attempt so the lane does
-            # not remain "completed" while still looking blocked.
+            # not remain "completed" while still looking blocked. Also drop any
+            # inherited receipt/confidence so completion backfill records a
+            # fresh receipt for the current salvaged deliverable.
             item["status"] = "completed"
             item["review_status"] = "pending_heterogeneous_review"
             for key in (
@@ -3778,6 +3780,8 @@ class SwarmSupervisor:
                 "merge_gate",
                 "verification_missing_reason",
                 "scope_violation",
+                "receipt_id",
+                "confidence",
             ):
                 item.pop(key, None)
             item.pop("blockers", None)

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -4207,7 +4207,8 @@ async def test_collect_results_backfills_receipt_for_salvaged_deliverable(
                 "lease_id": lease.lease_id,
                 "review_status": "pending",
                 "file_scope": ["aragora/swarm/supervisor.py"],
-                "receipt_id": None,
+                "receipt_id": "receipt-stale",
+                "confidence": 0.91,
                 "dispatch_error": "old crash",
                 "failure_reason": "worker_crash",
                 "blocking_question": "Old blocker?",
@@ -4252,6 +4253,7 @@ async def test_collect_results_backfills_receipt_for_salvaged_deliverable(
     assert wo["review_status"] == "pending_heterogeneous_review"
     assert wo["worker_outcome"] == "crash_with_salvage"
     assert wo["receipt_id"] is not None
+    assert wo["receipt_id"] != "receipt-stale"
     receipt = store.get_completion_receipt(wo["receipt_id"])
     assert receipt is not None
     assert receipt.outcome == "deliverable_created"


### PR DESCRIPTION
## Summary
- drop inherited receipt metadata before marking salvaged crash/timeout deliverables completed
- let the normal completion backfill path mint a fresh receipt for the current salvaged deliverable
- add a regression proving stale salvaged receipts are replaced instead of preserved

## Testing
- python -m ruff check aragora/swarm/supervisor.py tests/swarm/test_supervisor.py
- python -m pytest tests/swarm/test_supervisor.py -q -k "collect_results_backfills_receipt_for_salvaged_deliverable"
- python -m pytest tests/swarm/test_supervisor.py -q