### PR TITLE
Add GitHub Actions automation PR publisher

### DIFF
--- a/.github/workflows/auto-pr-publisher.yml
+++ b/.github/workflows/auto-pr-publisher.yml
@@ -117,7 +117,7 @@ jobs:
             const automationBacklog = openPulls.filter(isAutomationPull).length;
             core.info(`Open automation PR backlog: ${automationBacklog}`);
 
-            if (automationBacklog > backlogLimit) {
+            if (automationBacklog >= backlogLimit) {
               core.notice(`backlog_full count=${automationBacklog} limit=${backlogLimit}`);
               core.setOutput("status", "backlog_full");
               core.setOutput("backlog_count", String(automationBacklog));
@@ -167,7 +167,6 @@ jobs:
               const forbidden =
                 status === 403 ||
                 status === 401 ||
-                status === 422 ||
                 lowered.includes("resource not accessible by integration") ||
                 lowered.includes("github actions is not permitted to create pull requests") ||
                 lowered.includes("not permitted to create or approve pull requests") ||


### PR DESCRIPTION
## Summary
- add `.github/workflows/auto-pr-publisher.yml`
- open draft PRs automatically for pushed automation branches
- skip when a PR already exists for the branch head or when the open automation backlog is above 20
- label created PRs with `automation`
- log a clear non-failing `pr_creation_forbidden` outcome when Actions cannot create PRs in the repo

## Validation
- `python3 - <<'PY' ... yaml.load(..., Loader=yaml.BaseLoader) ... PY`
- `actionlint .github/workflows/auto-pr-publisher.yml`
