### PR TITLE
fix(nomic): narrow broad except Exception in hardened_orchestrator.py

### DIFF
--- a/aragora/nomic/hardened_orchestrator.py
+++ b/aragora/nomic/hardened_orchestrator.py
@@ -2363,7 +2363,7 @@ class HardenedOrchestrator(BudgetMixin, GauntletMixin, AuditMixin, AutonomousOrc
             # C. Post-execution gauntlet validation
             if self.hardened_config.enable_gauntlet_validation and assignment.status == "completed":
                 await self._run_gauntlet_validation(assignment)
-        except Exception:
+        except (OSError, RuntimeError, ValueError, TypeError, KeyError, subprocess.SubprocessError):
             self._cancel_budget_reservation(assignment, reason="assignment_aborted")
             raise
 


### PR DESCRIPTION
Replace catch-all `except Exception` with specific exception tuple
(OSError, RuntimeError, ValueError, TypeError, KeyError,
subprocess.SubprocessError) in _execute_single_assignment's budget
cleanup handler.

Closes #2968

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 37715bf7b1d508b96009e3a5c4701f42298ce60f)
