### PR TITLE
fix: update interrogator.py

### DIFF
--- a/aragora/swarm/interrogator.py
+++ b/aragora/swarm/interrogator.py
@@ -139,7 +139,7 @@ class SwarmInterrogator:
                     prompt=prompt,
                 )
                 response = result.raw_output if hasattr(result, "raw_output") else str(result)
-            except (OSError, RuntimeError, TypeError, ValueError):
+            except Exception:  # noqa: BLE001 - any harness/LLM failure must fall back to fixed questions
                 logger.warning("Claude interrogation failed, using fixed questions")
                 remaining = FALLBACK_QUESTIONS[turn:]
                 for q in remaining:
@@ -210,7 +210,7 @@ class SwarmInterrogator:
                 )
                 raw = result.raw_output if hasattr(result, "raw_output") else str(result)
                 spec_data = self._parse_json_from_response(raw)
-            except (OSError, RuntimeError, TypeError, ValueError):
+            except Exception:  # noqa: BLE001 - heuristic extraction is the safety net for any LLM failure
                 logger.warning("LLM spec extraction failed, using heuristic")
 
         if spec_data is None:
@@ -329,7 +329,7 @@ class SwarmInterrogator:
                     "estimated_complexity": "medium",
                     "requires_approval": False,
                 }
-        except (AttributeError, ImportError, OSError, RuntimeError, TypeError, ValueError):
+        except Exception:  # noqa: BLE001 - classifier inference is best effort before keyword fallback
             logger.debug("LLM spec inference failed, using keyword fallback", exc_info=True)
 
         # --- keyword fallback ---
@@ -373,7 +373,7 @@ class SwarmInterrogator:
             if await harness.initialize():
                 self._harness = harness
                 return harness
-        except (ImportError, OSError, RuntimeError, TypeError, ValueError):
+        except Exception:  # noqa: BLE001 - optional harness setup should fail closed to fallback mode
             pass
         return None
 

--- a/aragora/swarm/interrogator.py
+++ b/aragora/swarm/interrogator.py
@@ -139,7 +139,7 @@ class SwarmInterrogator:
                     prompt=prompt,
                 )
                 response = result.raw_output if hasattr(result, "raw_output") else str(result)
-            except Exception:
+            except (OSError, RuntimeError, TypeError, ValueError):
                 logger.warning("Claude interrogation failed, using fixed questions")
                 remaining = FALLBACK_QUESTIONS[turn:]
                 for q in remaining:
@@ -210,7 +210,7 @@ class SwarmInterrogator:
                 )
                 raw = result.raw_output if hasattr(result, "raw_output") else str(result)
                 spec_data = self._parse_json_from_response(raw)
-            except Exception:
+            except (OSError, RuntimeError, TypeError, ValueError):
                 logger.warning("LLM spec extraction failed, using heuristic")
 
         if spec_data is None:
@@ -329,7 +329,7 @@ class SwarmInterrogator:
                     "estimated_complexity": "medium",
                     "requires_approval": False,
                 }
-        except Exception:
+        except (AttributeError, ImportError, OSError, RuntimeError, TypeError, ValueError):
             logger.debug("LLM spec inference failed, using keyword fallback", exc_info=True)
 
         # --- keyword fallback ---
@@ -373,7 +373,7 @@ class SwarmInterrogator:
             if await harness.initialize():
                 self._harness = harness
                 return harness
-        except (ImportError, Exception):
+        except (ImportError, OSError, RuntimeError, TypeError, ValueError):
             pass
         return None
 


### PR DESCRIPTION
Closes #4292.

## Summary
- keep the interrogator's LLM and harness fallback boundaries intentionally broad, but annotate them with explicit `# noqa: BLE001` reasons
- preserve the existing behavior: if the harness, LLM call, classifier inference, or harness setup fails, the interrogator must still fall back and keep gathering enough context to proceed

## Validation
- `python3 -m ruff check aragora/swarm/interrogator.py --select BLE001`
- `python3 -m pytest tests/swarm/test_interrogator.py -q --timeout=60`
