### PR TITLE
fix(cli): add debug logging to silent ImportError handlers in pipeline.py (#4670)

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -451,7 +451,8 @@ def _run_self_improve_handoff(
     """Run extracted pipeline objectives through the self-improvement engine."""
     try:
         from aragora.nomic.self_improve import SelfImproveConfig, SelfImprovePipeline
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("SelfImprovePipeline import failed: %s", exc)
         print("\nSelfImprovePipeline unavailable.")
         print('Install nomic dependencies or use: aragora self-improve "<objective>"')
         return
@@ -600,7 +601,8 @@ def _run_pipeline_dry_run(ideas: list[str]) -> None:
 
         print(f"\nProvenance chain: {len(result.provenance)} links")
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("IdeaToExecutionPipeline import failed: %s", exc)
         print("\nIdeaToExecutionPipeline unavailable.")
         print("Install required dependencies or check aragora/pipeline/.")
         return
@@ -652,7 +654,8 @@ def _run_pipeline_execute(
 
         print()
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("IdeaToExecutionPipeline import failed: %s", exc)
         print("\nError: IdeaToExecutionPipeline unavailable.")
         print("Check that aragora/pipeline/ is properly installed.")
 
@@ -734,7 +737,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         subtasks = decomposition.subtasks
         print()
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("TaskDecomposer import failed: %s", exc)
         print("\nTaskDecomposer unavailable, skipping decomposition.")
         print()
 
@@ -758,7 +762,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                 print(f"     Rationale: {pg.rationale}")
         print()
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("MetaPlanner import failed: %s", exc)
         print("\nMetaPlanner unavailable, skipping priority debate.")
         print()
 
@@ -876,7 +881,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
         print(f"\nProvenance chain: {len(result.provenance)} links")
         print(f"Duration: {result.duration:.1f}s")
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("IdeaToExecutionPipeline import failed: %s", exc)
         print("\nIdeaToExecutionPipeline unavailable.")
         print("Showing decomposition results only.")
 
@@ -1135,7 +1141,8 @@ def _cmd_pipeline_status(args: argparse.Namespace) -> None:
             print('  aragora pipeline run "Build rate limiter, Add caching"')
             print('  aragora pipeline self-improve "Improve test coverage"')
 
-    except ImportError:
+    except ImportError as exc:
+        logger.debug("Pipeline module import failed: %s", exc)
         print("\nPipeline module unavailable.")
         print("Check that aragora/pipeline/ is properly installed.")
 


### PR DESCRIPTION
Seven ImportError handlers were printing user-facing messages but
silently discarding the exception. Add logger.debug calls so the
actual import failure is traceable in debug logs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 3936d33ec98f248317c6daaca7be9eafbd576571)
