### PR TITLE
fix(teams): reject non-object integration payloads

### DIFF
--- a/aragora/server/handlers/social/teams.py
+++ b/aragora/server/handlers/social/teams.py
@@ -1384,7 +1384,8 @@ class TeamsIntegrationHandler(BaseHandler):
             if content_length > 10 * 1024 * 1024:
                 return None
             body = handler.rfile.read(content_length)
-            return json.loads(body.decode("utf-8"))
+            parsed = json.loads(body.decode("utf-8"))
+            return parsed if isinstance(parsed, dict) else None
         except (json.JSONDecodeError, ValueError, TypeError):
             return None
 

--- a/tests/server/handlers/social/test_teams_handler.py
+++ b/tests/server/handlers/social/test_teams_handler.py
@@ -478,6 +478,20 @@ class TestCommandEndpoint:
         assert result is not None
         assert get_status_code(result) == 400
 
+    async def test_non_object_json_body(self, handler):
+        """Non-object JSON should return 400 instead of crashing."""
+        mock_http = MockHandler(
+            headers={"Content-Type": "application/json", "Content-Length": "3"},
+            body=b"[1]",
+            path="/api/v1/integrations/teams/commands",
+            method="POST",
+        )
+
+        result = await handler.handle_post("/api/v1/integrations/teams/commands", {}, mock_http)
+
+        assert result is not None
+        assert get_status_code(result) == 400
+
 
 # ===========================================================================
 # Interactive Endpoint Tests
@@ -558,6 +572,20 @@ class TestInteractiveEndpoint:
         mock_http = MockHandler(
             headers={"Content-Type": "application/json", "Content-Length": "5"},
             body=b"null",
+            path="/api/v1/integrations/teams/interactive",
+            method="POST",
+        )
+
+        result = await handler.handle_post("/api/v1/integrations/teams/interactive", {}, mock_http)
+
+        assert result is not None
+        assert get_status_code(result) == 400
+
+    async def test_non_object_json_body(self, handler):
+        """Non-object JSON should return 400 instead of crashing."""
+        mock_http = MockHandler(
+            headers={"Content-Type": "application/json", "Content-Length": "5"},
+            body=b'["x"]',
             path="/api/v1/integrations/teams/interactive",
             method="POST",
         )
@@ -665,6 +693,20 @@ class TestNotifyEndpoint:
         mock_teams_connector.send_message.assert_called_once()
         call_kwargs = mock_teams_connector.send_message.call_args[1]
         assert call_kwargs.get("blocks") == blocks
+
+    async def test_notify_non_object_json_body(self, handler):
+        """Non-object JSON should return 400 instead of crashing."""
+        mock_http = MockHandler(
+            headers={"Content-Type": "application/json", "Content-Length": "3"},
+            body=b"[1]",
+            path="/api/v1/integrations/teams/notify",
+            method="POST",
+        )
+
+        result = await handler.handle_post("/api/v1/integrations/teams/notify", {}, mock_http)
+
+        assert result is not None
+        assert get_status_code(result) == 400
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- reject non-object JSON bodies at the Teams integration parse boundary
- add regressions for commands, interactive, and notify endpoints

## Validation
- python3 -m pytest tests/server/handlers/social/test_teams_handler.py -q -o cache_dir=/tmp/pytest-cache-teams-handler-20260409
- ruff check aragora/server/handlers/social/teams.py tests/server/handlers/social/test_teams_handler.py
- direct repro with [1] and ["x"] now returns 400 on commands, interactive, and notify