### PR TITLE
fix: narrow exception handler in bug_detector.py scan_repository

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except (ValueError, OSError) as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines


### PR DESCRIPTION
Remove SyntaxError from the catch tuple in scan_repository() since
neither open/read nor detect_in_file can raise SyntaxError. Keep
ValueError (encoding) and OSError (file I/O) which are the actual
possible exceptions.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 566b54453a71be5a5b930d52e5aeeef82b33c4a1)
