### PR TITLE
fix: replace except pass with debug logging in approval.py expiry handler

### DIFF
--- a/aragora/computer_use/approval.py
+++ b/aragora/computer_use/approval.py
@@ -537,7 +537,7 @@ class ApprovalWorkflow:
             )
 
         except asyncio.CancelledError:
-            pass
+            logger.debug("Expiry task cancelled for request %s", request_id)
         finally:
             # Ensure expired/cancelled tasks are removed from tracking
             self._expiry_tasks.pop(request_id, None)


### PR DESCRIPTION
Replace silent `except asyncio.CancelledError: pass` with a debug log
message in the expiry task handler to aid troubleshooting.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ea6d4c9a0cdf76f3407a560adff6e15ec3ef21e5)
