### PR TITLE
fix(swarm): block file_scope path escapes

### DIFF
--- a/aragora/swarm/supervisor_probes.py
+++ b/aragora/swarm/supervisor_probes.py
@@ -1460,10 +1460,21 @@ def _validate_file_scope(file_scope: list[str], worktree_path: str) -> list[str]
     dot_git = wt / ".git"
     if not dot_git.exists():
         return file_scope
+    wt_root = wt.resolve()
     valid: list[str] = []
     for scope_path in file_scope:
         clean = scope_path.removeprefix("./").strip()
         if not clean:
+            continue
+        try:
+            resolved = (wt_root / clean).resolve(strict=False)
+            resolved.relative_to(wt_root)
+        except ValueError:
+            logger.warning(
+                "Dropping out-of-worktree file_scope entry %r for %s",
+                scope_path,
+                worktree_path,
+            )
             continue
         root = clean.split("/")[0]
         if (wt / root).exists():

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -72,6 +72,18 @@ def _strip_github_tokens(env: dict[str, str]) -> None:
         env.pop(key, None)
 
 
+def _resolve_in_worktree(worktree_root: Path, raw_path: str) -> tuple[str, Path] | None:
+    clean = str(raw_path).removeprefix("./").strip()
+    if not clean:
+        return None
+    resolved = (worktree_root / clean).resolve(strict=False)
+    try:
+        relative = resolved.relative_to(worktree_root)
+    except ValueError:
+        return None
+    return relative.as_posix(), resolved
+
+
 class WorkerLauncher:
     """Launch and monitor Claude Code / Codex worker processes."""
 
@@ -859,10 +871,18 @@ class WorkerLauncher:
             return work_order
 
         context_snippets: list[str] = []
-        wt = Path(worktree_path)
+        wt = Path(worktree_path).resolve()
 
         for file_path in file_scope[:5]:  # Cap at 5 files
-            full_path = wt / file_path
+            resolved = _resolve_in_worktree(wt, file_path)
+            if resolved is None:
+                logger.warning(
+                    "Skipping out-of-worktree context path %r for %s",
+                    file_path,
+                    worktree_path,
+                )
+                continue
+            display_path, full_path = resolved
             if not full_path.exists():
                 continue
             try:
@@ -872,11 +892,11 @@ class WorkerLauncher:
                 if len(lines) > 200:
                     snippet = "\n".join(lines[:200])
                     context_snippets.append(
-                        f"--- {file_path} (first 200 of {len(lines)} lines) ---\n{snippet}\n--- end ---"
+                        f"--- {display_path} (first 200 of {len(lines)} lines) ---\n{snippet}\n--- end ---"
                     )
                 else:
                     context_snippets.append(
-                        f"--- {file_path} ({len(lines)} lines) ---\n{content}\n--- end ---"
+                        f"--- {display_path} ({len(lines)} lines) ---\n{content}\n--- end ---"
                     )
 
                 # Find key symbols (functions/classes) and their callers
@@ -891,7 +911,7 @@ class WorkerLauncher:
                             timeout=5,
                         )
                         callers = [
-                            f for f in result.stdout.strip().splitlines()[:5] if f != file_path
+                            f for f in result.stdout.strip().splitlines()[:5] if f != display_path
                         ]
                         if callers:
                             context_snippets.append(

--- a/tests/swarm/test_file_scope_enforcement.py
+++ b/tests/swarm/test_file_scope_enforcement.py
@@ -284,6 +284,17 @@ class TestValidateFileScope:
         scope = ["aragora/swarm/supervisor.py", "tests/swarm/test_supervisor.py"]
         assert SwarmSupervisor._validate_file_scope(scope, str(wt)) == scope
 
+    def test_parent_traversal_is_stripped(self, tmp_path: Path) -> None:
+        wt = tmp_path / "worktree"
+        wt.mkdir()
+        (wt / ".git").write_text("gitdir: /tmp/fake\n")
+        (wt / "aragora").mkdir()
+
+        scope = ["../outside.txt", "aragora/swarm/supervisor.py"]
+        assert SwarmSupervisor._validate_file_scope(scope, str(wt)) == [
+            "aragora/swarm/supervisor.py"
+        ]
+
     def test_no_git_dir_skips_validation(self, tmp_path: Path) -> None:
         """Directories without .git (e.g. test fixtures) skip validation."""
         wt = tmp_path / "worktree"

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -206,6 +206,25 @@ class TestBuildPrompt:
         assert "stop and report that blocker" in prompt
 
 
+class TestEnrichTaskContext:
+    def test_skips_paths_outside_worktree(self, tmp_path: Path) -> None:
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        (worktree / "inside.py").write_text("def inside():\n    return 1\n", encoding="utf-8")
+        outside = tmp_path / "outside.py"
+        outside.write_text("TOP_SECRET = 'nope'\n", encoding="utf-8")
+
+        enriched = WorkerLauncher._enrich_task_context(
+            {"task": "demo", "file_scope": ["../outside.py", "inside.py"]},
+            str(worktree),
+        )
+
+        context = enriched.get("_enriched_context", "")
+        assert "TOP_SECRET" not in context
+        assert "inside.py" in context
+        assert "def inside" in context
+
+
 class TestBuildCommand:
     def test_claude_command(self, monkeypatch):
         monkeypatch.setattr("aragora.swarm.worker_launcher.os.geteuid", lambda: 501)


### PR DESCRIPTION
## Summary
- reject out-of-worktree file_scope entries before worker dispatch
- skip out-of-worktree context reads inside worker prompt enrichment as a defense-in-depth guard
- add focused regression coverage for traversal stripping and context enrichment

## Validation
- python3 -m pytest tests/swarm/test_file_scope_enforcement.py -q -k 'TestValidateFileScope' -o cache_dir=/tmp/pytest-cache-file-scope-validate-class-20260410
- python3 -m pytest tests/swarm/test_file_scope_enforcement.py -q -k 'not TestWorkerPromptScopeLanguage' -o cache_dir=/tmp/pytest-cache-file-scope-enforcement-20260410-skip-prompt
- python3 -m pytest tests/swarm/test_worker_launcher.py -q -o cache_dir=/tmp/pytest-cache-worker-launcher-file-scope-20260410
- ruff check aragora/swarm/supervisor_probes.py aragora/swarm/worker_launcher.py tests/swarm/test_file_scope_enforcement.py tests/swarm/test_worker_launcher.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD

## Notes
- tests/swarm/test_file_scope_enforcement.py::TestWorkerPromptScopeLanguage::test_prompt_includes_mandatory_scope_when_file_scope_set is already stale against current origin/main prompt text and was left untouched in this bounded security fix.