### PR TITLE
fix: narrow broad except Exception handlers in idea.py

### DIFF
--- a/aragora/cli/commands/idea.py
+++ b/aragora/cli/commands/idea.py
@@ -557,7 +557,7 @@ async def _generate_founder_handoffs(
             acceptance_criteria=success_criteria or None,
             constraints=constraints or None,
         )
-    except Exception as exc:
+    except (asyncio.TimeoutError, OSError, ValueError, RuntimeError, ImportError) as exc:
         logger.warning("Idea triage planner fell back to heuristic decomposition: %s", exc)
         decomposition = decomposer.analyze(
             planning_prompt, file_scope_hints=file_scope_hints or None
@@ -968,7 +968,7 @@ async def _model_review_founder_handoffs(
             agent.generate(_founder_review_model_prompt(brief=brief, handoffs=handoffs)),
             timeout=timeout_seconds,
         )
-    except Exception as exc:
+    except (asyncio.TimeoutError, OSError, ValueError, RuntimeError, ImportError) as exc:
         logger.warning("model founder review unavailable: %s", exc)
         return {
             "status": "approved",


### PR DESCRIPTION
Replace two `except Exception` catches with specific exception tuples
(TimeoutError, OSError, ValueError, RuntimeError, ImportError) for
graceful degradation in the triage planner and founder review paths.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 25ea3758438111f86e87327e6da537a99fb52bab)
