### PR TITLE
fix: add justification comment for intentional CancelledError pass in backup scheduler

### DIFF
--- a/aragora/backup/scheduler.py
+++ b/aragora/backup/scheduler.py
@@ -367,7 +367,7 @@ class BackupScheduler:
             try:
                 await task
             except asyncio.CancelledError:
-                pass
+                pass  # Expected during shutdown — task was intentionally cancelled
 
         self._tasks.clear()
 


### PR DESCRIPTION
The except asyncio.CancelledError: pass pattern in BackupScheduler.stop()
is the standard idiom for awaiting intentionally cancelled tasks during
shutdown. Added inline justification so no bare except...pass remains
without explanation.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c7ecd35674808060f0b5cba1b7764f84dcb36e34)
