### PR TITLE
fix: update imessage.py

### DIFF
--- a/aragora/connectors/chat/imessage.py
+++ b/aragora/connectors/chat/imessage.py
@@ -209,7 +209,7 @@ class IMessageConnector(ChatPlatformConnector):
                 )
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(f"Failed to send iMessage to chat {channel_id}") from e
 
     async def update_message(
         self,
@@ -305,7 +305,9 @@ class IMessageConnector(ChatPlatformConnector):
                 )
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(
+                f"Failed to upload iMessage attachment {filename!r} to chat {channel_id}"
+            ) from e
 
     async def download_file(
         self,
@@ -346,7 +348,7 @@ class IMessageConnector(ChatPlatformConnector):
                 )
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(f"Failed to download iMessage attachment {file_id}") from e
 
     async def send_typing_indicator(
         self,
@@ -436,7 +438,9 @@ class IMessageConnector(ChatPlatformConnector):
                     return False
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(
+                f"Failed to send iMessage tapback {tapback_type!r} for message {message_id}"
+            ) from e
 
     async def mark_read(
         self,
@@ -730,7 +734,7 @@ class IMessageConnector(ChatPlatformConnector):
                 )
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(f"Failed to get iMessage chat info for {channel_id}") from e
 
     async def get_user_info(
         self,
@@ -908,7 +912,7 @@ class IMessageConnector(ChatPlatformConnector):
                 return data.get("data", [])
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError("Failed to list iMessage chats") from e
 
     async def get_messages(
         self,
@@ -952,7 +956,7 @@ class IMessageConnector(ChatPlatformConnector):
                 return messages
         except (httpx.HTTPError, OSError) as e:
             self._record_failure(e)
-            raise
+            raise RuntimeError(f"Failed to get iMessage messages for chat {channel_id}") from e
 
 
 __all__ = ["IMessageConnector"]

--- a/tests/connectors/chat/test_imessage_connector.py
+++ b/tests/connectors/chat/test_imessage_connector.py
@@ -8,6 +8,7 @@ Tests cover:
 """
 
 import pytest
+import httpx
 from unittest.mock import AsyncMock, MagicMock, patch
 from datetime import datetime
 
@@ -115,6 +116,23 @@ class TestIMessageConnectorMessages:
             )
 
             assert result.success is False
+
+    @pytest.mark.asyncio
+    async def test_send_message_raises_contextual_runtime_error(self, connector):
+        """Test send_message preserves cause while adding chat context."""
+        with patch("httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__.return_value.post = AsyncMock(
+                side_effect=httpx.ConnectError("boom")
+            )
+
+            with pytest.raises(RuntimeError) as exc_info:
+                await connector.send_message(
+                    channel_id="+1234567890",
+                    text="Hello!",
+                )
+
+            assert "+1234567890" in str(exc_info.value)
+            assert isinstance(exc_info.value.__cause__, httpx.ConnectError)
 
     @pytest.mark.asyncio
     async def test_update_message_not_supported(self, connector):


### PR DESCRIPTION
Replace the remaining bare re-raises in the iMessage connector with contextual runtime errors.

This preserves exception chaining while adding operation-specific context for iMessage failures such as sending messages, uploading attachments, downloading attachments, sending tapbacks, and listing chats. It also adds a focused regression test proving `send_message()` now raises a contextual `RuntimeError` with the original `httpx` exception preserved as `__cause__`.

Refs: #4302

Validation:
- `python3 -m pytest tests/connectors/chat/test_imessage_connector.py -q --timeout=60`
- `python3 -c "import ast; ast.parse(open('aragora/connectors/chat/imessage.py').read()); print('OK')"`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
