### PR TITLE
fix: narrow broad Exception handler in compliance monitor.py

### DIFF
--- a/aragora/compliance/monitor.py
+++ b/aragora/compliance/monitor.py
@@ -498,7 +498,7 @@ class ComplianceMonitor:
                     else {},
                 },
             )
-        except Exception as e:  # noqa: BLE001
+        except (ImportError, AttributeError, TypeError, RuntimeError) as e:
             logger.debug("Compliance event emission unavailable: %s", e)
 
     def _emit_compliance_event(self, alert_type: str, severity: str, data: dict[str, Any]) -> None:


### PR DESCRIPTION
Replace `except Exception` with specific exception types
(ImportError, AttributeError, TypeError, RuntimeError) in
_emit_compliance_status_event, removing the noqa: BLE001 suppression.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 30c65e35a9dad6a8c7a759d646a897441629d353)
