### PR TITLE
feat(automation): gate autonomous PR publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ When many agents are committing concurrently, use disposable worktrees with freq
 
 For Codex-driven automations in this repo, default to maximum safe autonomy. Finish the bounded task when the next action is clear, and only stop when the remaining step is irreversible, human-gated, or materially unsafe.
 
+- Use the shared automation merge contract in `docs/briefs/automation-merge-contract.md`.
+  Before publishing local Codex app automation or Aragora boss-loop worker branches, run `bash scripts/automation_pr_preflight.sh origin/main HEAD` from the branch worktree, or run it against the explicit worker branch.
 - Prefer execution over advice:
   verify the issue, make the smallest credible fix, validate it, commit it, push it, open the PR, and leave the inbox or memory handoff in the same run when the task is otherwise ready.
 - Do not stop at the first blocked path:

--- a/docs-site/docs/api/reference.md
+++ b/docs-site/docs/api/reference.md
@@ -518,16 +518,37 @@ Trigger a multi-agent security debate on vulnerability findings.
 
 ### GET /api/v1/audit/security/debate/\{id\}
 
-Get the status of a previously triggered security debate. Currently debates are synchronous,
-so this endpoint returns `not_found` for any ID (placeholder for future async support).
+Get the status of a previously triggered security debate. Debates are still synchronous,
+but completed results are cached in-process so callers can re-fetch the latest result payload
+when it is still available. If no cached result is present, the endpoint returns `not_found`.
 
 **Response (200):**
 
 ```json
 {
     "debate_id": "the-id",
+    "status": "completed",
+    "debate_status": "completed",
+    "debate_status_source": "live",
+    "repository": "repo-name",
+    "findings_count": 2,
+    "consensus_reached": true,
+    "confidence": 0.85,
+    "final_answer": "Remediation recommendations...",
+    "completed_at": "2026-04-07T21:30:00+00:00",
+    "message": "Cached security debate result available."
+}
+```
+
+When the cache is empty:
+
+```json
+{
+    "debate_id": "the-id",
     "status": "not_found",
-    "message": "Debate results are not persisted. Use POST to trigger a new debate."
+    "debate_status": "pending",
+    "debate_status_source": "live",
+    "message": "No cached security debate result found. Use POST to trigger a new debate."
 }
 ```
 
@@ -6538,21 +6559,23 @@ Authorization: Bearer <token>
 ### Create Shareable Link
 
 ```http
-POST /api/gauntlet/receipts/\{receipt_id\}/share
+POST /api/v2/receipts/\{receipt_id\}/share
 Authorization: Bearer <token>
 Content-Type: application/json
 
 {
-  "expires_in": 86400,
-  "allow_download": true
+  "expires_in_hours": 24
 }
 ```
 
 **Response:**
 ```json
 {
-  "share_url": "https://app.aragora.ai/receipts/share/abc123",
+  "success": true,
+  "receipt_id": "rcpt_test123",
+  "share_url": "/api/v2/receipts/share/abc123",
   "expires_at": "2026-01-21T11:00:00Z",
+  "max_accesses": null,
   "token": "abc123"
 }
 ```

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -21,6 +21,14 @@ Use it to create or reconcile GitHub issues. Keep issue titles stable when possi
 6. **Decision Integrity Core**
 7. **Commercialization & Scale-Out**
 
+## GitHub Issue Links
+
+The strict status reconciler requires this canonical map to link the live execution backlog directly.
+
+- Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
+- Current execution epics: [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806)
+- Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+
 ## Reverse-Staged Rocket Bootstrap
 
 This is the near-term sequencing layer across the full task tree. Do not treat all `[30d]` work as equally active at once.

