### PR TITLE
fix: narrow broad exception handler in bug_detector.py

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except OSError as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines


### PR DESCRIPTION
Replace `except (SyntaxError, ValueError, OSError)` with `except OSError`
in detect_in_directory. SyntaxError and ValueError are not expected from
file reading and regex matching — only OSError is relevant for I/O failures.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f450fc11caa1bba12044d8a1128cffb921f4c2e9)
