### PR TITLE
feat(swarm): add merge arbiter for unattended PR merging

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -48,6 +48,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "claim-pr",
         "report",
         "findings",
+        "merge-arbiter",
     }:
         return str(first), second
     return "run", first
@@ -1711,6 +1712,34 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             file=sys.stderr,
         )
         sys.exit(1)
+
+    if action == "merge-arbiter":
+        from aragora.swarm.merge_arbiter import MergeArbiter, MergeArbiterConfig
+
+        prefixes_raw = str(getattr(args, "boss_branch_prefix", "") or "boss-harvest,codex/")
+        prefixes = [p.strip() for p in prefixes_raw.split(",") if p.strip()]
+        arbiter_config = MergeArbiterConfig(
+            repo=getattr(args, "boss_repo", None) or "synaptent/aragora",
+            branch_prefixes=prefixes,
+            poll_interval_seconds=float(getattr(args, "interval_seconds", 120.0) or 120.0),
+            max_runtime_hours=float(getattr(args, "max_hours", 12.0) or 12.0),
+            max_consecutive_failures=int(getattr(args, "max_consecutive_failures", 3) or 3),
+            dry_run=bool(getattr(args, "dry_run", False)),
+        )
+        arbiter = MergeArbiter(config=arbiter_config)
+        summary = asyncio.run(arbiter.run())
+        if as_json:
+            print(json.dumps(summary.to_dict(), indent=2))
+        else:
+            print(f"\nMerge arbiter finished: {summary.stop_reason}")
+            print(
+                f"polls={summary.polls} merged={len(summary.merged)} "
+                f"skipped={len(summary.skipped)} failed={len(summary.failed)} "
+                f"elapsed={summary.elapsed_seconds:.1f}s"
+            )
+            if summary.merged:
+                print(f"  merged PRs: {summary.merged}")
+        return
 
     if action == "boss-loop":
         from aragora.swarm.boss_loop import BossLoop, BossLoopConfig

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2299,7 +2299,7 @@ def _add_swarm_parser(subparsers) -> None:
         nargs="?",
         help=(
             "Action (run/status/reconcile/campaign/integrator/tranche/coord/assign/"
-            "claim-pr/report/findings) or your goal in plain language"
+            "claim-pr/report/findings/merge-arbiter) or your goal in plain language"
         ),
     )
     swarm_parser.add_argument(
@@ -2620,6 +2620,13 @@ def _add_swarm_parser(subparsers) -> None:
         type=int,
         default=3,
         help="Stop boss-loop or tranche queue after N consecutive hard failures (default: 3)",
+    )
+    swarm_parser.add_argument(
+        "--branch-prefix",
+        dest="boss_branch_prefix",
+        type=str,
+        default=None,
+        help="Comma-separated branch prefixes for merge-arbiter (default: boss-harvest,codex/)",
     )
     swarm_parser.add_argument(
         "--boss-max-parallel-dispatches",

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -1,0 +1,310 @@
+"""Admin merge arbiter for the boss loop.
+
+Polls open PRs matching configured branch prefixes and auto-merges them
+when all 5 required CI checks pass.  Designed to run alongside the boss
+loop for unattended overnight operation.
+
+Usage:
+    arbiter = MergeArbiter(MergeArbiterConfig(branch_prefixes=["boss-harvest"]))
+    await arbiter.run()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import subprocess
+import time
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_CHECKS: list[str] = [
+    "lint",
+    "typecheck",
+    "sdk-parity",
+    "Generate & Validate",
+    "TypeScript SDK Type Check",
+]
+
+
+@dataclass
+class MergeArbiterConfig:
+    """Configuration for the merge arbiter polling loop."""
+
+    repo: str = "synaptent/aragora"
+    branch_prefixes: list[str] = field(default_factory=lambda: ["boss-harvest", "codex/"])
+    poll_interval_seconds: float = 120.0
+    max_runtime_hours: float = 12.0
+    max_consecutive_failures: int = 3
+    dry_run: bool = False
+
+
+@dataclass
+class MergeResult:
+    """Outcome of a single merge attempt."""
+
+    pr_number: int
+    branch: str
+    success: bool
+    reason: str
+
+
+@dataclass
+class ArbiterSummary:
+    """Final summary when the arbiter exits."""
+
+    merged: list[int] = field(default_factory=list)
+    skipped: list[int] = field(default_factory=list)
+    failed: list[int] = field(default_factory=list)
+    polls: int = 0
+    stop_reason: str = ""
+    elapsed_seconds: float = 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "merged": self.merged,
+            "skipped": self.skipped,
+            "failed": self.failed,
+            "polls": self.polls,
+            "stop_reason": self.stop_reason,
+            "elapsed_seconds": round(self.elapsed_seconds, 1),
+        }
+
+
+def _run_gh(args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
+    """Run a ``gh`` CLI command and return the result."""
+    return subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
+    """Return open PRs whose head branch matches any configured prefix."""
+    result = _run_gh(
+        [
+            "pr",
+            "list",
+            "--repo",
+            config.repo,
+            "--state",
+            "open",
+            "--json",
+            "number,headRefName,isDraft",
+            "--limit",
+            "100",
+        ]
+    )
+    if result.returncode != 0:
+        logger.warning("gh pr list failed: %s", result.stderr.strip())
+        return []
+    try:
+        prs = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Failed to parse gh pr list output")
+        return []
+    candidates = []
+    for pr in prs:
+        branch = pr.get("headRefName", "")
+        if any(branch.startswith(prefix) for prefix in config.branch_prefixes):
+            candidates.append(pr)
+    return candidates
+
+
+def _get_check_status(pr_number: int, repo: str) -> dict[str, str]:
+    """Return a mapping of check-name -> conclusion for a PR.
+
+    Merges both status checks and GitHub Actions check runs.
+    """
+    result = _run_gh(
+        [
+            "pr",
+            "checks",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--json",
+            "name,state",
+        ]
+    )
+    if result.returncode != 0:
+        logger.debug("gh pr checks failed for #%d: %s", pr_number, result.stderr.strip())
+        return {}
+    try:
+        checks = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return {c["name"]: c.get("state", "").upper() for c in checks if "name" in c}
+
+
+def _promote_draft(pr_number: int, repo: str) -> bool:
+    """Convert a draft PR to ready-for-review."""
+    result = _run_gh(
+        [
+            "pr",
+            "ready",
+            str(pr_number),
+            "--repo",
+            repo,
+        ]
+    )
+    if result.returncode != 0:
+        logger.warning("Failed to promote draft PR #%d: %s", pr_number, result.stderr.strip())
+        return False
+    logger.info("Promoted draft PR #%d to ready", pr_number)
+    return True
+
+
+def _merge_pr(pr_number: int, repo: str) -> tuple[bool, str]:
+    """Squash-merge a PR with admin override.  Returns (success, reason)."""
+    result = _run_gh(
+        [
+            "pr",
+            "merge",
+            str(pr_number),
+            "--repo",
+            repo,
+            "--admin",
+            "--squash",
+            "--delete-branch",
+        ]
+    )
+    if result.returncode != 0:
+        reason = result.stderr.strip() or "unknown error"
+        return False, reason
+    return True, "merged"
+
+
+def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
+    """Evaluate a single PR and merge it if all required checks pass."""
+    pr_number: int = pr["number"]
+    branch: str = pr.get("headRefName", "")
+    is_draft: bool = pr.get("isDraft", False)
+
+    if is_draft:
+        if not _promote_draft(pr_number, config.repo):
+            return MergeResult(pr_number, branch, False, "failed to promote draft")
+        # After promoting, checks may not have run yet -- skip this cycle
+        return MergeResult(pr_number, branch, False, "promoted from draft, waiting for checks")
+
+    checks = _get_check_status(pr_number, config.repo)
+    if not checks:
+        return MergeResult(pr_number, branch, False, "no checks found")
+
+    missing = []
+    failing = []
+    for name in REQUIRED_CHECKS:
+        status = checks.get(name)
+        if status is None:
+            missing.append(name)
+        elif status != "SUCCESS":
+            failing.append(f"{name}={status}")
+
+    if missing:
+        return MergeResult(pr_number, branch, False, f"missing checks: {', '.join(missing)}")
+    if failing:
+        return MergeResult(pr_number, branch, False, f"failing checks: {', '.join(failing)}")
+
+    # All required checks pass
+    if config.dry_run:
+        logger.info("[dry-run] Would merge PR #%d (%s)", pr_number, branch)
+        return MergeResult(pr_number, branch, True, "dry-run: would merge")
+
+    ok, reason = _merge_pr(pr_number, config.repo)
+    if ok:
+        logger.info("Merged PR #%d (%s)", pr_number, branch)
+    else:
+        logger.warning("Failed to merge PR #%d: %s", pr_number, reason)
+    return MergeResult(pr_number, branch, ok, reason)
+
+
+class MergeArbiter:
+    """Polling loop that auto-merges boss-loop PRs when CI passes."""
+
+    def __init__(self, config: MergeArbiterConfig | None = None) -> None:
+        self.config = config or MergeArbiterConfig()
+        self._consecutive_failures = 0
+
+    async def run(self) -> ArbiterSummary:
+        """Run the polling loop until max runtime or circuit breaker trips."""
+        summary = ArbiterSummary()
+        start = time.monotonic()
+        deadline = start + self.config.max_runtime_hours * 3600
+
+        logger.info(
+            "Merge arbiter started: repo=%s prefixes=%s interval=%ds max_hours=%.1f dry_run=%s",
+            self.config.repo,
+            self.config.branch_prefixes,
+            int(self.config.poll_interval_seconds),
+            self.config.max_runtime_hours,
+            self.config.dry_run,
+        )
+
+        while time.monotonic() < deadline:
+            summary.polls += 1
+            any_failure_this_poll = False
+            any_merge_this_poll = False
+
+            candidates = _list_candidate_prs(self.config)
+            logger.debug("Poll %d: %d candidate PRs", summary.polls, len(candidates))
+
+            for pr in candidates:
+                result = _evaluate_pr(pr, self.config)
+                if result.success:
+                    summary.merged.append(result.pr_number)
+                    any_merge_this_poll = True
+                    logger.info(
+                        "PR #%d: %s (%s)",
+                        result.pr_number,
+                        result.reason,
+                        result.branch,
+                    )
+                elif "failing" in result.reason or "failed" in result.reason:
+                    summary.failed.append(result.pr_number)
+                    any_failure_this_poll = True
+                    logger.info(
+                        "PR #%d skipped: %s (%s)",
+                        result.pr_number,
+                        result.reason,
+                        result.branch,
+                    )
+                else:
+                    summary.skipped.append(result.pr_number)
+                    logger.debug(
+                        "PR #%d waiting: %s (%s)",
+                        result.pr_number,
+                        result.reason,
+                        result.branch,
+                    )
+
+            # Circuit breaker: track consecutive polls with only failures
+            if any_failure_this_poll and not any_merge_this_poll:
+                self._consecutive_failures += 1
+            else:
+                self._consecutive_failures = 0
+
+            if self._consecutive_failures >= self.config.max_consecutive_failures:
+                summary.stop_reason = (
+                    f"circuit breaker: {self._consecutive_failures} consecutive failure-only polls"
+                )
+                logger.warning("Merge arbiter stopping: %s", summary.stop_reason)
+                break
+
+            await asyncio.sleep(self.config.poll_interval_seconds)
+        else:
+            summary.stop_reason = "max runtime reached"
+
+        summary.elapsed_seconds = time.monotonic() - start
+        logger.info(
+            "Merge arbiter finished: %s (merged=%d skipped=%d failed=%d polls=%d)",
+            summary.stop_reason,
+            len(summary.merged),
+            len(summary.skipped),
+            len(summary.failed),
+            summary.polls,
+        )
+        return summary

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -1,0 +1,264 @@
+"""Tests for the admin merge arbiter."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from aragora.swarm.merge_arbiter import (
+    REQUIRED_CHECKS,
+    ArbiterSummary,
+    MergeArbiter,
+    MergeArbiterConfig,
+    MergeResult,
+    _evaluate_pr,
+    _get_check_status,
+    _list_candidate_prs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_gh_result(stdout: str = "", stderr: str = "", returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _all_passing_checks() -> list[dict]:
+    return [{"name": name, "state": "SUCCESS"} for name in REQUIRED_CHECKS]
+
+
+def _pr(number: int = 1, branch: str = "boss-harvest/fix-1", draft: bool = False) -> dict:
+    return {"number": number, "headRefName": branch, "isDraft": draft}
+
+
+# ---------------------------------------------------------------------------
+# _list_candidate_prs
+# ---------------------------------------------------------------------------
+
+
+class TestListCandidatePrs:
+    def test_filters_by_prefix(self):
+        prs = [
+            _pr(1, "boss-harvest/fix-1"),
+            _pr(2, "codex/task-2"),
+            _pr(3, "dependabot/npm"),
+            _pr(4, "feat/manual-feature"),
+        ]
+        config = MergeArbiterConfig(branch_prefixes=["boss-harvest", "codex/"])
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(stdout=json.dumps(prs))
+            result = _list_candidate_prs(config)
+        assert len(result) == 2
+        assert result[0]["number"] == 1
+        assert result[1]["number"] == 2
+
+    def test_returns_empty_on_gh_failure(self):
+        config = MergeArbiterConfig()
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(returncode=1, stderr="error")
+            assert _list_candidate_prs(config) == []
+
+    def test_returns_empty_on_bad_json(self):
+        config = MergeArbiterConfig()
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(stdout="not json")
+            assert _list_candidate_prs(config) == []
+
+
+# ---------------------------------------------------------------------------
+# _get_check_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetCheckStatus:
+    def test_parses_check_output(self):
+        checks = _all_passing_checks()
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(stdout=json.dumps(checks))
+            result = _get_check_status(1, "owner/repo")
+        assert len(result) == 5
+        for name in REQUIRED_CHECKS:
+            assert result[name] == "SUCCESS"
+
+    def test_returns_empty_on_failure(self):
+        with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
+            mock_gh.return_value = _make_gh_result(returncode=1)
+            assert _get_check_status(1, "owner/repo") == {}
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_pr — all checks passing → merge
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePrAllPassing:
+    def test_merges_when_all_checks_pass(self):
+        config = MergeArbiterConfig()
+        checks = _all_passing_checks()
+        with (
+            patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+            patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
+        ):
+            mock_checks.return_value = {c["name"]: "SUCCESS" for c in checks}
+            mock_merge.return_value = (True, "merged")
+            result = _evaluate_pr(_pr(42, "boss-harvest/ok"), config)
+        assert result.success is True
+        assert result.pr_number == 42
+        mock_merge.assert_called_once_with(42, config.repo)
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_pr — failing check → skipped
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePrFailingCheck:
+    def test_skips_when_check_fails(self):
+        config = MergeArbiterConfig()
+        status = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        status["lint"] = "FAILURE"
+        with patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks:
+            mock_checks.return_value = status
+            result = _evaluate_pr(_pr(10, "boss-harvest/bad"), config)
+        assert result.success is False
+        assert "failing" in result.reason
+        assert "lint" in result.reason
+
+    def test_skips_when_check_missing(self):
+        config = MergeArbiterConfig()
+        # Only return 4 of 5 checks
+        status = dict.fromkeys(REQUIRED_CHECKS[:4], "SUCCESS")
+        with patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks:
+            mock_checks.return_value = status
+            result = _evaluate_pr(_pr(11, "boss-harvest/partial"), config)
+        assert result.success is False
+        assert "missing" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_pr — dry-run mode
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePrDryRun:
+    def test_dry_run_does_not_merge(self):
+        config = MergeArbiterConfig(dry_run=True)
+        checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        with (
+            patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+            patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
+        ):
+            mock_checks.return_value = checks
+            result = _evaluate_pr(_pr(99, "boss-harvest/dry"), config)
+        assert result.success is True
+        assert "dry-run" in result.reason
+        mock_merge.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_pr — draft promotion
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluatePrDraft:
+    def test_promotes_draft_pr(self):
+        config = MergeArbiterConfig()
+        with patch("aragora.swarm.merge_arbiter._promote_draft") as mock_promote:
+            mock_promote.return_value = True
+            result = _evaluate_pr(_pr(5, "boss-harvest/draft", draft=True), config)
+        assert result.success is False
+        assert "promoted" in result.reason
+        mock_promote.assert_called_once_with(5, config.repo)
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    @pytest.mark.asyncio
+    async def test_stops_after_consecutive_failures(self):
+        config = MergeArbiterConfig(
+            max_consecutive_failures=3,
+            poll_interval_seconds=0.01,
+            max_runtime_hours=0.01,
+        )
+        arbiter = MergeArbiter(config=config)
+
+        failing_pr = _pr(1, "boss-harvest/fail")
+        failing_checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        failing_checks["lint"] = "FAILURE"
+
+        call_count = 0
+
+        def fake_list(_cfg):
+            nonlocal call_count
+            call_count += 1
+            return [failing_pr]
+
+        with (
+            patch("aragora.swarm.merge_arbiter._list_candidate_prs", side_effect=fake_list),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value=failing_checks),
+        ):
+            summary = await arbiter.run()
+
+        assert "circuit breaker" in summary.stop_reason
+        assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# ArbiterSummary
+# ---------------------------------------------------------------------------
+
+
+class TestArbiterSummary:
+    def test_to_dict_roundtrip(self):
+        summary = ArbiterSummary(
+            merged=[1, 2],
+            skipped=[3],
+            failed=[4],
+            polls=5,
+            stop_reason="done",
+            elapsed_seconds=123.456,
+        )
+        d = summary.to_dict()
+        assert d["merged"] == [1, 2]
+        assert d["elapsed_seconds"] == 123.5
+        assert d["stop_reason"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Full run with merges
+# ---------------------------------------------------------------------------
+
+
+class TestFullRun:
+    @pytest.mark.asyncio
+    async def test_merges_eligible_pr(self):
+        config = MergeArbiterConfig(
+            poll_interval_seconds=0.01,
+            max_runtime_hours=0.0001,  # Very short — exits after 1 poll
+        )
+        arbiter = MergeArbiter(config=config)
+
+        pr = _pr(7, "boss-harvest/good")
+        checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+
+        with (
+            patch("aragora.swarm.merge_arbiter._list_candidate_prs", return_value=[pr]),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value=checks),
+            patch("aragora.swarm.merge_arbiter._merge_pr", return_value=(True, "merged")),
+        ):
+            summary = await arbiter.run()
+
+        assert 7 in summary.merged
+        assert summary.polls >= 1


### PR DESCRIPTION
## Summary

- Adds `MergeArbiter` (`aragora/swarm/merge_arbiter.py`) that polls open PRs matching configured branch prefixes and auto-merges them via `gh pr merge --admin --squash` when all 5 required CI checks pass
- Wires into CLI as `aragora swarm merge-arbiter` with `--branch-prefix`, `--interval-seconds`, `--max-hours`, `--max-consecutive-failures`, `--dry-run`, and `--boss-repo` flags
- Includes circuit breaker (stops after N consecutive failure-only polls), draft-to-ready promotion, and JSON output mode

## Design decisions

- Uses `gh pr merge --admin --squash --delete-branch` -- explicit admin override policy for boss-loop PRs only
- Only touches PRs whose branch matches the prefix filter (default: `boss-harvest,codex/`); dependabot, manual PRs, etc. are never considered
- Simple polling loop (no daemon) -- run with `nohup` alongside the boss loop
- Draft PRs are promoted to ready on first encounter, then merged on the next poll after checks pass

## Test plan

- [x] 13 unit tests covering all paths (all passing)
- [x] PR with all 5 checks passing gets merged
- [x] PR with failing check is skipped
- [x] PR with missing check is skipped
- [x] Dry-run mode logs but does not merge
- [x] Circuit breaker stops after 3 consecutive failure-only polls
- [x] Draft PR promotion
- [x] Bad JSON / gh CLI failure handled gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)