### PR TITLE
fix: replace silent exception pass with debug logging in pr_watch_daemon.py

### DIFF
--- a/aragora/compat/openclaw/pr_watch_daemon.py
+++ b/aragora/compat/openclaw/pr_watch_daemon.py
@@ -502,7 +502,7 @@ async def run_daemon(config: WatcherConfig) -> None:
         try:
             loop.add_signal_handler(sig, _on_signal)
         except NotImplementedError:
-            pass  # Windows
+            logger.debug("Signal %s not supported on this platform", sig)
 
     if daemon._task:
         try:


### PR DESCRIPTION
Replace the bare `except NotImplementedError: pass` when registering
signal handlers with a debug log message indicating the platform
doesn't support the signal. Other except-pass patterns (CancelledError,
TimeoutError) are standard asyncio idioms and left as-is.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 9978c5317b3643f81788229244c0a8e82eb4bd91)
