### PR TITLE
fix(swarm): suppress duplicate decomposition fan-out

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -1574,6 +1574,13 @@ class BossLoop:
         except Exception:
             pass
 
+        parent_signature = self._decomposition_issue_signature(
+            number=issue.number,
+            title=issue.title,
+            body=issue.body or "",
+            url=issue.url,
+        )
+
         # Try LLM-based decomposition
         sub_issues_created = 0
         decomposition_candidates = 0
@@ -1629,6 +1636,13 @@ class BossLoop:
                         scope_entries=valid_scope,
                         validation_command=validation_cmd,
                     )
+                    if decomposition_depth > 0 and self._decomposition_candidate_restates_parent(
+                        candidate=signature,
+                        parent=parent_signature,
+                        candidate_text=f"{sub_title}\n{sub_desc}",
+                    ):
+                        covered_candidates += 1
+                        continue
                     if self._decomposition_candidate_is_covered(
                         signature=signature,
                         existing_signatures=existing_decomposition_signatures,
@@ -1689,8 +1703,8 @@ class BossLoop:
         elif decomposition_candidates > 0 and covered_candidates == decomposition_candidates:
             comment = (
                 f"Boss loop exhausted {self.config.max_retries_per_issue} attempts. "
-                "All decomposition candidates are already covered by existing open "
-                "`boss-ready` issues or open PRs."
+                "All decomposition candidates are already covered by the parent task, "
+                "existing open `boss-ready` issues, or open PRs."
             )
         else:
             comment = (
@@ -1851,6 +1865,41 @@ class BossLoop:
             return False
         shared = left_tokens & right_tokens
         return len(shared) >= max(3, min(len(left_tokens), len(right_tokens)) // 2)
+
+    @staticmethod
+    def _decomposition_intent_is_generic(text: str) -> bool:
+        normalized = re.sub(r"\s+", " ", str(text or "").lower())
+        generic_phrases = (
+            "fix failing tests",
+            "repair failing tests",
+            "ensure comprehensive coverage",
+            "comprehensive test coverage",
+            "comprehensive unit tests",
+            "execute and verify",
+            "run and verify",
+        )
+        return any(phrase in normalized for phrase in generic_phrases)
+
+    @classmethod
+    def _decomposition_candidate_restates_parent(
+        cls,
+        *,
+        candidate: dict[str, Any],
+        parent: dict[str, Any],
+        candidate_text: str,
+    ) -> bool:
+        if not cls._decomposition_intent_is_generic(candidate_text):
+            return False
+        candidate_scopes = tuple(candidate.get("scopes") or ())
+        parent_scopes = tuple(parent.get("scopes") or ())
+        if not candidate_scopes or not parent_scopes:
+            return False
+        if not cls._decomposition_scope_sets_overlap(candidate_scopes, parent_scopes):
+            return False
+        return cls._decomposition_intents_overlap(
+            str(candidate.get("intent") or ""),
+            str(parent.get("intent") or ""),
+        )
 
     @classmethod
     def _decomposition_candidate_is_covered(

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -48,6 +48,7 @@ from aragora.swarm.boss_feed import (  # noqa: F401
     infer_issue_lane_hints,
     infer_issue_scope_entries,
     select_eligible_issue,
+    scope_entries_overlap,
 )
 from aragora.swarm.boss_freshness import RunnerFreshnessResult, check_runner_freshness  # noqa: F401
 from aragora.swarm.boss_validation import (  # noqa: F401
@@ -1511,8 +1512,16 @@ class BossLoop:
         except Exception:
             pass
 
-        # Collect existing issue titles to avoid creating duplicates
+        open_pr_changed_paths: set[str] = set()
+        if repo:
+            try:
+                open_pr_changed_paths = fetch_open_pr_changed_paths(repo=repo)
+            except Exception as exc:
+                logger.debug("Open PR scope lookup failed during auto-decomposition: %s", exc)
+
+        # Collect existing boss-ready issues to avoid duplicate fan-out.
         existing_titles: set[str] = set()
+        existing_decomposition_signatures: list[dict[str, Any]] = []
         try:
             proc = subprocess.run(
                 [
@@ -1528,23 +1537,47 @@ class BossLoop:
                     "--limit",
                     "100",
                     "--json",
-                    "title",
-                    "--jq",
-                    ".[].title",
+                    "number,title,body,url",
                 ],
                 capture_output=True,
                 text=True,
                 timeout=15,
             )
             if proc.returncode == 0:
-                existing_titles = {
-                    line.strip().lower() for line in proc.stdout.splitlines() if line.strip()
-                }
+                raw_issues = json.loads(proc.stdout or "[]")
+                if isinstance(raw_issues, list):
+                    for raw_issue in raw_issues:
+                        if not isinstance(raw_issue, dict):
+                            continue
+                        try:
+                            existing_number = int(raw_issue.get("number", 0) or 0)
+                        except (TypeError, ValueError):
+                            existing_number = 0
+                        if existing_number == int(issue.number):
+                            continue
+                        existing_title = str(raw_issue.get("title", "") or "").strip()
+                        existing_body = str(raw_issue.get("body", "") or "").strip()
+                        if existing_title:
+                            existing_titles.add(existing_title.lower())
+                        signature = self._decomposition_issue_signature(
+                            number=existing_number,
+                            title=existing_title,
+                            body=existing_body,
+                            url=str(raw_issue.get("url", "") or "").strip(),
+                        )
+                        if signature["scopes"]:
+                            existing_decomposition_signatures.append(signature)
+                else:
+                    existing_titles = {
+                        line.strip().lower() for line in proc.stdout.splitlines() if line.strip()
+                    }
         except Exception:
             pass
 
         # Try LLM-based decomposition
         sub_issues_created = 0
+        decomposition_candidates = 0
+        covered_candidates = 0
         try:
             from aragora.nomic.task_decomposer import TaskDecomposer
 
@@ -1567,8 +1600,10 @@ class BossLoop:
                     sub_title = (subtask.title or sub_desc[:60]).strip()[:80]
                     title = f"[from #{issue.number}] {sub_title}"
                     if title.lower() in existing_titles:
+                        decomposition_candidates += 1
+                        covered_candidates += 1
                         continue
-                    valid_scope = [f for f in (subtask.file_scope or []) if f and "/" in f]
+                    valid_scope = self._decomposition_scope_entries(subtask.file_scope or [])
                     if not valid_scope:
                         logger.debug(
                             "Skipping subtask with no valid file scope: %r",
@@ -1587,6 +1622,20 @@ class BossLoop:
                         validation_cmd = f"`ruff check {' '.join(src_files)}`"
                     else:
                         validation_cmd = "`pytest` on the changed files passes"
+                    decomposition_candidates += 1
+                    signature = self._decomposition_candidate_signature(
+                        title=sub_title,
+                        description=sub_desc,
+                        scope_entries=valid_scope,
+                        validation_command=validation_cmd,
+                    )
+                    if self._decomposition_candidate_is_covered(
+                        signature=signature,
+                        existing_signatures=existing_decomposition_signatures,
+                        open_pr_changed_paths=open_pr_changed_paths,
+                    ):
+                        covered_candidates += 1
+                        continue
                     child_depth = decomposition_depth + 1
                     body = (
                         f"Auto-decomposed from #{issue.number} after {self.config.max_retries_per_issue} "
@@ -1637,6 +1686,12 @@ class BossLoop:
                 f"Boss loop exhausted {self.config.max_retries_per_issue} attempts. "
                 f"Auto-decomposed into {sub_issues_created} smaller sub-issues with `boss-ready` label."
             )
+        elif decomposition_candidates > 0 and covered_candidates == decomposition_candidates:
+            comment = (
+                f"Boss loop exhausted {self.config.max_retries_per_issue} attempts. "
+                "All decomposition candidates are already covered by existing open "
+                "`boss-ready` issues or open PRs."
+            )
         else:
             comment = (
                 f"Boss loop exhausted {self.config.max_retries_per_issue} attempts without "
@@ -1680,6 +1735,146 @@ class BossLoop:
             depth = 0
 
         return root_issue, depth
+
+    @staticmethod
+    def _decomposition_scope_entries(
+        paths: list[str] | tuple[str, ...] | set[str],
+    ) -> tuple[str, ...]:
+        scope_issue = GitHubIssue(
+            number=0,
+            title="",
+            body="\n".join(f"`{path}`" for path in paths if str(path or "").strip()),
+            labels=[],
+            url="",
+            state="OPEN",
+            created_at="",
+        )
+        return tuple(infer_issue_scope_entries(scope_issue))
+
+    @staticmethod
+    def _normalize_decomposition_validation(command: str) -> str:
+        text = str(command or "").strip()
+        if not text:
+            return ""
+        text = re.sub(r"`([^`]+)`", r"\1", text)
+        text = text.replace("python -m pytest", "python3 -m pytest")
+        text = re.sub(r"\s+", " ", text).strip().lower()
+        return text
+
+    @staticmethod
+    def _normalize_decomposition_intent(*parts: str) -> str:
+        text = " ".join(str(part or "") for part in parts)
+        text = re.sub(r"\[from #\d+\]", " ", text.lower())
+        tokens = re.findall(r"[a-z0-9_/.]+", text)
+        stopwords = {
+            "a",
+            "add",
+            "all",
+            "and",
+            "are",
+            "by",
+            "for",
+            "from",
+            "in",
+            "is",
+            "it",
+            "keep",
+            "of",
+            "on",
+            "or",
+            "the",
+            "to",
+            "with",
+        }
+        return " ".join(token for token in tokens if token not in stopwords)
+
+    @classmethod
+    def _decomposition_issue_signature(
+        cls,
+        *,
+        number: int,
+        title: str,
+        body: str,
+        url: str,
+    ) -> dict[str, Any]:
+        issue = GitHubIssue(
+            number=number,
+            title=title,
+            body=body,
+            labels=["boss-ready"],
+            url=url,
+            state="OPEN",
+            created_at="",
+        )
+        return {
+            "scopes": tuple(infer_issue_scope_entries(issue)),
+            "validations": tuple(
+                cls._normalize_decomposition_validation(command)
+                for command in extract_pre_dispatch_validation_commands(body)
+                if cls._normalize_decomposition_validation(command)
+            ),
+            "intent": cls._normalize_decomposition_intent(title, body),
+        }
+
+    @classmethod
+    def _decomposition_candidate_signature(
+        cls,
+        *,
+        title: str,
+        description: str,
+        scope_entries: tuple[str, ...],
+        validation_command: str,
+    ) -> dict[str, Any]:
+        validation = cls._normalize_decomposition_validation(validation_command)
+        return {
+            "scopes": tuple(scope_entries),
+            "validations": (validation,) if validation else (),
+            "intent": cls._normalize_decomposition_intent(title, description),
+        }
+
+    @staticmethod
+    def _decomposition_scope_sets_overlap(
+        left: tuple[str, ...] | set[str],
+        right: tuple[str, ...] | set[str],
+    ) -> bool:
+        return any(
+            scope_entries_overlap(left_scope, right_scope)
+            for left_scope in left
+            for right_scope in right
+        )
+
+    @classmethod
+    def _decomposition_intents_overlap(cls, left: str, right: str) -> bool:
+        left_tokens = set((left or "").split())
+        right_tokens = set((right or "").split())
+        if not left_tokens or not right_tokens:
+            return False
+        shared = left_tokens & right_tokens
+        return len(shared) >= max(3, min(len(left_tokens), len(right_tokens)) // 2)
+
+    @classmethod
+    def _decomposition_candidate_is_covered(
+        cls,
+        *,
+        signature: dict[str, Any],
+        existing_signatures: list[dict[str, Any]],
+        open_pr_changed_paths: set[str],
+    ) -> bool:
+        scopes = tuple(signature.get("scopes") or ())
+        validations = set(signature.get("validations") or ())
+        intent = str(signature.get("intent") or "")
+        if scopes and cls._decomposition_scope_sets_overlap(scopes, open_pr_changed_paths):
+            return True
+        for existing in existing_signatures:
+            existing_scopes = tuple(existing.get("scopes") or ())
+            if not cls._decomposition_scope_sets_overlap(scopes, existing_scopes):
+                continue
+            existing_validations = set(existing.get("validations") or ())
+            if validations and existing_validations and validations & existing_validations:
+                return True
+            if cls._decomposition_intents_overlap(intent, str(existing.get("intent") or "")):
+                return True
+        return False
 
     @staticmethod
     def _extract_file_scope_hints(body: str) -> list[str]:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3792,6 +3792,63 @@ def test_auto_decompose_skips_existing_boss_ready_scope_and_validation() -> None
     assert "already covered" in comments[-1]
 
 
+def test_auto_decompose_skips_generic_same_scope_restatement() -> None:
+    issue = _make_issue(
+        4512,
+        "[from #4409] Fix failing evidence metric tests",
+        body=(
+            "Auto-decomposed from #4409 after 3 failed autonomous attempts.\n\n"
+            "## Decomposition Lineage\n"
+            "- Root issue: #4409\n"
+            "- Parent issue: #4488\n"
+            "- Depth: 1\n\n"
+            "## Task\n"
+            "Fix failing tests and ensure comprehensive coverage for evidence metrics.\n\n"
+            "## Files\n"
+            "- `tests/observability/metrics/test_evidence.py`\n\n"
+        ),
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    created: list[list[str]] = []
+    comments: list[str] = []
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        if cmd[:3] == ["gh", "issue", "list"]:
+            result.stdout = "[]"
+        if cmd[:3] == ["gh", "issue", "create"]:
+            created.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            comments.append(cmd[cmd.index("--body") + 1])
+        return result
+
+    subtask = SimpleNamespace(
+        title="Fix failing evidence metric tests",
+        description=(
+            "Fix failing tests and ensure comprehensive coverage for evidence metrics "
+            "in the existing evidence metric test module."
+        ),
+        file_scope=["tests/observability/metrics/test_evidence.py"],
+        estimated_complexity="small",
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = SimpleNamespace(should_decompose=True, subtasks=[subtask])
+
+    with (
+        patch("subprocess.run", side_effect=_run),
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+        patch("aragora.swarm.boss_loop.fetch_open_pr_changed_paths", return_value=set()),
+    ):
+        loop._auto_decompose_stuck_issue(4512, [issue])
+
+    assert created == []
+    assert comments
+    assert "parent task" in comments[-1]
+
+
 def test_auto_decompose_stops_at_body_lineage_depth_limit() -> None:
     issue = _make_issue(
         4475,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3677,6 +3677,121 @@ def test_auto_decompose_carries_lineage_and_removes_ready_label() -> None:
     assert "boss-ready" in edited[-1]
 
 
+def test_auto_decompose_skips_candidate_already_covered_by_open_pr(monkeypatch) -> None:
+    issue = _make_issue(
+        4510,
+        "[from #4409] Evidence metrics duplicate",
+        body="## Decomposition Lineage\n- Root issue: #4409\n- Parent issue: #4503\n- Depth: 2\n",
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    created: list[list[str]] = []
+    comments: list[str] = []
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        if cmd[:3] == ["gh", "issue", "list"]:
+            result.stdout = "[]"
+        if cmd[:3] == ["gh", "issue", "create"]:
+            created.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            comments.append(cmd[cmd.index("--body") + 1])
+        return result
+
+    subtask = SimpleNamespace(
+        title="Add complete evidence metric type coverage",
+        description=(
+            "Add focused coverage for every evidence metric type in the "
+            "observability evidence metrics contract and keep it hermetic."
+        ),
+        file_scope=["tests/observability/metrics/test_evidence.py"],
+        estimated_complexity="small",
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = SimpleNamespace(should_decompose=True, subtasks=[subtask])
+
+    monkeypatch.setattr(
+        "aragora.swarm.boss_loop.fetch_open_pr_changed_paths",
+        lambda repo=None: {"tests/observability/metrics/test_evidence.py"},
+    )
+
+    with (
+        patch("subprocess.run", side_effect=_run),
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+    ):
+        loop._auto_decompose_stuck_issue(4510, [issue])
+
+    assert created == []
+    assert comments
+    assert "already covered" in comments[-1]
+
+
+def test_auto_decompose_skips_existing_boss_ready_scope_and_validation() -> None:
+    issue = _make_issue(
+        4511,
+        "[from #4409] Evidence metrics duplicate",
+        body="Auto-decomposed from #4409 after 2 failed autonomous attempts.",
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(repo="synaptent/aragora"))
+    created: list[list[str]] = []
+    comments: list[str] = []
+    existing_body = (
+        "Auto-decomposed from #4488 after 3 failed autonomous attempts.\n\n"
+        "## Task\n"
+        "Fix failing evidence metric tests with comprehensive metric coverage.\n\n"
+        "## Files\n"
+        "- `tests/observability/metrics/test_evidence.py`\n\n"
+        "## Acceptance\n"
+        "`python3 -m pytest tests/observability/metrics/test_evidence.py -q`\n"
+    )
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        if cmd[:3] == ["gh", "issue", "list"]:
+            result.stdout = json.dumps(
+                [
+                    {
+                        "number": 4503,
+                        "title": "[from #4488] Fix evidence metric coverage",
+                        "body": existing_body,
+                    }
+                ]
+            )
+        if cmd[:3] == ["gh", "issue", "create"]:
+            created.append(list(cmd))
+        if cmd[:3] == ["gh", "issue", "comment"]:
+            comments.append(cmd[cmd.index("--body") + 1])
+        return result
+
+    subtask = SimpleNamespace(
+        title="Repair failing evidence metric coverage",
+        description=(
+            "Repair failing evidence metrics coverage so test_evidence exercises "
+            "all metric types without external monitoring dependencies."
+        ),
+        file_scope=["tests/observability/metrics/test_evidence.py"],
+        estimated_complexity="small",
+    )
+    decomposer = MagicMock()
+    decomposer.analyze.return_value = SimpleNamespace(should_decompose=True, subtasks=[subtask])
+
+    with (
+        patch("subprocess.run", side_effect=_run),
+        patch("aragora.nomic.task_decomposer.TaskDecomposer", return_value=decomposer),
+        patch("aragora.swarm.boss_loop.fetch_open_pr_changed_paths", return_value=set()),
+    ):
+        loop._auto_decompose_stuck_issue(4511, [issue])
+
+    assert created == []
+    assert comments
+    assert "already covered" in comments[-1]
+
+
 def test_auto_decompose_stops_at_body_lineage_depth_limit() -> None:
     issue = _make_issue(
         4475,


### PR DESCRIPTION
## Summary
- suppress auto-decomposition children when an open PR already covers the candidate file scope
- suppress child creation when an existing open boss-ready issue has overlapping scope plus matching validation or task intent
- keep exhausted parents marked/commented as boss-stuck when all decomposition candidates are already covered

## Validation
- python3 -m pytest tests/swarm/test_boss_loop.py -q -k 'auto_decompose' -o cache_dir=/tmp/pytest-cache-boss-dedupe-auto-postformat-20260410
- python3 -m pytest tests/swarm/test_boss_loop.py -q -o cache_dir=/tmp/pytest-cache-boss-loop-dedupe-full-20260410
- ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- ruff format --check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- The adjacent tests/swarm/test_boss_loop_autonomy.py tests/swarm/test_boss_loop_receipts.py check still has 4 baseline failures on clean origin/main.