### PR TITLE
fix(cli): add debug logging to print-only exception handlers in pipeline.py (#4697)

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -662,6 +662,7 @@ def _run_pipeline_execute(
         print("Check that aragora/pipeline/ is properly installed.")
 
     except (OSError, RuntimeError, ValueError) as e:
+        logger.debug("Pipeline execution failed: %s", e)
         print(f"\nPipeline failed: {e}")
 
 
@@ -819,6 +820,7 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                     raise RuntimeError("Live pipeline returned only 0.0s stages.")
                 execution_path = "live"
             except (RuntimeError, OSError, ConnectionError) as exc:
+                logger.debug("Live pipeline failed in strict mode: %s", exc)
                 print(f"\n[WARN] Live pipeline failed ({exc}), no fallback in strict mode.")
                 raise
         elif pipeline_mode == "hybrid":


### PR DESCRIPTION
Two exception handlers in pipeline.py printed user-facing messages but
lacked logger.debug calls for diagnostic visibility. Added debug logging
to the pipeline execution failure handler and the strict-mode live
pipeline failure handler.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 1a5b9b4fd9e70451f9ab6c85261a58a5c48497fb)
