### PR TITLE
fix: narrow broad except Exception in campaign.py

### DIFF
--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.agents.base import create_agent
-from aragora.agents.errors import CLISubprocessError
+from aragora.agents.errors import AgentConnectionError, CLISubprocessError
 from aragora.nomic.pipeline_bridge import NomicPipelineBridge
 from aragora.swarm.lane_telemetry import LaneTelemetryCollector, LaneTelemetryRecord
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
@@ -1099,7 +1099,14 @@ class CampaignReviewer:
                 reviewed_at=_now_iso(),
                 raw_review={"error": type(exc).__name__, "detail": str(exc)[:500]},
             )
-        except (RuntimeError, ValueError, OSError, KeyError, TypeError) as exc:
+        except (
+            AgentConnectionError,
+            RuntimeError,
+            ValueError,
+            OSError,
+            KeyError,
+            TypeError,
+        ) as exc:
             return CampaignReviewGate(
                 required=True,
                 review_model=chosen_review_model,

--- a/aragora/swarm/campaign.py
+++ b/aragora/swarm/campaign.py
@@ -767,7 +767,7 @@ class CampaignPlanner:
                     acceptance_criteria=base_spec.acceptance_criteria,
                     constraints=base_spec.constraints,
                 )
-            except Exception as exc:
+            except (RuntimeError, ValueError, OSError, KeyError, json.JSONDecodeError) as exc:
                 self._planner_fallbacks.append(
                     f"planner fallback to heuristic for source item {source_index}: "
                     f"{type(exc).__name__}: {exc}"
@@ -911,7 +911,7 @@ class CampaignPlanner:
                 response = asyncio.run(agent.generate(json.dumps(prompt, sort_keys=True)))
                 for finding in _extract_json_list(response):
                     findings.append(f"crosscheck: {finding}")
-            except Exception as exc:
+            except (RuntimeError, ValueError, OSError, KeyError, json.JSONDecodeError) as exc:
                 logger.debug("campaign_crosscheck_fallback: %s", exc)
         return findings
 
@@ -1099,7 +1099,7 @@ class CampaignReviewer:
                 reviewed_at=_now_iso(),
                 raw_review={"error": type(exc).__name__, "detail": str(exc)[:500]},
             )
-        except Exception as exc:
+        except (RuntimeError, ValueError, OSError, KeyError, TypeError) as exc:
             return CampaignReviewGate(
                 required=True,
                 review_model=chosen_review_model,
@@ -1940,7 +1940,7 @@ class CampaignExecutor:
                 acceptance_criteria=spec.acceptance_criteria,
                 constraints=spec.constraints,
             )
-        except Exception as exc:
+        except (RuntimeError, ValueError, OSError, KeyError, json.JSONDecodeError) as exc:
             planner_metadata["planner_strategy_used"] = "heuristic"
             planner_metadata["planner_fallback_reason"] = f"{type(exc).__name__}: {exc}"[:500]
             decomposition = self.decomposer.analyze(
@@ -2136,7 +2136,7 @@ class CampaignExecutor:
         supervisor = SwarmSupervisor(repo_root=self.repo_root)
         try:
             return supervisor.refresh_run(run_id).to_dict()
-        except Exception:
+        except (RuntimeError, ValueError, KeyError, OSError, TypeError):
             record = supervisor.store.get_supervisor_run(run_id)
             return dict(record) if isinstance(record, dict) else None
 
@@ -2287,7 +2287,7 @@ class CampaignExecutor:
                         },
                     )
                 )
-            except Exception:
+            except (RuntimeError, ValueError, TypeError, OSError, KeyError):
                 logger.debug("Campaign lane telemetry emission skipped", exc_info=True)
             logger.info(
                 "receipt_emitted: project=%s status=%s path=%s",
@@ -2297,7 +2297,7 @@ class CampaignExecutor:
             )
             return receipt_path
 
-        except Exception as exc:
+        except (RuntimeError, ValueError, TypeError, OSError, KeyError) as exc:
             logger.error(
                 "receipt_emit_failed: project=%s status=%s error=%s",
                 project.project_id,


### PR DESCRIPTION
## Summary
- Narrows broad `except Exception` handlers in `aragora/swarm/campaign.py` to specific exception tuples.
- Preserves the campaign reviewer `AgentConnectionError` handling path after local validation caught that regression in the generated PR.

## Validation
- `python3 -m ruff check aragora/swarm/campaign.py --select BLE001,F401`
- `python3 -m pytest tests/swarm/test_campaign_reviewer_diff.py::TestReviewerBillingErrorDetection::test_agent_connection_error_keeps_detail_in_raw_review tests/swarm/test_campaign.py tests/swarm/test_campaign_reviewer_diff.py tests/swarm/test_campaign_budget_enforcement.py -q --timeout=60`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Closes #4293.
