### PR TITLE
Harden playground public share ID collisions

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -97,6 +97,38 @@ _LANDING_EVENT_TYPES = set(_LANDING_EVENT_TYPE_ORDER)
 _LANDING_REVIEW_STATUSES = frozenset({"pending", "reviewed", "resolved", "dismissed"})
 
 
+def _ensure_unique_public_share_id(response: dict[str, Any]) -> str:
+    """Keep public playground share IDs immutable across persisted results.
+
+    Public playground callers may provide a debate ID early so the frontend can
+    bind spectate context before the HTTP response returns. That ID must not be
+    allowed to replace an already-persisted public debate. If the requested ID
+    is already in use, mint a fresh server-side ID for persistence and return it
+    in the response instead.
+    """
+    debate_id = str(response.get("id", "") or "").strip() or uuid.uuid4().hex[:16]
+
+    try:
+        from aragora.storage.debate_store import DebateResultStore, get_debate_store
+
+        store = get_debate_store()
+        if isinstance(store, DebateResultStore):
+            original_id = debate_id
+            while store.get(debate_id) is not None:
+                debate_id = uuid.uuid4().hex[:16]
+            if debate_id != original_id:
+                logger.warning(
+                    "Rejected colliding public playground debate id %s; issued %s instead",
+                    original_id,
+                    debate_id,
+                )
+    except (ImportError, OSError, RuntimeError, ValueError):
+        logger.debug("Could not verify public debate id uniqueness", exc_info=True)
+
+    response["id"] = debate_id
+    return debate_id
+
+
 def _check_rate_limit(
     client_ip: str,
     limit: int = _PLAYGROUND_RATE_LIMIT,
@@ -2418,11 +2450,12 @@ def _persist_playground_debate(response: dict[str, Any]) -> None:
     Non-fatal: if persistence fails, the debate still works but won't
     have a shareable link.
     """
+    debate_id = _ensure_unique_public_share_id(response)
+
     try:
         from aragora.persistence.repositories.debate import DebateEntity, DebateRepository
 
         topic = response.get("topic", "debate")
-        debate_id = response.get("id", uuid.uuid4().hex[:16])
 
         # Generate URL-friendly slug
         slug_base = re.sub(r"[^a-z0-9]+", "-", topic[:60].lower()).strip("-")
@@ -2451,7 +2484,7 @@ def _persist_playground_debate(response: dict[str, Any]) -> None:
     try:
         from aragora.storage.debate_store import get_debate_store
 
-        store_debate_id = response.get("id", uuid.uuid4().hex[:16])
+        store_debate_id = response.get("id", debate_id)
         store_topic = response.get("topic", "debate")
         store_source = response.get("source", "playground")
         store = get_debate_store()
@@ -3380,6 +3413,7 @@ class PlaygroundHandler(BaseHandler):
             data = _normalize_public_debate_payload(json.loads(body_bytes.decode("utf-8")))
             debate_id = data.get("id", "")
             if debate_id:
+                debate_id = _ensure_unique_public_share_id(data)
                 # Inject share fields and source into data BEFORE persisting
                 # so the public viewer's _is_shareable() check passes.
                 data["share_url"] = f"/debate/{debate_id}"

--- a/tests/server/handlers/test_playground_share_token.py
+++ b/tests/server/handlers/test_playground_share_token.py
@@ -11,9 +11,11 @@ import pytest
 from aragora.server.handlers.base import json_response
 from aragora.server.handlers.playground import (
     PlaygroundHandler,
+    _persist_playground_debate,
     _reset_oracle_sessions,
     _reset_rate_limits,
 )
+from aragora.storage.debate_store import get_debate_store
 
 
 @pytest.fixture(autouse=True)
@@ -130,3 +132,64 @@ class TestShareTokenInResponse:
         assert "share_token" in body, (
             f"Missing share_token in POST /debate response. Keys: {list(body.keys())}"
         )
+
+    def test_persist_and_respond_does_not_overwrite_existing_share_id(self, handler):
+        """Colliding public debate IDs must mint a new share instead of replacing the old one."""
+        original = {
+            "id": "abcdef1234567890",
+            "topic": "Original topic",
+            "final_answer": "Original answer",
+            "verdict": "approved",
+        }
+        attacker = {
+            "id": "abcdef1234567890",
+            "topic": "Attacker topic",
+            "final_answer": "Overwrite me",
+            "verdict": "approved",
+        }
+
+        handler._persist_and_respond(
+            json_response(original),
+            original["topic"],
+            "landing",
+        )
+
+        result = handler._persist_and_respond(
+            json_response(attacker),
+            attacker["topic"],
+            "landing",
+        )
+        body = json.loads(result.body.decode("utf-8"))
+        store = get_debate_store()
+
+        assert body["id"] != "abcdef1234567890"
+        assert body["share_token"] == body["id"]
+        assert store.get("abcdef1234567890")["final_answer"] == "Original answer"
+        assert store.get(body["id"])["final_answer"] == "Overwrite me"
+
+    def test_persist_playground_debate_does_not_reuse_existing_public_id(self, handler):
+        """Repository-backed playground persistence must also preserve existing public shares."""
+        existing = {
+            "id": "fedcba0987654321",
+            "topic": "Existing shared debate",
+            "final_answer": "Keep this result",
+            "verdict": "approved",
+            "participants": [],
+            "proposals": {},
+        }
+        _persist_playground_debate(existing)
+
+        colliding = {
+            "id": "fedcba0987654321",
+            "topic": "Collision attempt",
+            "final_answer": "New result",
+            "verdict": "approved",
+            "participants": [],
+            "proposals": {},
+        }
+        _persist_playground_debate(colliding)
+        store = get_debate_store()
+
+        assert colliding["id"] != "fedcba0987654321"
+        assert store.get("fedcba0987654321")["final_answer"] == "Keep this result"
+        assert store.get(colliding["id"])["final_answer"] == "New result"


### PR DESCRIPTION
## Summary
- prevent public playground persistence from reusing an existing shareable debate ID
- mint a fresh server-side ID when a caller-supplied or inherited public ID collides
- add regressions covering both `_persist_and_respond` and `_persist_playground_debate`

## Validation
- python -m ruff check aragora/server/handlers/playground.py tests/server/handlers/test_playground_share_token.py
- python -m pytest tests/server/handlers/test_playground_share_token.py -q
- python -m pytest tests/e2e/test_landing_funnel.py -q -k "share_token_matches_debate_id or shared_debate_retrievable_via_public_viewer"
- python -m pytest tests/handlers/test_playground.py -q