--- a/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
+++ b/docs-site/docs/contributing/documentation-hygiene-and-gap-register.md
@@ -75,19 +75,18 @@ The live execution backlog now tracks in [ACTIVE_EXECUTION_ISSUES.md](./active-e
 
 - OpenAPI drift remains: `9` handler routes are missing from the spec and `11` OpenAPI routes have no handler according to `scripts/validate_openapi_routes.py`.
 - OpenAPI and SDK parity claims are still inflated by spec-only endpoints defined in `aragora/server/openapi/endpoints/sdk_missing.py`.
-- `aragora/server/handlers/agent_evolution_dashboard.py` still raises `NotImplementedError("No real pending changes store yet")` for pending-change retrieval.
+- `aragora/server/handlers/agent_evolution_dashboard.py` now fails closed with an empty pending-change set when no live store exists; timeline and ELO trend surfaces still fall back to demo data when evolution history is unavailable.
 - `aragora/server/handlers/goal_canvas.py` now materializes a persisted Stage 3 action canvas from live goal-canvas state; metadata-only goal canvases still fail closed once the in-memory graph is gone.
 - `aragora/server/handlers/spectate_ws.py` now serves `/api/v1/spectate/stream` as a finite buffered SSE snapshot with JSON preview fallback; full real-time streaming on that endpoint still has not shipped.
 - `aragora/server/handlers/sme/slack_workspace.py` now uses the live Slack connector for channel listing, and the SME OAuth helper endpoints delegate into the canonical Slack install/callback flow.
 - `aragora/server/handlers/sme/teams_workspace.py` now uses the live Teams connector for channel listing when `team_id` is supplied, and the SME OAuth helper endpoints delegate into the canonical Teams install/callback flow.
-- `aragora/inbox/triage_runner.py` can still fall back to stub debates when agents or engine wiring are unavailable.
 - `aragora/server/handlers/gauntlet/receipts.py` and the compliance UI still have placeholder or optional anchor-verification paths.
 - `aragora/server/handlers/security_debate.py` exposes an async-status endpoint that is explicitly a placeholder because debates are synchronous and not persisted.
 - `aragora/server/handlers/features/documents_batch.py` returns placeholder chunk retrieval output pending vector-store integration.
 - `aragora/server/handlers/features/connectors.py` still carries `coming_soon` / stubbed connector flows (`gdrive` and related enterprise sync/test paths).
 - `aragora/server/handlers/computer_use_handler.py` does not implement the full action/policy detail surface advertised by the OpenAPI computer-use endpoints.
 - Self-host compose smoke can still fail because `/readyz` returns `503` when `system.health.read` is denied in the composed runtime, even while `/healthz` succeeds. The gating/docs work is landed, but the runtime permission model still needs follow-through.
-- FastAPI receipts currently expose `json`/`markdown`/`sarif`, while legacy handlers still own `html`/`pdf` exports.
+- FastAPI receipts now expose `json` / `html` / `markdown` / `sarif` / `pdf`, and batch export can package PDFs through the ZIP/raw path; legacy handlers remain compatibility surfaces for older v1 consumers.
 - Receipt delivery is only wired for `slack`, `teams`, `email`, and `discord`, not the broader connector/channel footprint implied elsewhere in the docs.
 - Unified and progressive memory handlers remain backend-conditional and still return `501` when optional backends or methods are unavailable.
 - `aragora/server/fastapi/routes/knowledge.py` can still return `501` when the configured KM backend lacks delete support.

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -15,7 +15,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior.
+The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 

--- a/docs-site/docs/getting-started/environment.md
+++ b/docs-site/docs/getting-started/environment.md
@@ -1267,8 +1267,9 @@ See [BOT_INTEGRATIONS.md](../guides/bot-integrations) for detailed setup guides.
 - `ARAGORA_ENCRYPTION_REQUIRED` is automatically enabled when `ARAGORA_ENV=production`
 - `ARAGORA_ALLOW_UNVERIFIED_WEBHOOKS` should **never** be set in production - webhooks will fail-closed if verification is unavailable
 - Webhook verification requires: Slack (signing secret), Discord (PyNaCl + public key), Teams/Google Chat (PyJWT)
-- When `AWS_REGION`/`AWS_DEFAULT_REGION` is set, Secrets Manager is enabled by default and
-  `ARAGORA_SECRET_NAME` falls back to `aragora/production` if not provided.
+- Secrets Manager is auto-enabled in production/staging or AWS-managed runtimes.
+  For local development, set `ARAGORA_USE_SECRETS_MANAGER=true` to opt in.
+  `ARAGORA_SECRET_NAME` still falls back to `aragora/production` when Secrets Manager is enabled.
 
 ## Knowledge System
 

--- a/docs-site/docs/operations/runbook.md
+++ b/docs-site/docs/operations/runbook.md
@@ -1140,14 +1140,14 @@ See `docs/deployment/PRODUCTION_RUNBOOK.md` for detailed key rotation procedures
 - [ ] Notify stakeholders of upcoming maintenance window
 - [ ] Verify rollback procedure works (check `/tmp/aragora_deploy_state` exists)
 - [ ] Open CloudWatch dashboard and Cloudflare analytics
-- [ ] Confirm all instances are healthy: `curl -s https://api.aragora.ai/api/health`
+- [ ] Confirm all instances are healthy: `curl -s https://api.aragora.ai/api/health` (legacy compatibility alias; native FastAPI route is `/api/v2/health`)
 - [ ] Record current commit SHA from each instance for rollback reference
 
 ### Post-Maintenance Checklist
 
 - [ ] Verify health endpoints return `"status":"healthy"` on all instances
 - [ ] Confirm all instances are on the same commit (Section 4.4)
-- [ ] Test debate creation: `POST /api/debates` with a simple question
+- [ ] Test debate creation: `POST /api/debates` with a simple question (legacy compatibility alias; native FastAPI route is `/api/v2/debates`)
 - [ ] Check CloudWatch for error spikes in the 15 minutes post-deploy
 - [ ] Confirm Cloudflare LB shows all origins healthy
 - [ ] Verify no error spikes in `journalctl -u aragora --since "15 min ago"`
@@ -1158,8 +1158,8 @@ See `docs/deployment/PRODUCTION_RUNBOOK.md` for detailed key rotation procedures
 
 | Task | Command |
 |------|---------|
-| External health | `curl -s https://api.aragora.ai/api/health \| jq .` |
-| Instance health | SSM: `curl -s http://localhost:8080/api/health \| jq` |
+| External health | `curl -s https://api.aragora.ai/api/health \| jq .` (legacy alias; native FastAPI route is `/api/v2/health`) |
+| Instance health | SSM: `curl -s http://localhost:8080/api/health \| jq` (legacy alias; native FastAPI route is `/api/v2/health`) |
 | View logs | SSM: `sudo journalctl -u aragora -n 100 --no-pager` |
 | Restart service | SSM: `sudo systemctl restart aragora` |
 | Check version | SSM: `cd /home/ec2-user/aragora && git rev-parse --short HEAD` |

--- a/docs/briefs/automation-merge-contract.md
+++ b/docs/briefs/automation-merge-contract.md
@@ -1,0 +1,78 @@
+# Automation Merge Contract
+
+This contract applies to both local Codex app automations and Aragora native boss-loop workers. The goal is not to maximize the number of opened PRs. The goal is to maximize PRs that are small, reviewable, validated, and mergeable without salvage work.
+
+## Producer Contract
+
+Every automation run should start from current `origin/main`, work on one bounded issue or one bounded maintenance task, and keep the branch scoped to the files needed for that task. It should prefer a disposable worktree when multiple agents are active.
+
+The run must not publish a PR for analysis-only output, a no-op branch, a branch containing session artifacts, or a branch whose final state is known to fail the declared validation. If it cannot finish, it should leave a handoff with the branch, failing command, blocker, and next action instead of opening a misleading PR.
+
+## Shared Preflight
+
+Before pushing or opening an automation PR, run:
+
+```bash
+bash scripts/automation_pr_preflight.sh origin/main HEAD
+```
+
+For local Codex app automation branches, `scripts/publish_codex_automation_branches.py --apply` runs this preflight by default before it pushes and opens a PR. Use `--skip-preflight` only for manual recovery when a human has already inspected the diff.
+
+For Aragora boss-loop workers, run the same script against the worker branch before merge arbitration:
+
+```bash
+bash scripts/automation_pr_preflight.sh origin/main <worker-branch>
+```
+
+The preflight fails on empty diffs, whitespace errors, and committed session artifacts such as worker logs, active-session markers, repair journals, or event directories. It also warns when source or config changes have no corresponding test-path changes so the PR body can explicitly name the validation command that covered the change.
+
+## PR Body Contract
+
+An automation PR should include:
+
+- the issue or task source
+- a short summary of changed behavior
+- the exact validation command and result
+- any skipped validation with the reason
+- known risks or assumptions
+- repair journal or handoff context when this is a retry
+
+Draft PRs are acceptable when the publisher is only preserving useful branch state. Ready PRs should have a passing preflight, scoped diff, and explicit validation evidence.
+
+## Merge Gate
+
+Automation PRs are merge candidates only when:
+
+- the diff is scoped to the task
+- CI or targeted validation passes
+- there is no duplicate open PR for the same issue or branch
+- any cross-host retry consumed the prior repair journal or explicitly explains why it ignored it
+- generated artifacts and local coordination files are absent from the branch
+
+If any gate fails, the next useful action is a repair attempt with the failure output in the handoff envelope, not another fresh worker staring at the same repo state.
+
+## Prompt Snippet For Codex App Automations
+
+Use this repo's automation merge contract at `docs/briefs/automation-merge-contract.md`. Work on one bounded issue or maintenance task. Make the smallest credible change, run the targeted validation, and before publishing run `bash scripts/automation_pr_preflight.sh origin/main HEAD`. If validation or publishing fails, leave an exact handoff with branch, failing command, blocker, and next action instead of opening a misleading PR.
+
+## Prompt Snippet For Boss-Loop Operators
+
+Run the boss loop with shared coordination state when multiple hosts are active:
+
+```bash
+export ARAGORA_DEV_COORDINATION_DB=/Users/armand/Development/aragora/.aragora/dev_coordination.sqlite3
+export ARAGORA_BOSS_VERIFIED_RUNNER_TARGET=0
+python3.11 -u -m aragora.cli.main swarm boss-loop \
+  --boss-repo synaptent/aragora \
+  --target-branch main \
+  --worker-model claude \
+  --label boss-ready \
+  --max-ticks 20 \
+  --interval 60 \
+  --autonomy full-auto \
+  --max-hours 8 \
+  --boss-max-parallel-dispatches 1 \
+  --allow-claude-write
+```
+
+Keep host parallelism conservative until repair journals, handoff envelopes, and the publisher preflight show that retries are improving PR quality rather than generating duplicate work.

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -16,6 +16,14 @@ Use it to create or reconcile GitHub issues. Keep issue titles stable when possi
 6. **Decision Integrity Core**
 7. **Commercialization & Scale-Out**
 
+## GitHub Issue Links
+
+The strict status reconciler requires this canonical map to link the live execution backlog directly.
+
+- Enterprise assurance carryover: [#273](https://github.com/synaptent/aragora/issues/273), [#274](https://github.com/synaptent/aragora/issues/274), [#509](https://github.com/synaptent/aragora/issues/509)
+- Current execution epics: [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), [#806](https://github.com/synaptent/aragora/issues/806)
+- Current execution lanes: [#807](https://github.com/synaptent/aragora/issues/807), [#808](https://github.com/synaptent/aragora/issues/808), [#809](https://github.com/synaptent/aragora/issues/809), [#810](https://github.com/synaptent/aragora/issues/810), [#811](https://github.com/synaptent/aragora/issues/811), [#812](https://github.com/synaptent/aragora/issues/812), [#813](https://github.com/synaptent/aragora/issues/813), [#814](https://github.com/synaptent/aragora/issues/814), [#815](https://github.com/synaptent/aragora/issues/815), [#816](https://github.com/synaptent/aragora/issues/816), [#817](https://github.com/synaptent/aragora/issues/817), [#818](https://github.com/synaptent/aragora/issues/818), [#819](https://github.com/synaptent/aragora/issues/819), [#820](https://github.com/synaptent/aragora/issues/820)
+
 ## Reverse-Staged Rocket Bootstrap
 
 This is the near-term sequencing layer across the full task tree. Do not treat all `[30d]` work as equally active at once.

--- a/docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md
+++ b/docs/status/EXECUTION_NEXT_6_WEEKS_2026-03-05.md
@@ -1,6 +1,6 @@
 # Execution Plan (Next 6 Weeks)
 
-Last updated: 2026-03-22  
+Last updated: 2026-03-22
 Owner: Platform program (Product, Backend, Integrations, QA, SRE)
 
 This is the active short-horizon plan in the agreed priority order.

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior.
+The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 

--- a/scripts/automation_pr_preflight.sh
+++ b/scripts/automation_pr_preflight.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Shared mergeability preflight for local Codex automations and swarm/boss-loop PRs.
+
+set -euo pipefail
+
+BASE_REF="${1:-origin/main}"
+HEAD_REF="${2:-HEAD}"
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/automation_pr_preflight.sh [BASE_REF] [HEAD_REF]
+
+Checks an automation branch before it is pushed or turned into a PR.
+
+Checks:
+  - base and head refs exist
+  - branch has a non-empty diff versus the base
+  - diff has no whitespace errors
+  - session/log/coordination artifacts are not committed
+  - source changes without test changes are called out for operator review
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if ! git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+    echo "preflight: base ref not found: ${BASE_REF}" >&2
+    exit 2
+fi
+
+if ! git rev-parse --verify "${HEAD_REF}^{commit}" >/dev/null 2>&1; then
+    echo "preflight: head ref not found: ${HEAD_REF}" >&2
+    exit 2
+fi
+
+changed_files="$(git diff --name-only "${BASE_REF}...${HEAD_REF}")"
+if [[ -z "${changed_files}" ]]; then
+    echo "preflight: no branch diff versus ${BASE_REF}" >&2
+    exit 1
+fi
+
+echo "preflight: checking whitespace"
+git diff --check "${BASE_REF}...${HEAD_REF}"
+
+forbidden_regex='(^|/)(\.codex_session_active|\.claude-session-active|\.nomic-session-active|\.codex_session_meta\.json|\.swarm_worker_stdout\.log|\.swarm_worker_stderr\.log|\.swarm_worker_status\.json|\.swarm_repair_journal\.json)$|(^|/)(\.aragora_events|\.pytest_cache|__pycache__)/'
+forbidden_files="$(printf '%s\n' "${changed_files}" | grep -E "${forbidden_regex}" || true)"
+if [[ -n "${forbidden_files}" ]]; then
+    echo "preflight: automation/session artifacts must not be committed:" >&2
+    printf '%s\n' "${forbidden_files}" >&2
+    exit 1
+fi
+
+source_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^aragora/|^scripts/|^\.github/|^tests/).*\.(py|sh|ya?ml|toml|json|ts|tsx|js|jsx)$' || true)"
+test_changes="$(printf '%s\n' "${changed_files}" | grep -E '(^tests/|__tests__/|\.test\.|\.spec\.)' || true)"
+docs_only_changes="$(printf '%s\n' "${changed_files}" | grep -Ev '(^docs/|^docs-site/|\.md$)' || true)"
+
+if [[ -n "${source_changes}" && -z "${test_changes}" ]]; then
+    echo "preflight: source/config changes found without test changes." >&2
+    echo "preflight: run the relevant validation command and include it in the PR body." >&2
+    echo "preflight: changed source/config paths:" >&2
+    printf '%s\n' "${source_changes}" >&2
+fi
+
+if [[ -z "${docs_only_changes}" ]]; then
+    echo "preflight: docs-only diff detected"
+fi
+
+echo "preflight: changed files"
+printf '%s\n' "${changed_files}" | sed 's/^/  - /'
+echo "preflight: ok"

--- a/scripts/publish_codex_automation_branches.py
+++ b/scripts/publish_codex_automation_branches.py
@@ -23,6 +23,7 @@ DEFAULT_SINCE_HOURS = 72
 DEFAULT_PUBLISH_LIMIT = 1
 DEFAULT_MAX_OPEN_PRS = 1
 CODEX_BRANCH_PREFIX = "codex/"
+DEFAULT_PREFLIGHT_SCRIPT = "scripts/automation_pr_preflight.sh"
 ACTIVE_SESSION_FILES = (
     ".claude-session-active",
     ".codex_session_active",
@@ -395,6 +396,23 @@ def _add_labels(repo_root: Path, repo: str, number: int, labels: list[str]) -> N
         return
 
 
+def _run_publish_preflight(
+    repo_root: Path,
+    base: str,
+    branch: str,
+    preflight_script: str,
+) -> tuple[bool, str]:
+    script_path = repo_root / preflight_script
+    if not script_path.exists():
+        return False, f"preflight script not found: {preflight_script}"
+
+    proc = _run(["bash", str(script_path), base, branch], cwd=repo_root)
+    output = "\n".join(part.strip() for part in (proc.stdout, proc.stderr) if part.strip()).strip()
+    if proc.returncode == 0:
+        return True, output
+    return False, output or f"preflight failed for {branch}"
+
+
 def _publish_decisions(
     repo_root: Path,
     repo: str,
@@ -405,6 +423,7 @@ def _publish_decisions(
     open_pr_count: int,
     max_open_prs: int,
     labels: list[str],
+    preflight_script: str | None = None,
 ) -> list[dict[str, Any]]:
     _ensure_gh_auth(repo_root)
     results: list[dict[str, Any]] = []
@@ -418,6 +437,25 @@ def _publish_decisions(
         if open_pr_count + published >= max_open_prs:
             break
 
+        if preflight_script:
+            ok, output = _run_publish_preflight(
+                repo_root,
+                base,
+                decision.branch,
+                preflight_script,
+            )
+            if not ok:
+                results.append(
+                    {
+                        "branch": decision.branch,
+                        "status": "preflight_failed",
+                        "subject": decision.subject,
+                        "head_sha": decision.head_sha,
+                        "reason": output[:2000],
+                    }
+                )
+                continue
+
         _push_branch(repo_root, decision.branch, decision.upstream)
         number = _existing_pr_number(repo_root, repo, decision.branch, base)
         if number is None:
@@ -427,6 +465,7 @@ def _publish_decisions(
         results.append(
             {
                 "branch": decision.branch,
+                "status": "published",
                 "pr_number": number,
                 "subject": decision.subject,
                 "head_sha": decision.head_sha,
@@ -488,6 +527,19 @@ def _build_parser() -> argparse.ArgumentParser:
         "--apply",
         action="store_true",
         help="Push eligible branches and open PRs; default is dry-run planning only",
+    )
+    parser.add_argument(
+        "--preflight-script",
+        default=DEFAULT_PREFLIGHT_SCRIPT,
+        help=(
+            "Repo-relative script to run before publishing each eligible branch "
+            f"(default: {DEFAULT_PREFLIGHT_SCRIPT})"
+        ),
+    )
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Skip the automation PR preflight before publishing.",
     )
     return parser
 
@@ -555,6 +607,7 @@ def main(argv: list[str] | None = None) -> int:
             open_pr_count=len(open_pr_heads),
             max_open_prs=args.max_open_prs,
             labels=list(dict.fromkeys(args.labels)),
+            preflight_script=None if args.skip_preflight else str(args.preflight_script),
         )
         payload["published"] = published
 
@@ -569,7 +622,10 @@ def main(argv: list[str] | None = None) -> int:
             if published:
                 print("\npublished:")
                 for item in published:
-                    print(f"  - {item['branch']} -> PR #{item['pr_number']}")
+                    if item.get("status") == "preflight_failed":
+                        print(f"  - {item['branch']} skipped: preflight_failed")
+                    else:
+                        print(f"  - {item['branch']} -> PR #{item['pr_number']}")
 
     return 0
 

--- a/tests/scripts/test_automation_pr_preflight.py
+++ b/tests/scripts/test_automation_pr_preflight.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "automation_pr_preflight.sh"
+
+
+def _run(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-b", "main"], cwd=repo)
+    _run(["git", "config", "user.name", "Test User"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _run(["git", "add", "README.md"], cwd=repo)
+    _run(["git", "commit", "-m", "init"], cwd=repo)
+    _run(["git", "update-ref", "refs/remotes/origin/main", "HEAD"], cwd=repo)
+    return repo
+
+
+def test_automation_pr_preflight_accepts_docs_diff(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/docs-update"], cwd=repo)
+    (repo / "docs").mkdir()
+    (repo / "docs" / "note.md").write_text("note\n", encoding="utf-8")
+    _run(["git", "add", "docs/note.md"], cwd=repo)
+    _run(["git", "commit", "-m", "docs: add note"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 0
+    assert "preflight: ok" in proc.stdout
+
+
+def test_automation_pr_preflight_rejects_worker_artifacts(tmp_path: Path) -> None:
+    repo = _init_repo(tmp_path)
+    _run(["git", "switch", "-c", "codex/bad-artifact"], cwd=repo)
+    (repo / ".swarm_worker_stdout.log").write_text("worker log\n", encoding="utf-8")
+    _run(["git", "add", ".swarm_worker_stdout.log"], cwd=repo)
+    _run(["git", "commit", "-m", "bad: commit worker log"], cwd=repo)
+
+    proc = _run(["bash", str(SCRIPT), "origin/main", "HEAD"], cwd=repo)
+
+    assert proc.returncode == 1
+    assert "automation/session artifacts" in proc.stderr

--- a/tests/scripts/test_publish_codex_automation_branches.py
+++ b/tests/scripts/test_publish_codex_automation_branches.py
@@ -70,6 +70,8 @@ def test_parser_defaults_to_single_branch_publish_budget() -> None:
 
     assert args.limit == 1
     assert args.max_open_prs == 1
+    assert args.skip_preflight is False
+    assert args.preflight_script == mod.DEFAULT_PREFLIGHT_SCRIPT
 
 
 def test_select_publishable_branches_skips_open_pr_and_old_or_merged_branches() -> None:
@@ -237,6 +239,57 @@ def test_publish_decisions_respects_open_pr_cap(monkeypatch: Any, tmp_path: Path
     )
 
     assert results == []
+    assert calls == []
+
+
+def test_publish_decisions_skips_branch_when_preflight_fails(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(mod, "_ensure_gh_auth", lambda repo_root: None)
+    monkeypatch.setattr(
+        mod,
+        "_run_publish_preflight",
+        lambda repo_root, base, branch, preflight_script: (False, "session artifact found"),
+    )
+    monkeypatch.setattr(
+        mod, "_push_branch", lambda repo_root, branch, upstream: calls.append(f"push:{branch}")
+    )
+
+    results = mod._publish_decisions(
+        tmp_path,
+        "synaptent/aragora",
+        "main",
+        [
+            mod.PublishDecision(
+                branch="codex/artifact-branch",
+                eligible=True,
+                reason="eligible",
+                subject="fix one",
+                head_sha="abc1234",
+                unique_commit_count=1,
+                upstream=None,
+                committed_at=datetime.now(UTC).isoformat(),
+                worktree_paths=[],
+            )
+        ],
+        limit=5,
+        open_pr_count=0,
+        max_open_prs=3,
+        labels=["codex"],
+        preflight_script=mod.DEFAULT_PREFLIGHT_SCRIPT,
+    )
+
+    assert results == [
+        {
+            "branch": "codex/artifact-branch",
+            "status": "preflight_failed",
+            "subject": "fix one",
+            "head_sha": "abc1234",
+            "reason": "session artifact found",
+        }
+    ]
     assert calls == []
 
 


### PR DESCRIPTION
## Summary
- add a shared automation merge contract for Codex app automations and Aragora boss-loop workers
- add scripts/automation_pr_preflight.sh to reject empty diffs, whitespace errors, and committed session artifacts
- wire the local Codex automation branch publisher to run the preflight before pushing/opening PRs, with an explicit --skip-preflight escape hatch
- repair strict status-doc execution issue links and sync generated docs-site output so docs/status gates can pass

## Validation
- bash scripts/automation_pr_preflight.sh origin/main HEAD
- python -m pytest tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_automation_pr_preflight.py -q
- ruff format scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_automation_pr_preflight.py --check
- ruff check scripts/publish_codex_automation_branches.py tests/scripts/test_publish_codex_automation_branches.py tests/scripts/test_automation_pr_preflight.py
- bash -n scripts/automation_pr_preflight.sh
- python scripts/reconcile_status_docs.py --strict --output /tmp/reconciliation_report.md
- python scripts/check_version_alignment.py
- python scripts/check_capability_matrix_sync.py
- python scripts/check_legacy_entrypoints.py
- python scripts/generate_cli_reference.py --check
- python scripts/doc_stats.py --write
- node docs-site/scripts/sync-docs.js
- npm run build (from docs-site; existing broken-link warnings, build completed successfully)

## Risk
- Low: publisher enforcement only affects the explicit local Codex automation publisher path, and manual recovery can use --skip-preflight.