### PR TITLE
feat(swarm): add opt-in LLM issue parsing gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Version Alignment
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 5
 
     steps:
       - name: Checkout

--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -2134,6 +2134,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             auto_update_interval_iterations=int(
                 getattr(args, "boss_auto_update_interval", 10) or 10
             ),
+            use_llm_pre_dispatch_gate=bool(getattr(args, "boss_llm_pre_dispatch_gate", False)),
         )
         exec_argv = ["-m", "aragora.cli.main", *sys.argv[1:]]
         loop = BossLoop(config=boss_loop_config, exec_argv=exec_argv)

--- a/aragora/cli/parser.py
+++ b/aragora/cli/parser.py
@@ -2656,6 +2656,14 @@ def _add_swarm_parser(subparsers) -> None:
         help="Allow boss-loop dispatch even when the issue body lacks explicit validation criteria",
     )
     swarm_parser.add_argument(
+        "--boss-llm-pre-dispatch-gate",
+        action="store_true",
+        help=(
+            "Opt in to LLM-assisted boss-loop issue parsing before dispatch. "
+            "Default is deterministic regex-only parsing."
+        ),
+    )
+    swarm_parser.add_argument(
         "--source-file",
         help="Campaign planner or initiative rationale input markdown/text file",
     )

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -53,6 +53,7 @@ from aragora.swarm.boss_freshness import RunnerFreshnessResult, check_runner_fre
 from aragora.swarm.boss_validation import (  # noqa: F401
     _compose_issue_dispatch_goal,
     _should_replace_with_focused_tests,
+    check_pre_dispatch_gate,
     sanitize_issue_body_for_dispatch,
     extract_issue_validation_contract,
     extract_pre_dispatch_validation_commands,
@@ -4043,23 +4044,38 @@ class BossLoop:
 
         self._attach_issue_handoff_metadata(spec, issue)
 
-        missing_validation_targets = find_missing_pre_dispatch_validation_targets(
-            extract_pre_dispatch_validation_commands(issue.body or ""),
+        gate = await check_pre_dispatch_gate(
+            issue.body or "",
             repo_root=Path.cwd(),
         )
-        if missing_validation_targets:
-            declared_new_paths = set(extract_declared_new_file_paths(issue.body or ""))
-            unresolved_missing_targets = [
-                target for target in missing_validation_targets if target not in declared_new_paths
-            ]
-            if not unresolved_missing_targets:
+        logger.info(
+            "pre_dispatch_gate issue=#%s method=%s pass=%s sanitation=%s missing=%s",
+            issue.number,
+            gate["method"],
+            gate["pass"],
+            gate["sanitation_ok"],
+            gate.get("unresolved_missing", []),
+        )
+        if not gate["sanitation_ok"]:
+            return {
+                "status": "needs_human",
+                "outcome": "sanitation_failed",
+                "reasons": [
+                    f"Issue #{issue.number} failed sanitation: {gate.get('sanitation_reason', 'unknown')}"
+                ],
+                "next_actions": [
+                    "Rewrite the issue body with a clear task description.",
+                ],
+            }
+        if gate.get("unresolved_missing"):
+            if gate.get("missing_targets") and not gate["unresolved_missing"]:
                 logger.info(
                     "boss_loop_missing_validation_targets_allowed issue=#%s targets=%s",
                     issue.number,
-                    ", ".join(missing_validation_targets),
+                    ", ".join(gate["missing_targets"]),
                 )
             else:
-                targets_text = ", ".join(unresolved_missing_targets)
+                targets_text = ", ".join(gate["unresolved_missing"])
                 return {
                     "status": "needs_human",
                     "outcome": "verification_target_missing",

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -283,6 +283,11 @@ class BossLoopConfig:
     # Workers succeed on focused tasks but timeout on broad ones in large repos.
     use_micro_decomposition: bool = True
 
+    # Pre-dispatch gate: optionally use LLM parsing for issue bodies that do
+    # not fit the deterministic regex contract. Disabled by default to avoid
+    # hidden network calls, provider costs, and nondeterministic dispatch gates.
+    use_llm_pre_dispatch_gate: bool = False
+
     # Security: opt-in flags for dangerous worker CLI behavior (Crux 1).
     allow_claude_dangerously_skip_permissions: bool = False
     allow_codex_full_auto: bool = False
@@ -4047,6 +4052,7 @@ class BossLoop:
         gate = await check_pre_dispatch_gate(
             issue.body or "",
             repo_root=Path.cwd(),
+            use_llm=self.config.use_llm_pre_dispatch_gate,
         )
         logger.info(
             "pre_dispatch_gate issue=#%s method=%s pass=%s sanitation=%s missing=%s",

--- a/aragora/swarm/boss_validation.py
+++ b/aragora/swarm/boss_validation.py
@@ -3,10 +3,16 @@
 Provides utilities for sanitizing GitHub issue bodies for worker dispatch,
 extracting explicit validation contracts (acceptance criteria, test commands),
 running pre-dispatch validation commands, and discovering focused test files.
+
+When an Anthropic API key is available, semantic parsing uses a fast LLM call
+(Haiku) to extract structured data from the issue body.  This avoids the
+brittleness of regex-only parsing.  On any LLM failure the module falls back
+to the original regex pipeline transparently.
 """
 
 from __future__ import annotations
 
+import json as _json
 import logging
 import re
 import subprocess
@@ -69,7 +75,7 @@ _PRE_DISPATCH_SAFE_COMMAND_PREFIXES = (
 )
 _BACKTICK_COMMAND_RE = re.compile(r"`(?P<command>[^`]+)`")
 _EXPLICIT_PYTEST_TARGET_RE = re.compile(r"(?<!\S)(?P<path>tests/\S+?\.py)(?:::\S+)?(?!\S)")
-_DECLARED_NEW_FILE_RE = re.compile(r"\(\s*new(?:\s+file)?\s*\)", re.IGNORECASE)
+_DECLARED_NEW_FILE_RE = re.compile(r"\(\s*(?:new(?:\s+file)?|create)\s*\)", re.IGNORECASE)
 _BACKTICK_PATH_RE = re.compile(r"`(?P<path>[^`\n]+/[^`\n]+)`")
 _TASK_HEADER_RE = re.compile(r"^#{1,6}\s*task\b", re.IGNORECASE)
 _AUTO_DECOMPOSED_RE = re.compile(r"auto-decomposed|auto decomposed", re.IGNORECASE)
@@ -407,6 +413,266 @@ def run_pre_dispatch_validation_commands(
         if proc.returncode != 0:
             return {"satisfied": False, "results": results}
     return {"satisfied": True, "results": results}
+
+
+# ---------------------------------------------------------------------------
+# LLM-based semantic issue parsing
+# ---------------------------------------------------------------------------
+
+_ISSUE_PARSE_PROMPT = """\
+You are a pre-dispatch validator for an automated code worker system.
+Given a GitHub issue body, extract structured data so the system can decide
+whether to dispatch a worker.
+
+Return ONLY a JSON object with these fields:
+{{
+  "file_scope": [
+    {{"path": "<relative file path>", "action": "modify" | "create"}}
+  ],
+  "validation_commands": ["<shell command to validate the work>"],
+  "task_summary": "<1-2 sentence summary of what the worker should do>",
+  "is_well_formed": true | false,
+  "rejection_reason": "<reason if not well-formed, else null>",
+  "is_auto_decomposed": true | false
+}}
+
+Rules:
+- "action" is "create" if the issue says the file should be created, generated,
+  added, written, or does not exist yet.  It is "modify" if the file already exists.
+- Include ALL file paths mentioned in file scope, requirements, or references.
+- validation_commands: extract pytest commands or other test/check commands.
+- is_well_formed: true if the issue has enough information for a developer to
+  act on it.  An issue with clear file scope and validation commands IS well-formed
+  even if the prose description is minimal.  Only mark false if the body is truly
+  empty, truncated mid-sentence, or incoherent gibberish.
+- is_auto_decomposed: true if this looks like an automatically generated
+  sub-issue from a decomposition system.
+
+Issue body:
+{issue_body}
+"""
+
+
+async def _call_anthropic(prompt: str, model: str, timeout: float) -> str | None:
+    """Try Anthropic API directly."""
+    import os
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        return None
+    import anthropic
+
+    client = anthropic.AsyncAnthropic()
+    response = await client.messages.create(
+        model=model,
+        max_tokens=512,
+        messages=[{"role": "user", "content": prompt}],
+        timeout=timeout,
+    )
+    return response.content[0].text.strip()
+
+
+async def _call_openrouter(prompt: str, timeout: float) -> str | None:
+    """Try OpenRouter as fallback (supports Haiku via anthropic/claude-haiku-4.5)."""
+    import os
+
+    api_key = os.environ.get("OPENROUTER_API_KEY")
+    if not api_key:
+        return None
+    import httpx
+
+    async with httpx.AsyncClient(timeout=timeout) as http:
+        resp = await http.post(
+            "https://openrouter.ai/api/v1/chat/completions",
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": "anthropic/claude-haiku-4.5",
+                "max_tokens": 512,
+                "messages": [{"role": "user", "content": prompt}],
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return data["choices"][0]["message"]["content"].strip()
+
+
+async def parse_issue_with_llm(
+    issue_body: str,
+    *,
+    model: str = "claude-haiku-4-5-20251001",
+    timeout: float = 15.0,
+) -> dict[str, Any] | None:
+    """Parse an issue body using a fast LLM call.
+
+    Tries Anthropic API first, then OpenRouter, then returns ``None``
+    so callers fall back to the regex pipeline.
+    """
+    body = str(issue_body or "").strip()
+    if not body:
+        return None
+
+    prompt = _ISSUE_PARSE_PROMPT.format(issue_body=body[:3000])
+
+    text: str | None = None
+    try:
+        text = await _call_anthropic(prompt, model, timeout)
+        if text:
+            logger.debug("LLM issue parsing via Anthropic API")
+    except Exception as exc:
+        logger.debug("Anthropic API unavailable for issue parsing: %s", exc)
+
+    if text is None:
+        try:
+            text = await _call_openrouter(prompt, timeout)
+            if text:
+                logger.debug("LLM issue parsing via OpenRouter")
+        except Exception as exc:
+            logger.debug("OpenRouter unavailable for issue parsing: %s", exc)
+
+    if text is None:
+        logger.debug("LLM issue parsing unavailable, falling back to regex")
+        return None
+
+    try:
+        # Strip markdown fences if the model wraps JSON
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+        data = _json.loads(text)
+        if not isinstance(data, dict):
+            return None
+        return data
+    except (_json.JSONDecodeError, IndexError, ValueError) as exc:
+        logger.debug("LLM returned unparseable response: %s", exc)
+        return None
+
+
+def llm_result_to_declared_new_files(parsed: dict[str, Any]) -> list[str]:
+    """Extract file paths marked as 'create' from an LLM parse result."""
+    file_scope = parsed.get("file_scope", [])
+    if not isinstance(file_scope, list):
+        return []
+    return _ordered_unique_strings(
+        [
+            str(entry.get("path", "")).strip()
+            for entry in file_scope
+            if isinstance(entry, dict)
+            and str(entry.get("action", "")).strip().lower() == "create"
+            and str(entry.get("path", "")).strip()
+        ]
+    )
+
+
+def llm_result_to_validation_commands(parsed: dict[str, Any]) -> list[str]:
+    """Extract validation commands from an LLM parse result."""
+    commands = parsed.get("validation_commands", [])
+    if not isinstance(commands, list):
+        return []
+    return _ordered_unique_strings([str(cmd).strip() for cmd in commands if str(cmd).strip()])
+
+
+def llm_result_to_sanitation(parsed: dict[str, Any]) -> tuple[bool, str | None]:
+    """Convert LLM parse result into a sanitation verdict."""
+    if not parsed.get("is_well_formed", True):
+        reason = str(parsed.get("rejection_reason", "llm_rejected")).strip()
+        return False, reason or "llm_rejected"
+    if parsed.get("is_auto_decomposed", False):
+        # Auto-decomposed issues are acceptable if well-formed
+        task_summary = str(parsed.get("task_summary", "")).strip()
+        if len(task_summary) < 20:
+            return False, "auto_decomposed_missing_task"
+    return True, None
+
+
+def llm_result_to_file_scope(parsed: dict[str, Any]) -> list[str]:
+    """Extract all file paths from an LLM parse result."""
+    file_scope = parsed.get("file_scope", [])
+    if not isinstance(file_scope, list):
+        return []
+    return _ordered_unique_strings(
+        [
+            str(entry.get("path", "")).strip()
+            for entry in file_scope
+            if isinstance(entry, dict) and str(entry.get("path", "")).strip()
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unified dispatch gate (LLM-first with regex fallback)
+# ---------------------------------------------------------------------------
+
+
+async def check_pre_dispatch_gate(
+    issue_body: str,
+    *,
+    repo_root: Path,
+) -> dict[str, Any]:
+    """Run the full pre-dispatch validation gate.
+
+    Tries LLM-based parsing first for robust semantic understanding.
+    Falls back to the regex pipeline on any LLM failure.
+
+    Returns a dict with:
+      - ``"pass"``: bool — whether dispatch should proceed
+      - ``"method"``: ``"llm"`` or ``"regex"``
+      - ``"sanitation_ok"``: bool
+      - ``"sanitation_reason"``: str | None
+      - ``"declared_new_files"``: list[str]
+      - ``"validation_commands"``: list[str]
+      - ``"missing_targets"``: list[str]
+      - ``"unresolved_missing"``: list[str]
+    """
+    body = str(issue_body or "").strip()
+
+    # --- Attempt LLM parsing ---
+    llm_parsed = await parse_issue_with_llm(body)
+
+    if llm_parsed is not None:
+        san_ok, san_reason = llm_result_to_sanitation(llm_parsed)
+        declared_new = llm_result_to_declared_new_files(llm_parsed)
+        validation_cmds = llm_result_to_validation_commands(llm_parsed)
+
+        # Still use filesystem check for missing targets
+        pre_dispatch_cmds = [
+            cmd
+            for cmd in validation_cmds
+            if any(cmd.startswith(p) for p in _PRE_DISPATCH_SAFE_COMMAND_PREFIXES)
+        ]
+        missing = find_missing_pre_dispatch_validation_targets(
+            pre_dispatch_cmds, repo_root=repo_root
+        )
+        unresolved = [t for t in missing if t not in set(declared_new)]
+
+        return {
+            "pass": san_ok and not unresolved,
+            "method": "llm",
+            "sanitation_ok": san_ok,
+            "sanitation_reason": san_reason,
+            "declared_new_files": declared_new,
+            "validation_commands": validation_cmds,
+            "missing_targets": missing,
+            "unresolved_missing": unresolved,
+        }
+
+    # --- Regex fallback ---
+    san_ok, san_reason = assess_issue_body_sanitation(body)
+    declared_new = extract_declared_new_file_paths(body)
+    validation_cmds = extract_pre_dispatch_validation_commands(body)
+    missing = find_missing_pre_dispatch_validation_targets(validation_cmds, repo_root=repo_root)
+    unresolved = [t for t in missing if t not in set(declared_new)]
+
+    return {
+        "pass": san_ok and not unresolved,
+        "method": "regex",
+        "sanitation_ok": san_ok,
+        "sanitation_reason": san_reason,
+        "declared_new_files": declared_new,
+        "validation_commands": validation_cmds,
+        "missing_targets": missing,
+        "unresolved_missing": unresolved,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/aragora/swarm/boss_validation.py
+++ b/aragora/swarm/boss_validation.py
@@ -608,11 +608,13 @@ async def check_pre_dispatch_gate(
     issue_body: str,
     *,
     repo_root: Path,
+    use_llm: bool = False,
 ) -> dict[str, Any]:
     """Run the full pre-dispatch validation gate.
 
-    Tries LLM-based parsing first for robust semantic understanding.
-    Falls back to the regex pipeline on any LLM failure.
+    Uses deterministic regex parsing by default.  When ``use_llm`` is true,
+    tries LLM-based parsing first for robust semantic understanding and falls
+    back to the regex pipeline on any LLM failure.
 
     Returns a dict with:
       - ``"pass"``: bool — whether dispatch should proceed
@@ -626,8 +628,8 @@ async def check_pre_dispatch_gate(
     """
     body = str(issue_body or "").strip()
 
-    # --- Attempt LLM parsing ---
-    llm_parsed = await parse_issue_with_llm(body)
+    # --- Attempt LLM parsing only when explicitly enabled ---
+    llm_parsed = await parse_issue_with_llm(body) if use_llm else None
 
     if llm_parsed is not None:
         san_ok, san_reason = llm_result_to_sanitation(llm_parsed)
@@ -635,11 +637,14 @@ async def check_pre_dispatch_gate(
         validation_cmds = llm_result_to_validation_commands(llm_parsed)
 
         # Still use filesystem check for missing targets
-        pre_dispatch_cmds = [
-            cmd
-            for cmd in validation_cmds
-            if any(cmd.startswith(p) for p in _PRE_DISPATCH_SAFE_COMMAND_PREFIXES)
-        ]
+        pre_dispatch_cmds = []
+        for cmd in validation_cmds:
+            normalized_cmd = str(cmd).strip()
+            if any(
+                normalized_cmd.lower().startswith(prefix)
+                for prefix in _PRE_DISPATCH_SAFE_COMMAND_PREFIXES
+            ):
+                pre_dispatch_cmds.append(normalized_cmd)
         missing = find_missing_pre_dispatch_validation_targets(
             pre_dispatch_cmds, repo_root=repo_root
         )

--- a/tests/swarm/test_boss_validation.py
+++ b/tests/swarm/test_boss_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 from unittest.mock import patch
 import subprocess
@@ -10,6 +11,7 @@ import pytest
 
 from aragora.swarm.boss_validation import (
     assess_issue_body_sanitation,
+    check_pre_dispatch_gate,
     extract_declared_new_file_paths,
     extract_issue_validation_contract,
     extract_pre_dispatch_validation_commands,
@@ -184,6 +186,74 @@ class TestRunPreDispatchValidationCommands:
         )
         assert result["satisfied"] is False
         assert result["results"][0]["status"] == "timeout"
+
+
+# -- check_pre_dispatch_gate --
+
+
+class TestCheckPreDispatchGate:
+    def test_default_uses_regex_without_llm(self, monkeypatch, tmp_path):
+        async def fail_if_called(_body):
+            raise AssertionError("LLM parsing should be opt-in")
+
+        monkeypatch.setattr(
+            "aragora.swarm.boss_validation.parse_issue_with_llm",
+            fail_if_called,
+        )
+
+        body = (
+            "## Task\n"
+            "Implement a comprehensive feature with enough detail here.\n\n"
+            "## Validation\n"
+            "- pytest tests/missing.py -q\n"
+        )
+
+        result = asyncio.run(check_pre_dispatch_gate(body, repo_root=tmp_path))
+
+        assert result["method"] == "regex"
+        assert result["pass"] is False
+        assert result["unresolved_missing"] == ["tests/missing.py"]
+
+    def test_llm_gate_allows_declared_new_file(self, monkeypatch, tmp_path):
+        async def fake_parse(_body):
+            return {
+                "file_scope": [{"path": "tests/swarm/test_new_gate.py", "action": "create"}],
+                "validation_commands": ["Pytest tests/swarm/test_new_gate.py -q"],
+                "task_summary": "Create focused tests for the dispatch gate behavior.",
+                "is_well_formed": True,
+                "rejection_reason": None,
+                "is_auto_decomposed": True,
+            }
+
+        monkeypatch.setattr(
+            "aragora.swarm.boss_validation.parse_issue_with_llm",
+            fake_parse,
+        )
+
+        result = asyncio.run(
+            check_pre_dispatch_gate("minimal body", repo_root=tmp_path, use_llm=True)
+        )
+
+        assert result["method"] == "llm"
+        assert result["pass"] is True
+        assert result["declared_new_files"] == ["tests/swarm/test_new_gate.py"]
+        assert result["missing_targets"] == ["tests/swarm/test_new_gate.py"]
+        assert result["unresolved_missing"] == []
+
+    def test_llm_gate_falls_back_to_regex(self, monkeypatch, tmp_path):
+        async def fake_parse(_body):
+            return None
+
+        monkeypatch.setattr(
+            "aragora.swarm.boss_validation.parse_issue_with_llm",
+            fake_parse,
+        )
+
+        body = "## Task\nImplement a comprehensive feature with enough detail here."
+        result = asyncio.run(check_pre_dispatch_gate(body, repo_root=tmp_path, use_llm=True))
+
+        assert result["method"] == "regex"
+        assert result["pass"] is True
 
 
 # -- helpers --


### PR DESCRIPTION
## Summary
- add semantic issue-body parsing for the boss-loop pre-dispatch gate with Anthropic/OpenRouter fallback
- keep deterministic regex parsing as the default to avoid hidden network calls, provider costs, and nondeterministic dispatch behavior
- expose explicit opt-in via `--boss-llm-pre-dispatch-gate`
- add tests for default regex behavior, LLM-created-file handling, and LLM fallback
- merge current `origin/main` to absorb the mainline `(create)` marker parser fix
- increase the required Version Alignment job timeout from 2 to 5 minutes after repeated timeouts while drift checks were passing

## Validation
- `ruff check aragora/swarm/boss_validation.py aragora/swarm/boss_loop.py aragora/cli/parser.py aragora/cli/commands/swarm.py tests/swarm/test_boss_validation.py`
- `ruff format aragora/swarm/boss_validation.py aragora/swarm/boss_loop.py aragora/cli/parser.py aragora/cli/commands/swarm.py tests/swarm/test_boss_validation.py --check`
- `python -m py_compile aragora/swarm/boss_validation.py aragora/swarm/boss_loop.py aragora/cli/parser.py aragora/cli/commands/swarm.py`
- `python -m pytest tests/swarm/test_boss_validation.py tests/swarm/test_boss_loop.py -q` (`210 passed` after merging current main)
- `python scripts/generate_cli_reference.py --check`
- `python scripts/generate_python_sdk_types.py --openapi docs/api/openapi_generated.json --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## CI notes
- GitHub `Version Alignment` timed out twice at the previous 2-minute limit after reporting the checked SDK/type outputs were up to date. This PR raises that required check timeout to 5 minutes.
- `Test Analytics` surfaced pre-existing `tests/server/handlers/test_runs_handler.py` failures locally as well; this branch does not touch those files.