### PR TITLE
Prevent cached playground TTS responses

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -2757,7 +2757,10 @@ class PlaygroundHandler(BaseHandler):
             content_type="audio/mpeg",
             body=audio_bytes,
             headers={
-                "Cache-Control": "public, max-age=3600",
+                # User-supplied speech can contain sensitive content and should
+                # never be retained by shared caches.
+                "Cache-Control": "private, no-store, max-age=0",
+                "Pragma": "no-cache",
             },
         )
 

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -1259,6 +1259,8 @@ class TestTTS:
             assert _status(result) == 200
             assert result.content_type == "audio/mpeg"
             assert result.body == fake_audio
+            assert result.headers["Cache-Control"] == "private, no-store, max-age=0"
+            assert result.headers["Pragma"] == "no-cache"
 
     def test_elevenlabs_http_error_returns_502(self, handler):
         import urllib.error


### PR DESCRIPTION
## Summary
- mark public playground TTS responses as non-cacheable
- prevent shared intermediaries from retaining user-supplied synthesized audio
- add a focused regression covering the cache headers on successful TTS responses

## Validation
- python -m ruff check aragora/server/handlers/playground.py tests/handlers/test_playground.py
- python -m pytest tests/handlers/test_playground.py -q -k "test_successful_tts_returns_audio or test_tts_rate_limit or test_missing_text_returns_400 or test_elevenlabs_http_error_returns_502 or test_elevenlabs_timeout_returns_503 or test_text_truncated_to_max"