### PR TITLE
fix: narrow broad except Exception in blockchain/action_store.py (#2956)

### DIFF
--- a/aragora/blockchain/action_store.py
+++ b/aragora/blockchain/action_store.py
@@ -303,7 +303,7 @@ def process_chain_action(action_id: str, *, approval_id: str = "") -> ChainActio
             result={"token_id": token_id, "owner": signer.address},
         )
         return confirmed or record
-    except Exception as exc:
+    except (RuntimeError, ValueError, TypeError, KeyError, OSError) as exc:
         logger.error("Chain action %s failed: %s", action_id, exc)
         get_chain_action_store().update_action(
             action_id,


### PR DESCRIPTION
Replace `except Exception` with specific types (RuntimeError, ValueError,
TypeError, KeyError, OSError) covering contract call, serialization, and
network failure modes in process_chain_action.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ae5f8e1f93a34de59d96486fda82f7600fe003fe)
