### PR TITLE
fix(autonomous): justify CancelledError pass in proactive_intelligence.py

### DIFF
--- a/aragora/autonomous/proactive_intelligence.py
+++ b/aragora/autonomous/proactive_intelligence.py
@@ -229,7 +229,7 @@ class ScheduledTrigger:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected during shutdown — not an error
         logger.info("Scheduled trigger manager stopped")
 
     async def _run_scheduler(self) -> None:


### PR DESCRIPTION
The only except-pass pattern in this file is the standard asyncio
CancelledError handling during task shutdown — added inline comment
documenting why it is intentional and not silent swallowing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 5b7ba69562c34d7f0b59a50a302f5772e8846d57)
