### PR TITLE
fix: update template_registry.py (#4848)

### DIFF
--- a/aragora/server/openapi/endpoints/template_registry.py
+++ b/aragora/server/openapi/endpoints/template_registry.py
@@ -10,6 +10,9 @@ from aragora.server.openapi.helpers import _ok_response, STANDARD_ERRORS
 __all__ = [
     "TEMPLATE_REGISTRY_ENDPOINTS",
     "get_registry_listing_schema",
+    "get_registry_listing_required_fields",
+    "get_registry_listing_property_names",
+    "build_sample_listing",
 ]
 
 _REGISTRY_LISTING_SCHEMA: dict[str, Any] = {
@@ -57,6 +60,40 @@ _REGISTRY_LISTING_SCHEMA: dict[str, Any] = {
 def get_registry_listing_schema() -> dict[str, Any]:
     """Return a copy of the registry listing schema for validation and testing."""
     return deepcopy(_REGISTRY_LISTING_SCHEMA)
+
+
+def get_registry_listing_required_fields() -> list[str]:
+    """Return the list of required fields for a registry listing."""
+    return list(_REGISTRY_LISTING_SCHEMA["required"])
+
+
+def get_registry_listing_property_names() -> list[str]:
+    """Return all property names defined in the registry listing schema."""
+    return sorted(_REGISTRY_LISTING_SCHEMA["properties"].keys())
+
+
+def build_sample_listing(**overrides: Any) -> dict[str, Any]:
+    """Build a sample registry listing dict suitable for schema validation tests."""
+    sample: dict[str, Any] = {
+        "id": "tpl_sample_001",
+        "name": "Sample Template",
+        "description": "A sample template for testing.",
+        "category": "general",
+        "author_id": "user_test",
+        "version": "1.0.0",
+        "tags": ["test", "sample"],
+        "status": "published",
+        "is_verified": False,
+        "is_builtin": False,
+        "install_count": 0,
+        "rating_average": 0.0,
+        "rating_count": 0,
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "approved_by": None,
+    }
+    sample.update(overrides)
+    return sample
 
 
 TEMPLATE_REGISTRY_ENDPOINTS: dict[str, Any] = {


### PR DESCRIPTION
Add test helper functions to improve unit test coverage:
- get_registry_listing_required_fields() exposes required field list
- get_registry_listing_property_names() exposes all property names
- build_sample_listing() builds valid sample data with overrides

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 66ec2989ae46e80e3ac32ffb8e7bef01a0dd0238)
