### PR TITLE
fix: replace silent exception swallowing in policy_store.py (#4704)

### DIFF
--- a/aragora/compliance/policy_store.py
+++ b/aragora/compliance/policy_store.py
@@ -1132,7 +1132,9 @@ def get_policy_store(db_path: Path | None = None) -> PolicyStore | PostgresPolic
                         f"PostgreSQL backend unavailable: {e}",
                     )
                 except ImportError:
-                    pass
+                    logger.debug(
+                        "production_guards not available, skipping distributed store check"
+                    )
 
     # Default: SQLite
     from aragora.storage.production_guards import require_distributed_store, StorageMode


### PR DESCRIPTION
Replace bare `except ImportError: pass` with a debug log message
to provide visibility when the production_guards module is unavailable.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f7295058b4841df18590448a5abac2c4795fa1b5)
