### PR TITLE
fix: narrow broad except Exception in shipstation.py (#2979)

### DIFF
--- a/aragora/connectors/ecommerce/shipstation.py
+++ b/aragora/connectors/ecommerce/shipstation.py
@@ -657,10 +657,12 @@ def _parse_datetime(value: str | None) -> datetime | None:
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (ValueError, AttributeError):
-        try:
-            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
-        except (ValueError, AttributeError):
-            return None
+        pass
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S.%f")
+    except (ValueError, AttributeError):
+        logger.warning("shipstation: unparseable datetime value: %r", value)
+        return None
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Stop silent error swallowing in _parse_datetime by logging a warning
when datetime parsing fails instead of silently returning None.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 4e94bac20bb6cf025a9ffe54c6408e7dd9212a52)
