### PR TITLE
fix: narrow broad except Exception in pr_registry.py

### DIFF
--- a/aragora/swarm/pr_registry.py
+++ b/aragora/swarm/pr_registry.py
@@ -53,7 +53,7 @@ class PullRequestRegistry:
                 for branch, raw in data.items():
                     if isinstance(raw, dict):
                         self._entries[branch] = PREntry(**raw)
-            except Exception:
+            except (OSError, yaml.YAMLError, TypeError, KeyError):
                 logger.warning("Failed to load PR registry from %s", self._file)
 
     def _save(self) -> None:


### PR DESCRIPTION
Replace bare 'except Exception' with specific types (OSError,
yaml.YAMLError, TypeError, KeyError) matching what the try block
can actually raise. No behavior change.

Refs: #4289
(cherry picked from commit e3fa409404dd66baa1e68726f4101f340bd4f3bb)
