### PR TITLE
fix(demo): re-raise unexpected live debate errors

### DIFF
--- a/aragora/cli/demo.py
+++ b/aragora/cli/demo.py
@@ -68,6 +68,7 @@ DEMO_TASKS: dict[str, dict[str, Any]] = {
 }
 
 _DEFAULT_DEMO = "microservices"
+_REAL_DEMO_HANDLED_ERRORS = (ImportError, OSError, RuntimeError, TimeoutError, ValueError)
 
 
 def list_demos() -> list[str]:
@@ -565,7 +566,7 @@ def _run_real_demo(topic: str, receipt_path: str | None = None) -> None:
         print("=" * 64)
         print()
 
-    except Exception as exc:
+    except _REAL_DEMO_HANDLED_ERRORS as exc:
         print(f"  Debate failed: {exc}")
         print("  Try 'aragora demo --offline' for an offline demo.")
         print()

--- a/tests/cli/test_demo_real.py
+++ b/tests/cli/test_demo_real.py
@@ -165,6 +165,33 @@ def test_run_real_demo_calls_playground(capsys):
     assert "85%" in captured.out
 
 
+def test_run_real_demo_handles_expected_live_errors(capsys):
+    """Operational live-demo failures should still render the offline hint."""
+    from aragora.cli.demo import _run_real_demo
+
+    with patch(
+        "aragora.server.handlers.playground.start_playground_debate",
+        side_effect=ValueError("At least 2 agent providers with API keys are required"),
+    ):
+        _run_real_demo("Should we use Rust?")
+
+    captured = capsys.readouterr()
+    assert "Debate failed: At least 2 agent providers with API keys are required" in captured.out
+    assert "Try 'aragora demo --offline' for an offline demo." in captured.out
+
+
+def test_run_real_demo_reraises_unexpected_live_errors():
+    """Unexpected programmer errors should not be hidden behind the offline fallback."""
+    from aragora.cli.demo import _run_real_demo
+
+    with patch(
+        "aragora.server.handlers.playground.start_playground_debate",
+        side_effect=TypeError("boom-typeerror"),
+    ):
+        with pytest.raises(TypeError, match="boom-typeerror"):
+            _run_real_demo("Should we use Rust?")
+
+
 @pytest.mark.parametrize(
     ("raw_consensus", "expected"),
     [("true", True), ("false", False)],


### PR DESCRIPTION
## Summary
- narrow the live demo fallback to expected operational errors
- let unexpected playground bugs propagate instead of printing a generic offline hint
- add focused tests for expected live failures and unexpected programmer errors

## Testing
- python3 -m pytest tests/cli/test_demo_real.py -q -o cache_dir=/tmp/pytest-cache-demo-real-full-expected-vs-unexpected
- python3 -m ruff check aragora/cli/demo.py tests/cli/test_demo_real.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD