### PR TITLE
fix: replace silent CancelledError pass with debug log in metering.py (#4694)

### DIFF
--- a/aragora/billing/metering.py
+++ b/aragora/billing/metering.py
@@ -434,7 +434,7 @@ class UsageMeter:
             try:
                 await self._flush_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("Flush task cancelled during stop")
         await self._flush_events()
         logger.info("Usage metering stopped")
 


### PR DESCRIPTION
Replace the bare `except CancelledError: pass` in UsageMeter.stop()
with a debug log for visibility, consistent with the goal of eliminating
silent exception swallowing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 8b609c438f4064fabe5b06bbd71061240b3f68e4)
