### PR TITLE
fix(cli): replace silent exception swallowing in quickstart.py with logging

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -266,8 +266,8 @@ def _load_dotenv() -> bool:
                         if key and key not in os.environ:
                             os.environ[key] = value
                 return True
-            except OSError:
-                pass
+            except OSError as exc:
+                logger.debug("Failed to load .env from %s: %s", candidate, exc)
     return False
 
 
@@ -1072,7 +1072,7 @@ async def _run_live_debate(
 
         reset_secret_manager()
     except ImportError:
-        pass
+        logger.debug("aragora.config.secrets not available, skipping reset")
 
     from aragora.agents.base import AgentType, create_agent
     from aragora.core import Environment


### PR DESCRIPTION
Add logger.debug calls to two bare `except: pass` patterns:
- _load_dotenv: log OSError when .env file read fails
- _run_live_debate: log when secrets manager import unavailable

The third except-pass (TLS writer close) already has a justifying comment.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 884109f1d5809d72d15e02b0bcf1b41fc5458478)
