### PR TITLE
fix(playground): validate landing feedback queue

### DIFF
--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -257,6 +257,38 @@ def _truncate_feedback_text(value: Any, *, limit: int) -> str | None:
     return text[:limit]
 
 
+def _validate_landing_feedback_payload(payload: dict[str, Any]) -> list[str]:
+    """Return field-level validation errors for public landing feedback."""
+    errors: list[str] = []
+
+    for field_name in ("question", "final_answer"):
+        if _truncate_feedback_text(payload.get(field_name), limit=10_000) is None:
+            errors.append(f"{field_name} must be a non-empty string")
+
+    for field_name in (
+        "interpreted_question",
+        "result_warning",
+        "result_mode",
+        "debate_id",
+        "verdict",
+    ):
+        value = payload.get(field_name)
+        if value is not None and not isinstance(value, str):
+            errors.append(f"{field_name} must be a string")
+
+    participant_count = payload.get("participant_count")
+    if participant_count is not None and (
+        not isinstance(participant_count, int) or isinstance(participant_count, bool)
+    ):
+        errors.append("participant_count must be an integer")
+
+    rewritten = payload.get("rewritten")
+    if rewritten is not None and not isinstance(rewritten, bool):
+        errors.append("rewritten must be a boolean")
+
+    return errors
+
+
 def _client_tag(client_ip: str) -> str:
     """Return a stable, privacy-safer tag for client grouping."""
     normalized = client_ip.strip()
@@ -2730,7 +2762,18 @@ class PlaygroundHandler(BaseHandler):
         if not report_id:
             return error_response("Missing landing feedback report id", 400)
 
-        review_status = _normalize_landing_review_status(body.get("review_status"))
+        raw_review_status = body.get("review_status")
+        normalized_review_status = (
+            raw_review_status.strip().lower() if isinstance(raw_review_status, str) else None
+        )
+        if normalized_review_status not in _LANDING_REVIEW_STATUSES:
+            valid_statuses = ", ".join(sorted(_LANDING_REVIEW_STATUSES))
+            return error_response(
+                f"Invalid landing feedback review status. Valid statuses: {valid_statuses}",
+                400,
+            )
+        review_status = normalized_review_status
+
         reviewed_at = None
         reviewed_by = None
         if review_status != "pending":
@@ -3077,6 +3120,13 @@ class PlaygroundHandler(BaseHandler):
             body = {}
         if not isinstance(body, dict):
             return error_response("Invalid landing feedback payload", 400)
+
+        field_errors = _validate_landing_feedback_payload(body)
+        if field_errors:
+            return error_response(
+                "Invalid landing feedback payload: " + "; ".join(field_errors),
+                400,
+            )
 
         report = _record_landing_feedback(
             client_ip=_extract_client_ip(handler),

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -691,6 +691,38 @@ class TestLandingTelemetry:
         assert report["participant_count"] == 3
         assert report["rewritten"] is True
 
+    def test_feedback_rejects_missing_required_text_fields(self, handler):
+        result = handler.handle_post(
+            "/api/v1/playground/landing/feedback",
+            {},
+            _MockHTTPHandler("POST", body={"participant_count": 3, "rewritten": True}),
+        )
+
+        assert _status(result) == 400
+        error = _body(result)["error"]
+        assert "question must be a non-empty string" in error
+        assert "final_answer must be a non-empty string" in error
+
+    def test_feedback_rejects_invalid_field_types(self, handler):
+        result = handler.handle_post(
+            "/api/v1/playground/landing/feedback",
+            {},
+            _MockHTTPHandler(
+                "POST",
+                body={
+                    "question": "Should I microwave nuggets?",
+                    "final_answer": "Yes, if they are heated through.",
+                    "participant_count": "three",
+                    "rewritten": "yes",
+                },
+            ),
+        )
+
+        assert _status(result) == 400
+        error = _body(result)["error"]
+        assert "participant_count must be an integer" in error
+        assert "rewritten must be a boolean" in error
+
     def test_feedback_list_requires_admin(self, handler):
         from aragora.server.handlers.base import error_response
 
@@ -854,6 +886,44 @@ class TestLandingTelemetry:
             )
 
         assert _status(result) == 404
+
+    def test_feedback_review_update_rejects_invalid_status(self, handler):
+        now = datetime.now(timezone.utc)
+        store = get_landing_review_store()
+        store.record_feedback(
+            {
+                "id": "lfb_1",
+                "timestamp": now.isoformat(),
+                "client_tag": "ip:abc123",
+                "question": "Should I microwave chicken nuggets for my child?",
+                "interpreted_question": "Is it safe to reheat pre-cooked chicken nuggets?",
+                "final_answer_preview": "Yes, reheat until hot all the way through.",
+                "result_warning": None,
+                "result_mode": "preview",
+                "debate_id": "debate-123",
+                "verdict": "needs_review",
+                "participant_count": 3,
+                "rewritten": True,
+                "review_status": "pending",
+                "reviewed_at": None,
+                "reviewed_by": None,
+            }
+        )
+
+        admin_user = MagicMock()
+        admin_user.email = "owner@aragora.ai"
+
+        with patch.object(handler, "require_admin_or_error", return_value=(admin_user, None)):
+            result = handler.handle_post(
+                "/api/v1/playground/landing/feedback/review",
+                {},
+                _MockHTTPHandler("POST", body={"id": "lfb_1", "review_status": "bogus"}),
+            )
+
+        assert _status(result) == 400
+        assert "Valid statuses" in _body(result)["error"]
+        reports = get_landing_review_store().list_recent_feedback(window_seconds=3600, limit=10)
+        assert reports[0]["review_status"] == "pending"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- reject malformed or incomplete landing feedback payloads before they enter the public demo review queue
- reject invalid landing feedback review statuses instead of silently coercing them to pending
- cover the new fail-closed behavior with focused playground handler tests

## Testing
- python3 -m pytest tests/handlers/test_playground.py -q -k 'records_bounded_wrong_answer_report or feedback_rejects_missing_required_text_fields or feedback_rejects_invalid_field_types or feedback_review_update_requires_admin or feedback_review_update_persists_status or feedback_review_update_returns_404_when_missing or feedback_review_update_rejects_invalid_status' -o cache_dir=/tmp/pytest-cache-playground-feedback-20260409
- ruff check aragora/server/handlers/playground.py tests/handlers/test_playground.py
- git diff --check