### PR TITLE
fix: replace silent exception swallowing in compliance monitor.py

### DIFF
--- a/aragora/compliance/monitor.py
+++ b/aragora/compliance/monitor.py
@@ -519,8 +519,8 @@ class ComplianceMonitor:
                     },
                 )
             )
-        except (ImportError, AttributeError, TypeError):
-            pass
+        except (ImportError, AttributeError, TypeError) as e:
+            logger.debug("Compliance event emission failed: %s", e)
 
     async def _send_alert(
         self,
@@ -579,7 +579,7 @@ class ComplianceMonitor:
                     context=alert_data,
                 )
         except ImportError:
-            pass
+            logger.debug("SLO alert bridge not available")
         except (RuntimeError, ValueError, TypeError, AttributeError) as e:
             logger.debug("Could not route to SLO alert bridge: %s", e)
 


### PR DESCRIPTION
Replace two `except ...: pass` patterns with debug logging so errors
are visible instead of silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 9272c00908191058840e24500334ea599b0b140d)
