### PR TITLE
test(scripts): cover boss cycle refill paths

### DIFF
--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import sys
+
+from aragora.swarm.issue_scanner import BossIssueCandidate
+from scripts import generate_boss_issues as mod
+
+
+def _candidate(name: str, *, file_scope: list[str]) -> BossIssueCandidate:
+    return BossIssueCandidate(
+        category="test_coverage",
+        title=f"Add tests for {name}",
+        description=f"Create tests covering {name}.",
+        file_scope=file_scope,
+        new_files=[f"tests/test_{name}.py"],
+        validation_command=f"pytest tests/test_{name}.py -v",
+        acceptance_criteria=["All tests pass"],
+    )
+
+
+def test_main_dry_run_fetches_and_filters_like_real_mode(
+    monkeypatch,
+    capsys,
+) -> None:
+    duplicate = _candidate("duplicate_module", file_scope=["aragora/duplicate_module.py"])
+    pr_conflict = _candidate("pr_conflict_module", file_scope=["aragora/pr_conflict_module.py"])
+    eligible = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+
+    scan_calls: list[tuple[object, object]] = []
+    fetch_existing_calls: list[str] = []
+    fetch_pr_calls: list[str] = []
+    create_calls: list[tuple[str, str, str, str]] = []
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None: (
+            scan_calls.append((repo_root, categories)) or [duplicate, pr_conflict, eligible]
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "fetch_existing_boss_issues",
+        lambda repo: (
+            fetch_existing_calls.append(repo)
+            or [{"title": "Other issue", "body": f"<!-- fingerprint:{duplicate.fingerprint} -->"}]
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "fetch_open_pr_files",
+        lambda repo: (fetch_pr_calls.append(repo) or {"aragora/pr_conflict_module.py"}),
+    )
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        mod,
+        "create_github_issue",
+        lambda repo, title, body, label: (create_calls.append((repo, title, body, label)) or True),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--dry-run",
+            "--max-issues",
+            "5",
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert scan_calls
+    assert fetch_existing_calls == ["org/repo"]
+    assert fetch_pr_calls == ["org/repo"]
+    assert "DRY RUN — would create 1 issues" in out
+    assert eligible.title in out
+    assert "Skipped: 1 duplicates, 1 PR conflicts, 0 validation failures" in out
+    assert not create_calls
+
+
+def test_main_create_mode_trims_to_max_and_writes_fingerprint(
+    monkeypatch,
+    capsys,
+) -> None:
+    first = _candidate("first_module", file_scope=["aragora/first_module.py"])
+    second = _candidate("second_module", file_scope=["aragora/second_module.py"])
+
+    created: list[tuple[str, str, str, str]] = []
+    monkeypatch.setattr(mod, "scan_all", lambda repo_root, categories=None: [first, second])
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        mod,
+        "create_github_issue",
+        lambda repo, title, body, label: (created.append((repo, title, body, label)) or True),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--repo",
+            "org/repo",
+            "--max-issues",
+            "1",
+            "--label",
+            "boss-ready",
+        ],
+    )
+
+    mod.main()
+
+    out = capsys.readouterr().out
+    assert "Done: 1 created, 0 failed" in out
+    assert len(created) == 1
+    repo, title, body, label = created[0]
+    assert repo == "org/repo"
+    assert title == first.title
+    assert label == "boss-ready"
+    assert f"<!-- fingerprint:{first.fingerprint} -->" in body

--- a/tests/scripts/test_run_boss_cycle.py
+++ b/tests/scripts/test_run_boss_cycle.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "run_boss_cycle.sh"
+
+
+def _write_fake_python3(tmp_path: Path) -> tuple[Path, Path]:
+    log_path = tmp_path / "python3.log"
+    fake_python3 = tmp_path / "python3"
+    fake_python3.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+{
+  first=1
+  for arg in "$@"; do
+    if [[ "$first" -eq 0 ]]; then
+      printf '\\t'
+    fi
+    printf '%s' "$arg"
+    first=0
+  done
+  printf '\\n'
+} >> "${FAKE_PYTHON3_LOG}"
+if [[ "${1:-}" == "-u" ]]; then
+  exit "${FAKE_PYTHON3_BOSS_EXIT:-0}"
+fi
+exit "${FAKE_PYTHON3_REFILL_EXIT:-0}"
+""",
+        encoding="utf-8",
+    )
+    fake_python3.chmod(0o755)
+    return fake_python3, log_path
+
+
+def _read_calls(log_path: Path) -> list[list[str]]:
+    if not log_path.exists():
+        return []
+    return [line.split("\t") for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_run_boss_cycle_runs_post_loop_refill_after_success(tmp_path: Path) -> None:
+    _fake_python3, log_path = _write_fake_python3(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["FAKE_PYTHON3_LOG"] = str(log_path)
+    env["FAKE_PYTHON3_BOSS_EXIT"] = "0"
+    env["FAKE_PYTHON3_REFILL_EXIT"] = "0"
+    env["ARAGORA_POST_LOOP_DRY_RUN"] = "1"
+    env["ARAGORA_POST_LOOP_MAX_ISSUES"] = "7"
+    env["ARAGORA_POST_LOOP_ISSUE_REFILL"] = "1"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--boss-repo",
+            "org/repo",
+            "--label",
+            "lane:test",
+            "--worker-model",
+            "codex",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    calls = _read_calls(log_path)
+    assert len(calls) == 2
+    assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
+    assert "--boss-repo" in calls[0]
+    assert "org/repo" in calls[0]
+    assert calls[1] == [
+        "scripts/generate_boss_issues.py",
+        "--repo",
+        "org/repo",
+        "--max-issues",
+        "7",
+        "--label",
+        "lane:test",
+        "--dry-run",
+    ]
+
+
+def test_run_boss_cycle_skips_post_loop_refill_after_failure(tmp_path: Path) -> None:
+    _fake_python3, log_path = _write_fake_python3(tmp_path)
+    env = os.environ.copy()
+    env["PATH"] = f"{tmp_path}:{env['PATH']}"
+    env["FAKE_PYTHON3_LOG"] = str(log_path)
+    env["FAKE_PYTHON3_BOSS_EXIT"] = "9"
+    env["FAKE_PYTHON3_REFILL_EXIT"] = "0"
+    env["ARAGORA_POST_LOOP_ISSUE_REFILL"] = "1"
+
+    result = subprocess.run(
+        [
+            "bash",
+            str(SCRIPT_PATH),
+            "--boss-repo",
+            "org/repo",
+            "--label",
+            "boss-ready",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 9
+    calls = _read_calls(log_path)
+    assert len(calls) == 1
+    assert calls[0][:5] == ["-u", "-m", "aragora.cli.main", "swarm", "boss-loop"]
+    assert "Skipping post-loop issue refill because boss loop exited non-zero." in result.stderr


### PR DESCRIPTION
## Summary
- add dry-run and fingerprint assertions for `scripts/generate_boss_issues.py`
- add post-loop refill coverage for `scripts/run_boss_cycle.sh`

## Validation
- `python3 -m pytest tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py -q -o cache_dir=/tmp/pytest-cache-boss-cycle-test-hardening-20260411`
- `python3 -m ruff check tests/scripts/test_generate_boss_issues.py tests/scripts/test_run_boss_cycle.py`
