### PR TITLE
fix: narrow broad exception handler and fix f-string logging in bug_detector.py

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except OSError as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines
@@ -945,7 +945,7 @@ class BugDetector:
 
         elapsed = (report.completed_at - start_time).total_seconds()
         logger.info(
-            f"[{scan_id}] Completed in {elapsed:.2f}s: {report.total_bugs} potential bugs found"
+            "[%s] Completed in %.2fs: %s potential bugs found", scan_id, elapsed, report.total_bugs
         )
 
         return report


### PR DESCRIPTION
Replace (SyntaxError, ValueError, OSError) with just OSError since
SyntaxError and ValueError cannot occur in the file-reading code path.
Also convert f-string logging to %-formatting for consistency.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 3283a88e04a1e1ddff840678e12ad096955071d6)
