### PR TITLE
fix: narrow broad except Exception in demo.py

### DIFF
--- a/aragora/cli/demo.py
+++ b/aragora/cli/demo.py
@@ -565,7 +565,7 @@ def _run_real_demo(topic: str, receipt_path: str | None = None) -> None:
         print("=" * 64)
         print()
 
-    except Exception as exc:
+    except (OSError, RuntimeError, ValueError, TimeoutError) as exc:
         print(f"  Debate failed: {exc}")
         print("  Try 'aragora demo --offline' for an offline demo.")
         print()


### PR DESCRIPTION
Replace `except Exception` with specific types (OSError,
RuntimeError, ValueError, TimeoutError) in _run_real_demo
to satisfy BLE001 lint rule.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d3c5eaa5501308ca7c76d2bc2816c9928515ec99)
