### PR TITLE
fix: replace bare raise with contextual errors in rabbitmq connector

### DIFF
--- a/aragora/connectors/enterprise/streaming/rabbitmq.py
+++ b/aragora/connectors/enterprise/streaming/rabbitmq.py
@@ -294,9 +294,9 @@ class RabbitMQConnector(EnterpriseConnector):
             )
             logger.info("[RabbitMQ] Sent message to DLQ: %s", dlq_queue)
 
-        except (OSError, RuntimeError, ConnectionError, TimeoutError) as e:
-            logger.error("[RabbitMQ] Failed to send to DLQ: %s", e)
-            raise
+        except (OSError, RuntimeError, ConnectionError, TimeoutError) as exc:
+            logger.error("[RabbitMQ] Failed to send to DLQ: %s", exc)
+            raise RuntimeError(f"Failed to send message to RabbitMQ DLQ '{queue_name}'") from exc
 
     async def connect(self) -> bool:
         """
@@ -556,9 +556,9 @@ class RabbitMQConnector(EnterpriseConnector):
                             await message.reject(requeue=False)
                         self._nacked_count += 1
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             logger.info("[RabbitMQ] Consumer cancelled")
-            raise
+            raise asyncio.CancelledError("RabbitMQ consumer cancelled during consume") from exc
 
     async def _process_with_resilience(
         self,


### PR DESCRIPTION
## Summary
- Replace 2 bare `raise` statements in `rabbitmq.py` with contextual re-raises using `from exc` to preserve the exception chain
- DLQ send failures now raise `RuntimeError` with the queue name for easier debugging
- Consumer cancellation now includes a descriptive message in the `CancelledError`

Closes #4308

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('aragora/connectors/enterprise/streaming/rabbitmq.py').read()); print('OK')"` passes
- [ ] Existing RabbitMQ connector tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)