### PR TITLE
fix(nomic): narrow broad except Exception in meta_planner_utils.py

### DIFF
--- a/aragora/nomic/meta_planner_utils.py
+++ b/aragora/nomic/meta_planner_utils.py
@@ -50,7 +50,7 @@ def infer_track(description: str, available_tracks: list[Track]) -> Track:
         result = _infer_track_llm(description, available_tracks)
         if result is not None:
             return result
-    except Exception:
+    except (ImportError, ValueError, TypeError, RuntimeError, OSError, TimeoutError):
         logger.debug("LLM track classification unavailable, using keyword fallback")
 
     # Keyword-based fallback
@@ -103,7 +103,7 @@ def _infer_track_llm(description: str, available_tracks: list[Track]) -> Track |
                 response = pool.submit(asyncio.run, agent.generate(prompt)).result(timeout=15)
         else:
             response = asyncio.run(agent.generate(prompt))
-    except Exception:
+    except (RuntimeError, OSError, TimeoutError):
         logger.debug("LLM classification call failed")
         return None
 


### PR DESCRIPTION
Replace two broad `except Exception` clauses with specific exception types:
- infer_track: catch ImportError, ValueError, TypeError, RuntimeError, OSError, TimeoutError
- _infer_track_llm: catch RuntimeError, OSError, TimeoutError

Closes #2972

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 58fd9fd7b2494342b87b971a0a00c71a200188c9)
