### PR TITLE
fix(swarm): align parallel boss-loop safeguards

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -819,6 +819,55 @@ class BossLoop:
             return retry_routed
         return issues
 
+    def _already_maxed_issue_numbers(self, issues: list[GitHubIssue]) -> set[int]:
+        already_maxed: set[int] = set()
+        for num, count in self._issue_attempt_counts.items():
+            if count >= self.config.max_retries_per_issue:
+                try:
+                    issue_number = int(num)
+                except (TypeError, ValueError):
+                    continue
+                already_maxed.add(issue_number)
+                if count == self.config.max_retries_per_issue and self.config.repo:
+                    self._auto_decompose_stuck_issue(issue_number, issues)
+        return already_maxed
+
+    def _existing_open_pr_skip_status(
+        self,
+        *,
+        iteration: int,
+        timestamp: str,
+        runner_freshness: dict[str, Any],
+        issue: GitHubIssue,
+        elapsed_seconds: float,
+    ) -> BossIterationStatus | None:
+        existing_pr = self._has_open_pr_for_issue(issue.number)
+        if not existing_pr:
+            return None
+        logger.info(
+            "boss_loop_skip_existing_pr issue=#%s pr=%s",
+            issue.number,
+            existing_pr,
+        )
+        issue_dict = self._issue_payload(issue)
+        self._completed_issues.append(issue_dict)
+        self._issue_attempt_counts[issue.number] = max(
+            self._issue_attempt_counts.get(issue.number, 0),
+            self.config.max_retries_per_issue,
+        )
+        return BossIterationStatus(
+            iteration=iteration,
+            run_id=self.run_id,
+            timestamp=timestamp,
+            runner_freshness=runner_freshness,
+            selected_issue=issue_dict,
+            worker_status="completed",
+            stop_reason=None,
+            needs_human_reasons=[],
+            next_actions=[f"Skipped: issue #{issue.number} already has open PR {existing_pr}."],
+            elapsed_seconds=elapsed_seconds,
+        )
+
     def _requested_runner_type_for_freshness(
         self,
         selected_issues: list[GitHubIssue],
@@ -2700,13 +2749,7 @@ class BossLoop:
 
         # Step 2: Select eligible issue
         # Skip issues that have exceeded retry limits and auto-label them
-        already_maxed = set()
-        for num, count in self._issue_attempt_counts.items():
-            if count >= self.config.max_retries_per_issue:
-                already_maxed.add(num)
-                # Auto-decompose exhausted issues into sub-issues (best-effort, once)
-                if count == self.config.max_retries_per_issue and self.config.repo:
-                    self._auto_decompose_stuck_issue(num, issues)
+        already_maxed = self._already_maxed_issue_numbers(issues)
         blocked_scopes = self._blocked_issue_scopes()
         pending_handoffs = self._pending_handoff_candidates(
             issues,
@@ -2808,32 +2851,15 @@ class BossLoop:
             )
 
         # Step 3b: Pre-dispatch guard — skip issues that already have an open PR
-        existing_pr = self._has_open_pr_for_issue(selected.number)
-        if existing_pr:
-            logger.info(
-                "boss_loop_skip_existing_pr issue=#%s pr=%s",
-                selected.number,
-                existing_pr,
-            )
-            self._completed_issues.append(self._issue_payload(selected))
-            self._issue_attempt_counts[selected.number] = max(
-                self._issue_attempt_counts.get(selected.number, 0),
-                self.config.max_retries_per_issue,
-            )
-            return BossIterationStatus(
-                iteration=iteration,
-                run_id=self.run_id,
-                timestamp=now,
-                runner_freshness=freshness_dict,
-                selected_issue=self._issue_payload(selected),
-                worker_status="completed",
-                stop_reason=None,
-                needs_human_reasons=[],
-                next_actions=[
-                    f"Skipped: issue #{selected.number} already has open PR {existing_pr}."
-                ],
-                elapsed_seconds=time.monotonic() - iter_start,
-            )
+        existing_pr_status = self._existing_open_pr_skip_status(
+            iteration=iteration,
+            timestamp=now,
+            runner_freshness=freshness_dict,
+            issue=selected,
+            elapsed_seconds=time.monotonic() - iter_start,
+        )
+        if existing_pr_status is not None:
+            return existing_pr_status
 
         # Step 4: Dispatch supervised work for this issue
         issue_dict = self._issue_payload(selected)
@@ -2910,11 +2936,7 @@ class BossLoop:
                 )
             ]
 
-        already_maxed = {
-            num
-            for num, count in self._issue_attempt_counts.items()
-            if count >= self.config.max_retries_per_issue
-        }
+        already_maxed = self._already_maxed_issue_numbers(issues)
         blocked_scopes = self._blocked_issue_scopes()
         pending_handoffs = self._pending_handoff_candidates(
             issues,
@@ -2940,6 +2962,13 @@ class BossLoop:
             blocked_scopes=blocked_scopes,
         )
         selected_issues = self._filter_mixed_retry_routing_batch(selected_issues)
