### PR TITLE
fix(sdk): align spectate stream route with server contract

### DIFF
--- a/aragora/live/tests/sdk/test_sdk_namespaces_new.py
+++ b/aragora/live/tests/sdk/test_sdk_namespaces_new.py
@@ -326,7 +326,7 @@ class TestModesAsync:
 
 
 class TestSpectateSync:
-    """Sync SpectateAPI -- connect_sse (SSE streaming), get_recent, get_status, get_stream."""
+    """Sync SpectateAPI -- connect_sse, get_recent, get_status, get_stream."""
 
     @pytest.fixture(autouse=True)
     def setup(self, sync_client):
@@ -339,12 +339,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -385,7 +393,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/sdk/python/aragora_sdk/namespaces/spectate.py
+++ b/sdk/python/aragora_sdk/namespaces/spectate.py
@@ -19,7 +19,7 @@ class SpectateAPI:
 
     Example:
         >>> client = AragoraClient(base_url="https://api.aragora.ai")
-        >>> stream = client.spectate.connect_sse("debate-123")
+        >>> snapshot = client.spectate.connect_sse("debate-123")
     """
 
     def __init__(self, client: AragoraClient):
@@ -27,12 +27,16 @@ class SpectateAPI:
 
     def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
+        Request the debate-filtered spectate stream endpoint.
 
-        Returns connection details including the stream URL.
-        Use the stream URL with an SSE client for real-time events.
+        The server currently returns a buffered JSON preview by default and can
+        emit a finite SSE snapshot when requested at the HTTP layer.
         """
-        return self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""
@@ -59,7 +63,7 @@ class AsyncSpectateAPI:
 
     Example:
         >>> async with AragoraAsyncClient(base_url="https://api.aragora.ai") as client:
-        ...     stream = await client.spectate.connect_sse("debate-123")
+        ...     snapshot = await client.spectate.connect_sse("debate-123")
     """
 
     def __init__(self, client: AragoraAsyncClient):
@@ -67,11 +71,16 @@ class AsyncSpectateAPI:
 
     async def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
+        Request the debate-filtered spectate stream endpoint.
 
-        Returns connection details including the stream URL.
+        The server currently returns a buffered JSON preview by default and can
+        emit a finite SSE snapshot when requested at the HTTP layer.
         """
-        return await self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return await self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     async def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""

--- a/sdk/typescript/src/namespaces/__tests__/spectate.test.ts
+++ b/sdk/typescript/src/namespaces/__tests__/spectate.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import { SpectateAPI } from '../spectate';
+
+interface MockClient {
+  request: Mock;
+}
+
+describe('SpectateAPI', () => {
+  let api: SpectateAPI;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    mockClient = {
+      request: vi.fn().mockResolvedValue({}),
+    };
+    api = new SpectateAPI(mockClient as any);
+  });
+
+  it('uses the canonical debate-filtered stream query route', async () => {
+    await api.connectSSE('debate-1');
+
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/spectate/stream', {
+      params: { debate_id: 'debate-1' },
+    });
+  });
+
+  it('passes count and debate filters to the stream snapshot endpoint', async () => {
+    await api.getStream({ count: 25, debateId: 'debate-2' });
+
+    expect(mockClient.request).toHaveBeenCalledWith('GET', '/api/v1/spectate/stream', {
+      params: { count: 25, debate_id: 'debate-2' },
+    });
+  });
+});

--- a/sdk/typescript/src/namespaces/spectate.ts
+++ b/sdk/typescript/src/namespaces/spectate.ts
@@ -16,13 +16,15 @@ export class SpectateAPI {
   constructor(private client: SpectateClientInterface) {}
 
   /**
-   * Connect to SSE stream for a debate.
+   * Request the debate-filtered spectate stream endpoint.
    *
-   * Returns connection details including the stream URL.
-   * Use the stream URL with an EventSource client for real-time events.
+   * The server returns a buffered JSON preview by default and can emit a
+   * finite SSE snapshot when requested at the HTTP layer.
    */
   async connectSSE(debateId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/spectate/${encodeURIComponent(debateId)}/stream`);
+    return this.client.request('GET', '/api/v1/spectate/stream', {
+      params: { debate_id: debateId },
+    });
   }
 
   async getRecent(options?: { count?: number; debateId?: string }): Promise<Record<string, unknown>> {

--- a/tests/sdk/test_sdk_namespaces_new.py
+++ b/tests/sdk/test_sdk_namespaces_new.py
@@ -325,7 +325,7 @@ class TestModesAsync:
 
 
 class TestSpectateSync:
-    """Sync SpectateAPI -- connect_sse (SSE streaming), get_recent, get_status, get_stream."""
+    """Sync SpectateAPI -- connect_sse, get_recent, get_status, get_stream."""
 
     @pytest.fixture(autouse=True)
     def setup(self, sync_client):
@@ -338,12 +338,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -384,7 +392,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/tests/sdk/test_spectate_ns.py
+++ b/tests/sdk/test_spectate_ns.py
@@ -24,12 +24,16 @@ def api(mock_client):
 class TestSpectateAPI:
     def test_connect_sse(self, api, mock_client):
         result = api.connect_sse("debate-123")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-123/stream")
+        mock_client.request.assert_called_once_with(
+            "GET", "/api/v1/spectate/stream", params={"debate_id": "debate-123"}
+        )
         assert "stream_url" in result
 
     def test_connect_sse_different_debate(self, api, mock_client):
         api.connect_sse("debate-456")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-456/stream")
+        mock_client.request.assert_called_once_with(
+            "GET", "/api/v1/spectate/stream", params={"debate_id": "debate-456"}
+        )
 
     def test_async_class_exists(self):
         """Verify AsyncSpectateAPI can be instantiated."""


### PR DESCRIPTION
Automated fix from Codex automation.