### PR TITLE
fix(sdk): align spectate SSE path with live server

### DIFF
--- a/aragora/live/tests/sdk/test_sdk_namespaces_new.py
+++ b/aragora/live/tests/sdk/test_sdk_namespaces_new.py
@@ -339,12 +339,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -385,7 +393,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/sdk/python/aragora_sdk/namespaces/spectate.py
+++ b/sdk/python/aragora_sdk/namespaces/spectate.py
@@ -32,7 +32,11 @@ class SpectateAPI:
         Returns connection details including the stream URL.
         Use the stream URL with an SSE client for real-time events.
         """
-        return self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""
@@ -71,7 +75,11 @@ class AsyncSpectateAPI:
 
         Returns connection details including the stream URL.
         """
-        return await self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return await self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     async def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""

--- a/sdk/typescript/src/namespaces/spectate.ts
+++ b/sdk/typescript/src/namespaces/spectate.ts
@@ -22,7 +22,9 @@ export class SpectateAPI {
    * Use the stream URL with an EventSource client for real-time events.
    */
   async connectSSE(debateId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/spectate/${encodeURIComponent(debateId)}/stream`);
+    return this.client.request('GET', '/api/v1/spectate/stream', {
+      params: { debate_id: debateId },
+    });
   }
 
   async getRecent(options?: { count?: number; debateId?: string }): Promise<Record<string, unknown>> {

--- a/tests/sdk/test_sdk_namespaces_new.py
+++ b/tests/sdk/test_sdk_namespaces_new.py
@@ -338,12 +338,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -384,7 +392,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/tests/sdk/test_spectate_ns.py
+++ b/tests/sdk/test_spectate_ns.py
@@ -24,12 +24,20 @@ def api(mock_client):
 class TestSpectateAPI:
     def test_connect_sse(self, api, mock_client):
         result = api.connect_sse("debate-123")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-123/stream")
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-123"},
+        )
         assert "stream_url" in result
 
     def test_connect_sse_different_debate(self, api, mock_client):
         api.connect_sse("debate-456")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-456/stream")
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-456"},
+        )
 
     def test_async_class_exists(self):
         """Verify AsyncSpectateAPI can be instantiated."""


### PR DESCRIPTION
Automated fix from Codex automation.