### PR TITLE
fix(actions): reject orchestration advance without live state

### DIFF
--- a/aragora/server/handlers/action_canvas.py
+++ b/aragora/server/handlers/action_canvas.py
@@ -578,8 +578,6 @@ class ActionCanvasHandler(SecureHandler):
     ) -> HandlerResult:
         """Advance action canvas to the orchestration stage (Stage 4)."""
         try:
-            from aragora.canvas import Canvas
-
             store = self._get_store()
             canvas_meta = store.load_canvas(canvas_id)
             if not canvas_meta:
@@ -588,13 +586,11 @@ class ActionCanvasHandler(SecureHandler):
             manager = self._get_canvas_manager()
             canvas = self._run_async(manager.get_canvas(canvas_id))
             if canvas is None:
-                canvas = Canvas(
-                    id=canvas_id,
-                    name=canvas_meta.get("name", "Untitled Actions"),
-                    metadata=dict(canvas_meta.get("metadata", {})),
-                    owner_id=user_id,
-                    workspace_id=canvas_meta.get("workspace_id"),
+                logger.warning(
+                    "Cannot advance action canvas %s: live state missing while metadata still exists",
+                    canvas_id,
                 )
+                return error_response("Action canvas state unavailable", 409)
 
             orchestration_canvas = self._build_orchestration_canvas(canvas, canvas_id, canvas_meta)
             orchestration_store = self._get_orchestration_store()

--- a/tests/handlers/test_action_canvas.py
+++ b/tests/handlers/test_action_canvas.py
@@ -389,6 +389,35 @@ class TestAdvanceToOrchestration:
             assert status == 404
 
     @patch("aragora.canvas.action_store.get_action_canvas_store")
+    def test_advance_requires_live_canvas_state(self, mock_get_store, handler):
+        mock_store = MagicMock()
+        mock_store.load_canvas.return_value = {
+            "id": "ac-1",
+            "name": "Sprint 1",
+            "workspace_id": "ws-1",
+            "metadata": {"stage": "actions"},
+        }
+        mock_get_store.return_value = mock_store
+
+        orchestration_store = MagicMock()
+
+        with patch.object(
+            handler, "_get_orchestration_store", return_value=orchestration_store, create=True
+        ):
+            with patch.object(handler, "_get_canvas_manager"):
+                with patch.object(handler, "_run_async", return_value=None):
+                    ctx = MagicMock()
+                    result = handler._advance_to_orchestration(ctx, "ac-1", {}, "u1")
+                    assert result is not None
+
+        status = getattr(result, "status_code", getattr(result, "status", None))
+        if status:
+            assert status == 409
+        body = json.loads(result.body.decode("utf-8"))
+        assert body["error"] == "Action canvas state unavailable"
+        orchestration_store.save_canvas.assert_not_called()
+
+    @patch("aragora.canvas.action_store.get_action_canvas_store")
     def test_advance_materializes_orchestration_canvas(self, mock_get_store, handler):
         mock_store = MagicMock()
         mock_store.load_canvas.return_value = {


### PR DESCRIPTION
Automated fix from Codex automation.