### PR TITLE
fix: replace bare raise with contextual error in slack queue.py

### DIFF
--- a/aragora/connectors/chat/slack/queue.py
+++ b/aragora/connectors/chat/slack/queue.py
@@ -467,9 +467,12 @@ class SlackMessageQueue:
 
             return True
 
-        except (OSError, ConnectionError, TimeoutError, ValueError, RuntimeError) as e:
-            logger.error("Failed to send message %s: %s", message.id, e)
-            raise
+        except (OSError, ConnectionError, TimeoutError, ValueError, RuntimeError) as exc:
+            logger.error("Failed to send message %s: %s", message.id, exc)
+            raise RuntimeError(
+                f"Slack message delivery failed for message {message.id} "
+                f"to channel {message.channel_id} in workspace {message.workspace_id}"
+            ) from exc
 
     async def process_pending(self) -> dict[str, int]:
         """


### PR DESCRIPTION
Replace the bare `raise` in `_send_message` with a `RuntimeError` that
includes the message ID, channel, and workspace, chained via `from exc`
to preserve the original exception.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 0e1d8b03b11419607e09de78f205d886f9ddbe34)
