### PR TITLE
fix(storage): add logger.warning for swallowed OSError in notification_template_store

### DIFF
--- a/aragora/storage/notification_template_store.py
+++ b/aragora/storage/notification_template_store.py
@@ -53,7 +53,10 @@ class NotificationTemplateStore:
             data_dir = str(Path(base).parent / "notification_templates")
 
         self._dir = Path(data_dir)
-        self._dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning("Could not create template store directory %s: %s", self._dir, exc)
         self._lock = threading.Lock()
         logger.info("NotificationTemplateStore initialized at %s", self._dir)
 


### PR DESCRIPTION
Wrap the mkdir call in NotificationTemplateStore.__init__ with a
try/except that logs a warning when the directory cannot be created,
instead of letting the OSError propagate unhandled.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit aa93c8de0b102829a80bde153d04a63f8c25f774)
