### PR TITLE
fix(billing): add logging to silent ImportError in metering.py (#4632)

### DIFF
--- a/aragora/billing/metering.py
+++ b/aragora/billing/metering.py
@@ -486,6 +486,7 @@ class UsageMeter:
 
             return get_current_tenant_id()
         except ImportError:
+            logger.debug("Tenancy module not available; skipping tenant ID lookup")
             return None
 
     def _get_billing_period(self, dt: datetime) -> str:


### PR DESCRIPTION
Replace silent exception swallowing in _get_tenant_id with a debug log
so missing tenancy module is visible in logs instead of silently returning None.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e61858de6e44f0a085e8371f96ab04ac723575af)
