### PR TITLE
fix(rlm): default invalid query iteration bounds

### DIFF
--- a/aragora/server/handlers/rlm.py
+++ b/aragora/server/handlers/rlm.py
@@ -181,14 +181,21 @@ class RLMContextHandler(BaseHandler):
         *,
         min_value: int | None = None,
         max_value: int | None = None,
+        default_on_invalid: bool = False,
     ) -> tuple[int, HandlerResult | None]:
         """Validate an optional integer field."""
         value = body.get(field_name, default)
         if type(value) is not int:
+            if default_on_invalid:
+                return default, None
             return default, error_response(f"'{field_name}' must be an integer", 400)
         if min_value is not None and value < min_value:
+            if default_on_invalid:
+                return default, None
             return default, error_response(f"'{field_name}' must be at least {min_value}", 400)
         if max_value is not None and value > max_value:
+            if default_on_invalid:
+                return default, None
             return default, error_response(f"'{field_name}' must be at most {max_value}", 400)
         return value, None
 
@@ -717,6 +724,7 @@ class RLMContextHandler(BaseHandler):
             3,
             min_value=1,
             max_value=10,
+            default_on_invalid=True,
         )
         if max_iterations_error:
             return max_iterations_error


### PR DESCRIPTION
Restores the RLM query endpoint contract for invalid optional max_iterations values to use the default instead of returning 400. Validation: focused max_iterations test passed, query subset passed, ruff check/format passed, git diff checks passed, automation_pr_preflight passed. Full tests/handlers/test_rlm.py still has a baseline origin/main failure in TestHandleCompress::test_compress_content_too_large.