### PR TITLE
fix(dashboard): expose debate proof details

### DIFF
--- a/aragora/server/handlers/admin/dashboard_metrics.py
+++ b/aragora/server/handlers/admin/dashboard_metrics.py
@@ -129,6 +129,14 @@ def _coerce_int(value: Any) -> int | None:
     return int(numeric)
 
 
+def _coerce_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    text = text.strip()
+    return text or None
+
+
 def _load_json_payload(raw_payload: Any) -> dict[str, Any] | None:
     if raw_payload is None:
         return None
@@ -172,6 +180,21 @@ def _artifact_size_bytes(raw_payload: Any) -> int:
         return 0
 
 
+def _get_nested(payload: dict[str, Any] | None, *path: str) -> Any:
+    current: Any = payload
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
+def _get_mapping_value(value: Any, key: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
 def _find_first_numeric(payload: Any, keys: tuple[str, ...]) -> float | None:
     if isinstance(payload, dict):
         for key in keys:
@@ -189,6 +212,242 @@ def _find_first_numeric(payload: Any, keys: tuple[str, ...]) -> float | None:
             if numeric is not None:
                 return numeric
     return None
+
+
+def _normalize_string_list(values: Any) -> list[str]:
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        return []
+
+    normalized: list[str] = []
+    for value in values:
+        text = _coerce_text(value)
+        if text is not None:
+            normalized.append(text)
+    return normalized
+
+
+def _normalize_float_dict(values: Any) -> dict[str, float]:
+    if not isinstance(values, dict):
+        return {}
+
+    normalized: dict[str, float] = {}
+    for key, value in values.items():
+        key_text = _coerce_text(key)
+        numeric = _coerce_float(value)
+        if key_text is not None and numeric is not None:
+            normalized[key_text] = numeric
+    return normalized
+
+
+def _get_receipt_store() -> Any:
+    from aragora.storage.receipt_store import get_receipt_store
+
+    return get_receipt_store()
+
+
+def _extract_receipt_per_agent_cost(cost_summary: Any) -> dict[str, float]:
+    if not isinstance(cost_summary, dict):
+        return {}
+
+    per_agent = cost_summary.get("per_agent")
+    if not isinstance(per_agent, dict):
+        return {}
+
+    costs: dict[str, float] = {}
+    for agent_name, raw_value in per_agent.items():
+        agent_key = _coerce_text(agent_name)
+        if agent_key is None:
+            continue
+        if isinstance(raw_value, dict):
+            numeric = _coerce_float(raw_value.get("total_cost_usd"))
+            if numeric is None:
+                numeric = _coerce_float(raw_value.get("cost"))
+        else:
+            numeric = _coerce_float(raw_value)
+        if numeric is not None:
+            costs[agent_key] = numeric
+    return costs
+
+
+def _extract_dashboard_proof(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not payload:
+        return None
+
+    cost_summary = _get_nested(payload, "receipt", "cost_summary")
+
+    proof: dict[str, Any] = {}
+
+    for candidate in (
+        _get_nested(payload, "receipt", "receipt_id"),
+        payload.get("receipt_id"),
+        _get_nested(payload, "result", "receipt_id"),
+        _get_nested(payload, "metadata", "receipt_id"),
+    ):
+        receipt_id = _coerce_text(candidate)
+        if receipt_id is not None:
+            proof["receipt_id"] = receipt_id
+            break
+
+    for candidate in (
+        payload.get("receipt_hash"),
+        _get_nested(payload, "result", "receipt_hash"),
+        _get_nested(payload, "receipt", "artifact_hash"),
+        _get_nested(payload, "receipt", "checksum"),
+        _get_nested(payload, "receipt", "hash"),
+        _get_nested(payload, "receipt", "signature"),
+    ):
+        receipt_hash = _coerce_text(candidate)
+        if receipt_hash is not None:
+            proof["receipt_hash"] = receipt_hash
+            break
+
+    for candidate in (
+        _get_nested(payload, "receipt", "timestamp"),
+        _get_nested(payload, "receipt", "created_at"),
+        _get_nested(payload, "result", "receipt_timestamp"),
+    ):
+        receipt_timestamp = _coerce_text(candidate)
+        if receipt_timestamp is not None:
+            proof["receipt_timestamp"] = receipt_timestamp
+            break
+
+    for candidate in (
+        payload.get("provider"),
+        _get_nested(payload, "metadata", "provider"),
+    ):
+        provider = _coerce_text(candidate)
+        if provider is not None:
+            proof["provider"] = provider
+            break
+
+    for candidate in (
+        payload.get("provider_route"),
+        _get_nested(payload, "metadata", "provider_route"),
+    ):
+        provider_route = _coerce_text(candidate)
+        if provider_route is not None:
+            proof["provider_route"] = provider_route
+            break
+
+    provider_names = _normalize_string_list(
+        payload.get("provider_names")
+        or _get_nested(payload, "result", "provider_names")
+        or _get_nested(payload, "metadata", "provider_names")
+    )
+    if provider_names:
+        proof["provider_names"] = provider_names
+
+    provider_hints = _normalize_string_list(
+        payload.get("provider_hints")
+        or _get_nested(payload, "result", "provider_hints")
+        or _get_nested(payload, "metadata", "provider_hints")
+    )
+    if provider_hints:
+        proof["provider_hints"] = provider_hints
+
+    provider_routing = (
+        payload.get("provider_routing")
+        or _get_nested(payload, "result", "provider_routing")
+        or _get_nested(payload, "metadata", "provider_routing")
+    )
+    if isinstance(provider_routing, dict) and provider_routing:
+        proof["provider_routing"] = provider_routing
+
+    for candidate in (
+        payload.get("total_cost_usd"),
+        _get_nested(payload, "result", "total_cost_usd"),
+        _get_nested(payload, "cost", "total_cost_usd"),
+        _get_nested(payload, "receipt", "cost_summary", "total_cost_usd"),
+        payload.get("cost_usd"),
+        _get_nested(payload, "result", "cost_usd"),
+    ):
+        total_cost_usd = _coerce_float(candidate)
+        if total_cost_usd is not None:
+            proof["total_cost_usd"] = total_cost_usd
+            break
+
+    per_agent_cost = _normalize_float_dict(
+        payload.get("per_agent_cost")
+        or _get_nested(payload, "result", "per_agent_cost")
+        or _get_nested(payload, "cost", "per_agent_cost")
+    )
+    if not per_agent_cost:
+        per_agent_cost = _extract_receipt_per_agent_cost(cost_summary)
+    if per_agent_cost:
+        proof["per_agent_cost"] = per_agent_cost
+
+    return proof or None
+
+
+def _receipt_lookup_candidates(debate_id: str) -> list[str]:
+    candidates = [debate_id]
+    if debate_id and not debate_id.startswith("debate-"):
+        candidates.append(f"debate-{debate_id}")
+    return candidates
+
+
+def build_debate_proof(record: dict[str, Any]) -> dict[str, Any] | None:
+    proof = dict(record.get("proof") or {}) if isinstance(record.get("proof"), dict) else {}
+    debate_id = _coerce_text(record.get("id"))
+    if debate_id is None:
+        return proof or None
+
+    needs_receipt_backfill = any(
+        field not in proof for field in ("receipt_id", "receipt_hash", "total_cost_usd")
+    )
+    if not needs_receipt_backfill:
+        return proof or None
+
+    try:
+        store = _get_receipt_store()
+    except (ImportError, RuntimeError, OSError):
+        return proof or None
+
+    receipt = None
+    for candidate in _receipt_lookup_candidates(debate_id):
+        try:
+            receipt = store.get_by_gauntlet(candidate)
+        except AttributeError:
+            return proof or None
+        if receipt is not None:
+            break
+
+    if receipt is None:
+        return proof or None
+
+    receipt_id = _coerce_text(_get_mapping_value(receipt, "receipt_id"))
+    if receipt_id is not None and "receipt_id" not in proof:
+        proof["receipt_id"] = receipt_id
+
+    receipt_hash = _coerce_text(
+        _get_mapping_value(receipt, "checksum") or _get_mapping_value(receipt, "artifact_hash")
+    )
+    if receipt_hash is not None and "receipt_hash" not in proof:
+        proof["receipt_hash"] = receipt_hash
+
+    receipt_timestamp = _get_mapping_value(receipt, "created_at")
+    if receipt_timestamp is not None and "receipt_timestamp" not in proof:
+        if hasattr(receipt_timestamp, "isoformat"):
+            proof["receipt_timestamp"] = receipt_timestamp.isoformat()
+        else:
+            text = _coerce_text(receipt_timestamp)
+            if text is not None:
+                proof["receipt_timestamp"] = text
+
+    cost_summary = _get_mapping_value(receipt, "cost_summary")
+    if "total_cost_usd" not in proof:
+        total_cost_usd = _find_first_numeric(cost_summary, ("total_cost_usd", "cost_usd"))
+        if total_cost_usd is not None:
+            proof["total_cost_usd"] = total_cost_usd
+
+    if "per_agent_cost" not in proof:
+        per_agent_cost = _extract_receipt_per_agent_cost(cost_summary)
+        if per_agent_cost:
+            proof["per_agent_cost"] = per_agent_cost
+
+    return proof or None
 
 
 def _extract_total_tokens(payload: dict[str, Any] | None) -> int:
@@ -377,6 +636,7 @@ def load_debate_records(storage: Any) -> list[dict[str, Any]]:
                         "task": str(
                             row_map.get("task") or (payload.get("task") if payload else "") or ""
                         ),
+                        "proof": _extract_dashboard_proof(payload),
                         "review_state": review_state,
                         "needs_attention": review_state != "dismissed"
                         and (

--- a/aragora/server/handlers/admin/dashboard_views.py
+++ b/aragora/server/handlers/admin/dashboard_views.py
@@ -24,6 +24,7 @@ from ..base import (
 from ..openapi_decorator import api_endpoint
 from .dashboard_metrics import (
     ACTIVE_DEBATE_STATUSES,
+    build_debate_proof,
     find_debate_record,
     load_debate_records,
     summarize_debate_records,
@@ -295,6 +296,9 @@ class DashboardViewsMixin:
                 detail["rounds_used"] = record["rounds_used"]
             if record.get("duration_seconds") is not None:
                 detail["duration_seconds"] = round(float(record["duration_seconds"]), 3)
+            proof = build_debate_proof(record)
+            if proof:
+                detail["proof"] = proof
             return json_response(detail)
         except (KeyError, ValueError, OSError, TypeError) as e:
             logger.warning("Dashboard debate detail error: %s: %s", type(e).__name__, e)

--- a/tests/handlers/admin/test_dashboard_views.py
+++ b/tests/handlers/admin/test_dashboard_views.py
@@ -28,8 +28,9 @@ from __future__ import annotations
 import json
 import sqlite3
 from contextlib import contextmanager
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -73,16 +74,60 @@ class InMemoryStorage:
                 status TEXT,
                 consensus_reached INTEGER,
                 confidence REAL,
-                created_at TEXT
+                created_at TEXT,
+                artifact_json TEXT,
+                task TEXT,
+                completed_at TEXT
             )"""
         )
         if rows:
-            cur.executemany("INSERT INTO debates VALUES (?, ?, ?, ?, ?, ?)", rows)
+            cur.executemany(
+                """
+                INSERT INTO debates (
+                    id, domain, status, consensus_reached, confidence, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                rows,
+            )
         self._conn.commit()
 
     @contextmanager
     def connection(self):
         yield self._conn
+
+    def insert_debate(
+        self,
+        *,
+        debate_id: str,
+        domain: str | None,
+        status: str,
+        consensus_reached: int,
+        confidence: float,
+        created_at: str,
+        artifact_json: str | None = None,
+        task: str | None = None,
+        completed_at: str | None = None,
+    ) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO debates (
+                id, domain, status, consensus_reached, confidence, created_at,
+                artifact_json, task, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                debate_id,
+                domain,
+                status,
+                consensus_reached,
+                confidence,
+                created_at,
+                artifact_json,
+                task,
+                completed_at,
+            ),
+        )
+        self._conn.commit()
 
 
 class ErrorStorage:
@@ -428,6 +473,93 @@ class TestGetDashboardDebate:
         assert body["domain"] == "finance"
         assert body["status"] == "completed"
         assert body["consensus_reached"] is True
+
+    def test_returns_dashboard_proof_details_from_artifact(self):
+        storage = InMemoryStorage()
+        storage.insert_debate(
+            debate_id="proof-123",
+            domain="ops",
+            status="completed",
+            consensus_reached=1,
+            confidence=0.91,
+            created_at="2026-04-05T12:00:00Z",
+            completed_at="2026-04-05T12:02:30Z",
+            task="Surface truthful proof details",
+            artifact_json=json.dumps(
+                {
+                    "id": "proof-123",
+                    "task": "Surface truthful proof details",
+                    "receipt": {
+                        "receipt_id": "rcpt-123",
+                        "artifact_hash": "sha256:abc123",
+                        "timestamp": "2026-04-05T12:02:31Z",
+                    },
+                    "total_cost_usd": 0.42,
+                    "per_agent_cost": {"claude": 0.24, "gpt-4.1": 0.18},
+                    "metadata": {
+                        "provider": "anthropic",
+                        "provider_route": "anthropic->openai-fallback",
+                    },
+                    "provider_names": ["anthropic", "openai"],
+                    "provider_routing": {"routing_applied": True},
+                }
+            ),
+        )
+        h = TestableHandler(storage=storage)
+
+        result = h._get_dashboard_debate("proof-123")
+
+        body = _body(result)
+        assert _status(result) == 200
+        assert body["proof"] == {
+            "receipt_id": "rcpt-123",
+            "receipt_hash": "sha256:abc123",
+            "receipt_timestamp": "2026-04-05T12:02:31Z",
+            "provider": "anthropic",
+            "provider_route": "anthropic->openai-fallback",
+            "provider_names": ["anthropic", "openai"],
+            "provider_routing": {"routing_applied": True},
+            "total_cost_usd": 0.42,
+            "per_agent_cost": {"claude": 0.24, "gpt-4.1": 0.18},
+        }
+
+    def test_backfills_receipt_store_proof_when_artifact_is_sparse(self):
+        storage = InMemoryStorage(
+            [("receipt-backed", "ops", "completed", 1, 0.78, "2026-04-05T12:00:00Z")]
+        )
+        h = TestableHandler(storage=storage)
+        receipt = SimpleNamespace(
+            receipt_id="rcpt-789",
+            checksum="sha256:receipt-proof",
+            created_at="2026-04-05T12:03:00Z",
+            cost_summary={
+                "total_cost_usd": "0.17",
+                "per_agent": {
+                    "claude": {"total_cost_usd": "0.10"},
+                    "gpt-4.1": {"cost": "0.07"},
+                },
+            },
+        )
+        store = MagicMock()
+        store.get_by_gauntlet.side_effect = lambda candidate: (
+            receipt if candidate == "debate-receipt-backed" else None
+        )
+
+        with patch(
+            "aragora.server.handlers.admin.dashboard_metrics._get_receipt_store",
+            return_value=store,
+        ):
+            result = h._get_dashboard_debate("receipt-backed")
+
+        body = _body(result)
+        assert _status(result) == 200
+        assert body["proof"] == {
+            "receipt_id": "rcpt-789",
+            "receipt_hash": "sha256:receipt-proof",
+            "receipt_timestamp": "2026-04-05T12:03:00Z",
+            "total_cost_usd": 0.17,
+            "per_agent_cost": {"claude": 0.1, "gpt-4.1": 0.07},
+        }
 
     def test_empty_debate_id(self, handler):
         result = handler._get_dashboard_debate("")


### PR DESCRIPTION
## Summary
- preserve receipt, provider, and cost proof metadata when dashboard debate rows are normalized
- backfill receipt and cost proof from the receipt store for sparse stored debates
- add focused dashboard view regressions for artifact-backed and receipt-store-backed proof details

## Validation
- pytest -q tests/handlers/admin/test_dashboard.py tests/handlers/admin/test_dashboard_views.py
- git diff --check