### PR TITLE
fix: add noqa justification for broad except handlers in trust_wedge.py

### DIFF
--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -493,7 +493,7 @@ class InboxTrustWedgeStore:
         try:
             yield cursor
             conn.commit()
-        except Exception:
+        except Exception:  # noqa: BLE001 — rollback on any error before re-raise
             conn.rollback()
             raise
         finally:
@@ -1579,7 +1579,7 @@ class InboxTrustWedgeService:
             if updated is None or updated.receipt.state is not ReceiptState.EXECUTED:
                 raise ValueError("receipt execution state not persisted")
             return result
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 — release claim on any error before re-raise
             self.store.release_execution_claim(receipt_id, claim_token, error=str(exc))
             raise
 


### PR DESCRIPTION
Both except Exception handlers are catch-cleanup-reraise patterns that
legitimately need broad catching to ensure rollback/claim-release runs
for any error type before re-raising.

Refs: #4687

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit de449af168155bf8cd48bae401b154a816f89f70)
