### PR TITLE
fix(boss-loop): treat published PR as terminal state

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1712,6 +1712,22 @@ class BossLoop:
             )
         return open_boss_prs
 
+    def _has_open_pr_for_issue(self, issue_number: int) -> str | None:
+        """Check if there is already an open boss-loop PR for the given issue.
+
+        Returns the PR URL if found, otherwise ``None``.  Uses the cached
+        ``_list_open_boss_harvest_prs`` results when available — the branch
+        naming convention ``aragora/boss-harvest/issue-{N}`` encodes the issue
+        number so a substring match is sufficient.
+        """
+        open_prs = self._list_open_boss_harvest_prs()
+        suffix = f"issue-{issue_number}"
+        for pr in open_prs:
+            head_ref = str(pr.get("headRefName", ""))
+            if head_ref.endswith(suffix) or f"issue-{issue_number}-" in head_ref:
+                return str(pr.get("url") or "")
+        return None
+
     def _harvest_worker_commits_for_publish(
         self,
         *,
@@ -2663,6 +2679,34 @@ class BossLoop:
                 elapsed_seconds=time.monotonic() - iter_start,
             )
 
+        # Step 3b: Pre-dispatch guard — skip issues that already have an open PR
+        existing_pr = self._has_open_pr_for_issue(selected.number)
+        if existing_pr:
+            logger.info(
+                "boss_loop_skip_existing_pr issue=#%s pr=%s",
+                selected.number,
+                existing_pr,
+            )
+            self._completed_issues.append(self._issue_payload(selected))
+            self._issue_attempt_counts[selected.number] = max(
+                self._issue_attempt_counts.get(selected.number, 0),
+                self.config.max_retries_per_issue,
+            )
+            return BossIterationStatus(
+                iteration=iteration,
+                run_id=self.run_id,
+                timestamp=now,
+                runner_freshness=freshness_dict,
+                selected_issue=self._issue_payload(selected),
+                worker_status="completed",
+                stop_reason=None,
+                needs_human_reasons=[],
+                next_actions=[
+                    f"Skipped: issue #{selected.number} already has open PR {existing_pr}."
+                ],
+                elapsed_seconds=time.monotonic() - iter_start,
+            )
+
         # Step 4: Dispatch supervised work for this issue
         issue_dict = self._issue_payload(selected)
         self._attempted_issues.append(issue_dict)
@@ -3230,7 +3274,49 @@ class BossLoop:
                 worker_result
             )
             has_deliverable = bool(normalized_deliverable_type)
+            pr_url = self._published_pr_url(worker_result)
             self._emit_lane_receipt(worker_result, issue_dict, elapsed_seconds)
+
+            # Published PR = terminal: the worker produced a concrete deliverable
+            # that is now open for human review.  Do NOT retry the issue.
+            if has_deliverable and pr_url:
+                self._completed_issues.append(issue_dict)
+                self._consecutive_failures = 0
+                # Mark the issue as exhausted so it is never re-dispatched in
+                # this loop run.
+                self._issue_attempt_counts[issue_number] = max(
+                    self._issue_attempt_counts.get(issue_number, 0),
+                    self.config.max_retries_per_issue,
+                )
+                self._log_value_outcome(issue_dict, "completed", elapsed_seconds)
+                logger.info(
+                    "boss_loop_terminal_pr issue=#%s pr=%s",
+                    issue_dict.get("number", "?"),
+                    pr_url,
+                )
+                self._append_iteration_metrics(
+                    iteration=iteration,
+                    issue_number=issue_number,
+                    worker_result=worker_result,
+                    elapsed_seconds=elapsed_seconds,
+                )
+                return BossIterationStatus(
+                    iteration=iteration,
+                    run_id=self.run_id,
+                    timestamp=timestamp,
+                    runner_freshness=runner_freshness,
+                    selected_issue=issue_dict,
+                    worker_status="completed",
+                    stop_reason=None,
+                    needs_human_reasons=[],
+                    next_actions=[
+                        f"Terminal: PR {pr_url} published for issue "
+                        f"#{issue_dict.get('number', '?')}. Proceeding to next issue."
+                    ],
+                    elapsed_seconds=elapsed_seconds,
+                    worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
+                )
+
             if self.config.auto_continue_on_needs_human and has_deliverable:
                 self._failed_issues.append(issue_dict)
                 self._consecutive_failures = 0

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -4574,3 +4574,109 @@ class TestPostprocessConvertsToDraft:
         ):
             loop._postprocess_issue_result(issue, worker_result)
         mock_convert.assert_called_once_with(worker_result)
