### PR TITLE
feat(swarm): execute dependency-ready initiative slices

### DIFF
--- a/aragora/swarm/initiative_loop.py
+++ b/aragora/swarm/initiative_loop.py
@@ -1,0 +1,506 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from aragora.coordination.directives import DirectiveBoard, SessionDirective
+from aragora.nomic.dev_coordination import CompletionReceipt, DevCoordinationStore, WorkLease
+from aragora.pipeline.decision_plan.core import PlanStatus
+from aragora.swarm.initiative_models import InitiativeRecord
+from aragora.swarm.initiative_store import InitiativeStore
+from aragora.worktree.fleet import resolve_repo_root
+
+STATUS_QUEUED = "queued"
+STATUS_ACTIVE = "active"
+STATUS_BLOCKED = "blocked"
+STATUS_NEEDS_HUMAN = "needs_human"
+STATUS_MERGED = "merged"
+STATUS_SUPERSEDED = "superseded"
+
+_TERMINAL_SLICE_STATUSES = {
+    STATUS_NEEDS_HUMAN,
+    STATUS_MERGED,
+    STATUS_SUPERSEDED,
+}
+_RESOLVED_BOUNDARY_STATUSES = {
+    STATUS_MERGED,
+    STATUS_SUPERSEDED,
+    PlanStatus.COMPLETED.value,
+}
+_ACTIVE_DIRECTIVE_STATUSES = {
+    "active",
+    STATUS_ACTIVE,
+}
+_TERMINAL_OUTCOME_MAP = {
+    STATUS_NEEDS_HUMAN: STATUS_NEEDS_HUMAN,
+    STATUS_MERGED: STATUS_MERGED,
+    STATUS_SUPERSEDED: STATUS_SUPERSEDED,
+}
+_TASK_PREFIX = "initiative_task_id:"
+_INITIATIVE_PREFIX = "initiative_id:"
+_SLICE_PREFIX = "initiative_slice_id:"
+
+
+def _text(value: object) -> str:
+    return str(value or "").strip()
+
+
+def _status(value: object, *, default: str = "") -> str:
+    return _text(value) or default
+
+
+def _terminal_status_from_metadata(metadata: dict[str, object]) -> str | None:
+    for key in ("initiative_terminal_status", "terminal_status"):
+        status = _status(metadata.get(key))
+        if status in _TERMINAL_OUTCOME_MAP:
+            return status
+    return None
+
+
+def _task_id_for_slice(initiative_id: str, slice_id: str) -> str:
+    return f"initiative:{initiative_id}:slice:{slice_id}"
+
+
+def _constraint_value(constraints: list[str], prefix: str) -> str | None:
+    for item in constraints:
+        text = _text(item)
+        if text.startswith(prefix):
+            return text[len(prefix) :].strip() or None
+    return None
+
+
+def _directive_task_id(directive: SessionDirective) -> str | None:
+    return _constraint_value(list(directive.constraints), _TASK_PREFIX)
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for value in values:
+        text = _text(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        result.append(text)
+    return result
+
+
+def _latest_receipt_by_task(receipts: list[CompletionReceipt]) -> dict[str, CompletionReceipt]:
+    latest: dict[str, CompletionReceipt] = {}
+    for receipt in sorted(receipts, key=lambda item: (_text(item.created_at), item.receipt_id)):
+        latest[receipt.task_id] = receipt
+    return latest
+
+
+@dataclass(slots=True)
+class InitiativeExecutionSnapshot:
+    initiative: InitiativeRecord
+    ready_slice_ids: list[str]
+    boundary_blockers: list[str]
+    slice_statuses: dict[str, str]
+    checkpoint_statuses: dict[str, str]
+    milestone_statuses: dict[str, str]
+    owner_targets: dict[str, str]
+    dispatched_slice_ids: list[str] = field(default_factory=list)
+
+    @property
+    def initiative_id(self) -> str:
+        return self.initiative.initiative_id
+
+    @property
+    def status(self) -> str:
+        return self.initiative.status
+
+    def to_dict(self) -> dict[str, object]:
+        grouped: dict[str, list[str]] = {
+            STATUS_QUEUED: [],
+            STATUS_ACTIVE: [],
+            STATUS_BLOCKED: [],
+            STATUS_NEEDS_HUMAN: [],
+            STATUS_MERGED: [],
+            STATUS_SUPERSEDED: [],
+        }
+        for slice_id, status in self.slice_statuses.items():
+            grouped.setdefault(status, []).append(slice_id)
+        return {
+            "initiative_id": self.initiative_id,
+            "status": self.status,
+            "ready_slice_ids": list(self.ready_slice_ids),
+            "boundary_blockers": list(self.boundary_blockers),
+            "slice_statuses": dict(self.slice_statuses),
+            "checkpoint_statuses": dict(self.checkpoint_statuses),
+            "milestone_statuses": dict(self.milestone_statuses),
+            "owner_targets": dict(self.owner_targets),
+            "dispatched_slice_ids": list(self.dispatched_slice_ids),
+            "grouped_slice_ids": grouped,
+        }
+
+
+class InitiativeExecutor:
+    """Execute dependency-ready initiative slices through shared coordination state."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path | None = None,
+        store: InitiativeStore | None = None,
+        coordination_store: DevCoordinationStore | None = None,
+        directive_board: DirectiveBoard | None = None,
+    ) -> None:
+        resolved_repo = Path(repo_root or Path.cwd()).resolve()
+        self.repo_root = resolved_repo
+        self.coord_repo_root = resolve_repo_root(resolved_repo)
+        self.store = store or InitiativeStore(repo_root=resolved_repo)
+        self.coordination_store = coordination_store or DevCoordinationStore(
+            repo_root=resolved_repo
+        )
+        self.directive_board = directive_board or DirectiveBoard(repo_path=self.coord_repo_root)
+
+    def refresh(self, initiative_id: str) -> InitiativeExecutionSnapshot:
+        initiative = self.store.get(initiative_id)
+        if initiative is None:
+            raise KeyError(f"Unknown initiative: {initiative_id}")
+
+        directives = self.directive_board.list()
+        directive_by_task = {
+            task_id: directive
+            for directive in directives
+            if (task_id := _directive_task_id(directive)) is not None
+        }
+        active_leases = {
+            lease.task_id: lease for lease in self.coordination_store.list_active_leases()
+        }
+        latest_receipts = _latest_receipt_by_task(
+            self.coordination_store.list_completion_receipts(limit=1000)
+        )
+
+        slice_statuses: dict[str, str] = {}
+        owner_targets: dict[str, str] = {}
+        for slice_record in initiative.slices:
+            task_id = _task_id_for_slice(initiative.initiative_id, slice_record.slice_id)
+            metadata = dict(slice_record.metadata)
+            metadata["coordination_task_id"] = task_id
+            blocked_by = [
+                dep
+                for dep in slice_record.dependencies
+                if slice_statuses.get(dep) not in _TERMINAL_SLICE_STATUSES
+            ]
+
+            status = self._slice_status(
+                current_status=slice_record.status,
+                metadata=metadata,
+                blocked_by=blocked_by,
+                directive=directive_by_task.get(task_id),
+                lease=active_leases.get(task_id),
+                receipt=latest_receipts.get(task_id),
+            )
+            metadata["blocked_by"] = list(blocked_by)
+            metadata["coordination_task_id"] = task_id
+
+            directive = directive_by_task.get(task_id)
+            if directive is not None:
+                metadata["owner_target"] = directive.target
+                owner_targets[slice_record.slice_id] = directive.target
+            else:
+                owner_target = _text(metadata.get("owner_target"))
+                if owner_target:
+                    owner_targets[slice_record.slice_id] = owner_target
+
+            lease = active_leases.get(task_id)
+            if lease is not None:
+                metadata["lease_id"] = lease.lease_id
+                metadata["lease_owner_session_id"] = lease.owner_session_id
+
+            receipt = latest_receipts.get(task_id)
+            if receipt is not None:
+                metadata["receipt_id"] = receipt.receipt_id
+                metadata["pr_url"] = receipt.pr_url or metadata.get("pr_url") or ""
+                metadata["pr_number"] = receipt.pr_number
+                metadata["receipt_outcome"] = receipt.outcome
+
+            slice_record.status = status
+            slice_record.metadata = metadata
+            slice_statuses[slice_record.slice_id] = status
+
+        checkpoint_statuses = self._refresh_checkpoints(initiative, slice_statuses)
+        milestone_statuses = self._refresh_milestones(
+            initiative, slice_statuses, checkpoint_statuses
+        )
+        boundary_blockers = self._boundary_blockers(
+            initiative, checkpoint_statuses, milestone_statuses
+        )
+        ready_slice_ids = [
+            item.slice_id
+            for item in initiative.slices
+            if item.status == STATUS_QUEUED and not boundary_blockers
+        ]
+
+        initiative.status = self._initiative_status(
+            initiative=initiative,
+            ready_slice_ids=ready_slice_ids,
+            boundary_blockers=boundary_blockers,
+            slice_statuses=slice_statuses,
+        )
+        self.store.save(initiative)
+        return InitiativeExecutionSnapshot(
+            initiative=initiative,
+            ready_slice_ids=ready_slice_ids,
+            boundary_blockers=boundary_blockers,
+            slice_statuses=slice_statuses,
+            checkpoint_statuses=checkpoint_statuses,
+            milestone_statuses=milestone_statuses,
+            owner_targets=owner_targets,
+        )
+
+    def dispatch_ready_slices(
+        self,
+        initiative_id: str,
+        *,
+        owner_targets: list[str],
+        assigned_by: str = "initiative-loop",
+    ) -> InitiativeExecutionSnapshot:
+        snapshot = self.refresh(initiative_id)
+        if not snapshot.ready_slice_ids or snapshot.boundary_blockers:
+            return snapshot
+
+        initiative = snapshot.initiative
+        directives = self.directive_board.list()
+        busy_targets = {
+            directive.target
+            for directive in directives
+            if _status(directive.status, default="active") in _ACTIVE_DIRECTIVE_STATUSES
+        }
+        directive_task_ids = {
+            task_id
+            for directive in directives
+            if (task_id := _directive_task_id(directive)) is not None
+        }
+        available_targets = [
+            target for target in _ordered_unique(owner_targets) if target not in busy_targets
+        ]
+
+        dispatched: list[str] = []
+        target_iter = iter(available_targets)
+        for slice_record in initiative.slices:
+            if slice_record.slice_id not in snapshot.ready_slice_ids:
+                continue
+            task_id = _task_id_for_slice(initiative.initiative_id, slice_record.slice_id)
+            if task_id in directive_task_ids:
+                continue
+            try:
+                target = next(target_iter)
+            except StopIteration:
+                break
+            constraints = [
+                f"{_INITIATIVE_PREFIX}{initiative.initiative_id}",
+                f"{_SLICE_PREFIX}{slice_record.slice_id}",
+                f"{_TASK_PREFIX}{task_id}",
+            ]
+            constraints.extend(f"validation:{item}" for item in slice_record.validations)
+            self.directive_board.assign(
+                target,
+                f"Initiative slice {slice_record.slice_id}: {slice_record.title}",
+                scope=list(slice_record.file_scope),
+                constraints=constraints,
+                assigned_by=assigned_by,
+                status=STATUS_ACTIVE,
+            )
+            slice_record.status = STATUS_ACTIVE
+            slice_record.metadata = {
+                **dict(slice_record.metadata),
+                "owner_target": target,
+                "coordination_task_id": task_id,
+            }
+            dispatched.append(slice_record.slice_id)
+
+        if dispatched:
+            initiative.status = STATUS_ACTIVE
+            self.store.save(initiative)
+        refreshed = self.refresh(initiative_id)
+        refreshed.dispatched_slice_ids.extend(dispatched)
+        return refreshed
+
+    def _slice_status(
+        self,
+        *,
+        current_status: str,
+        metadata: dict[str, object],
+        blocked_by: list[str],
+        directive: SessionDirective | None,
+        lease: WorkLease | None,
+        receipt: CompletionReceipt | None,
+    ) -> str:
+        explicit_terminal = self._explicit_terminal_status(
+            current_status=current_status, metadata=metadata
+        )
+        if explicit_terminal is not None:
+            return explicit_terminal
+        if receipt is not None:
+            return self._receipt_terminal_status(receipt)
+        if lease is not None:
+            return STATUS_ACTIVE
+        if (
+            directive is not None
+            and _status(directive.status, default=STATUS_ACTIVE) in _ACTIVE_DIRECTIVE_STATUSES
+        ):
+            return STATUS_ACTIVE
+        if blocked_by:
+            return STATUS_BLOCKED
+        return STATUS_QUEUED
+
+    def _explicit_terminal_status(
+        self, *, current_status: str, metadata: dict[str, object]
+    ) -> str | None:
+        normalized = _status(current_status)
+        if normalized in _TERMINAL_SLICE_STATUSES:
+            return normalized
+        return _terminal_status_from_metadata(metadata)
+
+    def _receipt_terminal_status(self, receipt: CompletionReceipt) -> str:
+        metadata_status = _terminal_status_from_metadata(dict(receipt.metadata))
+        if metadata_status is not None:
+            return metadata_status
+        outcome = _status(receipt.outcome).lower()
+        if "supersed" in outcome:
+            return STATUS_SUPERSEDED
+        if outcome == STATUS_MERGED:
+            return STATUS_MERGED
+        return STATUS_NEEDS_HUMAN
+
+    def _refresh_checkpoints(
+        self, initiative: InitiativeRecord, slice_statuses: dict[str, str]
+    ) -> dict[str, str]:
+        statuses: dict[str, str] = {}
+        for checkpoint in initiative.checkpoints:
+            current_status = _status(checkpoint.status)
+            if (
+                current_status in _RESOLVED_BOUNDARY_STATUSES
+                or current_status == STATUS_NEEDS_HUMAN
+            ):
+                statuses[checkpoint.checkpoint_id] = current_status
+                continue
+            dependencies_satisfied = all(
+                slice_statuses.get(dep) in _TERMINAL_SLICE_STATUSES
+                for dep in checkpoint.dependencies
+            )
+            status = STATUS_NEEDS_HUMAN if dependencies_satisfied else STATUS_BLOCKED
+            checkpoint.status = status
+            checkpoint.metadata = {
+                **dict(checkpoint.metadata),
+                "blocked_by": [
+                    dep
+                    for dep in checkpoint.dependencies
+                    if slice_statuses.get(dep) not in _TERMINAL_SLICE_STATUSES
+                ],
+            }
+            statuses[checkpoint.checkpoint_id] = status
+        return statuses
+
+    def _refresh_milestones(
+        self,
+        initiative: InitiativeRecord,
+        slice_statuses: dict[str, str],
+        checkpoint_statuses: dict[str, str],
+    ) -> dict[str, str]:
+        statuses: dict[str, str] = {}
+        for milestone in initiative.milestones:
+            current_status = _status(milestone.status)
+            if (
+                current_status in _RESOLVED_BOUNDARY_STATUSES
+                or current_status == STATUS_NEEDS_HUMAN
+            ):
+                statuses[milestone.milestone_id] = current_status
+                continue
+            slice_ready = all(
+                slice_statuses.get(slice_id) in _TERMINAL_SLICE_STATUSES
+                for slice_id in milestone.slice_ids
+            )
+            checkpoint_ready = all(
+                checkpoint_statuses.get(checkpoint_id) in _RESOLVED_BOUNDARY_STATUSES
+                for checkpoint_id in milestone.checkpoint_ids
+            )
+            if (
+                (milestone.slice_ids or milestone.checkpoint_ids)
+                and slice_ready
+                and checkpoint_ready
+            ):
+                status = STATUS_NEEDS_HUMAN
+            else:
+                status = STATUS_BLOCKED
+            milestone.status = status
+            milestone.metadata = {
+                **dict(milestone.metadata),
+                "blocked_by": [
+                    item
+                    for item in milestone.slice_ids
+                    if slice_statuses.get(item) not in _TERMINAL_SLICE_STATUSES
+                ]
+                + [
+                    item
+                    for item in milestone.checkpoint_ids
+                    if checkpoint_statuses.get(item) not in _RESOLVED_BOUNDARY_STATUSES
+                ],
+            }
+            statuses[milestone.milestone_id] = status
+        return statuses
+
+    def _boundary_blockers(
+        self,
+        initiative: InitiativeRecord,
+        checkpoint_statuses: dict[str, str],
+        milestone_statuses: dict[str, str],
+    ) -> list[str]:
+        blockers: list[str] = []
+        blockers.extend(
+            checkpoint.checkpoint_id
+            for checkpoint in initiative.checkpoints
+            if checkpoint_statuses.get(checkpoint.checkpoint_id) == STATUS_NEEDS_HUMAN
+        )
+        blockers.extend(
+            milestone.milestone_id
+            for milestone in initiative.milestones
+            if milestone_statuses.get(milestone.milestone_id) == STATUS_NEEDS_HUMAN
+        )
+        return blockers
+
+    def _initiative_status(
+        self,
+        *,
+        initiative: InitiativeRecord,
+        ready_slice_ids: list[str],
+        boundary_blockers: list[str],
+        slice_statuses: dict[str, str],
+    ) -> str:
+        explicit_status = _status(initiative.status)
+        if explicit_status in {STATUS_MERGED, STATUS_SUPERSEDED}:
+            return explicit_status
+        status_values = list(slice_statuses.values())
+        if boundary_blockers:
+            return STATUS_NEEDS_HUMAN
+        if STATUS_ACTIVE in status_values:
+            return STATUS_ACTIVE
+        if ready_slice_ids:
+            return STATUS_QUEUED
+        if status_values and all(status == STATUS_SUPERSEDED for status in status_values):
+            return STATUS_SUPERSEDED
+        if status_values and all(
+            status in {STATUS_MERGED, STATUS_SUPERSEDED} for status in status_values
+        ):
+            return STATUS_MERGED
+        if STATUS_NEEDS_HUMAN in status_values:
+            return STATUS_NEEDS_HUMAN
+        if STATUS_BLOCKED in status_values:
+            return STATUS_BLOCKED
+        return STATUS_QUEUED
+
+
+__all__ = [
+    "InitiativeExecutionSnapshot",
+    "InitiativeExecutor",
+    "STATUS_ACTIVE",
+    "STATUS_BLOCKED",
+    "STATUS_MERGED",
+    "STATUS_NEEDS_HUMAN",
+    "STATUS_QUEUED",
+    "STATUS_SUPERSEDED",
+]

--- a/tests/swarm/test_initiative_loop.py
+++ b/tests/swarm/test_initiative_loop.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from aragora.nomic.dev_coordination import DevCoordinationStore
+from aragora.swarm.initiative_loop import (
+    InitiativeExecutor,
+    STATUS_ACTIVE,
+    STATUS_BLOCKED,
+    STATUS_MERGED,
+    STATUS_NEEDS_HUMAN,
+    STATUS_QUEUED,
+    STATUS_SUPERSEDED,
+)
+from aragora.swarm.initiative_models import (
+    InitiativeCheckpoint,
+    InitiativeMilestone,
+    InitiativeRecord,
+    InitiativeSlice,
+)
+from aragora.swarm.initiative_store import InitiativeStore
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(list(args), cwd=cwd, text=True, capture_output=True, check=True)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init", "-b", "main")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _run(repo, "git", "config", "user.name", "Test User")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _run(repo, "git", "add", "README.md")
+    _run(repo, "git", "commit", "-m", "initial")
+    _run(repo, "git", "remote", "add", "origin", str(repo))
+    _run(repo, "git", "update-ref", "refs/remotes/origin/main", "HEAD")
+    return repo
+
+
+def _store_and_executor(
+    repo: Path,
+) -> tuple[InitiativeStore, InitiativeExecutor, DevCoordinationStore]:
+    store = InitiativeStore(repo_root=repo)
+    coordination = DevCoordinationStore(repo_root=repo)
+    executor = InitiativeExecutor(repo_root=repo, store=store, coordination_store=coordination)
+    return store, executor, coordination
+
+
+def _record(
+    *,
+    initiative_id: str = "initiative-executor",
+    slices: list[InitiativeSlice],
+    checkpoints: list[InitiativeCheckpoint] | None = None,
+    milestones: list[InitiativeMilestone] | None = None,
+) -> InitiativeRecord:
+    return InitiativeRecord(
+        initiative_id=initiative_id,
+        title="Initiative executor",
+        goal="Execute roadmap slices only when dependencies are ready.",
+        rationale="PR2 needs dependency-aware initiative execution.",
+        slices=slices,
+        checkpoints=list(checkpoints or []),
+        milestones=list(milestones or []),
+    )
+
+
+def _record_receipt(
+    *,
+    coordination: DevCoordinationStore,
+    initiative_id: str,
+    slice_id: str,
+    metadata: dict[str, object] | None = None,
+    pr_url: str | None = None,
+) -> None:
+    task_id = f"initiative:{initiative_id}:slice:{slice_id}"
+    lease = coordination.claim_lease(
+        task_id=task_id,
+        title=f"Slice {slice_id}",
+        owner_agent="codex",
+        owner_session_id="codex-a",
+        branch=f"codex/{slice_id}",
+        worktree_path=f"/tmp/{slice_id}",
+        claimed_paths=[f"aragora/{slice_id}.py"],
+        expected_tests=[f"python3 -m pytest tests/{slice_id}.py -q"],
+    )
+    coordination.record_completion(
+        lease_id=lease.lease_id,
+        owner_agent="codex",
+        owner_session_id="codex-a",
+        branch=f"codex/{slice_id}",
+        worktree_path=f"/tmp/{slice_id}",
+        commit_shas=["deadbeef"],
+        changed_paths=[f"aragora/{slice_id}.py"],
+        tests_run=[f"python3 -m pytest tests/{slice_id}.py -q"],
+        pr_url=pr_url,
+        metadata=metadata,
+    )
+
+
+def test_refresh_marks_dependency_ready_slices_and_blocked_dependents(tmp_path) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, _coordination = _store_and_executor(repo)
+    store.save(
+        _record(
+            slices=[
+                InitiativeSlice(
+                    slice_id="slice-1",
+                    title="First",
+                    description="First slice",
+                ),
+                InitiativeSlice(
+                    slice_id="slice-2",
+                    title="Second",
+                    description="Second slice",
+                    dependencies=["slice-1"],
+                ),
+            ]
+        )
+    )
+
+    snapshot = executor.refresh("initiative-executor")
+
+    assert snapshot.status == STATUS_QUEUED
+    assert snapshot.ready_slice_ids == ["slice-1"]
+    assert snapshot.slice_statuses["slice-1"] == STATUS_QUEUED
+    assert snapshot.slice_statuses["slice-2"] == STATUS_BLOCKED
+
+
+def test_dispatch_ready_slices_assigns_one_owner_per_slice_without_duplicates(tmp_path) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, _coordination = _store_and_executor(repo)
+    store.save(
+        _record(
+            slices=[
+                InitiativeSlice(slice_id="slice-1", title="One", description="One"),
+                InitiativeSlice(slice_id="slice-2", title="Two", description="Two"),
+            ]
+        )
+    )
+
+    snapshot = executor.dispatch_ready_slices(
+        "initiative-executor",
+        owner_targets=["codex-a", "codex-b"],
+        assigned_by="initiative-boss",
+    )
+
+    assert snapshot.dispatched_slice_ids == ["slice-1", "slice-2"]
+    assert snapshot.slice_statuses["slice-1"] == STATUS_ACTIVE
+    assert snapshot.slice_statuses["slice-2"] == STATUS_ACTIVE
+    assert snapshot.owner_targets == {"slice-1": "codex-a", "slice-2": "codex-b"}
+
+    repeated = executor.dispatch_ready_slices(
+        "initiative-executor",
+        owner_targets=["codex-a", "codex-b"],
+        assigned_by="initiative-boss",
+    )
+
+    assert repeated.dispatched_slice_ids == []
+    assert len(executor.directive_board.list()) == 2
+
+
+def test_receipt_backed_slice_becomes_terminal_and_checkpoint_blocks_follow_on_dispatch(
+    tmp_path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, coordination = _store_and_executor(repo)
+    store.save(
+        _record(
+            slices=[
+                InitiativeSlice(slice_id="slice-1", title="One", description="One"),
+                InitiativeSlice(
+                    slice_id="slice-2",
+                    title="Two",
+                    description="Two",
+                    dependencies=["slice-1"],
+                ),
+            ],
+            checkpoints=[
+                InitiativeCheckpoint(
+                    checkpoint_id="checkpoint-1",
+                    title="Review slice one",
+                    dependencies=["slice-1"],
+                )
+            ],
+        )
+    )
+    _record_receipt(
+        coordination=coordination,
+        initiative_id="initiative-executor",
+        slice_id="slice-1",
+        pr_url="https://github.com/synaptent/aragora/pull/9999",
+    )
+
+    snapshot = executor.refresh("initiative-executor")
+
+    assert snapshot.status == STATUS_NEEDS_HUMAN
+    assert snapshot.slice_statuses["slice-1"] == STATUS_NEEDS_HUMAN
+    assert snapshot.checkpoint_statuses["checkpoint-1"] == STATUS_NEEDS_HUMAN
+    assert snapshot.ready_slice_ids == []
+    assert snapshot.boundary_blockers == ["checkpoint-1"]
+
+
+def test_resolved_checkpoint_releases_next_dependency_ready_slice(tmp_path) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, coordination = _store_and_executor(repo)
+    initiative = _record(
+        slices=[
+            InitiativeSlice(slice_id="slice-1", title="One", description="One"),
+            InitiativeSlice(
+                slice_id="slice-2",
+                title="Two",
+                description="Two",
+                dependencies=["slice-1"],
+            ),
+        ],
+        checkpoints=[
+            InitiativeCheckpoint(
+                checkpoint_id="checkpoint-1",
+                title="Review slice one",
+                dependencies=["slice-1"],
+            )
+        ],
+    )
+    store.save(initiative)
+    _record_receipt(
+        coordination=coordination,
+        initiative_id="initiative-executor",
+        slice_id="slice-1",
+    )
+    executor.refresh("initiative-executor")
+
+    updated = store.get("initiative-executor")
+    assert updated is not None
+    updated.checkpoints[0].status = STATUS_MERGED
+    store.save(updated)
+
+    snapshot = executor.refresh("initiative-executor")
+
+    assert snapshot.status == STATUS_QUEUED
+    assert snapshot.ready_slice_ids == ["slice-2"]
+    assert snapshot.slice_statuses["slice-2"] == STATUS_QUEUED
+
+
+def test_milestone_boundary_stops_after_completed_slice_group(tmp_path) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, coordination = _store_and_executor(repo)
+    initiative = _record(
+        slices=[
+            InitiativeSlice(slice_id="slice-1", title="One", description="One"),
+            InitiativeSlice(slice_id="slice-2", title="Two", description="Two"),
+        ],
+        milestones=[
+            InitiativeMilestone(
+                milestone_id="milestone-1",
+                title="Pause for review",
+                slice_ids=["slice-1"],
+            )
+        ],
+    )
+    store.save(initiative)
+    _record_receipt(
+        coordination=coordination,
+        initiative_id="initiative-executor",
+        slice_id="slice-1",
+    )
+
+    snapshot = executor.refresh("initiative-executor")
+
+    assert snapshot.milestone_statuses["milestone-1"] == STATUS_NEEDS_HUMAN
+    assert snapshot.ready_slice_ids == []
+
+    updated = store.get("initiative-executor")
+    assert updated is not None
+    updated.milestones[0].status = STATUS_MERGED
+    store.save(updated)
+
+    resumed = executor.refresh("initiative-executor")
+
+    assert resumed.ready_slice_ids == ["slice-2"]
+
+
+def test_receipt_metadata_can_mark_slice_merged_or_superseded(tmp_path) -> None:
+    repo = _init_repo(tmp_path)
+    store, executor, coordination = _store_and_executor(repo)
+    store.save(
+        _record(
+            slices=[
+                InitiativeSlice(slice_id="slice-1", title="Merged", description="Merged"),
+                InitiativeSlice(slice_id="slice-2", title="Superseded", description="Superseded"),
+            ]
+        )
+    )
+    _record_receipt(
+        coordination=coordination,
+        initiative_id="initiative-executor",
+        slice_id="slice-1",
+        metadata={"initiative_terminal_status": STATUS_MERGED},
+    )
+    _record_receipt(
+        coordination=coordination,
+        initiative_id="initiative-executor",
+        slice_id="slice-2",
+        metadata={"initiative_terminal_status": STATUS_SUPERSEDED},
+    )
+
+    snapshot = executor.refresh("initiative-executor")
+
+    assert snapshot.slice_statuses["slice-1"] == STATUS_MERGED
+    assert snapshot.slice_statuses["slice-2"] == STATUS_SUPERSEDED
+    assert snapshot.status == STATUS_MERGED


### PR DESCRIPTION
## Summary
- add an initiative executor that reconciles slice state from directives, leases, and receipts
- dispatch only dependency-ready slices while preventing duplicate dispatch
- stop at milestone and checkpoint boundaries and track truthful terminal outcomes for each slice

## Validation
- python3 -m ruff check aragora/swarm/initiative_loop.py tests/swarm/test_initiative_loop.py
- python3 -m pytest tests/swarm/test_initiative_loop.py -q
- python3 -m pytest tests/swarm/test_initiative_store.py tests/swarm/test_initiative_planner.py tests/swarm/test_initiative_loop.py -q