### PR TITLE
fix(sdk): align spectate helpers with server route

### DIFF
--- a/aragora/live/tests/sdk/test_sdk_namespaces_new.py
+++ b/aragora/live/tests/sdk/test_sdk_namespaces_new.py
@@ -339,12 +339,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -385,7 +393,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/docs-site/docs/contributing/feature-discovery.md
+++ b/docs-site/docs/contributing/feature-discovery.md
@@ -67,7 +67,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` now serves a finite buffered SSE snapshot with JSON preview fallback, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
+| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` serves a finite buffered SSE snapshot with JSON preview fallback plus debate-scoped filtering, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/` |
 
 ### Configuration
 

--- a/docs/FEATURE_DISCOVERY.md
+++ b/docs/FEATURE_DISCOVERY.md
@@ -64,7 +64,7 @@ This document provides a comprehensive inventory of Aragora's features organized
 | **Voting** | Stable | User votes on debate positions | `aragora/debate/voting.py` |
 | **Suggestions** | Stable | User suggestions during debates | `aragora/audience/suggestions.py` |
 | **Audience System** | Stable | Audience engagement and spectator mode | `aragora/audience/` |
-| **Spectate** | Stable | Debate spectating includes live SSE on `/api/v1/spectate/stream`, buffered JSON preview fallback, and debate-scoped live spectators | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/`, `aragora/live/src/hooks/useSpectate.ts` |
+| **Spectate** | Partial | Debate spectating exists, and `/api/v1/spectate/stream` serves a finite buffered SSE snapshot with JSON preview fallback plus debate-scoped filtering, but full live streaming is still not shipped on that endpoint | `aragora/server/handlers/spectate_ws.py`, `aragora/spectate/`, `aragora/live/src/hooks/useSpectate.ts` |
 
 ### Configuration
 

--- a/sdk/python/aragora_sdk/namespaces/spectate.py
+++ b/sdk/python/aragora_sdk/namespaces/spectate.py
@@ -1,8 +1,7 @@
 """
 Spectate Namespace API
 
-Provides methods for real-time debate observation:
-- Connect to Server-Sent Events (SSE) stream for a debate
+Provides methods for debate spectating via the canonical public endpoints.
 """
 
 from __future__ import annotations
@@ -27,12 +26,13 @@ class SpectateAPI:
 
     def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
-
-        Returns connection details including the stream URL.
-        Use the stream URL with an SSE client for real-time events.
+        Request the spectate stream endpoint scoped to a single debate.
         """
-        return self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""
@@ -67,11 +67,13 @@ class AsyncSpectateAPI:
 
     async def connect_sse(self, debate_id: str) -> dict[str, Any]:
         """
