### PR TITLE
fix: update streaming.py

### DIFF
--- a/aragora/agents/streaming.py
+++ b/aragora/agents/streaming.py
@@ -105,6 +105,8 @@ class StreamingMixin:
 
                 try:
                     event = json.loads(data_str)
+                    if not isinstance(event, dict):
+                        continue
                     content = self._extract_content_from_event(event, format_type)
                     if content:
                         yield content


### PR DESCRIPTION
Closes #4314.

## Summary
- add a focused streaming test module with 10 async tests for SSE chunk parsing, partial packet assembly, malformed events, buffer limits, and unknown formats
- keep the branch's non-dict JSON guard in `aragora/agents/streaming.py` and cover it with a regression test

## Validation
- `python3 -m pytest tests/agents/test_streaming.py -q --timeout=60`
- `python3 -m pytest tests/agents/api_agents/test_common.py -q --timeout=60`
- `python3 -m ruff check aragora/agents/streaming.py tests/agents/test_streaming.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
