### PR TITLE
fix(swarm): scope repair journals by handoff key

### DIFF
--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -1136,12 +1136,14 @@ def _lease_work_order(
     session_key = f"swarm-{run_id[:8]}-{wo_id}"
     metadata = dict(work_order.get("metadata") or {})
     handoff_key = str(metadata.get("handoff_key", "")).strip()
-    persisted_journals = self.store.list_worker_repair_journals(
-        task_id=wo_id,
-        task_key=task_key,
-        handoff_key=handoff_key,
-        work_order_id=wo_id,
-    )
+    journal_lookup: dict[str, str] = {}
+    if handoff_key:
+        journal_lookup["handoff_key"] = handoff_key
+    else:
+        # Work-order ids such as "micro-1" are reused across boss-loop issues;
+        # only fall back to run-scoped keys when no cross-host handoff key exists.
+        journal_lookup["task_key"] = task_key
+    persisted_journals = self.store.list_worker_repair_journals(**journal_lookup)
     if persisted_journals:
         metadata["repair_journal"] = [
             dict(record.get("entry") or {}) for record in persisted_journals if record.get("entry")

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -120,6 +120,82 @@ def test_start_run_creates_leased_work_orders(repo: Path, store: DevCoordination
     assert store.status_summary()["counts"]["active_leases"] == 2
 
 
+def test_lease_work_order_uses_handoff_key_for_repair_journal(
+    repo: Path,
+    store: DevCoordinationStore,
+) -> None:
+    """Repair journals must not leak across issues that reuse micro-1 ids."""
+    session = ManagedWorktreeSession(
+        session_id="swarm-new-micro-1",
+        agent="claude",
+        branch="codex/swarm-new-micro-1",
+        path=repo / "wt-repair",
+        created=True,
+        reconcile_status="up_to_date",
+        payload={},
+    )
+    session.path.mkdir()
+    lifecycle = MagicMock()
+    lifecycle.ensure_managed_worktree.return_value = session
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=lifecycle,
+    )
+
+    store.record_worker_repair_journal(
+        task_id="micro-1",
+        task_key="old-run:micro-1",
+        handoff_key="github-issue:synaptent/aragora:4297:micro-1",
+        work_order_id="micro-1",
+        supervisor_run_id="old-run",
+        lease_id="lease-old",
+        owner_agent="codex",
+        owner_session_id="session-old",
+        branch="codex/old",
+        worktree_path="/tmp/old",
+        entry={"failure_reason": "wrong_issue", "changed_paths": ["aragora/old.py"]},
+    )
+    store.record_worker_repair_journal(
+        task_id="micro-1",
+        task_key="new-run:micro-1",
+        handoff_key="github-issue:synaptent/aragora:4296:micro-1",
+        work_order_id="micro-1",
+        supervisor_run_id="new-run",
+        lease_id="lease-new",
+        owner_agent="claude",
+        owner_session_id="session-new",
+        branch="codex/new",
+        worktree_path="/tmp/new",
+        entry={"failure_reason": "right_issue", "changed_paths": ["aragora/new.py"]},
+    )
+    work_order: dict[str, Any] = {
+        "work_order_id": "micro-1",
+        "title": "Narrow supervisor probes exceptions",
+        "target_agent": "claude",
+        "file_scope": ["aragora/swarm/supervisor_probes.py"],
+        "expected_tests": ["ruff check aragora/swarm/supervisor_probes.py --select BLE001"],
+        "metadata": {
+            "handoff_key": "github-issue:synaptent/aragora:4296:micro-1",
+        },
+    }
+
+    leased = supervisor._lease_work_order(
+        run_id="new-run",
+        target_branch="main",
+        work_order=work_order,
+        work_orders=[work_order],
+        managed_dir_pattern=str(repo / ".worktrees" / "{agent}"),
+        approval_policy=SwarmApprovalPolicy(),
+    )
+
+    assert leased is True
+    repair_journal = work_order["metadata"]["repair_journal"]
+    assert repair_journal == [
+        {"failure_reason": "right_issue", "changed_paths": ["aragora/new.py"]}
+    ]
+
+
 @pytest.mark.asyncio
 async def test_dispatch_workers_reuses_persisted_launcher_profile(
     repo: Path, store: DevCoordinationStore


### PR DESCRIPTION
## Summary
- load persisted repair journals by issue-scoped `handoff_key` when available
- avoid falling back to reusable work-order ids such as `micro-1` when a handoff key exists
- add regression coverage proving #4297-style journals do not leak into #4296-style work orders that reuse `micro-1`

## Canary finding
The second 2026-04-10 one-host, one-lane canary was stopped after the #4296 worker prompt included prior repair-journal notes from the earlier #4297/base.py attempt. The root cause was `_lease_work_order()` querying `list_worker_repair_journals()` with `handoff_key OR work_order_id`, while `work_order_id=micro-1` is reused across boss-loop issues. This PR scopes retrieval to the exact handoff key when present.

## Validation
- `python3 -m pytest tests/swarm/test_supervisor.py::test_lease_work_order_uses_handoff_key_for_repair_journal -q --timeout=30` -> 1 passed
- `python3 -m pytest tests/swarm/test_supervisor.py::test_lease_work_order_uses_handoff_key_for_repair_journal tests/swarm/test_worker_launcher.py::TestBuildPrompt::test_repair_journal_included tests/nomic/test_dev_coordination.py::test_record_worker_repair_journal_lists_by_handoff_key_and_publishes_event -q --timeout=30` -> 3 passed
- `bash scripts/automation_pr_preflight.sh origin/main HEAD` -> ok

## Merge gate
Diff is limited to `aragora/swarm/supervisor_workers.py` and `tests/swarm/test_supervisor.py`. This is required before rerunning the canary because the current shared coordination DB already contains cross-issue repair journals.