### PR TITLE
H4: strict queue admission schema and work classification

### DIFF
--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -37,6 +37,7 @@ from aragora.swarm.tranche_state import (
 )
 from aragora.swarm.tranche_submit import (
     campaign_projects_to_candidate_lanes,
+    summarize_execution_contract,
     submit_intake_bundle,
 )
 from aragora.swarm.tranche_watch import (
@@ -65,6 +66,16 @@ QUEUE_ITEM_PHASE_QUEUED = "queued"
 QUEUE_ITEM_PHASE_EXPLORED = "explored"
 QUEUE_ITEM_PHASE_PLANNED = "planned"
 QUEUE_ITEM_PHASE_APPROVED = "approved"
+QUEUE_WORK_CLASS_HARVEST = "harvest"
+QUEUE_WORK_CLASS_BOUNDED_FEATURE = "bounded_feature"
+QUEUE_WORK_CLASS_INITIATIVE_MANUAL = "initiative_manual"
+_QUEUE_WORK_CLASSES = frozenset(
+    {
+        QUEUE_WORK_CLASS_HARVEST,
+        QUEUE_WORK_CLASS_BOUNDED_FEATURE,
+        QUEUE_WORK_CLASS_INITIATIVE_MANUAL,
+    }
+)
 
 _QUEUE_TERMINAL_STATUSES = frozenset(
     {
@@ -124,6 +135,36 @@ def _normalize_scope(scope: list[str]) -> list[str]:
     return list(dict.fromkeys(normalized))
 
 
+def _normalize_work_class(value: Any) -> str | None:
+    text = _optional_text(value)
+    if text is None:
+        return None
+    normalized = text.lower()
+    if normalized not in _QUEUE_WORK_CLASSES:
+        raise ValueError(f"Unsupported queue work_class: {text!r}")
+    return normalized
+
+
+def _classify_queue_source_work_class(source: TrancheQueueSource) -> str:
+    if source.work_class in _QUEUE_WORK_CLASSES:
+        return str(source.work_class)
+    bounded = bool(source.allowed_write_scope) and bool(source.verification_commands)
+    if source.kind == "doc":
+        return QUEUE_WORK_CLASS_BOUNDED_FEATURE if bounded else QUEUE_WORK_CLASS_INITIATIVE_MANUAL
+    if source.kind == "issue":
+        return QUEUE_WORK_CLASS_BOUNDED_FEATURE if bounded else QUEUE_WORK_CLASS_HARVEST
+    return QUEUE_WORK_CLASS_HARVEST
+
+
+def _classify_queue_item_work_class(item: TrancheQueueItem) -> str:
+    if item.work_class in _QUEUE_WORK_CLASSES:
+        return str(item.work_class)
+    bounded = bool(item.allowed_write_scope) and bool(item.verification_commands)
+    if item.kind == "intake":
+        return QUEUE_WORK_CLASS_BOUNDED_FEATURE
+    return QUEUE_WORK_CLASS_BOUNDED_FEATURE if bounded else QUEUE_WORK_CLASS_HARVEST
+
+
 def _resolve_queue_autonomy_mode(
     requested_mode: str | None, *, merge_class: str
 ) -> tuple[str, bool]:
@@ -172,9 +213,7 @@ def _derive_queue_item_phase(
 ) -> str:
     normalized = _optional_text(phase)
     recommendation = _optional_text(design_review_recommendation)
-    if recommendation == "approved":
-        inferred = QUEUE_ITEM_PHASE_APPROVED
-    elif recommendation:
+    if recommendation:
         inferred = QUEUE_ITEM_PHASE_PLANNED
     elif _optional_text(manifest_path):
         inferred = QUEUE_ITEM_PHASE_EXPLORED
@@ -255,6 +294,75 @@ def _queue_item_next_action(item_state: TrancheQueueItemRunState) -> str | None:
     return None
 
 
+def _queue_item_admission(
+    item: TrancheQueueItem, *, normalized_bundle: dict[str, Any]
+) -> dict[str, Any]:
+    work_class = _classify_queue_item_work_class(item)
+    execution_contract = summarize_execution_contract(normalized_bundle)
+    payload: dict[str, Any] = {
+        "work_class": work_class,
+        "execution_contract": execution_contract,
+    }
+    if work_class == QUEUE_WORK_CLASS_INITIATIVE_MANUAL:
+        payload.update(
+            {
+                "status": "blocked",
+                "reason": "initiative_manual_requires_operator_split",
+                "next_action": "plan-queue",
+                "question": (
+                    "Which bounded feature slices, write scope, and verification commands must be defined "
+                    "before this initiative can run unattended?"
+                ),
+                "detail": (
+                    "This queue item is initiative/manual work and is not eligible for unattended overnight execution."
+                ),
+            }
+        )
+        return payload
+    if execution_contract.get("ready") is True:
+        payload.update(
+            {
+                "status": "ready",
+                "reason": None,
+                "next_action": "run-queue",
+                "question": None,
+                "detail": "Queue item has bounded scope and focused verification coverage.",
+            }
+        )
+        return payload
+    missing_scope = _string_list(execution_contract.get("missing_scope_lanes"))
+    unbounded_scope = _string_list(execution_contract.get("unbounded_scope_lanes"))
+    missing_verification = _string_list(execution_contract.get("missing_verification_lanes"))
+    if unbounded_scope:
+        reason = "queue_item_unbounded_write_scope"
+        question = "Which narrower write scope should replace the current unbounded scope before unattended execution?"
+        detail = "Queue item still has unbounded write scope in one or more lanes."
+    elif missing_scope and missing_verification:
+        reason = "queue_item_missing_scope_and_verification"
+        question = "Which bounded write scope and focused verification commands should be added before unattended execution?"
+        detail = "Queue item is missing both bounded write scope and focused verification coverage."
+    elif missing_scope:
+        reason = "queue_item_missing_allowed_write_scope"
+        question = (
+            "Which bounded write scope should gate this queue item before unattended execution?"
+        )
+        detail = "Queue item is missing bounded write scope."
+    else:
+        reason = "queue_item_missing_verification_commands"
+        question = "Which focused verification commands should gate this queue item before unattended execution?"
+        detail = "Queue item is missing focused verification coverage."
+    payload.update(
+        {
+            "status": "blocked",
+            "reason": reason,
+            "next_action": "plan-queue",
+            "question": question,
+            "detail": detail,
+        }
+    )
+    return payload
+
+
 def _load_structured_object(path: str | Path) -> dict[str, Any]:
     raw = Path(path).resolve().read_text(encoding="utf-8")
     try:
@@ -289,6 +397,7 @@ class TrancheQueueItem:
     item_id: str
     kind: str
     source: str
+    work_class: str | None = None
     objective_override: str | None = None
     merge_class: str = "manual"
     max_lanes: int = 1
@@ -301,6 +410,7 @@ class TrancheQueueItem:
             "id": self.item_id,
             "kind": self.kind,
             "source": self.source,
+            "work_class": self.work_class or _classify_queue_item_work_class(self),
             "merge_class": self.merge_class,
             "max_lanes": self.max_lanes,
         }
@@ -329,10 +439,11 @@ class TrancheQueueItem:
         if merge_class not in {"low_risk", "manual"}:
             raise ValueError(f"Queue item {item_id} has unsupported merge_class: {merge_class!r}")
         max_lanes = max(1, int(data.get("max_lanes", 1) or 1))
-        return cls(
+        item = cls(
             item_id=item_id,
             kind=kind,
             source=source,
+            work_class=_normalize_work_class(data.get("work_class")),
             objective_override=_optional_text(data.get("objective_override")),
             merge_class=merge_class,
             max_lanes=max_lanes,
@@ -340,6 +451,8 @@ class TrancheQueueItem:
             autonomy_mode=_optional_text(data.get("autonomy_mode")),
             verification_commands=_string_list(data.get("verification_commands")),
         )
+        item.work_class = _classify_queue_item_work_class(item)
+        return item
 
 
 @dataclass(slots=True)
@@ -395,6 +508,7 @@ class TrancheQueueSource:
     kind: str
     mode: str
     source: str
+    work_class: str | None = None
     merge_class: str = "manual"
     priority: int = 100
     repo: str | None = None
@@ -411,6 +525,7 @@ class TrancheQueueSource:
             "kind": self.kind,
             "mode": self.mode,
             "source": self.source,
+            "work_class": self.work_class or _classify_queue_source_work_class(self),
             "merge_class": self.merge_class,
             "priority": self.priority,
             "max_lanes": self.max_lanes,
@@ -452,11 +567,12 @@ class TrancheQueueSource:
             raise ValueError(
                 f"Queue source {source_id} has unsupported merge_class: {merge_class!r}"
             )
-        return cls(
+        source_obj = cls(
             source_id=source_id,
             kind=kind,
             mode=mode,
             source=source,
+            work_class=_normalize_work_class(data.get("work_class")),
             merge_class=merge_class,
             priority=int(data.get("priority", 100) or 100),
             repo=_optional_text(data.get("repo")),
@@ -467,6 +583,8 @@ class TrancheQueueSource:
             autonomy_mode=_optional_text(data.get("autonomy_mode")),
             verification_commands=_string_list(data.get("verification_commands")),
         )
+        source_obj.work_class = _classify_queue_source_work_class(source_obj)
+        return source_obj
 
 
 @dataclass(slots=True)
@@ -939,10 +1057,12 @@ def _compile_doc_source_to_bundle(
             item_id=item_id,
             kind="intake",
             source=relative_bundle,
+            work_class=_classify_queue_source_work_class(source),
             merge_class=source.merge_class,
             max_lanes=source.max_lanes,
             allowed_write_scope=list(source.allowed_write_scope),
             autonomy_mode=source.autonomy_mode,
+            verification_commands=list(source.verification_commands),
         ),
         None,
     )
@@ -960,6 +1080,7 @@ def _compile_issue_source(
                 item_id=item_id,
                 kind="issue",
                 source=source.source,
+                work_class=_classify_queue_source_work_class(source),
                 objective_override=source.objective,
                 merge_class=source.merge_class,
                 max_lanes=source.max_lanes,
@@ -988,6 +1109,7 @@ def _compile_issue_query_source(
                 item_id=_unique_compiled_item_id(base_item_id, seen_item_ids),
                 kind="issue",
                 source=issue_url,
+                work_class=_classify_queue_source_work_class(source),
                 objective_override=source.objective,
                 merge_class=source.merge_class,
                 max_lanes=source.max_lanes,
@@ -1894,6 +2016,36 @@ class TrancheQueueExecutor:
         if item_state.status == QUEUE_ITEM_STATUS_NEEDS_HUMAN:
             return False
 
+        normalized_bundle = self._load_normalized_bundle_for_item(item_state)
+        admission = _queue_item_admission(item, normalized_bundle=normalized_bundle)
+        item_state.result["admission"] = dict(admission)
+        if (
+            admission.get("status") == "blocked"
+            and admission.get("reason") == "initiative_manual_requires_operator_split"
+        ):
+            item_state.status = QUEUE_ITEM_STATUS_NEEDS_HUMAN
+            item_state.stop_reason = _optional_text(admission.get("reason"))
+            item_state.recommended_action = (
+                _optional_text(admission.get("next_action")) or "plan-queue"
+            )
+            item_state.set_blocker(
+                reason=admission.get("reason"),
+                question=admission.get("question"),
+            )
+            item_state.finished_at = _utcnow()
+            self._append_finding(
+                item_state,
+                _optional_text(admission.get("detail"))
+                or "Queue item requires operator decomposition before unattended execution.",
+            )
+            self._persist_item_progress(
+                manifest=manifest,
+                item_state=item_state,
+                current_item_id=item.item_id,
+                queue_status=queue_status,
+            )
+            return False
+
         design_review_path = manifest_path.with_name("design_review.yaml")
         item_state.design_review_path = str(design_review_path)
         design_review_recommendation = item_state.design_review_recommendation
@@ -1947,6 +2099,32 @@ class TrancheQueueExecutor:
             self._append_finding(
                 item_state,
                 f"Design review did not approve execution: {design_review_recommendation or 'unknown'}.",
+            )
+            self._persist_item_progress(
+                manifest=manifest,
+                item_state=item_state,
+                current_item_id=item.item_id,
+                queue_status=queue_status,
+            )
+            return False
+
+        admission = _queue_item_admission(item, normalized_bundle=normalized_bundle)
+        item_state.result["admission"] = dict(admission)
+        if admission.get("status") != "ready":
+            item_state.status = QUEUE_ITEM_STATUS_NEEDS_HUMAN
+            item_state.stop_reason = _optional_text(admission.get("reason"))
+            item_state.recommended_action = (
+                _optional_text(admission.get("next_action")) or "plan-queue"
+            )
+            item_state.set_blocker(
+                reason=admission.get("reason"),
+                question=admission.get("question"),
+            )
+            item_state.finished_at = _utcnow()
+            self._append_finding(
+                item_state,
+                _optional_text(admission.get("detail"))
+                or "Queue item is not ready for unattended execution.",
             )
             self._persist_item_progress(
                 manifest=manifest,
@@ -2699,6 +2877,7 @@ def tranche_queue_status(
         items.append(
             {
                 "item_id": item.item_id,
+                "work_class": _classify_queue_item_work_class(item),
                 "status": item_state.status,
                 "phase": item_state.phase,
                 "next_action": _queue_item_next_action(item_state),
@@ -2713,7 +2892,12 @@ def tranche_queue_status(
                 "submission_status": item_state.submission_status,
                 "inspection_status": item_state.inspection_status,
                 "recommended_action": item_state.recommended_action,
+                "blocked_reason": item_state.blocked_reason,
+                "blocking_question": item_state.blocking_question,
                 "design_review_recommendation": item_state.design_review_recommendation,
+                "admission": dict(item_state.result.get("admission", {}))
+                if isinstance(item_state.result.get("admission"), dict)
+                else None,
                 "elapsed_seconds": _queue_item_elapsed_seconds(item_state, now=now),
                 "started_at": item_state.started_at.isoformat() if item_state.started_at else None,
                 "phase_updated_at": item_state.phase_updated_at.isoformat()

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -738,12 +738,24 @@ class TrancheQueueItemRunState:
             blocker = {}
         manifest_path = _optional_text(data.get("manifest_path"))
         design_review_recommendation = _optional_text(data.get("design_review_recommendation"))
+        phase_value = data.get("phase")
+        admission = result.get("admission", {})
+        if not isinstance(admission, dict):
+            admission = {}
+        # Legacy queue state predates explicit phase persistence. Preserve the old
+        # "approved means execution-ready" resume semantics when no phase was stored.
+        if (
+            _optional_text(phase_value) is None
+            and design_review_recommendation == "approved"
+            and not _optional_text(admission.get("status"))
+        ):
+            phase_value = QUEUE_ITEM_PHASE_APPROVED
         return cls(
             item_id=str(data.get("item_id", "")).strip(),
             status=str(data.get("status", QUEUE_ITEM_STATUS_PENDING)).strip()
             or QUEUE_ITEM_STATUS_PENDING,
             phase=_derive_queue_item_phase(
-                phase=data.get("phase"),
+                phase=phase_value,
                 manifest_path=manifest_path,
                 design_review_recommendation=design_review_recommendation,
             ),

--- a/aragora/swarm/tranche_submit.py
+++ b/aragora/swarm/tranche_submit.py
@@ -359,6 +359,7 @@ def _build_normalized_bundle(
         "references": {"source_refs": _source_ref_map(enriched)},
         "lanes": lanes,
         "terminal_outcomes": dict(bundle.get("terminal_outcomes") or {}),
+        "execution_contract": summarize_execution_contract({"lanes": lanes}),
     }
 
 
@@ -565,6 +566,60 @@ def _submission_decision(
     if mode in {"checkpoint", "spectator"}:
         return "awaiting_confirmation", "design-review" if has_writable_lanes else "prepare"
     return "awaiting_confirmation", "design-review" if has_writable_lanes else "prepare"
+
+
+def summarize_execution_contract(bundle: dict[str, Any]) -> dict[str, Any]:
+    raw_lanes = bundle.get("lanes")
+    if not isinstance(raw_lanes, list):
+        raw_lanes = bundle.get("candidate_lanes")
+    lanes = (
+        [dict(item) for item in raw_lanes if isinstance(item, dict)]
+        if isinstance(raw_lanes, list)
+        else []
+    )
+    missing_scope_lanes: list[str] = []
+    unbounded_scope_lanes: list[str] = []
+    missing_verification_lanes: list[str] = []
+    lane_summaries: list[dict[str, Any]] = []
+    for index, lane in enumerate(lanes, start=1):
+        lane_id = _optional_text(lane.get("lane_id")) or f"lane-{index:02d}"
+        scope = _string_list(lane.get("allowed_write_scope"))
+        verification_commands = _string_list(lane.get("verification_commands"))
+        if not scope:
+            missing_scope_lanes.append(lane_id)
+        elif not all(_scope_is_bounded(entry) for entry in scope):
+            unbounded_scope_lanes.append(lane_id)
+        if not verification_commands:
+            missing_verification_lanes.append(lane_id)
+        lane_summaries.append(
+            {
+                "lane_id": lane_id,
+                "has_bounded_scope": bool(scope) and lane_id not in unbounded_scope_lanes,
+                "has_verification_commands": bool(verification_commands),
+            }
+        )
+    ready = bool(lanes) and not (
+        missing_scope_lanes or unbounded_scope_lanes or missing_verification_lanes
+    )
+    return {
+        "ready": ready,
+        "lane_count": len(lanes),
+        "lanes": lane_summaries,
+        "missing_scope_lanes": missing_scope_lanes,
+        "unbounded_scope_lanes": unbounded_scope_lanes,
+        "missing_verification_lanes": missing_verification_lanes,
+    }
+
+
+def _scope_is_bounded(value: str) -> bool:
+    normalized = str(value or "").strip().removeprefix("./").rstrip("/")
+    if not normalized:
+        return False
+    if normalized in {".", "*", "**"}:
+        return False
+    if normalized.endswith("/**"):
+        return bool(normalized[:-3])
+    return True
 
 
 def _write_yaml_like(path: Path, payload: dict[str, Any]) -> None:

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -1124,6 +1124,18 @@ def test_queue_item_defaults_to_single_lane() -> None:
     assert item.work_class == QUEUE_WORK_CLASS_HARVEST
 
 
+def test_legacy_approved_queue_state_without_phase_loads_as_execution_ready() -> None:
+    item_state = TrancheQueueItemRunState.from_dict(
+        {
+            "item_id": "intake-docs",
+            "manifest_path": "/tmp/tranche.yaml",
+            "design_review_recommendation": "approved",
+        }
+    )
+
+    assert item_state.phase == QUEUE_ITEM_PHASE_APPROVED
+
+
 def test_low_risk_queue_item_keeps_fire_and_forget_and_sets_auto_merge_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -13,6 +13,9 @@ from aragora.swarm.tranche_queue import (
     QUEUE_ITEM_PHASE_EXPLORED,
     QUEUE_ITEM_PHASE_PLANNED,
     QUEUE_ITEM_PHASE_QUEUED,
+    QUEUE_WORK_CLASS_BOUNDED_FEATURE,
+    QUEUE_WORK_CLASS_HARVEST,
+    QUEUE_WORK_CLASS_INITIATIVE_MANUAL,
     QUEUE_STATUS_PENDING,
     QUEUE_ITEM_STATUS_COMPLETED,
     QUEUE_ITEM_STATUS_NEEDS_HUMAN,
@@ -101,6 +104,38 @@ sources:
     bundle = bundle_path.read_text(encoding="utf-8")
     assert "Ship the roadmap tranche work." in bundle
     assert "merge_policy: manual" in bundle
+
+
+def test_compile_queue_classifies_unbounded_execute_doc_source_as_initiative_manual(
+    tmp_path: Path,
+) -> None:
+    sources_path = tmp_path / "sources.yaml"
+    output_path = tmp_path / "overnight.yaml"
+    doc_path = tmp_path / "roadmap.md"
+    doc_path.write_text("# Roadmap\n\nShip tranche queue.\n", encoding="utf-8")
+    sources_path.write_text(
+        """
+queue_id: overnight
+sources:
+  - id: roadmap-doc
+    kind: doc
+    mode: execute
+    path: roadmap.md
+    objective: Ship the roadmap tranche work.
+    merge_class: manual
+""".strip(),
+        encoding="utf-8",
+    )
+
+    payload = compile_tranche_queue(
+        sources_path=sources_path,
+        output_path=output_path,
+        repo_root=tmp_path,
+    )
+
+    assert payload["item_count"] == 1
+    manifest = TrancheQueueManifest.load(output_path)
+    assert manifest.items[0].work_class == QUEUE_WORK_CLASS_INITIATIVE_MANUAL
 
 
 def test_harvest_queue_executes_merge_for_merge_now_pr(
@@ -420,7 +455,18 @@ async def test_explore_queue_persists_normalize_and_inspect_without_dispatch(
     intake_path = tranche_dir / "intake_bundle.yaml"
     intake_path.write_text("objective: test\n", encoding="utf-8")
     normalized_path = tranche_dir / "normalized_bundle.yaml"
-    normalized_path.write_text("{}\n", encoding="utf-8")
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
     manifest_path = tranche_dir / "tranche.yaml"
     manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
     inspection_path = tranche_dir / "inspection.yaml"
@@ -499,7 +545,18 @@ async def test_plan_queue_marks_item_approved_without_dispatch(
     intake_path = tranche_dir / "intake_bundle.yaml"
     intake_path.write_text("objective: test\n", encoding="utf-8")
     normalized_path = tranche_dir / "normalized_bundle.yaml"
-    normalized_path.write_text("{}\n", encoding="utf-8")
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
     manifest_path = tranche_dir / "tranche.yaml"
     manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
     inspection_path = tranche_dir / "inspection.yaml"
@@ -556,6 +613,177 @@ async def test_plan_queue_marks_item_approved_without_dispatch(
     persisted = state.item_states["intake-docs"]
     assert persisted.phase == QUEUE_ITEM_PHASE_APPROVED
     assert persisted.design_review_recommendation == "approved"
+
+
+@pytest.mark.asyncio
+async def test_plan_queue_blocks_initiative_manual_item_before_unattended_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = TrancheQueueManifest.from_dict(
+        {
+            "queue_id": "overnight",
+            "items": [
+                {
+                    "id": "initiative-docs",
+                    "kind": "intake",
+                    "source": "bundles/docs.yaml",
+                    "work_class": "initiative_manual",
+                }
+            ],
+        }
+    )
+    queue_path.write_text(manifest.to_yaml(), encoding="utf-8")
+
+    tranche_dir = tmp_path / ".aragora" / "tranches" / "tranche-a"
+    tranche_dir.mkdir(parents=True, exist_ok=True)
+    intake_path = tranche_dir / "intake_bundle.yaml"
+    intake_path.write_text("objective: test\n", encoding="utf-8")
+    normalized_path = tranche_dir / "normalized_bundle.yaml"
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_path = tranche_dir / "tranche.yaml"
+    manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
+    inspection_path = tranche_dir / "inspection.yaml"
+    inspection_path.write_text("preflight_status: ready\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.submit_intake_bundle",
+        lambda *args, **kwargs: {
+            "manifest_id": "tranche-a",
+            "intake_path": str(intake_path),
+            "normalized_bundle_path": str(normalized_path),
+            "manifest_path": str(manifest_path),
+            "inspection_path": str(inspection_path),
+            "tranche_dir": str(tranche_dir),
+            "submission_status": "awaiting_confirmation",
+            "inspection_status": "ready",
+            "recommended_action": "design-review",
+        },
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.load_tranche_manifest",
+        lambda path: SimpleNamespace(manifest_id="tranche-a"),
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.TrancheInspector",
+        lambda repo_root: SimpleNamespace(
+            inspect=lambda tranche_manifest: {"preflight_status": "ready"}
+        ),
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.TrancheQueueExecutor._bundle_for_item",
+        lambda self, item, effective_autonomy_mode: {"objective": "test"},
+    )
+
+    async def fail_design_review(**kwargs):
+        raise AssertionError("initiative/manual items should stop before unattended design review")
+
+    monkeypatch.setattr("aragora.swarm.tranche_queue.run_design_review", fail_design_review)
+
+    payload = await plan_tranche_queue(queue_path=queue_path, repo_root=tmp_path)
+
+    item = payload["items"][0]
+    assert item["work_class"] == QUEUE_WORK_CLASS_INITIATIVE_MANUAL
+    assert item["status"] == QUEUE_ITEM_STATUS_NEEDS_HUMAN
+    assert item["phase"] == QUEUE_ITEM_PHASE_EXPLORED
+    assert item["blocked_reason"] == "initiative_manual_requires_operator_split"
+    assert item["next_action"] == "plan-queue"
+    assert item["admission"]["status"] == "blocked"
+
+
+@pytest.mark.asyncio
+async def test_plan_queue_blocks_item_missing_verification_commands_after_design_review(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = TrancheQueueManifest.from_dict(
+        {
+            "queue_id": "overnight",
+            "items": [{"id": "intake-docs", "kind": "intake", "source": "bundles/docs.yaml"}],
+        }
+    )
+    queue_path.write_text(manifest.to_yaml(), encoding="utf-8")
+
+    tranche_dir = tmp_path / ".aragora" / "tranches" / "tranche-a"
+    tranche_dir.mkdir(parents=True, exist_ok=True)
+    intake_path = tranche_dir / "intake_bundle.yaml"
+    intake_path.write_text("objective: test\n", encoding="utf-8")
+    normalized_path = tranche_dir / "normalized_bundle.yaml"
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    manifest_path = tranche_dir / "tranche.yaml"
+    manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
+    inspection_path = tranche_dir / "inspection.yaml"
+    inspection_path.write_text("preflight_status: ready\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.submit_intake_bundle",
+        lambda *args, **kwargs: {
+            "manifest_id": "tranche-a",
+            "intake_path": str(intake_path),
+            "normalized_bundle_path": str(normalized_path),
+            "manifest_path": str(manifest_path),
+            "inspection_path": str(inspection_path),
+            "tranche_dir": str(tranche_dir),
+            "submission_status": "awaiting_confirmation",
+            "inspection_status": "ready",
+            "recommended_action": "design-review",
+        },
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.load_tranche_manifest",
+        lambda path: SimpleNamespace(manifest_id="tranche-a"),
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.TrancheInspector",
+        lambda repo_root: SimpleNamespace(
+            inspect=lambda tranche_manifest: {"preflight_status": "ready"}
+        ),
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.TrancheQueueExecutor._bundle_for_item",
+        lambda self, item, effective_autonomy_mode: {"objective": "test"},
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.save_design_review",
+        lambda *args, **kwargs: None,
+    )
+
+    async def fake_design_review(*, manifest, normalized_bundle, inspection):
+        return {"recommendation": "approved", "record": {"recommendation": "approved"}}
+
+    monkeypatch.setattr("aragora.swarm.tranche_queue.run_design_review", fake_design_review)
+
+    payload = await plan_tranche_queue(queue_path=queue_path, repo_root=tmp_path)
+
+    item = payload["items"][0]
+    assert item["work_class"] == QUEUE_WORK_CLASS_BOUNDED_FEATURE
+    assert item["status"] == QUEUE_ITEM_STATUS_NEEDS_HUMAN
+    assert item["phase"] == QUEUE_ITEM_PHASE_PLANNED
+    assert item["blocked_reason"] == "queue_item_missing_verification_commands"
+    assert item["next_action"] == "plan-queue"
+    assert item["admission"]["status"] == "blocked"
 
 
 @pytest.mark.asyncio
@@ -664,11 +892,26 @@ async def test_process_item_resumes_legacy_approved_manifest_without_resubmittin
     tranche_dir.mkdir(parents=True, exist_ok=True)
     manifest_path = tranche_dir / "tranche.yaml"
     manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
+    normalized_path = tranche_dir / "normalized_bundle.yaml"
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
 
     item_state = TrancheQueueItemRunState(
         item_id=item.item_id,
         manifest_id="tranche-a",
         manifest_path=str(manifest_path),
+        normalized_bundle_path=str(normalized_path),
+        phase=QUEUE_ITEM_PHASE_APPROVED,
         design_review_recommendation="approved",
     )
 
@@ -861,6 +1104,7 @@ sources:
     assert payload["item_count"] == 2
     manifest = TrancheQueueManifest.load(output_path)
     assert [item.kind for item in manifest.items] == ["issue", "issue"]
+    assert all(item.work_class == QUEUE_WORK_CLASS_HARVEST for item in manifest.items)
     assert all(item.max_lanes == 1 for item in manifest.items)
     assert manifest.items[0].source == "https://github.com/org/repo/issues/1046"
     assert manifest.items[1].source == "https://github.com/org/repo/issues/1047"
@@ -877,6 +1121,7 @@ def test_queue_item_defaults_to_single_lane() -> None:
     )
 
     assert item.max_lanes == 1
+    assert item.work_class == QUEUE_WORK_CLASS_HARVEST
 
 
 def test_low_risk_queue_item_keeps_fire_and_forget_and_sets_auto_merge_policy(
@@ -1283,7 +1528,18 @@ async def test_process_item_persists_manifest_path_before_drive_manifest(
     manifest_path = tranche_dir / "tranche.yaml"
     manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
     normalized_path = tranche_dir / "normalized_bundle.yaml"
-    normalized_path.write_text("{}\n", encoding="utf-8")
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(
         executor,
@@ -1360,7 +1616,18 @@ async def test_process_item_records_design_review_blocker_when_confirmation_requ
     manifest_path = tranche_dir / "tranche.yaml"
     manifest_path.write_text("manifest_id: tranche-a\n", encoding="utf-8")
     normalized_path = tranche_dir / "normalized_bundle.yaml"
-    normalized_path.write_text("{}\n", encoding="utf-8")
+    normalized_path.write_text(
+        """
+lanes:
+  - lane_id: lane-a
+    allowed_write_scope:
+      - aragora/cli/**
+    verification_commands:
+      - python3 -m pytest tests/cli/test_setup.py -q
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
 
     monkeypatch.setattr(
         executor,


### PR DESCRIPTION
## Summary
- add explicit queue work classification for compiled and direct tranche items
- fail closed on initiative/manual or underspecified items before unattended execution
- persist explicit admission status, blocker reasons, and execution contract details in queue state/status

## Validation
- python3 -m ruff check aragora/swarm/tranche_queue.py aragora/swarm/tranche_submit.py tests/swarm/test_tranche_queue.py
- python3 -m pytest tests/swarm/test_tranche_queue.py -q