### PR TITLE
fix(webhooks): return 403 for non-owner access

### DIFF
--- a/aragora/server/handlers/webhooks.py
+++ b/aragora/server/handlers/webhooks.py
@@ -270,9 +270,9 @@ class WebhookHandler(SecureHandler):
         return False
 
     @staticmethod
-    def _hidden_webhook_not_found(webhook_id: str) -> HandlerResult:
-        """Return a generic not-found for unauthorized single-record access."""
-        return error_response(f"Webhook not found: {webhook_id}", 404)
+    def _forbidden_webhook_access() -> HandlerResult:
+        """Return the documented forbidden response for non-owner access."""
+        return error_response("Access denied - not the webhook owner", 403)
 
     @api_endpoint(
         path="/api/v1/webhooks",
@@ -637,7 +637,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return self._hidden_webhook_not_found(webhook_id)
+            return self._forbidden_webhook_access()
 
         return json_response({"webhook": webhook.to_dict(include_secret=False)})
 
@@ -725,7 +725,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return self._hidden_webhook_not_found(webhook_id)
+            return self._forbidden_webhook_access()
 
         store.delete(webhook_id)
 
@@ -761,7 +761,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return self._hidden_webhook_not_found(webhook_id)
+            return self._forbidden_webhook_access()
 
         # Validate URL if provided (SSRF check)
         new_url = body.get("url")
@@ -819,7 +819,7 @@ The webhook secret is only returned once on creation - save it securely.""",
         # Check ownership
         user = self.get_current_user(handler)
         if self._is_webhook_access_denied(webhook, user):
-            return self._hidden_webhook_not_found(webhook_id)
+            return self._forbidden_webhook_access()
 
         # Import here to avoid circular dependency
         from aragora.events.dispatcher import dispatch_webhook


### PR DESCRIPTION
Automated fix from Codex automation.