### PR TITLE
feat(swarm): add initiative registry planner

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -41,6 +41,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "status",
         "reconcile",
         "campaign",
+        "initiative",
         "integrator",
         "tranche",
         "coord",
@@ -99,6 +100,51 @@ def _print_table(
     print("  ".join("-" * widths[key] for key, _label in headers))
     for row in rows:
         print("  ".join(str(row.get(key, "") or "").ljust(widths[key]) for key, _label in headers))
+
+
+def _initiative_rows(items: list[object]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for item in items:
+        rows.append(
+            {
+                "initiative_id": getattr(item, "initiative_id", "") or "",
+                "status": getattr(item, "status", "") or "",
+                "feature_flag": getattr(item, "feature_flag_name", "") or "-",
+                "slices": len(getattr(item, "slices", []) or []),
+                "title": getattr(item, "title", "") or "",
+                "updated_at": getattr(item, "updated_at", "") or "",
+            }
+        )
+    return rows
+
+
+def _render_initiative(item: object) -> None:
+    print(f"initiative_id={getattr(item, 'initiative_id', '')}")
+    print(f"title={getattr(item, 'title', '')}")
+    print(f"status={getattr(item, 'status', '')}")
+    feature_flag = getattr(item, "feature_flag_name", None)
+    if feature_flag:
+        print(f"feature_flag={feature_flag}")
+    dependencies = [
+        str(value).strip() for value in getattr(item, "dependencies", []) if str(value).strip()
+    ]
+    validations = [
+        str(value).strip() for value in getattr(item, "validations", []) if str(value).strip()
+    ]
+    if dependencies:
+        print(f"dependencies={', '.join(dependencies)}")
+    if validations:
+        print(f"validations={', '.join(validations)}")
+    print(f"slices={len(getattr(item, 'slices', []) or [])}")
+    for slice_item in getattr(item, "slices", [])[:5]:
+        print(
+            "  slice {slice_id} status={status} complexity={complexity} title={title}".format(
+                slice_id=getattr(slice_item, "slice_id", ""),
+                status=getattr(slice_item, "status", ""),
+                complexity=getattr(slice_item, "estimated_complexity", ""),
+                title=getattr(slice_item, "title", ""),
+            )
+        )
 
 
 def _coordination_session_id(args: argparse.Namespace) -> str:
@@ -1192,6 +1238,116 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                         message=finding.get("message", ""),
                     )
                 )
+        return
+
+    if action == "initiative":
+        from aragora.swarm.initiative_planner import InitiativePlanner
+        from aragora.swarm.initiative_store import InitiativeStore
+
+        subaction = str(goal or "list").strip().lower() or "list"
+        if subaction not in {"plan", "show", "list"}:
+            raise ValueError("initiative action must be one of: plan, show, list")
+
+        repo_root = resolve_repo_root(Path.cwd())
+        initiative_dir = _optional_text(getattr(args, "initiative_dir", None))
+        state_dir = Path(initiative_dir).expanduser().resolve() if initiative_dir else None
+        store = InitiativeStore(repo_root=repo_root, state_dir=state_dir)
+
+        if subaction == "list":
+            items = store.list()
+            payload = {
+                "mode": "initiative-list",
+                "action": subaction,
+                "count": len(items),
+                "items": [item.to_dict() for item in items],
+                "state_dir": str(store.state_dir),
+            }
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                print(f"initiatives={len(items)} state_dir={store.state_dir}")
+                _print_table(
+                    [
+                        ("initiative_id", "Initiative"),
+                        ("status", "Status"),
+                        ("feature_flag", "Feature Flag"),
+                        ("slices", "Slices"),
+                        ("title", "Title"),
+                    ],
+                    _initiative_rows(items),
+                )
+            return
+
+        initiative_id = _optional_text(getattr(args, "swarm_campaign_target", None))
+        if subaction == "show":
+            if not initiative_id:
+                raise ValueError("initiative show requires an initiative id as the third argument")
+            item = store.get(initiative_id)
+            if item is None:
+                raise FileNotFoundError(f"initiative not found: {initiative_id}")
+            payload = {
+                "mode": "initiative-show",
+                "action": subaction,
+                "initiative": item.to_dict(),
+                "state_dir": str(store.state_dir),
+            }
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                _render_initiative(item)
+            return
+
+        goal_text = initiative_id
+        if not goal_text:
+            raise ValueError("initiative plan requires a goal as the third argument")
+        rationale = ""
+        source_file = _optional_text(getattr(args, "source_file", None))
+        if source_file:
+            rationale = Path(source_file).expanduser().resolve().read_text().strip()
+        planner = InitiativePlanner(repo_root=repo_root)
+        initiative = planner.plan(
+            goal=goal_text,
+            rationale=rationale,
+            dependencies=[
+                str(item).strip()
+                for item in (getattr(args, "dependency", None) or [])
+                if str(item).strip()
+            ],
+            validations=[
+                str(item).strip()
+                for item in (getattr(args, "validation", None) or [])
+                if str(item).strip()
+            ],
+            feature_flag_name=_optional_text(getattr(args, "feature_flag", None)),
+            milestone_titles=[
+                str(item).strip()
+                for item in (getattr(args, "milestone", None) or [])
+                if str(item).strip()
+            ],
+            checkpoint_titles=[
+                str(item).strip()
+                for item in (getattr(args, "checkpoint", None) or [])
+                if str(item).strip()
+            ],
+            planner_strategy=str(getattr(args, "planner_strategy", "heuristic") or "heuristic"),
+            planner_model=str(getattr(args, "planner_model", "claude") or "claude"),
+        )
+        if source_file:
+            initiative.metadata["source_file"] = str(Path(source_file).expanduser().resolve())
+        saved_path = store.save(initiative)
+        payload = {
+            "mode": "initiative-plan",
+            "action": subaction,
+            "initiative": initiative.to_dict(),
+            "path": str(saved_path),
+            "state_dir": str(store.state_dir),
+        }
+        if as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"initiative_id={initiative.initiative_id}")
+            print(f"path={saved_path}")
+            print(f"slices={len(initiative.slices)}")
         return
 
     if action == "runner":

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2298,7 +2298,7 @@ def _add_swarm_parser(subparsers) -> None:
         "swarm_action_or_goal",
         nargs="?",
         help=(
-            "Action (run/status/reconcile/campaign/integrator/tranche/coord/assign/"
+            "Action (run/status/reconcile/campaign/initiative/integrator/tranche/coord/assign/"
             "claim-pr/report/findings/merge-arbiter) or your goal in plain language"
         ),
     )
