### PR TITLE
fix: replace silent exception swallowing with debug logging in devops agent.py (#4662)

### DIFF
--- a/aragora/agents/devops/agent.py
+++ b/aragora/agents/devops/agent.py
@@ -548,7 +548,7 @@ class DevOpsAgent:
                         }
                     )
             except json.JSONDecodeError:
-                pass
+                logger.debug("Failed to parse release JSON for %s", self._config.repo)
 
         result.details = checks
         result.items_processed = len(checks)


### PR DESCRIPTION
Replace `except json.JSONDecodeError: pass` with debug logging in
health_check's release JSON parsing to aid troubleshooting.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 72b0526424a625e72758ecc66e08d85b4f090604)
