### PR TITLE
fix(channels): log skipped dock imports instead of silently swallowing ImportError

### DIFF
--- a/aragora/channels/registry.py
+++ b/aragora/channels/registry.py
@@ -225,46 +225,46 @@ def _register_builtin_docks(registry: DockRegistry) -> None:
 
         registry.register(SlackDock)
     except ImportError:
-        pass
+        logger.debug("Slack dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.telegram import TelegramDock
 
         registry.register(TelegramDock)
     except ImportError:
-        pass
+        logger.debug("Telegram dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.discord import DiscordDock
 
         registry.register(DiscordDock)
     except ImportError:
-        pass
+        logger.debug("Discord dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.teams import TeamsDock
 
         registry.register(TeamsDock)
     except ImportError:
-        pass
+        logger.debug("Teams dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.whatsapp import WhatsAppDock
 
         registry.register(WhatsAppDock)
     except ImportError:
-        pass
+        logger.debug("WhatsApp dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.email import EmailDock
 
         registry.register(EmailDock)
     except ImportError:
-        pass
+        logger.debug("Email dock not available (missing dependencies)")
 
     try:
         from aragora.channels.docks.google_chat import GoogleChatDock
 
         registry.register(GoogleChatDock)
     except ImportError:
-        pass
+        logger.debug("Google Chat dock not available (missing dependencies)")


### PR DESCRIPTION
Replace 7 bare `except ImportError: pass` patterns in
_register_builtin_docks with logger.debug calls so missing
optional dependencies are visible when debugging.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d05498a6f5674a1570e9cbb4f8ca2a4c28195c32)