@@ -2641,7 +2641,41 @@ def _add_swarm_parser(subparsers) -> None:
     )
     swarm_parser.add_argument(
         "--source-file",
-        help="Campaign planner input markdown/text file",
+        help="Campaign planner or initiative rationale input markdown/text file",
+    )
+    swarm_parser.add_argument(
+        "--initiative-dir",
+        default=None,
+        help="Local initiative artifact directory for 'swarm initiative' commands",
+    )
+    swarm_parser.add_argument(
+        "--feature-flag",
+        default=None,
+        help="Feature flag name to persist on an initiative plan",
+    )
+    swarm_parser.add_argument(
+        "--dependency",
+        action="append",
+        default=None,
+        help="Dependency to persist on an initiative plan (repeatable)",
+    )
+    swarm_parser.add_argument(
+        "--validation",
+        action="append",
+        default=None,
+        help="Validation command to persist on an initiative plan (repeatable)",
+    )
+    swarm_parser.add_argument(
+        "--milestone",
+        action="append",
+        default=None,
+        help="Milestone title to persist on an initiative plan (repeatable)",
+    )
+    swarm_parser.add_argument(
+        "--checkpoint",
+        action="append",
+        default=None,
+        help="Checkpoint title to persist on an initiative plan (repeatable)",
     )
     swarm_parser.add_argument(
         "--issue-list",

--- a/aragora/pipeline/receipt_gate.py
+++ b/aragora/pipeline/receipt_gate.py
@@ -33,6 +33,8 @@ _HUMAN_OVERRIDE_REASON_CODES = frozenset(
         "untrusted_intake_tier",
     }
 )
+_MISSING = object()
+_TRUE_FLAG_VALUES = frozenset({"true", "1", "yes", "on"})
 
 
 class PlanReceiptGateError(RuntimeError):
@@ -129,6 +131,18 @@ def _list_of_strings(value: Any) -> list[str]:
     return []
 
 
+def _parse_fail_closed_flag(value: Any, *, default: bool = False) -> bool:
+    if value is _MISSING:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in _TRUE_FLAG_VALUES
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    return False
+
+
 def _resolve_backbone_run(plan: Any, plan_store: Any | None = None) -> Any | None:
     metadata = _metadata(plan)
     run_id = str(metadata.get("backbone_run_id", "") or "").strip()
@@ -183,7 +197,10 @@ def evaluate_plan_execution_gate(
         gate = {}
 
     reason_codes = _list_of_strings(gate.get("reason_codes"))
-    allow_auto_execution = bool(gate.get("allow_auto_execution", True))
+    allow_auto_execution = _parse_fail_closed_flag(
+        gate.get("allow_auto_execution", _MISSING),
+        default=True,
+    )
     if "gate_evaluation_failed" in reason_codes:
         allow_auto_execution = False
 
@@ -293,9 +310,9 @@ def _synthetic_debate_result(plan: Any) -> Any:
         or metadata.get("decision_confidence")
         or 0.0
     )
-    consensus_reached = bool(deliberation.get("consensus_reached"))
+    consensus_reached = _parse_fail_closed_flag(deliberation.get("consensus_reached", _MISSING))
     if not consensus_reached:
