### PR TITLE
fix: narrow broad except Exception in reasoning/provenance_enhanced.py

### DIFF
--- a/aragora/reasoning/provenance_enhanced.py
+++ b/aragora/reasoning/provenance_enhanced.py
@@ -182,7 +182,7 @@ class GitProvenanceTracker:
             return True, result.stdout.strip()
         except subprocess.TimeoutExpired:
             return False, "git command timed out after 30s"
-        except Exception as e:
+        except (OSError, subprocess.SubprocessError) as e:
             return False, str(e)
 
     def get_current_commit(self) -> str | None:
@@ -427,7 +427,7 @@ class WebProvenanceTracker:
                 checked_at=datetime.now().isoformat(),
                 reason="http pool not available for web checking",
             )
-        except Exception as e:
+        except (OSError, ValueError) as e:
             return StalenessCheck(
                 evidence_id=source_info.url,
                 status=StalenessStatus.ERROR,


### PR DESCRIPTION
Replace two broad `except Exception` handlers with specific types:
- `_run_git`: catch (OSError, subprocess.SubprocessError) for git process errors
- `WebProvenanceTracker.check_staleness`: catch (OSError, ValueError) for network/URL errors

Closes #2974

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e3442f4f71b2b36430f9cc56f0e7c88e5dc3afd3)