+        serialize_retry_routed_batch = self._selected_issues_need_retry_routing(selected_issues)
+        if serialize_retry_routed_batch and len(selected_issues) > 1:
+            logger.info(
+                "Boss loop serializing retry-routed parallel batch: selected=%s",
+                [issue.number for issue in selected_issues],
+            )
+            selected_issues = selected_issues[:1]
 
         if not selected_issues:
             if self.config.issue_number is not None:
@@ -3001,6 +3030,24 @@ class BossLoop:
             ]
 
         parallel_limit = self._parallel_dispatch_limit(freshness)
+        if serialize_retry_routed_batch:
+            parallel_limit = 1
+        statuses: list[BossIterationStatus] = []
+        dispatchable_issues: list[GitHubIssue] = []
+        for issue in selected_issues:
+            existing_pr_status = self._existing_open_pr_skip_status(
+                iteration=iteration,
+                timestamp=now,
+                runner_freshness=freshness_dict,
+                issue=issue,
+                elapsed_seconds=time.monotonic() - iter_start,
+            )
+            if existing_pr_status is not None:
+                statuses.append(existing_pr_status)
+                continue
+            dispatchable_issues.append(issue)
+        if not dispatchable_issues:
+            parallel_limit = 0
         self._current_effective_parallel_dispatches = parallel_limit
         logger.info(
             "Boss loop iteration %d parallel dispatches: configured=%d effective=%d",
@@ -3008,11 +3055,13 @@ class BossLoop:
             self._configured_parallel_dispatches,
             parallel_limit,
         )
-        pending_issues = list(selected_issues)
+        if not dispatchable_issues:
+            return statuses
+
+        pending_issues = list(dispatchable_issues)
         active_tasks: dict[
             asyncio.Task[dict[str, Any]], tuple[GitHubIssue, dict[str, Any], float]
         ] = {}
-        statuses: list[BossIterationStatus] = []
         stop_launching = False
 
         while pending_issues and len(active_tasks) < parallel_limit:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3520,6 +3520,154 @@ def test_boss_loop_batch_uses_configured_limit_when_no_capacity_reported() -> No
     assert {status.effective_parallel_dispatches for status in statuses} == {4}
 
 
