### PR TITLE
fix(server): harden live spectate SSE cache headers

### DIFF
--- a/aragora/server/unified_server.py
+++ b/aragora/server/unified_server.py
@@ -530,7 +530,7 @@ class UnifiedHandler(  # type: ignore[misc]
         self._response_status = 200
         self.send_response(200)
         self.send_header("Content-Type", "text/event-stream")
-        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
         self.send_header("Connection", "keep-alive")
         self.send_header("Vary", "Accept")
         self.send_header("X-Accel-Buffering", "no")

--- a/tests/server/test_unified_server.py
+++ b/tests/server/test_unified_server.py
@@ -315,6 +315,7 @@ class TestHTTPDispatch:
         assert mock_request_handler.wfile.getvalue() == b"event: connected\ndata: {}\n\n"
         handler.send_response.assert_called_once_with(200)
         handler.send_header.assert_any_call("Content-Type", "text/event-stream")
+        handler.send_header.assert_any_call("Cache-Control", "no-cache, no-store, must-revalidate")
         handler.send_header.assert_any_call("X-Aragora-Stream-Transport", "sse_live")
 
     def test_serve_live_spectate_stream_keeps_private_events_for_debate_readers(


### PR DESCRIPTION
Automated fix from Codex automation.