### PR TITLE
fix: handle non-import exceptions in cv.py get_cv_builder()

### DIFF
--- a/aragora/agents/cv.py
+++ b/aragora/agents/cv.py
@@ -523,6 +523,8 @@ def get_cv_builder() -> CVBuilder:
             elo_system = get_elo_store()
         except ImportError:
             logger.debug("ELO system not available for CV builder")
+        except Exception as e:
+            logger.warning("Failed to initialise ELO system for CV builder: %s", e)
 
         try:
             from aragora.agents.calibration import CalibrationTracker
@@ -530,6 +532,8 @@ def get_cv_builder() -> CVBuilder:
             calibration_tracker = CalibrationTracker()
         except ImportError:
             logger.debug("CalibrationTracker not available for CV builder")
+        except Exception as e:
+            logger.warning("Failed to initialise CalibrationTracker for CV builder: %s", e)
 
         _cv_builder = CVBuilder(
             elo_system=elo_system,


### PR DESCRIPTION
The get_elo_store() and CalibrationTracker() calls could raise
non-ImportError exceptions that would propagate unhandled. Add
explicit except clauses with warning-level logging for visibility.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 2a3c446d71eec4d8672924f47825fbad454d6259)
