### PR TITLE
fix(dashboard): accept nested receipt stats payload in useDecisionIntegrity

### DIFF
--- a/aragora/live/src/hooks/__tests__/useDecisionIntegrity.test.tsx
+++ b/aragora/live/src/hooks/__tests__/useDecisionIntegrity.test.tsx
@@ -69,7 +69,7 @@ describe('useDecisionIntegrity', () => {
     });
   });
 
-  it('uses the canonical receipt stats route and normalizes delivery history for the UI', () => {
+  it('normalizes legacy flat receipt stats and delivery history for the UI', () => {
     const { result } = renderHook(() => useDecisionIntegrity());
 
     expect(mockUseSWRFetch).toHaveBeenCalledWith(
@@ -112,6 +112,91 @@ describe('useDecisionIntegrity', () => {
           created_at: '2026-03-31T18:00:00Z',
           delivered_at: '2026-03-31T18:00:00Z',
           channel: 'teams',
+        },
+      ],
+    });
+  });
+
+  it('normalizes the canonical nested receipt stats payload returned by the backend', () => {
+    mockUseSWRFetch.mockImplementation((endpoint: string | null) => {
+      if (endpoint === '/api/v2/receipts/stats') {
+        return {
+          data: {
+            stats: {
+              total: 12,
+              signed: 9,
+              by_verdict: { approved: 8, rejected: 4 },
+              by_risk_level: { low: 10, high: 2 },
+            },
+            generated_at: '2026-04-07T18:00:00Z',
+          },
+          error: null,
+          isLoading: false,
+          isValidating: false,
+          mutate: jest.fn(),
+        };
+      }
+
+      if (endpoint === '/api/v1/receipts/deliveries?limit=20') {
+        return {
+          data: {
+            deliveries: [
+              {
+                receiptId: 'rcpt-1',
+                status: 'success',
+                deliveredAt: '2026-03-31T20:00:00Z',
+                channel: 'slack',
+              },
+              {
+                receiptId: 'rcpt-2',
+                status: 'failed',
+                deliveredAt: '2026-03-31T19:00:00Z',
+                channel: 'email',
+              },
+            ],
+          },
+          error: null,
+          isLoading: false,
+          isValidating: false,
+          mutate: jest.fn(),
+        };
+      }
+
+      return {
+        data: null,
+        error: null,
+        isLoading: false,
+        isValidating: false,
+        mutate: jest.fn(),
+      };
+    });
+
+    const { result } = renderHook(() => useDecisionIntegrity());
+
+    expect(result.current.receipts).toEqual({
+      total_receipts: 12,
+      verified_count: 9,
+      delivered: 1,
+      pending: 0,
+      failed: 1,
+      delivery_rate: 0.5,
+      by_verdict: { approved: 8, rejected: 4 },
+      by_risk_level: { low: 10, high: 2 },
+      generated_at: '2026-04-07T18:00:00Z',
+      recent: [
+        {
+          id: 'rcpt-1',
+          status: 'delivered',
+          created_at: '2026-03-31T20:00:00Z',
+          delivered_at: '2026-03-31T20:00:00Z',
+          channel: 'slack',
+        },
+        {
+          id: 'rcpt-2',
+          status: 'failed',
+          created_at: '2026-03-31T19:00:00Z',
+          delivered_at: '2026-03-31T19:00:00Z',
+          channel: 'email',
         },
       ],
     });

--- a/aragora/live/src/hooks/useDecisionIntegrity.ts
+++ b/aragora/live/src/hooks/useDecisionIntegrity.ts
@@ -92,8 +92,20 @@ export interface ReceiptStats {
 type RecentReceipt = NonNullable<ReceiptStats['recent']>[number];
 
 interface ReceiptStatsApiResponse {
+  stats?: {
+    total?: number;
+    total_receipts?: number;
+    verified?: number;
+    verified_count?: number;
+    signed?: number;
+    by_verdict?: Record<string, number>;
+    by_risk_level?: Record<string, number>;
+  };
   total?: number;
+  total_receipts?: number;
   verified?: number;
+  verified_count?: number;
+  signed?: number;
   by_verdict?: Record<string, number>;
   by_risk_level?: Record<string, number>;
   generated_at?: string;
@@ -252,6 +264,8 @@ function normalizeReceiptStats(
 ): ReceiptStats | null {
   if (!stats && !history) return null;
 
+  const resolvedStats = stats?.stats ?? stats;
+
   const recent: RecentReceipt[] = (history?.deliveries ?? []).flatMap((delivery) => {
     const id = delivery.receiptId ?? delivery.receipt_id ?? delivery.id;
     if (!id) return [];
@@ -275,14 +289,20 @@ function normalizeReceiptStats(
     delivered + failed > 0 ? delivered / (delivered + failed) : undefined;
 
   return {
-    total_receipts: stats?.total ?? recent.length,
-    verified_count: stats?.verified,
+    total_receipts:
+      resolvedStats?.total ??
+      resolvedStats?.total_receipts ??
+      recent.length,
+    verified_count:
+      resolvedStats?.verified ??
+      resolvedStats?.verified_count ??
+      resolvedStats?.signed,
     delivered,
     pending,
     failed,
     delivery_rate: deliveryRate,
-    by_verdict: stats?.by_verdict ?? {},
-    by_risk_level: stats?.by_risk_level ?? {},
+    by_verdict: resolvedStats?.by_verdict ?? {},
+    by_risk_level: resolvedStats?.by_risk_level ?? {},
     generated_at: stats?.generated_at,
     recent,
   };


### PR DESCRIPTION
Automated engineering fix from Codex automation. PR creation was blocked by GitHub API connectivity — creating retroactively.