### PR TITLE
fix: add error logging to DR drill exception handler in scheduler.py (#4693)

### DIFF
--- a/aragora/backup/scheduler.py
+++ b/aragora/backup/scheduler.py
@@ -834,6 +834,7 @@ class BackupScheduler:
             )
 
         except (OSError, IOError, RuntimeError) as e:
+            logger.error("DR drill failed: %s", e)
             result["error"] = str(e)
             result["success"] = False
 


### PR DESCRIPTION
The _execute_dr_drill method caught exceptions and set result fields but
never logged the error, silently swallowing it. Added logger.error call
for visibility.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f657765522199fff05504b239bd9ab0beaf9fd59)
