### PR TITLE
Harden supervisor dependency context propagation

### DIFF
--- a/aragora/swarm/dependency_context.py
+++ b/aragora/swarm/dependency_context.py
@@ -15,6 +15,9 @@ _TERMINAL_FAILURE_DEPENDENCY_STATUSES = frozenset(
 _MAX_CHANGED_PATHS = 10
 _MAX_COMMIT_SHAS = 5
 _MAX_VERIFICATION_RESULTS = 5
+_NON_TERMINAL_NEEDS_HUMAN_REASONS = frozenset(
+    {"stale_lease_reaped", "expired_lease_reaped", "needs_human"}
+)
 
 
 def _text(value: Any) -> str:
@@ -40,6 +43,9 @@ def _normalize_verification_status(result: dict[str, Any]) -> str:
         value = _text(result.get(key))
         if value:
             return value.lower()
+    passed = result.get("passed")
+    if isinstance(passed, bool):
+        return "passed" if passed else "failed"
     success = result.get("success")
     if isinstance(success, bool):
         return "passed" if success else "failed"
@@ -47,6 +53,34 @@ def _normalize_verification_status(result: dict[str, Any]) -> str:
     if isinstance(exit_code, int):
         return "passed" if exit_code == 0 else "failed"
     return "unknown"
+
+
+def _terminal_dependency_failure_reason(work_order: dict[str, Any]) -> str:
+    metadata = work_order.get("metadata")
+    archived_due_to = _text(metadata.get("archived_due_to")) if isinstance(metadata, dict) else ""
+    return (
+        _text(work_order.get("failure_reason"))
+        or _text(work_order.get("dispatch_error"))
+        or (_text(metadata.get("archive_reason")) if isinstance(metadata, dict) else "")
+        or archived_due_to
+        or _text(work_order.get("worker_outcome"))
+        or _text(work_order.get("status")).lower()
+    )
+
+
+def _is_terminal_dependency_failure(work_order: dict[str, Any]) -> bool:
+    status = _text(work_order.get("status")).lower()
+    if status in {"discarded", "dispatch_failed", "failed", "scope_violation", "timed_out"}:
+        return True
+    if status != "needs_human":
+        return False
+
+    metadata = work_order.get("metadata")
+    archived_due_to = _text(metadata.get("archived_due_to")) if isinstance(metadata, dict) else ""
+    dependency_reason = _terminal_dependency_failure_reason(work_order).lower()
+    if dependency_reason in _NON_TERMINAL_NEEDS_HUMAN_REASONS and not archived_due_to:
+        return False
+    return True
 
 
 @dataclass(slots=True)
@@ -85,6 +119,7 @@ class DependencyContext:
     failure_reason: str = ""
     blocked_reason: str = ""
     deliverable: dict[str, Any] | None = None
+    terminal_failure_reason: str = ""
 
     @property
     def ready_for_dispatch(self) -> bool:
@@ -92,7 +127,7 @@ class DependencyContext:
 
     @property
     def terminal_failure(self) -> bool:
-        return self.status in _TERMINAL_FAILURE_DEPENDENCY_STATUSES
+        return bool(self.terminal_failure_reason)
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -184,6 +219,11 @@ def build_dependency_context(
         deliverable=dict(qualification.deliverable)
         if isinstance(qualification.deliverable, dict)
         else None,
+        terminal_failure_reason=(
+            _terminal_dependency_failure_reason(work_order)
+            if _is_terminal_dependency_failure(work_order)
+            else ""
+        ),
     )
 
 
@@ -234,7 +274,7 @@ def build_dependency_context_payload(
         terminal_failure = {
             "dependency_id": context.dependency_id,
             "dependency_status": context.status,
-            "dependency_reason": context.failure_reason or context.blocked_reason or context.status,
+            "dependency_reason": context.terminal_failure_reason,
         }
         break
 

--- a/aragora/swarm/dependency_context.py
+++ b/aragora/swarm/dependency_context.py
@@ -1,0 +1,305 @@
+"""Helpers for summarizing completed dependency results for supervisor work orders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from aragora.swarm.terminal_truth import qualify_work_order_terminal_state
+
+_DEPENDENCY_ID_KEYS = ("pipeline_task_id", "work_order_id", "task_key")
+_COMPLETED_DEPENDENCY_STATUSES = frozenset({"completed", "merged", "salvage"})
+_TERMINAL_FAILURE_DEPENDENCY_STATUSES = frozenset(
+    {"discarded", "dispatch_failed", "failed", "needs_human", "scope_violation", "timed_out"}
+)
+_MAX_CHANGED_PATHS = 10
+_MAX_COMMIT_SHAS = 5
+_MAX_VERIFICATION_RESULTS = 5
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _text_list(value: Any, *, limit: int) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    values: list[str] = []
+    for raw in value:
+        text = _text(raw)
+        if not text or text in values:
+            continue
+        values.append(text)
+        if len(values) >= limit:
+            break
+    return values
+
+
+def _normalize_verification_status(result: dict[str, Any]) -> str:
+    for key in ("status", "outcome", "conclusion", "result"):
+        value = _text(result.get(key))
+        if value:
+            return value.lower()
+    success = result.get("success")
+    if isinstance(success, bool):
+        return "passed" if success else "failed"
+    exit_code = result.get("exit_code")
+    if isinstance(exit_code, int):
+        return "passed" if exit_code == 0 else "failed"
+    return "unknown"
+
+
+@dataclass(slots=True)
+class DependencyVerificationOutcome:
+    """Bounded verification summary for a completed predecessor."""
+
+    command: str
+    status: str
+    exit_code: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "command": self.command,
+            "status": self.status,
+            "exit_code": self.exit_code,
+        }
+
+
+@dataclass(slots=True)
+class DependencyContext:
+    """Stable snapshot of one predecessor work order."""
+
+    dependency_id: str
+    work_order_id: str
+    pipeline_task_id: str
+    title: str
+    status: str
+    terminal_outcome: str
+    base_ref: str
+    branch: str
+    head_sha: str
+    changed_paths: list[str] = field(default_factory=list)
+    commit_shas: list[str] = field(default_factory=list)
+    tests_run: list[str] = field(default_factory=list)
+    verification_outcomes: list[DependencyVerificationOutcome] = field(default_factory=list)
+    failure_reason: str = ""
+    blocked_reason: str = ""
+    deliverable: dict[str, Any] | None = None
+
+    @property
+    def ready_for_dispatch(self) -> bool:
+        return self.status in _COMPLETED_DEPENDENCY_STATUSES
+
+    @property
+    def terminal_failure(self) -> bool:
+        return self.status in _TERMINAL_FAILURE_DEPENDENCY_STATUSES
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dependency_id": self.dependency_id,
+            "work_order_id": self.work_order_id,
+            "pipeline_task_id": self.pipeline_task_id,
+            "title": self.title,
+            "status": self.status,
+            "terminal_outcome": self.terminal_outcome,
+            "base_ref": self.base_ref,
+            "branch": self.branch,
+            "head_sha": self.head_sha,
+            "changed_paths": list(self.changed_paths),
+            "commit_shas": list(self.commit_shas),
+            "tests_run": list(self.tests_run),
+            "verification_outcomes": [item.to_dict() for item in self.verification_outcomes],
+            "failure_reason": self.failure_reason,
+            "blocked_reason": self.blocked_reason,
+            "deliverable": dict(self.deliverable) if isinstance(self.deliverable, dict) else None,
+        }
+
+
+def dependency_ids_for_work_order(item: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for raw in item.get("dependency_ids", []) if isinstance(item, dict) else []:
+        dependency_id = _text(raw)
+        if dependency_id and dependency_id not in values:
+            values.append(dependency_id)
+    return values
+
+
+def build_dependency_lookup(work_orders: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for candidate in work_orders:
+        if not isinstance(candidate, dict):
+            continue
+        for key in _DEPENDENCY_ID_KEYS:
+            candidate_id = _text(candidate.get(key))
+            if candidate_id:
+                lookup[candidate_id] = candidate
+    return lookup
+
+
+def build_dependency_context(
+    dependency_id: str,
+    work_order: dict[str, Any],
+) -> DependencyContext:
+    qualification = qualify_work_order_terminal_state(work_order)
+    verification_outcomes: list[DependencyVerificationOutcome] = []
+    for result in (
+        work_order.get("verification_results", []) if isinstance(work_order, dict) else []
+    ):
+        if not isinstance(result, dict):
+            continue
+        command = _text(result.get("command"))
+        if not command:
+            continue
+        exit_code = result.get("exit_code")
+        verification_outcomes.append(
+            DependencyVerificationOutcome(
+                command=command,
+                status=_normalize_verification_status(result),
+                exit_code=exit_code if isinstance(exit_code, int) else None,
+            )
+        )
+        if len(verification_outcomes) >= _MAX_VERIFICATION_RESULTS:
+            break
+
+    return DependencyContext(
+        dependency_id=dependency_id,
+        work_order_id=_text(work_order.get("work_order_id")),
+        pipeline_task_id=_text(work_order.get("pipeline_task_id")),
+        title=_text(work_order.get("title")),
+        status=_text(work_order.get("status")).lower(),
+        terminal_outcome=qualification.terminal_outcome,
+        base_ref=(
+            _text(work_order.get("branch"))
+            or _text(work_order.get("head_sha"))
+            or _text(work_order.get("initial_head"))
+        ),
+        branch=_text(work_order.get("branch")),
+        head_sha=_text(work_order.get("head_sha")),
+        changed_paths=_text_list(work_order.get("changed_paths"), limit=_MAX_CHANGED_PATHS),
+        commit_shas=_text_list(work_order.get("commit_shas"), limit=_MAX_COMMIT_SHAS),
+        tests_run=_text_list(work_order.get("tests_run"), limit=_MAX_VERIFICATION_RESULTS),
+        verification_outcomes=verification_outcomes,
+        failure_reason=_text(work_order.get("failure_reason")),
+        blocked_reason=_text(qualification.blocked_reason),
+        deliverable=dict(qualification.deliverable)
+        if isinstance(qualification.deliverable, dict)
+        else None,
+    )
+
+
+def build_dependency_context_payload(
+    item: dict[str, Any],
+    work_orders: list[dict[str, Any]],
+) -> dict[str, Any]:
+    dependency_ids = dependency_ids_for_work_order(item)
+    if not dependency_ids:
+        return {
+            "dependency_ids": [],
+            "contexts": [],
+            "missing_dependency_ids": [],
+            "ready_for_dispatch": True,
+            "base_reference": None,
+            "base_reference_dependency_id": None,
+            "terminal_failure": None,
+            "prompt_summary": "",
+        }
+
+    lookup = build_dependency_lookup(work_orders)
+    contexts: list[DependencyContext] = []
+    missing_dependency_ids: list[str] = []
+    for dependency_id in dependency_ids:
+        dependency = lookup.get(dependency_id)
+        if not isinstance(dependency, dict):
+            missing_dependency_ids.append(dependency_id)
+            continue
+        contexts.append(build_dependency_context(dependency_id, dependency))
+
+    ready_for_dispatch = (
+        not missing_dependency_ids
+        and len(contexts) == len(dependency_ids)
+        and all(context.ready_for_dispatch for context in contexts)
+    )
+    base_reference: str | None = None
+    base_reference_dependency_id: str | None = None
+    for context in reversed(contexts):
+        if context.ready_for_dispatch and context.base_ref:
+            base_reference = context.base_ref
+            base_reference_dependency_id = context.dependency_id
+            break
+
+    terminal_failure: dict[str, Any] | None = None
+    for context in contexts:
+        if not context.terminal_failure:
+            continue
+        terminal_failure = {
+            "dependency_id": context.dependency_id,
+            "dependency_status": context.status,
+            "dependency_reason": context.failure_reason or context.blocked_reason or context.status,
+        }
+        break
+
+    return {
+        "dependency_ids": list(dependency_ids),
+        "contexts": [context.to_dict() for context in contexts],
+        "missing_dependency_ids": list(missing_dependency_ids),
+        "ready_for_dispatch": ready_for_dispatch,
+        "base_reference": base_reference,
+        "base_reference_dependency_id": base_reference_dependency_id,
+        "terminal_failure": terminal_failure,
+        "prompt_summary": render_dependency_context_summary(contexts, missing_dependency_ids),
+    }
+
+
+def render_dependency_context_summary(
+    contexts: list[DependencyContext],
+    missing_dependency_ids: list[str] | None = None,
+) -> str:
+    if not contexts and not missing_dependency_ids:
+        return ""
+
+    lines = [
+        "Upstream dependency context (reference only; do not widen file scope from these paths):"
+    ]
+    for context in contexts:
+        header = f"- {context.dependency_id}: status={context.status}"
+        if context.terminal_outcome:
+            header += f", outcome={context.terminal_outcome}"
+        if context.base_ref:
+            header += f", base_ref={context.base_ref}"
+        lines.append(header)
+        if context.changed_paths:
+            lines.append(f"  changed_paths: {', '.join(context.changed_paths)}")
+        if context.commit_shas:
+            lines.append(f"  commit_shas: {', '.join(context.commit_shas)}")
+        if context.verification_outcomes:
+            verification_bits = ", ".join(
+                f"{item.command} [{item.status}]" for item in context.verification_outcomes
+            )
+            lines.append(f"  verification: {verification_bits}")
+        elif context.tests_run:
+            lines.append(f"  tests_run: {', '.join(context.tests_run)}")
+        if context.blocked_reason and not context.ready_for_dispatch:
+            lines.append(f"  blocked_reason: {context.blocked_reason}")
+    if missing_dependency_ids:
+        lines.append(f"- missing dependencies: {', '.join(missing_dependency_ids)}")
+    return "\n".join(lines)
+
+
+def compose_dependency_description(base_description: str, prompt_summary: str) -> str:
+    if not prompt_summary:
+        return base_description.strip()
+    parts = [base_description.strip()] if base_description.strip() else []
+    parts.append(prompt_summary.strip())
+    return "\n\n".join(part for part in parts if part).strip()
+
+
+__all__ = [
+    "DependencyContext",
+    "DependencyVerificationOutcome",
+    "build_dependency_context",
+    "build_dependency_context_payload",
+    "build_dependency_lookup",
+    "compose_dependency_description",
+    "dependency_ids_for_work_order",
+    "render_dependency_context_summary",
+]

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -30,6 +30,11 @@ from aragora.nomic.dev_coordination import (
 )
 from aragora.nomic.pipeline_bridge import BoundedWorkOrder, NomicPipelineBridge
 from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
+from aragora.swarm.dependency_context import (
+    build_dependency_context_payload,
+    compose_dependency_description,
+    dependency_ids_for_work_order,
+)
 from aragora.swarm.lane_telemetry import LaneTelemetryCollector
 from aragora.swarm.spec import SwarmSpec
 from aragora.swarm.terminal_truth import (
@@ -809,29 +814,71 @@ class SwarmSupervisor:
         item: dict[str, Any],
         work_orders: list[dict[str, Any]],
     ) -> bool:
-        dependency_ids = {
-            str(dep).strip() for dep in item.get("dependency_ids", []) if str(dep).strip()
-        }
+        return bool(build_dependency_context_payload(item, work_orders)["ready_for_dispatch"])
+
+    @staticmethod
+    def _sync_dependency_context_metadata(
+        item: dict[str, Any],
+        work_orders: list[dict[str, Any]],
+        *,
+        prompt_ready: bool = False,
+    ) -> dict[str, Any]:
+        metadata = dict(item.get("metadata") or {})
+        dependency_ids = dependency_ids_for_work_order(item)
+        base_description = str(
+            metadata.get("dependency_context_base_description", item.get("description", "")) or ""
+        ).strip()
+
         if not dependency_ids:
-            return True
+            for key in (
+                "dependency_context",
+                "dependency_context_prompt",
+                "dependency_context_ready",
+                "dependency_missing_ids",
+                "dependency_terminal_failure",
+                "dependency_context_base_description",
+            ):
+                metadata.pop(key, None)
+            if metadata:
+                item["metadata"] = metadata
+            else:
+                item.pop("metadata", None)
+            item["description"] = base_description
+            return {
+                "dependency_ids": [],
+                "contexts": [],
+                "missing_dependency_ids": [],
+                "ready_for_dispatch": True,
+                "base_reference": None,
+                "base_reference_dependency_id": None,
+                "terminal_failure": None,
+                "prompt_summary": "",
+            }
 
-        completed_statuses = {"completed", "merged", "salvage"}
-        dependency_lookup: dict[str, dict[str, Any]] = {}
-        for candidate in work_orders:
-            if not isinstance(candidate, dict):
-                continue
-            for key in ("pipeline_task_id", "work_order_id", "task_key"):
-                candidate_id = str(candidate.get(key, "")).strip()
-                if candidate_id:
-                    dependency_lookup[candidate_id] = candidate
-
-        for dependency_id in dependency_ids:
-            dependency = dependency_lookup.get(dependency_id)
-            if not isinstance(dependency, dict):
-                return False
-            if str(dependency.get("status", "")).strip().lower() not in completed_statuses:
-                return False
-        return True
+        payload = build_dependency_context_payload(item, work_orders)
+        metadata["dependency_context_base_description"] = base_description
+        metadata["dependency_context"] = list(payload["contexts"])
+        metadata["dependency_context_ready"] = bool(payload["ready_for_dispatch"])
+        if payload["missing_dependency_ids"]:
+            metadata["dependency_missing_ids"] = list(payload["missing_dependency_ids"])
+        else:
+            metadata.pop("dependency_missing_ids", None)
+        if payload["terminal_failure"] is not None:
+            metadata["dependency_terminal_failure"] = dict(payload["terminal_failure"])
+        else:
+            metadata.pop("dependency_terminal_failure", None)
+        prompt_summary = str(payload["prompt_summary"]).strip()
+        if prompt_summary:
+            metadata["dependency_context_prompt"] = prompt_summary
+        else:
+            metadata.pop("dependency_context_prompt", None)
+        item["metadata"] = metadata
+        item["description"] = (
+            compose_dependency_description(base_description, prompt_summary)
+            if prompt_ready
+            else base_description
+        )
+        return payload
 
     @staticmethod
     def _replacement_active_lease(
@@ -1633,36 +1680,11 @@ class SwarmSupervisor:
         item: dict[str, Any],
         work_orders: list[dict[str, Any]],
     ) -> tuple[str, str] | None:
-        dependency_ids = [
-            str(dep).strip() for dep in item.get("dependency_ids", []) if str(dep).strip()
-        ]
-        if not dependency_ids:
-            return None
-
-        completed_statuses = {"completed", "merged", "salvage"}
-        references: dict[str, str] = {}
-        for candidate in work_orders:
-            if not isinstance(candidate, dict):
-                continue
-            status = str(candidate.get("status", "")).strip().lower()
-            if status not in completed_statuses:
-                continue
-            reference = (
-                str(candidate.get("branch", "")).strip()
-                or str(candidate.get("head_sha", "")).strip()
-                or str(candidate.get("initial_head", "")).strip()
-            )
-            if not reference:
-                continue
-            for key in ("pipeline_task_id", "work_order_id", "task_key"):
-                candidate_id = str(candidate.get(key, "")).strip()
-                if candidate_id:
-                    references[candidate_id] = reference
-
-        for dependency_id in reversed(dependency_ids):
-            resolved_reference = references.get(dependency_id)
-            if resolved_reference:
-                return resolved_reference, dependency_id
+        payload = build_dependency_context_payload(item, work_orders)
+        base_reference = str(payload.get("base_reference") or "").strip()
+        dependency_id = str(payload.get("base_reference_dependency_id") or "").strip()
+        if base_reference and dependency_id:
+            return base_reference, dependency_id
         return None
 
     def _reseed_dependent_session_branch(

--- a/aragora/swarm/supervisor_workers.py
+++ b/aragora/swarm/supervisor_workers.py
@@ -86,6 +86,12 @@ def refresh_run(self, run_id: str) -> SupervisorRun:
         worker_type_circuit_breakers=worker_type_circuit_breakers,
         worker_type_circuit_breaker_policy=worker_type_circuit_breaker_policy,
     )
+    for item in work_orders:
+        self._sync_dependency_context_metadata(
+            item,
+            work_orders,
+            prompt_ready=str(item.get("status", "")).strip() in {"leased", "dispatched"},
+        )
     active_count = sum(
         1 for item in work_orders if str(item.get("status", "")) in {"leased", "dispatched"}
     )
@@ -1194,6 +1200,11 @@ def _lease_work_order(
     else:
         work_order.pop("dependency_base_ref", None)
         work_order.pop("dependency_base_source", None)
+    dependency_payload = self._sync_dependency_context_metadata(
+        work_order,
+        work_orders,
+        prompt_ready=True,
+    )
     claimed_paths = [item for item in file_scope if not self._looks_like_glob(item)]
     allowed_globs = [item for item in file_scope if self._looks_like_glob(item)]
     if not allowed_globs and not claimed_paths and file_scope:
@@ -1218,6 +1229,8 @@ def _lease_work_order(
             "risk_level": str(work_order.get("risk_level", "review")),
             "approval_required": True,
             "repair_journal_count": len(metadata.get("repair_journal", []) or []),
+            "dependency_context_ready": bool(dependency_payload["ready_for_dispatch"]),
+            "dependency_context_count": len(dependency_payload["contexts"]),
         },
     )
     work_order.update(

--- a/tests/swarm/test_dependency_context.py
+++ b/tests/swarm/test_dependency_context.py
@@ -30,7 +30,10 @@ def test_build_dependency_context_payload_summarizes_completed_dependency() -> N
         "changed_paths": ["aragora/swarm/supervisor.py", "tests/swarm/test_supervisor.py"],
         "tests_run": ["python3 -m pytest tests/swarm/test_supervisor.py -q"],
         "verification_results": [
-            {"command": "python3 -m pytest tests/swarm/test_supervisor.py -q", "exit_code": 0}
+            {
+                "command": "python3 -m pytest tests/swarm/test_supervisor.py -q",
+                "passed": True,
+            }
         ],
     }
     dependent = {
@@ -58,7 +61,7 @@ def test_build_dependency_context_payload_summarizes_completed_dependency() -> N
         {
             "command": "python3 -m pytest tests/swarm/test_supervisor.py -q",
             "status": "passed",
-            "exit_code": 0,
+            "exit_code": None,
         }
     ]
     assert "do not widen file scope" in payload["prompt_summary"]
@@ -102,3 +105,45 @@ def test_build_dependency_context_payload_records_terminal_failure_and_missing_d
     assert context["failure_reason"] == "work_order_leasing_failed"
     assert "missing dependencies: micro-task-2" in payload["prompt_summary"]
     assert "blocked_reason: worktree creation failed" in payload["prompt_summary"]
+
+
+def test_build_dependency_context_payload_does_not_mark_recoverable_needs_human_as_terminal() -> (
+    None
+):
+    dependency = {
+        "work_order_id": "micro-1",
+        "pipeline_task_id": "micro-task-1",
+        "title": "Implementation lane",
+        "status": "needs_human",
+        "failure_reason": "stale_lease_reaped",
+        "branch": "codex/swarm-micro-1",
+    }
+
+    payload = build_dependency_context_payload({"dependency_ids": ["micro-task-1"]}, [dependency])
+
+    assert payload["ready_for_dispatch"] is False
+    assert payload["terminal_failure"] is None
+    assert payload["contexts"][0]["status"] == "needs_human"
+
+
+def test_build_dependency_context_payload_marks_archived_needs_human_as_terminal() -> None:
+    dependency = {
+        "work_order_id": "micro-1",
+        "pipeline_task_id": "micro-task-1",
+        "title": "Implementation lane",
+        "status": "needs_human",
+        "failure_reason": "stale_lease_reaped",
+        "branch": "codex/swarm-micro-1",
+        "metadata": {
+            "archived_due_to": "stale_lease_reaped",
+        },
+    }
+
+    payload = build_dependency_context_payload({"dependency_ids": ["micro-task-1"]}, [dependency])
+
+    assert payload["ready_for_dispatch"] is False
+    assert payload["terminal_failure"] == {
+        "dependency_id": "micro-task-1",
+        "dependency_status": "needs_human",
+        "dependency_reason": "stale_lease_reaped",
+    }

--- a/tests/swarm/test_dependency_context.py
+++ b/tests/swarm/test_dependency_context.py
@@ -1,0 +1,104 @@
+"""Tests for dependency context summaries used by supervisor dispatch."""
+
+from __future__ import annotations
+
+from aragora.swarm.dependency_context import (
+    build_dependency_context_payload,
+    compose_dependency_description,
+    dependency_ids_for_work_order,
+)
+
+
+def test_dependency_ids_for_work_order_deduplicates_ids() -> None:
+    work_order = {
+        "dependency_ids": ["micro-task-1", " micro-task-2 ", "", "micro-task-1", None],
+    }
+
+    assert dependency_ids_for_work_order(work_order) == ["micro-task-1", "micro-task-2"]
+
+
+def test_build_dependency_context_payload_summarizes_completed_dependency() -> None:
+    dependency = {
+        "work_order_id": "micro-1",
+        "pipeline_task_id": "micro-task-1",
+        "task_key": "run-1:micro-1",
+        "title": "Implementation lane",
+        "status": "completed",
+        "branch": "codex/swarm-micro-1",
+        "head_sha": "abc123",
+        "commit_shas": ["abc123", "def456"],
+        "changed_paths": ["aragora/swarm/supervisor.py", "tests/swarm/test_supervisor.py"],
+        "tests_run": ["python3 -m pytest tests/swarm/test_supervisor.py -q"],
+        "verification_results": [
+            {"command": "python3 -m pytest tests/swarm/test_supervisor.py -q", "exit_code": 0}
+        ],
+    }
+    dependent = {
+        "dependency_ids": ["micro-task-1"],
+    }
+
+    payload = build_dependency_context_payload(dependent, [dependency])
+
+    assert payload["ready_for_dispatch"] is True
+    assert payload["base_reference"] == "codex/swarm-micro-1"
+    assert payload["base_reference_dependency_id"] == "micro-task-1"
+    assert payload["missing_dependency_ids"] == []
+    assert payload["terminal_failure"] is None
+
+    context = payload["contexts"][0]
+    assert context["dependency_id"] == "micro-task-1"
+    assert context["branch"] == "codex/swarm-micro-1"
+    assert context["head_sha"] == "abc123"
+    assert context["commit_shas"] == ["abc123", "def456"]
+    assert context["changed_paths"] == [
+        "aragora/swarm/supervisor.py",
+        "tests/swarm/test_supervisor.py",
+    ]
+    assert context["verification_outcomes"] == [
+        {
+            "command": "python3 -m pytest tests/swarm/test_supervisor.py -q",
+            "status": "passed",
+            "exit_code": 0,
+        }
+    ]
+    assert "do not widen file scope" in payload["prompt_summary"]
+    assert "base_ref=codex/swarm-micro-1" in payload["prompt_summary"]
+    assert (
+        compose_dependency_description("Run validation lane", payload["prompt_summary"])
+        == "Run validation lane\n\n" + payload["prompt_summary"]
+    )
+
+
+def test_build_dependency_context_payload_records_terminal_failure_and_missing_dependencies() -> (
+    None
+):
+    dependency = {
+        "work_order_id": "micro-1",
+        "pipeline_task_id": "micro-task-1",
+        "title": "Implementation lane",
+        "status": "discarded",
+        "failure_reason": "work_order_leasing_failed",
+        "dispatch_error": "worktree creation failed",
+        "branch": "codex/swarm-micro-1",
+        "changed_paths": ["aragora/swarm/supervisor.py"],
+    }
+    dependent = {
+        "dependency_ids": ["micro-task-1", "micro-task-2"],
+    }
+
+    payload = build_dependency_context_payload(dependent, [dependency])
+
+    assert payload["ready_for_dispatch"] is False
+    assert payload["base_reference"] is None
+    assert payload["missing_dependency_ids"] == ["micro-task-2"]
+    assert payload["terminal_failure"] == {
+        "dependency_id": "micro-task-1",
+        "dependency_status": "discarded",
+        "dependency_reason": "work_order_leasing_failed",
+    }
+
+    context = payload["contexts"][0]
+    assert context["status"] == "discarded"
+    assert context["failure_reason"] == "work_order_leasing_failed"
+    assert "missing dependencies: micro-task-2" in payload["prompt_summary"]
+    assert "blocked_reason: worktree creation failed" in payload["prompt_summary"]

--- a/tests/swarm/test_supervisor.py
+++ b/tests/swarm/test_supervisor.py
@@ -1241,6 +1241,37 @@ def test_refresh_run_does_not_lease_downstream_lane_before_dependencies_complete
     assert work_orders["micro-2"]["status"] == "leased"
     assert work_orders["micro-3"]["status"] == "queued"
     assert "lease_id" not in work_orders["micro-3"]
+    assert work_orders["micro-2"]["file_scope"] == ["tests/swarm/test_boss_loop.py"]
+    assert work_orders["micro-2"]["description"].startswith(
+        "Upstream dependency context (reference only; do not widen file scope from these paths):"
+    )
+    dependency_context = work_orders["micro-2"]["metadata"]["dependency_context"]
+    assert work_orders["micro-2"]["metadata"]["dependency_context_ready"] is True
+    assert dependency_context == [
+        {
+            "dependency_id": "micro-task-1",
+            "work_order_id": "micro-1",
+            "pipeline_task_id": "micro-task-1",
+            "title": "Implementation lane",
+            "status": "completed",
+            "terminal_outcome": "deliverable_created",
+            "base_ref": "main",
+            "branch": "main",
+            "head_sha": current_head,
+            "changed_paths": ["README.md"],
+            "commit_shas": [current_head],
+            "tests_run": [],
+            "verification_outcomes": [],
+            "failure_reason": "",
+            "blocked_reason": "",
+            "deliverable": {
+                "type": "branch",
+                "branch": "main",
+                "commit_shas": [current_head],
+                "work_order_id": "micro-1",
+            },
+        }
+    ]
     assert lifecycle.ensure_managed_worktree.call_count == 1
 
 
@@ -8398,6 +8429,12 @@ def test_refresh_run_requeues_ignorable_scope_violation_and_dependency_children(
 def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branch(
     repo: Path, store: DevCoordinationStore
 ) -> None:
+    scope_path = repo / "tests" / "swarm" / "test_supervisor.py"
+    scope_path.parent.mkdir(parents=True, exist_ok=True)
+    scope_path.write_text("def test_placeholder() -> None:\n    pass\n", encoding="utf-8")
+    _run(repo, "git", "add", str(scope_path.relative_to(repo)))
+    _run(repo, "git", "commit", "-m", "add dependency scope file")
+
     dependency_branch = "codex/swarm-dependency-base"
     _run(repo, "git", "checkout", "-b", dependency_branch)
     (repo / "README.md").write_text("hello\ndependency\n", encoding="utf-8")
@@ -8453,6 +8490,14 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
                 "review_status": "pending_heterogeneous_review",
                 "branch": dependency_branch,
                 "head_sha": dependency_head,
+                "commit_shas": [dependency_head],
+                "changed_paths": ["README.md"],
+                "verification_results": [
+                    {
+                        "command": "python3 -m pytest tests/swarm/test_supervisor.py -q",
+                        "exit_code": 0,
+                    }
+                ],
                 "file_scope": ["README.md"],
                 "target_agent": "codex",
             },
@@ -8460,10 +8505,11 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
                 "work_order_id": "micro-2",
                 "pipeline_task_id": "micro-task-2",
                 "title": "Run validation and fix failures",
+                "description": "Run validation and fix failures",
                 "status": "queued",
                 "review_status": "pending",
                 "dependency_ids": ["micro-task-1"],
-                "file_scope": ["README.md"],
+                "file_scope": ["tests/swarm/test_supervisor.py"],
                 "target_agent": "codex",
                 "reviewer_agent": "claude",
             },
@@ -8479,6 +8525,44 @@ def test_refresh_run_leases_dependent_work_order_from_completed_dependency_branc
     assert dependent["status"] == "leased"
     assert dependent["dependency_base_ref"] == dependency_branch
     assert dependent["dependency_base_source"] == "micro-task-1"
+    assert dependent["file_scope"] == ["tests/swarm/test_supervisor.py"]
+    assert dependent["metadata"]["dependency_context_ready"] is True
+    assert dependent["metadata"]["dependency_context"] == [
+        {
+            "dependency_id": "micro-task-1",
+            "work_order_id": "micro-1",
+            "pipeline_task_id": "micro-task-1",
+            "title": "Write tests",
+            "status": "completed",
+            "terminal_outcome": "deliverable_created",
+            "base_ref": dependency_branch,
+            "branch": dependency_branch,
+            "head_sha": dependency_head,
+            "changed_paths": ["README.md"],
+            "commit_shas": [dependency_head],
+            "tests_run": [],
+            "verification_outcomes": [
+                {
+                    "command": "python3 -m pytest tests/swarm/test_supervisor.py -q",
+                    "status": "passed",
+                    "exit_code": 0,
+                }
+            ],
+            "failure_reason": "",
+            "blocked_reason": "",
+            "deliverable": {
+                "type": "branch",
+                "branch": dependency_branch,
+                "commit_shas": [dependency_head],
+                "work_order_id": "micro-1",
+            },
+        }
+    ]
+    assert dependent["metadata"]["dependency_context_prompt"].startswith(
+        "Upstream dependency context (reference only; do not widen file scope from these paths):"
+    )
+    assert dependent["description"].startswith("Run validation and fix failures\n\n")
+    assert "base_ref=" + dependency_branch in dependent["description"]
     assert _run(session_path, "git", "rev-parse", "HEAD").stdout.strip() == dependency_head
     assert (
         _run(session_path, "git", "rev-parse", "codex/swarm-dependent-base").stdout.strip()
@@ -8587,6 +8671,102 @@ def test_refresh_run_marks_invalid_dependency_ref_needs_human(
         assert cleared_key not in dependent
     assert dependent["blockers"] == [
         "Dependent lane received an invalid prerequisite branch reference; reconcile the dependency chain before rerunning."
+    ]
+
+
+def test_refresh_run_records_terminal_dependency_context_without_dispatch(
+    repo: Path, store: DevCoordinationStore
+) -> None:
+    supervisor = SwarmSupervisor(
+        repo_root=repo,
+        store=store,
+        lifecycle=MagicMock(),
+        decomposer=MagicMock(),
+    )
+    run_record = store.create_supervisor_run(
+        goal="record terminal dependency context",
+        target_branch="main",
+        supervisor_agents={},
+        approval_policy={},
+        spec={"raw_goal": "record terminal dependency context"},
+        metadata={"max_concurrency": 1},
+        work_orders=[
+            {
+                "work_order_id": "micro-1",
+                "pipeline_task_id": "micro-task-1",
+                "title": "Implementation lane",
+                "description": "Implementation lane",
+                "status": "discarded",
+                "failure_reason": "work_order_leasing_failed",
+                "dispatch_error": "worktree creation failed",
+                "branch": "codex/swarm-micro-1",
+                "file_scope": ["aragora/swarm/supervisor.py"],
+                "target_agent": "codex",
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                    "archived_due_to": "work_order_leasing_failed",
+                    "archive_reason": "work_order_leasing_failed",
+                },
+            },
+            {
+                "work_order_id": "micro-2",
+                "pipeline_task_id": "micro-task-2",
+                "title": "Validation lane",
+                "description": "Validation lane",
+                "status": "queued",
+                "dependency_ids": ["micro-task-1"],
+                "file_scope": ["tests/swarm/test_supervisor.py"],
+                "target_agent": "codex",
+                "reviewer_agent": "claude",
+                "metadata": {
+                    "source": "explicit_spec_work_order",
+                },
+            },
+        ],
+        status="active",
+    )
+
+    refreshed = supervisor.refresh_run(run_record["run_id"])
+
+    dependent = next(
+        item for item in refreshed.work_orders if item.get("pipeline_task_id") == "micro-task-2"
+    )
+    assert dependent["status"] == "discarded"
+    assert dependent["failure_reason"] == "terminal_dependency_failure"
+    assert dependent["file_scope"] == ["tests/swarm/test_supervisor.py"]
+    assert "lease_id" not in dependent
+    assert dependent["description"] == "Validation lane"
+    assert dependent["blocker"] == {
+        "reason": "terminal_dependency_failure",
+        "dependency_id": "micro-task-1",
+        "dependency_status": "discarded",
+        "dependency_reason": "work_order_leasing_failed",
+    }
+    assert dependent["metadata"]["dependency_context_ready"] is False
+    assert dependent["metadata"]["dependency_terminal_failure"] == {
+        "dependency_id": "micro-task-1",
+        "dependency_status": "discarded",
+        "dependency_reason": "work_order_leasing_failed",
+    }
+    assert dependent["metadata"]["dependency_context"] == [
+        {
+            "dependency_id": "micro-task-1",
+            "work_order_id": "micro-1",
+            "pipeline_task_id": "micro-task-1",
+            "title": "Implementation lane",
+            "status": "discarded",
+            "terminal_outcome": "blocked",
+            "base_ref": "codex/swarm-micro-1",
+            "branch": "codex/swarm-micro-1",
+            "head_sha": "",
+            "changed_paths": [],
+            "commit_shas": [],
+            "tests_run": [],
+            "verification_outcomes": [],
+            "failure_reason": "work_order_leasing_failed",
+            "blocked_reason": "worktree creation failed",
+            "deliverable": None,
+        }
     ]
 
 


### PR DESCRIPTION
## Summary
- add a focused dependency context helper for completed and failed predecessor work orders
- preserve dependency gating and reseed logic while injecting prompt-ready predecessor context before dispatch
- cover dependency context payloads, branch reseed propagation, and truthful terminal dependency blocking in supervisor tests

## Validation
- python3 -m pytest tests/swarm/test_dependency_context.py tests/swarm/test_supervisor.py -q --maxfail=1
- python3 -m ruff check aragora/swarm/dependency_context.py aragora/swarm/supervisor.py aragora/swarm/supervisor_workers.py tests/swarm/test_dependency_context.py tests/swarm/test_supervisor.py