### PR TITLE
fix(routing): refresh provider selection cache on new outcomes

### DIFF
--- a/aragora/routing/provider_router.py
+++ b/aragora/routing/provider_router.py
@@ -145,7 +145,8 @@ class ProviderRouter:
     ) -> None:
         """Convenience method to record a debate outcome.
 
-        Delegates to the underlying ProviderMetricsStore.
+        Delegates to the underlying ProviderMetricsStore and refreshes any
+        cached routing decision derived from stale metrics.
         """
         self._store.record_debate_outcome(
             provider,
@@ -155,6 +156,7 @@ class ProviderRouter:
             consensus_reached=consensus_reached,
             failed=failed,
         )
+        self._optimizer.invalidate_cache()
 
     def get_provider_hints(self) -> dict[str, float]:
         """Return a provider_name -> quality_score mapping for TeamSelector integration.

--- a/tests/routing/test_provider_routing.py
+++ b/tests/routing/test_provider_routing.py
@@ -424,6 +424,20 @@ class TestProviderRouter:
         assert m is not None
         assert m.total_debates == 1
 
+    def test_record_outcome_invalidates_cached_selection(self) -> None:
+        router = ProviderRouter()
+        for _ in range(5):
+            router.record_outcome("cheap", cost=0.02, quality=0.60)
+            router.record_outcome("balanced", cost=0.08, quality=0.80)
+            router.record_outcome("quality", cost=0.30, quality=0.95)
+
+        assert router.optimizer.select_provider(SelectionStrategy.QUALITY_OPTIMIZED) == "quality"
+
+        for _ in range(20):
+            router.record_outcome("quality", cost=0.30, quality=0.05, failed=True)
+
+        assert router.optimizer.select_provider(SelectionStrategy.QUALITY_OPTIMIZED) == "balanced"
+
     def test_get_status(self) -> None:
         router = ProviderRouter()
         status = router.get_status()


### PR DESCRIPTION
Automated fix from Codex automation.