### PR TITLE
fix(swarm): prevent empty canary publish loops

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -2271,8 +2271,37 @@ class BossLoop:
                 }
             if harvest_result is not None:
                 worker_result["harvest_result"] = harvest_result
-                if str(harvest_result.get("action", "")).strip() != "harvest_failed":
+                harvest_action = str(harvest_result.get("action", "")).strip()
+                if harvest_action != "harvest_failed":
                     branch = str(harvest_result.get("branch") or branch).strip() or branch
+                else:
+                    branch_has_diff = self._publish_branch_has_target_diff(
+                        repo_root=repo_root,
+                        branch=branch,
+                    )
+                    if branch_has_diff is not True:
+                        reason = (
+                            "harvest_failed_empty_diff"
+                            if branch_has_diff is False
+                            else "harvest_failed_unverified_diff"
+                        )
+                        logger.warning(
+                            "Boss publish skipped for issue #%s branch %s: %s",
+                            issue.number,
+                            branch,
+                            reason,
+                        )
+                        return {
+                            "action": "skipped_empty_publish_branch"
+                            if branch_has_diff is False
+                            else "skipped_unverified_publish_branch",
+                            "published": False,
+                            "reason": reason,
+                            "branch": branch,
+                            "source_branch": branch,
+                            "commit_shas": commit_shas,
+                            "harvest_result": dict(harvest_result),
+                        }
             artifact = _BossDeliverableArtifact(
                 branch=branch,
                 metadata={
@@ -2390,6 +2419,109 @@ class BossLoop:
             head_ref = str(pr.get("headRefName", ""))
             if head_ref.endswith(suffix) or f"issue-{issue_number}-" in head_ref:
                 return str(pr.get("url") or "")
+        return None
+
+    def _git_repo_cmd(
+        self,
+        repo_root: Path,
+        args: list[str],
+        *,
+        timeout: float = 30.0,
+    ) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            env=git_safe_env(self._env),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+
+    def _verify_git_commit_ref(self, repo_root: Path, ref: str) -> str | None:
+        ref = str(ref or "").strip()
+        if not ref:
+            return None
+        try:
+            proc = self._git_repo_cmd(
+                repo_root,
+                ["rev-parse", "--verify", f"{ref}^{{commit}}"],
+                timeout=10.0,
+            )
+        except Exception:
+            return None
+        if proc.returncode != 0:
+            return None
+        return ref
+
+    def _publish_branch_has_target_diff(
+        self,
+        *,
+        repo_root: Path,
+        branch: str,
+    ) -> bool | None:
+        """Return whether a branch has publishable diff against target branch."""
+        branch = str(branch or "").strip()
+        if not branch:
+            return None
+
+        target_branch = str(self.config.target_branch or "main").strip() or "main"
+        base_ref = self._verify_git_commit_ref(repo_root, f"origin/{target_branch}")
+        if base_ref is None:
+            try:
+                self._git_repo_cmd(
+                    repo_root,
+                    ["fetch", "--no-tags", "origin", target_branch],
+                    timeout=60.0,
+                )
+            except Exception:
+                pass
+            base_ref = self._verify_git_commit_ref(repo_root, f"origin/{target_branch}")
+        if base_ref is None:
+            base_ref = self._verify_git_commit_ref(repo_root, target_branch)
+        if base_ref is None:
+            return None
+
+        branch_ref = self._verify_git_commit_ref(repo_root, branch)
+        if branch_ref is None:
+            remote_branch = branch.removeprefix("origin/")
+            remote_ref = f"origin/{remote_branch}"
+            branch_ref = self._verify_git_commit_ref(repo_root, remote_ref)
+            if branch_ref is None:
+                try:
+                    self._git_repo_cmd(
+                        repo_root,
+                        [
+                            "fetch",
+                            "--no-tags",
+                            "origin",
+                            f"refs/heads/{remote_branch}:refs/remotes/origin/{remote_branch}",
+                        ],
+                        timeout=60.0,
+                    )
+                except Exception:
+                    pass
+                branch_ref = self._verify_git_commit_ref(repo_root, remote_ref)
+        if branch_ref is None:
+            return None
+
+        try:
+            diff_proc = self._git_repo_cmd(
+                repo_root,
+                ["diff", "--quiet", f"{base_ref}...{branch_ref}", "--"],
+                timeout=30.0,
+            )
+        except Exception:
+            return None
+        if diff_proc.returncode == 0:
+            return False
+        if diff_proc.returncode == 1:
+            return True
+        logger.debug(
+            "Failed to diff publish branch %s against %s: %s",
+            branch_ref,
+            base_ref,
+            (diff_proc.stderr or diff_proc.stdout or "").strip(),
+        )
         return None
 
     def _harvest_worker_commits_for_publish(
@@ -4081,6 +4213,10 @@ class BossLoop:
 
         if worker_result.get("status") == "completed":
             self._completed_issues.append(issue_dict)
+            self._issue_attempt_counts[issue_number] = max(
+                self._issue_attempt_counts.get(issue_number, 0),
+                self.config.max_retries_per_issue,
+            )
             self._consecutive_failures = 0
             self._emit_lane_receipt(worker_result, issue_dict, elapsed_seconds)
             self._log_value_outcome(issue_dict, "completed", elapsed_seconds)

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -5165,6 +5165,54 @@ class TestMaybePublishDeliverable:
         assert worker_result["pr_url"] == pr_url
         assert worker_result["pr_number"] == 2124
 
+    def test_skips_harvest_fallback_when_source_branch_has_no_diff(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+            )
+        )
+        issue = _make_issue(number=125)
+        worker_result = {
+            "status": "completed",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/swarm-empty",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(loop, "_list_open_boss_harvest_prs", return_value=[]),
+            patch.object(
+                loop,
+                "_harvest_worker_commits_for_publish",
+                side_effect=RuntimeError("previous cherry-pick is now empty"),
+            ),
+            patch.object(loop, "_publish_branch_has_target_diff", return_value=False),
+            patch("aragora.swarm.tranche_integrate.publish_lane_deliverable") as mock_publish,
+        ):
+            result = loop._maybe_publish_deliverable(issue, worker_result)
+
+        assert result == {
+            "action": "skipped_empty_publish_branch",
+            "published": False,
+            "reason": "harvest_failed_empty_diff",
+            "branch": "codex/swarm-empty",
+            "source_branch": "codex/swarm-empty",
+            "commit_shas": ["abc123"],
+            "harvest_result": {
+                "action": "harvest_failed",
+                "reason": "RuntimeError",
+                "branch": "codex/swarm-empty",
+                "source_branch": "codex/swarm-empty",
+                "commit_shas": ["abc123"],
+                "error": "previous cherry-pick is now empty",
+            },
+        }
+        assert worker_result["harvest_result"]["action"] == "harvest_failed"
+        mock_publish.assert_not_called()
+
 
 class TestPostprocessConvertsToDraft:
     """Verify _postprocess_issue_result calls _convert_pr_to_draft."""
@@ -5245,6 +5293,37 @@ class TestPublishedPrTerminal:
         assert any(pr_url in str(a) for a in actions), (
             f"next_actions should mention PR URL, got {actions}"
         )
+
+    def test_completed_result_is_not_redispatched_in_same_run(self):
+        """A completed result should exhaust retries for the current loop run."""
+        issue = _make_issue(43, "Complete once")
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [issue]
+        dispatch_count = 0
+
+        async def _dispatch(issue, freshness):
+            nonlocal dispatch_count
+            dispatch_count += 1
+            return {"status": "completed"}
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=3,
+                max_retries_per_issue=3,
+                auto_continue_on_needs_human=True,
+                repo=None,
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._dispatch_issue = _dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert dispatch_count == 1
+        completed_numbers = {i.get("number") for i in result.issues_completed}
+        assert 43 in completed_numbers
+        assert loop._issue_attempt_counts[43] == 3
 
     def test_existing_open_pr_skips_dispatch(self):
         """Issue with an existing open boss-harvest PR is skipped in dispatch."""


### PR DESCRIPTION
## Summary
- skip harvest-fallback publishing when the source branch has no verified diff against the target branch
- mark completed boss-loop issues as exhausted for the current run so they are not immediately redispatched
- add regression coverage for the empty-branch publish skip and completed-result redispatch suppression

## Canary finding
During the 2026-04-10 one-host, one-lane boss-loop canary, issue #4297 produced a harvest failure with an empty cherry-pick. The old fallback still published the original worker branch and created draft PR #4514 with no diff against main, then selected #4297 again on the next tick. This PR blocks that failure mode before another canary or overnight run.

## Validation
- `python3 -m pytest tests/swarm/test_boss_loop.py -q -k "skips_harvest_fallback or completed_result_is_not_redispatched" --timeout=30` -> 2 passed
- `python3 -m pytest tests/swarm/test_boss_loop.py -q --timeout=60` -> 180 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Merge gate
Diff is limited to `aragora/swarm/boss_loop.py` and `tests/swarm/test_boss_loop.py`. This does not duplicate another open PR and is required before resuming the broader boss-loop.