### PR TITLE
fix(pipeline): narrow broad except Exception handlers to specific types

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -74,7 +74,7 @@ def _check_objective_fidelity(
         scores = _check_fidelity_llm(original_goal, objectives)
         if scores is not None:
             return scores
-    except Exception:
+    except (ImportError, ValueError, TypeError, RuntimeError, OSError):
         pass
 
     # Fallback: keyword-based Jaccard similarity
@@ -124,7 +124,7 @@ def _check_fidelity_llm(
             scores = _json.loads(match.group())
             if len(scores) == len(objectives):
                 return [max(0.0, min(1.0, float(s))) for s in scores]
-    except Exception:
+    except (ValueError, TypeError, RuntimeError, OSError, json.JSONDecodeError):
         pass
 
     return None


### PR DESCRIPTION
Replace two `except Exception:` blocks in pipeline.py with specific
exception types (ImportError, ValueError, TypeError, RuntimeError,
OSError, json.JSONDecodeError) to satisfy BLE001 linting rules.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 70d1cdc10f8e2dbb7e0779ab79a8d7204b959c54)
