### PR TITLE
fix(cli): replace silent exception swallowing in pipeline.py with logger.debug calls

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -93,6 +93,7 @@ def _check_fidelity_llm(
         from aragora.agents import create_agent
         from aragora.agents.base import AgentType
     except ImportError:
+        logger.debug("Agent modules not available for LLM fidelity scoring")
         return None
 
     agent = None
@@ -101,7 +102,8 @@ def _check_fidelity_llm(
             agent = create_agent(AgentType(agent_type))  # type: ignore[arg-type]
             if agent is not None:
                 break
-        except (ImportError, ValueError, TypeError):
+        except (ImportError, ValueError, TypeError) as exc:
+            logger.debug("Agent type %s unavailable: %s", agent_type, exc)
             continue
 
     if agent is None:


### PR DESCRIPTION
Add debug logging to two silent exception handlers in _check_fidelity_llm:
- ImportError when agent modules are unavailable
- Per-agent-type creation failures during provider iteration

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 01aaad2cdee7b59f095e0a6e059f4cf46ffbbace)
