### PR TITLE
fix: narrow except Exception in error_handler.py docstring example (#4685)

### DIFF
--- a/aragora/cli/error_handler.py
+++ b/aragora/cli/error_handler.py
@@ -9,7 +9,7 @@ Usage:
 
     try:
         # CLI operation
-    except Exception as e:
+    except (OSError, ValueError, RuntimeError) as e:
         handle_cli_error(e)
 """
 


### PR DESCRIPTION
Update the module docstring to show specific exception types instead of
broad `except Exception`. The runtime catch-all in cli_error_handler()
retains its justified `# noqa: BLE001` as it is the CLI top-level handler.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f63e731394210ab59316bd9a331ff1a16468d753)
