### PR TITLE
fix(live): keep onboarding receipt export backend-aware

### DIFF
--- a/aragora/live/src/components/onboarding/CompletionStep.tsx
+++ b/aragora/live/src/components/onboarding/CompletionStep.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { API_BASE_URL } from '@/config';
+import { getRuntimeBackendConfig } from '@/components/BackendSelector';
 import { useOnboardingStore } from '@/store';
 
 interface CompletionStepProps {
@@ -8,6 +8,7 @@ interface CompletionStepProps {
 }
 
 export function CompletionStep({ onComplete }: CompletionStepProps) {
+  const apiBase = getRuntimeBackendConfig().config.api;
   const {
     organizationName,
     firstDebateId,
@@ -68,7 +69,7 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
             description="See your decision summary"
             href={
               firstReceiptId
-                ? `${API_BASE_URL}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html`
+                ? `${apiBase}/api/v2/receipts/${encodeURIComponent(firstReceiptId)}/export?format=html`
                 : (firstDebateId ? `/debate/${firstDebateId}` : '/debates')
             }
           />

--- a/aragora/live/src/components/onboarding/__tests__/backendSelection.test.tsx
+++ b/aragora/live/src/components/onboarding/__tests__/backendSelection.test.tsx
@@ -32,6 +32,7 @@ jest.mock('../steps', () => ({
 }));
 
 import { OnboardingFlow } from '../OnboardingFlow';
+import { CompletionStep } from '../CompletionStep';
 import { FirstDebateStep } from '../FirstDebateStep';
 import { IntegrationSelector } from '../IntegrationSelector';
 import { QuickDebatePanel } from '../QuickDebatePanel';
@@ -157,6 +158,23 @@ describe('Onboarding backend selection', () => {
         expect.objectContaining({ method: 'POST' }),
       );
     });
+  });
+
+  it('CompletionStep opens receipt exports against the selected backend', () => {
+    mockStoreState = {
+      ...mockStoreState,
+      organizationName: 'Aragora Labs',
+      firstDebateId: 'debate-first',
+      firstReceiptId: 'receipt-first',
+      teamMembers: [],
+    };
+
+    render(<CompletionStep />);
+
+    expect(screen.getByRole('link', { name: /view receipt/i })).toHaveAttribute(
+      'href',
+      'https://api.aragora.ai/api/v2/receipts/receipt-first/export?format=html',
+    );
   });
 
   it('IntegrationSelector checks integrations against the selected backend', async () => {


### PR DESCRIPTION
Automated fix from Codex automation.