### PR TITLE
fix: harden handler input validation

### DIFF
--- a/aragora/server/handlers/accounting.py
+++ b/aragora/server/handlers/accounting.py
@@ -715,7 +715,18 @@ async def handle_accounting_report(request: web.Request) -> web.Response:
         start_date_str = data.get("start_date")
         end_date_str = data.get("end_date")
 
-        if not start_date_str or not end_date_str:
+        if start_date_str is None or end_date_str is None:
+            return web.json_response(
+                {
+                    "error": "start_date and end_date are required",
+                },
+                status=400,
+            )
+        if not isinstance(start_date_str, str) or not isinstance(end_date_str, str):
+            return web.json_response(
+                {"error": "Invalid date range or format. Use ISO 8601."}, status=400
+            )
+        if not start_date_str.strip() or not end_date_str.strip():
             return web.json_response(
                 {
                     "error": "start_date and end_date are required",
@@ -1317,13 +1328,58 @@ async def handle_gusto_journal_entry(request: web.Request) -> web.Response:
                 status=400,
             )
         for key, value in raw_mappings.items():
+            if not isinstance(key, str) or not key.strip():
+                return web.json_response(
+                    {
+                        "error": "account_mappings entries must contain string account references",
+                    },
+                    status=400,
+                )
             if isinstance(value, dict):
                 account_id = value.get("account_id") or value.get("id")
                 account_name = value.get("account_name") or value.get("name")
-                if account_id and account_name:
-                    account_mappings[key] = (str(account_id), str(account_name))
-            elif isinstance(value, (list, tuple)) and len(value) == 2:
-                account_mappings[key] = (str(value[0]), str(value[1]))
+                if (
+                    not isinstance(account_id, str)
+                    or not account_id.strip()
+                    or not isinstance(account_name, str)
+                    or not account_name.strip()
+                ):
+                    return web.json_response(
+                        {
+                            "error": "account_mappings entries must contain string account references",
+                        },
+                        status=400,
+                    )
+                account_mappings[key] = (account_id, account_name)
+            elif isinstance(value, (list, tuple)):
+                if len(value) != 2:
+                    return web.json_response(
+                        {
+                            "error": "account_mappings entries must contain string account references",
+                        },
+                        status=400,
+                    )
+                account_id, account_name = value
+                if (
+                    not isinstance(account_id, str)
+                    or not account_id.strip()
+                    or not isinstance(account_name, str)
+                    or not account_name.strip()
+                ):
+                    return web.json_response(
+                        {
+                            "error": "account_mappings entries must contain string account references",
+                        },
+                        status=400,
+                    )
+                account_mappings[key] = (account_id, account_name)
+            else:
+                return web.json_response(
+                    {
+                        "error": "account_mappings entries must contain string account references",
+                    },
+                    status=400,
+                )
 
         payroll = await connector.get_payroll(payroll_id)
         if not payroll:

--- a/aragora/server/handlers/budgets.py
+++ b/aragora/server/handlers/budgets.py
@@ -435,6 +435,8 @@ class BudgetHandler(BaseHandler):
             body = self.read_json_body(handler)
             if not body:
                 return error_response("Invalid request body", 400)
+            if not isinstance(body, dict):
+                return error_response("Request body must be a JSON object", 400)
 
             # Validate name
             name = body.get("name")
@@ -560,6 +562,8 @@ class BudgetHandler(BaseHandler):
             body = self.read_json_body(handler)
             if not body:
                 return error_response("Invalid request body", 400)
+            if not isinstance(body, dict):
+                return error_response("Request body must be a JSON object", 400)
 
             # Validate name if provided
             name = body.get("name")
@@ -704,6 +708,8 @@ class BudgetHandler(BaseHandler):
             body = self.read_json_body(handler)
             if not body:
                 return error_response("Invalid request body", 400)
+            if not isinstance(body, dict):
+                return error_response("Request body must be a JSON object", 400)
 
             estimated_cost = body.get("estimated_cost_usd", 0)
             try:
@@ -813,6 +819,8 @@ class BudgetHandler(BaseHandler):
             body = self.read_json_body(handler)
             if not body:
                 return error_response("Invalid request body", 400)
+            if not isinstance(body, dict):
+                return error_response("Request body must be a JSON object", 400)
 
             target_user_id = body.get("user_id")
             if not target_user_id:

--- a/aragora/server/handlers/cloud_storage.py
+++ b/aragora/server/handlers/cloud_storage.py
@@ -546,7 +546,11 @@ class CloudStorageHandler(BaseHandler):
         handler: Any,
     ) -> HandlerResult | None:
         """Route POST requests to appropriate handler method."""
-        body = self.read_json_body(handler) or {}
+        body = self.read_json_body(handler)
+        if body is None:
+            body = {}
+        elif not isinstance(body, dict):
+            return error_response("Request body must be a JSON object", 400)
         query_params = query_params or {}
 
         try:


### PR DESCRIPTION
## Summary
- harden `accounting.py` so malformed report dates and journal-entry account mappings fail fast with 400s instead of falling through to 500s
- reject truthy non-object JSON payloads in the budgets write handlers and the cloud storage POST dispatcher before downstream `.get()` calls
- issue #2583 and issue #2584 were already fixed on `main` and were closed separately with code-line evidence

## Validation
- python3 -m ruff check aragora/server/handlers/accounting.py aragora/server/handlers/budgets.py aragora/server/handlers/cloud_storage.py
- python3 -c "import ast; ast.parse(open("aragora/server/handlers/accounting.py").read()); import ast as _ast; _ast.parse(open("aragora/server/handlers/budgets.py").read()); _ast.parse(open("aragora/server/handlers/cloud_storage.py").read())"
- python3 -m pytest tests/handlers/test_accounting.py -x -q
- python3 -m pytest tests/server/handlers/test_accounting.py -x -q
- python3 -m pytest tests/handlers/test_budgets.py -x -q
- python3 -m pytest tests/handlers/test_cloud_storage.py -x -q
- python3 -m pytest tests/handlers/test_audience_suggestions.py -x -q

Closes #2581
Closes #2582
Closes #2585