### PR TITLE
fix(dashboard): accept quality metrics alias

### DIFF
--- a/aragora/server/handlers/admin/dashboard.py
+++ b/aragora/server/handlers/admin/dashboard.py
@@ -81,6 +81,7 @@ class DashboardHandler(DashboardActionsMixin, DashboardViewsMixin, SecureHandler
 
     ROUTES = [
         "/api/dashboard/debates",
+        "/api/dashboard/quality-metrics",
         "/api/v1/dashboard",
         "/api/v1/dashboard/overview",
         "/api/v1/dashboard/debates",
@@ -209,7 +210,7 @@ class DashboardHandler(DashboardActionsMixin, DashboardViewsMixin, SecureHandler
             query = query_params.get("q") or ""
             return self._search_dashboard(query)
 
-        if path == "/api/v1/dashboard/quality-metrics":
+        if path in ("/api/dashboard/quality-metrics", "/api/v1/dashboard/quality-metrics"):
             # Additional permission check for metrics endpoints
             try:
                 self.check_permission(auth_context, PERM_ADMIN_METRICS_READ)

--- a/tests/handlers/admin/test_dashboard.py
+++ b/tests/handlers/admin/test_dashboard.py
@@ -597,6 +597,16 @@ class TestHandleRouteDispatch:
         assert "evolution" in body
 
     @pytest.mark.asyncio
+    async def test_unversioned_quality_metrics_endpoint(self, handler, mock_http):
+        """GET /api/dashboard/quality-metrics returns quality data."""
+        result = await handler.handle("/api/dashboard/quality-metrics", {}, mock_http)
+        assert _status(result) == 200
+        body = _body(result)
+        assert "calibration" in body
+        assert "performance" in body
+        assert "evolution" in body
+
+    @pytest.mark.asyncio
     async def test_unmatched_path_returns_none(self, handler, mock_http):
         """Handle returns None for unmatched path."""
         result = await handler.handle("/api/v1/totally-unknown", {}, mock_http)

--- a/tests/server/handlers/admin/test_dashboard.py
+++ b/tests/server/handlers/admin/test_dashboard.py
@@ -115,6 +115,7 @@ class TestDashboardRouting:
     def test_can_handle_quality_metrics_route(self, handler):
         """Can handle quality metrics route."""
         assert handler.can_handle("/api/v1/dashboard/quality-metrics") is True
+        assert handler.can_handle("/api/dashboard/quality-metrics") is True
 
     def test_cannot_handle_unknown_route(self, handler):
         """Cannot handle unknown routes."""
@@ -164,6 +165,26 @@ class TestDashboardRouting:
                 with patch.object(handler, "get_auth_context", return_value=mock_auth_context):
                     with patch.object(handler, "check_permission"):
                         await handler.handle("/api/v1/dashboard/quality-metrics", {}, mock_handler)
+
+                        mock_method.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handle_routes_to_unversioned_quality_metrics(self, handler):
+        """Handle routes unversioned quality metrics path correctly."""
+        mock_handler = MagicMock()
+        mock_auth_context = MagicMock()
+
+        with patch.object(handler, "_get_quality_metrics") as mock_method:
+            mock_method.return_value = {"data": {}}
+
+            with patch(
+                "aragora.server.handlers.admin.dashboard._dashboard_limiter"
+            ) as mock_limiter:
+                mock_limiter.is_allowed.return_value = True
+
+                with patch.object(handler, "get_auth_context", return_value=mock_auth_context):
+                    with patch.object(handler, "check_permission"):
+                        await handler.handle("/api/dashboard/quality-metrics", {}, mock_handler)
 
                         mock_method.assert_called_once()
 


### PR DESCRIPTION
Automated fix from Codex automation.