+def test_boss_loop_batch_skips_existing_open_pr_before_dispatch() -> None:
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [
+        _make_issue(
+            451,
+            "Batch issue with existing PR",
+            body=(
+                "Touch aragora/swarm/open_pr_guard.py\n\n"
+                "Acceptance Criteria:\n- pytest -q tests/swarm/test_boss_loop.py\n"
+            ),
+        ),
+        _make_issue(
+            452,
+            "Batch issue without PR",
+            body=(
+                "Touch aragora/server/parallel_guard.py\n\n"
+                "Acceptance Criteria:\n- pytest -q tests/swarm/test_boss_loop.py\n"
+            ),
+        ),
+    ]
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_parallel_dispatches=2, repo="synaptent/aragora"),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: RunnerFreshnessResult(
+            fresh=True,
+            runner_ids=["codex-runner-1", "codex-runner-2"],
+            checked_at=datetime.now(UTC).isoformat(),
+            details={
+                "routing": {
+                    "selected_runners": [
+                        {"runner_id": "codex-runner-1", "available_capacity": 1},
+                        {"runner_id": "codex-runner-2", "available_capacity": 1},
+                    ]
+                }
+            },
+        ),
+    )
+    dispatch_seen: list[int] = []
+
+    async def _dispatch(issue, freshness):
+        dispatch_seen.append(issue.number)
+        return {"status": "completed"}
+
+    loop._dispatch_issue = _dispatch
+    loop._select_issues_for_iteration = lambda issues, **kwargs: list(issues)
+    existing_pr_url = "https://github.com/synaptent/aragora/pull/451"
+
+    with patch.object(
+        loop,
+        "_has_open_pr_for_issue",
+        side_effect=lambda number: existing_pr_url if number == 451 else None,
+    ):
+        result = asyncio.run(loop.run())
+
+    assert dispatch_seen == [452]
+    attempted_numbers = {item.get("number") for item in result.issues_attempted}
+    assert 451 not in attempted_numbers
+    assert 452 in attempted_numbers
+    completed_numbers = {item.get("number") for item in result.issues_completed}
+    assert 451 in completed_numbers
+    skipped = [
+        status
+        for status in result.iteration_statuses
+        if (status.get("selected_issue") or {}).get("number") == 451
+    ]
+    assert len(skipped) == 1
+    assert any(existing_pr_url in str(action) for action in skipped[0].get("next_actions", []))
+
+
+def test_boss_loop_batch_auto_decomposes_maxed_retry_issue() -> None:
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [
+        _make_issue(461, "Exhausted batch issue"),
+        _make_issue(462, "Fresh batch issue"),
+    ]
+    loop = BossLoop(
+        config=_boss_config(
+            max_iterations=1,
+            max_parallel_dispatches=2,
+            max_retries_per_issue=2,
+            repo="synaptent/aragora",
+        ),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: RunnerFreshnessResult(
+            fresh=True,
+            runner_ids=["codex-runner-1", "codex-runner-2"],
+            checked_at=datetime.now(UTC).isoformat(),
+        ),
+    )
+    loop._issue_attempt_counts[461] = 2
+    loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+    loop._select_issues_for_iteration = lambda issues, **kwargs: list(issues)
+
+    with patch.object(loop, "_auto_decompose_stuck_issue") as mock_decompose:
+        result = asyncio.run(loop.run())
+
+    mock_decompose.assert_called_once()
+    assert mock_decompose.call_args.args[0] == 461
+    loop._dispatch_issue.assert_awaited_once()
+    dispatched_issue = loop._dispatch_issue.await_args.args[0]
+    assert dispatched_issue.number == 462
+    attempted_numbers = {item.get("number") for item in result.issues_attempted}
+    assert 461 not in attempted_numbers
+    assert 462 in attempted_numbers
+
+
+def test_boss_loop_batch_serializes_retry_routed_dispatches() -> None:
+    feed = MagicMock(spec=GitHubIssueFeed)
+    feed.fetch.return_value = [
+        _make_issue(471, "Retry-routed batch issue A"),
+        _make_issue(472, "Retry-routed batch issue B"),
+    ]
+    loop = BossLoop(
+        config=_boss_config(max_iterations=1, max_parallel_dispatches=2),
+        issue_feed=feed,
+        freshness_checker=lambda **kw: RunnerFreshnessResult(
+            fresh=True,
+            runner_ids=["codex-runner-1", "codex-runner-2"],
+            checked_at=datetime.now(UTC).isoformat(),
+            details={
+                "routing": {
+                    "selected_runners": [
+                        {"runner_id": "codex-runner-1", "available_capacity": 1},
+                        {"runner_id": "codex-runner-2", "available_capacity": 1},
+                    ]
+                }
+            },
+        ),
+    )
+    loop._issue_attempt_counts[471] = 1
+    loop._issue_attempt_counts[472] = 1
+    dispatch_seen: list[int] = []
+
+    async def _dispatch(issue, freshness):
+        dispatch_seen.append(issue.number)
+        return {"status": "completed"}
+
+    loop._dispatch_issue = AsyncMock(side_effect=_dispatch)
+
+    statuses: list[BossIterationStatus] = []
+    result = asyncio.run(loop.run(on_status=statuses.append))
+
+    assert dispatch_seen == [471]
+    assert result.configured_max_parallel_dispatches == 2
+    assert result.effective_parallel_dispatches_observed == 1
+    assert {status.effective_parallel_dispatches for status in statuses} == {1}
+
+
 # ---------------------------------------------------------------------------
 # _classify_terminal_run_outcome regression tests
 # ---------------------------------------------------------------------------
@@ -4832,10 +4980,18 @@ class TestPublishedPrTerminal:
 
         # Simulate that an open PR already exists for issue #42
         existing_pr_url = "https://github.com/synaptent/aragora/pull/200"
-        with patch.object(
-            loop,
-            "_has_open_pr_for_issue",
-            return_value=existing_pr_url,
+        with (
+            patch.object(
+                loop,
+                "_has_open_pr_for_issue",
+                return_value=existing_pr_url,
+            ),
+            patch(
+                "aragora.swarm.boss_loop.select_eligible_issue",
+                side_effect=lambda issues, **kwargs: next(
+                    (i for i in issues if i is not None), None
+                ),
+            ),
         ):
             result = asyncio.run(loop.run())
 


### PR DESCRIPTION
## Root cause
The unattended parallel boss-loop path had drifted from serial safeguards in three places: it skipped the serial open-PR pre-dispatch guard, it did not auto-decompose maxed-out issues before filtering them away, and it could batch multiple retry-routed issues concurrently even though retry handoff logic is intentionally serial.

## What changed
- reuse the same open-PR skip handling in serial and parallel dispatch
- reuse the same max-retry auto-decomposition scan in serial and parallel issue selection
- serialize retry-routed parallel batches down to one issue so unattended parallel mode preserves serial retry safety instead of widening the handoff path
- add focused regressions for open-PR parity, max-retry decomposition parity, and retry-routed batch serialization

## Validation
- python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m pytest tests/swarm/test_boss_loop.py -q
- python3 -m pytest tests/swarm/test_boss_loop.py -q -k 'batch_skips_existing_open_pr_before_dispatch or batch_auto_decomposes_maxed_retry_issue or batch_serializes_retry_routed_dispatches or batch_reports_effective_parallel_dispatches or existing_open_pr_skips_dispatch'