### PR TITLE
fix(billing): add logging to silent JSON parse error in models.py

### DIFF
--- a/aragora/billing/models.py
+++ b/aragora/billing/models.py
@@ -484,7 +484,12 @@ class User:
             return []
         try:
             return json.loads(self.service_account_scopes)
-        except (json.JSONDecodeError, TypeError):
+        except (json.JSONDecodeError, TypeError) as e:
+            logger.warning(
+                "Failed to parse service_account_scopes for user %s: %s",
+                self.id,
+                e,
+            )
             return []
 
     def set_service_account_scopes(self, scopes: list[str]) -> None:


### PR DESCRIPTION
The get_service_account_scopes method was silently swallowing
json.JSONDecodeError and TypeError exceptions when parsing
service_account_scopes. Added warning-level logging with user ID
and error details to aid debugging.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 2bbcad35c223f46628ae57ac314cceae73a62071)
