### PR TITLE
fix(swarm): persist prompt telemetry and sanitize file-scope hints

### DIFF
--- a/aragora/nomic/task_decomposer.py
+++ b/aragora/nomic/task_decomposer.py
@@ -34,6 +34,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_file_scope_entries(values: list[Any]) -> list[str]:
+    from aragora.swarm.spec import SwarmSpec
+
+    return [
+        normalized for path in values if (normalized := SwarmSpec.sanitize_file_scope_entry(path))
+    ]
+
+
 @dataclass
 class SubTask:
     """A subtask extracted from a larger task.
@@ -921,11 +929,7 @@ class TaskDecomposer:
                         str(dep).strip() for dep in item.get("dependencies", []) if str(dep).strip()
                     ],
                     estimated_complexity=complexity,
-                    file_scope=[
-                        str(path).strip()
-                        for path in item.get("file_scope", [])
-                        if str(path).strip()
-                    ],
+                    file_scope=_sanitize_file_scope_entries(item.get("file_scope", [])),
                     success_criteria=success_criteria,
                 )
             )
@@ -970,11 +974,9 @@ class TaskDecomposer:
 
     @staticmethod
     def _is_concrete_repo_path(path: str) -> bool:
-        clean = path.strip().removeprefix("./").rstrip("/")
-        if not clean or any(token in clean for token in ("*", "?", "[", "]", "{", "}")):
-            return False
-        name = clean.rsplit("/", 1)[-1]
-        return "." in name
+        from aragora.swarm.spec import SwarmSpec
+
+        return SwarmSpec.is_concrete_repo_path_hint(path)
 
     @classmethod
     def _path_in_scope(cls, path: str, scope_pattern: str) -> bool:
@@ -997,22 +999,22 @@ class TaskDecomposer:
         *,
         file_scope_hints: list[str] | None = None,
     ) -> list[str]:
-        raw_candidates: list[str] = []
-        for text in (
-            task_description,
-            subtask.title,
-            subtask.description,
-            *(file_scope_hints or []),
-        ):
-            for raw in re.split(r"\s+", str(text or "")):
-                token = raw.strip().strip("`'\".,;:()[]{}<>")
-                if not token or token.startswith(("http://", "https://")):
-                    continue
-                normalized = token.removeprefix("./").rstrip("/")
-                if "/" not in normalized:
-                    continue
-                raw_candidates.append(normalized)
-        return [path for path in dict.fromkeys(raw_candidates) if cls._is_concrete_repo_path(path)]
+        from aragora.swarm.spec import SwarmSpec
+
+        combined = "\n".join(
+            str(text or "")
+            for text in (
+                task_description,
+                subtask.title,
+                subtask.description,
+                *(file_scope_hints or []),
+            )
+        )
+        return [
+            path
+            for path in SwarmSpec.infer_file_scope_hints(combined)
+            if cls._is_concrete_repo_path(path)
+        ]
 
     @classmethod
     def _narrow_subtask_scope_to_explicit_paths(
@@ -1621,7 +1623,7 @@ class TaskDecomposer:
                     id=f"subtask_{i + 1}",
                     title=item.get("title", f"Subtask {i + 1}"),
                     description=item.get("description", ""),
-                    file_scope=item.get("file_scope", []),
+                    file_scope=_sanitize_file_scope_entries(item.get("file_scope", [])),
                     estimated_complexity=item.get("estimated_complexity", "medium"),
                 )
             )

--- a/aragora/server/handlers/playground.py
+++ b/aragora/server/handlers/playground.py
@@ -2277,11 +2277,20 @@ def _try_oracle_tentacles(
                 "code": "landing_preview_needs_clarification",
                 "is_live": False,
             }
-    # Assess consensus from proposals using frontier model intelligence
-    consensus_reached, confidence = _assess_proposal_consensus(
-        question,
-        results,
-    )
+    consensus_method = "frontier_model_assessment"
+    supporting_agents = participants
+    dissenting_agents: list[str] = []
+    if is_landing_preview:
+        consensus_reached = False
+        confidence = 0.0
+        consensus_method = "landing_preview"
+        supporting_agents = []
+    else:
+        # Assess consensus from proposals using frontier model intelligence
+        consensus_reached, confidence = _assess_proposal_consensus(
+            question,
+            results,
+        )
     verdict_label = "consensus_reached" if consensus_reached else "needs_review"
     debate_id = client_debate_id or uuid.uuid4().hex[:16]
     now_iso = datetime.now(timezone.utc).isoformat()
@@ -2313,10 +2322,10 @@ def _try_oracle_tentacles(
             "confidence": confidence,
             "consensus": {
                 "reached": consensus_reached,
-                "method": "frontier_model_assessment",
+                "method": consensus_method,
                 "confidence": confidence,
-                "supporting_agents": participants,
-                "dissenting_agents": [],
+                "supporting_agents": supporting_agents,
+                "dissenting_agents": dissenting_agents,
                 "dissents": [],
             },
             "agents": participants,

--- a/aragora/swarm/spec.py
+++ b/aragora/swarm/spec.py
@@ -9,6 +9,11 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+_FILE_SCOPE_HINT_RE = re.compile(r"(?:\./)?(?:[A-Za-z0-9_*?\[\]{}.-]+/)+[A-Za-z0-9_*?\[\]{}.-]+/?")
+_EXACT_FILE_SCOPE_RE = re.compile(r"(?:\./)?(?:[A-Za-z0-9_*?\[\]{}.-]+/)*[A-Za-z0-9_*?\[\]{}.-]+/?")
+_URL_RE = re.compile(r"https?://\S+")
+_PATH_WRAPPER_CHARS = "`'\".,;:()[]{}<>"
+
 
 @dataclass
 class SwarmSpec:
@@ -64,20 +69,51 @@ class SwarmSpec:
         return [str(item).strip() for item in values if str(item).strip()]
 
     @staticmethod
-    def infer_file_scope_hints(text: str) -> list[str]:
-        """Extract path-like hints from free-form prompt text."""
+    def _normalize_exact_file_scope_hint(value: str) -> str | None:
+        text = str(value or "").strip()
+        if not text:
+            return None
+        clean = text.split("::", 1)[0].strip(_PATH_WRAPPER_CHARS)
+        had_path_separator = "/" in clean
+        clean = clean.removeprefix("./").rstrip("/")
+        if not clean or re.search(r"\s", clean):
+            return None
+        if not had_path_separator and "." not in clean:
+            return None
+        if _EXACT_FILE_SCOPE_RE.fullmatch(clean) is None:
+            return None
+        return clean
+
+    @classmethod
+    def sanitize_file_scope_entry(cls, value: Any) -> str | None:
+        exact = cls._normalize_exact_file_scope_hint(str(value or ""))
+        if exact:
+            return exact
+        inferred = cls.infer_file_scope_hints(str(value or ""))
+        return inferred[0] if inferred else None
+
+    @classmethod
+    def is_concrete_repo_path_hint(cls, value: str) -> bool:
+        clean = cls._normalize_exact_file_scope_hint(value)
+        if not clean or any(token in clean for token in ("*", "?", "[", "]", "{", "}")):
+            return False
+        name = clean.rsplit("/", 1)[-1]
+        return "." in name
+
+    @classmethod
+    def infer_file_scope_hints(cls, text: str) -> list[str]:
+        """Extract path-like hints from free-form prompt text.
+
+        Uses regex extraction over the whole string so command wrappers like
+        ``ast.parse(open('aragora/foo.py').read())`` yield the real repo path
+        instead of the full wrapper fragment.
+        """
+        scrubbed = _URL_RE.sub(" ", text or "")
         hints: list[str] = []
-        for raw in re.split(r"\s+", text or ""):
-            token = raw.strip().strip("`'\".,;:()[]{}<>")
-            if not token or token.startswith(("http://", "https://")):
-                continue
-            normalized = token.removeprefix("./")
-            if "/" not in normalized:
-                continue
-            normalized = normalized.rstrip("/")
-            if not normalized:
-                continue
-            hints.append(normalized)
+        for match in _FILE_SCOPE_HINT_RE.finditer(scrubbed):
+            normalized = cls._normalize_exact_file_scope_hint(match.group(0))
+            if normalized:
+                hints.append(normalized)
         return list(dict.fromkeys(hints))
 
     @staticmethod

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -88,11 +88,7 @@ def _path_in_scope(path: str, scope_pattern: str) -> bool:
 
 
 def _is_concrete_repo_path(path: str) -> bool:
-    clean = path.strip().removeprefix("./").rstrip("/")
-    if not clean or any(token in clean for token in ("*", "?", "[", "]", "{", "}")):
-        return False
-    name = clean.rsplit("/", 1)[-1]
-    return "." in name
+    return SwarmSpec.is_concrete_repo_path_hint(path)
 
 
 def _strict_bool(value: Any) -> bool | None:
@@ -2179,9 +2175,9 @@ class SwarmSupervisor:
                     or spec.refined_goal
                     or spec.raw_goal,
                     file_scope=[
-                        str(item).strip()
+                        normalized
                         for item in payload.get("file_scope", [])
-                        if str(item).strip()
+                        if (normalized := SwarmSpec.sanitize_file_scope_entry(item))
                     ],
                     dependency_ids=dependency_ids,
                     success_criteria=success_criteria,

--- a/aragora/swarm/supervisor_probes.py
+++ b/aragora/swarm/supervisor_probes.py
@@ -145,6 +145,8 @@ def _worker_result_from_persisted_work_order(item: dict[str, Any]) -> WorkerProc
         expected_tests=[
             str(test).strip() for test in item.get("expected_tests", []) if str(test).strip()
         ],
+        prompt_chars=int(item.get("prompt_chars") or 0),
+        enriched_context_chars=int(item.get("enriched_context_chars") or 0),
     )
 
 
@@ -458,6 +460,11 @@ def _apply_worker_result(
     item["verification_results"] = self._verification_results_from_result(result)
     item["commit_shas"] = list(result.commit_shas)
     item["head_sha"] = result.head_sha
+    item["prompt_chars"] = max(int(item.get("prompt_chars") or 0), int(result.prompt_chars or 0))
+    item["enriched_context_chars"] = max(
+        int(item.get("enriched_context_chars") or 0),
+        int(result.enriched_context_chars or 0),
+    )
     self._update_log_tails(item, stdout=result.stdout, stderr=result.stderr)
     item.pop("pid", None)
 

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -349,6 +349,8 @@ def _build_dead_worker_salvage_result(
         expected_tests=[
             str(test).strip() for test in item.get("expected_tests", []) if str(test).strip()
         ],
+        prompt_chars=int(item.get("prompt_chars") or 0),
+        enriched_context_chars=int(item.get("enriched_context_chars") or 0),
     )
 
 
@@ -694,6 +696,8 @@ async def dispatch_workers(self, run_id: str) -> list[WorkerProcess]:
                     "stderr_mtime_ns": 0,
                     "has_output": False,
                 }
+                item["prompt_chars"] = int(worker.prompt_chars or 0)
+                item["enriched_context_chars"] = int(worker.enriched_context_chars or 0)
                 # Persist worker PID in lease metadata so reap_stale_leases
                 # can detect dead processes even if this supervisor dies.
                 lease_id = str(item.get("lease_id", "")).strip()

--- a/tests/handlers/test_playground.py
+++ b/tests/handlers/test_playground.py
@@ -1597,6 +1597,8 @@ class TestTryOracleTentacles:
         assert result["confidence"] == 0.0
         assert result["is_live"] is False
         assert result["receipt"]["consensus"]["method"] == "landing_preview"
+        assert result["receipt"]["consensus"]["reached"] is False
+        assert result["receipt"]["consensus"]["supporting_agents"] == []
         assert "preview" in result["result_warning"].lower()
 
     def test_landing_source_rejects_off_topic_preview_drift(self):

--- a/tests/nomic/test_task_decomposer.py
+++ b/tests/nomic/test_task_decomposer.py
@@ -165,6 +165,30 @@ class TestTaskDecomposer:
         assert result.subtasks[0].title == "Gate defaults"
 
     @pytest.mark.asyncio
+    async def test_analyze_with_model_sanitizes_command_wrapped_file_scope(self):
+        decomposer = TaskDecomposer()
+        mock_agent = SimpleNamespace(
+            generate=AsyncMock(
+                return_value=(
+                    '{"rationale":"planner output","subtasks":[{"id":"lane_1",'
+                    '"title":"Fix parser","description":"Update parser logic",'
+                    '"estimated_complexity":"medium",'
+                    '"file_scope":["ast.parse(open(\'aragora/connectors/chat/signal.py\').read())"]}]}'
+                )
+            )
+        )
+
+        with patch("aragora.agents.base.create_agent", return_value=mock_agent):
+            result = await decomposer.analyze_with_model(
+                "Fix signal connector parsing",
+                planner_model="codex",
+                file_scope_hints=["aragora/connectors/chat/signal.py"],
+            )
+
+        assert len(result.subtasks) == 1
+        assert result.subtasks[0].file_scope == ["aragora/connectors/chat/signal.py"]
+
+    @pytest.mark.asyncio
     async def test_analyze_with_model_collapses_same_scope_siblings(self):
         decomposer = TaskDecomposer()
         task = "Add --json output flag to aragora quickstart CLI"

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -1970,6 +1970,9 @@ class TestBossLoop:
         async def _completed_dispatch(issue, freshness):
             return {
                 "status": "completed",
+                "outcome": "deliverable_created",
+                "deliverable": {"branch": "codex/test-branch"},
+                "publish_result": {"action": "opened_pr", "published": True},
                 "run": {
                     "work_orders": [
                         {
@@ -1984,6 +1987,8 @@ class TestBossLoop:
                                     "passed": True,
                                 }
                             ],
+                            "prompt_chars": 2048,
+                            "enriched_context_chars": 1536,
                         }
                     ]
                 },
@@ -2001,6 +2006,12 @@ class TestBossLoop:
         assert payload["files_changed"] == 2
         assert payload["tests_run"] == 1
         assert payload["tests_passed"] == 1
+        assert payload["worker_outcome"] == "deliverable_created"
+        assert payload["prompt_version"] == "v2"
+        assert payload["prompt_chars"] == 2048
+        assert payload["enriched_context_chars"] == 1536
+        assert payload["has_deliverable"] is True
+        assert payload["publish_action"] == "opened_pr"
         assert payload["elapsed_seconds"] >= 0.0
 
     def test_missing_validation_contract_stops_with_needs_human(self):

--- a/tests/swarm/test_spec.py
+++ b/tests/swarm/test_spec.py
@@ -176,3 +176,21 @@ class TestSwarmSpecDispatchBounds:
         )
         assert spec.is_dispatch_bounded() is True
         assert "aragora/swarm/spec.py" in spec.file_scope_hints
+
+
+class TestSwarmSpecFileScopeExtraction:
+    def test_infer_file_scope_hints_extracts_embedded_repo_paths(self):
+        text = (
+            'Acceptance: run `python3 -c "import ast; '
+            "ast.parse(open('aragora/connectors/chat/signal.py').read())\"` "
+            "and validate against tests/connectors/chat/test_signal.py::test_parse."
+        )
+        hints = SwarmSpec.infer_file_scope_hints(text)
+
+        assert "aragora/connectors/chat/signal.py" in hints
+        assert "tests/connectors/chat/test_signal.py" in hints
+        assert not any("ast.parse(open" in hint for hint in hints)
+
+    def test_sanitize_file_scope_entry_strips_command_wrapper(self):
+        raw = "ast.parse(open('aragora/connectors/ecommerce/shopify.py').read())"
+        assert SwarmSpec.sanitize_file_scope_entry(raw) == "aragora/connectors/ecommerce/shopify.py"

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -3952,6 +3952,8 @@ async def test_dispatch_workers_launches_leased_orders(
         worktree_path=str(repo),
         branch="swarm-dispatch-1",
         pid=999,
+        prompt_chars=1234,
+        enriched_context_chars=890,
     )
     mock_launcher.launch = AsyncMock(return_value=mock_worker)
 
@@ -3978,6 +3980,11 @@ async def test_dispatch_workers_launches_leased_orders(
     assert len(launched) >= 1
     assert launched[0].pid == 999
     mock_launcher.launch.assert_called()
+
+    updated = store.get_supervisor_run(run.run_id)
+    assert updated is not None
+    assert updated["work_orders"][0]["prompt_chars"] == 1234
+    assert updated["work_orders"][0]["enriched_context_chars"] == 890
 
 
 @pytest.mark.asyncio
@@ -7656,7 +7663,7 @@ def test_worker_prompt_includes_boss_lane_contract() -> None:
         }
     )
 
-    assert "Aragora-managed CLI worker lane" in prompt
+    assert prompt.startswith("# Implement boss-facing reporter output")
     assert "FILE SCOPE GUIDANCE" in prompt
     assert "Expected validation:" in prompt
     assert "Acceptance criteria:" in prompt


### PR DESCRIPTION
## Summary
- persist prompt/enriched-context sizes on supervisor work orders so boss-loop iteration metrics can record real non-zero prompt telemetry
- sanitize command-wrapped and embedded path strings into real repo paths before they become file_scope hints or LLM subtask scopes
- update stale prompt-contract test expectations to match the prompt redesign already live on main

## Validation
- `python3 -m pytest tests/swarm/test_spec.py tests/nomic/test_task_decomposer.py tests/swarm/test_supervisor.py tests/swarm/test_boss_loop.py -x -q --timeout=120`
- `python3 -m pytest tests/swarm/test_file_scope_enforcement.py tests/nomic/test_decomposer_scope_constraints.py -x -q --timeout=120`
- `python3 -m pytest tests/swarm/test_spec.py tests/nomic/test_task_decomposer.py -q --timeout=120`
- `python3 -m ruff check aragora/swarm/spec.py aragora/swarm/supervisor.py aragora/swarm/supervisor_workers.py aragora/swarm/supervisor_probes.py aragora/nomic/task_decomposer.py tests/swarm/test_spec.py tests/nomic/test_task_decomposer.py tests/swarm/test_supervisor.py tests/swarm/test_boss_loop.py`
- `python3 -m ruff format --check aragora/swarm/spec.py aragora/swarm/supervisor.py aragora/swarm/supervisor_workers.py aragora/swarm/supervisor_probes.py aragora/nomic/task_decomposer.py tests/swarm/test_spec.py tests/nomic/test_task_decomposer.py tests/swarm/test_supervisor.py tests/swarm/test_boss_loop.py`
- `git diff --check`

## Why this matters for overnight
- boss_metrics.jsonl will now record prompt_chars and enriched_context_chars from the real launched worker instead of zeros
- validation commands like `ast.parse(open('aragora/...').read())` now sanitize down to `aragora/...` instead of poisoning file_scope with wrapper text
- explicit top-level files and directory scopes like `README.md` and `docs/` still remain valid scopes
