### PR TITLE
fix: narrow broad except Exception in debate_origin slack sender

### DIFF
--- a/aragora/server/debate_origin/senders/slack.py
+++ b/aragora/server/debate_origin/senders/slack.py
@@ -79,7 +79,7 @@ async def _get_slack_token() -> str:
                     return access_token
                 else:
                     logger.warning("Slack token refresh failed: %s", data.get("error"))
-        except Exception as exc:
+        except (httpx.HTTPError, OSError, ValueError, KeyError) as exc:
             logger.warning("Slack token refresh error: %s", exc)
 
     # Fallback to static token


### PR DESCRIPTION
Replace `except Exception` in `_get_slack_token()` with specific
exceptions (httpx.HTTPError, OSError, ValueError, KeyError) matching
the failure modes of the HTTP token refresh call.

Closes #2975

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ebaadd19015102cfd83606f57607859f64fd6cc9)
