### PR TITLE
fix(swarm): allow publish fallback with unverified target refs

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -2279,29 +2279,29 @@ class BossLoop:
                         repo_root=repo_root,
                         branch=branch,
                     )
-                    if branch_has_diff is not True:
-                        reason = (
-                            "harvest_failed_empty_diff"
-                            if branch_has_diff is False
-                            else "harvest_failed_unverified_diff"
-                        )
+                    if branch_has_diff is False:
                         logger.warning(
                             "Boss publish skipped for issue #%s branch %s: %s",
                             issue.number,
                             branch,
-                            reason,
+                            "harvest_failed_empty_diff",
                         )
                         return {
-                            "action": "skipped_empty_publish_branch"
-                            if branch_has_diff is False
-                            else "skipped_unverified_publish_branch",
+                            "action": "skipped_empty_publish_branch",
                             "published": False,
-                            "reason": reason,
+                            "reason": "harvest_failed_empty_diff",
                             "branch": branch,
                             "source_branch": branch,
                             "commit_shas": commit_shas,
                             "harvest_result": dict(harvest_result),
                         }
+                    if branch_has_diff is None:
+                        logger.warning(
+                            "Boss publish fallback could not verify diff for issue #%s branch %s; "
+                            "continuing branch publish",
+                            issue.number,
+                            branch,
+                        )
             artifact = _BossDeliverableArtifact(
                 branch=branch,
                 metadata={

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -5213,6 +5213,51 @@ class TestMaybePublishDeliverable:
         assert worker_result["harvest_result"]["action"] == "harvest_failed"
         mock_publish.assert_not_called()
 
+    def test_harvest_fallback_publishes_when_branch_diff_unverified(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+                target_branch="release/2026.04",
+            )
+        )
+        issue = _make_issue(number=126)
+        worker_result = {
+            "status": "needs_human",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/swarm-valid",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(loop, "_list_open_boss_harvest_prs", return_value=[]),
+            patch.object(
+                loop,
+                "_harvest_worker_commits_for_publish",
+                side_effect=RuntimeError("fatal: invalid reference: release/2026.04"),
+            ),
+            patch.object(loop, "_publish_branch_has_target_diff", return_value=None),
+            patch(
+                "aragora.swarm.tranche_integrate.publish_lane_deliverable",
+                return_value={
+                    "published": True,
+                    "branch": "codex/swarm-valid",
+                    "pr_url": "https://github.com/synaptent/aragora/pull/2126",
+                },
+            ) as mock_publish,
+            patch("aragora.swarm.pr_registry.PullRequestRegistry"),
+        ):
+            result = loop._maybe_publish_deliverable(issue, worker_result)
+
+        assert result is not None
+        assert result["published"] is True
+        assert result["pr_url"] == "https://github.com/synaptent/aragora/pull/2126"
+        assert worker_result["harvest_result"]["action"] == "harvest_failed"
+        assert mock_publish.call_args.kwargs["target_branch"] == "release/2026.04"
+        assert mock_publish.call_args.args[0].branch == "codex/swarm-valid"
+
 
 class TestPostprocessConvertsToDraft:
     """Verify _postprocess_issue_result calls _convert_pr_to_draft."""


### PR DESCRIPTION
## Summary
- Fixes the boss-loop auto-publish fallback so a harvest failure with an unverified local target-branch diff does not suppress branch-to-PR publication.
- Keeps the #4517 guard intact for verified empty source branches by only blocking when `_publish_branch_has_target_diff(...)` returns `False`.
- Adds a regression test proving `None` diff verification still reaches `publish_lane_deliverable` while the existing empty-diff skip remains covered.

## Handoff Source
- founder-triage automation 2026-04-10T18:18:37Z
- Reproduced on current main after #4519/#4520: `tests/swarm/test_boss_loop_autonomy.py::test_auto_publish_promotes_branch_deliverable_to_pr_metadata` failed with `harvest_failed_unverified_diff` before this patch.

## Validation
- `python3 -m pytest tests/swarm/test_boss_loop_autonomy.py::test_auto_publish_promotes_branch_deliverable_to_pr_metadata tests/swarm/test_boss_loop.py::TestMaybePublishDeliverable::test_skips_harvest_fallback_when_source_branch_has_no_diff tests/swarm/test_boss_loop.py::TestMaybePublishDeliverable::test_harvest_fallback_publishes_when_branch_diff_unverified -q --timeout=30`
- `python3 -m pytest tests/swarm/test_boss_loop_autonomy.py tests/swarm/test_boss_loop_receipts.py -q --timeout=60`
- `python3 -m pytest tests/swarm/test_boss_loop.py -q --timeout=60`
- `python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `python3 -m ruff format --check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
