### PR TITLE
fix(receipts): ignore test delivery history

### DIFF
--- a/aragora/server/fastapi/routes/receipts.py
+++ b/aragora/server/fastapi/routes/receipts.py
@@ -542,11 +542,21 @@ def _resolve_delivery_aggregates(stats: dict[str, Any]) -> tuple[int, int, int, 
         _derive_delivery_aggregates_from_history()
     )
 
+    resolved_delivered = delivered if delivered is not None else history_delivered
+    resolved_pending = pending if pending is not None else history_pending
+    resolved_failed = failed if failed is not None else history_failed
+
+    if delivery_rate is None:
+        total_attempted = resolved_delivered + resolved_failed
+        delivery_rate = (
+            resolved_delivered / total_attempted if total_attempted > 0 else history_delivery_rate
+        )
+
     return (
-        delivered if delivered is not None else history_delivered,
-        pending if pending is not None else history_pending,
-        failed if failed is not None else history_failed,
-        delivery_rate if delivery_rate is not None else history_delivery_rate,
+        resolved_delivered,
+        resolved_pending,
+        resolved_failed,
+        delivery_rate,
     )
 
 

--- a/aragora/server/fastapi/routes/receipts.py
+++ b/aragora/server/fastapi/routes/receipts.py
@@ -504,6 +504,10 @@ def _derive_delivery_aggregates_from_history() -> tuple[int, int, int, float | N
     failed = 0
 
     for item in get_receipt_delivery_history_store():
+        if item.get("is_test"):
+            continue
+        if not (item.get("receipt_id") or item.get("receiptId")):
+            continue
         status = str(item.get("status") or "").strip().lower()
         if status in {"delivered", "success"}:
             delivered += 1

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -767,6 +767,40 @@ class TestReceiptStats:
         assert data["failed"] == 1
         assert data["delivery_rate"] == pytest.approx(2 / 3)
 
+    def test_stats_ignore_test_and_orphan_delivery_history(self, client, mock_receipt_store):
+        """Stats should ignore test sends and non-receipt history entries."""
+        mock_receipt_store.get_stats = MagicMock(return_value={"total": 1, "verified": 1})
+        get_receipt_delivery_history_store().extend(
+            [
+                {
+                    "status": "success",
+                    "is_test": True,
+                    "receiptId": "test-1",
+                },
+                {
+                    "status": "failed",
+                    "is_test": True,
+                    "receiptId": "test-2",
+                },
+                {
+                    "status": "delivered",
+                    "receiptId": "real-1",
+                },
+                {
+                    "status": "failed",
+                    "channel_type": "slack",
+                },
+            ]
+        )
+
+        response = client.get("/api/v2/receipts/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["delivered"] == 1
+        assert data["pending"] == 0
+        assert data["failed"] == 0
+        assert data["delivery_rate"] == pytest.approx(1.0)
+
 
 class TestShareReceipt:
     """Tests for POST /api/v2/receipts/{receipt_id}/share."""

--- a/tests/server/fastapi/test_receipts_routes.py
+++ b/tests/server/fastapi/test_receipts_routes.py
@@ -697,6 +697,40 @@ class TestReceiptStats:
         assert data["failed"] == 1
         assert data["delivery_rate"] == pytest.approx(0.8889)
 
+    def test_stats_derive_delivery_rate_from_store_counts(self, client, mock_receipt_store):
+        """Stats should compute a missing delivery rate from the returned counts."""
+        mock_receipt_store.get_stats = MagicMock(
+            return_value={
+                "total": 12,
+                "verified": 10,
+                "delivered": 8,
+                "pending": 3,
+                "failed": 1,
+            }
+        )
+        get_receipt_delivery_history_store().extend(
+            [
+                {
+                    "receiptId": "r-1",
+                    "status": "delivered",
+                    "deliveredAt": "2026-04-08T00:00:00Z",
+                },
+                {
+                    "receiptId": "r-2",
+                    "status": "failed",
+                    "deliveredAt": "2026-04-08T00:01:00Z",
+                },
+            ]
+        )
+
+        response = client.get("/api/v2/receipts/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["delivered"] == 8
+        assert data["pending"] == 3
+        assert data["failed"] == 1
+        assert data["delivery_rate"] == pytest.approx(8 / 9)
+
     def test_stats_backfill_delivery_aggregates_from_history(self, client, mock_receipt_store):
         """Stats should derive delivery aggregates when the store omits them."""
         mock_receipt_store.get_stats = MagicMock(return_value={"total": 5, "verified": 4})


### PR DESCRIPTION
Automated fix from Codex automation.