### PR TITLE
fix(swarm): keep publish fallback on unverified targets

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -2279,12 +2279,8 @@ class BossLoop:
                         repo_root=repo_root,
                         branch=branch,
                     )
-                    if branch_has_diff is not True:
-                        reason = (
-                            "harvest_failed_empty_diff"
-                            if branch_has_diff is False
-                            else "harvest_failed_unverified_diff"
-                        )
+                    if branch_has_diff is False:
+                        reason = "harvest_failed_empty_diff"
                         logger.warning(
                             "Boss publish skipped for issue #%s branch %s: %s",
                             issue.number,
@@ -2292,9 +2288,7 @@ class BossLoop:
                             reason,
                         )
                         return {
-                            "action": "skipped_empty_publish_branch"
-                            if branch_has_diff is False
-                            else "skipped_unverified_publish_branch",
+                            "action": "skipped_empty_publish_branch",
                             "published": False,
                             "reason": reason,
                             "branch": branch,
@@ -2302,6 +2296,14 @@ class BossLoop:
                             "commit_shas": commit_shas,
                             "harvest_result": dict(harvest_result),
                         }
+                    if branch_has_diff is None:
+                        harvest_result["diff_verification"] = "unverified"
+                        logger.warning(
+                            "Boss publish diff verification inconclusive for issue #%s branch %s; "
+                            "continuing original-branch publish after harvest failure",
+                            issue.number,
+                            branch,
+                        )
             artifact = _BossDeliverableArtifact(
                 branch=branch,
                 metadata={


### PR DESCRIPTION
## Summary
- Keep boss-loop branch deliverable auto-publish moving when harvest fallback cannot verify the configured target branch locally.
- Preserve the empty-diff guard for the proven empty case, and record `diff_verification: unverified` when the check is inconclusive.

## Why
The latest `origin/main` regressed `tests/swarm/test_boss_loop_autonomy.py::test_auto_publish_promotes_branch_deliverable_to_pr_metadata`: a missing `release/2026.04` local ref made the fallback classify a valid branch deliverable as `skipped_unverified_publish_branch` before normal publish handling could run.

## Validation
- `python3 -m pytest tests/swarm/test_boss_loop_autonomy.py::test_auto_publish_promotes_branch_deliverable_to_pr_metadata -q -o cache_dir=/tmp/pytest-cache-boss-publish-prefail-20260410` failed before the fix.
- `python3 -m pytest tests/swarm/test_boss_loop_autonomy.py::test_auto_publish_promotes_branch_deliverable_to_pr_metadata -q -o cache_dir=/tmp/pytest-cache-boss-publish-postsingle-20260410`
- `python3 -m pytest tests/swarm/test_boss_loop_autonomy.py tests/swarm/test_boss_loop_receipts.py -q -o cache_dir=/tmp/pytest-cache-boss-publish-autonomy-receipts-20260410`
- `python3 -m pytest tests/swarm/test_boss_loop.py -q -o cache_dir=/tmp/pytest-cache-boss-publish-loop-full-20260410`
- `python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop_autonomy.py tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py`
- `python3 -m ruff format --check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop_autonomy.py tests/swarm/test_boss_loop.py tests/swarm/test_boss_loop_receipts.py`
- `git diff --check`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
