### PR TITLE
fix: update outcome_signals.py

### DIFF
--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -126,7 +126,7 @@ class OutcomeSignalBus:
         for handler in handlers:
             try:
                 handler(signal)
-            except Exception as exc:
+            except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
                 logger.debug("Signal handler failed: %s", exc)
 
     def subscribe(self, key: str, handler: SignalHandler) -> None:
@@ -162,7 +162,14 @@ class OutcomeSignalBus:
                         **{k: v for k, v in data.items() if k in OutcomeSignal.__dataclass_fields__}
                     )
                 )
-            except Exception:
+            except (
+                AttributeError,
+                json.JSONDecodeError,
+                OSError,
+                OverflowError,
+                TypeError,
+                ValueError,
+            ):
                 continue
         return list(reversed(signals))
 

--- a/aragora/swarm/outcome_signals.py
+++ b/aragora/swarm/outcome_signals.py
@@ -126,7 +126,7 @@ class OutcomeSignalBus:
         for handler in handlers:
             try:
                 handler(signal)
-            except (AttributeError, KeyError, OSError, RuntimeError, TypeError, ValueError) as exc:
+            except Exception as exc:  # noqa: BLE001 - subscriber callbacks are external and must not break the bus
                 logger.debug("Signal handler failed: %s", exc)
 
     def subscribe(self, key: str, handler: SignalHandler) -> None:


### PR DESCRIPTION
Closes #4291.

## Summary
- keep `OutcomeSignalBus.emit()` resilient to arbitrary subscriber failures by using an explicitly justified broad catch on callback execution
- keep the narrowed parsing exceptions in `recent()` so malformed log entries are skipped without hiding unrelated runtime behavior

## Validation
- `python3 -m ruff check aragora/swarm/outcome_signals.py --select BLE001`
- `python3 -m pytest tests/swarm/test_outcome_signals.py -q --timeout=60`
