### PR TITLE
fix(cli): capture exception variable in remaining ImportError handlers in pipeline.py (#4719)

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -1018,8 +1018,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                         min_p=plan_quality_min_practicality,
                     )
                 )
-            except ImportError:
-                logger.debug("Output quality module unavailable, skipping quality gate")
+            except ImportError as exc:
+                logger.debug("Output quality module unavailable, skipping quality gate: %s", exc)
             except (RuntimeError, ValueError, TypeError, AttributeError) as e:
                 logger.debug("Quality gate check failed: %s", e)
 
@@ -1074,8 +1074,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
                     fidelity_score=avg_fidelity,
                 )
                 queue.enqueue(suggestion)
-        except ImportError:
-            logger.debug("Suggestion queue unavailable, skipping enqueue")
+        except ImportError as exc:
+            logger.debug("Suggestion queue unavailable, skipping enqueue: %s", exc)
 
     print("-" * 60)
     print("STEP 4: HANDOFF TO SELF-IMPROVEMENT ENGINE")


### PR DESCRIPTION
Two ImportError handlers were missing the `as exc` capture and exception
details in their debug log messages, inconsistent with the rest of the file.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 7c7ed76ca5c092921fccb10295c1924981916fe5)
