### PR TITLE
fix: replace silent exception swallowing with debug logging in replication_monitor.py (#4630)

### DIFF
--- a/aragora/backup/replication_monitor.py
+++ b/aragora/backup/replication_monitor.py
@@ -516,7 +516,7 @@ class ReplicationHealthMonitor:
             try:
                 await self._monitoring_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("Replication monitoring task cancelled")
             self._monitoring_task = None
 
         logger.info("Stopped replication monitoring")


### PR DESCRIPTION
Replace `except asyncio.CancelledError: pass` with debug logging for
visibility into task cancellation during monitoring shutdown.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 6f82d10ed20a3e4305a870204f934f719be802b5)
