### PR TITLE
feat(swarm): add initiative integrator promotion flow

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -40,6 +40,7 @@ def _resolve_swarm_action_goal(args: argparse.Namespace) -> tuple[str, str | Non
         "runner",
         "status",
         "reconcile",
+        "initiative",
         "campaign",
         "initiative",
         "integrator",
@@ -144,6 +145,47 @@ def _render_initiative(item: object) -> None:
                 complexity=getattr(slice_item, "estimated_complexity", ""),
                 title=getattr(slice_item, "title", ""),
             )
+        )
+
+
+def _render_initiative_status(payload: dict[str, object]) -> None:
+    print(
+        "initiative_id={initiative_id} completed={completed}/{total} milestones={done}/{count}".format(
+            initiative_id=payload.get("initiative_id", ""),
+            completed=payload.get("completed_slices", 0),
+            total=payload.get("total_slices", 0),
+            done=payload.get("milestones_complete", 0),
+            count=payload.get("milestones_total", 0),
+        )
+    )
+    milestones = [item for item in payload.get("milestones", []) if isinstance(item, dict)]
+    if milestones:
+        print("\nMilestones")
+        _print_table(
+            [
+                ("milestone", "Milestone"),
+                ("completed", "Done"),
+                ("total", "Total"),
+                ("waiting_for_pr", "WaitPR"),
+                ("waiting_for_merge", "WaitMerge"),
+                ("promotable", "Promotable"),
+                ("blocked", "Blocked"),
+            ],
+            milestones,
+        )
+    slices = [item for item in payload.get("slices", []) if isinstance(item, dict)]
+    if slices:
+        print("\nSlices")
+        _print_table(
+            [
+                ("project_id", "Slice"),
+                ("milestone", "Milestone"),
+                ("status", "Status"),
+                ("next_action", "Next"),
+                ("pr_number", "PR"),
+                ("feature_flag", "Flag"),
+            ],
+            slices[:10],
         )
 
 
@@ -2010,6 +2052,46 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 print(f"  needs_human: {reason}")
             for action_text in result.next_actions[:3]:
                 print(f"  next: {action_text}")
+        return
+
+    if action == "initiative":
+        from aragora.swarm.initiative_integrator import (
+            DEFAULT_INITIATIVE_MANIFEST,
+            InitiativeIntegrator,
+        )
+
+        subaction = str(goal or "status").strip().lower() or "status"
+        manifest_path = Path(
+            getattr(args, "manifest", None) or DEFAULT_INITIATIVE_MANIFEST
+        ).resolve()
+        if not manifest_path.exists():
+            raise ValueError(f"initiative manifest not found: {manifest_path}")
+
+        integrator = InitiativeIntegrator(
+            manifest_path=manifest_path,
+            repo_root=Path.cwd(),
+            target_branch=target_branch,
+            repo=getattr(args, "boss_repo", None) or "synaptent/aragora",
+        )
+        if subaction == "run":
+            payload = asyncio.run(integrator.run())
+        elif subaction == "status":
+            payload = integrator.status()
+        elif subaction == "promote":
+            payload = integrator.promote(
+                project_id=_optional_text(getattr(args, "swarm_campaign_target", None)),
+                dry_run=bool(getattr(args, "dry_run", False)),
+            )
+        else:
+            raise ValueError("initiative action must be one of: run, status, promote")
+
+        if as_json:
+            print(json.dumps(payload, indent=2))
+        else:
+            if subaction in {"run", "status"}:
+                _render_initiative_status(payload)
+            else:
+                print(json.dumps(payload, indent=2))
         return
 
     if action == "campaign":

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -1283,14 +1283,52 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         return
 
     if action == "initiative":
+        from aragora.swarm.initiative_integrator import (
+            DEFAULT_INITIATIVE_MANIFEST,
+            InitiativeIntegrator,
+        )
         from aragora.swarm.initiative_planner import InitiativePlanner
         from aragora.swarm.initiative_store import InitiativeStore
 
         subaction = str(goal or "list").strip().lower() or "list"
-        if subaction not in {"plan", "show", "list"}:
-            raise ValueError("initiative action must be one of: plan, show, list")
+        if subaction not in {"plan", "show", "list", "run", "status", "promote"}:
+            raise ValueError(
+                "initiative action must be one of: plan, show, list, run, status, promote"
+            )
 
         repo_root = resolve_repo_root(Path.cwd())
+        if subaction in {"run", "status", "promote"}:
+            manifest_path = Path(
+                getattr(args, "manifest", None) or DEFAULT_INITIATIVE_MANIFEST
+            ).resolve()
+            if not manifest_path.exists():
+                raise ValueError(f"initiative manifest not found: {manifest_path}")
+
+            integrator = InitiativeIntegrator(
+                manifest_path=manifest_path,
+                repo_root=repo_root,
+                target_branch=target_branch,
+                repo=getattr(args, "boss_repo", None) or "synaptent/aragora",
+            )
+            if subaction == "run":
+                payload = asyncio.run(integrator.run())
+            elif subaction == "status":
+                payload = integrator.status()
+            else:
+                payload = integrator.promote(
+                    project_id=_optional_text(getattr(args, "swarm_campaign_target", None)),
+                    dry_run=bool(getattr(args, "dry_run", False)),
+                )
+
+            if as_json:
+                print(json.dumps(payload, indent=2))
+            else:
+                if subaction in {"run", "status"}:
+                    _render_initiative_status(payload)
+                else:
+                    print(json.dumps(payload, indent=2))
+            return
+
         initiative_dir = _optional_text(getattr(args, "initiative_dir", None))
         state_dir = Path(initiative_dir).expanduser().resolve() if initiative_dir else None
         store = InitiativeStore(repo_root=repo_root, state_dir=state_dir)
@@ -2052,46 +2090,6 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 print(f"  needs_human: {reason}")
             for action_text in result.next_actions[:3]:
                 print(f"  next: {action_text}")
