### PR TITLE
fix(config): prefer env api keys before secrets lookup

### DIFF
--- a/aragora/config/legacy.py
+++ b/aragora/config/legacy.py
@@ -188,8 +188,8 @@ def get_api_key(*env_vars: str, required: bool = True) -> str | None:
     (non-empty, non-whitespace) value found. Strips whitespace from the result.
 
     Priority order:
-    1. AWS Secrets Manager (if ARAGORA_USE_SECRETS_MANAGER=true)
-    2. Environment variables
+    1. Environment variables
+    2. AWS Secrets Manager (if enabled and env vars are unset)
 
     Args:
         *env_vars: Environment variable names to check (in order of preference)
@@ -205,7 +205,14 @@ def get_api_key(*env_vars: str, required: bool = True) -> str | None:
         >>> api_key = get_api_key("GEMINI_API_KEY", "GOOGLE_API_KEY")
         >>> optional_key = get_api_key("BACKUP_KEY", required=False)
     """
-    # Try AWS Secrets Manager first (if enabled)
+    # Prefer already-exported env vars to avoid unnecessary secrets-manager
+    # network lookups on hot paths like agent construction and demo flows.
+    for var in env_vars:
+        value = os.getenv(var)
+        if value and value.strip():
+            return value.strip()
+
+    # Fall back to AWS Secrets Manager only when env vars are not populated.
     try:
         from aragora.config.secrets import get_secret
 
@@ -214,13 +221,7 @@ def get_api_key(*env_vars: str, required: bool = True) -> str | None:
             if value and value.strip():
                 return value.strip()
     except ImportError:
-        pass  # secrets module not available, fall through to env vars
-
-    # Fall back to environment variables
-    for var in env_vars:
-        value = os.getenv(var)
-        if value and value.strip():
-            return value.strip()
+        pass  # secrets module not available, fall through to required check
 
     if required:
         var_names = " or ".join(env_vars)

--- a/tests/config/test_legacy.py
+++ b/tests/config/test_legacy.py
@@ -288,6 +288,37 @@ class TestGetApiKey:
             result = get_api_key("FIRST_KEY_LEGACY", "SECOND_KEY_LEGACY")
             assert result == "first-value"
 
+    def test_env_value_short_circuits_secret_lookup(self):
+        """Environment variables should satisfy lookups without AWS calls."""
+        from aragora.config.legacy import get_api_key
+
+        with (
+            patch.dict(os.environ, {"TEST_API_KEY_LEGACY": "sk-env-first"}),
+            patch(
+                "aragora.config.secrets.get_secret",
+                side_effect=RuntimeError("get_secret should not be called"),
+            ),
+        ):
+            result = get_api_key("TEST_API_KEY_LEGACY")
+
+        assert result == "sk-env-first"
+
+    def test_falls_back_to_secret_lookup_when_env_missing(self):
+        """AWS-backed secrets still work when env vars are absent."""
+        from aragora.config.legacy import get_api_key
+
+        env_clean = {k: v for k, v in os.environ.items() if k != "TEST_API_KEY_LEGACY"}
+        with (
+            patch.dict(os.environ, env_clean, clear=True),
+            patch(
+                "aragora.config.secrets.get_secret", return_value="sk-from-secret"
+            ) as mock_secret,
+        ):
+            result = get_api_key("TEST_API_KEY_LEGACY")
+
+        assert result == "sk-from-secret"
+        mock_secret.assert_called_once_with("TEST_API_KEY_LEGACY")
+
 
 class TestValidateDbPath:
     """Test validate_db_path security function."""

--- a/tests/memory/test_embeddings.py
+++ b/tests/memory/test_embeddings.py
@@ -27,14 +27,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _reset_secret_cache():
-    """Prevent SecretManager cached API keys from polluting tests.
-
-    When tests in other directories trigger SecretManager initialization with real
-    API keys, those keys get cached. get_api_key() checks get_secret() BEFORE
-    os.environ, so patch.dict("os.environ", ...) never takes effect if cached
-    keys exist. Patching get_secret to return None forces get_api_key to fall
-    through to os.environ where test patches work correctly.
-    """
+    """Prevent SecretManager cache state from leaking across embedding tests."""
     from aragora.config.secrets import reset_secret_manager
 
     reset_secret_manager()


### PR DESCRIPTION
Automated fix from Codex automation.