### PR TITLE
fix: bind exception variable in remaining ImportError handlers in pipeline.py

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -92,8 +92,8 @@ def _check_fidelity_llm(
     try:
         from aragora.agents import create_agent
         from aragora.agents.base import AgentType
-    except ImportError:
-        logger.debug("Agent modules not available for LLM fidelity scoring")
+    except ImportError as exc:
+        logger.debug("Agent modules not available for LLM fidelity scoring: %s", exc)
         return None
 
     agent = None
@@ -1018,8 +1018,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                         min_p=plan_quality_min_practicality,
                     )
                 )
-            except ImportError:
-                logger.debug("Output quality module unavailable, skipping quality gate")
+            except ImportError as exc:
+                logger.debug("Output quality module unavailable, skipping quality gate: %s", exc)
             except (RuntimeError, ValueError, TypeError, AttributeError) as e:
                 logger.debug("Quality gate check failed: %s", e)
 
@@ -1074,8 +1074,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                     fidelity_score=avg_fidelity,
                 )
                 queue.enqueue(suggestion)
-        except ImportError:
-            logger.debug("Suggestion queue unavailable, skipping enqueue")
+        except ImportError as exc:
+            logger.debug("Suggestion queue unavailable, skipping enqueue: %s", exc)
 
     print("-" * 60)
     print("STEP 4: HANDOFF TO SELF-IMPROVEMENT ENGINE")


### PR DESCRIPTION
Three except ImportError handlers were catching without binding the
exception, so their debug log messages omitted the actual error detail.
Now all three bind `as exc` and include %s formatting.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit dc2e6f1fea2adfe5c13031155ab1cad8e3e8327a)
