### PR TITLE
fix: narrow broad except Exception in interrogation/crystallizer.py (#2959)

### DIFF
--- a/aragora/interrogation/crystallizer.py
+++ b/aragora/interrogation/crystallizer.py
@@ -309,7 +309,12 @@ class Crystallizer:
             if not summary and hasattr(research_result, "summary"):
                 try:
                     summary = str(research_result.summary())
-                except Exception:  # pragma: no cover - defensive
+                except (
+                    TypeError,
+                    ValueError,
+                    AttributeError,
+                    RuntimeError,
+                ):  # pragma: no cover - defensive
                     summary = ""
 
         return Spec(


### PR DESCRIPTION
Replace broad `except Exception` with specific `(TypeError, ValueError,
AttributeError, RuntimeError)` in the research_result.summary() fallback
handler.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 0a56246b7236bdff510ef5e4877f35c61ad3129b)
