### PR TITLE
fix: add category/terminal helpers to DeliberationEventType for testability (#4734)

### DIFF
--- a/aragora/control_plane/deliberation_events.py
+++ b/aragora/control_plane/deliberation_events.py
@@ -5,7 +5,20 @@ Defines event types emitted during deliberation execution for real-time
 monitoring via ControlPlaneStreamServer.
 """
 
+from __future__ import annotations
+
 from enum import Enum, unique
+
+
+EVENT_PREFIX = "deliberation."
+
+CATEGORY_LIFECYCLE = "lifecycle"
+CATEGORY_ROUND = "round"
+CATEGORY_AGENT = "agent"
+CATEGORY_CONSENSUS = "consensus"
+CATEGORY_SLA = "sla"
+CATEGORY_PROGRESS = "progress"
+CATEGORY_ERROR = "error"
 
 
 @unique
@@ -47,5 +60,67 @@ class DeliberationEventType(str, Enum):
     AGENT_ERROR = "deliberation.agent_error"
     RECOVERY_ATTEMPTED = "deliberation.recovery_attempted"
 
+    @property
+    def category(self) -> str:
+        """Return the category string for this event type."""
+        return _EVENT_CATEGORIES.get(self, "unknown")
 
-__all__ = ["DeliberationEventType"]
+    @property
+    def is_terminal(self) -> bool:
+        """True if this event signals the end of a deliberation."""
+        return self in _TERMINAL_EVENTS
+
+    @classmethod
+    def by_category(cls, category: str) -> frozenset[DeliberationEventType]:
+        """Return all event types belonging to *category*."""
+        return frozenset(e for e, c in _EVENT_CATEGORIES.items() if c == category)
+
+    @classmethod
+    def categories(cls) -> frozenset[str]:
+        """Return the set of all known category names."""
+        return frozenset(_EVENT_CATEGORIES.values())
+
+
+_EVENT_CATEGORIES: dict["DeliberationEventType", str] = {
+    DeliberationEventType.DELIBERATION_STARTED: CATEGORY_LIFECYCLE,
+    DeliberationEventType.DELIBERATION_COMPLETED: CATEGORY_LIFECYCLE,
+    DeliberationEventType.DELIBERATION_FAILED: CATEGORY_LIFECYCLE,
+    DeliberationEventType.DELIBERATION_CANCELLED: CATEGORY_LIFECYCLE,
+    DeliberationEventType.ROUND_START: CATEGORY_ROUND,
+    DeliberationEventType.ROUND_END: CATEGORY_ROUND,
+    DeliberationEventType.AGENT_MESSAGE: CATEGORY_AGENT,
+    DeliberationEventType.AGENT_PROPOSAL: CATEGORY_AGENT,
+    DeliberationEventType.AGENT_CRITIQUE: CATEGORY_AGENT,
+    DeliberationEventType.AGENT_REVISION: CATEGORY_AGENT,
+    DeliberationEventType.VOTE: CATEGORY_CONSENSUS,
+    DeliberationEventType.CONSENSUS_CHECK: CATEGORY_CONSENSUS,
+    DeliberationEventType.CONSENSUS_REACHED: CATEGORY_CONSENSUS,
+    DeliberationEventType.NO_CONSENSUS: CATEGORY_CONSENSUS,
+    DeliberationEventType.SLA_WARNING: CATEGORY_SLA,
+    DeliberationEventType.SLA_CRITICAL: CATEGORY_SLA,
+    DeliberationEventType.SLA_VIOLATED: CATEGORY_SLA,
+    DeliberationEventType.PROGRESS_UPDATE: CATEGORY_PROGRESS,
+    DeliberationEventType.CONVERGENCE_UPDATE: CATEGORY_PROGRESS,
+    DeliberationEventType.AGENT_ERROR: CATEGORY_ERROR,
+    DeliberationEventType.RECOVERY_ATTEMPTED: CATEGORY_ERROR,
+}
+
+_TERMINAL_EVENTS: frozenset[DeliberationEventType] = frozenset(
+    {
+        DeliberationEventType.DELIBERATION_COMPLETED,
+        DeliberationEventType.DELIBERATION_FAILED,
+        DeliberationEventType.DELIBERATION_CANCELLED,
+    }
+)
+
+__all__ = [
+    "EVENT_PREFIX",
+    "CATEGORY_LIFECYCLE",
+    "CATEGORY_ROUND",
+    "CATEGORY_AGENT",
+    "CATEGORY_CONSENSUS",
+    "CATEGORY_SLA",
+    "CATEGORY_PROGRESS",
+    "CATEGORY_ERROR",
+    "DeliberationEventType",
+]


### PR DESCRIPTION
Add category classification, is_terminal property, by_category and
categories class methods to support comprehensive test coverage.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
