### PR TITLE
fix(storage): fail-closed read in notification_template_store

### DIFF
--- a/aragora/storage/notification_template_store.py
+++ b/aragora/storage/notification_template_store.py
@@ -70,18 +70,23 @@ class NotificationTemplateStore:
     def _read_user_file(self, user_id: str) -> dict[str, dict[str, Any]]:
         """Read a user's override file. Returns empty dict if missing."""
         path = self._user_path(user_id)
-        if not path.exists():
-            return {}
         try:
-            data = json.loads(path.read_text(encoding="utf-8"))
-            if not isinstance(data, dict):
-                raise ValueError(
-                    f"Invalid template override file for {user_id}: expected object, got {type(data).__name__}"
-                )
-            return data
-        except (json.JSONDecodeError, OSError) as exc:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return {}
+        except OSError as exc:
             logger.error("Failed to read template overrides for %s: %s", user_id, exc)
             raise
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            logger.error("Failed to parse template overrides for %s: %s", user_id, exc)
+            raise
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Invalid template override file for {user_id}: expected object, got {type(data).__name__}"
+            )
+        return data
 
     def _write_user_file(self, user_id: str, data: dict[str, dict[str, Any]]) -> None:
         """Write a user's override file atomically."""


### PR DESCRIPTION
Replace path.exists() guard with EAFP try/read/catch-FileNotFoundError.
path.exists() can return False on permission errors, silently treating
an unreadable file as empty. Now permission errors propagate as OSError.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 66e63b560551709d12b634643e087ab1ba3e959b)
