### PR TITLE
fix(swarm): harden merge arbiter truth and gating

### DIFF
--- a/aragora/rbac/decorators.py
+++ b/aragora/rbac/decorators.py
@@ -166,10 +166,20 @@ def _get_context_from_args(
         if isinstance(value, AuthorizationContext):
             return value
 
-    # Check if any arg has _auth_context attribute (e.g., HTTP request handler)
+    # Check if any arg has _auth_context attribute (e.g., HTTP request handler).
+    # Use getattr_static first so AttributeError from descriptor access does not
+    # get treated as a missing attribute.
+    import inspect
+
     for arg in args:
-        if hasattr(arg, "_auth_context") and isinstance(arg._auth_context, AuthorizationContext):
-            return arg._auth_context
+        try:
+            inspect.getattr_static(arg, "_auth_context")
+        except AttributeError:
+            continue
+
+        auth_context = arg._auth_context
+        if isinstance(auth_context, AuthorizationContext):
+            return auth_context
 
     return None
 

--- a/aragora/swarm/merge_arbiter.py
+++ b/aragora/swarm/merge_arbiter.py
@@ -1,11 +1,12 @@
-"""Admin merge arbiter for the boss loop.
+"""Admin merge arbiter for automation PRs.
 
-Polls open PRs matching configured branch prefixes and auto-merges them
-when all 5 required CI checks pass.  Designed to run alongside the boss
-loop for unattended overnight operation.
+Polls open automation PRs matching configured branch prefixes and auto-merges
+only ready PRs whose branch-protection checks and ready-only full-suite checks
+have all passed. Draft PRs are never auto-merged here; the boss loop owns draft
+promotion separately.
 
 Usage:
-    arbiter = MergeArbiter(MergeArbiterConfig(branch_prefixes=["boss-harvest"]))
+    arbiter = MergeArbiter()
     await arbiter.run()
 """
 
@@ -17,6 +18,7 @@ import logging
 import subprocess
 import time
 from dataclasses import dataclass, field
+from functools import lru_cache
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +29,24 @@ REQUIRED_CHECKS: list[str] = [
     "Generate & Validate",
     "TypeScript SDK Type Check",
 ]
+AUTOMATION_BRANCH_PREFIXES: list[str] = [
+    "codex/",
+    "factory/",
+    "aragora/boss-harvest/",
+]
+PASSING_CHECK_STATES = frozenset({"SUCCESS", "NEUTRAL", "SKIPPED"})
+READY_SUITE_GATE_CHECKS = frozenset({"Prioritize Required Checks"})
+REDUCED_LANE_ONLY_CHECKS = frozenset(
+    {
+        "PR Admission Signal (Advisory)",
+        "Prioritize Required Checks",
+        "OpenAPI Scope",
+        "SDK Change Detection",
+        "publish-draft-pr",
+        "review",
+        "changes",
+    }
+)
 
 
 @dataclass
@@ -34,7 +54,7 @@ class MergeArbiterConfig:
     """Configuration for the merge arbiter polling loop."""
 
     repo: str = "synaptent/aragora"
-    branch_prefixes: list[str] = field(default_factory=lambda: ["boss-harvest"])
+    branch_prefixes: list[str] = field(default_factory=lambda: list(AUTOMATION_BRANCH_PREFIXES))
     poll_interval_seconds: float = 120.0
     max_runtime_hours: float = 12.0
     max_consecutive_failures: int = 3
@@ -90,6 +110,83 @@ def _classify_required_checks(
     return missing, failing
 
 
+def _normalize_branch_prefixes(branch_prefixes: list[str] | None) -> list[str]:
+    """Normalize configured prefixes to the canonical automation branch forms."""
+    raw_prefixes = list(branch_prefixes or AUTOMATION_BRANCH_PREFIXES)
+    normalized: list[str] = []
+    seen: set[str] = set()
+    aliases = {
+        "boss-harvest": "aragora/boss-harvest/",
+        "boss-harvest/": "aragora/boss-harvest/",
+        "aragora/boss-harvest": "aragora/boss-harvest/",
+        "codex": "codex/",
+        "factory": "factory/",
+    }
+    for prefix in raw_prefixes:
+        value = aliases.get(str(prefix or "").strip(), str(prefix or "").strip())
+        if not value:
+            continue
+        if value not in seen:
+            seen.add(value)
+            normalized.append(value)
+    return normalized or list(AUTOMATION_BRANCH_PREFIXES)
+
+
+@lru_cache(maxsize=8)
+def _get_required_checks(repo: str, base_branch: str = "main") -> list[str]:
+    """Load required branch-protection contexts, with a local fallback."""
+    result = _run_gh(
+        [
+            "api",
+            f"repos/{repo}/branches/{base_branch}/protection",
+            "--jq",
+            ".required_status_checks.contexts",
+        ]
+    )
+    if result.returncode != 0:
+        return list(REQUIRED_CHECKS)
+    try:
+        contexts = json.loads(result.stdout or "[]")
+    except (json.JSONDecodeError, TypeError):
+        return list(REQUIRED_CHECKS)
+    if not isinstance(contexts, list):
+        return list(REQUIRED_CHECKS)
+    normalized = [str(item).strip() for item in contexts if str(item).strip()]
+    return normalized or list(REQUIRED_CHECKS)
+
+
+def _classify_non_passing_checks(
+    checks: dict[str, str],
+    *,
+    ignored_checks: set[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    """Split non-passing checks into waiting and failing buckets."""
+    waiting: list[str] = []
+    failing: list[str] = []
+    ignored = ignored_checks or set()
+    for name in sorted(checks):
+        if name in ignored:
+            continue
+        status = checks.get(name, "")
+        if status in PASSING_CHECK_STATES:
+            continue
+        detail = f"{name}={status}"
+        if status in {"PENDING", "QUEUED", "IN_PROGRESS", "EXPECTED", "WAITING", "REQUESTED"}:
+            waiting.append(detail)
+        else:
+            failing.append(detail)
+    return waiting, failing
+
+
+def _ready_suite_check_names(
+    checks: dict[str, str],
+    *,
+    required_checks: list[str],
+) -> list[str]:
+    ignored = set(required_checks) | set(REDUCED_LANE_ONLY_CHECKS)
+    return sorted(name for name in checks if name not in ignored)
+
+
 def _run_gh(args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess[str]:
     """Run a ``gh`` CLI command and return the result."""
     return subprocess.run(
@@ -102,6 +199,7 @@ def _run_gh(args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedPr
 
 def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
     """Return open PRs whose head branch matches any configured prefix."""
+    prefixes = _normalize_branch_prefixes(config.branch_prefixes)
     result = _run_gh(
         [
             "pr",
@@ -127,7 +225,7 @@ def _list_candidate_prs(config: MergeArbiterConfig) -> list[dict]:
     candidates = []
     for pr in prs:
         branch = pr.get("headRefName", "")
-        if any(branch.startswith(prefix) for prefix in config.branch_prefixes):
+        if any(branch.startswith(prefix) for prefix in prefixes):
             candidates.append(pr)
     return candidates
 
@@ -195,48 +293,88 @@ def _evaluate_pr(pr: dict, config: MergeArbiterConfig) -> MergeResult:
     branch: str = pr.get("headRefName", "")
     head_sha = pr.get("headRefOid")
     is_draft: bool = pr.get("isDraft", False)
+    required_checks = _get_required_checks(config.repo)
 
     if is_draft:
-        # Auto-promote drafts: check if required checks pass, then mark ready
         checks = _get_check_status(pr_number, config.repo)
-        if checks:
-            missing, failing = _classify_required_checks(checks)
-            if not missing and not failing:
-                if _promote_draft(pr_number, config.repo):
-                    logger.info("Promoted draft PR #%d to ready", pr_number)
-                    is_draft = False
-                    # Fall through to merge logic below
-                else:
-                    return MergeResult(
-                        pr_number,
-                        branch,
-                        False,
-                        "draft promotion failed: gh pr ready returned non-zero",
-                    )
-            else:
-                reason_parts = []
-                if missing:
-                    reason_parts.append(f"missing: {', '.join(missing)}")
-                if failing:
-                    reason_parts.append(f"failing: {', '.join(failing)}")
-                return MergeResult(
-                    pr_number, branch, False, f"draft waiting on checks ({'; '.join(reason_parts)})"
-                )
-        else:
-            return MergeResult(pr_number, branch, False, "draft with no checks yet")
+        if not checks:
+            return MergeResult(
+                pr_number,
+                branch,
+                False,
+                "draft PR: never auto-merged; no fast required checks reported yet",
+            )
+        missing, failing = _classify_required_checks(checks, required_checks=required_checks)
+        if missing or failing:
+            reason_parts = ["draft PR: never auto-merged"]
+            if missing:
+                reason_parts.append(f"fast required checks missing: {', '.join(missing)}")
+            if failing:
+                reason_parts.append(f"fast required checks failing: {', '.join(failing)}")
+            return MergeResult(pr_number, branch, False, "; ".join(reason_parts))
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            "draft PR: fast required checks passed; waiting for boss-loop promotion to ready",
+        )
 
     checks = _get_check_status(pr_number, config.repo)
     if not checks:
         return MergeResult(pr_number, branch, False, "no checks found")
 
-    missing, failing = _classify_required_checks(checks)
+    missing, failing = _classify_required_checks(checks, required_checks=required_checks)
 
     if missing:
-        return MergeResult(pr_number, branch, False, f"missing checks: {', '.join(missing)}")
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            f"missing required checks: {', '.join(missing)}",
+        )
     if failing:
-        return MergeResult(pr_number, branch, False, f"failing checks: {', '.join(failing)}")
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            f"failing required checks: {', '.join(failing)}",
+        )
 
-    # All required checks pass
+    missing_ready_gates = sorted(name for name in READY_SUITE_GATE_CHECKS if name not in checks)
+    if missing_ready_gates:
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            f"ready PR missing full-suite gate checks: {', '.join(missing_ready_gates)}",
+        )
+
+    ready_suite_checks = _ready_suite_check_names(checks, required_checks=required_checks)
+    if not ready_suite_checks:
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            "ready PR still only has reduced fast-lane checks; no full-suite checks reported yet",
+        )
+
+    ready_suite_statuses = {name: checks[name] for name in ready_suite_checks}
+    waiting_ready, failing_ready = _classify_non_passing_checks(ready_suite_statuses)
+    if waiting_ready:
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            f"waiting on full-suite checks: {', '.join(waiting_ready)}",
+        )
+    if failing_ready:
+        return MergeResult(
+            pr_number,
+            branch,
+            False,
+            f"failing full-suite checks: {', '.join(failing_ready)}",
+        )
+
     if config.dry_run:
         logger.info("[dry-run] Would merge PR #%d (%s)", pr_number, branch)
         return MergeResult(pr_number, branch, True, "dry-run: would merge")

--- a/tests/swarm/test_merge_arbiter.py
+++ b/tests/swarm/test_merge_arbiter.py
@@ -38,7 +38,16 @@ def _all_passing_checks() -> list[dict]:
     return [{"name": name, "state": "SUCCESS"} for name in REQUIRED_CHECKS]
 
 
-def _pr(number: int = 1, branch: str = "boss-harvest/fix-1", draft: bool = False) -> dict:
+def _all_passing_ready_checks(*extra_names: str) -> dict[str, str]:
+    names = list(REQUIRED_CHECKS) + ["Prioritize Required Checks", "Quality Gates", *extra_names]
+    return dict.fromkeys(names, "SUCCESS")
+
+
+def _pr(
+    number: int = 1,
+    branch: str = "aragora/boss-harvest/fix-1",
+    draft: bool = False,
+) -> dict:
     return {
         "number": number,
         "headRefName": branch,
@@ -53,25 +62,27 @@ def _pr(number: int = 1, branch: str = "boss-harvest/fix-1", draft: bool = False
 
 
 class TestListCandidatePrs:
-    def test_default_scope_excludes_generic_codex_branches(self):
+    def test_default_scope_matches_real_automation_branches(self):
         prs = [
-            _pr(1, "boss-harvest/fix-1"),
+            _pr(1, "aragora/boss-harvest/fix-1"),
             _pr(2, "codex/manual-fix"),
+            _pr(3, "factory/manual-fix"),
+            _pr(4, "feat/manual-fix"),
         ]
         config = MergeArbiterConfig()
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(stdout=json.dumps(prs))
             result = _list_candidate_prs(config)
-        assert [pr["number"] for pr in result] == [1]
+        assert [pr["number"] for pr in result] == [1, 2, 3]
 
-    def test_filters_by_prefix(self):
+    def test_filters_by_prefix_and_normalizes_legacy_boss_prefix(self):
         prs = [
-            _pr(1, "boss-harvest/fix-1"),
+            _pr(1, "aragora/boss-harvest/fix-1"),
             _pr(2, "codex/task-2"),
             _pr(3, "dependabot/npm"),
             _pr(4, "feat/manual-feature"),
         ]
-        config = MergeArbiterConfig(branch_prefixes=["boss-harvest", "codex/"])
+        config = MergeArbiterConfig(branch_prefixes=["boss-harvest", "codex"])
         with patch("aragora.swarm.merge_arbiter._run_gh") as mock_gh:
             mock_gh.return_value = _make_gh_result(stdout=json.dumps(prs))
             result = _list_candidate_prs(config)
@@ -195,15 +206,19 @@ class TestMergePr:
 
 
 class TestEvaluatePrAllPassing:
-    def test_merges_when_all_checks_pass(self):
+    def test_merges_ready_pr_when_required_and_full_suite_checks_pass(self):
         config = MergeArbiterConfig()
-        checks = _all_passing_checks()
-        pr = _pr(42, "boss-harvest/ok")
+        checks = _all_passing_ready_checks("Status Doc Reconciliation")
+        pr = _pr(42, "codex/ok")
         with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
             patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
             patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
         ):
-            mock_checks.return_value = {c["name"]: "SUCCESS" for c in checks}
+            mock_checks.return_value = checks
             mock_merge.return_value = (True, "merged")
             result = _evaluate_pr(pr, config)
         assert result.success is True
@@ -219,24 +234,65 @@ class TestEvaluatePrAllPassing:
 class TestEvaluatePrFailingCheck:
     def test_skips_when_check_fails(self):
         config = MergeArbiterConfig()
-        status = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        status = _all_passing_ready_checks()
         status["lint"] = "FAILURE"
-        with patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks:
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+        ):
             mock_checks.return_value = status
-            result = _evaluate_pr(_pr(10, "boss-harvest/bad"), config)
+            result = _evaluate_pr(_pr(10, "codex/bad"), config)
         assert result.success is False
         assert "failing" in result.reason
         assert "lint" in result.reason
 
     def test_skips_when_check_missing(self):
         config = MergeArbiterConfig()
-        # Only return 4 of 5 checks
         status = dict.fromkeys(REQUIRED_CHECKS[:4], "SUCCESS")
-        with patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks:
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
+        ):
             mock_checks.return_value = status
-            result = _evaluate_pr(_pr(11, "boss-harvest/partial"), config)
+            result = _evaluate_pr(_pr(11, "codex/partial"), config)
         assert result.success is False
-        assert "missing" in result.reason
+        assert "missing required" in result.reason
+
+    def test_ready_pr_waits_for_full_suite_signal(self):
+        config = MergeArbiterConfig()
+        status = dict.fromkeys([*REQUIRED_CHECKS, "Prioritize Required Checks"], "SUCCESS")
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value=status),
+        ):
+            result = _evaluate_pr(_pr(12, "codex/reduced"), config)
+        assert result.success is False
+        assert "reduced fast-lane checks" in result.reason
+
+    def test_ready_pr_blocks_on_failing_full_suite_check(self):
+        config = MergeArbiterConfig()
+        status = _all_passing_ready_checks("Status Doc Reconciliation")
+        status["Quality Gates"] = "FAILURE"
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value=status),
+        ):
+            result = _evaluate_pr(_pr(13, "codex/full-suite-fail"), config)
+        assert result.success is False
+        assert "failing full-suite checks" in result.reason
+        assert "Quality Gates=FAILURE" in result.reason
 
 
 # ---------------------------------------------------------------------------
@@ -247,13 +303,17 @@ class TestEvaluatePrFailingCheck:
 class TestEvaluatePrDryRun:
     def test_dry_run_does_not_merge(self):
         config = MergeArbiterConfig(dry_run=True)
-        checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        checks = _all_passing_ready_checks("Status Doc Reconciliation")
         with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
             patch("aragora.swarm.merge_arbiter._get_check_status") as mock_checks,
             patch("aragora.swarm.merge_arbiter._merge_pr") as mock_merge,
         ):
             mock_checks.return_value = checks
-            result = _evaluate_pr(_pr(99, "boss-harvest/dry"), config)
+            result = _evaluate_pr(_pr(99, "codex/dry"), config)
         assert result.success is True
         assert "dry-run" in result.reason
         mock_merge.assert_not_called()
@@ -267,25 +327,36 @@ class TestEvaluatePrDryRun:
 class TestEvaluatePrDraft:
     def test_draft_pr_with_no_checks_skipped(self):
         config = MergeArbiterConfig()
-        with patch("aragora.swarm.merge_arbiter._get_check_status", return_value={}):
-            result = _evaluate_pr(_pr(5, "boss-harvest/draft", draft=True), config)
+        with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
+            patch("aragora.swarm.merge_arbiter._get_check_status", return_value={}),
+        ):
+            result = _evaluate_pr(_pr(5, "codex/draft", draft=True), config)
         assert result.success is False
-        assert "no checks" in result.reason
+        assert "never auto-merged" in result.reason
 
-    def test_draft_pr_auto_promoted_when_checks_pass(self):
+    def test_draft_pr_is_not_auto_promoted_or_merged_when_checks_pass(self):
         config = MergeArbiterConfig()
         checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
         with (
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
             patch("aragora.swarm.merge_arbiter._get_check_status", return_value=checks),
             patch("aragora.swarm.merge_arbiter._promote_draft", return_value=True) as promote_draft,
             patch(
                 "aragora.swarm.merge_arbiter._merge_pr", return_value=(True, "merged")
             ) as merge_pr,
         ):
-            result = _evaluate_pr(_pr(5, "boss-harvest/draft", draft=True), config)
-        assert result.success is True
-        promote_draft.assert_called_once_with(5, config.repo)
-        merge_pr.assert_called_once()
+            result = _evaluate_pr(_pr(5, "codex/draft", draft=True), config)
+        assert result.success is False
+        assert "waiting for boss-loop promotion" in result.reason
+        promote_draft.assert_not_called()
+        merge_pr.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -303,8 +374,8 @@ class TestCircuitBreaker:
         )
         arbiter = MergeArbiter(config=config)
 
-        failing_pr = _pr(1, "boss-harvest/fail")
-        failing_checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        failing_pr = _pr(1, "codex/fail")
+        failing_checks = _all_passing_ready_checks()
         failing_checks["lint"] = "FAILURE"
 
         call_count = 0
@@ -316,6 +387,10 @@ class TestCircuitBreaker:
 
         with (
             patch("aragora.swarm.merge_arbiter._list_candidate_prs", side_effect=fake_list),
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
             patch("aragora.swarm.merge_arbiter._get_check_status", return_value=failing_checks),
         ):
             summary = await arbiter.run()
@@ -359,11 +434,15 @@ class TestFullRun:
         )
         arbiter = MergeArbiter(config=config)
 
-        pr = _pr(7, "boss-harvest/good")
-        checks = dict.fromkeys(REQUIRED_CHECKS, "SUCCESS")
+        pr = _pr(7, "codex/good")
+        checks = _all_passing_ready_checks("Status Doc Reconciliation")
 
         with (
             patch("aragora.swarm.merge_arbiter._list_candidate_prs", return_value=[pr]),
+            patch(
+                "aragora.swarm.merge_arbiter._get_required_checks",
+                return_value=list(REQUIRED_CHECKS),
+            ),
             patch("aragora.swarm.merge_arbiter._get_check_status", return_value=checks),
             patch("aragora.swarm.merge_arbiter._merge_pr", return_value=(True, "merged")),
         ):


### PR DESCRIPTION
## Summary
- match real automation branch prefixes used by queue and boss automation
- keep draft PRs out of auto-merge and leave draft promotion to the boss loop
- require ready PRs to show the ready-only full-suite gate before merge, then block on any visible full-suite failures or pending lanes

## Root Cause
The arbiter had drifted in three ways:
1. it defaulted to the stale `boss-harvest` prefix instead of the real automation branch shapes (`codex/`, `factory/`, `aragora/boss-harvest/`)
2. it auto-promoted and auto-merged draft PRs even though boss-loop owns draft promotion separately
3. it merged ready PRs off only the 5 branch-protection checks, which is the reduced fast draft lane, instead of waiting for ready-only full-suite evidence and truthful ready-lane outcomes

## Validation
- `python3 -m pytest tests/swarm/test_merge_arbiter.py -q -k 'ListCandidatePrs or EvaluatePr'`
- `python3 -m ruff check aragora/swarm/merge_arbiter.py tests/swarm/test_merge_arbiter.py`
- `python3 -m pytest tests/swarm/test_merge_arbiter.py -q`
