### PR TITLE
fix: bind exception variables in remaining silent handlers in debate.py (#4696)

### DIFF
--- a/aragora/cli/commands/debate.py
+++ b/aragora/cli/commands/debate.py
@@ -111,8 +111,8 @@ def get_event_emitter_if_available(server_url: str = DEFAULT_API_URL) -> Any | N
                     return SyncEventEmitter()
                 except ImportError:
                     logger.debug("SyncEventEmitter not available")
-    except (OSError, TimeoutError):
-        logger.debug("Streaming server not available at %s", server_url)
+    except (OSError, TimeoutError) as e:
+        logger.debug("Streaming server not available at %s: %s", server_url, e)
     return None
 
 
@@ -488,9 +488,9 @@ def _maybe_add_vertical_specialist_local(
         )
         try:
             specialist.system_prompt = specialist.build_system_prompt()
-        except (AttributeError, TypeError, ValueError):
+        except (AttributeError, TypeError, ValueError) as e:
             logger.debug(
-                "Failed to build system prompt for specialist %s", resolved_vertical, exc_info=True
+                "Failed to build system prompt for specialist %s: %s", resolved_vertical, e
             )
         agents.append(specialist)
         print(f"[verticals] Injected specialist: {resolved_vertical}")


### PR DESCRIPTION
Two exception handlers logged errors but didn't bind the exception
variable, reducing debuggability. Now both bind `as e` and include
the error in the log message.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ea33e3096bce436350cf08b292123e8e7924abf5)
