### PR TITLE
fix: replace last silent exception pass in quickstart.py with debug logging

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -1479,9 +1479,9 @@ async def _can_reach_provider_tls(provider: str) -> tuple[bool, str | None]:
     writer.close()
     try:
         await writer.wait_closed()
-    except (ConnectionError, OSError, ssl.SSLError):
+    except (ConnectionError, OSError, ssl.SSLError) as exc:
         # The verified handshake already succeeded; some transports raise while closing.
-        pass
+        logger.debug("TLS close raised after successful handshake: %s", exc)
     return True, None
 
 


### PR DESCRIPTION
Replace the remaining `except ...: pass` in the TLS close handler with
a logger.debug call for visibility, completing the silent-swallowing cleanup.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ae1964ef3cd00319c664b387fca8e191ce68fa4d)
