### PR TITLE
fix(admin): validate feature-flag request bodies

### DIFF
--- a/aragora/server/handlers/admin/feature_flags.py
+++ b/aragora/server/handlers/admin/feature_flags.py
@@ -235,6 +235,8 @@ class FeatureFlagAdminHandler(BaseHandler):
         body = self.read_json_body(handler)
         if body is None:
             return error_response("Invalid JSON body", 400)
+        if not isinstance(body, dict):
+            return error_response("JSON body must deserialize to an object", 400)
 
         if "value" not in body:
             return error_response("'value' field is required", 400)

--- a/tests/handlers/admin/test_feature_flags.py
+++ b/tests/handlers/admin/test_feature_flags.py
@@ -54,7 +54,7 @@ def _status(result: HandlerResult) -> int:
     return result.status_code
 
 
-def _make_http_handler(body: dict | None = None) -> MagicMock:
+def _make_http_handler(body: Any | None = None) -> MagicMock:
     """Create a mock HTTP handler with optional JSON body."""
     h = MagicMock()
     h.command = "GET"
@@ -738,6 +738,20 @@ class TestSetFlag:
             result = handler.handle_put("/api/v1/admin/feature-flags/enable_checkpointing", {}, h)
         assert _status(result) == 400
         assert "'value'" in _body(result)["error"]
+
+    def test_set_flag_string_body_returns_object_validation_error(self, handler, mock_registry):
+        h = _make_http_handler(body="value")
+        with _patch_flags_available(mock_registry):
+            result = handler.handle_put("/api/v1/admin/feature-flags/enable_checkpointing", {}, h)
+        assert _status(result) == 400
+        assert "object" in _body(result)["error"].lower()
+
+    def test_set_flag_array_body_returns_object_validation_error(self, handler, mock_registry):
+        h = _make_http_handler(body=["value"])
+        with _patch_flags_available(mock_registry):
+            result = handler.handle_put("/api/v1/admin/feature-flags/enable_checkpointing", {}, h)
+        assert _status(result) == 400
+        assert "object" in _body(result)["error"].lower()
 
     def test_set_flag_wrong_type_str_for_bool(self, handler, mock_registry):
         h = _make_http_handler(body={"value": "true"})


### PR DESCRIPTION
## Summary
- validate that admin feature-flag PUT bodies deserialize to JSON objects before reading fields
- return an explicit 400 validation error for string and array payloads instead of falling through the generic handler error path
- add regressions covering malformed non-object JSON payloads

## Validation
- python3 -m pytest tests/handlers/admin/test_feature_flags.py -q -o cache_dir=/tmp/pytest-cache-feature-flags-admin
- python3 -m ruff check aragora/server/handlers/admin/feature_flags.py tests/handlers/admin/test_feature_flags.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD