### PR TITLE
fix: add error logging to restore drill exception handler in backup/manager.py

### DIFF
--- a/aragora/backup/manager.py
+++ b/aragora/backup/manager.py
@@ -992,6 +992,7 @@ class BackupManager:
                     tmp_path.unlink()
 
         except (OSError, IOError, RuntimeError, zlib.error) as e:
+            logger.error("Restore drill failed for backup %s: %s", backup_id, e)
             report.errors.append(f"Restore drill failed: {e}")
 
         # Finalize report


### PR DESCRIPTION
The restore_drill method's outer exception handler appended errors to the
report but did not log them, silently swallowing the failure context.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit dbe0e9aecb54f38d068bba6d632483ea5f0efb91)
