### PR TITLE
fix(kafka): preserve consume cancellation context

### DIFF
--- a/aragora/connectors/enterprise/streaming/kafka.py
+++ b/aragora/connectors/enterprise/streaming/kafka.py
@@ -477,9 +477,9 @@ class KafkaConnector(EnterpriseConnector):
                         if sent_to_dlq:
                             self._dlq_count += 1
 
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
             logger.info("[Kafka] Consumer cancelled")
-            raise
+            raise asyncio.CancelledError("Kafka consumer cancelled during consume") from exc
 
     async def _process_with_resilience(
         self,

--- a/tests/connectors/enterprise/streaming/test_kafka.py
+++ b/tests/connectors/enterprise/streaming/test_kafka.py
@@ -431,6 +431,34 @@ class TestKafkaConsume:
 
         assert len(consumed) == 5
 
+    @pytest.mark.asyncio
+    async def test_consume_cancelled_error_preserves_context(self):
+        """Should re-raise cancellation with Kafka consume context."""
+        from aragora.connectors.enterprise.streaming.kafka import (
+            KafkaConnector,
+            KafkaConfig,
+        )
+
+        class CancelledConsumer:
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                raise asyncio.CancelledError()
+
+        connector = KafkaConnector(KafkaConfig())
+        connector._consumer = CancelledConsumer()
+        connector._running = True
+
+        with pytest.raises(
+            asyncio.CancelledError,
+            match="Kafka consumer cancelled during consume",
+        ) as exc_info:
+            async for _ in connector.consume():
+                pass
+
+        assert isinstance(exc_info.value.__cause__, asyncio.CancelledError)
+
 
 # =============================================================================
 # Sync Tests


### PR DESCRIPTION
Fixes #4383. Covers duplicate #4385.\n\nReplaces the Kafka consume bare cancellation re-raise with a contextual chained CancelledError and adds a focused regression test.\n\nValidation: focused Kafka consume test passed; full Kafka connector test passed; Kafka resilience tests passed; ruff check and format check passed; automation_pr_preflight passed.