### PR TITLE
fix: replace silent exception swallowing with debug logging in devops agent.py

### DIFF
--- a/aragora/agents/devops/agent.py
+++ b/aragora/agents/devops/agent.py
@@ -265,6 +265,7 @@ class DevOpsAgent:
         try:
             prs = json.loads(output) if output and output != "[dry run]" else []
         except json.JSONDecodeError:
+            logger.debug("Failed to parse PR list JSON, defaulting to empty list")
             prs = []
 
         for pr in prs:
@@ -342,6 +343,7 @@ class DevOpsAgent:
         try:
             data = json.loads(review_json)
         except json.JSONDecodeError:
+            logger.debug("Failed to parse review JSON for PR #%d, using empty data", pr_number)
             data = {}
 
         lines = [
@@ -392,6 +394,7 @@ class DevOpsAgent:
         try:
             issues = json.loads(output) if output and output != "[dry run]" else []
         except json.JSONDecodeError:
+            logger.debug("Failed to parse issue list JSON, defaulting to empty list")
             issues = []
 
         for issue in issues:
@@ -516,6 +519,7 @@ class DevOpsAgent:
             try:
                 pr_count = int(output.strip())
             except ValueError:
+                logger.debug("Failed to parse open PR count from output: %s", output[:50])
                 pr_count = -1
             checks.append({"check": "open_prs", "count": pr_count})
 
@@ -528,6 +532,7 @@ class DevOpsAgent:
             try:
                 issue_count = int(output.strip())
             except ValueError:
+                logger.debug("Failed to parse open issue count from output: %s", output[:50])
                 issue_count = -1
             checks.append({"check": "open_issues", "count": issue_count})
 


### PR DESCRIPTION
Add logger.debug calls to all except blocks that previously swallowed
exceptions silently (JSONDecodeError, ValueError) in health_check,
review_prs, triage_issues, and _format_review_comment methods.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit fd15102150e7220dd2090b87cb62820f43c0d4b8)
