### PR TITLE
feat: add opt-in debate publish gate

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -29,6 +29,7 @@ from typing import Any
 
 from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.terminal_truth import (
     extract_run_deliverable,
@@ -297,6 +298,10 @@ class BossLoopConfig:
     # Autonomous post-processing: publish verified branch deliverables and
     # optionally close already-resolved no-op issues.
     auto_publish_deliverables: bool = False
+    use_debate_publish_gate: bool = False
+    debate_publish_gate_fail_closed: bool = False
+    debate_publish_gate_agent: str | None = None
+    debate_publish_gate_timeout_seconds: float = 90.0
     max_open_auto_publish_prs: int = 4
     auto_close_already_done_issues: bool = False
 
@@ -2126,6 +2131,93 @@ class BossLoop:
         worker_result["pr_number"] = BossLoop._pr_number_from_url(pr_url)
         return dict(publish_result)
 
+    @staticmethod
+    def _debate_gate_changed_files(worker_result: dict[str, Any]) -> list[str]:
+        changed_files: list[str] = []
+        seen: set[str] = set()
+        run = worker_result.get("run")
+        if isinstance(run, dict):
+            for work_order in run.get("work_orders", []) or []:
+                if not isinstance(work_order, dict):
+                    continue
+                for path in work_order.get("changed_paths", []) or []:
+                    text = str(path).strip()
+                    if not text or text in seen:
+                        continue
+                    seen.add(text)
+                    changed_files.append(text)
+        deliverable = worker_result.get("deliverable")
+        if isinstance(deliverable, dict):
+            for path in deliverable.get("changed_paths", []) or []:
+                text = str(path).strip()
+                if not text or text in seen:
+                    continue
+                seen.add(text)
+                changed_files.append(text)
+        return changed_files
+
+    def _run_debate_publish_gate(
+        self,
+        issue: GitHubIssue,
+        worker_result: dict[str, Any],
+        *,
+        branch: str,
+        commit_shas: list[str],
+    ) -> dict[str, Any] | None:
+        if not self.config.use_debate_publish_gate:
+            return None
+        gate = DebateGate(
+            repo_root=Path.cwd().resolve(),
+            config=DebateGateConfig(
+                enabled=True,
+                fail_closed=bool(self.config.debate_publish_gate_fail_closed),
+                agent_type=(
+                    str(self.config.debate_publish_gate_agent or "").strip()
+                    or str(self.config.default_reviewer_agent or "").strip()
+                    or "codex"
+                ),
+                timeout_seconds=float(self.config.debate_publish_gate_timeout_seconds or 90.0),
+            ),
+        )
+        result = gate.evaluate(
+            DebateGateRequest(
+                issue_number=issue.number,
+                issue_title=issue.title,
+                issue_body=issue.body,
+                source_branch=branch,
+                target_branch=self.config.target_branch,
+                commit_shas=list(commit_shas),
+                changed_files=self._debate_gate_changed_files(worker_result),
+                tests_run=[
+                    str(item).strip()
+                    for item in worker_result.get("tests_run", []) or []
+                    if str(item).strip()
+                ],
+                verification_results=[
+                    dict(item)
+                    for item in worker_result.get("verification_results", []) or []
+                    if isinstance(item, dict)
+                ],
+                receipt_id=str(worker_result.get("receipt_id", "")).strip() or None,
+            )
+        ).to_dict()
+        worker_result["debate_gate_result"] = dict(result)
+        if result.get("verdict") == "blocked":
+            blocked_reason = (
+                f"Debate publish gate blocked publication: "
+                f"{str(result.get('reason', '')).strip() or 'human review required before PR publication.'}"
+            )
+            reasons = worker_result.get("reasons")
+            normalized_reasons = (
+                [str(item).strip() for item in reasons if str(item).strip()]
+                if isinstance(reasons, list)
+                else []
+            )
+            if blocked_reason not in normalized_reasons:
+                normalized_reasons.append(blocked_reason)
+            worker_result["reasons"] = normalized_reasons
+        return result
+
     def _maybe_publish_deliverable(
         self,
         issue: GitHubIssue,
@@ -2334,6 +2426,47 @@ class BossLoop:
                             issue.number,
                             branch,
                         )
+            debate_gate_result = None
+            if self.config.use_debate_publish_gate:
+                debate_gate_result = self._run_debate_publish_gate(
+                    issue,
+                    worker_result,
+                    branch=branch,
+                    commit_shas=commit_shas,
+                )
+            if isinstance(debate_gate_result, dict):
+                worker_result.setdefault("debate_gate_result", dict(debate_gate_result))
+            if isinstance(debate_gate_result, dict) and not debate_gate_result.get(
+                "publication_allowed", True
+            ):
+                blocked_reason = "Debate publish gate blocked publication: " + (
+                    str(debate_gate_result.get("reason", "")).strip()
+                    or "human review required before PR publication."
+                )
+                reasons = worker_result.get("reasons")
+                normalized_reasons = (
+                    [str(item).strip() for item in reasons if str(item).strip()]
+                    if isinstance(reasons, list)
+                    else []
+                )
+                if blocked_reason not in normalized_reasons:
+                    normalized_reasons.append(blocked_reason)
+                worker_result["reasons"] = normalized_reasons
+                logger.info(
+                    "Boss publish blocked by debate gate for issue #%s branch %s: %s",
+                    issue.number,
+                    branch,
+                    str(debate_gate_result.get("reason", "")).strip() or "no reason provided",
+                )
+                return {
+                    "action": "blocked_by_debate_gate",
+                    "published": False,
+                    "branch": branch,
+                    "pr_url": None,
+                    "reason": str(debate_gate_result.get("reason", "")).strip()
+                    or "Debate gate blocked publication.",
+                    "concerns": list(debate_gate_result.get("concerns", []) or []),
+                }
             artifact = _BossDeliverableArtifact(
                 branch=branch,
                 metadata={
@@ -2794,6 +2927,11 @@ class BossLoop:
             normalized_harvest = dict(harvest_result)
             receipt_metadata["harvest_result"] = normalized_harvest
             postprocess["harvest_result"] = normalized_harvest
+        debate_gate_result = worker_result.get("debate_gate_result")
+        if isinstance(debate_gate_result, dict):
+            normalized_gate = dict(debate_gate_result)
+            receipt_metadata["debate_gate_result"] = normalized_gate
+            postprocess["debate_gate_result"] = normalized_gate
         issue_comment_result = worker_result.get("issue_comment_result")
         if isinstance(issue_comment_result, dict):
             normalized_comment = dict(issue_comment_result)
@@ -2855,6 +2993,19 @@ class BossLoop:
         if action == "pr_created":
             return f"Auto-continuing: published PR {pr_url} for human review."
         return f"Auto-continuing: deliverable is available at {pr_url} for human review."
+
+    @staticmethod
+    def _debate_gate_followup(worker_result: dict[str, Any]) -> str | None:
+        gate_result = worker_result.get("debate_gate_result")
+        if not isinstance(gate_result, dict):
+            return None
+        verdict = str(gate_result.get("verdict", "")).strip()
+        if verdict != "blocked":
+            return None
+        reason = str(gate_result.get("reason", "")).strip()
+        if not reason:
+            reason = "human review required before PR publication."
+        return f"Publish skipped by debate gate: {reason}"
 
     def _convert_pr_to_draft(self, worker_result: dict[str, Any]) -> None:
         """Convert a newly-created PR to draft so only the 5 required checks run.
@@ -4252,7 +4403,11 @@ class BossLoop:
             self._consecutive_failures = 0
             self._emit_lane_receipt(worker_result, issue_dict, elapsed_seconds)
             self._log_value_outcome(issue_dict, "completed", elapsed_seconds)
-            next_action = self._published_pr_followup(worker_result) or "Proceeding to next issue."
+            next_action = (
+                self._published_pr_followup(worker_result)
+                or self._debate_gate_followup(worker_result)
+                or "Proceeding to next issue."
+            )
             self._append_iteration_metrics(
                 iteration=iteration,
                 issue_number=issue_number,
@@ -4307,6 +4462,15 @@ class BossLoop:
                     worker_result=worker_result,
                     elapsed_seconds=elapsed_seconds,
                 )
+                next_action = (
+                    self._published_pr_followup(worker_result)
+                    or self._debate_gate_followup(worker_result)
+                    or (
+                        f"Terminal: deliverable ({normalized_deliverable_type}) for issue "
+                        f"#{issue_dict.get('number', '?')}"
+                        f"{f' PR {pr_url}' if pr_url else ''}. Proceeding to next issue."
+                    )
+                )
                 return BossIterationStatus(
                     iteration=iteration,
                     run_id=self.run_id,
@@ -4316,11 +4480,7 @@ class BossLoop:
                     worker_status="completed",
                     stop_reason=None,
                     needs_human_reasons=[],
-                    next_actions=[
-                        f"Terminal: deliverable ({normalized_deliverable_type}) for issue "
-                        f"#{issue_dict.get('number', '?')}"
-                        f"{f' PR {pr_url}' if pr_url else ''}. Proceeding to next issue."
-                    ],
+                    next_actions=[next_action],
                     elapsed_seconds=elapsed_seconds,
                     worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
                 )

--- a/aragora/swarm/debate_gate.py
+++ b/aragora/swarm/debate_gate.py
@@ -1,0 +1,390 @@
+"""Opt-in publish-time debate gate for boss-loop deliverables.
+
+The gate is intentionally small, fail-open by default, and only evaluates
+branch deliverables immediately before PR publication. It never changes worker
+classification; it can only allow or skip the publish step.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import subprocess
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.worker_process import is_ignored_changed_path
+
+logger = logging.getLogger(__name__)
+
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _string_list(values: Any) -> list[str]:
+    if not isinstance(values, (list, tuple, set)):
+        return []
+    return [_text(value) for value in values if _text(value)]
+
+
+def _bounded(text: str, max_chars: int) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    return text[: max_chars - 3].rstrip() + "..."
+
+
+def _normalize_confidence(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        confidence = float(value)
+    except (TypeError, ValueError):
+        return None
+    return max(0.0, min(1.0, confidence))
+
+
+def _normalize_passed(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    lowered = _text(value).lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    raise ValueError("Debate gate response missing strict boolean 'passed' field.")
+
+
+@dataclass(slots=True)
+class DebateGateConfig:
+    """Runtime configuration for the publish-time debate gate."""
+
+    enabled: bool = False
+    fail_closed: bool = False
+    agent_type: str = "codex"
+    timeout_seconds: float = 90.0
+    max_changed_files: int = 12
+    max_diff_chars: int = 12000
+    max_issue_body_chars: int = 1500
+
+
+@dataclass(slots=True)
+class DebateGateRequest:
+    """Bounded context for one publish-time gate decision."""
+
+    issue_number: int | None = None
+    issue_title: str = ""
+    issue_body: str = ""
+    source_branch: str = ""
+    target_branch: str = "main"
+    commit_shas: list[str] = field(default_factory=list)
+    changed_files: list[str] = field(default_factory=list)
+    tests_run: list[str] = field(default_factory=list)
+    verification_results: list[dict[str, Any]] = field(default_factory=list)
+    receipt_id: str | None = None
+
+
+@dataclass(slots=True)
+class DebateGateResult:
+    """Structured machine-readable publish-gate verdict."""
+
+    verdict: str
+    publication_allowed: bool
+    passed: bool
+    confidence: float | None = None
+    concerns: list[str] = field(default_factory=list)
+    fail_open_used: bool = False
+    reason: str = ""
+    ran: bool = False
+    agent_type: str | None = None
+    source_branch: str | None = None
+    target_branch: str | None = None
+    changed_files: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdict": self.verdict,
+            "publication_allowed": self.publication_allowed,
+            "passed": self.passed,
+            "confidence": self.confidence,
+            "concerns": list(self.concerns),
+            "fail_open_used": self.fail_open_used,
+            "reason": self.reason,
+            "ran": self.ran,
+            "agent_type": self.agent_type,
+            "source_branch": self.source_branch,
+            "target_branch": self.target_branch,
+            "changed_files": list(self.changed_files),
+        }
+
+
+class DebateGate:
+    """Evaluate whether a verified branch deliverable should be published."""
+
+    def __init__(
+        self,
+        *,
+        repo_root: Path,
+        config: DebateGateConfig,
+        llm_caller: Callable[[str, str, float], str] | None = None,
+        diff_loader: Callable[[Path, DebateGateRequest, DebateGateConfig], dict[str, Any]]
+        | None = None,
+    ) -> None:
+        self.repo_root = repo_root
+        self.config = config
+        self._llm_caller = llm_caller or self._default_llm_caller
+        self._diff_loader = diff_loader or self._default_diff_loader
+
+    def evaluate(self, request: DebateGateRequest) -> DebateGateResult:
+        """Return a structured publish verdict for one branch deliverable."""
+        agent_type = _text(self.config.agent_type) or "codex"
+        if not self.config.enabled:
+            return DebateGateResult(
+                verdict="skipped_disabled",
+                publication_allowed=True,
+                passed=False,
+                reason="Debate publish gate disabled.",
+                ran=False,
+                agent_type=agent_type,
+                source_branch=request.source_branch or None,
+                target_branch=request.target_branch or None,
+                changed_files=list(request.changed_files),
+            )
+
+        try:
+            payload = self._diff_loader(self.repo_root, request, self.config)
+            prompt = self._build_prompt(request, payload)
+            raw = self._llm_caller(prompt, agent_type, float(self.config.timeout_seconds or 90.0))
+            parsed = self._parse_response(raw)
+            parsed.agent_type = agent_type
+            parsed.source_branch = request.source_branch or None
+            parsed.target_branch = request.target_branch or None
+            parsed.changed_files = list(payload.get("changed_files", []))
+            return parsed
+        except Exception as exc:
+            reason = f"{type(exc).__name__}: {exc}"
+            fail_open = not self.config.fail_closed
+            verdict = "fail_open" if fail_open else "blocked"
+            logger.info("Debate publish gate %s: %s", verdict, reason)
+            return DebateGateResult(
+                verdict=verdict,
+                publication_allowed=fail_open,
+                passed=False,
+                fail_open_used=fail_open,
+                reason=reason,
+                ran=False,
+                agent_type=agent_type,
+                source_branch=request.source_branch or None,
+                target_branch=request.target_branch or None,
+                changed_files=list(request.changed_files),
+            )
+
+    @staticmethod
+    def _default_llm_caller(prompt: str, agent_type: str, timeout_seconds: float) -> str:
+        result: dict[str, Any] = {}
+        error: dict[str, BaseException] = {}
+
+        def _worker() -> None:
+            try:
+                from aragora.agents.base import create_agent
+
+                agent = create_agent(
+                    agent_type,
+                    name="debate-publish-gate",
+                    role="critic",
+                )
+                result["raw"] = asyncio.run(agent.generate(prompt))
+            except BaseException as exc:  # pragma: no cover - defensive thread handoff
+                error["exc"] = exc
+
+        thread = threading.Thread(target=_worker, name="debate-publish-gate", daemon=True)
+        thread.start()
+        thread.join(timeout_seconds)
+        if thread.is_alive():
+            raise TimeoutError(f"Debate gate timed out after {timeout_seconds:.1f}s")
+        if "exc" in error:
+            raise RuntimeError(str(error["exc"])) from error["exc"]
+        return _text(result.get("raw"))
+
+    @staticmethod
+    def _default_diff_loader(
+        repo_root: Path,
+        request: DebateGateRequest,
+        config: DebateGateConfig,
+    ) -> dict[str, Any]:
+        changed_files = DebateGate._resolve_changed_files(repo_root, request, config)
+        diff_target = f"{request.target_branch}...{request.source_branch}"
+        diff_stat = DebateGate._run_git_capture(
+            repo_root,
+            ["git", "diff", "--stat", diff_target, "--", *changed_files]
+            if changed_files
+            else ["git", "diff", "--stat", diff_target],
+        )
+        diff_excerpt = DebateGate._run_git_capture(
+            repo_root,
+            [
+                "git",
+                "diff",
+                "--unified=2",
+                "--no-ext-diff",
+                diff_target,
+                "--",
+                *changed_files,
+            ]
+            if changed_files
+            else [
+                "git",
+                "diff",
+                "--unified=2",
+                "--no-ext-diff",
+                diff_target,
+            ],
+            max_chars=config.max_diff_chars,
+        )
+        return {
+            "changed_files": changed_files,
+            "diff_stat": diff_stat,
+            "diff_excerpt": diff_excerpt,
+            "verification_summary": DebateGate._verification_summary(request),
+        }
+
+    @staticmethod
+    def _resolve_changed_files(
+        repo_root: Path,
+        request: DebateGateRequest,
+        config: DebateGateConfig,
+    ) -> list[str]:
+        files = [path for path in request.changed_files if not is_ignored_changed_path(path)]
+        if not files:
+            raw = DebateGate._run_git_capture(
+                repo_root,
+                [
+                    "git",
+                    "diff",
+                    "--name-only",
+                    f"{request.target_branch}...{request.source_branch}",
+                ],
+            )
+            files = [
+                path for path in raw.splitlines() if path and not is_ignored_changed_path(path)
+            ]
+
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for path in files:
+            clean = _text(path)
+            if not clean or clean in seen:
+                continue
+            seen.add(clean)
+            ordered.append(clean)
+            if len(ordered) >= max(int(config.max_changed_files or 0), 1):
+                break
+        return ordered
+
+    @staticmethod
+    def _run_git_capture(repo_root: Path, cmd: list[str], *, max_chars: int | None = None) -> str:
+        proc = subprocess.run(
+            cmd,
+            cwd=str(repo_root),
+            env=git_safe_env(),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "git diff failed")
+        return _bounded(proc.stdout, max_chars or 1_000_000)
+
+    @staticmethod
+    def _verification_summary(request: DebateGateRequest) -> dict[str, Any]:
+        checks = list(request.verification_results)
+        passed = sum(1 for item in checks if item.get("passed") is True)
+        failed = sum(1 for item in checks if item.get("passed") is False)
+        names = [
+            _text(item.get("name") or item.get("command") or item.get("target"))
+            for item in checks
+            if _text(item.get("name") or item.get("command") or item.get("target"))
+        ]
+        return {
+            "tests_run": list(request.tests_run),
+            "checks_observed": len(checks),
+            "checks_passed": passed,
+            "checks_failed": failed,
+            "check_names": names[:10],
+        }
+
+    def _build_prompt(self, request: DebateGateRequest, payload: dict[str, Any]) -> str:
+        prompt_payload = {
+            "issue": {
+                "number": request.issue_number,
+                "title": request.issue_title,
+                "body_excerpt": _bounded(
+                    _text(request.issue_body), self.config.max_issue_body_chars
+                ),
+            },
+            "publish_candidate": {
+                "source_branch": request.source_branch,
+                "target_branch": request.target_branch,
+                "commit_shas": list(request.commit_shas),
+                "changed_files": list(payload.get("changed_files", [])),
+                "receipt_id": request.receipt_id,
+            },
+            "verification": payload.get("verification_summary", {}),
+            "diff_stat": _text(payload.get("diff_stat")),
+            "diff_excerpt": _text(payload.get("diff_excerpt")),
+        }
+        return (
+            "You are a conservative publish gate for an autonomous software lane. "
+            "A worker already passed verification and produced a branch deliverable. "
+            "Decide only whether PR publication should proceed now. "
+            "Block only for concrete correctness, safety, or task-intent problems visible in the context. "
+            "Do not require perfection or merge-readiness.\n\n"
+            "Return ONLY JSON with this exact shape:\n"
+            '{"passed": true, "confidence": 0.0, "reason": "short reason", "concerns": ["optional concern"]}\n\n'
+            f"{json.dumps(prompt_payload, indent=2, sort_keys=True)}"
+        )
+
+    @staticmethod
+    def _parse_response(raw: str) -> DebateGateResult:
+        payload = DebateGate._extract_json_payload(raw)
+        passed = _normalize_passed(payload.get("passed"))
+        concerns = _string_list(payload.get("concerns"))
+        reason = _text(payload.get("reason"))
+        if not reason and concerns:
+            reason = concerns[0]
+        if not reason:
+            reason = "Gate approved publication." if passed else "Gate requested human review."
+        return DebateGateResult(
+            verdict="passed" if passed else "blocked",
+            publication_allowed=passed,
+            passed=passed,
+            confidence=_normalize_confidence(payload.get("confidence")),
+            concerns=concerns,
+            fail_open_used=False,
+            reason=reason,
+            ran=True,
+        )
+
+    @staticmethod
+    def _extract_json_payload(raw: str) -> dict[str, Any]:
+        text = _text(raw)
+        if not text:
+            raise ValueError("Debate gate returned empty output.")
+        try:
+            payload = json.loads(text)
+        except json.JSONDecodeError:
+            match = _JSON_OBJECT_RE.search(text)
+            if not match:
+                raise ValueError("Debate gate did not return JSON.") from None
+            payload = json.loads(match.group(0))
+        if not isinstance(payload, dict):
+            raise ValueError("Debate gate JSON payload must be an object.")
+        return payload

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -5042,6 +5042,55 @@ class TestListOpenBossHarvestPrs:
 class TestMaybePublishDeliverable:
     """Tests for auto-publish queue capping."""
 
+    def test_debate_gate_disabled_preserves_existing_publish_path(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+            )
+        )
+        issue = _make_issue(number=127)
+        worker_result = {
+            "status": "needs_human",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/issue-127",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(loop, "_run_debate_publish_gate") as gate_mock,
+            patch.object(loop, "_list_open_boss_harvest_prs", return_value=[]),
+            patch.object(
+                loop,
+                "_harvest_worker_commits_for_publish",
+                return_value={
+                    "action": "harvested",
+                    "branch": "codex/issue-127",
+                    "source_branch": "codex/issue-127",
+                    "commit_shas": ["abc123"],
+                },
+            ),
+            patch(
+                "aragora.swarm.tranche_integrate.publish_lane_deliverable",
+                return_value={
+                    "published": True,
+                    "branch": "codex/issue-127",
+                    "pr_url": "https://github.com/synaptent/aragora/pull/2127",
+                },
+            ) as mock_publish,
+            patch("aragora.swarm.pr_registry.PullRequestRegistry"),
+        ):
+            result = loop._maybe_publish_deliverable(issue, worker_result)
+
+        gate_mock.assert_not_called()
+        assert result is not None
+        assert result["published"] is True
+        assert result["pr_url"] == "https://github.com/synaptent/aragora/pull/2127"
+        assert "debate_gate_result" not in worker_result
+        assert mock_publish.called
+
     def test_reuses_existing_published_pr_for_branch_deliverable(self) -> None:
         loop = BossLoop(
             config=BossLoopConfig(
@@ -5269,6 +5318,128 @@ class TestMaybePublishDeliverable:
         assert mock_publish.call_args.kwargs["target_branch"] == "release/2026.04"
         assert mock_publish.call_args.args[0].branch == "codex/swarm-valid"
 
+    def test_debate_gate_blocks_publish_and_records_metadata(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+                use_debate_publish_gate=True,
+            )
+        )
+        issue = _make_issue(number=128)
+        worker_result = {
+            "status": "needs_human",
+            "outcome": "blocked",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/issue-128",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(
+                loop,
+                "_run_debate_publish_gate",
+                return_value={
+                    "verdict": "blocked",
+                    "publication_allowed": False,
+                    "passed": False,
+                    "reason": "Publish summary mismatches the verified diff.",
+                    "concerns": ["publish metadata hides a blocker"],
+                    "fail_open_used": False,
+                    "ran": True,
+                },
+            ),
+            patch.object(loop, "_list_open_boss_harvest_prs", return_value=[]),
+            patch.object(
+                loop,
+                "_harvest_worker_commits_for_publish",
+                return_value={
+                    "action": "harvested",
+                    "branch": "codex/issue-128",
+                    "source_branch": "codex/issue-128",
+                    "commit_shas": ["abc123"],
+                },
+            ),
+            patch("aragora.swarm.tranche_integrate.publish_lane_deliverable") as mock_publish,
+            patch.object(loop, "_maybe_comment_published_deliverable", return_value=None),
+            patch.object(loop, "_maybe_auto_close_already_done_issue", return_value=None),
+            patch.object(loop, "_convert_pr_to_draft"),
+        ):
+            result = loop._postprocess_issue_result(issue, worker_result)
+
+        assert result["status"] == "needs_human"
+        assert result["publish_result"]["action"] == "blocked_by_debate_gate"
+        assert result["publish_result"]["published"] is False
+        assert result["receipt_metadata"]["debate_gate_result"]["verdict"] == "blocked"
+        assert "Debate publish gate blocked publication" in result["reasons"][-1]
+        mock_publish.assert_not_called()
+
+    def test_debate_gate_fail_open_preserves_publish(self) -> None:
+        loop = BossLoop(
+            config=BossLoopConfig(
+                repo="synaptent/aragora",
+                auto_publish_deliverables=True,
+                use_debate_publish_gate=True,
+            )
+        )
+        issue = _make_issue(number=129)
+        worker_result = {
+            "status": "needs_human",
+            "outcome": "blocked",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/issue-129",
+                "commit_shas": ["abc123"],
+            },
+        }
+
+        with (
+            patch.object(
+                loop,
+                "_run_debate_publish_gate",
+                return_value={
+                    "verdict": "fail_open",
+                    "publication_allowed": True,
+                    "passed": False,
+                    "reason": "TimeoutError: model unavailable",
+                    "concerns": [],
+                    "fail_open_used": True,
+                    "ran": False,
+                },
+            ),
+            patch.object(loop, "_list_open_boss_harvest_prs", return_value=[]),
+            patch.object(
+                loop,
+                "_harvest_worker_commits_for_publish",
+                return_value={
+                    "action": "harvested",
+                    "branch": "codex/issue-129",
+                    "source_branch": "codex/issue-129",
+                    "commit_shas": ["abc123"],
+                },
+            ),
+            patch(
+                "aragora.swarm.tranche_integrate.publish_lane_deliverable",
+                return_value={
+                    "published": True,
+                    "branch": "codex/issue-129",
+                    "pr_url": "https://github.com/synaptent/aragora/pull/2129",
+                },
+            ) as mock_publish,
+            patch("aragora.swarm.pr_registry.PullRequestRegistry"),
+            patch.object(loop, "_maybe_comment_published_deliverable", return_value=None),
+            patch.object(loop, "_maybe_auto_close_already_done_issue", return_value=None),
+            patch.object(loop, "_convert_pr_to_draft"),
+        ):
+            result = loop._postprocess_issue_result(issue, worker_result)
+
+        assert result["publish_result"]["published"] is True
+        assert result["receipt_metadata"]["debate_gate_result"]["verdict"] == "fail_open"
+        assert result["deliverable"]["type"] == "pr"
+        assert mock_publish.called
+
 
 class TestPostprocessConvertsToDraft:
     """Verify _postprocess_issue_result calls _convert_pr_to_draft."""
@@ -5289,6 +5460,69 @@ class TestPostprocessConvertsToDraft:
         ):
             loop._postprocess_issue_result(issue, worker_result)
         mock_convert.assert_called_once_with(worker_result)
+
+    def test_run_iteration_reports_debate_gate_block_followup(self) -> None:
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(130, "Publish gate followup")]
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                auto_publish_deliverables=True,
+                use_debate_publish_gate=True,
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+        loop._emit_lane_receipt = MagicMock(return_value="lane-130")
+        loop._log_value_outcome = MagicMock()
+
+        with patch.object(
+            loop,
+            "_dispatch_issue",
+            AsyncMock(
+                return_value={
+                    "status": "needs_human",
+                    "outcome": "blocked",
+                    "deliverable": {
+                        "type": "branch",
+                        "branch": "codex/issue-130",
+                        "commit_shas": ["abc123"],
+                    },
+                    "publish_result": {
+                        "action": "blocked_by_debate_gate",
+                        "published": False,
+                        "branch": "codex/issue-130",
+                        "pr_url": None,
+                        "reason": "Publish gate requires human review before PR creation.",
+                        "concerns": ["diff summary omits the blocker"],
+                    },
+                    "debate_gate_result": {
+                        "verdict": "blocked",
+                        "publication_allowed": False,
+                        "passed": False,
+                        "reason": "Publish gate requires human review before PR creation.",
+                        "concerns": ["diff summary omits the blocker"],
+                        "fail_open_used": False,
+                        "ran": True,
+                    },
+                    "receipt_metadata": {
+                        "debate_gate_result": {
+                            "verdict": "blocked",
+                            "publication_allowed": False,
+                            "passed": False,
+                            "reason": "Publish gate requires human review before PR creation.",
+                            "concerns": ["diff summary omits the blocker"],
+                            "fail_open_used": False,
+                            "ran": True,
+                        }
+                    },
+                }
+            ),
+        ):
+            status = asyncio.run(loop._run_iteration(1))
+
+        assert status.worker_status == "completed"
+        assert "Publish skipped by debate gate" in status.next_actions[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/swarm/test_debate_gate.py
+++ b/tests/swarm/test_debate_gate.py
@@ -1,0 +1,139 @@
+"""Unit tests for the publish-time debate gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
+
+
+def _request(**overrides: object) -> DebateGateRequest:
+    payload = {
+        "issue_number": 101,
+        "issue_title": "Tighten publish metadata handling",
+        "issue_body": "Acceptance Criteria:\n- keep publish metadata truthful\n",
+        "source_branch": "codex/issue-101",
+        "target_branch": "main",
+        "commit_shas": ["abc123"],
+        "changed_files": ["aragora/swarm/boss_loop.py"],
+        "tests_run": ["python3 -m pytest tests/swarm/test_boss_loop.py -q"],
+        "verification_results": [{"name": "pytest", "passed": True}],
+        "receipt_id": "lane-101",
+    }
+    payload.update(overrides)
+    return DebateGateRequest(**payload)
+
+
+def _payload(*, changed_files: list[str] | None = None) -> dict[str, object]:
+    return {
+        "changed_files": changed_files or ["aragora/swarm/boss_loop.py"],
+        "diff_stat": " aragora/swarm/boss_loop.py | 12 ++++++++++--",
+        "diff_excerpt": "@@ -1,2 +1,4 @@\n+guard publish metadata\n",
+        "verification_summary": {
+            "tests_run": ["python3 -m pytest tests/swarm/test_boss_loop.py -q"],
+            "checks_observed": 1,
+            "checks_passed": 1,
+            "checks_failed": 0,
+            "check_names": ["pytest"],
+        },
+    }
+
+
+def test_debate_gate_skips_when_disabled() -> None:
+    llm_caller = MagicMock()
+    diff_loader = MagicMock()
+    gate = DebateGate(
+        repo_root=Path.cwd(),
+        config=DebateGateConfig(enabled=False),
+        llm_caller=llm_caller,
+        diff_loader=diff_loader,
+    )
+
+    result = gate.evaluate(_request())
+
+    assert result.verdict == "skipped_disabled"
+    assert result.publication_allowed is True
+    assert result.ran is False
+    llm_caller.assert_not_called()
+    diff_loader.assert_not_called()
+
+
+def test_debate_gate_passes_structured_response() -> None:
+    gate = DebateGate(
+        repo_root=Path.cwd(),
+        config=DebateGateConfig(enabled=True),
+        llm_caller=lambda prompt, agent_type, timeout_seconds: (
+            '{"passed": true, "confidence": 0.82, "reason": "Diff matches the verified task.", '
+            '"concerns": []}'
+        ),
+        diff_loader=lambda repo_root, request, config: _payload(),
+    )
+
+    result = gate.evaluate(_request())
+
+    assert result.verdict == "passed"
+    assert result.publication_allowed is True
+    assert result.passed is True
+    assert result.confidence == 0.82
+    assert result.reason == "Diff matches the verified task."
+    assert result.changed_files == ["aragora/swarm/boss_loop.py"]
+
+
+def test_debate_gate_blocks_on_embedded_json_response() -> None:
+    gate = DebateGate(
+        repo_root=Path.cwd(),
+        config=DebateGateConfig(enabled=True),
+        llm_caller=lambda prompt, agent_type, timeout_seconds: (
+            "Review complete.\n"
+            '{"passed": false, "confidence": 0.34, "reason": "Observed a publish-time truth regression.", '
+            '"concerns": ["publish metadata omits blocker context"]}'
+        ),
+        diff_loader=lambda repo_root, request, config: _payload(
+            changed_files=["aragora/swarm/boss_loop.py", "tests/swarm/test_boss_loop.py"]
+        ),
+    )
+
+    result = gate.evaluate(_request())
+
+    assert result.verdict == "blocked"
+    assert result.publication_allowed is False
+    assert result.passed is False
+    assert result.concerns == ["publish metadata omits blocker context"]
+    assert result.reason == "Observed a publish-time truth regression."
+
+
+def test_debate_gate_runtime_failure_fails_open_by_default() -> None:
+    gate = DebateGate(
+        repo_root=Path.cwd(),
+        config=DebateGateConfig(enabled=True),
+        llm_caller=lambda prompt, agent_type, timeout_seconds: (_ for _ in ()).throw(
+            RuntimeError("model unavailable")
+        ),
+        diff_loader=lambda repo_root, request, config: _payload(),
+    )
+
+    result = gate.evaluate(_request())
+
+    assert result.verdict == "fail_open"
+    assert result.publication_allowed is True
+    assert result.fail_open_used is True
+    assert "model unavailable" in result.reason
+
+
+def test_debate_gate_runtime_failure_can_fail_closed() -> None:
+    gate = DebateGate(
+        repo_root=Path.cwd(),
+        config=DebateGateConfig(enabled=True, fail_closed=True),
+        llm_caller=lambda prompt, agent_type, timeout_seconds: (_ for _ in ()).throw(
+            RuntimeError("network unreachable")
+        ),
+        diff_loader=lambda repo_root, request, config: _payload(),
+    )
+
+    result = gate.evaluate(_request())
+
+    assert result.verdict == "blocked"
+    assert result.publication_allowed is False
+    assert result.fail_open_used is False
+    assert "network unreachable" in result.reason


### PR DESCRIPTION
## Summary
- add a small opt-in publish-time debate gate that evaluates verified branch deliverables before PR publication
- record machine-readable gate verdict metadata and surface gate blocks as publish-only follow-up state
- cover disabled, pass, block, fail-open, and existing publish-path regressions in boss-loop tests

## Validation
- python3 -m pytest tests/swarm/test_debate_gate.py tests/swarm/test_boss_loop.py -q --maxfail=1
- python3 -m ruff check aragora/swarm/debate_gate.py aragora/swarm/boss_loop.py tests/swarm/test_debate_gate.py tests/swarm/test_boss_loop.py
- python3 -m pytest tests/swarm/test_boss_loop_autonomy.py -q -k 'full_auto_continues_when_needs_human_has_deliverable or auto_publish_promotes_branch_deliverable_to_pr_metadata or run_iteration_surfaces_published_pr_after_blocked_deliverable'