### PR TITLE
feat(swarm): add JSONL metrics emission per boss loop iteration

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1450,7 +1450,7 @@ class BossLoop:
         )
 
         worker_result = await self._dispatch_issue(selected, freshness)
-        return self._finalize_worker_result(
+        status = self._finalize_worker_result(
             iteration=iteration,
             timestamp=now,
             runner_freshness=freshness_dict,
@@ -1459,6 +1459,8 @@ class BossLoop:
             worker_result=worker_result,
             elapsed_seconds=time.monotonic() - iter_start,
         )
+        self._emit_metrics_line(status, worker_result)
+        return status
 
     async def _run_iteration_batch(self, iteration: int) -> list[BossIterationStatus]:
         import asyncio
@@ -1596,6 +1598,7 @@ class BossLoop:
                     worker_result=worker_result,
                     elapsed_seconds=time.monotonic() - started_at,
                 )
+                self._emit_metrics_line(status, worker_result)
                 statuses.append(status)
                 if status.stop_reason and status.stop_reason != BossStopReason.STILL_RUNNING.value:
                     stop_launching = True
@@ -1690,6 +1693,31 @@ class BossLoop:
             if limit is not None and len(selected_issues) >= limit:
                 break
         return selected_issues
+
+    def _emit_metrics_line(
+        self,
+        status: BossIterationStatus,
+        worker_result: dict[str, Any],
+    ) -> None:
+        """Append a JSONL metrics line for this iteration to the boss metrics log."""
+        try:
+            metrics_dir = Path(".aragora") / "overnight"
+            metrics_dir.mkdir(parents=True, exist_ok=True)
+            metrics_path = metrics_dir / "boss_metrics.jsonl"
+            issue_number = status.selected_issue.get("number") if status.selected_issue else None
+            record = {
+                "iteration": status.iteration,
+                "issue_number": issue_number,
+                "worker_status": status.worker_status,
+                "elapsed_seconds": status.elapsed_seconds,
+                "files_changed": len(worker_result.get("changed_files", [])),
+                "tests_run": worker_result.get("tests_run", 0),
+                "tests_passed": worker_result.get("tests_passed", 0),
+            }
+            with open(metrics_path, "a") as f:
+                f.write(json.dumps(record) + "\n")
+        except Exception as exc:
+            logger.debug("Boss metrics emission skipped: %s", exc)
 
     def _finalize_worker_result(
         self,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1689,3 +1689,110 @@ class TestDiscoverFocusedTests:
         assert "tests/swarm/test_boss_loop.py" in paths
         assert "tests/cli/test_parser.py" in paths
         assert len(paths) == 2
+
+
+# ---------------------------------------------------------------------------
+# Boss metrics JSONL emission
+# ---------------------------------------------------------------------------
+
+
+class TestBossMetricsEmission:
+    """Verify that each iteration appends a JSONL metrics line."""
+
+    def test_metrics_jsonl_written_on_completed_iteration(self, tmp_path, monkeypatch):
+        """Run one iteration with a mock worker and verify the JSONL file has expected fields."""
+        # Ensure metrics are written inside tmp_path
+        monkeypatch.chdir(tmp_path)
+
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(42, "Metrics test issue")]
+
+        config = _boss_config(max_iterations=1, issue_number=42)
+
+        async def _completing_dispatch(issue, freshness):
+            return {
+                "status": "completed",
+                "changed_files": ["aragora/foo.py", "aragora/bar.py"],
+                "tests_run": 5,
+                "tests_passed": 4,
+            }
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _completing_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.iterations_completed == 1
+
+        metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+        assert metrics_path.exists(), "JSONL metrics file was not created"
+
+        lines = metrics_path.read_text().strip().splitlines()
+        assert len(lines) == 1
+
+        record = json.loads(lines[0])
+        expected_keys = {
+            "iteration",
+            "issue_number",
+            "worker_status",
+            "elapsed_seconds",
+            "files_changed",
+            "tests_run",
+            "tests_passed",
+        }
+        assert expected_keys.issubset(record.keys()), (
+            f"Missing keys: {expected_keys - record.keys()}"
+        )
+        assert record["iteration"] == 1
+        assert record["issue_number"] == 42
+        assert record["worker_status"] == "completed"
+        assert record["files_changed"] == 2
+        assert record["tests_run"] == 5
+        assert record["tests_passed"] == 4
+        assert isinstance(record["elapsed_seconds"], (int, float))
+        assert record["elapsed_seconds"] >= 0
+
+    def test_metrics_accumulates_across_iterations(self, tmp_path, monkeypatch):
+        """Multiple iterations append separate lines."""
+        monkeypatch.chdir(tmp_path)
+
+        call_count = 0
+
+        def _fetch():
+            nonlocal call_count
+            call_count += 1
+            return [_make_issue(call_count, f"Issue {call_count}")]
+
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.side_effect = _fetch
+
+        config = _boss_config(max_iterations=3)
+
+        async def _completing_dispatch(issue, freshness):
+            return {
+                "status": "completed",
+                "changed_files": ["a.py"],
+                "tests_run": 1,
+                "tests_passed": 1,
+            }
+
+        loop = BossLoop(
+            config=config,
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _completing_dispatch
+
+        asyncio.run(loop.run())
+
+        metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+        lines = metrics_path.read_text().strip().splitlines()
+        assert len(lines) == 3
+
+        for i, line in enumerate(lines, 1):
+            record = json.loads(line)
+            assert record["iteration"] == i


### PR DESCRIPTION
Automated fix from Codex automation.