### PR TITLE
fix: narrow broad except Exception in prompt_engine_stream.py

### DIFF
--- a/aragora/server/stream/prompt_engine_stream.py
+++ b/aragora/server/stream/prompt_engine_stream.py
@@ -299,7 +299,15 @@ async def _run_pipeline(
             },
         )
 
-    except Exception as exc:
+    except (
+        KeyError,
+        ValueError,
+        TypeError,
+        AttributeError,
+        RuntimeError,
+        OSError,
+        ImportError,
+    ) as exc:
         logger.exception("Prompt engine pipeline error: %s", exc)
         await emitter.emit(
             session_id,


### PR DESCRIPTION
Replace catch-all `except Exception` with specific exception types
(KeyError, ValueError, TypeError, AttributeError, RuntimeError,
OSError, ImportError) in the pipeline error handler.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 9ad5910aee7d951fffed69b1741967a799739ea9)
