### PR TITLE
fix: narrow broad exception handler to OSError in bug_detector.py

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except OSError as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines


### PR DESCRIPTION
Remove unnecessary SyntaxError and ValueError from the except tuple in
detect_in_directory — only OSError can occur from file I/O operations
in that code path.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 45400330b42919282104d11b9a5d6b7a58e8bd9d)
