### PR TITLE
fix: narrow exception handler in bug_detector.py

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except (ValueError, OSError) as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines


### PR DESCRIPTION
Remove unnecessary SyntaxError from the except clause in
detect_in_directory — neither open() nor detect_in_file() (which uses
regex matching, not ast.parse) raises SyntaxError.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 3ad0b128c5e17336f7fa2cd34eda452878895f94)
