### PR TITLE
fix: narrow except Exception to except ImportError in nomic/testfixer/proposer.py

### DIFF
--- a/aragora/nomic/testfixer/proposer.py
+++ b/aragora/nomic/testfixer/proposer.py
@@ -318,7 +318,7 @@ class SimpleCodeGenerator:
                         "try:\n"
                         "    import tiktoken\n"
                         "    TIKTOKEN_AVAILABLE = True  # Kept for backwards compatibility\n"
-                        "except Exception:\n"
+                        "except ImportError:\n"
                         "    tiktoken = None\n"
                         "    TIKTOKEN_AVAILABLE = False\n"
                     )


### PR DESCRIPTION
The broad `except Exception` in the tiktoken import fallback template
was narrowed to `except ImportError` since it only guards an import.

Closes #2969

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f25acc282a9d7ef65083673915a8e3b355cc700c)
