### PR TITLE
fix(live): allow runtime spectate detail routes

### DIFF
--- a/aragora/live/src/app/(app)/spectate/[debateId]/page.tsx
+++ b/aragora/live/src/app/(app)/spectate/[debateId]/page.tsx
@@ -1,11 +1,12 @@
 import SpectateClient from './SpectateClient';
 
-// For static export - no pages pre-rendered, client-side navigation only
-export const dynamicParams = false;
+// Allow runtime debate IDs in standalone/server mode.
+// Static export still uses the placeholder param below.
+export const dynamicParams = true;
 
 export async function generateStaticParams() {
-  // Return a placeholder so static export has at least one path
-  // Actual debate IDs are resolved client-side via useParams()
+  // Return a placeholder so static export has at least one path.
+  // Actual debate IDs are resolved client-side via useParams().
   return [{ debateId: '_' }];
 }
 

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -386,3 +386,21 @@ class TestFrontendConfig:
         """TypeScript config exists for the frontend."""
         tsconfig = PROJECT_ROOT / "aragora" / "live" / "tsconfig.json"
         assert tsconfig.exists(), f"Missing: {tsconfig}"
+
+    def test_spectate_detail_route_accepts_runtime_ids(self):
+        """Live spectate links should resolve against a route that allows runtime IDs."""
+        page = (
+            PROJECT_ROOT
+            / "aragora"
+            / "live"
+            / "src"
+            / "app"
+            / "(app)"
+            / "spectate"
+            / "[debateId]"
+            / "page.tsx"
+        )
+        source = page.read_text()
+
+        assert "export const dynamicParams = true;" in source
+        assert "return [{ debateId: '_' }];" in source


### PR DESCRIPTION
Automated fix from Codex automation.