### PR TITLE
fix(mongodb): preserve connector error context

### DIFF
--- a/aragora/connectors/enterprise/database/mongodb.py
+++ b/aragora/connectors/enterprise/database/mongodb.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from typing import Any
-from collections.abc import AsyncIterator
 
 from aragora.connectors.enterprise.base import (
     EnterpriseConnector,
@@ -189,9 +189,9 @@ class MongoDBConnector(EnterpriseConnector):
             self._db = self._client[self.database_name]  # type: ignore[index]
             return self._client
 
-        except ImportError:
+        except ImportError as exc:
             logger.error("motor not installed. Run: pip install motor")
-            raise
+            raise ImportError("MongoDB connector requires motor. Run: pip install motor") from exc
 
     async def _discover_collections(self) -> list[str]:
         """Discover collections in the database."""
@@ -361,9 +361,14 @@ class MongoDBConnector(EnterpriseConnector):
 
             except (OSError, ConnectionError, ValueError, KeyError, RuntimeError) as e:
                 error_message = f"{collection_name}: sync failed"
-                logger.exception("Failed to sync collection %s", collection_name)
+                logger.warning(
+                    "Failed to sync collection %s (%s): %s",
+                    collection_name,
+                    type(e).__name__,
+                    e,
+                )
                 state.errors.append(error_message)
-                raise RuntimeError(error_message) from e
+                continue
 
     async def search(
         self,
@@ -382,7 +387,12 @@ class MongoDBConnector(EnterpriseConnector):
         results = []
 
         collections = self.collections or await self._discover_collections()
-        from pymongo.errors import OperationFailure
+        try:
+            from pymongo.errors import OperationFailure
+        except ImportError:
+
+            class OperationFailure(Exception):  # type: ignore[no-redef]
+                """Fallback sentinel for tests without pymongo installed."""
 
         for collection_name in collections[:5]:  # Limit to first 5 collections
             try:
@@ -409,7 +419,8 @@ class MongoDBConnector(EnterpriseConnector):
                     continue
                 except OperationFailure as e:
                     if "text index required" not in str(e).lower():
-                        raise
+                        error_message = f"{collection_name}: text search failed"
+                        raise RuntimeError(error_message) from e
                     logger.debug(
                         "Text search not available for %s, falling back to regex: %s",
                         collection_name,

--- a/tests/connectors/enterprise/test_mongodb.py
+++ b/tests/connectors/enterprise/test_mongodb.py
@@ -285,8 +285,10 @@ class TestMongoDBClientConnection:
 
         # Simulate motor not being installed
         with patch.dict(sys.modules, {"motor": None, "motor.motor_asyncio": None}):
-            with pytest.raises(ImportError):
+            with pytest.raises(ImportError, match="MongoDB connector requires motor") as exc_info:
                 await connector._get_client()
+
+        assert exc_info.value.__cause__ is not None
 
 
 class TestMongoDBSyncItems:
@@ -384,6 +386,45 @@ class TestMongoDBSearch:
 
             # Should return some results (may be empty if search not fully mocked)
             assert isinstance(results, list)
+
+    @pytest.mark.asyncio
+    async def test_search_preserves_text_search_failure_context(self, mock_credentials):
+        """Should add collection context while preserving text search failures."""
+        import sys
+        import types
+
+        from aragora.connectors.enterprise.database.mongodb import MongoDBConnector
+
+        class FakeOperationFailure(Exception):
+            pass
+
+        fake_errors = types.ModuleType("pymongo.errors")
+        fake_errors.OperationFailure = FakeOperationFailure
+
+        connector = MongoDBConnector(collections=["test"])
+        connector.credentials = mock_credentials
+
+        mock_collection = MagicMock()
+        mock_collection.find = MagicMock(side_effect=FakeOperationFailure("bad command"))
+
+        mock_db = MagicMock()
+        mock_db.__getitem__ = MagicMock(return_value=mock_collection)
+
+        with (
+            patch.dict(
+                sys.modules, {"pymongo": types.ModuleType("pymongo"), "pymongo.errors": fake_errors}
+            ),
+            patch.object(connector, "_get_client", new_callable=AsyncMock),
+        ):
+            connector._db = mock_db
+
+            with pytest.raises(RuntimeError, match="test: search failed") as exc_info:
+                await connector.search("document", limit=5)
+
+        text_search_error = exc_info.value.__cause__
+        assert isinstance(text_search_error, RuntimeError)
+        assert str(text_search_error) == "test: text search failed"
+        assert isinstance(text_search_error.__cause__, FakeOperationFailure)
 
 
 class TestMongoDBErrorHandling:


### PR DESCRIPTION
## Summary
- replace MongoDB connector bare raises with contextual chained exceptions
- keep mocked/search-only paths working when pymongo is not installed
- align per-collection MongoDB sync errors with sibling database connectors by recording the error and continuing

## Validation
- python3 -m pytest tests/connectors/enterprise/test_mongodb.py -q -o cache_dir=/tmp/pytest-cache-mongodb-context-full-20260410
- python3 -m pytest tests/connectors/enterprise/database/test_mongodb_security.py -q -o cache_dir=/tmp/pytest-cache-mongodb-security-context-20260410
- python3 -m pytest tests/connectors/enterprise/test_mongodb.py tests/connectors/enterprise/database/test_mongodb_security.py -q -o cache_dir=/tmp/pytest-cache-mongodb-context-combined-20260410
- python3 -m pytest tests/connectors/enterprise -q -k 'mongodb' -o cache_dir=/tmp/pytest-cache-enterprise-mongodb-context-20260410
- python3 -m ruff check aragora/connectors/enterprise/database/mongodb.py tests/connectors/enterprise/test_mongodb.py tests/connectors/enterprise/database/test_mongodb_security.py
- python3 -m ruff format --check aragora/connectors/enterprise/database/mongodb.py tests/connectors/enterprise/test_mongodb.py tests/connectors/enterprise/database/test_mongodb_security.py
- git diff --check
- bash scripts/automation_pr_preflight.sh origin/main HEAD

Refs #4391