### PR TITLE
fix(security): return cached debate status for security audit debates

### DIFF
--- a/aragora/server/handlers/security_debate.py
+++ b/aragora/server/handlers/security_debate.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     pass
 
+from aragora.core_types import DebateStatus, DebateStatusSource
 from aragora.server.http_utils import run_async
 from aragora.server.middleware.rate_limit import rate_limit
 
@@ -208,10 +209,33 @@ class SecurityDebateHandler(SecureHandler):
         end_time = datetime.now(timezone.utc)
         duration_ms = (end_time - start_time).total_seconds() * 1000
 
+        response_debate_id = result.debate_id if hasattr(result, "debate_id") else event.id
+
+        try:
+            from aragora.events.security_events import _store_security_debate_result
+        except ImportError:
+            logger.debug("Security debate result store unavailable")
+        else:
+            store_coro: Coroutine[Any, Any, Any] | None = _store_security_debate_result(
+                response_debate_id,
+                event,
+                result,
+            )
+            try:
+                run_async(store_coro)
+            except (RuntimeError, OSError, ConnectionError, TimeoutError, ValueError, TypeError):
+                logger.exception(
+                    "Failed to persist security debate result for %s", response_debate_id
+                )
+            finally:
+                store_coro.close()
+
         # Build response
         response = {
-            "debate_id": result.debate_id if hasattr(result, "debate_id") else event.id,
+            "debate_id": response_debate_id,
             "status": "completed",
+            "debate_status": DebateStatus.COMPLETED.value,
+            "debate_status_source": DebateStatusSource.LIVE.value,
             "consensus_reached": result.consensus_reached,
             "confidence": result.confidence,
             "final_answer": result.final_answer,
@@ -241,8 +265,8 @@ class SecurityDebateHandler(SecureHandler):
         Get the status of a security debate.
 
         This endpoint allows checking on the status of a previously triggered
-        security debate. For now, debates are synchronous, so this mainly
-        provides a way to retrieve cached results.
+        security debate. Debates are still synchronous, but completed results
+        are cached in-process so callers can re-fetch the latest status payload.
 
         Returns:
             {
@@ -251,12 +275,37 @@ class SecurityDebateHandler(SecureHandler):
                 "message": "Status message"
             }
         """
-        # For now, debates are synchronous and not persisted
-        # This endpoint is a placeholder for future async debate support
+        cached_result: dict[str, Any] | None = None
+        try:
+            from aragora.events.security_events import get_security_debate_result
+        except ImportError:
+            logger.debug("Security debate result store unavailable")
+        else:
+            fetch_coro: Coroutine[Any, Any, Any] | None = get_security_debate_result(debate_id)
+            try:
+                cached = run_async(fetch_coro)
+            except (RuntimeError, OSError, ConnectionError, TimeoutError, ValueError, TypeError):
+                logger.exception("Failed to load cached security debate result for %s", debate_id)
+            else:
+                if isinstance(cached, dict):
+                    cached_result = dict(cached)
+            finally:
+                fetch_coro.close()
+
+        if cached_result is not None:
+            cached_result.setdefault("debate_id", debate_id)
+            cached_result.setdefault("status", DebateStatus.COMPLETED.value)
+            cached_result.setdefault("debate_status", DebateStatus.COMPLETED.value)
+            cached_result.setdefault("debate_status_source", DebateStatusSource.LIVE.value)
+            cached_result.setdefault("message", "Cached security debate result available.")
+            return json_response(cached_result)
+
         return json_response(
             {
                 "debate_id": debate_id,
                 "status": "not_found",
-                "message": "Debate results are not persisted. Use POST to trigger a new debate.",
+                "debate_status": DebateStatus.PENDING.value,
+                "debate_status_source": DebateStatusSource.LIVE.value,
+                "message": "No cached security debate result found. Use POST to trigger a new debate.",
             }
         )

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -513,16 +513,37 @@ Trigger a multi-agent security debate on vulnerability findings.
 
 ### GET /api/v1/audit/security/debate/{id}
 
-Get the status of a previously triggered security debate. Currently debates are synchronous,
-so this endpoint returns `not_found` for any ID (placeholder for future async support).
+Get the status of a previously triggered security debate. Debates are still synchronous,
+but completed results are cached in-process so callers can re-fetch the latest result payload
+when it is still available. If no cached result is present, the endpoint returns `not_found`.
 
 **Response (200):**
 
 ```json
 {
     "debate_id": "the-id",
+    "status": "completed",
+    "debate_status": "completed",
+    "debate_status_source": "live",
+    "repository": "repo-name",
+    "findings_count": 2,
+    "consensus_reached": true,
+    "confidence": 0.85,
+    "final_answer": "Remediation recommendations...",
+    "completed_at": "2026-04-07T21:30:00+00:00",
+    "message": "Cached security debate result available."
+}
+```
+
+When the cache is empty:
+
+```json
+{
+    "debate_id": "the-id",
     "status": "not_found",
-    "message": "Debate results are not persisted. Use POST to trigger a new debate."
+    "debate_status": "pending",
+    "debate_status_source": "live",
+    "message": "No cached security debate result found. Use POST to trigger a new debate."
 }
 ```
 

--- a/tests/server/handlers/test_security_debate.py
+++ b/tests/server/handlers/test_security_debate.py
@@ -11,6 +11,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import asyncio
 import gc
 import functools
 import json
@@ -119,6 +120,16 @@ def handler():
     return h
 
 
+@pytest.fixture(autouse=True)
+def clear_security_debate_results():
+    """Keep the shared in-memory debate cache isolated between tests."""
+    from aragora.events.security_events import _security_debate_results
+
+    _security_debate_results.clear()
+    yield
+    _security_debate_results.clear()
+
+
 # ===========================================================================
 # Test Instantiation and Basics
 # ===========================================================================
@@ -156,19 +167,56 @@ class TestSecurityDebateHandlerBasics:
 class TestGetDebateStatus:
     """Tests for getting debate status."""
 
-    def test_get_status_returns_not_found(self, handler):
+    def test_get_status_returns_not_found_when_cache_is_empty(self, handler):
         result = handler.get_api_v1_audit_security_debate_id("debate-sec-001")
         assert result.status_code == 200
         data = _parse_body(result)
         assert data["debate_id"] == "debate-sec-001"
         assert data["status"] == "not_found"
-        assert "not persisted" in data["message"].lower()
+        assert "no cached" in data["message"].lower()
 
     def test_get_status_arbitrary_id(self, handler):
         result = handler.get_api_v1_audit_security_debate_id("any-id-works")
         assert result.status_code == 200
         data = _parse_body(result)
         assert data["debate_id"] == "any-id-works"
+
+    def test_get_status_returns_cached_result(self, handler):
+        from aragora.events.security_events import (
+            SecurityEvent,
+            SecurityFinding,
+            SecuritySeverity,
+            _store_security_debate_result,
+        )
+
+        class CachedResult:
+            consensus_reached = True
+            confidence = 0.93
+            final_answer = "Patch the dependency and rotate the token."
+
+        event = SecurityEvent(
+            id="evt-sec-001",
+            repository="synaptent/aragora",
+            findings=[
+                SecurityFinding(
+                    id="finding-1",
+                    finding_type="vulnerability",
+                    severity=SecuritySeverity.CRITICAL,
+                    title="Leaked token enables admin actions",
+                    description="The token is committed in a production workflow file.",
+                )
+            ],
+        )
+        asyncio.run(_store_security_debate_result("debate-sec-001", event, CachedResult()))
+
+        result = handler.get_api_v1_audit_security_debate_id("debate-sec-001")
+        assert result.status_code == 200
+        data = _parse_body(result)
+        assert data["status"] == "completed"
+        assert data["debate_status"] == "completed"
+        assert data["debate_status_source"] == "live"
+        assert data["final_answer"] == "Patch the dependency and rotate the token."
+        assert data["repository"] == "synaptent/aragora"
 
 
 # ===========================================================================
@@ -253,7 +301,7 @@ class TestPostSecurityDebate:
             with patch.dict("sys.modules", {}):
                 with patch(
                     "aragora.server.handlers.security_debate.run_async",
-                    return_value=mock_result,
+                    side_effect=[mock_result, None],
                 ) as mock_run_async:
                     # Patch the imports inside the method
                     mock_sec_debate = MagicMock()
@@ -262,6 +310,10 @@ class TestPostSecurityDebate:
                     mock_sec_events.SecurityEventType = mock_event_type_cls
                     mock_sec_events.SecurityFinding = MagicMock(return_value=mock_finding_obj)
                     mock_sec_events.SecurityEvent = MagicMock(return_value=mock_security_event)
+                    store_coro = MagicMock()
+                    mock_sec_events._store_security_debate_result = MagicMock(
+                        return_value=store_coro
+                    )
 
                     with patch.dict(
                         "sys.modules",
@@ -275,7 +327,16 @@ class TestPostSecurityDebate:
                         data = _parse_body(result)
                         assert data["status"] == "completed"
                         assert data["consensus_reached"] is True
+                        assert data["debate_status"] == "completed"
+                        assert data["debate_status_source"] == "live"
                         assert data["findings_analyzed"] == 1
+                        mock_sec_events._store_security_debate_result.assert_called_once_with(
+                            "debate-sec-001",
+                            mock_security_event,
+                            mock_result,
+                        )
+                        assert mock_run_async.call_count == 2
+                        store_coro.close.assert_called_once()
 
     def test_post_success_does_not_leak_coroutine_when_run_async_short_circuits(self, handler):
         findings = [

--- a/tests/server/handlers/test_security_debate_handler.py
+++ b/tests/server/handlers/test_security_debate_handler.py
@@ -10,6 +10,8 @@ Tests cover:
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
@@ -143,6 +145,14 @@ class TestSecurityDebatePost:
 class TestSecurityDebateGet:
     """Test GET /api/v1/audit/security/debate/:id behaviour."""
 
+    @pytest.fixture(autouse=True)
+    def clear_security_debate_results(self):
+        from aragora.events.security_events import _security_debate_results
+
+        _security_debate_results.clear()
+        yield
+        _security_debate_results.clear()
+
     @pytest.fixture
     def handler(self):
         from aragora.server.handlers.security_debate import SecurityDebateHandler
@@ -152,8 +162,45 @@ class TestSecurityDebateGet:
         handler.server_context = mock_context
         return handler
 
-    def test_get_returns_not_found(self, handler):
-        result = handler.get_api_v1_audit_security_debate_id("some-id")
+    def test_get_returns_not_found_when_cache_is_empty(self, handler):
+        result = handler.get_api_v1_audit_security_debate_id("missing-id")
         body = parse_handler_response(result)
         assert body.get("status") == "not_found"
-        assert body.get("debate_id") == "some-id"
+        assert body.get("debate_id") == "missing-id"
+        assert "no cached" in body.get("message", "").lower()
+
+    def test_get_returns_cached_result(self, handler):
+        from aragora.events.security_events import (
+            SecurityEvent,
+            SecurityFinding,
+            SecuritySeverity,
+            _store_security_debate_result,
+        )
+
+        class Result:
+            consensus_reached = True
+            confidence = 0.91
+            final_answer = "Rotate the key and revoke the leaked token."
+
+        event = SecurityEvent(
+            id="evt-123",
+            repository="synaptent/aragora",
+            findings=[
+                SecurityFinding(
+                    id="finding-1",
+                    finding_type="secret",
+                    severity=SecuritySeverity.CRITICAL,
+                    title="Leaked API key",
+                    description="A production key is committed to the repository.",
+                )
+            ],
+        )
+        asyncio.run(_store_security_debate_result("debate-123", event, Result()))
+
+        result = handler.get_api_v1_audit_security_debate_id("debate-123")
+        body = parse_handler_response(result)
+        assert body.get("status") == "completed"
+        assert body.get("debate_status") == "completed"
+        assert body.get("debate_status_source") == "live"
+        assert body.get("repository") == "synaptent/aragora"
+        assert body.get("final_answer") == "Rotate the key and revoke the leaked token."


### PR DESCRIPTION
Automated engineering fix from Codex automation. PR creation was blocked by GitHub API connectivity — creating retroactively.