### PR TITLE
fix: replace silent exception swallowing in review_pr.py

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -615,6 +615,7 @@ def _extract_first_json_object(text: str) -> dict[str, Any]:
         try:
             payload, _ = decoder.raw_decode(text[index:])
         except json.JSONDecodeError:
+            logger.debug("skipping non-JSON fragment at offset %d", index)
             continue
         if isinstance(payload, dict):
             return payload


### PR DESCRIPTION
Add debug-level logging to the silent JSONDecodeError handler in
_extract_first_json_object so failed parse attempts are visible
when debugging.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 8d050a9c970e9b64b5287d68183eea990fbd7218)
