### PR TITLE
fix: narrow exception handler in model_combinations.py with noqa justification (#4686)

### DIFF
--- a/aragora/debate/model_combinations.py
+++ b/aragora/debate/model_combinations.py
@@ -277,7 +277,7 @@ class MultiModelDebateRunner:
                 debate_result=debate_result,
                 started_at=started_at,
             )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 – intentional catch-all: one combination failure must not abort the batch
             return self._build_failure_result(
                 combination=combination,
                 resolved_specs=resolved_specs,


### PR DESCRIPTION
The broad `except Exception` in `_run_combination` is intentional: it
converts any single-combination failure into a CombinationDebateResult
so the batch continues. Added `# noqa: BLE001` with inline rationale.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 6913f7145638413f61bcf300f3f3ccf9487fc7f6)
