### PR TITLE
fix(swarm): hide stale session directives

### DIFF
--- a/aragora/coordination/registry.py
+++ b/aragora/coordination/registry.py
@@ -189,6 +189,12 @@ class SessionRegistry:
 
         return sessions
 
+    def known_session_ids(self) -> set[str]:
+        """Return session IDs with registration files, regardless of liveness."""
+        if not self._sessions_dir.exists():
+            return set()
+        return {path.stem for path in self._sessions_dir.glob("*.json")}
+
     def get(self, session_id: str) -> SessionInfo | None:
         """Get a specific session by ID, or None if not found/dead."""
         path = self._sessions_dir / f"{session_id}.json"

--- a/aragora/swarm/session_coordinator.py
+++ b/aragora/swarm/session_coordinator.py
@@ -174,8 +174,15 @@ def list_findings(
 
 def read_directives(repo_root: Path | None = None, *, findings_limit: int = 10) -> dict[str, Any]:
     root = _coord_repo_root(repo_root)
-    directives = [item.to_dict() for item in DirectiveBoard(repo_path=root).list()]
-    sessions = [item.to_dict() for item in SessionRegistry(repo_path=root).discover()]
+    registry = SessionRegistry(repo_path=root)
+    known_session_ids = registry.known_session_ids()
+    sessions = [item.to_dict() for item in registry.discover()]
+    live_session_ids = {str(item["session_id"]) for item in sessions}
+    directives = [
+        item.to_dict()
+        for item in DirectiveBoard(repo_path=root).list()
+        if item.target not in known_session_ids or item.target in live_session_ids
+    ]
     claims = [item.to_dict() for item in ClaimManager(repo_path=root).list_all()]
     findings = list_findings(limit=findings_limit, repo_root=root)
     return {

--- a/tests/swarm/test_session_coordinator.py
+++ b/tests/swarm/test_session_coordinator.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+
+from aragora.coordination.registry import SessionRegistry
 from aragora.swarm.session_coordinator import (
     claim_pr,
     get_my_assignment,
@@ -62,3 +65,17 @@ class TestSessionCoordinator:
         assert view["summary"]["claim_count"] == 1
         assert view["summary"]["finding_count"] == 1
         assert view["directives"][0]["target"] == "codex-a"
+
+    def test_read_directives_skips_stale_session_assignments(self, tmp_path):
+        registry = SessionRegistry(repo_path=tmp_path)
+        live = registry.register("codex", tmp_path, focus="Live lane", pid=os.getpid())
+        stale = registry.register("codex", tmp_path, focus="Stale lane", pid=999999)
+
+        set_assignment(live.session_id, "Own live lane", repo_root=tmp_path)
+        set_assignment(stale.session_id, "Obsolete lane", repo_root=tmp_path)
+
+        view = read_directives(repo_root=tmp_path, findings_limit=5)
+
+        assert view["summary"]["session_count"] == 1
+        assert view["summary"]["directive_count"] == 1
+        assert [directive["target"] for directive in view["directives"]] == [live.session_id]


### PR DESCRIPTION
Automated fix from Codex engineering automation.