### PR TITLE
feat(admin): back dashboard endpoints with debate metrics

### DIFF
--- a/aragora/server/handlers/admin/dashboard_actions.py
+++ b/aragora/server/handlers/admin/dashboard_actions.py
@@ -8,6 +8,7 @@ Extracted from dashboard.py for maintainability.
 
 from __future__ import annotations
 
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -20,11 +21,86 @@ from ..base import (
     ttl_cache,
 )
 from ..openapi_decorator import api_endpoint
+from .dashboard_metrics import (
+    ACTIVE_DEBATE_STATUSES,
+    load_debate_records,
+    summarize_debate_records,
+)
 
 if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _build_quick_actions(summary: dict[str, Any]) -> list[dict[str, Any]]:
+    action_specs = [
+        (
+            "review_needs_attention",
+            "Review urgent debates",
+            f"Review {summary.get('needs_attention_debates', 0)} debates lacking consensus or flagged low-confidence",
+            "alert-triangle",
+            summary.get("needs_attention_debates", 0) > 0,
+        ),
+        (
+            "resume_in_progress",
+            "Resume active debates",
+            f"Resume {summary.get('in_progress_debates', 0)} active debates still in progress",
+            "play-circle",
+            summary.get("in_progress_debates", 0) > 0,
+        ),
+        (
+            "complete_pending",
+            "Complete pending debates",
+            f"Close {summary.get('pending_debates', 0)} pending debates waiting for a final decision",
+            "check-circle",
+            summary.get("pending_debates", 0) > 0,
+        ),
+        (
+            "inspect_low_confidence",
+            "Inspect low-confidence outcomes",
+            f"Inspect {summary.get('low_confidence_debates', 0)} debates below the confidence threshold",
+            "gauge",
+            summary.get("low_confidence_debates", 0) > 0,
+        ),
+    ]
+    return [
+        {
+            "id": action_id,
+            "name": name,
+            "description": description,
+            "icon": icon,
+            "available": available,
+        }
+        for action_id, name, description, icon, available in action_specs
+    ]
+
+
+def _load_summary_with_records(
+    storage: Any,
+    summary_getter: Any,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    records = load_debate_records(storage)
+    summary = summarize_debate_records(records)
+    try:
+        summary.update(summary_getter(storage, None) or {})
+    except (KeyError, ValueError, OSError, TypeError, AttributeError) as e:
+        logger.warning("Dashboard action summary error: %s: %s", type(e).__name__, e)
+    return records, summary
+
+
+def _load_payload(raw_payload: Any) -> dict[str, Any] | None:
+    if raw_payload is None:
+        return None
+    if isinstance(raw_payload, dict):
+        return raw_payload
+    if isinstance(raw_payload, str):
+        try:
+            decoded = json.loads(raw_payload)
+            return decoded if isinstance(decoded, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
 
 
 class DashboardActionsMixin:
@@ -44,9 +120,14 @@ class DashboardActionsMixin:
 
     ctx: dict[str, Any]
 
-    def _get_summary_metrics_sql(self, storage: Any, domain: str | None) -> dict[str, Any]: ...
-    def _get_agent_performance(self, limit: int) -> dict[str, Any]: ...
-    def _get_consensus_insights(self, domain: str | None) -> dict[str, Any]: ...
+    def _get_summary_metrics_sql(self, storage: Any, domain: str | None) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _get_agent_performance(self, limit: int) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _get_consensus_insights(self, domain: str | None) -> dict[str, Any]:
+        raise NotImplementedError
 
     @api_endpoint(
         method="GET",
@@ -60,50 +141,17 @@ class DashboardActionsMixin:
     )
     def _get_quick_actions(self) -> HandlerResult:
         """Return quick actions list."""
-        actions = [
-            {
-                "id": "archive_read",
-                "name": "Archive All Read",
-                "description": "Archive all read emails older than 24 hours",
-                "icon": "archive",
-                "available": True,
-            },
-            {
-                "id": "snooze_low",
-                "name": "Snooze Low Priority",
-                "description": "Snooze all low priority emails until tomorrow",
-                "icon": "clock",
-                "available": True,
-            },
-            {
-                "id": "mark_spam",
-                "name": "Mark Bulk as Spam",
-                "description": "Mark selected promotional emails as spam",
-                "icon": "slash",
-                "available": True,
-            },
-            {
-                "id": "complete_actions",
-                "name": "Complete Done Actions",
-                "description": "Mark action items you've completed",
-                "icon": "check-circle",
-                "available": True,
-            },
-            {
-                "id": "ai_respond",
-                "name": "AI Auto-Respond",
-                "description": "Let AI draft responses for simple emails",
-                "icon": "sparkles",
-                "available": True,
-            },
-            {
-                "id": "sync_inbox",
-                "name": "Sync Inbox",
-                "description": "Force sync with email provider",
-                "icon": "refresh",
-                "available": True,
-            },
-        ]
+        actions: list[dict[str, Any]] = []
+        try:
+            storage = self.get_storage()
+            if storage:
+                _, summary = _load_summary_with_records(storage, self._get_summary_metrics_sql)
+                actions = _build_quick_actions(summary)
+            else:
+                actions = _build_quick_actions({})
+        except (KeyError, ValueError, OSError, TypeError) as e:
+            logger.warning("Quick actions error: %s: %s", type(e).__name__, e)
+            actions = _build_quick_actions({})
         return json_response({"actions": actions, "total": len(actions)})
 
     @api_endpoint(
@@ -124,13 +172,37 @@ class DashboardActionsMixin:
         """Execute a quick action (stub)."""
         if not action_id:
             return error_response("action_id is required", 400)
-        return json_response(
-            {
-                "success": True,
-                "action_id": action_id,
-                "executed_at": datetime.now(timezone.utc).isoformat(),
+        try:
+            storage = self.get_storage()
+            summary: dict[str, Any] = {}
+            actions = _build_quick_actions({})
+            if storage:
+                _, summary = _load_summary_with_records(storage, self._get_summary_metrics_sql)
+                actions = _build_quick_actions(summary)
+
+            action_map = {action["id"]: action for action in actions}
+            if action_id not in action_map:
+                return error_response("Action not found", 404)
+
+            action = action_map[action_id]
+            matched_count_map = {
+                "review_needs_attention": int(summary.get("needs_attention_debates", 0)),
+                "resume_in_progress": int(summary.get("in_progress_debates", 0)),
+                "complete_pending": int(summary.get("pending_debates", 0)),
+                "inspect_low_confidence": int(summary.get("low_confidence_debates", 0)),
             }
-        )
+            return json_response(
+                {
+                    "success": True,
+                    "action_id": action_id,
+                    "matched_count": matched_count_map.get(action_id, 0),
+                    "available": bool(action.get("available")),
+                    "executed_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        except (KeyError, ValueError, OSError, TypeError) as e:
+            logger.warning("Execute quick action error: %s: %s", type(e).__name__, e)
+            return error_response("Failed to execute action", 500)
 
     @api_endpoint(
         method="GET",
@@ -149,33 +221,32 @@ class DashboardActionsMixin:
     def _get_urgent_items(self, limit: int, offset: int) -> HandlerResult:
         """Return urgent items: debates with low confidence or no consensus."""
         items: list[dict[str, Any]] = []
+        total = 0
 
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        "SELECT id, domain, confidence, created_at FROM debates "
-                        "WHERE consensus_reached = 0 OR confidence < 0.3 "
-                        "ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                        (limit, offset),
-                    )
-                    for row in cursor.fetchall():
-                        items.append(
-                            {
-                                "id": row[0],
-                                "type": "low_consensus",
-                                "domain": row[1],
-                                "confidence": row[2],
-                                "created_at": row[3],
-                                "description": f"Debate in {row[1] or 'general'} needs attention",
-                            }
-                        )
+                urgent_records = [
+                    record
+                    for record in load_debate_records(storage)
+                    if record.get("needs_attention")
+                ]
+                total = len(urgent_records)
+                items = [
+                    {
+                        "id": record.get("id"),
+                        "type": "low_consensus",
+                        "domain": record.get("domain"),
+                        "confidence": record.get("confidence"),
+                        "created_at": record.get("created_at"),
+                        "description": f"Debate in {record.get('domain_label') or 'general'} needs attention",
+                    }
+                    for record in urgent_records[max(offset, 0) : max(offset, 0) + max(limit, 0)]
+                ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Urgent items error: %s: %s", type(e).__name__, e)
 
-        return json_response({"items": items, "total": len(items)})
+        return json_response({"items": items, "total": total})
 
     @api_endpoint(
         method="POST",
@@ -191,22 +262,33 @@ class DashboardActionsMixin:
         },
     )
     def _dismiss_urgent_item(self, item_id: str) -> HandlerResult:
-        """Dismiss an urgent item by marking it as reviewed."""
+        """Dismiss an urgent item without mutating debate outcome fields."""
         if not item_id:
             return error_response("item_id is required", 400)
         try:
             storage = self.get_storage()
+            persisted = False
             if storage:
                 with storage.connection() as conn:
                     cursor = conn.cursor()
-                    # Mark as reviewed by setting confidence to indicate human review
-                    cursor.execute(
-                        "UPDATE debates SET consensus_reached = 1 WHERE id = ?",
-                        (item_id,),
-                    )
-                    conn.commit()
-                    if cursor.rowcount == 0:
+                    cursor.execute("SELECT * FROM debates WHERE id = ?", (item_id,))
+                    row = cursor.fetchone()
+                    if not row:
                         return error_response("Item not found", 404)
+                    columns = [str(column[0]) for column in (cursor.description or [])]
+                    row_map = dict(zip(columns, row, strict=False))
+
+                    if "artifact_json" in row_map or "result" in row_map:
+                        payload_column = "artifact_json" if "artifact_json" in row_map else "result"
+                        payload = _load_payload(row_map.get(payload_column)) or {}
+                        payload["dashboard_review_state"] = "dismissed"
+                        payload["dashboard_reviewed_at"] = datetime.now(timezone.utc).isoformat()
+                        cursor.execute(
+                            f"UPDATE debates SET {payload_column} = ? WHERE id = ?",  # noqa: S608
+                            (json.dumps(payload), item_id),
+                        )
+                        conn.commit()
+                        persisted = True
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Dismiss urgent item error: %s: %s", type(e).__name__, e)
             return error_response("Failed to dismiss item", 500)
@@ -215,6 +297,7 @@ class DashboardActionsMixin:
                 "success": True,
                 "item_id": item_id,
                 "dismissed_at": datetime.now(timezone.utc).isoformat(),
+                "persisted": persisted,
             }
         )
 
@@ -235,32 +318,31 @@ class DashboardActionsMixin:
     def _get_pending_actions(self, limit: int, offset: int) -> HandlerResult:
         """Return pending actions: recent debates awaiting review."""
         actions: list[dict[str, Any]] = []
+        total = 0
 
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        "SELECT id, domain, created_at FROM debates "
-                        "WHERE status = 'pending' OR status = 'in_progress' "
-                        "ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                        (limit, offset),
-                    )
-                    for row in cursor.fetchall():
-                        actions.append(
-                            {
-                                "id": row[0],
-                                "type": "review_debate",
-                                "domain": row[1],
-                                "created_at": row[2],
-                                "description": f"Review debate in {row[1] or 'general'}",
-                            }
-                        )
+                pending_records = [
+                    record
+                    for record in load_debate_records(storage)
+                    if str(record.get("status") or "") in ACTIVE_DEBATE_STATUSES
+                ]
+                total = len(pending_records)
+                actions = [
+                    {
+                        "id": record.get("id"),
+                        "type": "review_debate",
+                        "domain": record.get("domain"),
+                        "created_at": record.get("created_at"),
+                        "description": f"Review debate in {record.get('domain_label') or 'general'}",
+                    }
+                    for record in pending_records[max(offset, 0) : max(offset, 0) + max(limit, 0)]
+                ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Pending actions error: %s: %s", type(e).__name__, e)
 
-        return json_response({"actions": actions, "total": len(actions)})
+        return json_response({"actions": actions, "total": total})
 
     @api_endpoint(
         method="POST",
@@ -282,16 +364,49 @@ class DashboardActionsMixin:
             return error_response("action_id is required", 400)
         try:
             storage = self.get_storage()
+            persisted = False
             if storage:
                 with storage.connection() as conn:
                     cursor = conn.cursor()
-                    cursor.execute(
-                        "UPDATE debates SET status = 'completed' WHERE id = ? AND (status = 'pending' OR status = 'in_progress')",
-                        (action_id,),
-                    )
-                    conn.commit()
-                    if cursor.rowcount == 0:
+                    cursor.execute("SELECT * FROM debates WHERE id = ?", (action_id,))
+                    row = cursor.fetchone()
+                    if not row:
                         return error_response("Action not found or already completed", 404)
+
+                    columns = [str(column[0]) for column in (cursor.description or [])]
+                    row_map = dict(zip(columns, row, strict=False))
+                    payload_column = "artifact_json" if "artifact_json" in row_map else "result"
+                    payload = _load_payload(row_map.get(payload_column))
+                    current_status = (
+                        str(
+                            row_map.get("status")
+                            or (payload.get("status") if payload else "")
+                            or ""
+                        )
+                        .strip()
+                        .lower()
+                    )
+                    if current_status and current_status not in ACTIVE_DEBATE_STATUSES:
+                        return error_response("Action not found or already completed", 404)
+
+                    completed_at = datetime.now(timezone.utc).isoformat()
+                    if "status" in row_map:
+                        cursor.execute(
+                            "UPDATE debates SET status = 'completed' WHERE id = ?",
+                            (action_id,),
+                        )
+                        persisted = True
+                    elif payload_column in row_map and payload is not None:
+                        payload["status"] = "completed"
+                        payload["completed_at"] = completed_at
+                        cursor.execute(
+                            f"UPDATE debates SET {payload_column} = ? WHERE id = ?",  # noqa: S608
+                            (json.dumps(payload), action_id),
+                        )
+                        persisted = True
+
+                    if persisted:
+                        conn.commit()
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Complete action error: %s: %s", type(e).__name__, e)
             return error_response("Failed to complete action", 500)
@@ -300,6 +415,7 @@ class DashboardActionsMixin:
                 "success": True,
                 "action_id": action_id,
                 "completed_at": datetime.now(timezone.utc).isoformat(),
+                "persisted": persisted,
             }
         )
 
@@ -326,26 +442,21 @@ class DashboardActionsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    like_query = f"%{query}%"
-                    cursor.execute(
-                        "SELECT id, domain, consensus_reached, confidence, "
-                        "created_at FROM debates "
-                        "WHERE id LIKE ? OR domain LIKE ? "
-                        "ORDER BY created_at DESC LIMIT 20",
-                        (like_query, like_query),
-                    )
-                    for row in cursor.fetchall():
-                        results.append(
-                            {
-                                "id": row[0],
-                                "domain": row[1],
-                                "consensus_reached": bool(row[2]),
-                                "confidence": row[3],
-                                "created_at": row[4],
-                            }
-                        )
+                lowered = query.lower()
+                results = [
+                    {
+                        "id": record.get("id"),
+                        "domain": record.get("domain"),
+                        "consensus_reached": bool(record.get("consensus_reached")),
+                        "confidence": record.get("confidence"),
+                        "created_at": record.get("created_at"),
+                    }
+                    for record in load_debate_records(storage)
+                    if lowered in str(record.get("id") or "").lower()
+                    or lowered in str(record.get("domain_label") or "").lower()
+                    or lowered in str(record.get("task") or "").lower()
+                    or lowered in str(record.get("status") or "").lower()
+                ][:20]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Dashboard search error: %s: %s", type(e).__name__, e)
 
@@ -563,26 +674,33 @@ class DashboardActionsMixin:
         }
 
         try:
-            # Get from ELO system
-            elo_system = self.ctx.get("elo_system")
-            if elo_system:
-                recent = elo_system.get_recent_matches(limit=10)
-                if recent:
-                    winners = [m.get("winner") for m in recent if m.get("winner")]
-                    metrics["recent_winners"] = winners[:5]
-
-                    # Calculate avg confidence from matches
-                    confidences = [m.get("confidence", 0) for m in recent if m.get("confidence")]
-                    if confidences:
-                        metrics["avg_confidence"] = sum(confidences) / len(confidences)
-
-            # Get from storage
             storage = self.get_storage()
             if storage:
-                summary = self._get_summary_metrics_sql(storage, None)
-                if summary:
-                    metrics["consensus_rate"] = summary.get("consensus_rate", 0.0)
-                    metrics["avg_rounds"] = summary.get("avg_rounds", 0.0)
+                records, summary = _load_summary_with_records(
+                    storage, self._get_summary_metrics_sql
+                )
+                metrics["avg_confidence"] = summary.get("avg_confidence", 0.0)
+                metrics["consensus_rate"] = summary.get("consensus_rate", 0.0)
+                metrics["avg_rounds"] = summary.get("avg_rounds", 0.0)
+                metrics["evidence_quality"] = summary.get("high_confidence_consensus_rate", 0.0)
+                metrics["recent_winners"] = [
+                    str(record.get("id")) for record in records if record.get("consensus_reached")
+                ][:5]
+
+            elo_system = self.ctx.get("elo_system")
+            if elo_system and (not metrics["recent_winners"] or metrics["avg_confidence"] == 0.0):
+                recent = elo_system.get_recent_matches(limit=10)
+                if recent:
+                    if not metrics["recent_winners"]:
+                        winners = [m.get("winner") for m in recent if m.get("winner")]
+                        metrics["recent_winners"] = winners[:5]
+
+                    if metrics["avg_confidence"] == 0.0:
+                        confidences = [
+                            m.get("confidence", 0) for m in recent if m.get("confidence")
+                        ]
+                        if confidences:
+                            metrics["avg_confidence"] = sum(confidences) / len(confidences)
 
         except (KeyError, ValueError, OSError, TypeError, AttributeError) as e:
             logger.warning("Debate quality metrics error: %s", e)

--- a/aragora/server/handlers/admin/dashboard_metrics.py
+++ b/aragora/server/handlers/admin/dashboard_metrics.py
@@ -13,9 +13,10 @@ All functions require admin:metrics:read permission and are rate limited.
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from aragora.rbac.checker import get_permission_checker
@@ -27,6 +28,15 @@ logger = logging.getLogger(__name__)
 
 # RBAC permission for admin metrics access
 PERM_ADMIN_METRICS_READ = "admin:metrics:read"
+ACTIVE_DEBATE_STATUSES = frozenset(
+    {"pending", "in_progress", "starting", "initializing", "running", "active"}
+)
+IN_PROGRESS_DEBATE_STATUSES = frozenset(
+    {"in_progress", "starting", "initializing", "running", "active"}
+)
+LOW_CONFIDENCE_THRESHOLD = 0.5
+HIGH_CONFIDENCE_THRESHOLD = 0.8
+URGENT_CONFIDENCE_THRESHOLD = 0.3
 
 
 def _get_context_from_args_strict(
@@ -101,6 +111,432 @@ def require_permission(
     return decorator
 
 
+def _coerce_float(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_int(value: Any) -> int | None:
+    numeric = _coerce_float(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _load_json_payload(raw_payload: Any) -> dict[str, Any] | None:
+    if raw_payload is None:
+        return None
+    if isinstance(raw_payload, dict):
+        return raw_payload
+    if isinstance(raw_payload, str):
+        try:
+            decoded = json.loads(raw_payload)
+            return decoded if isinstance(decoded, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        text = str(value).strip()
+        if not text:
+            return None
+        try:
+            dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _artifact_size_bytes(raw_payload: Any) -> int:
+    if raw_payload is None:
+        return 0
+    if isinstance(raw_payload, str):
+        return len(raw_payload.encode("utf-8"))
+    try:
+        return len(json.dumps(raw_payload).encode("utf-8"))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _find_first_numeric(payload: Any, keys: tuple[str, ...]) -> float | None:
+    if isinstance(payload, dict):
+        for key in keys:
+            numeric = _coerce_float(payload.get(key))
+            if numeric is not None:
+                return numeric
+
+        for value in payload.values():
+            numeric = _find_first_numeric(value, keys)
+            if numeric is not None:
+                return numeric
+    elif isinstance(payload, list):
+        for item in payload:
+            numeric = _find_first_numeric(item, keys)
+            if numeric is not None:
+                return numeric
+    return None
+
+
+def _extract_total_tokens(payload: dict[str, Any] | None) -> int:
+    if not payload:
+        return 0
+
+    for key_group in (
+        ("total_tokens",),
+        ("tokens_used",),
+        ("total_tokens_in", "total_tokens_out"),
+        ("tokens_in", "tokens_out"),
+    ):
+        values = [
+            value
+            for key in key_group
+            if (value := _find_first_numeric(payload, (key,))) is not None
+        ]
+        if values:
+            return int(sum(values))
+    return 0
+
+
+def _extract_domain(payload: dict[str, Any] | None, fallback: Any) -> str | None:
+    for candidate in (
+        fallback,
+        payload.get("domain") if payload else None,
+        payload.get("classification", {}).get("domain") if payload else None,
+        payload.get("metadata", {}).get("domain") if payload else None,
+    ):
+        if candidate not in (None, ""):
+            return str(candidate)
+    return None
+
+
+def _extract_status(
+    raw_status: Any,
+    payload: dict[str, Any] | None,
+    consensus_reached: bool,
+    completed_at_dt: datetime | None,
+) -> str:
+    for candidate in (
+        raw_status,
+        payload.get("status") if payload else None,
+        payload.get("state") if payload else None,
+    ):
+        if candidate not in (None, ""):
+            return str(candidate).strip().lower()
+    if completed_at_dt is not None or consensus_reached:
+        return "completed"
+    return "pending"
+
+
+def _extract_rounds_used(payload: dict[str, Any] | None, raw_rounds: Any) -> int | None:
+    direct_rounds = _coerce_int(raw_rounds)
+    if direct_rounds is not None:
+        return direct_rounds
+    if not payload:
+        return None
+    for key in ("rounds_used", "rounds_completed", "rounds"):
+        rounds = _find_first_numeric(payload, (key,))
+        if rounds is not None:
+            return int(rounds)
+    return None
+
+
+def _extract_duration_seconds(
+    payload: dict[str, Any] | None,
+    created_at_dt: datetime | None,
+    completed_at_dt: datetime | None,
+) -> float | None:
+    if payload:
+        duration_seconds = _find_first_numeric(payload, ("duration_seconds",))
+        if duration_seconds is not None:
+            return duration_seconds
+
+        duration_ms = _find_first_numeric(payload, ("duration_ms", "execution_time_ms"))
+        if duration_ms is not None:
+            return duration_ms / 1000.0
+
+        duration = _find_first_numeric(payload, ("duration",))
+        if duration is not None:
+            return duration
+
+    if created_at_dt is not None and completed_at_dt is not None:
+        return max((completed_at_dt - created_at_dt).total_seconds(), 0.0)
+    return None
+
+
+def load_debate_records(storage: Any) -> list[dict[str, Any]]:
+    """Load dashboard-ready debate records across sqlite/postgres variants."""
+    records: list[dict[str, Any]] = []
+    min_dt = datetime.min.replace(tzinfo=timezone.utc)
+
+    try:
+        with storage.connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute("SELECT * FROM debates")
+            columns = [str(column[0]) for column in (cursor.description or [])]
+
+            for row in cursor.fetchall():
+                row_map = dict(zip(columns, row, strict=False))
+                raw_payload = row_map.get("artifact_json")
+                if raw_payload is None:
+                    raw_payload = row_map.get("result")
+                payload = _load_json_payload(raw_payload)
+
+                debate_id = (
+                    row_map.get("id")
+                    or row_map.get("slug")
+                    or (payload.get("id") if payload else None)
+                    or ""
+                )
+
+                consensus_value = row_map.get("consensus_reached")
+                if consensus_value is None and payload:
+                    consensus_value = payload.get("consensus_reached")
+                consensus_reached = bool(consensus_value)
+
+                confidence_value = row_map.get("confidence")
+                if confidence_value is None and payload:
+                    confidence_value = payload.get("confidence")
+                confidence = _coerce_float(confidence_value)
+
+                created_at_value = row_map.get("created_at")
+                if created_at_value is None and payload:
+                    created_at_value = payload.get("created_at")
+                created_at_dt = _parse_datetime(created_at_value)
+
+                completed_at_value = row_map.get("completed_at")
+                if completed_at_value is None and payload:
+                    completed_at_value = payload.get("completed_at")
+                completed_at_dt = _parse_datetime(completed_at_value)
+
+                status = _extract_status(
+                    row_map.get("status"),
+                    payload,
+                    consensus_reached,
+                    completed_at_dt,
+                )
+                domain_name = _extract_domain(payload, row_map.get("domain"))
+                rounds_used = _extract_rounds_used(payload, row_map.get("rounds_used"))
+                duration_seconds = _extract_duration_seconds(
+                    payload,
+                    created_at_dt,
+                    completed_at_dt,
+                )
+                total_tokens = _extract_total_tokens(payload)
+                review_state = (
+                    str(payload.get("dashboard_review_state", "")).strip().lower()
+                    if payload
+                    else ""
+                )
+
+                if isinstance(created_at_value, datetime):
+                    created_at_text = created_at_value.isoformat()
+                elif created_at_value is not None:
+                    created_at_text = str(created_at_value)
+                elif created_at_dt is not None:
+                    created_at_text = created_at_dt.isoformat()
+                else:
+                    created_at_text = None
+
+                if isinstance(completed_at_value, datetime):
+                    completed_at_text = completed_at_value.isoformat()
+                elif completed_at_value is not None:
+                    completed_at_text = str(completed_at_value)
+                elif completed_at_dt is not None:
+                    completed_at_text = completed_at_dt.isoformat()
+                else:
+                    completed_at_text = None
+
+                records.append(
+                    {
+                        "id": str(debate_id),
+                        "domain": domain_name,
+                        "domain_label": domain_name or "general",
+                        "status": status,
+                        "consensus_reached": consensus_reached,
+                        "confidence": confidence,
+                        "created_at": created_at_text,
+                        "completed_at": completed_at_text,
+                        "rounds_used": rounds_used,
+                        "duration_seconds": duration_seconds,
+                        "total_tokens": total_tokens,
+                        "artifact_bytes": _artifact_size_bytes(raw_payload),
+                        "task": str(
+                            row_map.get("task") or (payload.get("task") if payload else "") or ""
+                        ),
+                        "review_state": review_state,
+                        "needs_attention": review_state != "dismissed"
+                        and (
+                            not consensus_reached
+                            or (confidence is not None and confidence < URGENT_CONFIDENCE_THRESHOLD)
+                        ),
+                        "_sort_created_at": created_at_dt or min_dt,
+                    }
+                )
+    except (KeyError, ValueError, OSError, TypeError, AttributeError) as e:
+        logger.warning("Dashboard debate load error: %s: %s", type(e).__name__, e)
+        return []
+
+    records.sort(key=lambda record: record.get("_sort_created_at", min_dt), reverse=True)
+    return records
+
+
+def find_debate_record(storage: Any, debate_id: str) -> dict[str, Any] | None:
+    """Find a single debate record by identifier."""
+    for record in load_debate_records(storage):
+        if record.get("id") == debate_id:
+            return record
+    return None
+
+
+def summarize_debate_records(debates: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute dashboard summary metrics from normalized debate records."""
+    summary: dict[str, Any] = {
+        "total_debates": 0,
+        "consensus_reached": 0,
+        "consensus_rate": 0.0,
+        "avg_confidence": 0.0,
+        "avg_rounds": 0.0,
+        "avg_duration_ms": 0.0,
+        "total_tokens_used": 0,
+        "completed_debates": 0,
+        "open_debates": 0,
+        "pending_debates": 0,
+        "in_progress_debates": 0,
+        "low_confidence_debates": 0,
+        "needs_attention_debates": 0,
+        "urgent_debates": 0,
+        "high_confidence_consensus_count": 0,
+        "high_confidence_consensus_rate": 0.0,
+    }
+
+    if not debates:
+        return summary
+
+    total = len(debates)
+    consensus_count = sum(1 for debate in debates if debate.get("consensus_reached"))
+    confidence_values = [
+        confidence
+        for debate in debates
+        if (confidence := _coerce_float(debate.get("confidence"))) is not None
+    ]
+    rounds_values = [
+        rounds
+        for debate in debates
+        if (rounds := _coerce_int(debate.get("rounds_used"))) is not None
+    ]
+    duration_values_ms = [
+        duration * 1000.0
+        for debate in debates
+        if (duration := _coerce_float(debate.get("duration_seconds"))) is not None and duration > 0
+    ]
+
+    summary["total_debates"] = total
+    summary["consensus_reached"] = consensus_count
+    summary["consensus_rate"] = round(consensus_count / total, 3)
+    if confidence_values:
+        summary["avg_confidence"] = round(sum(confidence_values) / len(confidence_values), 3)
+    if rounds_values:
+        summary["avg_rounds"] = round(sum(rounds_values) / len(rounds_values), 3)
+    if duration_values_ms:
+        summary["avg_duration_ms"] = round(sum(duration_values_ms) / len(duration_values_ms), 3)
+
+    summary["total_tokens_used"] = sum(
+        int(_coerce_float(debate.get("total_tokens")) or 0) for debate in debates
+    )
+    summary["completed_debates"] = sum(
+        1 for debate in debates if str(debate.get("status") or "") == "completed"
+    )
+    summary["pending_debates"] = sum(
+        1 for debate in debates if str(debate.get("status") or "") == "pending"
+    )
+    summary["in_progress_debates"] = sum(
+        1 for debate in debates if str(debate.get("status") or "") in IN_PROGRESS_DEBATE_STATUSES
+    )
+    summary["open_debates"] = sum(
+        1 for debate in debates if str(debate.get("status") or "") in ACTIVE_DEBATE_STATUSES
+    )
+    summary["low_confidence_debates"] = sum(
+        1
+        for debate in debates
+        if (
+            (confidence := _coerce_float(debate.get("confidence"))) is not None
+            and confidence < LOW_CONFIDENCE_THRESHOLD
+        )
+    )
+    summary["needs_attention_debates"] = sum(
+        1 for debate in debates if bool(debate.get("needs_attention"))
+    )
+    summary["urgent_debates"] = summary["needs_attention_debates"]
+    summary["high_confidence_consensus_count"] = sum(
+        1
+        for debate in debates
+        if debate.get("consensus_reached")
+        and (
+            (confidence := _coerce_float(debate.get("confidence"))) is not None
+            and confidence >= HIGH_CONFIDENCE_THRESHOLD
+        )
+    )
+    summary["high_confidence_consensus_rate"] = round(
+        summary["high_confidence_consensus_count"] / total,
+        3,
+    )
+    return summary
+
+
+def recent_activity_from_debate_records(
+    debates: list[dict[str, Any]], hours: int
+) -> dict[str, Any]:
+    """Compute recent activity metrics from normalized debate records."""
+    activity: dict[str, Any] = {
+        "debates_last_period": 0,
+        "consensus_last_period": 0,
+        "domains_active": [],
+        "most_active_domain": None,
+        "period_hours": hours,
+    }
+
+    if not debates:
+        return activity
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    recent_debates = [
+        debate
+        for debate in debates
+        if isinstance(debate.get("_sort_created_at"), datetime)
+        and debate["_sort_created_at"] >= cutoff
+    ]
+    domain_counts: dict[str, int] = {}
+    for debate in recent_debates:
+        domain_name = str(debate.get("domain") or "general")
+        domain_counts[domain_name] = domain_counts.get(domain_name, 0) + 1
+
+    activity["debates_last_period"] = len(recent_debates)
+    activity["consensus_last_period"] = sum(
+        1 for debate in recent_debates if debate.get("consensus_reached")
+    )
+    activity["domains_active"] = list(domain_counts.keys())[:10]
+    if domain_counts:
+        activity["most_active_domain"] = max(
+            domain_counts,
+            key=lambda domain_name: domain_counts.get(domain_name, 0),
+        )
+    return activity
+
+
 @require_permission(PERM_ADMIN_METRICS_READ)
 @rate_limit(requests_per_minute=30, limiter_name="admin_dashboard_metrics")
 def get_summary_metrics_sql(storage: Any, domain: str | None) -> dict[str, Any]:
@@ -113,39 +549,11 @@ def get_summary_metrics_sql(storage: Any, domain: str | None) -> dict[str, Any]:
     Returns:
         Summary dict with total_debates, consensus_reached, consensus_rate, avg_confidence.
     """
-    summary = {
-        "total_debates": 0,
-        "consensus_reached": 0,
-        "consensus_rate": 0.0,
-        "avg_confidence": 0.0,
-    }
-
     try:
-        with storage.connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute("""
-                SELECT
-                    COUNT(*) as total,
-                    SUM(CASE WHEN consensus_reached THEN 1 ELSE 0 END) as consensus_count,
-                    AVG(confidence) as avg_conf
-                FROM debates
-            """)
-            row = cursor.fetchone()
-            if row:
-                total = row[0] or 0
-                consensus_count = row[1] or 0
-                avg_conf = row[2]
-
-                summary["total_debates"] = total
-                summary["consensus_reached"] = consensus_count
-                if total > 0:
-                    summary["consensus_rate"] = round(consensus_count / total, 3)
-                if avg_conf is not None:
-                    summary["avg_confidence"] = round(avg_conf, 3)
+        return summarize_debate_records(load_debate_records(storage))
     except (KeyError, ValueError, OSError, TypeError, AttributeError) as e:
         logger.warning("SQL summary metrics error: %s: %s", type(e).__name__, e)
-
-    return summary
+        return summarize_debate_records([])
 
 
 @require_permission(PERM_ADMIN_METRICS_READ)
@@ -160,35 +568,11 @@ def get_recent_activity_sql(storage: Any, hours: int) -> dict[str, Any]:
     Returns:
         Activity dict with debates_last_period, consensus_last_period, period_hours.
     """
-    activity = {
-        "debates_last_period": 0,
-        "consensus_last_period": 0,
-        "period_hours": hours,
-    }
-
     try:
-        cutoff = (datetime.now() - timedelta(hours=hours)).isoformat()
-
-        with storage.connection() as conn:
-            cursor = conn.cursor()
-            cursor.execute(
-                """
-                SELECT
-                    COUNT(*) as recent_total,
-                    SUM(CASE WHEN consensus_reached THEN 1 ELSE 0 END) as recent_consensus
-                FROM debates
-                WHERE created_at >= ?
-            """,
-                (cutoff,),
-            )
-            row = cursor.fetchone()
-            if row:
-                activity["debates_last_period"] = row[0] or 0
-                activity["consensus_last_period"] = row[1] or 0
+        return recent_activity_from_debate_records(load_debate_records(storage), hours)
     except (KeyError, ValueError, OSError, TypeError, AttributeError) as e:
         logger.warning("SQL recent activity error: %s: %s", type(e).__name__, e)
-
-    return activity
+        return recent_activity_from_debate_records([], hours)
 
 
 @require_permission(PERM_ADMIN_METRICS_READ)

--- a/aragora/server/handlers/admin/dashboard_views.py
+++ b/aragora/server/handlers/admin/dashboard_views.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from aragora.config import CACHE_TTL_DASHBOARD_DEBATES
 
@@ -22,11 +22,71 @@ from ..base import (
     ttl_cache,
 )
 from ..openapi_decorator import api_endpoint
+from .dashboard_metrics import (
+    ACTIVE_DEBATE_STATUSES,
+    find_debate_record,
+    load_debate_records,
+    summarize_debate_records,
+)
 
 if TYPE_CHECKING:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _merge_summary_metrics(
+    records: list[dict[str, Any]],
+    summary_metrics: dict[str, Any] | None,
+) -> dict[str, Any]:
+    summary = summarize_debate_records(records)
+    if summary_metrics:
+        summary.update(summary_metrics)
+    return summary
+
+
+def _debate_list_entry(record: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": record.get("id"),
+        "domain": record.get("domain"),
+        "status": record.get("status"),
+        "consensus_reached": bool(record.get("consensus_reached")),
+        "confidence": record.get("confidence"),
+        "created_at": record.get("created_at"),
+    }
+
+
+def _overview_debate_entry(record: dict[str, Any]) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "debate_id": record.get("id"),
+        "status": record.get("status"),
+        "consensus_reached": bool(record.get("consensus_reached")),
+        "created_at": record.get("created_at"),
+    }
+    if record.get("task"):
+        entry["task"] = record["task"]
+    if record.get("rounds_used") is not None:
+        entry["round_count"] = record["rounds_used"]
+    if record.get("duration_seconds") is not None:
+        entry["duration_ms"] = round(float(record["duration_seconds"]) * 1000, 3)
+    return entry
+
+
+def _count_records_since(records: list[dict[str, Any]], cutoff: datetime) -> int:
+    return sum(
+        1
+        for record in records
+        if isinstance(record.get("_sort_created_at"), datetime)
+        and record["_sort_created_at"] >= cutoff
+    )
+
+
+def _derive_system_health(summary: dict[str, Any]) -> str:
+    if summary.get("needs_attention_debates", 0) > 0:
+        return "degraded"
+    if summary.get("open_debates", 0) > 0 and summary.get("consensus_rate", 0.0) < 0.5:
+        return "degraded"
+    return "healthy"
 
 
 class DashboardViewsMixin:
@@ -44,9 +104,14 @@ class DashboardViewsMixin:
 
         def get_storage(self) -> Any: ...
 
-    def _get_summary_metrics_sql(self, storage: Any, domain: str | None) -> dict[str, Any]: ...
-    def _get_agent_performance(self, limit: int) -> dict[str, Any]: ...
-    def _get_performance_metrics(self) -> dict[str, Any]: ...
+    def _get_summary_metrics_sql(self, storage: Any, domain: str | None) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _get_agent_performance(self, limit: int) -> dict[str, Any]:
+        raise NotImplementedError
+
+    def _get_performance_metrics(self) -> dict[str, Any]:
+        raise NotImplementedError
 
     @api_endpoint(
         method="GET",
@@ -78,33 +143,43 @@ class DashboardViewsMixin:
 
         try:
             storage = self.get_storage()
+            records: list[dict[str, Any]] = []
+            summary: dict[str, Any] = {}
             if storage:
-                summary = self._get_summary_metrics_sql(storage, None)
-                overview["consensus_rate"] = summary.get("consensus_rate", 0.0)
-
-                # Count today's debates
-                today_start = (
-                    datetime.now(timezone.utc)
-                    .replace(hour=0, minute=0, second=0, microsecond=0)
-                    .isoformat()
-                )
                 try:
-                    with storage.connection() as conn:
-                        cursor = conn.cursor()
-                        cursor.execute(
-                            "SELECT COUNT(*) FROM debates WHERE created_at >= ?",
-                            (today_start,),
-                        )
-                        row = cursor.fetchone()
-                        overview["total_debates_today"] = row[0] if row else 0
-                except (OSError, ValueError, TypeError) as e:
-                    logger.debug("Could not get today's debates count: %s", e)
+                    records = load_debate_records(storage)
+                    summary = _merge_summary_metrics(
+                        records, self._get_summary_metrics_sql(storage, None)
+                    )
+                except (KeyError, ValueError, OSError, TypeError) as e:
+                    logger.warning("Overview summary error: %s: %s", type(e).__name__, e)
+                    summary = summarize_debate_records(records)
 
-            # Agent performance as stat cards
-            perf = self._get_agent_performance(5)
+            today_start = datetime.now(timezone.utc).replace(
+                hour=0,
+                minute=0,
+                second=0,
+                microsecond=0,
+            )
+            overview["recent_debates"] = [_overview_debate_entry(record) for record in records[:5]]
+            overview["active_debates"] = sum(
+                1 for record in records if str(record.get("status") or "") in ACTIVE_DEBATE_STATUSES
+            )
+            overview["total_debates_today"] = _count_records_since(records, today_start)
+            overview["consensus_rate"] = summary.get("consensus_rate", 0.0)
+            overview["avg_debate_duration_ms"] = summary.get("avg_duration_ms", 0)
+            overview["system_health"] = _derive_system_health(summary)
             overview["stats"] = [
-                {"label": "Total Agents", "value": perf.get("total_agents", 0)},
-                {"label": "Avg ELO", "value": perf.get("avg_elo", 0)},
+                {"label": "Total Debates", "value": summary.get("total_debates", 0)},
+                {"label": "Open Debates", "value": summary.get("open_debates", 0)},
+                {
+                    "label": "Consensus Rate",
+                    "value": f"{summary.get('consensus_rate', 0.0) * 100:.1f}%",
+                },
+                {
+                    "label": "Avg Confidence",
+                    "value": round(summary.get("avg_confidence", 0.0), 2),
+                },
             ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Overview error: %s: %s", type(e).__name__, e)
@@ -161,43 +236,21 @@ class DashboardViewsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    # Count total
-                    if status:
-                        cursor.execute("SELECT COUNT(*) FROM debates WHERE status = ?", (status,))
-                    else:
-                        cursor.execute("SELECT COUNT(*) FROM debates")
-                    row = cursor.fetchone()
-                    total = row[0] if row else 0
+                records = load_debate_records(storage)
+                normalized_status = str(status).strip().lower() if status else None
+                if normalized_status:
+                    records = [
+                        record
+                        for record in records
+                        if str(record.get("status") or "") == normalized_status
+                    ]
 
-                    # Fetch page
-                    if status:
-                        cursor.execute(
-                            "SELECT id, domain, status, consensus_reached, confidence, "
-                            "created_at FROM debates WHERE status = ? "
-                            "ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                            (status, limit, offset),
-                        )
-                    else:
-                        cursor.execute(
-                            "SELECT id, domain, status, consensus_reached, confidence, "
-                            "created_at FROM debates "
-                            "ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                            (limit, offset),
-                        )
-
-                    for row in cursor.fetchall():
-                        debates.append(
-                            {
-                                "id": row[0],
-                                "domain": row[1],
-                                "status": row[2],
-                                "consensus_reached": bool(row[3]),
-                                "confidence": row[4],
-                                "created_at": row[5],
-                            }
-                        )
+                safe_offset = max(offset, 0)
+                total = len(records)
+                debates = [
+                    _debate_list_entry(record)
+                    for record in records[safe_offset : safe_offset + max(limit, 0)]
+                ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Dashboard debates error: %s: %s", type(e).__name__, e)
 
@@ -221,7 +274,31 @@ class DashboardViewsMixin:
         """Return a single debate summary entry."""
         if not debate_id:
             return error_response("debate_id is required", 400)
-        return json_response({"debate_id": debate_id})
+
+        try:
+            storage = self.get_storage()
+            if not storage:
+                return error_response("Debate not found", 404)
+
+            record = find_debate_record(storage, debate_id)
+            if not record:
+                return error_response("Debate not found", 404)
+
+            detail = {
+                "debate_id": record.get("id"),
+                **_debate_list_entry(record),
+                "needs_attention": bool(record.get("needs_attention")),
+            }
+            if record.get("task"):
+                detail["task"] = record["task"]
+            if record.get("rounds_used") is not None:
+                detail["rounds_used"] = record["rounds_used"]
+            if record.get("duration_seconds") is not None:
+                detail["duration_seconds"] = round(float(record["duration_seconds"]), 3)
+            return json_response(detail)
+        except (KeyError, ValueError, OSError, TypeError) as e:
+            logger.warning("Dashboard debate detail error: %s: %s", type(e).__name__, e)
+            return error_response("Failed to load debate", 500)
 
     @api_endpoint(
         method="GET",
@@ -260,59 +337,62 @@ class DashboardViewsMixin:
             },
         }
 
+        records: list[dict[str, Any]] = []
+
         try:
             storage = self.get_storage()
             if storage:
-                summary = self._get_summary_metrics_sql(storage, None)
-                stats["debates"]["total"] = summary.get("total_debates", 0)
-                stats["performance"]["consensus_rate"] = summary.get("consensus_rate", 0.0)
+                records = load_debate_records(storage)
+                summary = summarize_debate_records(records)
+                try:
+                    summary.update(self._get_summary_metrics_sql(storage, None) or {})
+                except (KeyError, ValueError, OSError, TypeError) as e:
+                    logger.warning("Dashboard stats summary error: %s: %s", type(e).__name__, e)
 
                 now = datetime.now(timezone.utc)
-                today_start = now.replace(hour=0, minute=0, second=0, microsecond=0).isoformat()
-                week_start = (now - timedelta(days=7)).isoformat()
-                month_start = (now - timedelta(days=30)).isoformat()
+                today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+                week_start = now - timedelta(days=7)
+                month_start = now - timedelta(days=30)
 
-                try:
-                    with storage.connection() as conn:
-                        cursor = conn.cursor()
-                        # Today
-                        cursor.execute(
-                            "SELECT COUNT(*) FROM debates WHERE created_at >= ?",
-                            (today_start,),
-                        )
-                        row = cursor.fetchone()
-                        stats["debates"]["today"] = row[0] if row else 0
+                stats["debates"]["total"] = summary.get("total_debates", 0)
+                stats["debates"]["today"] = _count_records_since(records, today_start)
+                stats["debates"]["this_week"] = _count_records_since(records, week_start)
+                stats["debates"]["this_month"] = _count_records_since(records, month_start)
+                stats["performance"]["consensus_rate"] = summary.get("consensus_rate", 0.0)
 
-                        # This week
-                        cursor.execute(
-                            "SELECT COUNT(*) FROM debates WHERE created_at >= ?",
-                            (week_start,),
-                        )
-                        row = cursor.fetchone()
-                        stats["debates"]["this_week"] = row[0] if row else 0
+                by_status: dict[str, int] = {}
+                for record in records:
+                    status_name = str(record.get("status") or "")
+                    if status_name:
+                        by_status[status_name] = by_status.get(status_name, 0) + 1
+                stats["debates"]["by_status"] = by_status
 
-                        # This month
-                        cursor.execute(
-                            "SELECT COUNT(*) FROM debates WHERE created_at >= ?",
-                            (month_start,),
-                        )
-                        row = cursor.fetchone()
-                        stats["debates"]["this_month"] = row[0] if row else 0
+                today_records = [
+                    record
+                    for record in records
+                    if isinstance(record.get("_sort_created_at"), datetime)
+                    and record["_sort_created_at"] >= today_start
+                ]
+                stats["usage"]["api_calls_today"] = len(today_records)
+                stats["usage"]["tokens_used_today"] = sum(
+                    int(record.get("total_tokens") or 0) for record in today_records
+                )
+                stats["usage"]["storage_used_bytes"] = sum(
+                    int(artifact_bytes)
+                    for record in records
+                    if isinstance((artifact_bytes := record.get("artifact_bytes")), (int, float))
+                )
+        except (KeyError, ValueError, OSError, TypeError) as e:
+            logger.warning("Dashboard storage stats error: %s: %s", type(e).__name__, e)
 
-                        # By status
-                        cursor.execute("SELECT status, COUNT(*) FROM debates GROUP BY status")
-                        for row in cursor.fetchall():
-                            if row[0]:
-                                stats["debates"]["by_status"][row[0]] = row[1]
-                except (OSError, ValueError, TypeError) as e:
-                    logger.debug("Could not get debate stats: %s", e)
-
-            # Agent stats from ELO
+        try:
             perf = self._get_agent_performance(100)
             stats["agents"]["total"] = perf.get("total_agents", 0)
             stats["agents"]["active"] = len(perf.get("top_performers", []))
+        except (KeyError, ValueError, OSError, TypeError) as e:
+            logger.warning("Dashboard agent stats error: %s: %s", type(e).__name__, e)
 
-            # Performance metrics
+        try:
             pm = self._get_performance_metrics()
             stats["performance"]["avg_response_time_ms"] = pm.get("avg_latency_ms", 0.0)
             stats["performance"]["success_rate"] = pm.get("success_rate", 0.0)
@@ -321,7 +401,7 @@ class DashboardViewsMixin:
                     1.0 - stats["performance"]["success_rate"], 3
                 )
         except (KeyError, ValueError, OSError, TypeError) as e:
-            logger.warning("Dashboard stats error: %s: %s", type(e).__name__, e)
+            logger.warning("Dashboard performance stats error: %s: %s", type(e).__name__, e)
 
         return json_response(stats)
 
@@ -343,7 +423,12 @@ class DashboardViewsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                summary = self._get_summary_metrics_sql(storage, None)
+                records = load_debate_records(storage)
+                summary = summarize_debate_records(records)
+                try:
+                    summary.update(self._get_summary_metrics_sql(storage, None) or {})
+                except (KeyError, ValueError, OSError, TypeError) as e:
+                    logger.warning("Stat cards summary error: %s: %s", type(e).__name__, e)
                 cards.append(
                     {
                         "id": "total_debates",
@@ -515,28 +600,62 @@ class DashboardViewsMixin:
     def _get_top_senders(self, limit: int, offset: int) -> HandlerResult:
         """Return top debate initiators ranked by count."""
         senders: list[dict[str, Any]] = []
+        total = 0
 
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        "SELECT domain, COUNT(*) as cnt FROM debates "
-                        "GROUP BY domain ORDER BY cnt DESC LIMIT ? OFFSET ?",
-                        (limit, offset),
-                    )
-                    for row in cursor.fetchall():
-                        senders.append(
-                            {
-                                "domain": row[0] or "general",
-                                "debate_count": row[1],
-                            }
-                        )
+                grouped: dict[str, list[dict[str, Any]]] = {}
+                for record in load_debate_records(storage):
+                    domain_name = str(record.get("domain_label") or "general")
+                    grouped.setdefault(domain_name, []).append(record)
+
+                total = len(grouped)
+                senders = sorted(
+                    (
+                        {
+                            "domain": domain_name,
+                            "debate_count": len(entries),
+                            "consensus_rate": round(
+                                sum(1 for entry in entries if entry.get("consensus_reached"))
+                                / len(entries),
+                                3,
+                            ),
+                            "avg_confidence": round(
+                                sum(
+                                    float(entry["confidence"])
+                                    for entry in entries
+                                    if entry.get("confidence") is not None
+                                )
+                                / max(
+                                    1,
+                                    sum(
+                                        1
+                                        for entry in entries
+                                        if entry.get("confidence") is not None
+                                    ),
+                                ),
+                                3,
+                            )
+                            if any(entry.get("confidence") is not None for entry in entries)
+                            else 0.0,
+                            "open_debates": sum(
+                                1
+                                for entry in entries
+                                if str(entry.get("status") or "") in ACTIVE_DEBATE_STATUSES
+                            ),
+                        }
+                        for domain_name, entries in grouped.items()
+                    ),
+                    key=lambda sender: (
+                        -cast(int, sender["debate_count"]),
+                        str(sender["domain"]),
+                    ),
+                )[max(offset, 0) : max(offset, 0) + max(limit, 0)]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Top senders error: %s: %s", type(e).__name__, e)
 
-        return json_response({"senders": senders, "total": len(senders)})
+        return json_response({"senders": senders, "total": total})
 
     @api_endpoint(
         method="GET",
@@ -555,19 +674,18 @@ class DashboardViewsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute(
-                        "SELECT domain, COUNT(*) as cnt FROM debates "
-                        "GROUP BY domain ORDER BY cnt DESC LIMIT 20"
-                    )
-                    for row in cursor.fetchall():
-                        labels.append(
-                            {
-                                "name": row[0] or "general",
-                                "count": row[1],
-                            }
-                        )
+                grouped: dict[str, int] = {}
+                for record in load_debate_records(storage):
+                    domain_name = str(record.get("domain_label") or "general")
+                    grouped[domain_name] = grouped.get(domain_name, 0) + 1
+
+                labels = [
+                    {"name": domain_name, "count": count}
+                    for domain_name, count in sorted(
+                        grouped.items(),
+                        key=lambda item: (-item[1], item[0]),
+                    )[:20]
+                ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Labels error: %s: %s", type(e).__name__, e)
 
@@ -595,29 +713,19 @@ class DashboardViewsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                with storage.connection() as conn:
-                    cursor = conn.cursor()
-                    cursor.execute("SELECT COUNT(*) FROM debates")
-                    row = cursor.fetchone()
-                    total = row[0] if row else 0
-
-                    cursor.execute(
-                        "SELECT id, domain, consensus_reached, confidence, "
-                        "created_at FROM debates "
-                        "ORDER BY created_at DESC LIMIT ? OFFSET ?",
-                        (limit, offset),
-                    )
-                    for row in cursor.fetchall():
-                        activity.append(
-                            {
-                                "type": "debate",
-                                "debate_id": row[0],
-                                "domain": row[1],
-                                "consensus_reached": bool(row[2]),
-                                "confidence": row[3],
-                                "created_at": row[4],
-                            }
-                        )
+                records = load_debate_records(storage)
+                total = len(records)
+                activity = [
+                    {
+                        "type": "debate",
+                        "debate_id": record.get("id"),
+                        "domain": record.get("domain"),
+                        "consensus_reached": bool(record.get("consensus_reached")),
+                        "confidence": record.get("confidence"),
+                        "created_at": record.get("created_at"),
+                    }
+                    for record in records[max(offset, 0) : max(offset, 0) + max(limit, 0)]
+                ]
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Activity feed error: %s: %s", type(e).__name__, e)
 
@@ -650,26 +758,59 @@ class DashboardViewsMixin:
         try:
             storage = self.get_storage()
             if storage:
-                sql_summary = self._get_summary_metrics_sql(storage, None)
+                records = load_debate_records(storage)
+                sql_summary = summarize_debate_records(records)
+                try:
+                    sql_summary.update(self._get_summary_metrics_sql(storage, None) or {})
+                except (KeyError, ValueError, OSError, TypeError) as e:
+                    logger.warning("Inbox summary metrics error: %s: %s", type(e).__name__, e)
                 summary["total_messages"] = sql_summary.get("total_debates", 0)
+                summary["unread_messages"] = sql_summary.get("open_debates", 0)
+                summary["urgent_count"] = sql_summary.get("needs_attention_debates", 0)
                 summary["response_rate"] = sql_summary.get("consensus_rate", 0.0)
 
-                today_start = (
-                    datetime.now(timezone.utc)
-                    .replace(hour=0, minute=0, second=0, microsecond=0)
-                    .isoformat()
+                today_start = datetime.now(timezone.utc).replace(
+                    hour=0,
+                    minute=0,
+                    second=0,
+                    microsecond=0,
                 )
-                try:
-                    with storage.connection() as conn:
-                        cursor = conn.cursor()
-                        cursor.execute(
-                            "SELECT COUNT(*) FROM debates WHERE created_at >= ?",
-                            (today_start,),
-                        )
-                        row = cursor.fetchone()
-                        summary["today_count"] = row[0] if row else 0
-                except (OSError, ValueError, TypeError) as e:
-                    logger.debug("Could not get today's inbox count: %s", e)
+                summary["today_count"] = _count_records_since(records, today_start)
+
+                grouped: dict[str, int] = {}
+                by_importance = {"high": 0, "medium": 0, "low": 0}
+                durations_hours: list[float] = []
+
+                for record in records:
+                    domain_name = str(record.get("domain_label") or "general")
+                    grouped[domain_name] = grouped.get(domain_name, 0) + 1
+
+                    confidence = record.get("confidence")
+                    if confidence is None:
+                        by_importance["medium"] += 1
+                    elif float(confidence) >= 0.8:
+                        by_importance["high"] += 1
+                    elif float(confidence) >= 0.5:
+                        by_importance["medium"] += 1
+                    else:
+                        by_importance["low"] += 1
+
+                    if record.get("duration_seconds") is not None:
+                        durations_hours.append(float(record["duration_seconds"]) / 3600.0)
+
+                summary["by_label"] = [
+                    {"name": domain_name, "count": count}
+                    for domain_name, count in sorted(
+                        grouped.items(),
+                        key=lambda item: (-item[1], item[0]),
+                    )[:10]
+                ]
+                summary["by_importance"] = by_importance
+                if durations_hours:
+                    summary["avg_response_time_hours"] = round(
+                        sum(durations_hours) / len(durations_hours),
+                        3,
+                    )
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Inbox summary error: %s: %s", type(e).__name__, e)
 

--- a/tests/handlers/admin/test_dashboard.py
+++ b/tests/handlers/admin/test_dashboard.py
@@ -477,12 +477,14 @@ class TestHandleRouteDispatch:
             assert d["status"] == "completed"
 
     @pytest.mark.asyncio
-    async def test_debate_detail_endpoint(self, handler, mock_http):
-        """GET /api/v1/dashboard/debates/{id} returns debate detail stub."""
-        result = await handler.handle("/api/v1/dashboard/debates/d1", {}, mock_http)
+    async def test_debate_detail_endpoint(self, handler_with_storage, mock_http):
+        """GET /api/v1/dashboard/debates/{id} returns debate detail."""
+        result = await handler_with_storage.handle("/api/v1/dashboard/debates/d1", {}, mock_http)
         assert _status(result) == 200
         body = _body(result)
         assert body["debate_id"] == "d1"
+        assert body["id"] == "d1"
+        assert body["domain"] == "finance"
 
     @pytest.mark.asyncio
     async def test_stats_endpoint(self, handler, mock_http):
@@ -651,12 +653,12 @@ class TestHandlePostRouteDispatch:
     async def test_execute_quick_action(self, handler, mock_http):
         """POST /api/v1/dashboard/quick-actions/{id} executes action."""
         result = await handler.handle_post(
-            "/api/v1/dashboard/quick-actions/archive_read", {}, mock_http
+            "/api/v1/dashboard/quick-actions/review_needs_attention", {}, mock_http
         )
         assert _status(result) == 200
         body = _body(result)
         assert body["success"] is True
-        assert body["action_id"] == "archive_read"
+        assert body["action_id"] == "review_needs_attention"
 
     @pytest.mark.asyncio
     async def test_dismiss_urgent_item(self, handler_with_storage, mock_http):
@@ -1303,12 +1305,16 @@ class TestDashboardWithElo:
 
     @pytest.mark.asyncio
     async def test_overview_with_elo(self, handler_with_elo, mock_http):
-        """Overview stats include agent count from ELO."""
+        """Overview remains debate-backed even when ELO data is present."""
         result = await handler_with_elo.handle("/api/v1/dashboard/overview", {}, mock_http)
         body = _body(result)
-        agent_stat = [s for s in body["stats"] if s["label"] == "Total Agents"]
-        assert len(agent_stat) == 1
-        assert agent_stat[0]["value"] == 3
+        labels = {s["label"] for s in body["stats"]}
+        assert labels == {
+            "Total Debates",
+            "Open Debates",
+            "Consensus Rate",
+            "Avg Confidence",
+        }
 
     @pytest.mark.asyncio
     async def test_team_performance_groups_by_provider(self, handler_with_elo, mock_http):

--- a/tests/handlers/admin/test_dashboard_actions.py
+++ b/tests/handlers/admin/test_dashboard_actions.py
@@ -186,20 +186,18 @@ class TestGetQuickActions:
         body = _body(handler._get_quick_actions())
         assert body["total"] == len(body["actions"])
 
-    def test_has_six_actions(self, handler):
+    def test_has_four_actions(self, handler):
         body = _body(handler._get_quick_actions())
-        assert body["total"] == 6
+        assert body["total"] == 4
 
     def test_action_ids(self, handler):
         body = _body(handler._get_quick_actions())
         ids = {a["id"] for a in body["actions"]}
         expected = {
-            "archive_read",
-            "snooze_low",
-            "mark_spam",
-            "complete_actions",
-            "ai_respond",
-            "sync_inbox",
+            "review_needs_attention",
+            "resume_in_progress",
+            "complete_pending",
+            "inspect_low_confidence",
         }
         assert ids == expected
 
@@ -209,10 +207,10 @@ class TestGetQuickActions:
         for action in body["actions"]:
             assert set(action.keys()) == required_fields
 
-    def test_all_actions_available(self, handler):
+    def test_actions_expose_boolean_availability(self, handler):
         body = _body(handler._get_quick_actions())
         for action in body["actions"]:
-            assert action["available"] is True
+            assert isinstance(action["available"], bool)
 
     def test_actions_have_nonempty_names(self, handler):
         body = _body(handler._get_quick_actions())
@@ -222,7 +220,7 @@ class TestGetQuickActions:
 
     def test_icons_are_strings(self, handler):
         body = _body(handler._get_quick_actions())
-        expected_icons = {"archive", "clock", "slash", "check-circle", "sparkles", "refresh"}
+        expected_icons = {"alert-triangle", "play-circle", "check-circle", "gauge"}
         icons = {a["icon"] for a in body["actions"]}
         assert icons == expected_icons
 
@@ -240,14 +238,14 @@ class TestExecuteQuickAction:
     """Tests for the execute quick action endpoint."""
 
     def test_success(self, handler):
-        result = handler._execute_quick_action("archive_read")
+        result = handler._execute_quick_action("review_needs_attention")
         assert _status(result) == 200
         body = _body(result)
         assert body["success"] is True
-        assert body["action_id"] == "archive_read"
+        assert body["action_id"] == "review_needs_attention"
 
     def test_executed_at_present(self, handler):
-        body = _body(handler._execute_quick_action("test_action"))
+        body = _body(handler._execute_quick_action("review_needs_attention"))
         assert "executed_at" in body
         assert "T" in body["executed_at"]
 
@@ -260,24 +258,20 @@ class TestExecuteQuickAction:
             or "required" in body.get("error", "").lower()
         )
 
-    def test_arbitrary_action_id(self, handler):
+    def test_arbitrary_action_id_returns_not_found(self, handler):
         result = handler._execute_quick_action("custom_action_123")
-        assert _status(result) == 200
+        assert _status(result) == 404
         body = _body(result)
-        assert body["action_id"] == "custom_action_123"
+        assert "not found" in body.get("error", "").lower()
 
     def test_special_characters_in_action_id(self, handler):
         result = handler._execute_quick_action("action/with%special&chars")
-        assert _status(result) == 200
-        body = _body(result)
-        assert body["action_id"] == "action/with%special&chars"
+        assert _status(result) == 404
 
     def test_long_action_id(self, handler):
         long_id = "a" * 1000
         result = handler._execute_quick_action(long_id)
-        assert _status(result) == 200
-        body = _body(result)
-        assert body["action_id"] == long_id
+        assert _status(result) == 404
 
 
 # ===========================================================================
@@ -406,13 +400,14 @@ class TestDismissUrgentItem:
         rows = [("u1", "finance", "in_progress", 0, 0.1, "2026-02-23T10:00:00")]
         storage = InMemoryStorage(rows)
         h = TestableHandler(storage=storage)
-        h._dismiss_urgent_item("u1")
-        # Verify the database was updated
+        body = _body(h._dismiss_urgent_item("u1"))
+        assert body["persisted"] is False
+        # Verify the debate outcome is not rewritten
         with storage.connection() as conn:
             cursor = conn.cursor()
             cursor.execute("SELECT consensus_reached FROM debates WHERE id = ?", ("u1",))
             row = cursor.fetchone()
-            assert row[0] == 1
+            assert row[0] == 0
 
     def test_dismiss_nonexistent_item(self):
         storage = InMemoryStorage([])
@@ -1222,7 +1217,7 @@ class TestIntegration:
     def test_all_endpoints_return_200(self, handler):
         """Every action/analytics endpoint returns 200 with empty handler."""
         assert _status(handler._get_quick_actions()) == 200
-        assert _status(handler._execute_quick_action("test")) == 200
+        assert _status(handler._execute_quick_action("review_needs_attention")) == 200
         assert _status(handler._get_urgent_items(20, 0)) == 200
         assert _status(handler._dismiss_urgent_item("test")) == 200
         assert _status(handler._get_pending_actions(20, 0)) == 200

--- a/tests/handlers/admin/test_dashboard_views.py
+++ b/tests/handlers/admin/test_dashboard_views.py
@@ -276,10 +276,14 @@ class TestGetOverview:
         h = TestableHandler(agent_perf={"total_agents": 3, "avg_elo": 1100})
         result = h._get_overview({}, mock_http)
         body = _body(result)
-        assert len(body["stats"]) == 2
+        assert len(body["stats"]) == 4
         labels = {s["label"] for s in body["stats"]}
-        assert "Total Agents" in labels
-        assert "Avg ELO" in labels
+        assert labels == {
+            "Total Debates",
+            "Open Debates",
+            "Consensus Rate",
+            "Avg Confidence",
+        }
 
     def test_overview_storage_connection_error(self, mock_http):
         h = TestableHandler(storage=ErrorStorage())
@@ -299,13 +303,13 @@ class TestGetOverview:
         assert body["consensus_rate"] == 0.0
 
     def test_overview_agent_perf_error(self, mock_http):
-        """When _get_agent_performance raises, overview still returns."""
+        """Overview no longer depends on agent performance helper."""
         h = TestableHandler(storage=InMemoryStorage())
         h._get_agent_performance = MagicMock(side_effect=TypeError("bad"))
         result = h._get_overview({}, mock_http)
         body = _body(result)
         assert _status(result) == 200
-        assert body["stats"] == []
+        assert len(body["stats"]) == 4
 
 
 # ===========================================================================
@@ -411,11 +415,19 @@ class TestGetDashboardDebates:
 class TestGetDashboardDebate:
     """Tests for the single debate detail endpoint."""
 
-    def test_returns_debate_id(self, handler):
-        result = handler._get_dashboard_debate("abc-123")
+    def test_returns_debate_detail(self):
+        storage = InMemoryStorage(
+            [("abc-123", "finance", "completed", 1, 0.92, "2026-02-23T10:00:00")]
+        )
+        h = TestableHandler(storage=storage)
+        result = h._get_dashboard_debate("abc-123")
         body = _body(result)
         assert _status(result) == 200
         assert body["debate_id"] == "abc-123"
+        assert body["id"] == "abc-123"
+        assert body["domain"] == "finance"
+        assert body["status"] == "completed"
+        assert body["consensus_reached"] is True
 
     def test_empty_debate_id(self, handler):
         result = handler._get_dashboard_debate("")
@@ -423,8 +435,12 @@ class TestGetDashboardDebate:
         body = _body(result)
         assert "required" in body.get("error", "").lower()
 
-    def test_special_characters_in_id(self, handler):
-        result = handler._get_dashboard_debate("test/special%id")
+    def test_special_characters_in_id(self):
+        storage = InMemoryStorage(
+            [("test/special%id", "tech", "pending", 0, 0.25, "2026-02-23T10:00:00")]
+        )
+        h = TestableHandler(storage=storage)
+        result = h._get_dashboard_debate("test/special%id")
         body = _body(result)
         assert _status(result) == 200
         assert body["debate_id"] == "test/special%id"
@@ -1039,11 +1055,11 @@ class TestIntegration:
     """Cross-cutting integration tests."""
 
     def test_all_endpoints_return_200(self, mock_http):
-        """Every view endpoint returns 200 with empty handler."""
+        """View endpoints degrade gracefully; detail requires a real debate."""
         h = TestableHandler()
         assert _status(h._get_overview({}, mock_http)) == 200
         assert _status(h._get_dashboard_debates(10, 0, None)) == 200
-        assert _status(h._get_dashboard_debate("x")) == 200
+        assert _status(h._get_dashboard_debate("x")) == 404
         assert _status(h._get_dashboard_stats()) == 200
         assert _status(h._get_stat_cards()) == 200
         assert _status(h._get_team_performance(10, 0)) == 200
@@ -1171,12 +1187,12 @@ class TestOverviewEdgeCases:
         assert body["consensus_rate"] == 0.0
 
     def test_overview_missing_keys_in_agent_perf(self, mock_http):
-        """Agent perf dict missing expected keys uses defaults."""
+        """Overview stats stay debate-backed even if agent perf is empty."""
         h = TestableHandler(agent_perf={})
         result = h._get_overview({}, mock_http)
         body = _body(result)
         stats = body["stats"]
-        assert len(stats) == 2
+        assert len(stats) == 4
         assert stats[0]["value"] == 0
         assert stats[1]["value"] == 0
 


### PR DESCRIPTION
## Summary
- normalize stored debate rows and embedded artifacts into real dashboard records
- replace synthetic dashboard overview, detail, queue, inbox, and quality payloads with debate-backed aggregates while preserving endpoint envelopes
- update dashboard handler tests for the new real metrics and activity behavior

## Validation
- python3 -m ruff check aragora/server/handlers/admin/dashboard_metrics.py aragora/server/handlers/admin/dashboard_views.py aragora/server/handlers/admin/dashboard_actions.py tests/handlers/admin/test_dashboard_views.py tests/handlers/admin/test_dashboard_actions.py tests/handlers/admin/test_dashboard.py
- python3 -m mypy aragora/server/handlers/admin/dashboard_metrics.py aragora/server/handlers/admin/dashboard_views.py aragora/server/handlers/admin/dashboard_actions.py --ignore-missing-imports --follow-imports=skip
- python3 -m pytest tests/handlers/admin/test_dashboard_views.py tests/handlers/admin/test_dashboard_actions.py tests/handlers/admin/test_dashboard_metrics.py tests/handlers/admin/test_dashboard.py -q