### PR TITLE
fix: replace silent exception swallowing in approval.py

### DIFF
--- a/aragora/computer_use/approval.py
+++ b/aragora/computer_use/approval.py
@@ -45,8 +45,8 @@ async def _audit_approval_action(
             resource_id=request_id,
             **details,
         )
-    except (ImportError, TypeError, RuntimeError):
-        pass
+    except (ImportError, TypeError, RuntimeError) as e:
+        logger.debug("Audit approval action unavailable: %s", e)
 
 
 class ApprovalStatus(str, Enum):


### PR DESCRIPTION
Replace bare `except ...: pass` in _audit_approval_action with
logger.debug so audit failures are visible instead of silently lost.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 8df5e44bda136b64652e59c69661275ffbb36739)