-        return
-
-    if action == "initiative":
-        from aragora.swarm.initiative_integrator import (
-            DEFAULT_INITIATIVE_MANIFEST,
-            InitiativeIntegrator,
-        )
-
-        subaction = str(goal or "status").strip().lower() or "status"
-        manifest_path = Path(
-            getattr(args, "manifest", None) or DEFAULT_INITIATIVE_MANIFEST
-        ).resolve()
-        if not manifest_path.exists():
-            raise ValueError(f"initiative manifest not found: {manifest_path}")
-
-        integrator = InitiativeIntegrator(
-            manifest_path=manifest_path,
-            repo_root=Path.cwd(),
-            target_branch=target_branch,
-            repo=getattr(args, "boss_repo", None) or "synaptent/aragora",
-        )
-        if subaction == "run":
-            payload = asyncio.run(integrator.run())
-        elif subaction == "status":
-            payload = integrator.status()
-        elif subaction == "promote":
-            payload = integrator.promote(
-                project_id=_optional_text(getattr(args, "swarm_campaign_target", None)),
-                dry_run=bool(getattr(args, "dry_run", False)),
-            )
-        else:
-            raise ValueError("initiative action must be one of: run, status, promote")
-
-        if as_json:
-            print(json.dumps(payload, indent=2))
-        else:
-            if subaction in {"run", "status"}:
-                _render_initiative_status(payload)
-            else:
-                print(json.dumps(payload, indent=2))
         return
 
     if action == "campaign":

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2310,7 +2310,7 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "swarm_campaign_target",
         nargs="?",
