### PR TITLE
fix(coordination): clear directives for dead sessions

### DIFF
--- a/aragora/coordination/registry.py
+++ b/aragora/coordination/registry.py
@@ -49,13 +49,18 @@ class SessionInfo:
 
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> SessionInfo:
+        pid = data.get("pid", 0)
+        started_at = data.get("started_at", 0)
+        last_heartbeat = data.get("last_heartbeat", 0)
         return cls(
             session_id=str(data.get("session_id", "")),
             agent=str(data.get("agent", "")),
             worktree=str(data.get("worktree", "")),
-            pid=int(data.get("pid", 0)),
-            started_at=float(data.get("started_at", 0)),
-            last_heartbeat=float(data.get("last_heartbeat", 0)),
+            pid=int(pid) if isinstance(pid, (int, float, str)) else 0,
+            started_at=float(started_at) if isinstance(started_at, (int, float, str)) else 0.0,
+            last_heartbeat=float(last_heartbeat)
+            if isinstance(last_heartbeat, (int, float, str))
+            else 0.0,
             focus=str(data.get("focus", "")),
             track=str(data.get("track", "")),
             intent=str(data.get("intent", "")),
@@ -98,6 +103,16 @@ class SessionRegistry:
         self._sessions_dir.mkdir(parents=True, exist_ok=True)
         return self._sessions_dir
 
+    def _session_path(self, session_id: str) -> Path:
+        return self._sessions_dir / f"{session_id}.json"
+
+    def _load_session(self, path: Path) -> SessionInfo | None:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return SessionInfo.from_dict(data)
+        except (json.JSONDecodeError, KeyError, TypeError):
+            return None
+
     def register(
         self,
         agent: str,
@@ -137,7 +152,7 @@ class SessionRegistry:
 
     def deregister(self, session_id: str) -> bool:
         """Remove a session registration. Returns True if file was removed."""
-        path = self._sessions_dir / f"{session_id}.json"
+        path = self._session_path(session_id)
         if path.exists():
             path.unlink()
             logger.info("session_deregistered id=%s", session_id)
@@ -146,7 +161,7 @@ class SessionRegistry:
 
     def heartbeat(self, session_id: str) -> bool:
         """Update the last_heartbeat timestamp. Returns True if session found."""
-        path = self._sessions_dir / f"{session_id}.json"
+        path = self._session_path(session_id)
         if not path.exists():
             return False
 
@@ -172,10 +187,8 @@ class SessionRegistry:
 
         sessions: list[SessionInfo] = []
         for path in sorted(self._sessions_dir.glob("*.json")):
-            try:
-                data = json.loads(path.read_text(encoding="utf-8"))
-                session = SessionInfo.from_dict(data)
-            except (json.JSONDecodeError, KeyError, TypeError):
+            session = self._load_session(path)
+            if session is None:
                 logger.debug("skipping_corrupt_session path=%s", path)
                 continue
 
@@ -189,18 +202,16 @@ class SessionRegistry:
 
         return sessions
 
-    def get(self, session_id: str) -> SessionInfo | None:
+    def get(self, session_id: str, *, include_dead: bool = False) -> SessionInfo | None:
         """Get a specific session by ID, or None if not found/dead."""
-        path = self._sessions_dir / f"{session_id}.json"
+        path = self._session_path(session_id)
         if not path.exists():
             return None
-        try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            session = SessionInfo.from_dict(data)
-        except (json.JSONDecodeError, KeyError, TypeError):
+        session = self._load_session(path)
+        if session is None:
             return None
 
-        if not session.is_alive:
+        if not include_dead and not session.is_alive:
             return None
         return session
 

--- a/aragora/swarm/session_coordinator.py
+++ b/aragora/swarm/session_coordinator.py
@@ -174,8 +174,16 @@ def list_findings(
 
 def read_directives(repo_root: Path | None = None, *, findings_limit: int = 10) -> dict[str, Any]:
     root = _coord_repo_root(repo_root)
-    directives = [item.to_dict() for item in DirectiveBoard(repo_path=root).list()]
-    sessions = [item.to_dict() for item in SessionRegistry(repo_path=root).discover()]
+    board = DirectiveBoard(repo_path=root)
+    registry = SessionRegistry(repo_path=root)
+
+    for directive in board.list():
+        session = registry.get(directive.target, include_dead=True)
+        if session is not None and not session.is_alive:
+            board.clear(directive.target)
+
+    directives = [item.to_dict() for item in board.list()]
+    sessions = [item.to_dict() for item in registry.discover()]
     claims = [item.to_dict() for item in ClaimManager(repo_path=root).list_all()]
     findings = list_findings(limit=findings_limit, repo_root=root)
     return {

--- a/tests/coordination/test_registry.py
+++ b/tests/coordination/test_registry.py
@@ -153,6 +153,16 @@ class TestSessionRegistry:
 
         assert reg.get(session_id) is None
 
+    def test_get_include_dead_returns_dead_session(self, tmp_path):
+        reg = SessionRegistry(repo_path=tmp_path)
+        session = reg.register(agent="dead", worktree="/tmp/wt1", pid=999999999)
+
+        found = reg.get(session.session_id, include_dead=True)
+
+        assert found is not None
+        assert found.session_id == session.session_id
+        assert found.is_alive is False
+
     def test_get_missing_returns_none(self, tmp_path):
         reg = SessionRegistry(repo_path=tmp_path)
         assert reg.get("nonexistent") is None

--- a/tests/swarm/test_session_coordinator.py
+++ b/tests/swarm/test_session_coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from aragora.coordination.registry import SessionRegistry
 from aragora.swarm.session_coordinator import (
     claim_pr,
     get_my_assignment,
@@ -62,3 +63,17 @@ class TestSessionCoordinator:
         assert view["summary"]["claim_count"] == 1
         assert view["summary"]["finding_count"] == 1
         assert view["directives"][0]["target"] == "codex-a"
+
+    def test_read_directives_clears_dead_session_assignments(self, tmp_path):
+        session = SessionRegistry(repo_path=tmp_path).register(
+            agent="codex",
+            worktree="/tmp/wt1",
+            pid=999999999,
+        )
+        set_assignment(session.session_id, "Stale assignment", repo_root=tmp_path)
+
+        view = read_directives(repo_root=tmp_path)
+
+        assert view["summary"]["directive_count"] == 0
+        assert view["summary"]["session_count"] == 0
+        assert get_my_assignment(session.session_id, repo_root=tmp_path) is None


### PR DESCRIPTION
## Summary
- let session registry return dead session metadata when coordination cleanup needs to inspect it
- clear directives for dead sessions during `read_directives()` while preserving non-session assignments
- add regression coverage for dead-session lookup and stale directive cleanup

Closes #2694

## Validation
- python3 -m ruff check aragora/coordination/registry.py aragora/swarm/session_coordinator.py tests/coordination/test_registry.py tests/swarm/test_session_coordinator.py
- python3 -m mypy aragora/coordination/registry.py aragora/swarm/session_coordinator.py --ignore-missing-imports --follow-imports=skip
- python3 -m pytest tests/coordination/test_registry.py tests/swarm/test_session_coordinator.py -q