### PR TITLE
feat(swarm): persist repair journals for cross-host handoff

### DIFF
--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -89,6 +89,7 @@ _DOCS_ONLY_GENERATE_CAPABILITY_MATRIX_COMMANDS = (
     "python3 scripts/generate_capability_matrix.py",
     "python3 scripts/generate_capability_matrix.py --out docs-site/docs/contributing/capability-matrix.md",
 )
+_REPAIR_JOURNAL_MAX_ENTRIES = 20
 
 
 def _is_docs_only_path(path: Any) -> bool:
@@ -647,6 +648,24 @@ class DevCoordinationStore:
                     artifact_hash TEXT NOT NULL
                 );
                 CREATE INDEX IF NOT EXISTS idx_receipts_lease ON completion_receipts(lease_id, created_at);
+
+                CREATE TABLE IF NOT EXISTS worker_repair_journals (
+                    journal_id TEXT PRIMARY KEY,
+                    task_id TEXT NOT NULL,
+                    task_key TEXT NOT NULL,
+                    work_order_id TEXT NOT NULL,
+                    supervisor_run_id TEXT NOT NULL,
+                    lease_id TEXT NOT NULL,
+                    owner_agent TEXT NOT NULL,
+                    owner_session_id TEXT NOT NULL,
+                    branch TEXT NOT NULL,
+                    worktree_path TEXT NOT NULL,
+                    entry_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_repair_journal_task ON worker_repair_journals(task_id, created_at);
+                CREATE INDEX IF NOT EXISTS idx_repair_journal_key ON worker_repair_journals(task_key, created_at);
+                CREATE INDEX IF NOT EXISTS idx_repair_journal_work_order ON worker_repair_journals(work_order_id, created_at);
 
                 CREATE TABLE IF NOT EXISTS integration_decisions (
                     decision_id TEXT PRIMARY KEY,
@@ -1208,6 +1227,129 @@ class DevCoordinationStore:
             if task.task_key == str(task_key).strip():
                 return task
         return None
+
+    def record_worker_repair_journal(
+        self,
+        *,
+        task_id: str,
+        entry: dict[str, Any],
+        task_key: str | None = None,
+        work_order_id: str | None = None,
+        supervisor_run_id: str | None = None,
+        lease_id: str | None = None,
+        owner_agent: str | None = None,
+        owner_session_id: str | None = None,
+        branch: str | None = None,
+        worktree_path: str | None = None,
+    ) -> dict[str, Any]:
+        now = _utcnow().isoformat()
+        record = {
+            "journal_id": str(uuid.uuid4())[:12],
+            "task_id": str(task_id or "").strip(),
+            "task_key": str(task_key or "").strip(),
+            "work_order_id": str(work_order_id or "").strip(),
+            "supervisor_run_id": str(supervisor_run_id or "").strip(),
+            "lease_id": str(lease_id or "").strip(),
+            "owner_agent": str(owner_agent or "").strip(),
+            "owner_session_id": str(owner_session_id or "").strip(),
+            "branch": str(branch or "").strip(),
+            "worktree_path": str(worktree_path or "").strip(),
+            "entry": dict(entry),
+            "created_at": now,
+        }
+        if not record["task_id"] and not record["task_key"] and not record["work_order_id"]:
+            raise ValueError("repair journal requires task_id, task_key, or work_order_id")
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                INSERT INTO worker_repair_journals (
+                    journal_id, task_id, task_key, work_order_id, supervisor_run_id,
+                    lease_id, owner_agent, owner_session_id, branch, worktree_path,
+                    entry_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    record["journal_id"],
+                    record["task_id"],
+                    record["task_key"],
+                    record["work_order_id"],
+                    record["supervisor_run_id"],
+                    record["lease_id"],
+                    record["owner_agent"],
+                    record["owner_session_id"],
+                    record["branch"],
+                    record["worktree_path"],
+                    _json_dump(record["entry"]),
+                    record["created_at"],
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self._publish(
+            "worker_repair_journal_recorded",
+            track=record["branch"] or record["task_id"] or record["task_key"],
+            data={
+                "journal_id": record["journal_id"],
+                "task_id": record["task_id"],
+                "task_key": record["task_key"],
+                "work_order_id": record["work_order_id"],
+                "supervisor_run_id": record["supervisor_run_id"],
+            },
+        )
+        return record
+
+    def list_worker_repair_journals(
+        self,
+        *,
+        task_id: str | None = None,
+        task_key: str | None = None,
+        work_order_id: str | None = None,
+        limit: int = _REPAIR_JOURNAL_MAX_ENTRIES,
+    ) -> list[dict[str, Any]]:
+        filters: list[str] = []
+        params: list[Any] = []
+        for column, value in (
+            ("task_id", task_id),
+            ("task_key", task_key),
+            ("work_order_id", work_order_id),
+        ):
+            text = str(value or "").strip()
+            if text:
+                filters.append(f"{column} = ?")
+                params.append(text)
+        if not filters:
+            return []
+        sql = (
+            "SELECT * FROM worker_repair_journals WHERE "
+            + " OR ".join(filters)
+            + " ORDER BY created_at DESC LIMIT ?"
+        )
+        params.append(max(1, int(limit)))
+        conn = self._connect()
+        try:
+            rows = conn.execute(sql, params).fetchall()
+        finally:
+            conn.close()
+        records = [
+            {
+                "journal_id": row["journal_id"],
+                "task_id": row["task_id"],
+                "task_key": row["task_key"],
+                "work_order_id": row["work_order_id"],
+                "supervisor_run_id": row["supervisor_run_id"],
+                "lease_id": row["lease_id"],
+                "owner_agent": row["owner_agent"],
+                "owner_session_id": row["owner_session_id"],
+                "branch": row["branch"],
+                "worktree_path": row["worktree_path"],
+                "entry": _json_loads(row["entry_json"], {}),
+                "created_at": row["created_at"],
+            }
+            for row in rows
+        ]
+        return list(reversed(records))
 
     def update_supervisor_run(
         self,

--- a/aragora/swarm/supervisor_probes.py
+++ b/aragora/swarm/supervisor_probes.py
@@ -45,6 +45,7 @@ def _summarize_verification_failure(verification_results: list[dict[str, Any]]) 
 
 
 def _append_repair_journal(
+    self,
     item: dict[str, Any],
     result: WorkerProcess,
     *,
@@ -74,6 +75,23 @@ def _append_repair_journal(
     entries.append(entry)
     metadata["repair_journal"] = entries[-_REPAIR_JOURNAL_MAX_ENTRIES:]
     item["metadata"] = metadata
+    try:
+        self.store.record_worker_repair_journal(
+            task_id=str(item.get("work_order_id", "")).strip(),
+            task_key=str(item.get("task_key", "")).strip(),
+            work_order_id=str(item.get("work_order_id", "")).strip(),
+            supervisor_run_id=str(metadata.get("supervisor_run_id", "")).strip(),
+            lease_id=str(item.get("lease_id", result.lease_id)).strip(),
+            owner_agent=str(item.get("target_agent", result.agent)).strip(),
+            owner_session_id=str(item.get("owner_session_id", result.session_id)).strip(),
+            branch=str(item.get("branch", result.branch)).strip(),
+            worktree_path=str(item.get("worktree_path", result.worktree_path)).strip(),
+            entry=entry,
+        )
+    except Exception:
+        logger.debug(
+            "Failed to persist repair journal for %s", item.get("work_order_id"), exc_info=True
+        )
 
 
 def _worker_result_from_persisted_work_order(item: dict[str, Any]) -> WorkerProcess | None:
@@ -299,7 +317,7 @@ def _finalize_completed_work_order_result(
                 or "merge_gate_failed",
                 blocking_question=self._merge_gate_blocking_question(merge_gate),
             )
-            _append_repair_journal(item, result, reason="merge_gate_failed")
+            _append_repair_journal(self, item, result, reason="merge_gate_failed")
             item["review_status"] = "changes_requested"
             item["receipt_id"] = None
             item["worker_outcome"] = WorkerOutcome.MERGE_GATE_FAILED.value
@@ -435,7 +453,7 @@ def _apply_worker_result(
     if scope_violations:
         self._mark_scope_violation(item, scope_violations)
         item["worker_outcome"] = WorkerOutcome.SCOPE_VIOLATION.value
-        _append_repair_journal(item, result, reason="scope_violation")
+        _append_repair_journal(self, item, result, reason="scope_violation")
         lease_id = str(item.get("lease_id", "")).strip()
         if lease_id:
             self.store.release_lease(lease_id, status=LeaseStatus.RELEASED)
@@ -469,7 +487,7 @@ def _apply_worker_result(
                 "worker produced only session artifacts, no real deliverables",
                 failure_reason="clean_exit_no_deliverable",
             )
-            _append_repair_journal(item, result, reason="clean_exit_no_deliverable")
+            _append_repair_journal(self, item, result, reason="clean_exit_no_deliverable")
             if not _pre_outcome:
                 item["worker_outcome"] = WorkerOutcome.CLEAN_EXIT_NO_EFFECT.value
             self._release_terminal_lease(item)
@@ -506,7 +524,7 @@ def _apply_worker_result(
                 "worker exited 0 with no commits and no changed paths",
                 failure_reason="clean_exit_no_deliverable",
             )
-            _append_repair_journal(item, result, reason="clean_exit_no_deliverable")
+            _append_repair_journal(self, item, result, reason="clean_exit_no_deliverable")
             self._release_terminal_lease(item)
             item["exit_code"] = result.exit_code
             return
@@ -544,6 +562,7 @@ def _apply_worker_result(
         )
 
     _append_repair_journal(
+        self,
         item,
         result,
         reason=str(item.get("failure_reason", "")).strip() or "worker_failure",
@@ -648,7 +667,7 @@ def _apply_worker_result(
                 "Should the recovered deliverable be adopted as-is, amended, or rerun before integration?"
             ),
         )
-        _append_repair_journal(item, result, reason=failure_reason)
+        _append_repair_journal(self, item, result, reason=failure_reason)
         item["review_status"] = "changes_requested"
         item["receipt_id"] = None
         self._release_terminal_lease(item)
@@ -685,7 +704,7 @@ def _apply_worker_result(
         "reason": failure_reason,
         "question": blocking_question,
     }
-    _append_repair_journal(item, result, reason=failure_reason)
+    _append_repair_journal(self, item, result, reason=failure_reason)
     blockers: list[str] = []
     if item["dispatch_error"] not in blockers:
         blockers.append(item["dispatch_error"])

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -1134,6 +1134,17 @@ def _lease_work_order(
     wo_id = str(work_order.get("work_order_id", "task"))
     task_key = f"{run_id}:{wo_id}"
     session_key = f"swarm-{run_id[:8]}-{wo_id}"
+    metadata = dict(work_order.get("metadata") or {})
+    persisted_journals = self.store.list_worker_repair_journals(
+        task_id=wo_id,
+        task_key=task_key,
+        work_order_id=wo_id,
+    )
+    if persisted_journals:
+        metadata["repair_journal"] = [
+            dict(record.get("entry") or {}) for record in persisted_journals if record.get("entry")
+        ][-3:]
+        work_order["metadata"] = metadata
     raw_scope = [str(item) for item in work_order.get("file_scope", []) if str(item).strip()]
     if not raw_scope:
         self._clear_stale_prelaunch_deliverable_state(work_order)
@@ -1197,6 +1208,7 @@ def _lease_work_order(
             "reviewer_agent": str(work_order.get("reviewer_agent", "")),
             "risk_level": str(work_order.get("risk_level", "review")),
             "approval_required": True,
+            "repair_journal_count": len(metadata.get("repair_journal", []) or []),
         },
     )
     work_order.update(


### PR DESCRIPTION
## Summary
- add a shared worker_repair_journals table to the dev coordination store
- persist worker repair journal entries from failure classification alongside task/run metadata
- hydrate work order repair journal metadata before leasing so retries on another host can read prior failure context

## Testing
- python -m pytest tests/swarm/test_worker_launcher.py -q tests/nomic/test_dev_coordination.py -q