### PR TITLE
fix(sdk): return canonical spectate SSE URLs

### DIFF
--- a/aragora/live/tests/sdk/test_sdk_namespaces_new.py
+++ b/aragora/live/tests/sdk/test_sdk_namespaces_new.py
@@ -334,17 +334,17 @@ class TestSpectateSync:
         self.api = SpectateAPI(sync_client)
 
     def test_connect_sse(self):
-        self.client.request.return_value = {
-            "stream_url": "/sse/debate-1",
-            "debate_id": "debate-1",
-        }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
-        assert result["stream_url"] == "/sse/debate-1"
+        self.client.request.assert_not_called()
+        assert result == {
+            "debate_id": "debate-1",
+            "stream_url": "/api/v1/debates/debate-1/spectate",
+        }
 
     def test_connect_sse_different_id(self):
-        self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        result = self.api.connect_sse("debate/xyz")
+        self.client.request.assert_not_called()
+        assert result["stream_url"] == "/api/v1/debates/debate%2Fxyz/spectate"
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -383,10 +383,12 @@ class TestSpectateAsync:
 
     @pytest.mark.asyncio
     async def test_connect_sse(self):
-        self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
-        assert result["stream_url"] == "/sse/debate-async"
+        self.client.request.assert_not_awaited()
+        assert result == {
+            "debate_id": "debate-async",
+            "stream_url": "/api/v1/debates/debate-async/spectate",
+        }
 
     @pytest.mark.asyncio
     async def test_get_recent(self):

--- a/sdk/python/aragora_sdk/namespaces/spectate.py
+++ b/sdk/python/aragora_sdk/namespaces/spectate.py
@@ -8,9 +8,19 @@ Provides methods for real-time debate observation:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 
 if TYPE_CHECKING:
     from ..client import AragoraAsyncClient, AragoraClient
+
+
+def _build_sse_stream_info(debate_id: str) -> dict[str, Any]:
+    """Return the canonical live SSE endpoint without issuing a JSON request."""
+    encoded_debate_id = quote(debate_id, safe="")
+    return {
+        "debate_id": debate_id,
+        "stream_url": f"/api/v1/debates/{encoded_debate_id}/spectate",
+    }
 
 
 class SpectateAPI:
@@ -27,12 +37,12 @@ class SpectateAPI:
 
     def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
+        Return connection details for a debate's live SSE stream.
 
-        Returns connection details including the stream URL.
-        Use the stream URL with an SSE client for real-time events.
+        The generic SDK client only supports JSON APIs, so this helper returns
+        the canonical stream URL instead of attempting to open the SSE request.
         """
-        return self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return _build_sse_stream_info(debate_id)
 
     def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""
@@ -67,11 +77,12 @@ class AsyncSpectateAPI:
 
     async def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
+        Return connection details for a debate's live SSE stream.
 
-        Returns connection details including the stream URL.
+        The generic SDK client only supports JSON APIs, so this helper returns
+        the canonical stream URL instead of attempting to open the SSE request.
         """
-        return await self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return _build_sse_stream_info(debate_id)
 
     async def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""

--- a/sdk/typescript/src/namespaces/__tests__/parity-compat-routes.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/parity-compat-routes.test.ts
@@ -8,6 +8,7 @@ import { OutlookAPI } from '../outlook';
 import { SkillsAPI } from '../skills';
 import { SMEAPI } from '../sme';
 import { SSONamespace } from '../sso';
