### PR TITLE
fix: resolve issues #2576-#2580

### DIFF
--- a/aragora/rbac/approvals.py
+++ b/aragora/rbac/approvals.py
@@ -717,9 +717,6 @@ class ApprovalWorkflow:
         ) as e:
             logger.warning("Error finding default approvers: %s", e)
             return []
-        except Exception as e:  # noqa: BLE001 - avoid breaking approval flow on unexpected checker failures
-            logger.warning("Unexpected error finding default approvers: %s", e)
-            return []
 
     async def _grant_temporary_permission(self, request: ApprovalRequest) -> None:
         """


### PR DESCRIPTION
## Summary
- remove the final broad fallback from the RBAC approval default-approver lookup
- verified that #2576, #2577, #2579, and #2580 were already fixed on `main` and closed them with grep evidence

## Validation
- python3 -m ruff check aragora/rbac/approvals.py
- python3 -m ruff format --check aragora/rbac/approvals.py
- python3 -c "import ast; ast.parse(open("aragora/rbac/approvals.py").read()); print("OK")"
- python3 -m ruff check aragora/ --select F821,F811 | head -5
- python3 -c "import sys; sys.path.insert(0, "/Users/armand/Development/aragora-factory-1775571063"); import aragora; print("import OK")"