### PR TITLE
feat(swarm): prompt-version instrumentation for A/B canary

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -867,14 +867,42 @@ class BossLoop:
             files_changed, tests_run, tests_passed = self._extract_iteration_metrics(worker_result)
             metrics_path = Path(metrics_path_text)
             metrics_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Extract prompt/context instrumentation from worker result
+            run_dict = worker_result.get("run")
+            prompt_context_chars = 0
+            prompt_version = "v2"  # Context-first prompt (post a11848eac)
+            is_decomposed = bool(
+                re.search(
+                    r"\[from #\d+\]",
+                    str(worker_result.get("receipt_metadata", {}).get("issue_title", "")),
+                )
+            )
+            worker_outcome = str(worker_result.get("outcome", "")).strip()
+            has_deliverable = bool(worker_result.get("deliverable"))
+            publish_action = (
+                str((worker_result.get("publish_result") or {}).get("action", "")).strip() or None
+            )
+
+            if isinstance(run_dict, dict):
+                for wo in run_dict.get("work_orders", []):
+                    if isinstance(wo, dict):
+                        prompt_context_chars += len(str(wo.get("prompt", "")))
+
             payload = {
                 "iteration": int(iteration),
                 "issue_number": issue_number,
                 "worker_status": str(worker_result.get("status", "")).strip() or "unknown",
+                "worker_outcome": worker_outcome or None,
                 "elapsed_seconds": float(elapsed_seconds or 0.0),
                 "files_changed": files_changed,
                 "tests_run": tests_run,
                 "tests_passed": tests_passed,
+                "prompt_version": prompt_version,
+                "prompt_context_chars": prompt_context_chars,
+                "is_decomposed_issue": is_decomposed,
+                "has_deliverable": has_deliverable,
+                "publish_action": publish_action,
             }
             with metrics_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(payload, sort_keys=True))

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -868,14 +868,15 @@ class BossLoop:
             metrics_path = Path(metrics_path_text)
             metrics_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Extract prompt/context instrumentation from worker result
+            # Extract prompt/context instrumentation from work order data
             run_dict = worker_result.get("run")
-            prompt_context_chars = 0
+            prompt_chars = 0
+            enriched_context_chars = 0
             prompt_version = "v2"  # Context-first prompt (post a11848eac)
             is_decomposed = bool(
                 re.search(
                     r"\[from #\d+\]",
-                    str(worker_result.get("receipt_metadata", {}).get("issue_title", "")),
+                    str((worker_result.get("receipt_metadata") or {}).get("issue_title", "")),
                 )
             )
             worker_outcome = str(worker_result.get("outcome", "")).strip()
@@ -884,10 +885,12 @@ class BossLoop:
                 str((worker_result.get("publish_result") or {}).get("action", "")).strip() or None
             )
 
+            # Read prompt size from persisted WorkerProcess fields
             if isinstance(run_dict, dict):
                 for wo in run_dict.get("work_orders", []):
                     if isinstance(wo, dict):
-                        prompt_context_chars += len(str(wo.get("prompt", "")))
+                        prompt_chars += int(wo.get("prompt_chars", 0) or 0)
+                        enriched_context_chars += int(wo.get("enriched_context_chars", 0) or 0)
 
             payload = {
                 "iteration": int(iteration),
@@ -899,7 +902,8 @@ class BossLoop:
                 "tests_run": tests_run,
                 "tests_passed": tests_passed,
                 "prompt_version": prompt_version,
-                "prompt_context_chars": prompt_context_chars,
+                "prompt_chars": prompt_chars,
+                "enriched_context_chars": enriched_context_chars,
                 "is_decomposed_issue": is_decomposed,
                 "has_deliverable": has_deliverable,
                 "publish_action": publish_action,

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -243,6 +243,8 @@ class WorkerLauncher:
             admin_approved=admin_approved,
             worker_contract=contract_dict,
             worker_contract_checksum=contract_checksum,
+            prompt_chars=len(prompt),
+            enriched_context_chars=len(str(work_order.get("_enriched_context", ""))),
         )
         self._workers[work_order_id] = worker
         self._processes[work_order_id] = proc

--- a/aragora/swarm/worker_process.py
+++ b/aragora/swarm/worker_process.py
@@ -100,6 +100,8 @@ class WorkerProcess:
     admin_approved: bool = False
     worker_contract: dict[str, Any] = field(default_factory=dict)
     worker_contract_checksum: str = ""
+    prompt_chars: int = 0
+    enriched_context_chars: int = 0
 
     @property
     def is_running(self) -> bool:
@@ -132,6 +134,8 @@ class WorkerProcess:
             "admin_approved": self.admin_approved,
             "worker_contract": dict(self.worker_contract),
             "worker_contract_checksum": self.worker_contract_checksum,
+            "prompt_chars": self.prompt_chars,
+            "enriched_context_chars": self.enriched_context_chars,
         }
 
 


### PR DESCRIPTION
## Summary

Adds instrumentation fields to boss loop iteration metrics so the v2 context-first prompt can be measured against the v1 baseline.

New fields in `.aragora/overnight/boss_metrics.jsonl`:
- `prompt_version`: "v2" (context-first, post #4539)
- `prompt_context_chars`: total chars of context sent to worker
- `is_decomposed_issue`: whether this was a `[from #N]` sub-issue
- `has_deliverable`: whether worker produced a branch/PR
- `publish_action`: publish step outcome
- `worker_outcome`: terminal qualification

## Context

PR #4539 (prompt redesign) merged. This adds the measurement layer so the next canary run produces comparable data for evaluating whether the new prompt actually improves mergeable-PR throughput.

## Test plan

- [x] `pytest tests/swarm/test_boss_loop.py -k metric -q` — 1 passed
- [x] Syntax check clean
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)