### PR TITLE
[codex] fix(swarm): bound boss decomposition lineage

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1466,11 +1466,7 @@ class BossLoop:
             return
 
         # Guard: cap decomposition depth to prevent runaway recursion.
-        # Each decomposition adds a "[from #N]" prefix — count nesting depth.
-        import re
-
-        depth_markers = re.findall(r"\[from #\d+\]", issue.title)
-        decomposition_depth = len(depth_markers)
+        lineage_root, decomposition_depth = self._decomposition_lineage(issue)
         max_decomposition_depth = 3
         if decomposition_depth >= max_decomposition_depth:
             self._label_boss_stuck(
@@ -1591,9 +1587,14 @@ class BossLoop:
                         validation_cmd = f"`ruff check {' '.join(src_files)}`"
                     else:
                         validation_cmd = "`pytest` on the changed files passes"
+                    child_depth = decomposition_depth + 1
                     body = (
                         f"Auto-decomposed from #{issue.number} after {self.config.max_retries_per_issue} "
                         f"failed autonomous attempts.\n\n"
+                        f"## Decomposition Lineage\n"
+                        f"- Root issue: #{lineage_root}\n"
+                        f"- Parent issue: #{issue.number}\n"
+                        f"- Depth: {child_depth}\n\n"
                         f"## Task\n{sub_desc}\n\n"
                         f"## Files\n{scope_lines}\n\n"
                         f"## Acceptance\n"
@@ -1642,28 +1643,43 @@ class BossLoop:
                 f"producing a deliverable. The issue may be too complex for autonomous workers."
             )
 
-        try:
-            subprocess.run(
-                ["gh", "issue", "comment", str(issue_number), "--repo", repo, "--body", comment],
-                capture_output=True,
-                timeout=15,
-            )
-            subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "edit",
-                    str(issue_number),
-                    "--repo",
-                    repo,
-                    "--add-label",
-                    "boss-stuck",
-                ],
-                capture_output=True,
-                timeout=15,
-            )
-        except Exception:
-            pass
+        self._label_boss_stuck(issue_number, repo, comment)
+
+    @staticmethod
+    def _decomposition_lineage(issue: GitHubIssue) -> tuple[int, int]:
+        body = issue.body or ""
+        title = issue.title or ""
+        title_parents = [
+            int(match) for match in re.findall(r"\[from #(\d+)\]", title) if match.isdigit()
+        ]
+
+        root_match = re.search(r"\bRoot issue:\s*#?(\d+)", body, flags=re.IGNORECASE)
+        depth_match = re.search(r"\bDepth:\s*(\d+)", body, flags=re.IGNORECASE)
+        legacy_parent_match = re.search(
+            r"\bAuto-decomposed from #(\d+)",
+            body,
+            flags=re.IGNORECASE,
+        )
+
+        if root_match:
+            root_issue = int(root_match.group(1))
+        elif title_parents:
+            root_issue = title_parents[0]
+        elif legacy_parent_match:
+            root_issue = int(legacy_parent_match.group(1))
+        else:
+            root_issue = int(issue.number)
+
+        if depth_match:
+            depth = int(depth_match.group(1))
+        elif title_parents:
+            depth = len(title_parents)
+        elif legacy_parent_match:
+            depth = 1
+        else:
+            depth = 0
+
+        return root_issue, depth
 
     @staticmethod
     def _extract_file_scope_hints(body: str) -> list[str]:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3626,6 +3626,83 @@ def test_boss_loop_batch_auto_decomposes_maxed_retry_issue() -> None:
     assert 462 in attempted_numbers
 
 
+def test_auto_decompose_carries_lineage_and_removes_ready_label() -> None:
+    issue = _make_issue(
+        4412,
+        "[from #4409] Add evidence metrics",
+        body="Auto-decomposed from #4409 after 2 failed autonomous attempts.",
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    created: list[list[str]] = []
+    edited: list[list[str]] = []
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        if cmd[:3] == ["gh", "issue", "create"]:
+            created.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "edit"]:
+            edited.append(list(cmd))
+        return result
+
+    subtask = SimpleNamespace(
+        title="Add focused evidence metric assertion",
+        description=(
+            "Add a focused regression that verifies evidence metrics are not "
+            "auto-decomposed recursively when the root issue is already stuck."
+        ),
+        file_scope=["tests/swarm/test_boss_loop.py"],
+        estimated_complexity="small",
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = SimpleNamespace(should_decompose=True, subtasks=[subtask])
+
+    with (
+        patch("subprocess.run", side_effect=_run),
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+    ):
+        loop._auto_decompose_stuck_issue(4412, [issue])
+
+    assert len(created) == 1
+    create_body = created[0][created[0].index("--body") + 1]
+    assert "Root issue: #4409" in create_body
+    assert "Parent issue: #4412" in create_body
+    assert "Depth: 2" in create_body
+    assert edited
+    assert "--add-label" in edited[-1]
+    assert "boss-stuck" in edited[-1]
+    assert "--remove-label" in edited[-1]
+    assert "boss-ready" in edited[-1]
+
+
+def test_auto_decompose_stops_at_body_lineage_depth_limit() -> None:
+    issue = _make_issue(
+        4475,
+        "[from #4461] Recursive evidence metrics task",
+        body=("## Decomposition Lineage\n- Root issue: #4409\n- Parent issue: #4461\n- Depth: 3\n"),
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        return result
+
+    with (
+        patch("subprocess.run", side_effect=_run),
+        patch.object(loop, "_label_boss_stuck") as mock_label_stuck,
+        patch("aragora.nomic.task_decomposer.TaskDecomposer") as mock_decomposer,
+    ):
+        loop._auto_decompose_stuck_issue(4475, [issue])
+
+    mock_label_stuck.assert_called_once()
+    mock_decomposer.assert_not_called()
+
+
 def test_boss_loop_batch_serializes_retry_routed_dispatches() -> None:
     feed = MagicMock(spec=GitHubIssueFeed)
     feed.fetch.return_value = [


### PR DESCRIPTION
Bound boss auto-decomposition lineage and add focused tests. Validation: full tests/swarm/test_boss_loop.py, ruff check/format, git diff --check, automation_pr_preflight.