### PR TITLE
fix(billing): fail-closed on corrupt service_account_scopes JSON

### DIFF
--- a/aragora/billing/models.py
+++ b/aragora/billing/models.py
@@ -485,7 +485,12 @@ class User:
         try:
             return json.loads(self.service_account_scopes)
         except (json.JSONDecodeError, TypeError):
-            return []
+            logger.error(
+                "Corrupt service_account_scopes for user %s: %r",
+                self.id,
+                self.service_account_scopes,
+            )
+            raise
 
     def set_service_account_scopes(self, scopes: list[str]) -> None:
         """Set scopes for service account."""


### PR DESCRIPTION
get_service_account_scopes() silently returned an empty list on
JSONDecodeError/TypeError, hiding data corruption. Now logs the
corrupt value and re-raises so callers see the failure.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d21a9decb0ceba6304b19bc2708b12ad4bfa2378)