-        consensus_reached = bool(signed_consensus.get("reached"))
+        consensus_reached = _parse_fail_closed_flag(signed_consensus.get("reached", _MISSING))
 
     return SimpleNamespace(
         debate_id=str(getattr(plan, "debate_id", "") or getattr(plan, "id", "")),

--- a/aragora/swarm/initiative_models.py
+++ b/aragora/swarm/initiative_models.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from aragora.pipeline.decision_plan.core import PlanStatus
+
+
+DEFAULT_PLAN_STATUS = PlanStatus.CREATED.value
+
+
+def utcnow_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class InitiativeSlice:
+    slice_id: str
+    title: str
+    description: str
+    dependencies: list[str] = field(default_factory=list)
+    file_scope: list[str] = field(default_factory=list)
+    acceptance_criteria: list[str] = field(default_factory=list)
+    validations: list[str] = field(default_factory=list)
+    estimated_complexity: str = "medium"
+    status: str = DEFAULT_PLAN_STATUS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "slice_id": self.slice_id,
+            "title": self.title,
+            "description": self.description,
+            "dependencies": list(self.dependencies),
+            "file_scope": list(self.file_scope),
+            "acceptance_criteria": list(self.acceptance_criteria),
+            "validations": list(self.validations),
+            "estimated_complexity": self.estimated_complexity,
+            "status": self.status,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> InitiativeSlice:
+        return cls(
+            slice_id=str(payload.get("slice_id", "") or "").strip(),
+            title=str(payload.get("title", "") or "").strip(),
+            description=str(payload.get("description", "") or "").strip(),
+            dependencies=[
+                str(item).strip() for item in payload.get("dependencies", []) if str(item).strip()
+            ],
+            file_scope=[
+                str(item).strip() for item in payload.get("file_scope", []) if str(item).strip()
+            ],
+            acceptance_criteria=[
+                str(item).strip()
+                for item in payload.get("acceptance_criteria", [])
+                if str(item).strip()
+            ],
+            validations=[
+                str(item).strip() for item in payload.get("validations", []) if str(item).strip()
+            ],
+            estimated_complexity=str(
+                payload.get("estimated_complexity", "medium") or "medium"
+            ).strip()
+            or "medium",
+            status=str(payload.get("status", DEFAULT_PLAN_STATUS) or DEFAULT_PLAN_STATUS).strip()
+            or DEFAULT_PLAN_STATUS,
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+@dataclass
+class InitiativeCheckpoint:
+    checkpoint_id: str
+    title: str
+    description: str = ""
+    dependencies: list[str] = field(default_factory=list)
+    validations: list[str] = field(default_factory=list)
+    status: str = DEFAULT_PLAN_STATUS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "checkpoint_id": self.checkpoint_id,
+            "title": self.title,
+            "description": self.description,
+            "dependencies": list(self.dependencies),
+            "validations": list(self.validations),
+            "status": self.status,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> InitiativeCheckpoint:
+        return cls(
+            checkpoint_id=str(payload.get("checkpoint_id", "") or "").strip(),
+            title=str(payload.get("title", "") or "").strip(),
+            description=str(payload.get("description", "") or "").strip(),
+            dependencies=[
+                str(item).strip() for item in payload.get("dependencies", []) if str(item).strip()
+            ],
+            validations=[
+                str(item).strip() for item in payload.get("validations", []) if str(item).strip()
+            ],
+            status=str(payload.get("status", DEFAULT_PLAN_STATUS) or DEFAULT_PLAN_STATUS).strip()
+            or DEFAULT_PLAN_STATUS,
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+@dataclass
+class InitiativeMilestone:
+    milestone_id: str
+    title: str
+    description: str = ""
+    slice_ids: list[str] = field(default_factory=list)
+    checkpoint_ids: list[str] = field(default_factory=list)
+    status: str = DEFAULT_PLAN_STATUS
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "milestone_id": self.milestone_id,
+            "title": self.title,
+            "description": self.description,
+            "slice_ids": list(self.slice_ids),
+            "checkpoint_ids": list(self.checkpoint_ids),
+            "status": self.status,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> InitiativeMilestone:
+        return cls(
+            milestone_id=str(payload.get("milestone_id", "") or "").strip(),
+            title=str(payload.get("title", "") or "").strip(),
+            description=str(payload.get("description", "") or "").strip(),
+            slice_ids=[
+                str(item).strip() for item in payload.get("slice_ids", []) if str(item).strip()
+            ],
+            checkpoint_ids=[
+                str(item).strip() for item in payload.get("checkpoint_ids", []) if str(item).strip()
+            ],
+            status=str(payload.get("status", DEFAULT_PLAN_STATUS) or DEFAULT_PLAN_STATUS).strip()
+            or DEFAULT_PLAN_STATUS,
+            metadata=dict(payload.get("metadata") or {}),
+        )
+
+
+@dataclass
+class InitiativeRecord:
+    initiative_id: str
+    title: str
+    goal: str
+    rationale: str
+    slices: list[InitiativeSlice] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
+    validations: list[str] = field(default_factory=list)
+    feature_flag_name: str | None = None
+    milestones: list[InitiativeMilestone] = field(default_factory=list)
+    checkpoints: list[InitiativeCheckpoint] = field(default_factory=list)
+    status: str = DEFAULT_PLAN_STATUS
+    planner_rationale: str = ""
+    created_at: str = field(default_factory=utcnow_iso)
+    updated_at: str = field(default_factory=utcnow_iso)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def touch(self) -> None:
+        self.updated_at = utcnow_iso()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "initiative_id": self.initiative_id,
+            "title": self.title,
+            "goal": self.goal,
+            "rationale": self.rationale,
+            "slices": [item.to_dict() for item in self.slices],
+            "dependencies": list(self.dependencies),
+            "validations": list(self.validations),
+            "feature_flag_name": self.feature_flag_name,
+            "milestones": [item.to_dict() for item in self.milestones],
+            "checkpoints": [item.to_dict() for item in self.checkpoints],
+            "status": self.status,
+            "planner_rationale": self.planner_rationale,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "metadata": dict(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> InitiativeRecord:
+        return cls(
+            initiative_id=str(payload.get("initiative_id", "") or "").strip(),
+            title=str(payload.get("title", "") or "").strip(),
+            goal=str(payload.get("goal", "") or "").strip(),
+            rationale=str(payload.get("rationale", "") or "").strip(),
+            slices=[
+                InitiativeSlice.from_dict(item)
+                for item in payload.get("slices", [])
+                if isinstance(item, dict)
+            ],
+            dependencies=[
+                str(item).strip() for item in payload.get("dependencies", []) if str(item).strip()
+            ],
+            validations=[
+                str(item).strip() for item in payload.get("validations", []) if str(item).strip()
+            ],
+            feature_flag_name=(str(payload.get("feature_flag_name", "") or "").strip() or None),
+            milestones=[
+                InitiativeMilestone.from_dict(item)
+                for item in payload.get("milestones", [])
+                if isinstance(item, dict)
+            ],
+            checkpoints=[
+                InitiativeCheckpoint.from_dict(item)
+                for item in payload.get("checkpoints", [])
+                if isinstance(item, dict)
+            ],
+            status=str(payload.get("status", DEFAULT_PLAN_STATUS) or DEFAULT_PLAN_STATUS).strip()
+            or DEFAULT_PLAN_STATUS,
+            planner_rationale=str(payload.get("planner_rationale", "") or "").strip(),
+            created_at=str(payload.get("created_at", "") or "").strip() or utcnow_iso(),
+            updated_at=str(payload.get("updated_at", "") or "").strip() or utcnow_iso(),
+            metadata=dict(payload.get("metadata") or {}),
+        )

--- a/aragora/swarm/initiative_planner.py
+++ b/aragora/swarm/initiative_planner.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
+from aragora.pipeline.decision_plan.core import PlanStatus
+from aragora.swarm.initiative_models import (
+    InitiativeCheckpoint,
+    InitiativeMilestone,
+    InitiativeRecord,
+    InitiativeSlice,
+)
+from aragora.swarm.spec import SwarmSpec
+
+
+_SLUG_PATTERN = re.compile(r"[^a-z0-9]+")
+
+
+def _text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(item for item in [_text(value) for value in values] if item))
+
+
+def _slugify(value: str) -> str:
+    normalized = _SLUG_PATTERN.sub("-", value.lower()).strip("-")
+    return normalized or f"initiative-{uuid4().hex[:8]}"
+
+
+def _initiative_id(title: str) -> str:
+    return _slugify(title)
+
+
+def _derive_title(goal: str) -> str:
+    cleaned = " ".join(str(goal or "").split()).strip(" -:_")
+    if not cleaned:
+        return "Untitled initiative"
+    return cleaned[:120]
+
+
+def _feature_flag_name_for_title(title: str) -> str:
+    return f"initiative_{_slugify(title).replace('-', '_')}"
+
+
+def _success_criteria_lines(success_criteria: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for key, value in success_criteria.items():
+        lowered = str(key).strip().lower()
+        if lowered == "tests":
+            continue
+        if isinstance(value, list):
+            lines.extend(f"{key}: {str(item).strip()}" for item in value if str(item).strip())
+            continue
+        if isinstance(value, dict):
+            for nested_key, nested_value in value.items():
+                nested_text = _text(nested_value)
+                if nested_text:
+                    lines.append(f"{key}.{nested_key}: {nested_text}")
+            continue
+        text = _text(value)
+        if text:
+            lines.append(f"{key}: {text}")
+    return _dedupe(lines)
+
+
+def _validation_commands(success_criteria: dict[str, Any], fallback: list[str]) -> list[str]:
+    tests_value = success_criteria.get("tests")
+    commands: list[str] = []
+    if isinstance(tests_value, str) and tests_value.strip():
+        commands.append(tests_value.strip())
+    elif isinstance(tests_value, list):
+        commands.extend(str(item).strip() for item in tests_value if str(item).strip())
+    return _dedupe(commands or fallback)
+
+
+def _slice_from_subtask(
+    subtask: SubTask,
+    *,
+    fallback_validations: list[str],
+) -> InitiativeSlice:
+    acceptance_criteria = _success_criteria_lines(subtask.success_criteria)
+    validations = _validation_commands(subtask.success_criteria, fallback_validations)
+    if not acceptance_criteria and validations:
+        acceptance_criteria = [f"Run and satisfy: {command}" for command in validations]
+    if not acceptance_criteria:
+        acceptance_criteria = [f"Complete the bounded slice '{subtask.title}'."]
+    return InitiativeSlice(
+        slice_id=_text(subtask.id) or f"slice-{uuid4().hex[:8]}",
+        title=_text(subtask.title) or "Untitled slice",
+        description=_text(subtask.description) or (_text(subtask.title) or "Untitled slice"),
+        dependencies=_dedupe(list(subtask.dependencies)),
+        file_scope=_dedupe(list(subtask.file_scope)),
+        acceptance_criteria=acceptance_criteria,
+        validations=validations,
+        estimated_complexity=_text(subtask.estimated_complexity) or "medium",
+        status=PlanStatus.CREATED.value,
+        metadata={"depth": int(getattr(subtask, "depth", 0) or 0)},
+    )
+
+
+def _default_checkpoint_title(slice_title: str) -> str:
+    return f"Checkpoint: {slice_title}"
+
+
+class InitiativePlanner:
+    """Builds persistent roadmap initiatives from bounded decomposition."""
+
+    def __init__(
+        self, *, repo_root: Path | None = None, decomposer: TaskDecomposer | None = None
+    ) -> None:
+        self.repo_root = Path(repo_root or Path.cwd()).resolve()
+        self.decomposer = decomposer or TaskDecomposer()
+
+    def plan(
+        self,
+        *,
+        goal: str,
+        rationale: str = "",
+        title: str | None = None,
+        dependencies: list[str] | None = None,
+        validations: list[str] | None = None,
+        feature_flag_name: str | None = None,
+        milestone_titles: list[str] | None = None,
+        checkpoint_titles: list[str] | None = None,
+        planner_strategy: str = "heuristic",
+        planner_model: str = "claude",
+        status: str = PlanStatus.CREATED.value,
+    ) -> InitiativeRecord:
+        goal_text = _text(goal)
+        if not goal_text:
+            raise ValueError("goal is required")
+        title_text = _text(title) or _derive_title(goal_text)
+        rationale_text = _text(rationale) or goal_text
+        dependency_values = _dedupe(list(dependencies or []))
+        validation_values = _dedupe(list(validations or []))
+        file_scope_hints = SwarmSpec.infer_file_scope_hints("\n".join([goal_text, rationale_text]))
+
+        decomposition = self._decompose(
+            rationale_text=rationale_text,
+            validation_values=validation_values,
+            dependency_values=dependency_values,
+            file_scope_hints=file_scope_hints,
+            planner_strategy=planner_strategy,
+            planner_model=planner_model,
+        )
+        subtasks = list(decomposition.subtasks)
+        if not subtasks:
+            subtasks = [
+                SubTask(
+                    id="slice-1",
+                    title=title_text,
+                    description=rationale_text,
+                    file_scope=list(file_scope_hints),
+                    success_criteria={"tests": list(validation_values)},
+                )
+            ]
+        slices = [
+            _slice_from_subtask(subtask, fallback_validations=validation_values)
+            for subtask in subtasks
+        ]
+        if not slices:
+            raise ValueError("initiative planner produced no slices")
+
+        combined_validations = _dedupe(
+            validation_values + [command for item in slices for command in item.validations]
+        )
+        checkpoints = self._build_checkpoints(slices, checkpoint_titles or [])
+        milestones = self._build_milestones(slices, checkpoints, milestone_titles or [])
+
+        return InitiativeRecord(
+            initiative_id=_initiative_id(title_text),
+            title=title_text,
+            goal=goal_text,
+            rationale=rationale_text,
+            slices=slices,
+            dependencies=dependency_values,
+            validations=combined_validations,
+            feature_flag_name=_text(feature_flag_name) or _feature_flag_name_for_title(title_text),
+            milestones=milestones,
+            checkpoints=checkpoints,
+            status=_text(status) or PlanStatus.CREATED.value,
+            planner_rationale=_text(decomposition.rationale) or "",
+            metadata={
+                "planner_strategy": planner_strategy,
+                "planner_model": planner_model if planner_strategy == "model" else None,
+                "complexity_score": decomposition.complexity_score,
+                "complexity_level": decomposition.complexity_level,
+                "should_decompose": decomposition.should_decompose,
+            },
+        )
+
+    def _decompose(
+        self,
+        rationale_text: str,
+        validation_values: list[str],
+        dependency_values: list[str],
+        file_scope_hints: list[str],
+        planner_strategy: str,
+        planner_model: str,
+    ):
+        acceptance = [f"Run and satisfy: {command}" for command in validation_values]
+        constraints = [f"Respect dependency: {item}" for item in dependency_values]
+        if planner_strategy == "model":
+            return self.decomposer.analyze_with_model_sync(
+                rationale_text,
+                planner_model=planner_model,
+                file_scope_hints=file_scope_hints or None,
+                acceptance_criteria=acceptance or None,
+                constraints=constraints or None,
+            )
+        return self.decomposer.analyze(
+            rationale_text,
+            file_scope_hints=file_scope_hints or None,
+            acceptance_criteria=acceptance or None,
+            constraints=constraints or None,
+        )
+
+    def _build_checkpoints(
+        self,
+        slices: list[InitiativeSlice],
+        checkpoint_titles: list[str],
+    ) -> list[InitiativeCheckpoint]:
+        if checkpoint_titles:
+            checkpoints: list[InitiativeCheckpoint] = []
+            for index, title in enumerate(_dedupe(checkpoint_titles), start=1):
+                slice_ref = slices[min(index - 1, len(slices) - 1)]
+                checkpoints.append(
+                    InitiativeCheckpoint(
+                        checkpoint_id=f"checkpoint-{index}",
+                        title=title,
+                        description=f"Checkpoint for {slice_ref.title}.",
+                        dependencies=[slice_ref.slice_id],
+                        validations=list(slice_ref.validations),
+                        status=PlanStatus.CREATED.value,
+                    )
+                )
+            return checkpoints
+        return [
+            InitiativeCheckpoint(
+                checkpoint_id=f"checkpoint-{index}",
+                title=_default_checkpoint_title(item.title),
+                description=f"Validate completion for slice '{item.title}'.",
+                dependencies=[item.slice_id],
+                validations=list(item.validations),
+                status=PlanStatus.CREATED.value,
+            )
+            for index, item in enumerate(slices, start=1)
+        ]
+
+    def _build_milestones(
+        self,
+        slices: list[InitiativeSlice],
+        checkpoints: list[InitiativeCheckpoint],
+        milestone_titles: list[str],
+    ) -> list[InitiativeMilestone]:
+        titles = _dedupe(milestone_titles)
+        if titles:
+            milestones: list[InitiativeMilestone] = []
+            slice_groups = [item.slice_id for item in slices]
+            checkpoint_groups = [item.checkpoint_id for item in checkpoints]
+            for index, title in enumerate(titles, start=1):
+                milestones.append(
+                    InitiativeMilestone(
+                        milestone_id=f"milestone-{index}",
+                        title=title,
+                        description=f"Milestone {index} for the initiative roadmap.",
+                        slice_ids=list(slice_groups),
+                        checkpoint_ids=list(checkpoint_groups),
+                        status=PlanStatus.CREATED.value,
+                    )
+                )
+            return milestones
+        return [
+            InitiativeMilestone(
+                milestone_id="milestone-1",
+                title="Planned slices ready for execution",
+                description="Initial initiative decomposition persisted for follow-on execution.",
+                slice_ids=[item.slice_id for item in slices],
+                checkpoint_ids=[item.checkpoint_id for item in checkpoints],
+                status=PlanStatus.CREATED.value,
+            )
+        ]

--- a/aragora/swarm/initiative_store.py
+++ b/aragora/swarm/initiative_store.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aragora.swarm.initiative_models import InitiativeRecord
+
+
+class InitiativeStore:
+    """Local-first JSON store for initiative planning artifacts."""
+
+    def __init__(self, *, repo_root: Path | None = None, state_dir: Path | None = None) -> None:
+        resolved_root = Path(repo_root or Path.cwd()).resolve()
+        self._state_dir = (
+            Path(state_dir).resolve()
+            if state_dir is not None
+            else resolved_root / ".aragora" / "initiatives"
+        )
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def state_dir(self) -> Path:
+        return self._state_dir
+
+    def path_for(self, initiative_id: str) -> Path:
+        return self._state_dir / f"{initiative_id}.json"
+
+    def save(self, initiative: InitiativeRecord) -> Path:
+        initiative.touch()
+        payload = json.dumps(initiative.to_dict(), indent=2, sort_keys=False) + "\n"
+        destination = self.path_for(initiative.initiative_id)
+        tmp_path = destination.with_suffix(".json.tmp")
+        tmp_path.write_text(payload)
+        tmp_path.replace(destination)
+        return destination
+
+    def get(self, initiative_id: str) -> InitiativeRecord | None:
+        path = self.path_for(initiative_id)
+        if not path.exists():
+            return None
+        return InitiativeRecord.from_dict(json.loads(path.read_text()))
+
+    def list(self) -> list[InitiativeRecord]:
+        items: list[InitiativeRecord] = []
+        for path in sorted(self._state_dir.glob("*.json")):
+            try:
+                items.append(InitiativeRecord.from_dict(json.loads(path.read_text())))
+            except (json.JSONDecodeError, TypeError, ValueError):
+                continue
+        items.sort(
+            key=lambda item: (item.updated_at, item.created_at, item.initiative_id), reverse=True
+        )
+        return items

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from aragora.cli.commands.swarm import _classify_issue_validation_status, cmd_swarm
+from aragora.swarm.initiative_models import InitiativeRecord, InitiativeSlice
+from aragora.swarm.initiative_store import InitiativeStore
 from aragora.swarm.spec import SwarmSpec
 
 
@@ -92,6 +95,13 @@ def _swarm_args(**overrides: object) -> argparse.Namespace:
         "skip_review": False,
         "output": None,
         "audit_ref": None,
+        "source_file": None,
+        "initiative_dir": None,
+        "feature_flag": None,
+        "dependency": None,
+        "validation": None,
+        "milestone": None,
+        "checkpoint": None,
     }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
@@ -244,6 +254,36 @@ class TestSwarmParser:
         assert args.run_id == "run-123"
         assert args.watch is True
         assert args.interval_seconds == 1.5
+
+    def test_swarm_initiative_parser(self):
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "initiative",
+                "plan",
+                "Create an initiative registry",
+                "--feature-flag",
+                "initiative_registry",
+                "--dependency",
+                "decision-plan-core",
+                "--validation",
+                "python3 -m pytest tests/swarm/test_initiative_store.py -q",
+                "--milestone",
+                "Planning ready",
+                "--checkpoint",
+                "Registry validated",
+            ]
+        )
+        assert args.command == "swarm"
+        assert args.swarm_action_or_goal == "initiative"
+        assert args.swarm_goal == "plan"
+        assert args.swarm_campaign_target == "Create an initiative registry"
+        assert args.feature_flag == "initiative_registry"
+        assert args.dependency == ["decision-plan-core"]
+        assert args.validation == ["python3 -m pytest tests/swarm/test_initiative_store.py -q"]
 
     def test_swarm_runner_parser(self):
         from aragora.cli.parser import build_parser
@@ -2846,3 +2886,83 @@ class TestSwarmCommand:
         reconciler.tick_run.assert_not_called()
         out = capsys.readouterr().out
         assert "work_orders=1 [completed=1]" in out
+
+
+def test_cmd_swarm_initiative_plan_json(tmp_path, capsys):
+    args = _swarm_args(
+        swarm_action_or_goal="initiative",
+        swarm_goal="plan",
+        swarm_campaign_target="Create an initiative registry",
+        initiative_dir=str(tmp_path),
+        feature_flag="initiative_registry",
+        dependency=["decision-plan-core"],
+        validation=["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+        milestone=["Planning ready"],
+        checkpoint=["Registry validated"],
+        json=True,
+    )
+    initiative = InitiativeRecord(
+        initiative_id="initiative-registry",
+        title="Create an initiative registry",
+        goal="Create an initiative registry",
+        rationale="Create an initiative registry",
+        feature_flag_name="initiative_registry",
+        slices=[
+            InitiativeSlice(
+                slice_id="slice-1",
+                title="Registry",
+                description="Persist initiative artifacts locally.",
+            )
+        ],
+    )
+
+    with patch("aragora.swarm.initiative_planner.InitiativePlanner.plan", return_value=initiative):
+        cmd_swarm(args)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "initiative-plan"
+    assert payload["initiative"]["initiative_id"] == "initiative-registry"
+    assert Path(payload["path"]).exists()
+
+
+def test_cmd_swarm_initiative_show_and_list(tmp_path, capsys):
+    store = InitiativeStore(state_dir=tmp_path)
+    initiative = InitiativeRecord(
+        initiative_id="initiative-registry",
+        title="Create an initiative registry",
+        goal="Create an initiative registry",
+        rationale="Persist roadmap work locally.",
+        feature_flag_name="initiative_registry",
+        slices=[
+            InitiativeSlice(
+                slice_id="slice-1",
+                title="Registry",
+                description="Persist initiative artifacts locally.",
+            )
+        ],
+    )
+    store.save(initiative)
+
+    show_args = _swarm_args(
+        swarm_action_or_goal="initiative",
+        swarm_goal="show",
+        swarm_campaign_target="initiative-registry",
+        initiative_dir=str(tmp_path),
+        json=True,
+    )
+    cmd_swarm(show_args)
+    show_payload = json.loads(capsys.readouterr().out)
+    assert show_payload["mode"] == "initiative-show"
+    assert show_payload["initiative"]["feature_flag_name"] == "initiative_registry"
+
+    list_args = _swarm_args(
+        swarm_action_or_goal="initiative",
+        swarm_goal="list",
+        initiative_dir=str(tmp_path),
+        json=True,
+    )
+    cmd_swarm(list_args)
+    list_payload = json.loads(capsys.readouterr().out)
+    assert list_payload["mode"] == "initiative-list"
+    assert list_payload["count"] == 1
+    assert list_payload["items"][0]["initiative_id"] == "initiative-registry"

--- a/tests/pipeline/test_receipt_gate.py
+++ b/tests/pipeline/test_receipt_gate.py
@@ -22,6 +22,8 @@ from aragora.pipeline.receipt_gate import (
     PlanExecutionGateError,
     PlanReceiptGateError,
     _resolve_backbone_run,
+    _synthetic_debate_result,
+    evaluate_plan_execution_gate,
     ensure_plan_receipt,
 )
 
@@ -126,6 +128,43 @@ def test_resolve_backbone_run_logs_warning_when_lookup_fails(
         assert _resolve_backbone_run(plan, plan_store=store) is None
 
     assert "Backbone run lookup failed for run-lookup-fail: lookup unavailable" in caplog.text
+
+
+def test_string_gate_flags_fail_closed() -> None:
+    truthy_values = ("true", "1", "yes", "on")
+    falsey_values = ("false", "0", "no", "off", "", "malformed")
+
+    for raw_value in truthy_values:
+        plan = _plan(metadata={"execution_gate": {"allow_auto_execution": raw_value}})
+        decision = evaluate_plan_execution_gate(plan)
+        assert decision.allow_auto_execution is True
+        assert decision.reason_codes == []
+
+        plan = _plan(metadata={"deliberation_bundle": {"consensus_reached": raw_value}})
+        assert _synthetic_debate_result(plan).consensus_reached is True
+
+        plan = _plan(
+            metadata={
+                "execution_gate": {"signed_receipt": {"consensus_proof": {"reached": raw_value}}}
+            }
+        )
+        assert _synthetic_debate_result(plan).consensus_reached is True
+
+    for raw_value in falsey_values:
+        plan = _plan(metadata={"execution_gate": {"allow_auto_execution": raw_value}})
+        decision = evaluate_plan_execution_gate(plan)
+        assert decision.allow_auto_execution is False
+        assert decision.reason_codes == ["execution_gate_blocked"]
+
+        plan = _plan(metadata={"deliberation_bundle": {"consensus_reached": raw_value}})
+        assert _synthetic_debate_result(plan).consensus_reached is False
+
+        plan = _plan(
+            metadata={
+                "execution_gate": {"signed_receipt": {"consensus_proof": {"reached": raw_value}}}
+            }
+        )
+        assert _synthetic_debate_result(plan).consensus_reached is False
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_initiative_planner.py
+++ b/tests/swarm/test_initiative_planner.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from aragora.nomic.task_decomposer import SubTask, TaskDecomposition
+from aragora.pipeline.decision_plan.core import PlanStatus
+from aragora.swarm.initiative_planner import InitiativePlanner
+
+
+class _FakeDecomposer:
+    def __init__(self) -> None:
+        self.analyze_calls: list[dict[str, object]] = []
+        self.model_calls: list[dict[str, object]] = []
+
+    def analyze(self, task_description: str, **kwargs):
+        self.analyze_calls.append({"task_description": task_description, **kwargs})
+        return TaskDecomposition(
+            original_task=task_description,
+            complexity_score=6,
+            complexity_level="medium",
+            should_decompose=True,
+            rationale="heuristic decomposition",
+            subtasks=[
+                SubTask(
+                    id="slice-1",
+                    title="Registry store",
+                    description="Persist initiative JSON records.",
+                    dependencies=[],
+                    estimated_complexity="medium",
+                    file_scope=["aragora/swarm/initiative_store.py"],
+                    success_criteria={
+                        "tests": ["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+                        "behavior": ["initiative records survive reload"],
+                    },
+                ),
+                SubTask(
+                    id="slice-2",
+                    title="CLI surfacing",
+                    description="Expose initiative plan/show/list.",
+                    dependencies=["slice-1"],
+                    estimated_complexity="medium",
+                    file_scope=["aragora/cli/commands/swarm.py"],
+                    success_criteria={
+                        "tests": [
+                            "python3 -m pytest tests/cli/test_swarm_command.py -q -k initiative"
+                        ],
+                    },
+                ),
+            ],
+        )
+
+    def analyze_with_model_sync(self, task_description: str, **kwargs):
+        self.model_calls.append({"task_description": task_description, **kwargs})
+        return self.analyze(task_description, **kwargs)
+
+
+def test_initiative_planner_builds_persistent_initiative_from_subtasks(tmp_path) -> None:
+    planner = InitiativePlanner(repo_root=tmp_path, decomposer=_FakeDecomposer())
+
+    initiative = planner.plan(
+        goal="Create an initiative registry and planner",
+        rationale="Roadmap work needs a durable planning object instead of recycled issues.",
+        dependencies=["decision-plan-core"],
+        validations=["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+        feature_flag_name="initiative_registry",
+        milestone_titles=["Planning ready"],
+        checkpoint_titles=["Registry validated", "CLI validated"],
+    )
+
+    assert initiative.title == "Create an initiative registry and planner"
+    assert initiative.status == PlanStatus.CREATED.value
+    assert initiative.feature_flag_name == "initiative_registry"
+    assert [item.slice_id for item in initiative.slices] == ["slice-1", "slice-2"]
+    assert initiative.slices[1].dependencies == ["slice-1"]
+    assert initiative.slices[0].acceptance_criteria == [
+        "behavior: initiative records survive reload"
+    ]
+    assert initiative.checkpoints[0].title == "Registry validated"
+    assert initiative.milestones[0].title == "Planning ready"
+    assert initiative.metadata["planner_strategy"] == "heuristic"
+
+
+def test_initiative_planner_uses_model_strategy_when_requested(tmp_path) -> None:
+    decomposer = _FakeDecomposer()
+    planner = InitiativePlanner(repo_root=tmp_path, decomposer=decomposer)
+
+    initiative = planner.plan(
+        goal="Use model planning",
+        rationale="Planner should defer to the configured model strategy.",
+        planner_strategy="model",
+        planner_model="claude",
+    )
+
+    assert initiative.metadata["planner_strategy"] == "model"
+    assert initiative.metadata["planner_model"] == "claude"
+    assert len(decomposer.model_calls) == 1
+    assert decomposer.model_calls[0]["planner_model"] == "claude"

--- a/tests/swarm/test_initiative_store.py
+++ b/tests/swarm/test_initiative_store.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from aragora.swarm.initiative_models import (
+    InitiativeCheckpoint,
+    InitiativeMilestone,
+    InitiativeRecord,
+    InitiativeSlice,
+)
+from aragora.swarm.initiative_store import InitiativeStore
+
+
+def _record(initiative_id: str, *, updated_at: str) -> InitiativeRecord:
+    return InitiativeRecord(
+        initiative_id=initiative_id,
+        title=f"Title {initiative_id}",
+        goal="Track roadmap work as a durable initiative.",
+        rationale="Founders need a persistent planning artifact.",
+        slices=[
+            InitiativeSlice(
+                slice_id=f"{initiative_id}-slice-1",
+                title="Registry",
+                description="Persist initiatives locally.",
+                validations=["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+            )
+        ],
+        dependencies=["decision-plan-core"],
+        validations=["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+        feature_flag_name="initiative_registry",
+        milestones=[
+            InitiativeMilestone(
+                milestone_id=f"{initiative_id}-milestone-1",
+                title="Persistence landed",
+                slice_ids=[f"{initiative_id}-slice-1"],
+                checkpoint_ids=[f"{initiative_id}-checkpoint-1"],
+            )
+        ],
+        checkpoints=[
+            InitiativeCheckpoint(
+                checkpoint_id=f"{initiative_id}-checkpoint-1",
+                title="Registry validated",
+                dependencies=[f"{initiative_id}-slice-1"],
+                validations=["python3 -m pytest tests/swarm/test_initiative_store.py -q"],
+            )
+        ],
+        updated_at=updated_at,
+        created_at=updated_at,
+    )
+
+
+def test_initiative_store_round_trips_json_payload(tmp_path) -> None:
+    store = InitiativeStore(state_dir=tmp_path)
+    record = _record("initiative-registry", updated_at="2026-04-07T12:00:00+00:00")
+
+    saved_path = store.save(record)
+    loaded = store.get("initiative-registry")
+
+    assert saved_path.exists()
+    assert loaded is not None
+    assert loaded.initiative_id == "initiative-registry"
+    assert loaded.feature_flag_name == "initiative_registry"
+    assert loaded.slices[0].title == "Registry"
+    assert loaded.checkpoints[0].dependencies == ["initiative-registry-slice-1"]
+
+
+def test_initiative_store_lists_newest_first(tmp_path) -> None:
+    store = InitiativeStore(state_dir=tmp_path)
+    older = _record("older", updated_at="2026-04-07T10:00:00+00:00")
+    newer = _record("newer", updated_at="2026-04-07T11:00:00+00:00")
+
+    store.save(older)
+    store.save(newer)
+
+    items = store.list()
+
+    assert [item.initiative_id for item in items] == ["newer", "older"]


### PR DESCRIPTION
## Summary
- add durable initiative models and a local JSON-backed initiative store under .aragora/initiatives
- add an initiative planner that reuses TaskDecomposer output and PlanStatus lifecycle vocabulary
- extend \Error: provide a goal or --spec file (or --from-obsidian vault)
Usage: aragora swarm run "your goal here" with initiative plan/show/list plus focused store, planner, and CLI tests

## Validation
- python3 -m ruff check aragora/swarm/initiative_models.py aragora/swarm/initiative_store.py aragora/swarm/initiative_planner.py aragora/cli/commands/swarm.py aragora/cli/parser.py tests/swarm/test_initiative_store.py tests/swarm/test_initiative_planner.py tests/cli/test_swarm_command.py
- python3 -m pytest tests/swarm/test_initiative_store.py tests/swarm/test_initiative_planner.py tests/cli/test_swarm_command.py -q