### PR TITLE
fix(cli): skip secrets bootstrap for demo paths

### DIFF
--- a/aragora/cli/main.py
+++ b/aragora/cli/main.py
@@ -37,6 +37,32 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 # Default API URL from environment or localhost fallback
 DEFAULT_API_URL = os.environ.get("ARAGORA_API_URL", "http://localhost:8080")
 
+
+def _should_disable_secrets_manager_for_bootstrap(argv: list[str] | None = None) -> bool:
+    """Return True when the invocation is explicitly demo/offline oriented."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args:
+        return False
+    if args[0] == "demo":
+        return True
+    return "--demo" in args or "--offline" in args
+
+
+def _prime_cli_environment(argv: list[str] | None = None) -> None:
+    """Avoid network-backed secret hydration for demo/offline CLI startup paths."""
+    if not _should_disable_secrets_manager_for_bootstrap(argv):
+        return
+    os.environ.setdefault("ARAGORA_USE_SECRETS_MANAGER", "false")
+    try:
+        from aragora.config.secrets import reset_secret_manager
+
+        reset_secret_manager()
+    except ImportError:
+        logger.debug("Secret manager reset unavailable during CLI bootstrap", exc_info=True)
+
+
+_prime_cli_environment()
+
 # ---------------------------------------------------------------------------
 # Re-exports for backwards compatibility
 #
@@ -119,6 +145,7 @@ def __getattr__(name: str) -> object:
 
 
 def main() -> None:
+    _prime_cli_environment()
     try:
         from aragora.cli.api_keys import hydrate_env_from_secure_store
 

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -6,6 +6,7 @@ Covers argument parsing, command handlers, and utility functions.
 
 import argparse
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch, Mock
 import sys
@@ -17,6 +18,8 @@ from aragora.cli.main import (
     parse_agents,
     get_event_emitter_if_available,
     main,
+    _prime_cli_environment,
+    _should_disable_secrets_manager_for_bootstrap,
 )
 
 
@@ -456,6 +459,34 @@ class TestDemoTasks:
 
 class TestMain:
     """Tests for main entry point."""
+
+    def test_demo_bootstrap_disables_secrets_manager(self, monkeypatch: pytest.MonkeyPatch):
+        """Demo/offline invocations should skip AWS secrets-manager hydration."""
+        monkeypatch.delenv("ARAGORA_USE_SECRETS_MANAGER", raising=False)
+        reset_mock = Mock()
+        mock_secrets = Mock(reset_secret_manager=reset_mock)
+
+        with patch.dict(sys.modules, {"aragora.config.secrets": mock_secrets}):
+            _prime_cli_environment(["demo"])
+
+        assert os.environ["ARAGORA_USE_SECRETS_MANAGER"] == "false"
+        reset_mock.assert_called_once_with()
+
+    @pytest.mark.parametrize(
+        ("argv", "expected"),
+        [
+            (["demo"], True),
+            (["quickstart", "--demo"], True),
+            (["serve", "--offline"], True),
+            (["ask", "question"], False),
+        ],
+    )
+    def test_bootstrap_detection_matches_demo_and_offline_paths(
+        self,
+        argv: list[str],
+        expected: bool,
+    ):
+        assert _should_disable_secrets_manager_for_bootstrap(argv) is expected
 
     def test_main_no_command_shows_help(self, capsys):
         """Should show help when no command provided."""


### PR DESCRIPTION
Automated fix from Codex automation.