### PR TITLE
fix: normalize agent event value prefixes in deliberation_events.py

### DIFF
--- a/aragora/control_plane/deliberation_events.py
+++ b/aragora/control_plane/deliberation_events.py
@@ -24,8 +24,8 @@ class DeliberationEventType(str, Enum):
     # Agent interaction events
     AGENT_MESSAGE = "deliberation.agent_message"
     AGENT_PROPOSAL = "deliberation.agent_proposal"
-    AGENT_CRITIQUE = "deliberation.critique"
-    AGENT_REVISION = "deliberation.revision"
+    AGENT_CRITIQUE = "deliberation.agent_critique"
+    AGENT_REVISION = "deliberation.agent_revision"
 
     # Voting and consensus events
     VOTE = "deliberation.vote"


### PR DESCRIPTION
AGENT_CRITIQUE and AGENT_REVISION string values now use the 'agent_'
prefix consistent with AGENT_MESSAGE and AGENT_PROPOSAL.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ae8882e7a5a0ea62b40778e42f35a4032fa3095e)
