### PR TITLE
fix: narrow exception handler to OSError in bug_detector.py

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (SyntaxError, ValueError, OSError) as e:
+            except OSError as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines


### PR DESCRIPTION
Remove SyntaxError and ValueError from the except clause in
detect_in_directory since only OSError can be raised by the
file open/read operations in that try block.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 257000b39b9dcc61b86d35853f3ef0eb6d712815)