-        help="Campaign subtarget such as a project id for review",
+        help="Campaign or initiative subtarget such as a project id for review/promotion",
     )
     swarm_parser.add_argument(
         "--spec",
@@ -2746,7 +2746,7 @@ def _add_swarm_parser(subparsers) -> None:
     swarm_parser.add_argument(
         "--manifest",
         default=DEFAULT_CAMPAIGN_MANIFEST,
-        help="Campaign or tranche manifest path (default: .aragora/campaign_manifest.yaml)",
+        help="Campaign, initiative, or tranche manifest path (default: .aragora/campaign_manifest.yaml)",
     )
     swarm_parser.add_argument(
         "--queue",

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -51,6 +51,18 @@ def _optional_text(value: Any) -> str | None:
     return text
 
 
+def _coerce_boolish(value: Any, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"1", "true", "yes", "y", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "n", "off"}:
+            return False
+    return default
+
+
 # Statuses that represent terminal project transitions (no further retries).
 # Receipt emission fires only for these statuses.
 _TERMINAL_STATUSES: frozenset[str] = frozenset(
@@ -209,11 +221,14 @@ class CampaignProject:
     project_id: str
     title: str
     source_refs: list[str] = field(default_factory=list)
+    milestone: str | None = None
     spec: SwarmSpec = field(default_factory=SwarmSpec)
     file_scope_hints: list[str] = field(default_factory=list)
     acceptance_criteria: list[str] = field(default_factory=list)
     constraints: list[str] = field(default_factory=list)
     dependencies: list[CampaignDependency] = field(default_factory=list)
+    feature_flag: str | None = None
+    feature_flag_required: bool = False
     estimated_cost_usd: float = 0.0
     status: str = CampaignProjectStatus.PENDING.value
     retry_count: int = 0
@@ -233,11 +248,14 @@ class CampaignProject:
             "project_id": self.project_id,
             "title": self.title,
             "source_refs": list(self.source_refs),
+            "milestone": self.milestone,
             "spec": self.spec.to_dict(),
             "file_scope_hints": list(self.file_scope_hints),
             "acceptance_criteria": list(self.acceptance_criteria),
             "constraints": list(self.constraints),
             "dependencies": [item.to_dict() for item in self.dependencies],
+            "feature_flag": self.feature_flag,
+            "feature_flag_required": self.feature_flag_required,
             "estimated_cost_usd": self.estimated_cost_usd,
             "status": self.status,
             "retry_count": self.retry_count,
@@ -259,6 +277,7 @@ class CampaignProject:
             project_id=str(data.get("project_id", "")).strip(),
             title=str(data.get("title", "")).strip(),
             source_refs=[str(item) for item in data.get("source_refs", []) if str(item).strip()],
+            milestone=_optional_text(data.get("milestone")),
             spec=SwarmSpec.from_dict(dict(data.get("spec") or {})),
             file_scope_hints=[
                 str(item) for item in data.get("file_scope_hints", []) if str(item).strip()
@@ -272,6 +291,11 @@ class CampaignProject:
                 for item in data.get("dependencies", [])
                 if isinstance(item, dict)
             ],
+            feature_flag=_optional_text(data.get("feature_flag")),
+            feature_flag_required=_coerce_boolish(
+                data.get("feature_flag_required"),
+                default=False,
+            ),
             estimated_cost_usd=float(data.get("estimated_cost_usd", 0.0) or 0.0),
             status=str(data.get("status", CampaignProjectStatus.PENDING.value)).strip()
             or CampaignProjectStatus.PENDING.value,

--- a/aragora/swarm/initiative_integrator.py
+++ b/aragora/swarm/initiative_integrator.py
@@ -1,0 +1,612 @@
+"""Milestone-aware initiative integration on top of campaign manifests.
+
+The initiative layer reuses the campaign executor as the slice execution
+contract and adds:
+
+- milestone progress reporting
+- terminal handling for published PR slices
+- dependency-aware draft promotion / merge ordering
+- feature-flag-required merge gating
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from aragora.swarm.campaign import (
+    CampaignExecutor,
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    load_campaign_manifest,
+    locked_manifest_path,
+    save_campaign_manifest,
+)
+from aragora.swarm.merge_arbiter import (
+    REQUIRED_CHECKS,
+    _classify_required_checks,
+    _get_check_status,
+    _merge_pr,
+    _promote_draft,
+    _run_gh,
+)
+from aragora.swarm.pr_registry import PullRequestRegistry
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INITIATIVE_MANIFEST = ".aragora/campaign_manifest.yaml"
+_RUNNABLE_PROJECT_STATUSES = frozenset(
+    {
+        CampaignProjectStatus.PENDING.value,
+        CampaignProjectStatus.READY.value,
+        CampaignProjectStatus.NEEDS_REVISION.value,
+        CampaignProjectStatus.ACTIVE.value,
+        CampaignProjectStatus.DELIVERED.value,
+    }
+)
+
+
+def _project_milestone(project: CampaignProject) -> str:
+    return str(project.milestone or "").strip() or "default"
+
+
+def _project_pr_reference(project: CampaignProject) -> str | None:
+    for candidate in (project.pr_url, project.adopted_pr):
+        text = str(candidate or "").strip()
+        if text:
+            return text
+    return None
+
+
+def _parse_pr_number(reference: object) -> int | None:
+    text = str(reference or "").strip()
+    if not text:
+        return None
+    if text.isdigit():
+        return int(text)
+    marker = "/pull/"
+    if marker in text:
+        tail = text.split(marker, 1)[1].split("/", 1)[0].strip()
+        if tail.isdigit():
+            return int(tail)
+    return None
+
+
+def _gh_json(args: list[str], *, timeout: float = 30.0) -> Any:
+    result = _run_gh(args, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "gh command failed")
+    return json.loads(result.stdout or "null")
+
+
+def _get_pr_snapshot(
+    pr_reference: object,
+    *,
+    repo: str,
+) -> dict[str, Any] | None:
+    pr_number = _parse_pr_number(pr_reference)
+    ref = str(pr_number or pr_reference or "").strip()
+    if not ref:
+        return None
+    try:
+        payload = _gh_json(
+            [
+                "pr",
+                "view",
+                ref,
+                "--repo",
+                repo,
+                "--json",
+                "number,url,isDraft,state,headRefName,mergeStateStatus,mergedAt",
+            ]
+        )
+    except (RuntimeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _find_open_pr_for_branch(branch: str, *, repo: str) -> dict[str, Any] | None:
+    normalized = str(branch or "").strip()
+    if not normalized:
+        return None
+    try:
+        payload = _gh_json(
+            [
+                "pr",
+                "list",
+                "--repo",
+                repo,
+                "--state",
+                "open",
+                "--head",
+                normalized,
+                "--json",
+                "number,url,isDraft,state,headRefName,mergeStateStatus,mergedAt",
+                "--limit",
+                "10",
+            ]
+        )
+    except (RuntimeError, ValueError, TypeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, list) or not payload:
+        return None
+    first = payload[0]
+    return first if isinstance(first, dict) else None
+
+
+def _is_pr_merged(snapshot: dict[str, Any] | None) -> bool:
+    if not isinstance(snapshot, dict):
+        return False
+    if snapshot.get("mergedAt"):
+        return True
+    return str(snapshot.get("state", "")).strip().upper() == "MERGED"
+
+
+def _is_pr_open(snapshot: dict[str, Any] | None) -> bool:
+    if not isinstance(snapshot, dict):
+        return False
+    if _is_pr_merged(snapshot):
+        return False
+    return str(snapshot.get("state", "")).strip().upper() in {"OPEN", "DRAFT", ""}
+
+
+def _dependency_blockers(
+    manifest: CampaignManifest,
+    project: CampaignProject,
+) -> list[str]:
+    status_map = {item.project_id: item.status for item in manifest.projects}
+    blockers: list[str] = []
+    for dependency in project.dependencies:
+        dep_status = status_map.get(dependency.project_id)
+        if dep_status != CampaignProjectStatus.COMPLETED.value:
+            blockers.append(dependency.project_id)
+    return blockers
+
+
+def _ordered_projects(manifest: CampaignManifest) -> list[CampaignProject]:
+    projects = list(manifest.projects)
+    if len(projects) < 2:
+        return projects
+
+    project_map = {project.project_id: project for project in projects}
+    order = {project.project_id: index for index, project in enumerate(projects)}
+    indegree = {project.project_id: 0 for project in projects}
+    dependents: dict[str, list[str]] = {project.project_id: [] for project in projects}
+
+    for project in projects:
+        seen_dependencies: set[str] = set()
+        for dependency in project.dependencies:
+            dep_id = dependency.project_id
+            if (
+                dep_id == project.project_id
+                or dep_id not in project_map
+                or dep_id in seen_dependencies
+            ):
+                continue
+            indegree[project.project_id] += 1
+            dependents[dep_id].append(project.project_id)
+            seen_dependencies.add(dep_id)
+
+    ready = sorted(
+        [project_id for project_id, degree in indegree.items() if degree == 0],
+        key=order.__getitem__,
+    )
+    ordered_ids: list[str] = []
+    while ready:
+        project_id = ready.pop(0)
+        ordered_ids.append(project_id)
+        for dependent_id in sorted(dependents.get(project_id, []), key=order.__getitem__):
+            indegree[dependent_id] -= 1
+            if indegree[dependent_id] == 0:
+                ready.append(dependent_id)
+                ready.sort(key=order.__getitem__)
+
+    if len(ordered_ids) < len(projects):
+        remaining = sorted(
+            [project.project_id for project in projects if project.project_id not in ordered_ids],
+            key=order.__getitem__,
+        )
+        ordered_ids.extend(remaining)
+
+    return [project_map[project_id] for project_id in ordered_ids]
+
+
+class InitiativeIntegrator:
+    """Milestone-aware integration and promotion for campaign-backed slices."""
+
+    def __init__(
+        self,
+        *,
+        manifest_path: Path,
+        repo_root: Path | None = None,
+        target_branch: str = "main",
+        repo: str = "synaptent/aragora",
+        executor: CampaignExecutor | None = None,
+        registry: PullRequestRegistry | None = None,
+    ) -> None:
+        self.manifest_path = manifest_path.resolve()
+        self.repo_root = (repo_root or Path.cwd()).resolve()
+        self.target_branch = target_branch
+        self.repo = repo
+        self.executor = executor or CampaignExecutor(
+            manifest_path=self.manifest_path,
+            repo_root=self.repo_root,
+            target_branch=self.target_branch,
+        )
+        self.registry = registry or PullRequestRegistry(state_dir=self.repo_root / ".aragora")
+
+    async def run(self) -> dict[str, Any]:
+        self.sync_terminals()
+        manifest = load_campaign_manifest(self.manifest_path)
+        should_execute = any(
+            project.status in _RUNNABLE_PROJECT_STATUSES for project in manifest.projects
+        )
+        if should_execute:
+            campaign_payload = await self.executor.execute_once()
+        else:
+            campaign_payload = {
+                "stop_reason": "promotion_pending",
+                "dispatched_projects": [],
+                "merge_ready_projects": [],
+            }
+        payload = self.status(refresh=True)
+        payload.update(
+            {
+                "mode": "initiative-run",
+                "executed": should_execute,
+                "campaign": campaign_payload,
+            }
+        )
+        return payload
+
+    def status(self, *, refresh: bool = True) -> dict[str, Any]:
+        if refresh:
+            self.sync_terminals()
+        manifest = load_campaign_manifest(self.manifest_path)
+        slice_rows = [
+            self._slice_status(manifest, project) for project in _ordered_projects(manifest)
+        ]
+        milestones: dict[str, dict[str, Any]] = {}
+        for row in slice_rows:
+            milestone = str(row["milestone"])
+            bucket = milestones.setdefault(
+                milestone,
+                {
+                    "milestone": milestone,
+                    "total": 0,
+                    "completed": 0,
+                    "waiting_for_pr": 0,
+                    "waiting_for_merge": 0,
+                    "blocked": 0,
+                    "promotable": 0,
+                },
+            )
+            bucket["total"] += 1
+            status = str(row["status"])
+            if status == CampaignProjectStatus.COMPLETED.value:
+                bucket["completed"] += 1
+            if status == CampaignProjectStatus.WAITING_FOR_PR.value:
+                bucket["waiting_for_pr"] += 1
+            if status == CampaignProjectStatus.WAITING_FOR_MERGE.value:
+                bucket["waiting_for_merge"] += 1
+            if status in {
+                CampaignProjectStatus.BLOCKED.value,
+                CampaignProjectStatus.FAILED.value,
+                CampaignProjectStatus.STALLED.value,
+                CampaignProjectStatus.SKIPPED.value,
+            }:
+                bucket["blocked"] += 1
+            if row["next_action"] in {"promote_draft", "merge"}:
+                bucket["promotable"] += 1
+        milestone_rows = list(milestones.values())
+        total = len(slice_rows)
+        completed = sum(
+            1 for row in slice_rows if row["status"] == CampaignProjectStatus.COMPLETED.value
+        )
+        return {
+            "mode": "initiative-status",
+            "initiative_id": manifest.campaign_id,
+            "manifest_path": str(self.manifest_path),
+            "target_branch": self.target_branch,
+            "repo": self.repo,
+            "total_slices": total,
+            "completed_slices": completed,
+            "milestones_complete": sum(
+                1 for row in milestone_rows if row["completed"] == row["total"]
+            ),
+            "milestones_total": len(milestone_rows),
+            "milestones": milestone_rows,
+            "slices": slice_rows,
+        }
+
+    def promote(
+        self,
+        *,
+        project_id: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        self.sync_terminals()
+        manifest = load_campaign_manifest(self.manifest_path)
+        projects = _ordered_projects(manifest)
+        target: CampaignProject | None = None
+        row: dict[str, Any] | None = None
+        if project_id:
+            target = manifest.project_map().get(project_id)
+            if target is None:
+                raise KeyError(f"Unknown project_id: {project_id}")
+            row = self._slice_status(manifest, target)
+        else:
+            waiting_rows: list[tuple[CampaignProject, dict[str, Any]]] = []
+            for candidate in projects:
+                if candidate.status not in {
+                    CampaignProjectStatus.WAITING_FOR_PR.value,
+                    CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                }:
+                    continue
+                candidate_row = self._slice_status(manifest, candidate)
+                waiting_rows.append((candidate, candidate_row))
+                if candidate_row.get("next_action"):
+                    target = candidate
+                    row = candidate_row
+                    break
+            if target is None and waiting_rows:
+                target, row = waiting_rows[0]
+
+        if target is None:
+            payload = self.status(refresh=False)
+            payload.update(
+                {
+                    "mode": "initiative-promote",
+                    "action": "noop",
+                    "reason": "no waiting initiative slices",
+                }
+            )
+            return payload
+
+        if row is None:
+            raise RuntimeError("initiative promote selected a slice without computed status")
+        next_action = str(row.get("next_action") or "").strip()
+        blockers = list(row.get("promotion_blockers", []) or [])
+        if not next_action:
+            return {
+                "mode": "initiative-promote",
+                "initiative_id": manifest.campaign_id,
+                "project_id": target.project_id,
+                "action": "blocked",
+                "reason": blockers[0] if blockers else "slice is not promotable",
+                "promotion_blockers": blockers,
+            }
+
+        pr_number = _parse_pr_number(row.get("pr_number") or row.get("pr_url"))
+        if pr_number is None:
+            return {
+                "mode": "initiative-promote",
+                "initiative_id": manifest.campaign_id,
+                "project_id": target.project_id,
+                "action": "blocked",
+                "reason": "unable to resolve PR number for slice",
+                "promotion_blockers": ["unable to resolve PR number for slice"],
+            }
+
+        if next_action == "promote_draft":
+            if dry_run:
+                return {
+                    "mode": "initiative-promote",
+                    "initiative_id": manifest.campaign_id,
+                    "project_id": target.project_id,
+                    "action": "would_promote_draft",
+                    "pr_number": pr_number,
+                    "pr_url": row.get("pr_url"),
+                }
+            promoted = _promote_draft(pr_number, self.repo)
+            return {
+                "mode": "initiative-promote",
+                "initiative_id": manifest.campaign_id,
+                "project_id": target.project_id,
+                "action": "promoted_draft" if promoted else "blocked",
+                "pr_number": pr_number,
+                "pr_url": row.get("pr_url"),
+                "reason": "" if promoted else "failed to promote draft PR",
+            }
+
+        if next_action == "merge":
+            if dry_run:
+                return {
+                    "mode": "initiative-promote",
+                    "initiative_id": manifest.campaign_id,
+                    "project_id": target.project_id,
+                    "action": "would_merge",
+                    "pr_number": pr_number,
+                    "pr_url": row.get("pr_url"),
+                }
+            merged, reason = _merge_pr(pr_number, self.repo)
+            if not merged:
+                return {
+                    "mode": "initiative-promote",
+                    "initiative_id": manifest.campaign_id,
+                    "project_id": target.project_id,
+                    "action": "blocked",
+                    "pr_number": pr_number,
+                    "pr_url": row.get("pr_url"),
+                    "reason": reason,
+                }
+            completion = self.executor.complete_project(
+                target.project_id,
+                pr_url=str(row.get("pr_url") or "") or None,
+            )
+            return {
+                "mode": "initiative-promote",
+                "initiative_id": manifest.campaign_id,
+                "project_id": target.project_id,
+                "action": "merged",
+                "pr_number": pr_number,
+                "pr_url": row.get("pr_url"),
+                "completion": completion,
+            }
+
+        return {
+            "mode": "initiative-promote",
+            "initiative_id": manifest.campaign_id,
+            "project_id": target.project_id,
+            "action": "blocked",
+            "reason": f"unsupported promotion action: {next_action}",
+        }
+
+    def sync_terminals(self) -> None:
+        merged_projects: list[tuple[str, str | None]] = []
+        changed = False
+        with locked_manifest_path(self.manifest_path):
+            manifest = load_campaign_manifest(self.manifest_path)
+            for project in manifest.projects:
+                snapshot = self._resolve_project_pr_snapshot(project)
+                pr_ref = _project_pr_reference(project)
+                if _is_pr_merged(snapshot):
+                    merged_pr = str((snapshot or {}).get("url") or pr_ref or "").strip() or None
+                    if merged_pr and project.pr_url != merged_pr:
+                        project.pr_url = merged_pr
+                        changed = True
+                    if project.status == CampaignProjectStatus.COMPLETED.value:
+                        continue
+                    if project.status != CampaignProjectStatus.WAITING_FOR_MERGE.value:
+                        project.status = CampaignProjectStatus.WAITING_FOR_MERGE.value
+                        changed = True
+                    merged_projects.append((project.project_id, merged_pr))
+                    continue
+
+                if _is_pr_open(snapshot) or pr_ref:
+                    desired_pr = (
+                        str((snapshot or {}).get("url") or pr_ref or "").strip() or project.pr_url
+                    )
+                    desired_branch = (
+                        str((snapshot or {}).get("headRefName") or project.branch or "").strip()
+                        or project.branch
+                    )
+                    if desired_pr and project.pr_url != desired_pr:
+                        project.pr_url = desired_pr
+                        changed = True
+                    if desired_branch and project.branch != desired_branch:
+                        project.branch = desired_branch
+                        changed = True
+                    if project.status != CampaignProjectStatus.WAITING_FOR_MERGE.value:
+                        project.status = CampaignProjectStatus.WAITING_FOR_MERGE.value
+                        changed = True
+                    continue
+
+                if project.branch and project.status in _RUNNABLE_PROJECT_STATUSES:
+                    project.status = CampaignProjectStatus.WAITING_FOR_PR.value
+                    changed = True
+
+            if changed:
+                save_campaign_manifest(self.manifest_path, manifest)
+
+        for project_id, pr_url in merged_projects:
+            try:
+                self.executor.complete_project(project_id, pr_url=pr_url)
+            except ValueError:
+                logger.debug("initiative sync skipped completion for %s", project_id, exc_info=True)
+
+    def _resolve_project_pr_snapshot(self, project: CampaignProject) -> dict[str, Any] | None:
+        project_pr = _project_pr_reference(project)
+        if project_pr:
+            snapshot = _get_pr_snapshot(project_pr, repo=self.repo)
+            if snapshot is not None:
+                return snapshot
+            fallback_number = _parse_pr_number(project_pr)
+            return {
+                "number": fallback_number,
+                "url": project_pr,
+                "isDraft": None,
+                "state": "UNKNOWN",
+                "headRefName": project.branch,
+                "mergeStateStatus": "",
+                "mergedAt": None,
+            }
+
+        branch = str(project.branch or "").strip()
+        if branch:
+            registry_entry = self.registry.get(branch)
+            if isinstance(registry_entry, dict):
+                registry_pr = str(registry_entry.get("pr_url") or "").strip()
+                if registry_pr:
+                    snapshot = _get_pr_snapshot(registry_pr, repo=self.repo)
+                    if snapshot is not None:
+                        return snapshot
+                    return {
+                        "number": _parse_pr_number(registry_pr),
+                        "url": registry_pr,
+                        "isDraft": None,
+                        "state": "UNKNOWN",
+                        "headRefName": branch,
+                        "mergeStateStatus": "",
+                        "mergedAt": None,
+                    }
+            return _find_open_pr_for_branch(branch, repo=self.repo)
+        return None
+
+    def _slice_status(
+        self,
+        manifest: CampaignManifest,
+        project: CampaignProject,
+    ) -> dict[str, Any]:
+        snapshot = self._resolve_project_pr_snapshot(project)
+        pr_number = _parse_pr_number((snapshot or {}).get("number") or (snapshot or {}).get("url"))
+        checks = _get_check_status(pr_number, self.repo) if pr_number is not None else {}
+        missing_checks, failing_checks = _classify_required_checks(checks)
+        dependency_blockers = _dependency_blockers(manifest, project)
+        promotion_blockers: list[str] = []
+        next_action: str | None = None
+
+        if project.status == CampaignProjectStatus.WAITING_FOR_PR.value and not snapshot:
+            promotion_blockers.append("published PR not found for branch deliverable")
+        elif project.status == CampaignProjectStatus.WAITING_FOR_MERGE.value:
+            if dependency_blockers:
+                promotion_blockers.append(
+                    "dependencies not merged: " + ", ".join(dependency_blockers)
+                )
+            if missing_checks:
+                promotion_blockers.append("missing checks: " + ", ".join(missing_checks))
+            if failing_checks:
+                promotion_blockers.append("failing checks: " + ", ".join(failing_checks))
+            if snapshot is None:
+                promotion_blockers.append("PR snapshot unavailable")
+            elif bool(snapshot.get("isDraft")):
+                if not promotion_blockers:
+                    next_action = "promote_draft"
+            else:
+                if project.feature_flag_required and not project.feature_flag:
+                    promotion_blockers.append("feature flag required before merge")
+                if not promotion_blockers and not _is_pr_merged(snapshot):
+                    next_action = "merge"
+
+        return {
+            "project_id": project.project_id,
+            "title": project.title,
+            "milestone": _project_milestone(project),
+            "status": project.status,
+            "branch": project.branch,
+            "pr_url": (snapshot or {}).get("url") or _project_pr_reference(project),
+            "pr_number": pr_number,
+            "pr_draft": bool(snapshot.get("isDraft")) if isinstance(snapshot, dict) else None,
+            "pr_state": str((snapshot or {}).get("state") or "").strip() or None,
+            "dependencies": [dep.project_id for dep in project.dependencies],
+            "dependency_blockers": dependency_blockers,
+            "feature_flag": project.feature_flag,
+            "feature_flag_required": project.feature_flag_required,
+            "execution_terminal": bool(_project_pr_reference(project) or _is_pr_open(snapshot)),
+            "required_checks": list(REQUIRED_CHECKS),
+            "missing_checks": missing_checks,
+            "failing_checks": failing_checks,
+            "next_action": next_action,
+            "promotion_blockers": promotion_blockers,
+        }
+
+
+__all__ = [
+    "DEFAULT_INITIATIVE_MANIFEST",
+    "InitiativeIntegrator",
+]

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -73,6 +73,23 @@ class ArbiterSummary:
         }
 
 
+def _classify_required_checks(
+    checks: dict[str, str],
+    *,
+    required_checks: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Split required checks into missing and failing buckets."""
+    missing: list[str] = []
+    failing: list[str] = []
+    for name in required_checks or REQUIRED_CHECKS:
+        status = checks.get(name)
+        if status is None:
+            missing.append(name)
+        elif status != "SUCCESS":
+            failing.append(f"{name}={status}")
+    return missing, failing
+
+
 def _run_gh(args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
     """Run a ``gh`` CLI command and return the result."""
     return subprocess.run(
@@ -195,14 +212,7 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
     if not checks:
         return MergeResult(pr_number, branch, False, "no checks found")
 
-    missing = []
-    failing = []
-    for name in REQUIRED_CHECKS:
-        status = checks.get(name)
-        if status is None:
-            missing.append(name)
-        elif status != "SUCCESS":
-            failing.append(f"{name}={status}")
+    missing, failing = _classify_required_checks(checks)
 
     if missing:
         return MergeResult(pr_number, branch, False, f"missing checks: {', '.join(missing)}")

--- a/tests/swarm/test_initiative_integrator.py
+++ b/tests/swarm/test_initiative_integrator.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aragora.swarm.campaign import (
+    CampaignDependency,
+    CampaignManifest,
+    CampaignProject,
+    CampaignProjectStatus,
+    save_campaign_manifest,
+)
+from aragora.swarm.initiative_integrator import InitiativeIntegrator
+from aragora.swarm.merge_arbiter import REQUIRED_CHECKS
+from aragora.swarm.spec import SwarmSpec
+
+
+def _bounded_spec(goal: str) -> SwarmSpec:
+    return SwarmSpec(
+        raw_goal=goal,
+        refined_goal=goal,
+        acceptance_criteria=["pytest -q tests/swarm/test_initiative_integrator.py"],
+        constraints=["do not widen scope"],
+        file_scope_hints=["aragora/swarm/initiative_integrator.py"],
+        budget_limit_usd=5.0,
+    )
+
+
+def _project(
+    project_id: str,
+    title: str,
+    *,
+    status: str = CampaignProjectStatus.PENDING.value,
+    milestone: str | None = None,
+    dependencies: list[str] | None = None,
+    branch: str | None = None,
+    pr_url: str | None = None,
+    feature_flag: str | None = None,
+    feature_flag_required: bool = False,
+) -> CampaignProject:
+    return CampaignProject(
+        project_id=project_id,
+        title=title,
+        milestone=milestone,
+        spec=_bounded_spec(title),
+        file_scope_hints=["aragora/swarm/initiative_integrator.py"],
+        acceptance_criteria=["pytest -q tests/swarm/test_initiative_integrator.py"],
+        constraints=["stay in scope"],
+        dependencies=[
+            CampaignDependency(project_id=dependency_id, reason="depends_on")
+            for dependency_id in (dependencies or [])
+        ],
+        branch=branch,
+        pr_url=pr_url,
+        feature_flag=feature_flag,
+        feature_flag_required=feature_flag_required,
+        status=status,
+    )
+
+
+def _manifest_path(tmp_path: Path, *projects: CampaignProject) -> Path:
+    manifest_path = tmp_path / ".aragora" / "campaign_manifest.yaml"
+    manifest = CampaignManifest(
+        campaign_id="initiative-test",
+        created_at="2026-04-07T00:00:00+00:00",
+        source_kind="manual",
+        source_ref="initiative.md",
+        projects=list(projects),
+    )
+    save_campaign_manifest(manifest_path, manifest)
+    return manifest_path
+
+
+def _all_passing_checks() -> dict[str, str]:
+    return dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+
+
+def _args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "swarm_action_or_goal": "initiative",
+        "swarm_goal": "status",
+        "swarm_campaign_target": None,
+        "spec": None,
+        "skip_interrogation": False,
+        "dry_run": False,
+        "budget_limit": 50.0,
+        "require_approval": False,
+        "max_parallel": 20,
+        "concurrency_cap": 8,
+        "no_loop": False,
+        "target_branch": "main",
+        "managed_dir_pattern": ".worktrees/{agent}-auto",
+        "json": True,
+        "run_id": None,
+        "refresh_scaling": False,
+        "no_dispatch": False,
+        "watch": False,
+        "claude_runner_profiles": None,
+        "runner_rotation_interval": 1800.0,
+        "interval_seconds": 5.0,
+        "max_ticks": None,
+        "all_runs": False,
+        "dispatch_only": False,
+        "no_wait": False,
+        "profile": "ceo",
+        "from_obsidian": None,
+        "obsidian_vault": None,
+        "no_obsidian_receipts": False,
+        "autonomy": "propose",
+        "boss_repo": None,
+        "manifest": "unused.yaml",
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestInitiativeIntegrator:
+    def test_status_reports_milestone_progress(self, tmp_path: Path) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-001",
+                "Root slice",
+                status=CampaignProjectStatus.COMPLETED.value,
+                milestone="M1",
+            ),
+            _project(
+                "proj-002",
+                "Follow-up slice",
+                status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                milestone="M1",
+            ),
+            _project(
+                "proj-003",
+                "Blocked slice",
+                status=CampaignProjectStatus.BLOCKED.value,
+                milestone="M2",
+            ),
+        )
+
+        payload = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path).status(
+            refresh=False
+        )
+
+        assert payload["total_slices"] == 3
+        assert payload["completed_slices"] == 1
+        assert payload["milestones_total"] == 2
+        milestone_rows = {row["milestone"]: row for row in payload["milestones"]}
+        assert milestone_rows["M1"]["total"] == 2
+        assert milestone_rows["M1"]["completed"] == 1
+        assert milestone_rows["M1"]["waiting_for_merge"] == 1
+        assert milestone_rows["M2"]["blocked"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_does_not_retry_slice_with_published_pr(self, tmp_path: Path) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-001",
+                "Published slice",
+                branch="codex/initiative-published",
+                pr_url="https://github.com/synaptent/aragora/pull/1234",
+            ),
+        )
+        integrator = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path)
+        integrator.executor = MagicMock()
+        integrator.executor.execute_once = AsyncMock(return_value={"stop_reason": "should_not_run"})
+        with patch.object(
+            integrator,
+            "_resolve_project_pr_snapshot",
+            return_value={
+                "number": 91234,
+                "url": "https://github.com/synaptent/aragora/pull/91234",
+                "isDraft": False,
+                "state": "OPEN",
+                "headRefName": "codex/initiative-published",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": None,
+            },
+        ):
+            payload = await integrator.run()
+
+        assert payload["executed"] is False
+        integrator.executor.execute_once.assert_not_called()
+        assert payload["slices"][0]["status"] == CampaignProjectStatus.WAITING_FOR_MERGE.value
+        assert payload["slices"][0]["execution_terminal"] is True
+
+    def test_sync_terminals_completes_merged_pr_backed_slice(self, tmp_path: Path) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-001",
+                "Merged slice",
+                pr_url="https://github.com/synaptent/aragora/pull/5001",
+            ),
+        )
+        integrator = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with patch.object(
+            integrator,
+            "_resolve_project_pr_snapshot",
+            return_value={
+                "number": 5001,
+                "url": "https://github.com/synaptent/aragora/pull/5001",
+                "isDraft": False,
+                "state": "MERGED",
+                "headRefName": "codex/merged-slice",
+                "mergeStateStatus": "MERGED",
+                "mergedAt": "2026-04-07T00:00:00+00:00",
+            },
+        ):
+            integrator.sync_terminals()
+
+        payload = integrator.status(refresh=False)
+        assert payload["slices"][0]["status"] == CampaignProjectStatus.COMPLETED.value
+
+    def test_promote_prefers_dependency_root_even_when_manifest_unsorted(
+        self, tmp_path: Path
+    ) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-002",
+                "Child slice",
+                status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                dependencies=["proj-001"],
+                pr_url="https://github.com/synaptent/aragora/pull/2002",
+            ),
+            _project(
+                "proj-001",
+                "Parent slice",
+                status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                pr_url="https://github.com/synaptent/aragora/pull/2001",
+            ),
+        )
+        integrator = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path)
+        integrator.executor = MagicMock()
+        integrator.executor.complete_project.return_value = {
+            "project_id": "proj-001",
+            "status": CampaignProjectStatus.COMPLETED.value,
+        }
+
+        def resolve_snapshot(project: CampaignProject) -> dict[str, object]:
+            if project.project_id == "proj-001":
+                return {
+                    "number": 2001,
+                    "url": "https://github.com/synaptent/aragora/pull/2001",
+                    "isDraft": False,
+                    "state": "OPEN",
+                    "headRefName": "codex/parent",
+                    "mergeStateStatus": "CLEAN",
+                    "mergedAt": None,
+                }
+            return {
+                "number": 2002,
+                "url": "https://github.com/synaptent/aragora/pull/2002",
+                "isDraft": False,
+                "state": "OPEN",
+                "headRefName": "codex/child",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": None,
+            }
+
+        with (
+            patch.object(integrator, "_resolve_project_pr_snapshot", side_effect=resolve_snapshot),
+            patch(
+                "aragora.swarm.initiative_integrator._get_check_status",
+                return_value=_all_passing_checks(),
+            ),
+            patch(
+                "aragora.swarm.initiative_integrator._merge_pr", return_value=(True, "merged")
+            ) as merge_pr,
+        ):
+            payload = integrator.promote()
+
+        assert payload["action"] == "merged"
+        assert payload["project_id"] == "proj-001"
+        merge_pr.assert_called_once_with(2001, integrator.repo)
+
+    def test_promote_promotes_draft_slice_when_dependency_clear(self, tmp_path: Path) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-001",
+                "Draft slice",
+                status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                pr_url="https://github.com/synaptent/aragora/pull/3001",
+            ),
+        )
+        integrator = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with (
+            patch.object(
+                integrator,
+                "_resolve_project_pr_snapshot",
+                return_value={
+                    "number": 3001,
+                    "url": "https://github.com/synaptent/aragora/pull/3001",
+                    "isDraft": True,
+                    "state": "OPEN",
+                    "headRefName": "codex/draft-slice",
+                    "mergeStateStatus": "CLEAN",
+                    "mergedAt": None,
+                },
+            ),
+            patch(
+                "aragora.swarm.initiative_integrator._get_check_status",
+                return_value=_all_passing_checks(),
+            ),
+            patch(
+                "aragora.swarm.initiative_integrator._promote_draft", return_value=True
+            ) as promote_draft,
+        ):
+            payload = integrator.promote()
+
+        assert payload["action"] == "promoted_draft"
+        assert payload["project_id"] == "proj-001"
+        promote_draft.assert_called_once_with(3001, integrator.repo)
+
+    def test_promote_blocks_merge_when_feature_flag_is_required(self, tmp_path: Path) -> None:
+        manifest_path = _manifest_path(
+            tmp_path,
+            _project(
+                "proj-001",
+                "Flagged slice",
+                status=CampaignProjectStatus.WAITING_FOR_MERGE.value,
+                pr_url="https://github.com/synaptent/aragora/pull/4001",
+                feature_flag_required=True,
+            ),
+        )
+        integrator = InitiativeIntegrator(manifest_path=manifest_path, repo_root=tmp_path)
+
+        with (
+            patch.object(
+                integrator,
+                "_resolve_project_pr_snapshot",
+                return_value={
+                    "number": 4001,
+                    "url": "https://github.com/synaptent/aragora/pull/4001",
+                    "isDraft": False,
+                    "state": "OPEN",
+                    "headRefName": "codex/flagged-slice",
+                    "mergeStateStatus": "CLEAN",
+                    "mergedAt": None,
+                },
+            ),
+            patch(
+                "aragora.swarm.initiative_integrator._get_check_status",
+                return_value=_all_passing_checks(),
+            ),
+        ):
+            payload = integrator.promote()
+
+        assert payload["action"] == "blocked"
+        assert "feature flag required" in payload["reason"]
+
+
+class TestInitiativeCli:
+    def test_swarm_parser_accepts_initiative_status(self) -> None:
+        from aragora.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "swarm",
+                "initiative",
+                "status",
+                "--manifest",
+                ".aragora/campaign_manifest.yaml",
+            ]
+        )
+
+        assert args.swarm_action_or_goal == "initiative"
+        assert args.swarm_goal == "status"
+
+    def test_cmd_swarm_initiative_status_json(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from aragora.cli.commands.swarm import cmd_swarm
+
+        manifest_path = _manifest_path(tmp_path, _project("proj-001", "CLI slice"))
+        args = _args(manifest=str(manifest_path))
+
+        with patch("aragora.swarm.initiative_integrator.InitiativeIntegrator") as integrator_cls:
+            integrator_cls.return_value.status.return_value = {
+                "mode": "initiative-status",
+                "initiative_id": "initiative-1",
+                "total_slices": 1,
+                "completed_slices": 0,
+                "milestones_complete": 0,
+                "milestones_total": 1,
+                "milestones": [],
+                "slices": [],
+            }
+            cmd_swarm(args)
+
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["mode"] == "initiative-status"
+        assert parsed["initiative_id"] == "initiative-1"

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -14,6 +14,7 @@ from aragora.swarm.merge_arbiter import (
     MergeArbiter,
     MergeArbiterConfig,
     MergeResult,
+    _classify_required_checks,
     _evaluate_pr,
     _get_check_status,
     _list_candidate_prs,
@@ -92,6 +93,29 @@ class TestGetCheckStatus:
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(returncode=1)
             assert _get_check_status(1, "owner/repo") == {}
+
+
+class TestClassifyRequiredChecks:
+    def test_reports_missing_and_failing_required_checks(self):
+        checks = {
+            REQUIRED_CHECKS[0]: "SUCCESS",
+            REQUIRED_CHECKS[1]: "FAILURE",
+            REQUIRED_CHECKS[2]: "SUCCESS",
+        }
+
+        missing, failing = _classify_required_checks(checks)
+
+        assert missing == REQUIRED_CHECKS[3:]
+        assert failing == [f"{REQUIRED_CHECKS[1]}=FAILURE"]
+
+    def test_accepts_custom_required_checks(self):
+        missing, failing = _classify_required_checks(
+            {"custom-a": "SUCCESS", "custom-b": "PENDING"},
+            required_checks=["custom-a", "custom-b", "custom-c"],
+        )
+
+        assert missing == ["custom-c"]
+        assert failing == ["custom-b=PENDING"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a campaign-backed initiative integrator for milestone-aware run/status/promote flows
- preserve draft PR stack promotion, feature-flag-required merge gating, and terminal handling for already-published slices
- keep merge-arbiter reuse narrow via required-check classification and merge/promotion helpers

## Validation
- python3 -m ruff check aragora/cli/commands/swarm.py aragora/cli/parser.py aragora/swarm/campaign.py aragora/swarm/merge_arbiter.py aragora/swarm/initiative_integrator.py tests/swarm/test_initiative_integrator.py tests/swarm/test_merge_arbiter.py
- python3 -m pytest -q tests/swarm/test_initiative_integrator.py tests/swarm/test_merge_arbiter.py
- git diff --check