+
+
+# ---------------------------------------------------------------------------
+# Published PR = terminal (no retry)
+# ---------------------------------------------------------------------------
+
+
+class TestPublishedPrTerminal:
+    """When a worker produces a PR, the issue must be terminal for that run."""
+
+    def test_needs_human_with_pr_url_is_terminal_completed(self):
+        """Worker returns needs_human but produced a PR -> completed, not retried."""
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(42, "Implement widget")]
+
+        pr_url = "https://github.com/synaptent/aragora/pull/100"
+
+        async def _dispatch(issue, freshness):
+            return {
+                "status": "needs_human",
+                "reasons": ["Approval required."],
+                "deliverable": {"type": "pr", "pr_url": pr_url},
+                "pr_url": pr_url,
+            }
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=5,
+                max_retries_per_issue=5,
+                auto_continue_on_needs_human=True,
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _dispatch
+
+        result = asyncio.run(loop.run())
+
+        # The issue should be completed, not failed
+        completed_numbers = {i.get("number") for i in result.issues_completed}
+        failed_numbers = {i.get("number") for i in result.issues_failed}
+        assert 42 in completed_numbers, "Issue should be in completed list"
+        assert 42 not in failed_numbers, "Issue should NOT be in failed list"
+
+        # It should have been dispatched exactly once (terminal on first attempt)
+        dispatch_statuses = [
+            s
+            for s in result.iteration_statuses
+            if (s.get("selected_issue") or {}).get("number") == 42
+            and s.get("worker_status") == "completed"
+        ]
+        assert len(dispatch_statuses) == 1, (
+            f"Issue should be dispatched exactly once, got {len(dispatch_statuses)}"
+        )
+
+        # The next_actions should mention the PR URL
+        actions = dispatch_statuses[0].get("next_actions", [])
+        assert any(pr_url in str(a) for a in actions), (
+            f"next_actions should mention PR URL, got {actions}"
+        )
+
+    def test_existing_open_pr_skips_dispatch(self):
+        """Issue with an existing open boss-harvest PR is skipped in dispatch."""
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(42, "Implement widget")]
+
+        dispatch_called = []
+
+        async def _dispatch(issue, freshness):
+            dispatch_called.append(issue.number)
+            return {"status": "completed"}
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=3, repo="synaptent/aragora"),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _dispatch
+
+        # Simulate that an open PR already exists for issue #42
+        existing_pr_url = "https://github.com/synaptent/aragora/pull/200"
+        with patch.object(
+            loop,
+            "_has_open_pr_for_issue",
+            return_value=existing_pr_url,
+        ):
+            result = asyncio.run(loop.run())
+
+        # Dispatch should never have been called
+        assert 42 not in dispatch_called, "Issue with existing PR should not be dispatched"
+
+        # The issue should be marked completed
+        completed_numbers = {i.get("number") for i in result.issues_completed}
+        assert 42 in completed_numbers, "Issue should be in completed list"
+
+        # The iteration status should mention the existing PR
+        skipped = [
+            s
+            for s in result.iteration_statuses
+            if (s.get("selected_issue") or {}).get("number") == 42
+        ]
+        assert len(skipped) >= 1
+        actions = skipped[0].get("next_actions", [])
+        assert any(existing_pr_url in str(a) for a in actions), (
+            f"next_actions should mention existing PR, got {actions}"
+        )


### PR DESCRIPTION
## Summary

- **Published PR = terminal**: When a worker returns `needs_human` but has produced a PR URL, the issue is now marked as **completed** (not failed). The attempt count is maxed out so the issue is never re-dispatched in the same loop run.
- **Pre-dispatch guard**: Before dispatching any issue, `_has_open_pr_for_issue()` checks if a boss-harvest PR already exists for it. If so, the issue is skipped and marked completed.
- **Clear logging**: `boss_loop_terminal_pr issue=#N pr=URL` when a PR makes an issue terminal, `boss_loop_skip_existing_pr issue=#N pr=URL` when an existing PR causes a skip.

**Root cause**: Overnight the boss loop burned 79/80 attempts retrying issues that already had open PRs, because `needs_human` + deliverable was appended to `_failed_issues` instead of `_completed_issues`.

## Test plan

- [x] `test_needs_human_with_pr_url_is_terminal_completed` — worker produces PR URL, issue marked completed not retried
- [x] `test_existing_open_pr_skips_dispatch` — issue with existing open PR is skipped in dispatch
- [x] All 161 existing `test_boss_loop.py` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)