### PR TITLE
fix(spectate): log malformed bridge details

### DIFF
--- a/aragora/spectate/ws_bridge.py
+++ b/aragora/spectate/ws_bridge.py
@@ -72,7 +72,14 @@ def _extract_structured_details(details: str) -> dict[str, Any]:
 
     try:
         payload = json.loads(stripped)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        logger.warning(
+            "spectate_details_json_decode_failed",
+            extra={
+                "error": str(exc),
+                "details_length": len(details),
+            },
+        )
         return {}
 
     return payload if isinstance(payload, dict) else {}

--- a/tests/spectate/test_ws_bridge.py
+++ b/tests/spectate/test_ws_bridge.py
@@ -17,6 +17,7 @@ import pytest
 from aragora.spectate.ws_bridge import (
     SpectateEvent,
     SpectateWebSocketBridge,
+    _extract_structured_details,
     bind_spectate_context,
     get_spectate_bridge,
     reset_spectate_bridge,
@@ -265,6 +266,12 @@ class TestEventForwarding:
             assert events[0].data["stage"] == "goals"
         finally:
             bridge.stop()
+
+    def test_malformed_json_details_are_logged(self, caplog: pytest.LogCaptureFixture):
+        with caplog.at_level("WARNING", logger="aragora.spectate.ws_bridge"):
+            assert _extract_structured_details("{not valid json") == {}
+
+        assert "spectate_details_json_decode_failed" in caplog.messages
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Logs malformed JSON details in the spectate WebSocket bridge and adds focused regression coverage. Fixes #2995.