### PR TITLE
feat(swarm): expose truthful tranche queue telemetry

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -749,13 +749,49 @@ def _build_runner_probe_payload(
 
 
 def _render_tranche_queue_status(payload: dict[str, object]) -> None:
+    elapsed = _format_elapsed_seconds(payload.get("elapsed_seconds"))
     print(
-        "queue_id={queue_id} status={status} current_item_id={current_item_id}".format(
+        "queue_id={queue_id} status={status} current_item_id={current_item_id} elapsed={elapsed}".format(
             queue_id=payload.get("queue_id", ""),
             status=payload.get("status", ""),
             current_item_id=payload.get("current_item_id", "") or "none",
+            elapsed=elapsed,
         )
     )
+    stop_reason = str(payload.get("stop_reason", "") or "").strip()
+    if stop_reason:
+        print(f"stop_reason={stop_reason}")
+    counts = payload.get("counts", {})
+    if isinstance(counts, dict):
+        counts_text = ", ".join(
+            f"{key}={value}" for key, value in sorted(counts.items()) if int(value or 0) > 0
+        )
+        if counts_text:
+            print(f"counts={counts_text}")
+    terminal_counts = payload.get("terminal_counts", {})
+    if isinstance(terminal_counts, dict):
+        terminal_text = ", ".join(
+            f"{key}={value}"
+            for key, value in sorted(terminal_counts.items())
+            if int(value or 0) > 0
+        )
+        if terminal_text:
+            print(f"terminal_counts={terminal_text}")
+    current_item = payload.get("current_item", {})
+    if isinstance(current_item, dict) and str(current_item.get("item_id", "")).strip():
+        blocker = str(current_item.get("blocking_question", "") or "").strip()
+        pr_urls = [
+            str(pr_url).strip() for pr_url in current_item.get("pr_urls", []) if str(pr_url).strip()
+        ]
+        print(
+            "current_item next_action={next_action} status={status} pr_urls={pr_urls}".format(
+                next_action=str(current_item.get("next_action", "")).strip() or "-",
+                status=str(current_item.get("status", "")).strip() or "-",
+                pr_urls=", ".join(pr_urls) if pr_urls else "-",
+            )
+        )
+        if blocker:
+            print(f"current_item_blocker={blocker}")
     rows: list[dict[str, object]] = []
     for item in [entry for entry in payload.get("items", []) if isinstance(entry, dict)]:
         worker_branches = [

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -806,11 +806,13 @@ class TrancheQueueRunState:
     item_states: dict[str, TrancheQueueItemRunState] = field(default_factory=dict)
 
     def ensure_manifest(self, manifest: TrancheQueueManifest) -> None:
+        changed = False
         for item in manifest.items:
-            self.item_states.setdefault(
-                item.item_id, TrancheQueueItemRunState(item_id=item.item_id)
-            )
-        self.updated_at = _utcnow()
+            if item.item_id not in self.item_states:
+                self.item_states[item.item_id] = TrancheQueueItemRunState(item_id=item.item_id)
+                changed = True
+        if changed:
+            self.updated_at = _utcnow()
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -1361,6 +1363,97 @@ def _queue_item_elapsed_seconds(
     return max(0.0, (end_time - item_state.started_at).total_seconds())
 
 
+def _queue_elapsed_seconds(
+    state: TrancheQueueRunState,
+    *,
+    now: datetime,
+) -> float | None:
+    if state.started_at is None:
+        return None
+    end_time = state.finished_at or state.updated_at or now
+    return max(0.0, (end_time - state.started_at).total_seconds())
+
+
+def _queue_terminal_counts(counts: dict[str, int]) -> dict[str, int]:
+    return {
+        status: counts.get(status, 0)
+        for status in (
+            QUEUE_ITEM_STATUS_COMPLETED,
+            QUEUE_ITEM_STATUS_NEEDS_HUMAN,
+            QUEUE_ITEM_STATUS_STOPPED,
+        )
+        if counts.get(status, 0)
+    }
+
+
+def _queue_item_status_payload(
+    *,
+    item: TrancheQueueItem,
+    item_state: TrancheQueueItemRunState,
+    artifact_store: TrancheArtifactStore,
+    now: datetime,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    pr_urls = list(dict.fromkeys(item_state.pr_urls))
+    worker_branches = _queue_item_worker_branches(item_state, artifact_store=artifact_store)
+    payload: dict[str, Any] = {
+        "item_id": item.item_id,
+        "kind": item.kind,
+        "source": item.source,
+        "work_class": _classify_queue_item_work_class(item),
+        "status": item_state.status,
+        "phase": item_state.phase,
+        "next_action": _queue_item_next_action(item_state),
+        "merge_class": item.merge_class,
+        "intake_path": item_state.intake_path,
+        "normalized_bundle_path": item_state.normalized_bundle_path,
+        "requested_autonomy_mode": item_state.requested_autonomy_mode,
+        "effective_autonomy_mode": item_state.effective_autonomy_mode,
+        "manifest_id": item_state.manifest_id,
+        "manifest_path": item_state.manifest_path,
+        "inspection_path": item_state.inspection_path,
+        "submission_status": item_state.submission_status,
+        "inspection_status": item_state.inspection_status,
+        "recommended_action": item_state.recommended_action,
+        "design_review_recommendation": item_state.design_review_recommendation,
+        "design_review_path": item_state.design_review_path,
+        "tranche_status": item_state.tranche_status,
+        "pr_url": pr_urls[0] if pr_urls else None,
+        "pr_urls": pr_urls,
+        "worker_branch": worker_branches[0] if len(worker_branches) == 1 else None,
+        "worker_branches": worker_branches,
+        "findings": list(item_state.findings),
+        "stop_reason": item_state.stop_reason,
+        "blocked_reason": item_state.blocked_reason,
+        "blocking_question": item_state.blocking_question,
+        "blocking_lane_id": item_state.blocking_lane_id,
+        "elapsed_seconds": _queue_item_elapsed_seconds(item_state, now=now),
+        "started_at": item_state.started_at.isoformat() if item_state.started_at else None,
+        "phase_updated_at": item_state.phase_updated_at.isoformat()
+        if item_state.phase_updated_at
+        else None,
+        "updated_at": item_state.updated_at.isoformat() if item_state.updated_at else None,
+        "finished_at": item_state.finished_at.isoformat() if item_state.finished_at else None,
+    }
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _queue_current_item_payload(
+    items: list[dict[str, Any]],
+    *,
+    current_item_id: str | None,
+) -> dict[str, Any] | None:
+    current = _optional_text(current_item_id)
+    if not current:
+        return None
+    for item in items:
+        if str(item.get("item_id", "")).strip() == current:
+            return dict(item)
+    return None
+
+
 def _design_review_blocking_question(payload: dict[str, Any]) -> str:
     unresolved = _string_list(payload.get("unresolved_assumptions"))
     if not unresolved and isinstance(payload.get("record"), dict):
@@ -1635,6 +1728,7 @@ class TrancheQueueExecutor:
         manifest = TrancheQueueManifest.load(self.queue_path)
         state = TrancheQueueRunState.load(self.state_path, manifest=manifest)
         artifact_store = TrancheArtifactStore(repo_root=self.repo_root)
+        now = _utcnow()
         try:
             store: DevCoordinationStore | None = DevCoordinationStore(repo_root=self.repo_root)
         except RuntimeError:
@@ -1711,44 +1805,16 @@ class TrancheQueueExecutor:
             else:
                 status = item_state.status
             items.append(
-                {
-                    "item_id": item.item_id,
-                    "kind": item.kind,
-                    "source": item.source,
-                    "status": status,
-                    "phase": item_state.phase,
-                    "merge_class": item.merge_class,
-                    "intake_path": item_state.intake_path,
-                    "normalized_bundle_path": item_state.normalized_bundle_path,
-                    "requested_autonomy_mode": item_state.requested_autonomy_mode,
-                    "effective_autonomy_mode": item_state.effective_autonomy_mode,
-                    "manifest_id": item_state.manifest_id,
-                    "manifest_path": item_state.manifest_path,
-                    "inspection_path": item_state.inspection_path,
-                    "submission_status": item_state.submission_status,
-                    "inspection_status": item_state.inspection_status,
-                    "recommended_action": item_state.recommended_action,
-                    "design_review_recommendation": item_state.design_review_recommendation,
-                    "tranche_status": tranche_status,
-                    "pr_urls": list(item_state.pr_urls),
-                    "findings": list(item_state.findings),
-                    "stop_reason": item_state.stop_reason,
-                    "blocked_reason": item_state.blocked_reason,
-                    "blocking_question": item_state.blocking_question,
-                    "blocking_lane_id": item_state.blocking_lane_id,
-                    "next_action": _queue_item_next_action(item_state),
-                    "started_at": (
-                        item_state.started_at.isoformat() if item_state.started_at else None
-                    ),
-                    "phase_updated_at": (
-                        item_state.phase_updated_at.isoformat()
-                        if item_state.phase_updated_at
-                        else None
-                    ),
-                    "finished_at": (
-                        item_state.finished_at.isoformat() if item_state.finished_at else None
-                    ),
-                }
+                _queue_item_status_payload(
+                    item=item,
+                    item_state=item_state,
+                    artifact_store=artifact_store,
+                    now=now,
+                    extra={
+                        "status": status,
+                        "tranche_status": tranche_status,
+                    },
+                )
             )
         running_items = [
             item_id
@@ -1760,6 +1826,21 @@ class TrancheQueueExecutor:
             for item_id, item_state in state.item_states.items()
             if item_state.status == QUEUE_ITEM_STATUS_PENDING
         ]
+        blocked_items = [
+            item.item_id
+            for item in manifest.items
+            if state.item_states[item.item_id].status == QUEUE_ITEM_STATUS_NEEDS_HUMAN
+        ]
+        blocked_items.extend(
+            item.item_id
+            for item in manifest.items
+            if state.item_states[item.item_id].status == QUEUE_ITEM_STATUS_STOPPED
+        )
+        preserve_blocked_stop = bool(blocked_items) and (
+            state.status == QUEUE_STATUS_STOPPED
+            or state.current_item_id in blocked_items
+            or state.stop_reason is not None
+        )
         if running_items:
             next_current = running_items[0]
             if state.current_item_id != next_current:
@@ -1779,6 +1860,27 @@ class TrancheQueueExecutor:
                 state.stop_reason = state.stop_reason or "driver_stopped"
                 state.finished_at = state.finished_at or _utcnow()
                 changed = True
+        elif preserve_blocked_stop:
+            next_current = (
+                state.current_item_id
+                if state.current_item_id in blocked_items
+                else blocked_items[0]
+            )
+            if state.current_item_id != next_current:
+                state.current_item_id = next_current
+                changed = True
+            if state.status != QUEUE_STATUS_STOPPED:
+                state.status = QUEUE_STATUS_STOPPED
+                changed = True
+            if not state.stop_reason:
+                state.stop_reason = state.item_states[next_current].stop_reason or "driver_stopped"
+                changed = True
+            if state.finished_at is None:
+                current_item_state = state.item_states[next_current]
+                state.finished_at = (
+                    current_item_state.finished_at or current_item_state.updated_at or _utcnow()
+                )
+                changed = True
         else:
             if state.current_item_id is not None:
                 state.current_item_id = None
@@ -1794,6 +1896,7 @@ class TrancheQueueExecutor:
         counts = {}
         for item_state in state.item_states.values():
             counts[item_state.status] = counts.get(item_state.status, 0) + 1
+        terminal_counts = _queue_terminal_counts(counts)
         return {
             "mode": "tranche-queue",
             "queue_id": manifest.queue_id,
@@ -1802,12 +1905,17 @@ class TrancheQueueExecutor:
             "status": state.status,
             "stop_reason": state.stop_reason,
             "current_item_id": state.current_item_id,
+            "current_item": _queue_current_item_payload(
+                items, current_item_id=state.current_item_id
+            ),
             "consecutive_failures": state.consecutive_failures,
             "created_at": state.created_at.isoformat(),
             "started_at": state.started_at.isoformat() if state.started_at else None,
             "updated_at": state.updated_at.isoformat(),
             "finished_at": state.finished_at.isoformat() if state.finished_at else None,
+            "elapsed_seconds": _queue_elapsed_seconds(state, now=now),
             "counts": counts,
+            "terminal_counts": terminal_counts,
             "items": items,
         }
 
@@ -2884,42 +2992,21 @@ def tranche_queue_status(
         item_state = state.item_states[item.item_id]
         counts[item_state.status] = counts.get(item_state.status, 0) + 1
         phase_counts[item_state.phase] = phase_counts.get(item_state.phase, 0) + 1
-        pr_urls = list(dict.fromkeys(item_state.pr_urls))
-        worker_branches = _queue_item_worker_branches(item_state, artifact_store=artifact_store)
         items.append(
-            {
-                "item_id": item.item_id,
-                "work_class": _classify_queue_item_work_class(item),
-                "status": item_state.status,
-                "phase": item_state.phase,
-                "next_action": _queue_item_next_action(item_state),
-                "pr_url": pr_urls[0] if pr_urls else None,
-                "pr_urls": pr_urls,
-                "worker_branch": worker_branches[0] if len(worker_branches) == 1 else None,
-                "worker_branches": worker_branches,
-                "manifest_path": item_state.manifest_path,
-                "normalized_bundle_path": item_state.normalized_bundle_path,
-                "inspection_path": item_state.inspection_path,
-                "design_review_path": item_state.design_review_path,
-                "submission_status": item_state.submission_status,
-                "inspection_status": item_state.inspection_status,
-                "recommended_action": item_state.recommended_action,
-                "blocked_reason": item_state.blocked_reason,
-                "blocking_question": item_state.blocking_question,
-                "design_review_recommendation": item_state.design_review_recommendation,
-                "admission": dict(item_state.result.get("admission", {}))
-                if isinstance(item_state.result.get("admission"), dict)
-                else None,
-                "elapsed_seconds": _queue_item_elapsed_seconds(item_state, now=now),
-                "started_at": item_state.started_at.isoformat() if item_state.started_at else None,
-                "phase_updated_at": item_state.phase_updated_at.isoformat()
-                if item_state.phase_updated_at
-                else None,
-                "finished_at": item_state.finished_at.isoformat()
-                if item_state.finished_at
-                else None,
-            }
+            _queue_item_status_payload(
+                item=item,
+                item_state=item_state,
+                artifact_store=artifact_store,
+                now=now,
+                extra={
+                    "admission": dict(item_state.result.get("admission", {}))
+                    if isinstance(item_state.result.get("admission"), dict)
+                    else None,
+                },
+            )
         )
+
+    terminal_counts = _queue_terminal_counts(counts)
 
     return {
         "mode": "tranche-queue-status",
@@ -2929,11 +3016,14 @@ def tranche_queue_status(
         "status": state.status,
         "stop_reason": state.stop_reason,
         "current_item_id": state.current_item_id,
+        "current_item": _queue_current_item_payload(items, current_item_id=state.current_item_id),
         "created_at": state.created_at.isoformat(),
         "started_at": state.started_at.isoformat() if state.started_at else None,
         "updated_at": state.updated_at.isoformat(),
         "finished_at": state.finished_at.isoformat() if state.finished_at else None,
+        "elapsed_seconds": _queue_elapsed_seconds(state, now=now),
         "counts": counts,
+        "terminal_counts": terminal_counts,
         "phase_counts": phase_counts,
         "items": items,
     }
@@ -3007,6 +3097,8 @@ def harvest_tranche_queue(
     state_path = queue_state_path_for_queue(resolved_queue_path)
     state = TrancheQueueRunState.load(state_path, manifest=manifest)
     github = GitHubControl(repo_root=resolved_repo_root)
+    artifact_store = TrancheArtifactStore(repo_root=resolved_repo_root)
+    now = _utcnow()
 
     pr_counts: dict[str, int] = {}
     executed_merges: list[dict[str, Any]] = []
@@ -3054,22 +3146,19 @@ def harvest_tranche_queue(
                 pr_counts["error"] = pr_counts.get("error", 0) + 1
             pr_records.append(pr_record)
 
-        item_record = {
-            "item_id": item.item_id,
-            "kind": item.kind,
-            "source": item.source,
-            "status": item_state.status,
-            "merge_class": item.merge_class,
-            "tranche_status": item_state.tranche_status,
-            "pr_urls": list(item_state.pr_urls),
-            "findings": list(item_state.findings),
-            "stop_reason": item_state.stop_reason,
-            "prs": pr_records,
-        }
+        item_record = _queue_item_status_payload(
+            item=item,
+            item_state=item_state,
+            artifact_store=artifact_store,
+            now=now,
+            extra={"prs": pr_records},
+        )
         item_record["summary_outcome"] = _harvest_item_outcome(item_record)
         items.append(item_record)
 
     summary = _harvest_summary(items)
+    counts = dict(reconciled.get("counts") or {})
+    terminal_counts = dict(reconciled.get("terminal_counts") or _queue_terminal_counts(counts))
 
     return {
         "mode": "tranche-queue-harvest",
@@ -3079,7 +3168,10 @@ def harvest_tranche_queue(
         "status": state.status,
         "stop_reason": state.stop_reason,
         "current_item_id": state.current_item_id,
-        "counts": dict(reconciled.get("counts") or {}),
+        "current_item": _queue_current_item_payload(items, current_item_id=state.current_item_id),
+        "elapsed_seconds": _queue_elapsed_seconds(state, now=now),
+        "counts": counts,
+        "terminal_counts": terminal_counts,
         "pr_counts": pr_counts,
         "summary": summary,
         "execute_merge": bool(execute_merge),

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -7,7 +7,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from aragora.cli.commands.swarm import _render_tranche_queue_harvest_table
+from aragora.cli.commands.swarm import (
+    _render_tranche_queue_harvest_table,
+    _render_tranche_queue_status,
+)
 from aragora.swarm.tranche_queue import (
     QUEUE_ITEM_PHASE_APPROVED,
     QUEUE_ITEM_PHASE_EXPLORED,
@@ -370,6 +373,41 @@ def test_render_harvest_queue_summary_table_prints_counts(
     }
 
 
+def test_render_tranche_queue_status_prints_terminal_truth(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _render_tranche_queue_status(
+        {
+            "queue_id": "overnight",
+            "status": "stopped",
+            "current_item_id": "intake-docs",
+            "elapsed_seconds": 95.0,
+            "stop_reason": "driver_stopped",
+            "counts": {"completed": 1, "needs_human": 1, "pending": 1},
+            "terminal_counts": {"completed": 1, "needs_human": 1},
+            "current_item": {
+                "item_id": "intake-docs",
+                "status": "needs_human",
+                "next_action": "stop_and_replan",
+                "blocking_question": "What should be fixed before this lane is rerun?",
+                "pr_urls": ["https://example.test/pr/42"],
+            },
+            "items": [],
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "queue_id=overnight status=stopped current_item_id=intake-docs elapsed=1m 35s" in output
+    assert "stop_reason=driver_stopped" in output
+    assert "counts=completed=1, needs_human=1, pending=1" in output
+    assert "terminal_counts=completed=1, needs_human=1" in output
+    assert (
+        "current_item next_action=stop_and_replan status=needs_human pr_urls=https://example.test/pr/42"
+        in output
+    )
+    assert "current_item_blocker=What should be fixed before this lane is rerun?" in output
+
+
 def test_tranche_queue_status_reads_pr_url_branch_and_elapsed(tmp_path: Path) -> None:
     queue_path = tmp_path / "overnight.yaml"
     manifest = _write_queue(queue_path)
@@ -385,6 +423,7 @@ def test_tranche_queue_status_reads_pr_url_branch_and_elapsed(tmp_path: Path) ->
         updated_at=finished_at,
     )
     state.ensure_manifest(manifest)
+    state.updated_at = finished_at
     state.item_states["issue-1046"] = TrancheQueueItemRunState(
         item_id="issue-1046",
         status=QUEUE_ITEM_STATUS_COMPLETED,
@@ -427,6 +466,9 @@ def test_tranche_queue_status_reads_pr_url_branch_and_elapsed(tmp_path: Path) ->
         "completed": 1,
         "pending": 2,
     }
+    assert payload["terminal_counts"] == {"completed": 1}
+    assert payload["elapsed_seconds"] == 300.0
+    assert payload["current_item"] is None
     issue = next(item for item in payload["items"] if item["item_id"] == "issue-1046")
     assert issue["phase"] == QUEUE_ITEM_PHASE_EXPLORED
     assert issue["next_action"] is None
@@ -1791,7 +1833,88 @@ def test_reconcile_queue_reports_truthful_counts(tmp_path: Path) -> None:
     assert payload["stop_reason"] == "driver_stopped"
     assert payload["current_item_id"] is None
     assert payload["counts"] == {"completed": 1, "needs_human": 1, "pending": 1}
+    assert payload["terminal_counts"] == {"completed": 1, "needs_human": 1}
     assert payload["items"][1]["findings"] == ["Missing source material."]
+
+
+def test_tranche_queue_status_surfaces_current_item_truth(tmp_path: Path) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = _write_queue(queue_path)
+    started_at = datetime(2026, 3, 20, 12, 0, tzinfo=timezone.utc)
+    updated_at = started_at + timedelta(minutes=2)
+    state = TrancheQueueRunState(
+        queue_id=manifest.queue_id,
+        status=QUEUE_STATUS_STOPPED,
+        current_item_id="intake-docs",
+        stop_reason="driver_stopped",
+        started_at=started_at,
+        updated_at=updated_at,
+    )
+    state.ensure_manifest(manifest)
+    state.updated_at = updated_at
+    state.item_states["issue-1046"] = TrancheQueueItemRunState(
+        item_id="issue-1046",
+        status=QUEUE_ITEM_STATUS_COMPLETED,
+    )
+    state.item_states["intake-docs"] = TrancheQueueItemRunState(
+        item_id="intake-docs",
+        status=QUEUE_ITEM_STATUS_NEEDS_HUMAN,
+        phase=QUEUE_ITEM_PHASE_EXPLORED,
+        stop_reason="preflight_blocked",
+        blocked_reason="stop_and_replan",
+        blocking_question="Which prerequisite should be fixed before rerunning this item?",
+        pr_urls=["https://example.test/pr/9"],
+        started_at=started_at,
+        updated_at=updated_at,
+    )
+    state.item_states["issue-1047"] = TrancheQueueItemRunState(
+        item_id="issue-1047",
+        status=QUEUE_ITEM_STATUS_STOPPED,
+        stop_reason="processing_error",
+    )
+    state.save(queue_state_path_for_queue(queue_path))
+
+    payload = tranche_queue_status(queue_path=queue_path, repo_root=tmp_path)
+
+    assert payload["stop_reason"] == "driver_stopped"
+    assert payload["elapsed_seconds"] == 120.0
+    assert payload["terminal_counts"] == {
+        "completed": 1,
+        "needs_human": 1,
+        "stopped": 1,
+    }
+    current = payload["current_item"]
+    assert current is not None
+    assert current["item_id"] == "intake-docs"
+    assert current["status"] == QUEUE_ITEM_STATUS_NEEDS_HUMAN
+    assert (
+        current["blocking_question"]
+        == "Which prerequisite should be fixed before rerunning this item?"
+    )
+    assert current["pr_urls"] == ["https://example.test/pr/9"]
+    assert current["elapsed_seconds"] == 120.0
+
+
+def test_tranche_queue_status_nulls_stale_current_item_payload(tmp_path: Path) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = _write_queue(queue_path)
+    state = TrancheQueueRunState(
+        queue_id=manifest.queue_id,
+        status=QUEUE_STATUS_STOPPED,
+        current_item_id="missing",
+        stop_reason="driver_stopped",
+    )
+    state.ensure_manifest(manifest)
+    state.item_states["issue-1046"] = TrancheQueueItemRunState(
+        item_id="issue-1046",
+        status=QUEUE_ITEM_STATUS_COMPLETED,
+    )
+    state.save(queue_state_path_for_queue(queue_path))
+
+    payload = tranche_queue_status(queue_path=queue_path, repo_root=tmp_path)
+
+    assert payload["current_item_id"] == "missing"
+    assert payload["current_item"] is None
 
 
 def test_reconcile_queue_terminalizes_stale_running_item_and_stops_queue(
@@ -1940,6 +2063,70 @@ def test_reconcile_queue_surfaces_blocker_context_from_tranche_artifact(
     repaired = TrancheQueueRunState.load(queue_state_path_for_queue(queue_path), manifest=manifest)
     assert repaired.item_states["intake-docs"].blocked_reason == "required_checks_pending"
     assert repaired.item_states["intake-docs"].blocking_lane_id == "lane-a"
+
+
+def test_harvest_queue_preserves_needs_human_truth(
+    tmp_path: Path,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    manifest = _write_queue(queue_path)
+    started_at = datetime(2026, 3, 20, 12, 0, tzinfo=timezone.utc)
+    updated_at = started_at + timedelta(minutes=3)
+    state = TrancheQueueRunState(
+        queue_id=manifest.queue_id,
+        status=QUEUE_STATUS_STOPPED,
+        stop_reason="driver_stopped",
+        current_item_id="intake-docs",
+        started_at=started_at,
+        updated_at=updated_at,
+    )
+    state.ensure_manifest(manifest)
+    state.updated_at = updated_at
+    state.item_states["issue-1046"] = TrancheQueueItemRunState(
+        item_id="issue-1046",
+        status=QUEUE_ITEM_STATUS_COMPLETED,
+    )
+    state.item_states["intake-docs"] = TrancheQueueItemRunState(
+        item_id="intake-docs",
+        status=QUEUE_ITEM_STATUS_NEEDS_HUMAN,
+        phase=QUEUE_ITEM_PHASE_PLANNED,
+        stop_reason="awaiting_confirmation",
+        blocked_reason="design_review_awaiting_confirmation",
+        blocking_question="Can you confirm the design assumption before rerunning the lane?",
+        started_at=started_at,
+        updated_at=updated_at,
+    )
+    state.item_states["issue-1047"] = TrancheQueueItemRunState(
+        item_id="issue-1047",
+        status=QUEUE_ITEM_STATUS_STOPPED,
+        stop_reason="processing_error",
+    )
+    state.save(queue_state_path_for_queue(queue_path))
+
+    payload = harvest_tranche_queue(queue_path=queue_path, repo_root=tmp_path)
+
+    assert payload["status"] == QUEUE_STATUS_STOPPED
+    assert payload["stop_reason"] == "driver_stopped"
+    assert payload["current_item_id"] == "intake-docs"
+    assert payload["terminal_counts"] == {
+        "completed": 1,
+        "needs_human": 1,
+        "stopped": 1,
+    }
+    assert payload["elapsed_seconds"] == 180.0
+    current = payload["current_item"]
+    assert current is not None
+    assert current["item_id"] == "intake-docs"
+    intake = next(item for item in payload["items"] if item["item_id"] == "intake-docs")
+    assert intake["summary_outcome"] == "needs_human"
+    assert intake["stop_reason"] == "awaiting_confirmation"
+    assert intake["blocked_reason"] == "design_review_awaiting_confirmation"
+    assert (
+        intake["blocking_question"]
+        == "Can you confirm the design assumption before rerunning the lane?"
+    )
+    assert intake["pr_url"] is None
+    assert intake["pr_urls"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add durable queue telemetry for terminal counts, elapsed time, current item context, blocker details, and PR links
- surface truthful queue status details in the swarm CLI output and keep JSON payloads stable for automation
- preserve truthful stopped/needs-human queue state during reconcile and harvest instead of rewriting it to completed on load

## Validation
- python3 -m ruff check aragora/swarm/tranche_queue.py aragora/cli/commands/swarm.py tests/swarm/test_tranche_queue.py
- python3 -m pytest tests/swarm/test_tranche_queue.py -q