### PR TITLE
feat(swarm): synthesize session coordination protocol

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -43,6 +43,11 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "campaign",
         "integrator",
         "tranche",
+        "coord",
+        "assign",
+        "claim-pr",
+        "report",
+        "findings",
     }:
         return str(first), second
     return "run", first
@@ -93,6 +98,77 @@ def _print_table(
     print("  ".join("-" * widths[key] for key, _label in headers))
     for row in rows:
         print("  ".join(str(row.get(key, "") or "").ljust(widths[key]) for key, _label in headers))
+
+
+def _coordination_session_id(args: argparse.Namespace) -> str:
+    explicit = _optional_text(getattr(args, "session_id", None))
+    if explicit:
+        return explicit
+    for env_name in ("ARAGORA_SESSION_ID", "ARAGORA_AGENT_SESSION_ID", "ARAGORA_SWARM_SESSION_ID"):
+        from_env = _optional_text(os.environ.get(env_name))
+        if from_env:
+            return from_env
+    for env_name in ("ARAGORA_AGENT", "ARAGORA_AGENT_NAME"):
+        agent_name = _optional_text(os.environ.get(env_name))
+        if agent_name:
+            return f"{agent_name}-{os.getpid()}"
+    return f"session-{os.getpid()}"
+
+
+def _coordination_assigned_by(args: argparse.Namespace) -> str:
+    explicit = _optional_text(getattr(args, "assigned_by", None))
+    if explicit:
+        return explicit
+    from_env = _optional_text(os.environ.get("ARAGORA_BOSS_SESSION_ID"))
+    if from_env:
+        return from_env
+    return f"boss-{os.getpid()}"
+
+
+def _render_coordination_view(view: dict[str, object]) -> None:
+    summary = view.get("summary", {}) if isinstance(view.get("summary"), dict) else {}
+    print(
+        "coordination directives={directives} sessions={sessions} claims={claims} findings={findings}".format(
+            directives=summary.get("directive_count", 0),
+            sessions=summary.get("session_count", 0),
+            claims=summary.get("claim_count", 0),
+            findings=summary.get("finding_count", 0),
+        )
+    )
+    for directive in [item for item in view.get("directives", []) if isinstance(item, dict)][:5]:
+        print(
+            "directive {target} status={status} task={task}".format(
+                target=directive.get("target", ""),
+                status=directive.get("status", ""),
+                task=directive.get("task", ""),
+            )
+        )
+        scope = [str(item) for item in directive.get("scope", []) if str(item).strip()]
+        constraints = [str(item) for item in directive.get("constraints", []) if str(item).strip()]
+        if scope:
+            print(f"  scope: {', '.join(scope)}")
+        if constraints:
+            print(f"  constraints: {', '.join(constraints)}")
+    for claim in [item for item in view.get("claims", []) if isinstance(item, dict)][:5]:
+        paths = [str(item) for item in claim.get("paths", []) if str(item).strip()]
+        print(
+            "claim session={session} scope={scope} intent={intent}".format(
+                session=claim.get("session_id", ""),
+                scope=", ".join(paths) or "-",
+                intent=claim.get("intent", "") or "-",
+            )
+        )
+    for finding in [item for item in view.get("findings", []) if isinstance(item, dict)][:5]:
+        pr = finding.get("pr")
+        pr_text = f" pr=#{pr}" if pr not in (None, "", 0) else ""
+        print(
+            "finding {session} kind={kind}{pr} {message}".format(
+                session=finding.get("source_session", "") or "-",
+                kind=finding.get("kind", "finding"),
+                pr=pr_text,
+                message=finding.get("message", ""),
+            )
+        )
 
 
 def _trim_command_output(text: str, *, limit: int = 240) -> str | None:
@@ -983,6 +1059,139 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         "metrics": AutonomyLevel.METRICS_DRIVEN,
     }
     autonomy_level = autonomy_map.get(autonomy_str, AutonomyLevel.PROPOSE_APPROVE)