+import { SpectateAPI } from '../spectate';
 import { WebhooksAPI } from '../webhooks';
 
 interface MockClient {
@@ -66,6 +67,16 @@ describe('Parity Compatibility Routes', () => {
     expect(mockClient.request).toHaveBeenNthCalledWith(2, 'GET', '/api/debates/debate-1/spectate/public');
     expect(mockClient.request).toHaveBeenNthCalledWith(3, 'GET', '/api/debates/debate-1/package');
     expect(mockClient.request).toHaveBeenNthCalledWith(4, 'GET', '/api/debates/debate%2F1/package/markdown');
+  });
+
+  it('builds the canonical live spectate SSE URL without a JSON request', async () => {
+    const api = new SpectateAPI(mockClient as any);
+
+    await expect(api.connectSSE('debate/1')).resolves.toEqual({
+      debate_id: 'debate/1',
+      stream_url: '/api/v1/debates/debate%2F1/spectate',
+    });
+    expect(mockClient.request).not.toHaveBeenCalled();
   });
 
   it('maps debate diagnostics and share revoke compatibility routes', async () => {

--- a/sdk/typescript/src/namespaces/spectate.ts
+++ b/sdk/typescript/src/namespaces/spectate.ts
@@ -12,17 +12,24 @@ interface SpectateClientInterface {
   }): Promise<T>;
 }
 
+function buildSSEStreamInfo(debateId: string): Record<string, unknown> {
+  return {
+    debate_id: debateId,
+    stream_url: `/api/v1/debates/${encodeURIComponent(debateId)}/spectate`,
+  };
+}
+
 export class SpectateAPI {
   constructor(private client: SpectateClientInterface) {}
 
   /**
-   * Connect to SSE stream for a debate.
+   * Return connection details for a debate's live SSE stream.
    *
-   * Returns connection details including the stream URL.
-   * Use the stream URL with an EventSource client for real-time events.
+   * The shared HTTP client assumes JSON responses, so this helper returns
+   * the canonical stream URL instead of issuing the SSE request directly.
    */
   async connectSSE(debateId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/spectate/${encodeURIComponent(debateId)}/stream`);
+    return buildSSEStreamInfo(debateId);
   }
 
   async getRecent(options?: { count?: number; debateId?: string }): Promise<Record<string, unknown>> {

--- a/tests/sdk/test_sdk_namespaces_new.py
+++ b/tests/sdk/test_sdk_namespaces_new.py
@@ -333,17 +333,17 @@ class TestSpectateSync:
         self.api = SpectateAPI(sync_client)
 
     def test_connect_sse(self):
-        self.client.request.return_value = {
-            "stream_url": "/sse/debate-1",
-            "debate_id": "debate-1",
-        }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
-        assert result["stream_url"] == "/sse/debate-1"
+        self.client.request.assert_not_called()
+        assert result == {
+            "debate_id": "debate-1",
+            "stream_url": "/api/v1/debates/debate-1/spectate",
+        }
 
     def test_connect_sse_different_id(self):
-        self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        result = self.api.connect_sse("debate/xyz")
+        self.client.request.assert_not_called()
+        assert result["stream_url"] == "/api/v1/debates/debate%2Fxyz/spectate"
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -382,10 +382,12 @@ class TestSpectateAsync:
 
     @pytest.mark.asyncio
     async def test_connect_sse(self):
-        self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
-        assert result["stream_url"] == "/sse/debate-async"
+        self.client.request.assert_not_awaited()
+        assert result == {
+            "debate_id": "debate-async",
+            "stream_url": "/api/v1/debates/debate-async/spectate",
+        }
 
     @pytest.mark.asyncio
     async def test_get_recent(self):

--- a/tests/sdk/test_spectate_ns.py
+++ b/tests/sdk/test_spectate_ns.py
@@ -24,12 +24,17 @@ def api(mock_client):
 class TestSpectateAPI:
     def test_connect_sse(self, api, mock_client):
         result = api.connect_sse("debate-123")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-123/stream")
+        mock_client.request.assert_not_called()
+        assert result == {
+            "debate_id": "debate-123",
+            "stream_url": "/api/v1/debates/debate-123/spectate",
+        }
         assert "stream_url" in result
 
     def test_connect_sse_different_debate(self, api, mock_client):
-        api.connect_sse("debate-456")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-456/stream")
+        result = api.connect_sse("debate/456")
+        mock_client.request.assert_not_called()
+        assert result["stream_url"] == "/api/v1/debates/debate%2F456/spectate"
 
     def test_async_class_exists(self):
         """Verify AsyncSpectateAPI can be instantiated."""
@@ -46,4 +51,5 @@ class TestSpectateAPI:
     def test_connect_returns_response(self, api, mock_client):
         mock_client.request.return_value = {"stream_url": "/sse/test", "debate_id": "test"}
         result = api.connect_sse("test")
+        mock_client.request.assert_not_called()
         assert result["debate_id"] == "test"


### PR DESCRIPTION
Automated fix from Codex engineering automation.