### PR TITLE
fix(swarm): fail closed on unexpected refresh errors

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -2460,6 +2460,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
             claim_driver,
             list_tranche_states,
             load_tranche_run_state,
+            refresh_supervisor_run_dict,
             release_driver,
             run_state_path_for_manifest,
             watch_loop,
@@ -2746,16 +2747,12 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     }
                 if supervisor is None:
                     supervisor = SwarmSupervisor(repo_root=repo_root)
-                try:
-                    run_dict = supervisor.refresh_run(run_id).to_dict()
-                except Exception:
-                    record = supervisor.store.get_supervisor_run(run_id)
-                    if not isinstance(record, dict):
-                        return {
-                            "status": "blocked_nonreviewable",
-                            "findings": [f"Supervisor run {run_id} is not available."],
-                        }
-                    run_dict = dict(record)
+                run_dict = refresh_supervisor_run_dict(supervisor, run_id)
+                if run_dict is None:
+                    return {
+                        "status": "blocked_nonreviewable",
+                        "findings": [f"Supervisor run {run_id} is not available."],
+                    }
                 lane = manifest.lane(lane_id)
                 tier = select_review_tier(
                     write_scope=list(getattr(lane, "allowed_write_scope", [])),
@@ -2903,13 +2900,9 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 run_id = str(getattr(artifact, "run_id", None) or "").strip()
                 if not run_id:
                     raise ValueError(f"Artifact {artifact.lane_id} has no run_id.")
-                try:
-                    run_dict = supervisor.refresh_run(run_id).to_dict()
-                except Exception:
-                    record = supervisor.store.get_supervisor_run(run_id)
-                    if not isinstance(record, dict):
-                        raise ValueError(f"Supervisor run {run_id} is not available.") from None
-                    run_dict = dict(record)
+                run_dict = refresh_supervisor_run_dict(supervisor, run_id)
+                if run_dict is None:
+                    raise ValueError(f"Supervisor run {run_id} is not available.") from None
                 tier_arg = str(getattr(args, "tier", "auto") or "auto").strip()
                 if tier_arg == "auto":
                     lane = manifest.lane(artifact.lane_id)

--- a/aragora/swarm/tranche_queue.py
+++ b/aragora/swarm/tranche_queue.py
@@ -44,6 +44,7 @@ from aragora.swarm.tranche_watch import (
     DriverAlreadyClaimedError,
     claim_driver,
     load_tranche_run_state,
+    refresh_supervisor_run_dict,
     refresh_tranche_state,
     release_driver,
     run_state_path_for_manifest,
@@ -2584,19 +2585,15 @@ class TrancheQueueExecutor:
                 events.append(_event_summary("review", payload))
                 return payload
             supervisor = self._supervisor_store()
-            try:
-                run_dict = supervisor.refresh_run(run_id).to_dict()
-            except Exception:
-                record = supervisor.store.get_supervisor_run(run_id)
-                if not isinstance(record, dict):
-                    payload = {
-                        "lane_id": lane_id,
-                        "status": "blocked_nonreviewable",
-                        "findings": [f"Supervisor run {run_id} is not available."],
-                    }
-                    events.append(_event_summary("review", payload))
-                    return payload
-                run_dict = dict(record)
+            run_dict = refresh_supervisor_run_dict(supervisor, run_id)
+            if run_dict is None:
+                payload = {
+                    "lane_id": lane_id,
+                    "status": "blocked_nonreviewable",
+                    "findings": [f"Supervisor run {run_id} is not available."],
+                }
+                events.append(_event_summary("review", payload))
+                return payload
             lane = manifest.lane(lane_id)
             tier = select_review_tier(
                 write_scope=list(getattr(lane, "allowed_write_scope", [])),

--- a/aragora/swarm/tranche_watch.py
+++ b/aragora/swarm/tranche_watch.py
@@ -657,6 +657,28 @@ def _get_supervisor_run(store: Any | None, run_id: str | None) -> dict[str, Any]
     return record if isinstance(record, dict) else None
 
 
+def refresh_supervisor_run_dict(supervisor: Any, run_id: str | None) -> dict[str, Any] | None:
+    run = _optional_text(run_id)
+    if supervisor is None or not run or not hasattr(supervisor, "refresh_run"):
+        return None
+    try:
+        refreshed = supervisor.refresh_run(run)
+    except (KeyError, OSError, RuntimeError, ValueError):
+        logger.debug(
+            "Supervisor refresh failed for run %s; falling back to stored record",
+            run,
+            exc_info=True,
+        )
+        record = _get_supervisor_run(getattr(supervisor, "store", None), run)
+        return dict(record) if isinstance(record, dict) else None
+    if not hasattr(refreshed, "to_dict"):
+        raise TypeError(f"Supervisor refresh for {run} returned {type(refreshed).__name__}")
+    payload = refreshed.to_dict()
+    if not isinstance(payload, dict):
+        raise TypeError(f"Supervisor refresh for {run} returned non-dict payload")
+    return dict(payload)
+
+
 def _get_completion_receipt(store: Any | None, receipt_id: str | None) -> Any | None:
     if store is None or not receipt_id or not hasattr(store, "get_completion_receipt"):
         return None

--- a/tests/cli/test_swarm_command.py
+++ b/tests/cli/test_swarm_command.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from aragora.cli.commands.swarm import _classify_issue_validation_status, cmd_swarm
 from aragora.swarm.initiative_models import InitiativeRecord, InitiativeSlice
 from aragora.swarm.initiative_store import InitiativeStore
@@ -1235,6 +1237,48 @@ class TestSwarmCommand:
         assert '"mode": "tranche-review"' in out
         assert '"status": "passed"' in out
         assert '"action": "review"' in out
+
+    def test_cmd_swarm_tranche_review_raises_unexpected_refresh_errors(self):
+        args = _swarm_args(
+            swarm_action_or_goal="tranche",
+            swarm_goal="review",
+            manifest="docs/examples/boss-lane-manifest-2026-03-19.yaml",
+            lane_id="lane_a",
+            tier="1",
+            json=True,
+        )
+        fake_manifest = SimpleNamespace(
+            manifest_id="pmf-tranche",
+            lane=lambda _lane_id: SimpleNamespace(allowed_write_scope=["aragora/live/**"]),
+        )
+        fake_artifact = SimpleNamespace(
+            lane_id="lane_a",
+            status="completed",
+            run_id="run-1",
+            metadata={},
+        )
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("aragora.worktree.fleet.resolve_repo_root", return_value=Path("/tmp/repo")),
+            patch("aragora.swarm.tranche.load_tranche_manifest", return_value=fake_manifest),
+            patch("aragora.swarm.tranche.TrancheArtifactStore") as store_cls,
+            patch("aragora.swarm.supervisor.SwarmSupervisor") as supervisor_cls,
+            patch("aragora.swarm.tranche_review.review_lane") as mock_review,
+        ):
+            store_cls.return_value.load.return_value = fake_artifact
+            store_cls.return_value.list.return_value = [fake_artifact]
+            supervisor = supervisor_cls.return_value
+            supervisor.refresh_run.side_effect = TypeError("refresh exploded")
+            supervisor.store.get_supervisor_run.return_value = {
+                "run_id": "run-1",
+                "status": "completed",
+                "work_orders": [],
+            }
+
+            with pytest.raises(TypeError, match="refresh exploded"):
+                cmd_swarm(args)
+
+        mock_review.assert_not_called()
 
     def test_cmd_swarm_tranche_integrate_json(self, capsys):
         args = _swarm_args(

--- a/tests/swarm/test_tranche_queue.py
+++ b/tests/swarm/test_tranche_queue.py
@@ -2360,3 +2360,90 @@ async def test_drive_manifest_dispatches_all_ready_lanes_only_when_parallel_cap_
     )
 
     assert seen["all_ready"] is expected_all_ready
+
+
+@pytest.mark.asyncio
+async def test_drive_manifest_stops_on_unexpected_refresh_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queue_path = tmp_path / "overnight.yaml"
+    _write_queue(queue_path)
+    executor = TrancheQueueExecutor(queue_path=queue_path, repo_root=tmp_path)
+    manifest_path = tmp_path / "tranche.yaml"
+    manifest_path.write_text("manifest_id: tranche-test\n", encoding="utf-8")
+    item = TrancheQueueItem(
+        item_id="issue-1046",
+        kind="issue",
+        source="1046",
+        merge_class="manual",
+        max_lanes=1,
+    )
+    item_state = TrancheQueueItemRunState(
+        item_id=item.item_id,
+        status=QUEUE_ITEM_STATUS_RUNNING,
+        effective_autonomy_mode="adaptive",
+    )
+    current = TrancheRunState(
+        manifest_id="tranche-test",
+        status="running",
+        autonomy_mode="adaptive",
+        lane_states={"lane-a": LaneRunState(lane_id="lane-a", status="running")},
+    )
+    artifact = TrancheLaneArtifact(
+        lane_id="lane-a",
+        source_ref="issue-1046",
+        status="completed",
+        run_id="run-1",
+        metadata={},
+    )
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.store = SimpleNamespace(
+                get_supervisor_run=lambda _run_id: {
+                    "run_id": "run-1",
+                    "status": "completed",
+                    "work_orders": [],
+                }
+            )
+
+        def refresh_run(self, run_id: str):
+            raise TypeError(f"refresh exploded for {run_id}")
+
+    async def fake_watch_loop(state, *, review_fn, manifest, **kwargs):
+        await review_fn(manifest=manifest, lane_id="lane-a", artifact=artifact)
+        return state
+
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.load_tranche_run_state",
+        lambda _: current,
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.claim_driver",
+        lambda state, **kwargs: state,
+    )
+    monkeypatch.setattr(
+        "aragora.swarm.tranche_queue.release_driver",
+        lambda state, **kwargs: state,
+    )
+    monkeypatch.setattr("aragora.swarm.tranche_queue.watch_loop", fake_watch_loop)
+    monkeypatch.setattr(executor, "_github_client", lambda: object())
+    monkeypatch.setattr(executor, "_registry_client", lambda: object())
+    executor._supervisor = _FakeSupervisor()
+
+    result = await executor._drive_manifest(
+        item=item,
+        item_state=item_state,
+        manifest_path=manifest_path,
+        tranche_manifest=SimpleNamespace(
+            manifest_id="tranche-test",
+            lane=lambda _lane_id: SimpleNamespace(allowed_write_scope=["aragora/swarm/**"]),
+        ),
+        deadline=datetime.now(timezone.utc) + timedelta(minutes=5),
+    )
+
+    assert result == "watch_failure"
+    assert item_state.status == QUEUE_ITEM_STATUS_STOPPED
+    assert item_state.stop_reason == "watch_failure"
+    assert item_state.result["watch_error"] == {"error_type": "TypeError"}

--- a/tests/swarm/test_tranche_watch.py
+++ b/tests/swarm/test_tranche_watch.py
@@ -19,6 +19,7 @@ from aragora.swarm.tranche_watch import (
     DriverAlreadyClaimedError,
     claim_driver,
     heartbeat_driver,
+    refresh_supervisor_run_dict,
     refresh_tranche_state,
     release_driver,
 )
@@ -122,6 +123,43 @@ class _FakeCoordinationStore:
         if isinstance(limit, int) and limit > 0:
             return items[:limit]
         return items
+
+
+def test_refresh_supervisor_run_dict_falls_back_on_expected_refresh_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    store = _FakeCoordinationStore(
+        runs={"run-1": {"run_id": "run-1", "status": "completed", "source": "store"}}
+    )
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.store = store
+
+        def refresh_run(self, run_id: str):
+            raise RuntimeError(f"refresh failed for {run_id}")
+
+    with caplog.at_level("DEBUG"):
+        run_dict = refresh_supervisor_run_dict(_FakeSupervisor(), "run-1")
+
+    assert run_dict == {"run_id": "run-1", "status": "completed", "source": "store"}
+    assert "falling back to stored record" in caplog.text
+
+
+def test_refresh_supervisor_run_dict_raises_unexpected_errors() -> None:
+    store = _FakeCoordinationStore(
+        runs={"run-1": {"run_id": "run-1", "status": "completed", "source": "store"}}
+    )
+
+    class _FakeSupervisor:
+        def __init__(self) -> None:
+            self.store = store
+
+        def refresh_run(self, run_id: str):
+            raise TypeError(f"unexpected refresh failure for {run_id}")
+
+    with pytest.raises(TypeError, match="unexpected refresh failure"):
+        refresh_supervisor_run_dict(_FakeSupervisor(), "run-1")
 
 
 def test_refresh_updates_lane_status_from_artifact_store():


### PR DESCRIPTION
## Summary\n- fail closed when tranche review cannot refresh authoritative supervisor state because of unexpected errors\n- keep store fallback only for expected operational refresh failures via a shared helper\n- add regressions for tranche watch, tranche review, and queue-driver watch failures\n\n## Testing\n- python3 -m pytest tests/swarm/test_tranche_watch.py tests/cli/test_swarm_command.py tests/swarm/test_tranche_queue.py -q -o cache_dir=/tmp/pytest-cache-swarm-refresh-full\n- python3 -m ruff check aragora/swarm/tranche_watch.py aragora/cli/commands/swarm.py aragora/swarm/tranche_queue.py tests/swarm/test_tranche_watch.py tests/cli/test_swarm_command.py tests/swarm/test_tranche_queue.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD