### PR TITLE
fix: narrow broad except Exception in value_estimator.py

### DIFF
--- a/aragora/swarm/value_estimator.py
+++ b/aragora/swarm/value_estimator.py
@@ -337,7 +337,7 @@ def load_outcomes(*, path: Path | None = None) -> list[OutcomeRecord]:
                     **{k: v for k, v in data.items() if k in OutcomeRecord.__dataclass_fields__}
                 )
             )
-        except Exception:
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError):
             continue
     return records
 
@@ -439,7 +439,15 @@ async def estimate_with_llm(
         est.compute_score()
         return est
 
-    except Exception as exc:
+    except (
+        ImportError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+        OSError,
+        RuntimeError,
+    ) as exc:
         logger.debug("LLM value estimation failed, using heuristic: %s", exc)
         return fallback
 


### PR DESCRIPTION
Replace two `except Exception` handlers with specific exception types:
- load_outcomes: (JSONDecodeError, KeyError, TypeError, ValueError)
- estimate_with_llm: (ImportError, JSONDecodeError, KeyError, TypeError, ValueError, OSError, RuntimeError)

Closes #4192

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 4e2ae3be6eeb37c94bd2709361bcc7e4ada36bf6)
