### PR TITLE
fix: guard unprotected ImportError in policy_store.py get_policy_store

### DIFF
--- a/aragora/compliance/policy_store.py
+++ b/aragora/compliance/policy_store.py
@@ -1137,13 +1137,16 @@ def get_policy_store(db_path: Path | None = None) -> PolicyStore | PostgresPolic
                     )
 
     # Default: SQLite
-    from aragora.storage.production_guards import require_distributed_store, StorageMode
+    try:
+        from aragora.storage.production_guards import require_distributed_store, StorageMode
 
-    require_distributed_store(
-        "policy_store",
-        StorageMode.SQLITE,
-        "Compliance policy store using SQLite - configure PostgreSQL for multi-instance deployments.",
-    )
+        require_distributed_store(
+            "policy_store",
+            StorageMode.SQLITE,
+            "Compliance policy store using SQLite - configure PostgreSQL for multi-instance deployments.",
+        )
+    except ImportError:
+        logger.debug("production_guards not available, skipping distributed store check")
 
     _policy_store = PolicyStore(db_path)
     return _policy_store


### PR DESCRIPTION
The SQLite fallback path called `require_distributed_store` without an
ImportError guard, unlike the identical call in the PostgreSQL fallback
path. This would crash if production_guards was unavailable.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 98dad255afdb75a6a1aecf22e32a77afe4c06c4a)
