### PR TITLE
fix: propagate errors in servicenow.py search/fetch/resolve_reference (#2992)

### DIFF
--- a/aragora/connectors/enterprise/itsm/servicenow.py
+++ b/aragora/connectors/enterprise/itsm/servicenow.py
@@ -676,6 +676,7 @@ class ServiceNowConnector(EnterpriseConnector):
 
             except (OSError, RuntimeError, ValueError, TypeError, KeyError) as e:
                 logger.error("[%s] Search in %s failed: %s", self.name, tbl, e)
+                raise
 
         return results[:limit]
 
@@ -727,7 +728,7 @@ class ServiceNowConnector(EnterpriseConnector):
 
         except (OSError, RuntimeError, ValueError, TypeError, KeyError) as e:
             logger.error("[%s] Fetch failed: %s", self.name, e)
-            return None
+            raise
 
     async def handle_webhook(
         self,
@@ -889,8 +890,7 @@ class ServiceNowConnector(EnterpriseConnector):
             return results[0] if results else None
         except (OSError, RuntimeError, ValueError, TypeError, KeyError, AttributeError) as e:
             logger.error("[%s] Reference resolution failed: %s", self.name, e)
-
-        return None
+            raise
 
     async def get_user_details(self, user_sys_id: str) -> dict[str, str] | None:
         """


### PR DESCRIPTION
Stop silent error swallowing in three methods that were catching
exceptions and returning None/empty, making errors indistinguishable
from legitimate "not found" responses. All three now re-raise after
logging so callers fail closed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 0d73b3c0e88634c60def7c0ac39dcad5dc04a7e3)
