### PR TITLE
fix: update outcome_feedback.py

### DIFF
--- a/aragora/pipeline/outcome_feedback.py
+++ b/aragora/pipeline/outcome_feedback.py
@@ -14,6 +14,15 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+BRIDGE_RECORDING_ERRORS = (
+    AttributeError,
+    KeyError,
+    OSError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+)
+
 
 @dataclass
 class AgentContribution:
@@ -165,7 +174,7 @@ class OutcomeFeedbackRecorder:
         if self._km is not None:
             try:
                 self._km.ingest(outcome.to_dict())
-            except Exception:
+            except BRIDGE_RECORDING_ERRORS:
                 logger.warning("Failed to ingest outcome to KM: %s", outcome.pipeline_id)
 
         # Bridge to ELO
@@ -179,7 +188,7 @@ class OutcomeFeedbackRecorder:
         if self._calibrator is not None:
             try:
                 self._calibrator.record_pipeline_outcome(outcome)
-            except Exception:
+            except BRIDGE_RECORDING_ERRORS:
                 logger.warning("Failed to update calibrator: %s", outcome.pipeline_id)
 
     def get_recent_outcomes(

--- a/aragora/pipeline/outcome_feedback.py
+++ b/aragora/pipeline/outcome_feedback.py
@@ -14,15 +14,6 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-BRIDGE_RECORDING_ERRORS = (
-    AttributeError,
-    KeyError,
-    OSError,
-    RuntimeError,
-    TypeError,
-    ValueError,
-)
-
 
 @dataclass
 class AgentContribution:
@@ -174,7 +165,7 @@ class OutcomeFeedbackRecorder:
         if self._km is not None:
             try:
                 self._km.ingest(outcome.to_dict())
-            except BRIDGE_RECORDING_ERRORS:
+            except Exception:  # noqa: BLE001 - injected bridge implementations must not break feedback recording
                 logger.warning("Failed to ingest outcome to KM: %s", outcome.pipeline_id)
 
         # Bridge to ELO
@@ -188,7 +179,7 @@ class OutcomeFeedbackRecorder:
         if self._calibrator is not None:
             try:
                 self._calibrator.record_pipeline_outcome(outcome)
-            except BRIDGE_RECORDING_ERRORS:
+            except Exception:  # noqa: BLE001 - injected bridge implementations must not break feedback recording
                 logger.warning("Failed to update calibrator: %s", outcome.pipeline_id)
 
     def get_recent_outcomes(

--- a/tests/pipeline/test_outcome_feedback.py
+++ b/tests/pipeline/test_outcome_feedback.py
@@ -35,6 +35,10 @@ def make_outcome(**kwargs) -> PipelineOutcome:
     return PipelineOutcome(**defaults)
 
 
+class BridgeFailure(Exception):
+    pass
+
+
 class TestRecording:
     def test_record_basic(self, recorder):
         recorder.record(make_outcome())
@@ -138,6 +142,13 @@ class TestKMIntegration:
         recorder.record(make_outcome())
         assert len(recorder._outcomes) == 1
 
+    def test_km_custom_failure_graceful(self):
+        km = MagicMock()
+        km.ingest.side_effect = BridgeFailure("custom fail")
+        recorder = OutcomeFeedbackRecorder(knowledge_mound=km)
+        recorder.record(make_outcome())
+        assert len(recorder._outcomes) == 1
+
 
 class TestELOIntegration:
     def test_elo_high_influence(self):
@@ -170,6 +181,15 @@ class TestELOIntegration:
             )
         )
         elo.update_domain_elo.assert_called_with("gpt4", "technical:execution", won=False)
+
+
+class TestCalibratorIntegration:
+    def test_calibrator_failure_graceful(self):
+        calibrator = MagicMock()
+        calibrator.record_pipeline_outcome.side_effect = BridgeFailure("custom fail")
+        recorder = OutcomeFeedbackRecorder(calibrator=calibrator)
+        recorder.record(make_outcome())
+        assert len(recorder._outcomes) == 1
 
 
 class TestSerialization:


### PR DESCRIPTION
Keep the collaborator bridge boundaries intentionally broad in `OutcomeFeedbackRecorder`.

The `knowledge_mound` and `calibrator` hooks are injected bridge implementations, so feedback recording should isolate any exception they raise instead of assuming a closed set of concrete types. This updates the canary-generated patch to use explicit `# noqa: BLE001` waivers at those boundaries and adds regression coverage for custom bridge exception types.

Refs: #4288

Validation:
- `python3 -m ruff check aragora/pipeline/outcome_feedback.py tests/pipeline/test_outcome_feedback.py --select BLE001`
- `python3 -m pytest tests/pipeline/test_outcome_feedback.py -q --timeout=60`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