+
+    if action in {"coord", "assign", "claim-pr", "report", "findings"}:
+        from aragora.swarm.session_coordinator import (
+            claim_pr as coord_claim_pr,
+            list_findings as coord_list_findings,
+            read_directives as coord_read,
+            report_finding as coord_report_finding,
+            set_assignment as coord_set_assignment,
+        )
+        from aragora.worktree.fleet import resolve_repo_root
+
+        repo_root = resolve_repo_root(Path.cwd())
+        findings_limit = max(1, int(getattr(args, "findings_limit", 10)))
+        session_id = _coordination_session_id(args)
+
+        if action == "coord":
+            payload = coord_read(repo_root, findings_limit=findings_limit)
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                _render_coordination_view(payload)
+            return
+
+        if action == "assign":
+            target_session = _optional_text(goal)
+            task_text = _optional_text(getattr(args, "swarm_campaign_target", None))
+            if not target_session or not task_text:
+                print('Error: usage: aragora swarm assign <session-id> "task description"')
+                return
+            payload = coord_set_assignment(
+                target_session,
+                task_text,
+                scope=[
+                    str(item) for item in (getattr(args, "scope", None) or []) if str(item).strip()
+                ],
+                constraints=[
+                    str(item)
+                    for item in (getattr(args, "constraint", None) or [])
+                    if str(item).strip()
+                ],
+                status=str(getattr(args, "directive_status", "active") or "active"),
+                issued_by=_coordination_assigned_by(args),
+                repo_root=repo_root,
+            )
+            response = {"mode": "coordination-assign", "directive": payload}
+            if as_json:
+                print(json.dumps(response, indent=2))
+            else:
+                print(f"assigned {payload.get('target', '')}: {payload.get('task', '')}")
+            return
+
+        if action == "claim-pr":
+            pr_text = _optional_text(goal)
+            if not pr_text:
+                print("Error: usage: aragora swarm claim-pr <pr-number>")
+                return
+            try:
+                pr_number = int(pr_text)
+            except ValueError:
+                print(f"Error: invalid PR number: {pr_text}")
+                return
+            payload = coord_claim_pr(
+                pr_number,
+                session_id,
+                intent=_optional_text(getattr(args, "claim_intent", None)) or "",
+                ttl_minutes=max(1, int(getattr(args, "ttl_minutes", 30) or 30)),
+                repo_root=repo_root,
+            )
+            response = {"mode": "coordination-claim-pr", "pr": pr_number, **payload}
+            if as_json:
+                print(json.dumps(response, indent=2))
+            else:
+                status_text = str(payload.get("status", "unknown"))
+                if status_text == "granted":
+                    print(f"claimed PR#{pr_number} for {session_id}")
+                else:
+                    owners = [
+                        str(item.get("session_id", ""))
+                        for item in payload.get("contested_by", [])
+                        if isinstance(item, dict)
+                    ]
+                    print(
+                        f"PR#{pr_number} claim contested for {session_id}"
+                        + (f" (also claimed by {', '.join(owners)})" if owners else "")
+                    )
+            return
+
+        if action == "report":
+            message = _optional_text(goal)
+            if not message:
+                print('Error: usage: aragora swarm report "finding text"')
+                return
+            payload = coord_report_finding(
+                message,
+                session_id,
+                kind=_optional_text(getattr(args, "kind", None)) or "finding",
+                pr=getattr(args, "pr", None),
+                scope=[
+                    str(item) for item in (getattr(args, "scope", None) or []) if str(item).strip()
+                ],
+                repo_root=repo_root,
+            )
+            response = {"mode": "coordination-report", "finding": payload}
+            if as_json:
+                print(json.dumps(response, indent=2))
+            else:
+                print(f"reported {payload.get('kind', 'finding')} from {session_id}")
+            return
+
+        findings = coord_list_findings(
+            limit=findings_limit,
+            session_id=_optional_text(getattr(args, "session_id", None)),
+            kind=_optional_text(getattr(args, "kind", None)),
+            pr=getattr(args, "pr", None),
+            repo_root=repo_root,
+        )
+        if as_json:
+            print(json.dumps({"mode": "coordination-findings", "findings": findings}, indent=2))
+        elif not findings:
+            print("No findings reported yet.")
+        else:
+            for finding in findings:
+                pr_value = finding.get("pr")
+                pr_text = f" pr=#{pr_value}" if pr_value not in (None, "", 0) else ""
+                print(
+                    "[{session}] {kind}{pr} {message}".format(
+                        session=finding.get("source_session", "-") or "-",
+                        kind=finding.get("kind", "finding"),
+                        pr=pr_text,
+                        message=finding.get("message", ""),
+                    )
+                )
+        return
 
     if action == "runner":
         from aragora.swarm.reporter import render_runner_registration_text
@@ -2427,6 +2636,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 print(render_boss_text(payload))
             return
     if action == "status":
+        from aragora.swarm.session_coordinator import read_directives as coord_read
+
         repo_root = resolve_repo_root(Path.cwd())
         supervisor = SwarmSupervisor(repo_root=repo_root)
         payload = supervisor.status_summary(
@@ -2445,6 +2656,10 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             claims=claims,
             merge_queue=merge_queue,
             coordination=payload.get("coordination", {}),
+        )
+        payload["coordination_view"] = coord_read(
+            repo_root,
+            findings_limit=max(1, int(getattr(args, "findings_limit", 10))),
         )
         if as_json:
             print(json.dumps(payload, indent=2))