-        Connect to SSE stream for a debate.
-
-        Returns connection details including the stream URL.
+        Request the spectate stream endpoint scoped to a single debate.
         """
-        return await self._client.request("GET", f"/api/v1/spectate/{debate_id}/stream")
+        return await self._client.request(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": debate_id},
+        )
 
     async def get_recent(self, *, count: int = 50, debate_id: str | None = None) -> dict[str, Any]:
         """Get recent buffered spectate events."""

--- a/sdk/typescript/src/namespaces/spectate.ts
+++ b/sdk/typescript/src/namespaces/spectate.ts
@@ -1,7 +1,7 @@
 /**
  * Spectate Namespace API
  *
- * Real-time debate observation via Server-Sent Events (SSE).
+ * Debate spectating via the canonical public stream endpoints.
  */
 
 interface SpectateClientInterface {
@@ -16,13 +16,12 @@ export class SpectateAPI {
   constructor(private client: SpectateClientInterface) {}
 
   /**
-   * Connect to SSE stream for a debate.
-   *
-   * Returns connection details including the stream URL.
-   * Use the stream URL with an EventSource client for real-time events.
+   * Request the spectate stream endpoint scoped to a single debate.
    */
   async connectSSE(debateId: string): Promise<Record<string, unknown>> {
-    return this.client.request('GET', `/api/v1/spectate/${encodeURIComponent(debateId)}/stream`);
+    return this.client.request('GET', '/api/v1/spectate/stream', {
+      params: { debate_id: debateId },
+    });
   }
 
   async getRecent(options?: { count?: number; debateId?: string }): Promise<Record<string, unknown>> {

--- a/tests/sdk/test_contract_parity.py
+++ b/tests/sdk/test_contract_parity.py
@@ -84,6 +84,8 @@ BLOCKCHAIN_ENDPOINTS: list[tuple[str, str]] = [
     ("GET", "/api/v1/blockchain/health"),
 ]
 
+SPECTATE_STREAM_ENDPOINT = ("GET", "/api/v1/spectate/stream")
+
 
 def _normalize_path(path: str) -> str:
     """Normalize a path by replacing specific IDs with {id}."""
@@ -257,6 +259,28 @@ class TestOpenclawContractParity:
             f"TypeScript SDK openclaw missing {len(missing)} endpoints:\n"
             + "\n".join(f"  {m} {p}" for m, p in sorted(missing))
         )
+
+
+class TestSpectateContractParity:
+    """Verify SDK spectate helpers keep using the canonical stream endpoint."""
+
+    def test_openapi_exposes_canonical_stream_path(self):
+        spec_file = ROOT / "docs/api/openapi.json"
+        spec = spec_file.read_text()
+        assert SPECTATE_STREAM_ENDPOINT[1] in spec
+        assert "/api/v1/spectate/{debate_id}/stream" not in spec
+
+    def test_python_sdk_connect_sse_uses_canonical_path(self):
+        sdk_file = ROOT / "sdk/python/aragora_sdk/namespaces/spectate.py"
+        sdk_paths = set(_extract_python_sdk_paths(sdk_file))
+        assert SPECTATE_STREAM_ENDPOINT in sdk_paths
+        assert ("GET", "/api/v1/spectate/{id}/stream") not in sdk_paths
+
+    def test_typescript_sdk_connect_sse_uses_canonical_path(self):
+        ts_file = ROOT / "sdk/typescript/src/namespaces/spectate.ts"
+        ts_paths = set(_extract_ts_paths(ts_file))
+        assert SPECTATE_STREAM_ENDPOINT in ts_paths
+        assert ("GET", "/api/v1/spectate/{id}/stream") not in ts_paths
 
     def test_python_client_covers_all_endpoints(self):
         """Python client resource covers every server OpenClaw endpoint."""

--- a/tests/sdk/test_sdk_namespaces_new.py
+++ b/tests/sdk/test_sdk_namespaces_new.py
@@ -338,12 +338,20 @@ class TestSpectateSync:
             "debate_id": "debate-1",
         }
         result = self.api.connect_sse("debate-1")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-1/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-1"},
+        )
         assert result["stream_url"] == "/sse/debate-1"
 
     def test_connect_sse_different_id(self):
         self.api.connect_sse("debate-xyz")
-        self.client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-xyz/stream")
+        self.client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-xyz"},
+        )
 
     def test_get_recent_defaults(self):
         self.api.get_recent()
@@ -384,7 +392,11 @@ class TestSpectateAsync:
     async def test_connect_sse(self):
         self.client.request.return_value = {"stream_url": "/sse/debate-async"}
         result = await self.api.connect_sse("debate-async")
-        self.client.request.assert_awaited_once_with("GET", "/api/v1/spectate/debate-async/stream")
+        self.client.request.assert_awaited_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-async"},
+        )
         assert result["stream_url"] == "/sse/debate-async"
 
     @pytest.mark.asyncio

--- a/tests/sdk/test_spectate_ns.py
+++ b/tests/sdk/test_spectate_ns.py
@@ -24,12 +24,20 @@ def api(mock_client):
 class TestSpectateAPI:
     def test_connect_sse(self, api, mock_client):
         result = api.connect_sse("debate-123")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-123/stream")
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-123"},
+        )
         assert "stream_url" in result
 
     def test_connect_sse_different_debate(self, api, mock_client):
         api.connect_sse("debate-456")
-        mock_client.request.assert_called_once_with("GET", "/api/v1/spectate/debate-456/stream")
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/api/v1/spectate/stream",
+            params={"debate_id": "debate-456"},
+        )
 
     def test_async_class_exists(self):
         """Verify AsyncSpectateAPI can be instantiated."""


### PR DESCRIPTION
Automated fix from Codex automation.