### PR TITLE
fix: replace remaining silent exception swallowing in next_steps_runner.py

### DIFF
--- a/aragora/compat/openclaw/next_steps_runner.py
+++ b/aragora/compat/openclaw/next_steps_runner.py
@@ -215,7 +215,8 @@ def scan_code_markers(repo_path: Path) -> tuple[list[NextStep], int]:
 
             try:
                 content = filepath.read_text(errors="replace")
-            except OSError:
+            except OSError as exc:
+                logger.debug("Failed to read %s: %s", filepath, exc)
                 continue
 
             rel_path = str(filepath.relative_to(repo_path))
@@ -332,10 +333,12 @@ def scan_github_prs(repo: str, limit: int = 20) -> list[NextStep]:
             timeout=30,
         )
         if result.returncode != 0:
+            logger.debug("gh pr list failed: %s", result.stderr)
             return []
 
         prs = json.loads(result.stdout)
-    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+    except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError) as exc:
+        logger.debug("GitHub PRs scan failed: %s", exc)
         return []
 
     steps = []


### PR DESCRIPTION
Add debug logging to three silent exception handlers:
- OSError when reading source files in scan_code_markers
- Non-zero returncode from gh pr list in scan_github_prs
- Caught exceptions in scan_github_prs subprocess call

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e65edf155f351ec568708f29e00bea3afe3a3693)
