### PR TITLE
fix(oauth): preserve required callback validation

### DIFF
--- a/aragora/server/handlers/_oauth/account.py
+++ b/aragora/server/handlers/_oauth/account.py
@@ -152,12 +152,16 @@ class AccountManagementMixin:
         code = body.get("code")
         state = body.get("state")
 
+        if any(
+            value is None or (isinstance(value, str) and not value)
+            for value in (provider, code, state)
+        ):
+            return error_response("provider, code, and state are required", 400)
+
         if not all(isinstance(value, str) for value in (provider, code, state)):
             return error_response("provider, code, and state must be strings", 400)
 
         provider = provider.lower()
-        if not provider or not code or not state:
-            return error_response("provider, code, and state are required", 400)
 
         callback_map = {
             "google": self._handle_google_callback,

--- a/tests/handlers/_oauth/test_account.py
+++ b/tests/handlers/_oauth/test_account.py
@@ -389,6 +389,22 @@ class TestHandleOAuthCallbackApi:
         result = host._handle_oauth_callback_api(handler)
         assert _status(result) == 400
 
+    @pytest.mark.parametrize(
+        ("body", "field_name"),
+        [
+            ({"provider": 123, "code": "abc", "state": "xyz"}, "provider"),
+            ({"provider": "google", "code": 123, "state": "xyz"}, "code"),
+            ({"provider": "google", "code": "abc", "state": {"value": "xyz"}}, "state"),
+        ],
+    )
+    def test_non_string_callback_fields_return_400(self, host, handler, body, field_name):
+        host.read_json_body.return_value = body
+        result = host._handle_oauth_callback_api(handler)
+        assert _status(result) == 400
+        error = _body(result)["error"].lower()
+        assert "strings" in error
+        assert field_name in error
+
     def test_unsupported_provider_returns_400(self, host, handler):
         host.read_json_body.return_value = {"provider": "facebook", "code": "abc", "state": "xyz"}
         result = host._handle_oauth_callback_api(handler)


### PR DESCRIPTION
## Summary
- preserve the existing OAuth callback API contract for missing `provider`, `code`, or `state` fields by returning the required-fields error before type validation
- keep the stricter non-string validation for callback payloads once all required fields are present
- add focused regression coverage for non-string callback fields in the OAuth account handler tests

## Validation
- `python3 -m pytest tests/handlers/_oauth/test_account.py::TestHandleOAuthCallbackApi -q -o cache_dir=/tmp/pytest-cache-oauth-callback-api-class-20260410`
- `python3 -m pytest tests/handlers/_oauth/test_account.py -q -o cache_dir=/tmp/pytest-cache-oauth-account-full-20260410`
- `python3 -m ruff check aragora/server/handlers/_oauth/account.py tests/handlers/_oauth/test_account.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