@@ -2476,6 +2691,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 if isinstance(run, dict):
                     print("---")
                     _print_supervisor_run(run)
+            print("---")
+            _render_coordination_view(payload["coordination_view"])
         return
 
     if action == "reconcile":

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2297,7 +2297,10 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "swarm_action_or_goal",
         nargs="?",
-        help="Action (run/status/reconcile/campaign/integrator/tranche) or your goal in plain language",
+        help=(
+            "Action (run/status/reconcile/campaign/integrator/tranche/coord/assign/"
+            "claim-pr/report/findings) or your goal in plain language"
+        ),
     )
     swarm_parser.add_argument(
         "swarm_goal",
@@ -2448,6 +2451,57 @@ def _add_swarm_parser(subparsers) -> None:
         help="Integrator rationale for merge/archive/supersede actions",
     )
     swarm_parser.add_argument(
+        "--session-id",
+        default=None,
+        help="Coordination session id for claim/report actions (defaults from env or pid)",
+    )
+    swarm_parser.add_argument(
+        "--assigned-by",
+        default=None,
+        help="Actor recorded for 'swarm assign' (defaults from env or pid)",
+    )
+    swarm_parser.add_argument(
+        "--directive-status",
+        default="active",
+        choices=["active", "standby", "blocked", "done"],
+        help="Directive status for 'swarm assign' (default: active)",
+    )
+    swarm_parser.add_argument(
+        "--scope",
+        action="append",
+        default=None,
+        help="Shared scope item for coordination actions (repeatable)",
+    )
+    swarm_parser.add_argument(
+        "--constraint",
+        action="append",
+        default=None,
+        help="Constraint for 'swarm assign' (repeatable)",
+    )
+    swarm_parser.add_argument(
+        "--claim-intent",
+        default=None,
+        help="Intent text for 'swarm claim-pr'",
+    )
+    swarm_parser.add_argument(
+        "--ttl-minutes",
+        type=int,
+        default=30,
+        help="Claim TTL in minutes for 'swarm claim-pr' (default: 30)",
+    )
+    swarm_parser.add_argument(
+        "--kind",
+        default=None,
+        choices=["finding", "blocker", "handoff", "status"],
+        help="Finding kind for 'swarm report' and optional filter for 'swarm findings'",
+    )
+    swarm_parser.add_argument(
+        "--pr",
+        type=int,
+        default=None,
+        help="Optional PR number attached to a coordination finding",
+    )
+    swarm_parser.add_argument(
         "--new-pr-url",
         default=None,
         help="Replacement PR URL for 'integrator supersede'",
@@ -2457,6 +2511,12 @@ def _add_swarm_parser(subparsers) -> None:
         type=int,
         default=20,
         help="Maximum runs to show in 'status' (default: 20)",
+    )
+    swarm_parser.add_argument(
+        "--findings-limit",
+        type=int,
+        default=10,
+        help="Maximum coordination findings to show in 'status', 'coord', or 'findings' (default: 10)",
     )
     swarm_parser.add_argument(
         "--refresh-scaling",

--- a/aragora/coordination/__init__.py
+++ b/aragora/coordination/__init__.py
@@ -30,6 +30,10 @@ from aragora.coordination.claims import (
     ClaimStatus,
     FileClaim,
 )
+from aragora.coordination.directives import (
+    DirectiveBoard,
+    SessionDirective,
+)
 from aragora.coordination.cross_workspace import (
     CrossWorkspaceCoordinator,
     FederatedWorkspace,
@@ -76,6 +80,9 @@ __all__ = [
     # Event bus
     "CoordinationBus",
     "CoordinationEvent",
+    # Directive board
+    "DirectiveBoard",
+    "SessionDirective",
     # File claims
     "ClaimManager",
     "ClaimResult",

--- a/aragora/coordination/directives.py
+++ b/aragora/coordination/directives.py
@@ -1,0 +1,190 @@
+"""Durable directive board for cross-session coordination.
+
+This stores the current assignment for each session or role in a single JSON
+document under ``.aragora_coordination/directives.json``. The board is a thin,
+durable layer above the existing coordination primitives: claims are still
+handled by :mod:`aragora.coordination.claims`, findings by the event bus, and
+session liveness by the registry.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+_COORD_DIR = ".aragora_coordination"
+_DIRECTIVES_FILE = "directives.json"
+
+
+@dataclass
+class SessionDirective:
+    """Current assignment for one session or role."""
+
+    target: str
+    task: str
+    scope: list[str] = field(default_factory=list)
+    constraints: list[str] = field(default_factory=list)
+    assigned_by: str = ""
+    status: str = "active"
+    created_at: float = 0.0
+    updated_at: float = 0.0
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> SessionDirective:
+        return cls(
+            target=str(data.get("target", "")),
+            task=str(data.get("task", "")),
+            scope=[str(item) for item in list(data.get("scope", []))],
+            constraints=[str(item) for item in list(data.get("constraints", []))],
+            assigned_by=str(data.get("assigned_by", "")),
+            status=str(data.get("status", "active") or "active"),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+            updated_at=float(data.get("updated_at", 0.0) or 0.0),
+        )
+
+
+class DirectiveBoard:
+    """Atomic JSON-backed board of current session directives."""
+
+    def __init__(self, repo_path: Path | None = None):
+        self.repo_path = (repo_path or Path.cwd()).resolve()
+        self._coord_dir = self.repo_path / _COORD_DIR
+        self._path = self._coord_dir / _DIRECTIVES_FILE
+
+    def _ensure_dir(self) -> None:
+        self._coord_dir.mkdir(parents=True, exist_ok=True)
+
+    def _default_payload(self) -> dict[str, object]:
+        return {
+            "version": 1,
+            "updated_at": 0.0,
+            "directives": {},
+        }
+
+    def _read_unlocked(self, fh) -> dict[str, object]:
+        fh.seek(0)
+        raw = fh.read()
+        if not raw.strip():
+            return self._default_payload()
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return self._default_payload()
+        if not isinstance(data, dict):
+            return self._default_payload()
+        directives = data.get("directives")
+        if not isinstance(directives, dict):
+            directives = {}
+        return {
+            "version": int(data.get("version", 1) or 1),
+            "updated_at": float(data.get("updated_at", 0.0) or 0.0),
+            "directives": directives,
+        }
+
+    def _write_unlocked(self, fh, payload: dict[str, object]) -> None:
+        fh.seek(0)
+        fh.truncate()
+        json.dump(payload, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+
+    def _mutate(self, fn):
+        self._ensure_dir()
+        with open(self._path, "a+", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            try:
+                payload = self._read_unlocked(fh)
+                result = fn(payload)
+                payload["updated_at"] = time.time()
+                self._write_unlocked(fh, payload)
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+        return result
+
+    def _read(self) -> dict[str, object]:
+        self._ensure_dir()
+        with open(self._path, "a+", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_SH)
+            try:
+                return self._read_unlocked(fh)
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+
+    def assign(
+        self,
+        target: str,
+        task: str,
+        *,
+        scope: list[str] | None = None,
+        constraints: list[str] | None = None,
+        assigned_by: str = "",
+        status: str = "active",
+    ) -> SessionDirective:
+        def _update(payload: dict[str, object]) -> SessionDirective:
+            directives = dict(payload.get("directives", {}))
+            now = time.time()
+            existing = directives.get(target)
+            created_at = now
+            if isinstance(existing, dict):
+                created_at = float(existing.get("created_at", now) or now)
+            directive = SessionDirective(
+                target=target,
+                task=task,
+                scope=list(scope or []),
+                constraints=list(constraints or []),
+                assigned_by=assigned_by,
+                status=status,
+                created_at=created_at,
+                updated_at=now,
+            )
+            directives[target] = directive.to_dict()
+            payload["directives"] = directives
+            return directive
+
+        return self._mutate(_update)
+
+    def clear(self, target: str) -> bool:
+        def _clear(payload: dict[str, object]) -> bool:
+            directives = dict(payload.get("directives", {}))
+            if target not in directives:
+                return False
+            directives.pop(target, None)
+            payload["directives"] = directives
+            return True
+
+        return self._mutate(_clear)
+
+    def get(self, target: str) -> SessionDirective | None:
+        payload = self._read()
+        directives = payload.get("directives", {})
+        if not isinstance(directives, dict):
+            return None
+        record = directives.get(target)
+        if not isinstance(record, dict):
+            return None
+        return SessionDirective.from_dict(record)
+
+    def list(self) -> list[SessionDirective]:
+        payload = self._read()
+        directives = payload.get("directives", {})
+        if not isinstance(directives, dict):
+            return []
+        return [
+            SessionDirective.from_dict(record)
+            for _target, record in sorted(directives.items())
+            if isinstance(record, dict)
+        ]
+
+
+__all__ = [
+    "DirectiveBoard",
+    "SessionDirective",
+]

--- a/aragora/swarm/session_coordinator.py
+++ b/aragora/swarm/session_coordinator.py
@@ -1,0 +1,203 @@
+"""Session coordination facade for swarm operators and worker sessions.
+
+This module exposes a small, operator-friendly surface for cross-session
+coordination while delegating storage to the existing coordination primitives:
+
+- assignments -> :mod:`aragora.coordination.directives`
+- claims -> :mod:`aragora.coordination.claims`
+- findings -> :mod:`aragora.coordination.bus`
+- liveness -> :mod:`aragora.coordination.registry`
+
+All commands resolve the canonical repository root so sessions in disposable
+side worktrees still share the same coordination state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from aragora.coordination import (
+    ClaimManager,
+    CoordinationBus,
+    DirectiveBoard,
+    SessionRegistry,
+)
+from aragora.worktree.fleet import resolve_repo_root
+
+
+def _coord_repo_root(repo_root: Path | None = None) -> Path:
+    return resolve_repo_root((repo_root or Path.cwd()).resolve())
+
+
+def set_assignment(
+    session_id: str,
+    task: str,
+    *,
+    scope: list[str] | None = None,
+    constraints: list[str] | None = None,
+    status: str = "active",
+    issued_by: str = "",
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    root = _coord_repo_root(repo_root)
+    directive = DirectiveBoard(repo_path=root).assign(
+        session_id,
+        task,
+        scope=scope,
+        constraints=constraints,
+        assigned_by=issued_by,
+        status=status,
+    )
+    CoordinationBus(repo_path=root, source_session=issued_by).publish(
+        "directive_assigned",
+        {
+            "target": session_id,
+            "task": task,
+            "scope": list(scope or []),
+            "constraints": list(constraints or []),
+            "status": status,
+        },
+    )
+    return directive.to_dict()
+
+
+def get_my_assignment(session_id: str, repo_root: Path | None = None) -> dict[str, object] | None:
+    root = _coord_repo_root(repo_root)
+    directive = DirectiveBoard(repo_path=root).get(session_id)
+    return directive.to_dict() if directive is not None else None
+
+
+def claim_pr(
+    pr_number: int,
+    session_id: str,
+    *,
+    intent: str = "",
+    ttl_minutes: int = 30,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    root = _coord_repo_root(repo_root)
+    result = ClaimManager(repo_path=root).claim(
+        [f"pr:{pr_number}"],
+        session_id=session_id,
+        intent=intent or f"Own PR #{pr_number}",
+        ttl_minutes=ttl_minutes,
+    )
+    CoordinationBus(repo_path=root, source_session=session_id).publish(
+        "pr_claimed",
+        {
+            "pr": pr_number,
+            "intent": result.claim.intent,
+            "status": result.status.value,
+            "contested_by": [item.session_id for item in result.contested_by],
+        },
+    )
+    return {
+        "status": result.status.value,
+        "claim": result.claim.to_dict(),
+        "contested_by": [item.to_dict() for item in result.contested_by],
+        "contested_paths": list(result.contested_paths),
+    }
+
+
+def report_finding(
+    finding: str,
+    session_id: str,
+    *,
+    kind: str = "finding",
+    pr: int | None = None,
+    scope: list[str] | None = None,
+    repo_root: Path | None = None,
+) -> dict[str, object]:
+    root = _coord_repo_root(repo_root)
+    event = CoordinationBus(repo_path=root, source_session=session_id).publish(
+        "finding_reported",
+        {
+            "message": finding,
+            "kind": kind,
+            "pr": pr,
+            "scope": list(scope or []),
+            "session_id": session_id,
+        },
+    )
+    return {
+        "event_id": event.event_id,
+        "timestamp": event.timestamp,
+        "source_session": event.source_session,
+        "kind": kind,
+        "message": finding,
+        "pr": pr,
+        "scope": list(scope or []),
+    }
+
+
+def list_findings(
+    *,
+    limit: int = 10,
+    session_id: str | None = None,
+    kind: str | None = None,
+    pr: int | None = None,
+    repo_root: Path | None = None,
+) -> list[dict[str, object]]:
+    root = _coord_repo_root(repo_root)
+    events = CoordinationBus(repo_path=root).poll(
+        event_type="finding_reported",
+        limit=max(limit * 5, limit),
+    )
+    findings: list[dict[str, object]] = []
+    for event in reversed(events):
+        payload = event.payload if isinstance(event.payload, dict) else {}
+        event_session = str(payload.get("session_id") or event.source_session or "")
+        event_kind = str(payload.get("kind") or "finding")
+        event_pr = payload.get("pr")
+        if session_id and event_session != session_id:
+            continue
+        if kind and event_kind != kind:
+            continue
+        if pr is not None and event_pr != pr:
+            continue
+        findings.append(
+            {
+                "event_id": event.event_id,
+                "timestamp": event.timestamp,
+                "source_session": event_session,
+                "kind": event_kind,
+                "message": str(payload.get("message") or ""),
+                "pr": event_pr,
+                "scope": list(payload.get("scope") or []),
+            }
+        )
+        if len(findings) >= limit:
+            break
+    return findings
+
+
+def read_directives(repo_root: Path | None = None, *, findings_limit: int = 10) -> dict[str, Any]:
+    root = _coord_repo_root(repo_root)
+    directives = [item.to_dict() for item in DirectiveBoard(repo_path=root).list()]
+    sessions = [item.to_dict() for item in SessionRegistry(repo_path=root).discover()]
+    claims = [item.to_dict() for item in ClaimManager(repo_path=root).list_all()]
+    findings = list_findings(limit=findings_limit, repo_root=root)
+    return {
+        "repo_root": str(root),
+        "summary": {
+            "directive_count": len(directives),
+            "session_count": len(sessions),
+            "claim_count": len(claims),
+            "finding_count": len(findings),
+        },
+        "directives": directives,
+        "sessions": sessions,
+        "claims": claims,
+        "findings": findings,
+    }
+
+
+__all__ = [
+    "claim_pr",
+    "get_my_assignment",
+    "list_findings",
+    "read_directives",
+    "report_finding",
+    "set_assignment",
+]

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -51,9 +51,19 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "rationale": "",
         "new_pr_url": None,
         "status_limit": 20,
+        "findings_limit": 10,
         "refresh_scaling": False,
         "no_dispatch": False,
         "watch": False,
+        "session_id": None,
+        "assigned_by": None,
+        "directive_status": "active",
+        "scope": None,
+        "constraint": None,
+        "claim_intent": None,
+        "ttl_minutes": 30,
+        "kind": None,
+        "pr": None,
         "claude_runner_profiles": None,
         "runner_rotation_interval": 1800.0,
         "boss_max_parallel_dispatches": 1,
@@ -150,6 +160,77 @@ class TestSwarmParser:
         assert args.swarm_action_or_goal == "status"
         assert args.run_id == "run-123"
         assert args.json is True
+
+    def test_swarm_coord_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["swarm", "coord", "--findings-limit", "5", "--json"])
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "coord"
+        assert args.findings_limit == 5
+        assert args.json is True
+
+    def test_swarm_assign_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "assign",
+                "codex-a",
+                "SDK parity consolidation",
+                "--scope",
+                "#2684",
+                "--constraint",
+                "no queue drain",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "assign"
+        assert args.swarm_goal == "codex-a"
+        assert args.swarm_campaign_target == "SDK parity consolidation"
+        assert args.scope == ["#2684"]
+        assert args.constraint == ["no queue drain"]
+
+    def test_swarm_claim_pr_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["swarm", "claim-pr", "2684", "--session-id", "codex-a", "--ttl-minutes", "15"]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "claim-pr"
+        assert args.swarm_goal == "2684"
+        assert args.session_id == "codex-a"
+        assert args.ttl_minutes == 15
+
+    def test_swarm_report_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["swarm", "report", "Verification route bug", "--kind", "blocker", "--pr", "2677"]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "report"
+        assert args.swarm_goal == "Verification route bug"
+        assert args.kind == "blocker"
+        assert args.pr == 2677
+
+    def test_swarm_findings_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            ["swarm", "findings", "--kind", "blocker", "--session-id", "review-codex"]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "findings"
+        assert args.kind == "blocker"
+        assert args.session_id == "review-codex"
 
     def test_swarm_reconcile_parser(self):
         from aragora.cli.parser import build_parser
@@ -731,6 +812,115 @@ class TestSwarmParser:
 
 
 class TestSwarmCommand:
+    def test_cmd_swarm_assign_and_findings_flow(self, tmp_path: Path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        assign_args = _swarm_args(
+            swarm_action_or_goal="assign",
+            swarm_goal="codex-a",
+            swarm_campaign_target="SDK parity consolidation",
+            scope=["#2684"],
+            constraint=["no queue drain"],
+            assigned_by="boss-codex",
+            json=True,
+        )
+        cmd_swarm(assign_args)
+        assign_out = capsys.readouterr().out
+        assert '"mode": "coordination-assign"' in assign_out
+        assert '"target": "codex-a"' in assign_out
+
+        report_args = _swarm_args(
+            swarm_action_or_goal="report",
+            swarm_goal="Verification route bug",
+            session_id="review-codex",
+            kind="blocker",
+            pr=2677,
+            json=True,
+        )
+        cmd_swarm(report_args)
+        report_out = capsys.readouterr().out
+        assert '"mode": "coordination-report"' in report_out
+        assert '"kind": "blocker"' in report_out
+
+        findings_args = _swarm_args(
+            swarm_action_or_goal="findings",
+            session_id="review-codex",
+            kind="blocker",
+            json=True,
+        )
+        cmd_swarm(findings_args)
+        findings_out = capsys.readouterr().out
+        assert '"mode": "coordination-findings"' in findings_out
+        assert '"message": "Verification route bug"' in findings_out
+
+    def test_cmd_swarm_claim_pr_reports_contested_owner(self, tmp_path: Path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        first_args = _swarm_args(
+            swarm_action_or_goal="claim-pr",
+            swarm_goal="2684",
+            session_id="codex-a",
+        )
+        cmd_swarm(first_args)
+        assert "claimed PR#2684 for codex-a" in capsys.readouterr().out
+
+        second_args = _swarm_args(
+            swarm_action_or_goal="claim-pr",
+            swarm_goal="2684",
+            session_id="codex-b",
+        )
+        cmd_swarm(second_args)
+        out = capsys.readouterr().out
+        assert "PR#2684 claim contested for codex-b" in out
+        assert "codex-a" in out
+
+    def test_cmd_swarm_status_includes_coordination_view(self, tmp_path: Path, capsys, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        cmd_swarm(
+            _swarm_args(
+                swarm_action_or_goal="assign",
+                swarm_goal="codex-a",
+                swarm_campaign_target="Own parity lane",
+                assigned_by="boss-codex",
+            )
+        )
+        capsys.readouterr()
+        cmd_swarm(
+            _swarm_args(
+                swarm_action_or_goal="report",
+                swarm_goal="Bandit B310 in auth/oidc.py",
+                session_id="codex-b",
+                kind="blocker",
+                pr=2679,
+            )
+        )
+        capsys.readouterr()
+
+        with (
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=tmp_path),
+            patch("aragora.worktree.fleet.build_fleet_rows", return_value=[]),
+            patch("aragora.worktree.fleet.FleetCoordinationStore") as store_cls,
+            patch("aragora.swarm.SwarmSupervisor") as supervisor_cls,
+        ):
+            store_cls.return_value.list_claims.return_value = []
+            store_cls.return_value.list_merge_queue.return_value = []
+            supervisor_cls.return_value.status_summary.return_value = {
+                "runs": [],
+                "counts": {
+                    "runs": 0,
+                    "queued_work_orders": 0,
+                    "leased_work_orders": 0,
+                    "completed_work_orders": 0,
+                },
+                "coordination": {"counts": {"active_leases": 0}},
+            }
+            cmd_swarm(_swarm_args(swarm_action_or_goal="status"))
+
+        out = capsys.readouterr().out
+        assert "coordination directives=1 sessions=0 claims=0 findings=1" in out
+        assert "directive codex-a status=active task=Own parity lane" in out
+        assert "finding codex-b kind=blocker pr=#2679 Bandit B310 in auth/oidc.py" in out
+
     def test_cmd_swarm_runner_inspect_json(self, capsys):
         args = _swarm_args(
             swarm_action_or_goal="runner",

--- a/tests/coordination/test_directives.py
+++ b/tests/coordination/test_directives.py
@@ -1,0 +1,82 @@
+"""Tests for the durable coordination directive board."""
+
+from __future__ import annotations
+
+from aragora.coordination.directives import DirectiveBoard, SessionDirective
+
+
+class TestSessionDirective:
+    def test_roundtrip(self):
+        directive = SessionDirective(
+            target="codex-a",
+            task="SDK parity consolidation",
+            scope=["#2684"],
+            constraints=["no queue drain"],
+            assigned_by="boss-codex",
+            status="active",
+            created_at=1000.0,
+            updated_at=1001.0,
+        )
+        restored = SessionDirective.from_dict(directive.to_dict())
+        assert restored.target == "codex-a"
+        assert restored.task == "SDK parity consolidation"
+        assert restored.scope == ["#2684"]
+
+
+class TestDirectiveBoard:
+    def test_assign_and_get(self, tmp_path):
+        board = DirectiveBoard(repo_path=tmp_path)
+
+        directive = board.assign(
+            "codex-a",
+            "SDK parity consolidation",
+            scope=["#2684"],
+            constraints=["no queue drain"],
+            assigned_by="boss-codex",
+        )
+
+        assert directive.target == "codex-a"
+        stored = board.get("codex-a")
+        assert stored is not None
+        assert stored.task == "SDK parity consolidation"
+        assert stored.scope == ["#2684"]
+        assert stored.constraints == ["no queue drain"]
+
+    def test_assign_overwrites_and_preserves_created_at(self, tmp_path):
+        board = DirectiveBoard(repo_path=tmp_path)
+        first = board.assign("codex-a", "old task", assigned_by="boss-codex")
+        second = board.assign("codex-a", "new task", assigned_by="boss-codex")
+
+        assert second.created_at == first.created_at
+        assert second.updated_at >= first.updated_at
+        assert board.get("codex-a") is not None
+        assert board.get("codex-a").task == "new task"  # type: ignore[union-attr]
+
+    def test_list_returns_sorted_directives(self, tmp_path):
+        board = DirectiveBoard(repo_path=tmp_path)
+        board.assign("codex-b", "task b")
+        board.assign("codex-a", "task a")
+
+        directives = board.list()
+        assert [item.target for item in directives] == ["codex-a", "codex-b"]
+
+    def test_clear_removes_directive(self, tmp_path):
+        board = DirectiveBoard(repo_path=tmp_path)
+        board.assign("codex-a", "task")
+
+        assert board.clear("codex-a") is True
+        assert board.get("codex-a") is None
+
+    def test_clear_missing_returns_false(self, tmp_path):
+        board = DirectiveBoard(repo_path=tmp_path)
+        assert board.clear("missing") is False
+
+    def test_corrupt_payload_falls_back_to_empty(self, tmp_path):
+        path = tmp_path / ".aragora_coordination" / "directives.json"
+        path.parent.mkdir(parents=True)
+        path.write_text("{broken json")
+
+        board = DirectiveBoard(repo_path=tmp_path)
+        assert board.list() == []
+        directive = board.assign("codex-a", "task")
+        assert directive.target == "codex-a"

--- a/tests/swarm/test_session_coordinator.py
+++ b/tests/swarm/test_session_coordinator.py
@@ -1,0 +1,64 @@
+"""Tests for the swarm session coordinator facade."""
+
+from __future__ import annotations
+
+from aragora.swarm.session_coordinator import (
+    claim_pr,
+    get_my_assignment,
+    list_findings,
+    read_directives,
+    report_finding,
+    set_assignment,
+)
+
+
+class TestSessionCoordinator:
+    def test_set_assignment_roundtrip(self, tmp_path):
+        payload = set_assignment(
+            "codex-a",
+            "SDK parity consolidation",
+            scope=["#2684"],
+            constraints=["no queue drain"],
+            issued_by="boss-codex",
+            repo_root=tmp_path,
+        )
+
+        assert payload["target"] == "codex-a"
+        assignment = get_my_assignment("codex-a", repo_root=tmp_path)
+        assert assignment is not None
+        assert assignment["task"] == "SDK parity consolidation"
+        assert assignment["scope"] == ["#2684"]
+
+    def test_claim_pr_contested(self, tmp_path):
+        first = claim_pr(2684, "codex-a", repo_root=tmp_path)
+        second = claim_pr(2684, "codex-b", repo_root=tmp_path)
+
+        assert first["status"] == "granted"
+        assert second["status"] == "contested"
+        assert second["contested_by"][0]["session_id"] == "codex-a"
+
+    def test_report_and_list_findings(self, tmp_path):
+        report_finding(
+            "Bandit B310 in auth/oidc.py",
+            "codex-b",
+            kind="blocker",
+            pr=2679,
+            scope=["aragora/auth/oidc.py"],
+            repo_root=tmp_path,
+        )
+
+        findings = list_findings(repo_root=tmp_path, kind="blocker", pr=2679)
+        assert len(findings) == 1
+        assert findings[0]["message"] == "Bandit B310 in auth/oidc.py"
+        assert findings[0]["source_session"] == "codex-b"
+
+    def test_read_directives_aggregates_state(self, tmp_path):
+        set_assignment("codex-a", "Own parity lane", repo_root=tmp_path)
+        claim_pr(2684, "codex-a", repo_root=tmp_path)
+        report_finding("Verification route bug", "review-codex", pr=2677, repo_root=tmp_path)
+
+        view = read_directives(repo_root=tmp_path, findings_limit=5)
+        assert view["summary"]["directive_count"] == 1
+        assert view["summary"]["claim_count"] == 1
+        assert view["summary"]["finding_count"] == 1
+        assert view["directives"][0]["target"] == "codex-a"


### PR DESCRIPTION
## Summary
- add a durable directive board on top of Aragora's existing coordination primitives
- add a swarm session coordinator facade that resolves the canonical repo root across side worktrees
- add `swarm coord`, `swarm assign`, `swarm claim-pr`, `swarm report`, and `swarm findings`, and extend `swarm status` with coordination visibility
- cover the new directive, coordinator, and CLI flows with targeted tests

## Why this version
- keeps Claude's operator-facing coordination workflow
- keeps Codex's stronger typed CLI, findings/report split, and status integration
- avoids a second standalone coordination store by reusing directives, claims, bus, and registry
- shares state across disposable worktrees by resolving the canonical repo root before reading or writing coordination data

## Test plan
- python3 -m pytest tests/coordination/test_directives.py tests/swarm/test_session_coordinator.py tests/cli/test_swarm_command.py -q
- python3 -m ruff check aragora/coordination/directives.py aragora/coordination/__init__.py aragora/swarm/session_coordinator.py aragora/cli/parser.py aragora/cli/commands/swarm.py tests/coordination/test_directives.py tests/swarm/test_session_coordinator.py tests/cli/test_swarm_command.py
