### PR TITLE
fix: update pipeline.py (#4821)

### DIFF
--- a/aragora/cli/commands/pipeline.py
+++ b/aragora/cli/commands/pipeline.py
@@ -1021,7 +1021,8 @@ def _cmd_pipeline_self_improve(args: argparse.Namespace) -> None:
             except ImportError as exc:
                 logger.debug("Output quality module unavailable, skipping quality gate: %s", exc)
             except (RuntimeError, ValueError, TypeError, AttributeError) as e:
-                logger.debug("Quality gate check failed: %s", e)
+                logger.warning("Quality gate check failed: %s", e)
+                print(f"[QUALITY GATE] Check failed ({e}), skipping gate.")
 
     if quality_gate_failed and plan_quality_fail_closed:
         print("[QUALITY GATE] Blocking handoff because fail-closed policy is active.")


### PR DESCRIPTION
Upgrade quality gate runtime failure handler from logger.debug to
logger.warning with user-visible print, consistent with other
non-ImportError exception handlers in the file.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 165970e52ef24bd298d5c8cff32b1665cc542c8f)
