### PR TITLE
fix: replace silent exception swallowing with debug logging in cv.py (#4664)

### DIFF
--- a/aragora/agents/cv.py
+++ b/aragora/agents/cv.py
@@ -522,14 +522,14 @@ def get_cv_builder() -> CVBuilder:
 
             elo_system = get_elo_store()
         except ImportError:
-            pass
+            logger.debug("ELO system not available for CV builder")
 
         try:
             from aragora.agents.calibration import CalibrationTracker
 
             calibration_tracker = CalibrationTracker()
         except ImportError:
-            pass
+            logger.debug("CalibrationTracker not available for CV builder")
 
         _cv_builder = CVBuilder(
             elo_system=elo_system,


### PR DESCRIPTION
Replace bare `except ImportError: pass` patterns with `logger.debug()`
calls in `get_cv_builder()` so missing optional dependencies are visible
in debug logs instead of silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 2cb40dc83ae62ceb7aa1e4da46737cce63007322)
