### PR TITLE
fix(snssqs): preserve consume cancellation context

### DIFF
--- a/aragora/connectors/enterprise/streaming/snssqs.py
+++ b/aragora/connectors/enterprise/streaming/snssqs.py
@@ -580,6 +580,11 @@ class SNSSQSConnector(EnterpriseConnector):
                     if len(self._pending_deletes) >= self.config.batch_size:
                         await self._flush_pending_deletes()
 
+                except asyncio.CancelledError as exc:
+                    raise asyncio.CancelledError(
+                        "SNS/SQS consumer cancelled during consume"
+                    ) from exc
+
                 except CircuitBreakerOpenError:
                     logger.warning("[SNS/SQS] Circuit breaker tripped")
                     await asyncio.sleep(self.config.resilience.circuit_breaker_recovery_seconds)

--- a/tests/connectors/enterprise/streaming/test_snssqs.py
+++ b/tests/connectors/enterprise/streaming/test_snssqs.py
@@ -12,6 +12,7 @@ Tests cover:
 These tests mock aioboto3 to avoid requiring actual AWS services.
 """
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -464,6 +465,42 @@ class TestSNSSQSConnectorConnection:
         mock_client.__aexit__.assert_called_once()
         assert connector._sqs_client is None
         assert connector._running is False
+
+
+# =============================================================================
+# Consume Tests
+# =============================================================================
+
+
+class TestSNSSQSConnectorConsume:
+    """Tests for consuming SQS messages."""
+
+    @pytest.mark.asyncio
+    async def test_consume_cancelled_error_preserves_context(self):
+        """Should preserve the original cancellation context."""
+        from aragora.connectors.enterprise.streaming.snssqs import (
+            SNSSQSConnector,
+            SNSSQSConfig,
+        )
+
+        config = SNSSQSConfig(
+            queue_url="https://sqs.us-east-1.amazonaws.com/123456789/queue",
+            enable_circuit_breaker=False,
+            enable_dlq=False,
+            enable_graceful_shutdown=False,
+        )
+        connector = SNSSQSConnector(config)
+        cancelled = asyncio.CancelledError("poll cancelled")
+        connector._sqs_client = AsyncMock()
+        connector._sqs_client.receive_message = AsyncMock(side_effect=cancelled)
+
+        with pytest.raises(
+            asyncio.CancelledError,
+            match="SNS/SQS consumer cancelled during consume",
+        ) as exc_info:
+            await connector.consume().__anext__()
+
+        assert exc_info.value.__cause__ is cancelled
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- preserve SNS/SQS consume cancellation context with a chained CancelledError
- add a focused regression for cancelled SQS receive polling

## Validation
- direct cancellation probe: message=('SNS/SQS consumer cancelled during consume',) cause=CancelledError same_cause=True
- python3 -m pytest tests/connectors/enterprise/streaming/test_snssqs.py -q -k 'consume_cancelled_error_preserves_context' -o cache_dir=/tmp/pytest-cache-snssqs-cancel-focused-20260410
- python3 -m pytest tests/connectors/enterprise/streaming/test_snssqs.py -q -o cache_dir=/tmp/pytest-cache-snssqs-cancel-file-20260410
- python3 -m pytest tests/connectors/enterprise/streaming -q -o cache_dir=/tmp/pytest-cache-enterprise-streaming-snssqs-cancel-20260410
- python3 -m ruff check aragora/connectors/enterprise/streaming/snssqs.py tests/connectors/enterprise/streaming/test_snssqs.py
- python3 -m ruff format --check aragora/connectors/enterprise/streaming/snssqs.py tests/connectors/enterprise/streaming/test_snssqs.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD