### PR TITLE
fix: replace silent exception swallowing with debug logging in cv.py (#4626)

### DIFF
--- a/aragora/agents/cv.py
+++ b/aragora/agents/cv.py
@@ -522,14 +522,14 @@ def get_cv_builder() -> CVBuilder:
 
             elo_system = get_elo_store()
         except ImportError:
-            pass
+            logger.debug("ELO system unavailable, skipping for CV builder")
 
         try:
             from aragora.agents.calibration import CalibrationTracker
 
             calibration_tracker = CalibrationTracker()
         except ImportError:
-            pass
+            logger.debug("CalibrationTracker unavailable, skipping for CV builder")
 
         _cv_builder = CVBuilder(
             elo_system=elo_system,


### PR DESCRIPTION
Replace two `except ImportError: pass` patterns in get_cv_builder()
with logger.debug() calls for visibility when ELO or calibration
subsystems are unavailable.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
