### PR TITLE
feat(swarm): add mission lineage and gate metadata

### DIFF
--- a/aragora/nomic/pipeline_bridge.py
+++ b/aragora/nomic/pipeline_bridge.py
@@ -79,7 +79,30 @@ class BoundedWorkOrder:
     target_agent: str = ExecutionTarget.CODEX.value
     reviewer_agent: str = ExecutionTarget.CLAUDE.value
     approval_required: bool = False
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    roadmap_refs: list[str] = field(default_factory=list)
+    evidence_expectations: list[str] = field(default_factory=list)
+    gate_expectations: dict[str, Any] = field(default_factory=dict)
+    mission_context_policies: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        from aragora.swarm.mission import normalize_context_policies
+
+        self.mission_id = str(self.mission_id or "").strip()
+        self.stage_id = str(self.stage_id or "").strip()
+        self.assertion_ids = _dedupe_nonempty(self.assertion_ids)
+        self.roadmap_refs = _dedupe_nonempty(self.roadmap_refs)
+        self.evidence_expectations = _dedupe_nonempty(self.evidence_expectations)
+        self.gate_expectations = dict(self.gate_expectations or {})
+        self.mission_context_policies = normalize_context_policies(
+            self.mission_context_policies,
+            file_scope=list(self.file_scope),
+            evidence_expectations=list(self.evidence_expectations),
+        )
+        self.metadata = dict(self.metadata or {})
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -96,6 +119,13 @@ class BoundedWorkOrder:
             "target_agent": self.target_agent,
             "reviewer_agent": self.reviewer_agent,
             "approval_required": self.approval_required,
+            "mission_id": self.mission_id,
+            "stage_id": self.stage_id,
+            "assertion_ids": list(self.assertion_ids),
+            "roadmap_refs": list(self.roadmap_refs),
+            "evidence_expectations": list(self.evidence_expectations),
+            "gate_expectations": dict(self.gate_expectations),
+            "mission_context_policies": dict(self.mission_context_policies),
             "metadata": dict(self.metadata),
         }
 
@@ -462,6 +492,13 @@ class NomicPipelineBridge:
             budget_limit_usd=self._budget_limit_usd,
             file_scope_hints=list(work_order.file_scope),
             work_orders=[work_order.to_dict()],
+            mission_id=work_order.mission_id,
+            stage_id=work_order.stage_id,
+            assertion_ids=list(work_order.assertion_ids),
+            roadmap_refs=list(work_order.roadmap_refs),
+            evidence_expectations=list(work_order.evidence_expectations),
+            gate_expectations=dict(work_order.gate_expectations),
+            mission_context_policies=dict(work_order.mission_context_policies),
             estimated_complexity=work_order.estimated_complexity,
             requires_approval=work_order.approval_required,
             research_context={

--- a/aragora/swarm/boss_validation.py
+++ b/aragora/swarm/boss_validation.py
@@ -19,6 +19,8 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict
+
 logger = logging.getLogger(__name__)
 
 
@@ -418,6 +420,37 @@ def run_pre_dispatch_validation_commands(
     return {"satisfied": True, "results": results}
 
 
+def _pre_dispatch_gate_evaluation(
+    *,
+    sanitation_ok: bool,
+    sanitation_reason: str | None,
+    unresolved_missing: list[str],
+    validation_commands: list[str],
+) -> dict[str, Any]:
+    failure_classes: list[str] = []
+    notes: list[str] = []
+    if not sanitation_ok:
+        failure_classes.append("sanitation_failed")
+        if sanitation_reason:
+            notes.append(f"sanitation_reason={sanitation_reason}")
+    if unresolved_missing:
+        failure_classes.append("validation_target_missing")
+        notes.append("missing_targets=" + ", ".join(unresolved_missing))
+
+    verdict = GateVerdict.PASS.value if not failure_classes else GateVerdict.BLOCKED.value
+    gate = GateEvaluation(
+        gate_type=GateType.DISPATCH_READY.value,
+        verdict=verdict,
+        failure_classes=failure_classes,
+        repair_eligible=bool(
+            set(failure_classes).intersection({"sanitation_failed", "validation_target_missing"})
+        ),
+        required_evidence=["issue_body", *(["validation_command"] if validation_commands else [])],
+        notes=" ".join(notes).strip(),
+    )
+    return gate.to_dict()
+
+
 # ---------------------------------------------------------------------------
 # LLM-based semantic issue parsing
 # ---------------------------------------------------------------------------
@@ -652,6 +685,12 @@ async def check_pre_dispatch_gate(
             pre_dispatch_cmds, repo_root=repo_root
         )
         unresolved = [t for t in missing if t not in set(declared_new)]
+        gate = _pre_dispatch_gate_evaluation(
+            sanitation_ok=san_ok,
+            sanitation_reason=san_reason,
+            unresolved_missing=unresolved,
+            validation_commands=validation_cmds,
+        )
 
         return {
             "pass": san_ok and not unresolved,
@@ -662,6 +701,7 @@ async def check_pre_dispatch_gate(
             "validation_commands": validation_cmds,
             "missing_targets": missing,
             "unresolved_missing": unresolved,
+            "gate_evaluation": gate,
         }
 
     # --- Regex fallback ---
@@ -670,6 +710,12 @@ async def check_pre_dispatch_gate(
     validation_cmds = extract_pre_dispatch_validation_commands(body)
     missing = find_missing_pre_dispatch_validation_targets(validation_cmds, repo_root=repo_root)
     unresolved = [t for t in missing if t not in set(declared_new)]
+    gate = _pre_dispatch_gate_evaluation(
+        sanitation_ok=san_ok,
+        sanitation_reason=san_reason,
+        unresolved_missing=unresolved,
+        validation_commands=validation_cmds,
+    )
 
     return {
         "pass": san_ok and not unresolved,
@@ -680,6 +726,7 @@ async def check_pre_dispatch_gate(
         "validation_commands": validation_cmds,
         "missing_targets": missing,
         "unresolved_missing": unresolved,
+        "gate_evaluation": gate,
     }
 
 

--- a/aragora/swarm/mission.py
+++ b/aragora/swarm/mission.py
@@ -1,0 +1,345 @@
+"""Mission lineage and gate primitives for the swarm substrate.
+
+These models are intentionally additive. They annotate existing execution
+contracts without replacing ``SwarmSpec`` or ``BoundedWorkOrder`` as sources
+of truth.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class GateType(str, Enum):
+    DRAFT_READY = "draft_ready"
+    DISPATCH_READY = "dispatch_ready"
+    MILESTONE_READY = "milestone_ready"
+    PUBLISH_READY = "publish_ready"
+
+
+class GateVerdict(str, Enum):
+    PASS = "pass"
+    BLOCKED = "blocked"
+    NEEDS_HUMAN = "needs_human"
+
+
+class TranscriptAllowance(str, Enum):
+    NONE = "none"
+    SUMMARY_ONLY = "summary_only"
+    RAW_ALLOWED = "raw_allowed"
+
+
+def _ordered_unique_strings(values: list[Any]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        text = str(value or "").strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        ordered.append(text)
+    return ordered
+
+
+@dataclass(slots=True)
+class MissionEnvelope:
+    mission_id: str = ""
+    roadmap_refs: list[str] = field(default_factory=list)
+    goal_summary: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    evidence_expectations: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mission_id": str(self.mission_id or "").strip(),
+            "roadmap_refs": _ordered_unique_strings(self.roadmap_refs),
+            "goal_summary": str(self.goal_summary or "").strip(),
+            "assertion_ids": _ordered_unique_strings(self.assertion_ids),
+            "evidence_expectations": _ordered_unique_strings(self.evidence_expectations),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> MissionEnvelope:
+        data = dict(payload or {})
+        return cls(
+            mission_id=str(data.get("mission_id", "") or "").strip(),
+            roadmap_refs=_ordered_unique_strings(list(data.get("roadmap_refs") or [])),
+            goal_summary=str(data.get("goal_summary", "") or "").strip(),
+            assertion_ids=_ordered_unique_strings(list(data.get("assertion_ids") or [])),
+            evidence_expectations=_ordered_unique_strings(
+                list(data.get("evidence_expectations") or [])
+            ),
+        )
+
+
+@dataclass(slots=True)
+class RepairPolicy:
+    max_repair_rounds: int = 2
+    max_validator_rounds: int = 3
+    max_stage_wall_time_minutes: int = 90
+    escalate_after_terminal_classes: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "max_repair_rounds": max(0, int(self.max_repair_rounds)),
+            "max_validator_rounds": max(0, int(self.max_validator_rounds)),
+            "max_stage_wall_time_minutes": max(0, int(self.max_stage_wall_time_minutes)),
+            "escalate_after_terminal_classes": _ordered_unique_strings(
+                self.escalate_after_terminal_classes
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> RepairPolicy:
+        data = dict(payload or {})
+        return cls(
+            max_repair_rounds=int(data.get("max_repair_rounds", 2) or 2),
+            max_validator_rounds=int(data.get("max_validator_rounds", 3) or 3),
+            max_stage_wall_time_minutes=int(data.get("max_stage_wall_time_minutes", 90) or 90),
+            escalate_after_terminal_classes=_ordered_unique_strings(
+                list(data.get("escalate_after_terminal_classes") or [])
+            ),
+        )
+
+
+@dataclass(slots=True)
+class MissionStage:
+    stage_id: str = ""
+    mission_id: str = ""
+    title: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    file_scope: list[str] = field(default_factory=list)
+    validation_command: str = ""
+    acceptance_criteria: list[str] = field(default_factory=list)
+    repair_policy: RepairPolicy = field(default_factory=RepairPolicy)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stage_id": str(self.stage_id or "").strip(),
+            "mission_id": str(self.mission_id or "").strip(),
+            "title": str(self.title or "").strip(),
+            "assertion_ids": _ordered_unique_strings(self.assertion_ids),
+            "file_scope": _ordered_unique_strings(self.file_scope),
+            "validation_command": str(self.validation_command or "").strip(),
+            "acceptance_criteria": _ordered_unique_strings(self.acceptance_criteria),
+            "repair_policy": self.repair_policy.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> MissionStage:
+        data = dict(payload or {})
+        return cls(
+            stage_id=str(data.get("stage_id", "") or "").strip(),
+            mission_id=str(data.get("mission_id", "") or "").strip(),
+            title=str(data.get("title", "") or "").strip(),
+            assertion_ids=_ordered_unique_strings(list(data.get("assertion_ids") or [])),
+            file_scope=_ordered_unique_strings(list(data.get("file_scope") or [])),
+            validation_command=str(data.get("validation_command", "") or "").strip(),
+            acceptance_criteria=_ordered_unique_strings(
+                list(data.get("acceptance_criteria") or [])
+            ),
+            repair_policy=RepairPolicy.from_dict(data.get("repair_policy")),
+        )
+
+
+@dataclass(slots=True)
+class MissionContextPolicy:
+    role: str
+    allowed_artifact_classes: list[str] = field(default_factory=list)
+    max_source_count: int = 0
+    max_chars: int = 0
+    freshness_ttl_seconds: int = 0
+    transcript_allowance: str = TranscriptAllowance.NONE.value
+    required_sources: list[str] = field(default_factory=list)
+    forbidden_sources: list[str] = field(default_factory=list)
+
+    def is_resolvable(self) -> bool:
+        return bool(
+            str(self.role or "").strip()
+            and self.allowed_artifact_classes
+            and self.max_source_count > 0
+            and self.max_chars > 0
+            and self.freshness_ttl_seconds >= 0
+            and str(self.transcript_allowance or "").strip()
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "role": str(self.role or "").strip(),
+            "allowed_artifact_classes": _ordered_unique_strings(self.allowed_artifact_classes),
+            "max_source_count": max(0, int(self.max_source_count)),
+            "max_chars": max(0, int(self.max_chars)),
+            "freshness_ttl_seconds": max(0, int(self.freshness_ttl_seconds)),
+            "transcript_allowance": str(self.transcript_allowance or "").strip()
+            or TranscriptAllowance.NONE.value,
+            "required_sources": _ordered_unique_strings(self.required_sources),
+            "forbidden_sources": _ordered_unique_strings(self.forbidden_sources),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> MissionContextPolicy:
+        data = dict(payload or {})
+        role = str(data.get("role", "") or "").strip() or "worker"
+        return cls(
+            role=role,
+            allowed_artifact_classes=_ordered_unique_strings(
+                list(data.get("allowed_artifact_classes") or [])
+            ),
+            max_source_count=int(data.get("max_source_count", 0) or 0),
+            max_chars=int(data.get("max_chars", 0) or 0),
+            freshness_ttl_seconds=int(data.get("freshness_ttl_seconds", 0) or 0),
+            transcript_allowance=str(data.get("transcript_allowance", "") or "").strip()
+            or TranscriptAllowance.NONE.value,
+            required_sources=_ordered_unique_strings(list(data.get("required_sources") or [])),
+            forbidden_sources=_ordered_unique_strings(list(data.get("forbidden_sources") or [])),
+        )
+
+
+@dataclass(slots=True)
+class GateEvaluation:
+    gate_type: str
+    verdict: str
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    failure_classes: list[str] = field(default_factory=list)
+    repair_eligible: bool = False
+    required_evidence: list[str] = field(default_factory=list)
+    notes: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "gate_type": str(self.gate_type or "").strip(),
+            "verdict": str(self.verdict or "").strip(),
+            "mission_id": str(self.mission_id or "").strip(),
+            "stage_id": str(self.stage_id or "").strip(),
+            "assertion_ids": _ordered_unique_strings(self.assertion_ids),
+            "failure_classes": _ordered_unique_strings(self.failure_classes),
+            "repair_eligible": bool(self.repair_eligible),
+            "required_evidence": _ordered_unique_strings(self.required_evidence),
+            "notes": str(self.notes or "").strip(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> GateEvaluation:
+        data = dict(payload or {})
+        return cls(
+            gate_type=str(data.get("gate_type", "") or "").strip(),
+            verdict=str(data.get("verdict", "") or "").strip(),
+            mission_id=str(data.get("mission_id", "") or "").strip(),
+            stage_id=str(data.get("stage_id", "") or "").strip(),
+            assertion_ids=_ordered_unique_strings(list(data.get("assertion_ids") or [])),
+            failure_classes=_ordered_unique_strings(list(data.get("failure_classes") or [])),
+            repair_eligible=bool(data.get("repair_eligible", False)),
+            required_evidence=_ordered_unique_strings(list(data.get("required_evidence") or [])),
+            notes=str(data.get("notes", "") or "").strip(),
+        )
+
+
+def default_context_policy(
+    role: str,
+    *,
+    file_scope: list[str] | None = None,
+    evidence_expectations: list[str] | None = None,
+) -> MissionContextPolicy:
+    normalized_role = str(role or "").strip().lower() or "worker"
+    scope = _ordered_unique_strings(list(file_scope or []))
+    evidence = _ordered_unique_strings(list(evidence_expectations or []))
+
+    if normalized_role == "validator":
+        return MissionContextPolicy(
+            role="validator",
+            allowed_artifact_classes=[
+                "mission_envelope",
+                "mission_stage",
+                "validation_command",
+                "acceptance_criteria",
+                "receipt",
+                "artifact_ref",
+                "scope_report",
+                "summary",
+            ],
+            max_source_count=max(4, min(8, len(scope) + max(1, len(evidence)))),
+            max_chars=16000,
+            freshness_ttl_seconds=900,
+            transcript_allowance=TranscriptAllowance.SUMMARY_ONLY.value,
+            required_sources=evidence or ["validation_command"],
+            forbidden_sources=["raw_worker_transcript"],
+        )
+
+    return MissionContextPolicy(
+        role="worker",
+        allowed_artifact_classes=[
+            "mission_envelope",
+            "mission_stage",
+            "swarm_spec",
+            "file_scope",
+            "validation_command",
+            "acceptance_criteria",
+            "constraint",
+            "knowledge_snippet",
+            "evidence_expectation",
+        ],
+        max_source_count=max(4, min(12, len(scope) + 4)),
+        max_chars=24000,
+        freshness_ttl_seconds=3600,
+        transcript_allowance=TranscriptAllowance.NONE.value,
+        required_sources=scope[:6],
+        forbidden_sources=["raw_worker_transcript", "validator_private_notes"],
+    )
+
+
+def normalize_context_policies(
+    payload: Mapping[str, Any] | None,
+    *,
+    file_scope: list[str] | None = None,
+    evidence_expectations: list[str] | None = None,
+) -> dict[str, dict[str, Any]]:
+    data = dict(payload or {})
+    result: dict[str, dict[str, Any]] = {}
+    for role in ("worker", "validator"):
+        value = data.get(role)
+        if isinstance(value, Mapping):
+            policy = MissionContextPolicy.from_dict(value)
+        else:
+            policy = default_context_policy(
+                role,
+                file_scope=list(file_scope or []),
+                evidence_expectations=list(evidence_expectations or []),
+            )
+        result[role] = policy.to_dict()
+    return result
+
+
+def mission_lineage_payload(
+    *,
+    mission_id: str = "",
+    stage_id: str = "",
+    assertion_ids: list[str] | None = None,
+    roadmap_refs: list[str] | None = None,
+    evidence_expectations: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "mission_id": str(mission_id or "").strip(),
+        "stage_id": str(stage_id or "").strip(),
+        "assertion_ids": _ordered_unique_strings(list(assertion_ids or [])),
+        "roadmap_refs": _ordered_unique_strings(list(roadmap_refs or [])),
+        "evidence_expectations": _ordered_unique_strings(list(evidence_expectations or [])),
+    }
+
+
+__all__ = [
+    "GateEvaluation",
+    "GateType",
+    "GateVerdict",
+    "MissionContextPolicy",
+    "MissionEnvelope",
+    "MissionStage",
+    "RepairPolicy",
+    "TranscriptAllowance",
+    "default_context_policy",
+    "mission_lineage_payload",
+    "normalize_context_policies",
+]

--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict, MissionContextPolicy
 from aragora.swarm.worker_contract import checksum_contract_payload
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
 
@@ -28,6 +29,7 @@ class PreflightResult:
     pull_request_closed: bool
     cleanup_worktree_removed: bool
     cleanup_branch_removed: bool
+    dispatch_gate: dict[str, Any] = field(default_factory=dict)
     worker: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -42,6 +44,7 @@ class PreflightResult:
             "pull_request_closed": self.pull_request_closed,
             "cleanup_worktree_removed": self.cleanup_worktree_removed,
             "cleanup_branch_removed": self.cleanup_branch_removed,
+            "dispatch_gate": dict(self.dispatch_gate),
             "worker": dict(self.worker),
         }
 
@@ -79,6 +82,14 @@ def _work_order(agent: str) -> dict[str, object]:
     return {
         "work_order_id": f"preflight-{int(time.time())}",
         "target_agent": agent,
+        "mission_id": "mission-rs-worker-contract-preflight",
+        "stage_id": "stage-dispatch-ready-preflight",
+        "assertion_ids": ["RS-PREFLIGHT-ASSERT-1"],
+        "evidence_expectations": [
+            "worker_contract",
+            "worker_contract_checksum",
+            "receipt",
+        ],
         "title": "Preflight worker check",
         "description": (
             "Create a file named `scratch/preflight_worker_check.txt` with a single line "
@@ -112,7 +123,56 @@ async def _run_worker(
     )
 
 
-def _validate_worker_contract(worker: WorkerProcess) -> None:
+def evaluate_preflight_dispatch_gate(worker: WorkerProcess) -> dict[str, Any]:
+    contract = dict(worker.worker_contract or {})
+    mission_id = str(contract.get("mission_id", "") or "").strip()
+    stage_id = str(contract.get("stage_id", "") or "").strip()
+    assertion_ids = [
+        str(item).strip() for item in contract.get("assertion_ids", []) if str(item).strip()
+    ]
+    failure_classes: list[str] = []
+    notes: list[str] = []
+
+    if not contract:
+        failure_classes.append("contract_missing")
+        notes.append("Preflight worker did not emit a worker contract.")
+    if not worker.worker_contract_checksum:
+        failure_classes.append("contract_missing")
+        notes.append("Preflight worker did not emit a worker contract checksum.")
+    if contract and worker.worker_contract_checksum:
+        checksum = checksum_contract_payload(contract)
+        if checksum != worker.worker_contract_checksum:
+            failure_classes.append("contract_missing")
+            notes.append("Worker contract checksum does not match the contract payload.")
+
+    policy = MissionContextPolicy.from_dict(contract.get("mission_context_policy"))
+    if not policy.is_resolvable():
+        failure_classes.append("context_policy_unresolved")
+        notes.append("Worker mission context policy is missing or not enforceable.")
+
+    verdict = GateVerdict.PASS.value if not failure_classes else GateVerdict.BLOCKED.value
+    gate = GateEvaluation(
+        gate_type=GateType.DISPATCH_READY.value,
+        verdict=verdict,
+        mission_id=mission_id,
+        stage_id=stage_id,
+        assertion_ids=assertion_ids,
+        failure_classes=failure_classes,
+        repair_eligible=any(
+            failure in {"contract_missing", "context_policy_unresolved"}
+            for failure in failure_classes
+        ),
+        required_evidence=[
+            "worker_contract",
+            "worker_contract_checksum",
+            "mission_context_policy",
+        ],
+        notes=" ".join(notes).strip(),
+    )
+    return gate.to_dict()
+
+
+def _validate_worker_contract(worker: WorkerProcess) -> dict[str, Any]:
     if not worker.worker_contract:
         raise RuntimeError("Preflight worker did not emit a worker contract.")
     if not worker.worker_contract_checksum:
@@ -122,6 +182,10 @@ def _validate_worker_contract(worker: WorkerProcess) -> None:
         raise RuntimeError(
             "Preflight worker emitted a worker contract checksum that does not match the contract payload."
         )
+    gate = evaluate_preflight_dispatch_gate(worker)
+    if str(gate.get("verdict", "")).strip() != GateVerdict.PASS.value:
+        raise RuntimeError(str(gate.get("notes") or "Preflight dispatch gate failed."))
+    return gate
 
 
 def _create_pr(repo_root: Path, branch: str, base_ref: str) -> None:
@@ -184,6 +248,7 @@ def run_preflight(
     pull_request_closed = False
     cleanup_worktree_removed = False
     cleanup_branch_removed = False
+    dispatch_gate: dict[str, Any] = {}
 
     try:
         _run(
@@ -200,7 +265,7 @@ def run_preflight(
                 agent=normalized_agent,
             )
         )
-        _validate_worker_contract(worker)
+        dispatch_gate = _validate_worker_contract(worker)
         if not worker.commit_shas:
             raise RuntimeError("Preflight worker did not produce a commit.")
 
@@ -241,6 +306,7 @@ def run_preflight(
         pull_request_closed=pull_request_closed,
         cleanup_worktree_removed=cleanup_worktree_removed,
         cleanup_branch_removed=cleanup_branch_removed,
+        dispatch_gate=dispatch_gate,
         worker=worker.to_dict() if worker is not None else {},
     )
 

--- a/aragora/swarm/reporter.py
+++ b/aragora/swarm/reporter.py
@@ -114,6 +114,16 @@ def _first_list(*values: Any) -> list[str]:
     return []
 
 
+def _first_dict_list(*values: Any) -> list[dict[str, Any]]:
+    for value in values:
+        if not isinstance(value, (list, tuple, set)):
+            continue
+        items = [dict(item) for item in value if isinstance(item, dict)]
+        if items:
+            return items
+    return []
+
+
 def _extract_receipt_id(*sources: dict[str, Any] | None) -> str:
     for source in sources:
         if not isinstance(source, dict):
@@ -1105,6 +1115,48 @@ def build_integrator_view(
             "worker_outcome": worker_outcome,
             "branch": branch,
             "commit_shas": commit_shas,
+            "mission_id": _first_text(
+                work_order.get("mission_id"),
+                task.get("mission_id"),
+                task_meta.get("mission_id"),
+                receipt.get("mission_id"),
+                receipt_meta.get("mission_id"),
+            ),
+            "stage_id": _first_text(
+                work_order.get("stage_id"),
+                task.get("stage_id"),
+                task_meta.get("stage_id"),
+                receipt.get("stage_id"),
+                receipt_meta.get("stage_id"),
+            ),
+            "assertion_ids": _first_list(
+                work_order.get("assertion_ids"),
+                task.get("assertion_ids"),
+                task_meta.get("assertion_ids"),
+                receipt.get("assertion_ids"),
+                receipt_meta.get("assertion_ids"),
+            ),
+            "evidence_expectations": _first_list(
+                work_order.get("evidence_expectations"),
+                task.get("evidence_expectations"),
+                task_meta.get("evidence_expectations"),
+                receipt.get("evidence_expectations"),
+                receipt_meta.get("evidence_expectations"),
+            ),
+            "dispatch_gate": _pick_first(
+                work_order.get("dispatch_gate"),
+                task.get("dispatch_gate"),
+                task_meta.get("dispatch_gate"),
+                receipt.get("dispatch_gate"),
+                receipt_meta.get("dispatch_gate"),
+            ),
+            "gate_evaluations": _first_dict_list(
+                work_order.get("gate_evaluations"),
+                task.get("gate_evaluations"),
+                task_meta.get("gate_evaluations"),
+                receipt.get("gate_evaluations"),
+                receipt_meta.get("gate_evaluations"),
+            ),
             "pr_url": _first_text(
                 work_order.get("pr_url"),
                 task.get("pr_url"),
@@ -1530,6 +1582,17 @@ def build_integrator_view(
                 if _text(blocker).lower() not in {"stale_lease_reaped", "expired_lease_reaped"}
             ]
         blockers = sorted(set(blockers))
+        dispatch_gate = next(
+            (
+                dict(gate)
+                for gate in qualification.gate_evaluations
+                if _text(gate.get("gate_type")).lower() == "dispatch_ready"
+            ),
+            None,
+        )
+        last_gate = (
+            dict(qualification.gate_evaluations[-1]) if qualification.gate_evaluations else None
+        )
 
         available_actions = _available_actions(
             canonical_lane=canonical_lane,
@@ -1568,6 +1631,15 @@ def build_integrator_view(
             ),
             "deliverable_type": qualification.deliverable_type,
             "worker_outcome": worker_outcome or None,
+            "mission_id": qualification.mission_id or None,
+            "stage_id": qualification.stage_id or None,
+            "assertion_ids": list(qualification.assertion_ids),
+            "evidence_expectations": list(qualification.evidence_expectations),
+            "gate_evaluations": [dict(item) for item in qualification.gate_evaluations],
+            "dispatch_gate": dispatch_gate,
+            "last_gate_type": _text(last_gate.get("gate_type")) or None if last_gate else None,
+            "last_gate_verdict": _text(last_gate.get("verdict")) or None if last_gate else None,
+            "failure_classes": list(qualification.failure_classes),
             "canonical_lane": canonical_lane,
             "owner_agent": owner_agent or None,
             "reviewer_agent": reviewer_agent or None,

--- a/aragora/swarm/spec.py
+++ b/aragora/swarm/spec.py
@@ -9,6 +9,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
+from aragora.swarm.mission import normalize_context_policies
+
 _FILE_SCOPE_HINT_RE = re.compile(r"(?:\./)?(?:[A-Za-z0-9_*?\[\]{}.-]+/)+[A-Za-z0-9_*?\[\]{}.-]+/?")
 _EXACT_FILE_SCOPE_RE = re.compile(r"(?:\./)?(?:[A-Za-z0-9_*?\[\]{}.-]+/)*[A-Za-z0-9_*?\[\]{}.-]+/?")
 _URL_RE = re.compile(r"https?://\S+")
@@ -69,6 +71,15 @@ class SwarmSpec:
     file_scope_hints: list[str] = field(default_factory=list)
     work_orders: list[dict[str, Any]] = field(default_factory=list)
 
+    # Mission lineage (additive envelope over live execution contracts)
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    roadmap_refs: list[str] = field(default_factory=list)
+    evidence_expectations: list[str] = field(default_factory=list)
+    gate_expectations: dict[str, Any] = field(default_factory=dict)
+    mission_context_policies: dict[str, Any] = field(default_factory=dict)
+
     # Risk assessment
     estimated_complexity: str = "medium"
     requires_approval: bool = False
@@ -89,6 +100,26 @@ class SwarmSpec:
     # Metadata
     interrogation_turns: int = 0
     user_expertise: str = "non-developer"
+
+    def __post_init__(self) -> None:
+        self.raw_goal = str(self.raw_goal or "").strip()
+        self.refined_goal = str(self.refined_goal or "").strip()
+        self.acceptance_criteria = self._nonempty_strings(self.acceptance_criteria)
+        self.constraints = self._nonempty_strings(self.constraints)
+        self.track_hints = self._nonempty_strings(self.track_hints)
+        self.file_scope_hints = self._nonempty_strings(self.file_scope_hints)
+        self.work_orders = [dict(item) for item in self.work_orders if isinstance(item, dict)]
+        self.mission_id = str(self.mission_id or "").strip()
+        self.stage_id = str(self.stage_id or "").strip()
+        self.assertion_ids = self._nonempty_strings(self.assertion_ids)
+        self.roadmap_refs = self._nonempty_strings(self.roadmap_refs)
+        self.evidence_expectations = self._nonempty_strings(self.evidence_expectations)
+        self.gate_expectations = dict(self.gate_expectations or {})
+        self.mission_context_policies = normalize_context_policies(
+            self.mission_context_policies,
+            file_scope=list(self.file_scope_hints),
+            evidence_expectations=list(self.evidence_expectations),
+        )
 
     @staticmethod
     def _nonempty_strings(values: list[str]) -> list[str]:
@@ -306,4 +337,8 @@ class SwarmSpec:
             lines.append(f"File scope: {', '.join(self.file_scope_hints[:5])}")
         if self.work_orders:
             lines.append(f"Explicit work orders: {len(self.work_orders)}")
+        if self.mission_id:
+            lines.append(f"Mission: {self.mission_id}")
+        if self.stage_id:
+            lines.append(f"Stage: {self.stage_id}")
         return "\n".join(lines)

--- a/aragora/swarm/strategic_issue_bridge.py
+++ b/aragora/swarm/strategic_issue_bridge.py
@@ -18,6 +18,13 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from aragora.nomic.strategic_scanner import StrategicAssessment, StrategicFinding, StrategicScanner
+from aragora.swarm.mission import (
+    GateEvaluation,
+    GateType,
+    GateVerdict,
+    RepairPolicy,
+    normalize_context_policies,
+)
 from aragora.swarm.spec import SwarmSpec
 
 logger = logging.getLogger(__name__)
@@ -244,7 +251,14 @@ class StrategicIssueCandidate:
     priority: int
     success_estimate: float
     source: str
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
     roadmap_refs: list[str] = field(default_factory=list)
+    evidence_expectations: list[str] = field(default_factory=list)
+    repair_policy: dict[str, Any] = field(default_factory=dict)
+    gate_expectations: dict[str, Any] = field(default_factory=dict)
+    mission_context_policies: dict[str, Any] = field(default_factory=dict)
     metadata: dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -259,15 +273,105 @@ class StrategicIssueCandidate:
             "priority": self.priority,
             "success_estimate": self.success_estimate,
             "source": self.source,
+            "mission_id": self.mission_id,
+            "stage_id": self.stage_id,
+            "assertion_ids": list(self.assertion_ids),
             "roadmap_refs": list(self.roadmap_refs),
+            "evidence_expectations": list(self.evidence_expectations),
+            "repair_policy": dict(self.repair_policy),
+            "gate_expectations": dict(self.gate_expectations),
+            "mission_context_policies": dict(self.mission_context_policies),
             "metadata": dict(self.metadata),
         }
+
+    def boss_ready_issue_body(self) -> str:
+        parts: list[str] = [f"## Task\n\n{self.description}"]
+
+        mission_lines = [
+            f"- Mission ID: `{self.mission_id}`" if self.mission_id else "",
+            f"- Stage ID: `{self.stage_id}`" if self.stage_id else "",
+            (
+                f"- Assertion IDs: {', '.join(f'`{item}`' for item in self.assertion_ids)}"
+                if self.assertion_ids
+                else ""
+            ),
+            (
+                f"- Roadmap refs: {', '.join(f'`{item}`' for item in self.roadmap_refs)}"
+                if self.roadmap_refs
+                else ""
+            ),
+            (
+                "- Evidence expectations: "
+                + ", ".join(f"`{item}`" for item in self.evidence_expectations)
+                if self.evidence_expectations
+                else ""
+            ),
+        ]
+        mission_lines = [line for line in mission_lines if line]
+        if mission_lines:
+            parts.append("### Mission\n" + "\n".join(mission_lines))
+
+        if self.file_scope:
+            scope_lines = "\n".join(f"- `{path}`" for path in self.file_scope)
+            parts.append("### File Scope\n" + scope_lines)
+
+        if self.validation_command:
+            parts.append(f"### Validation\n```bash\n{self.validation_command}\n```")
+
+        if self.acceptance_criteria:
+            criteria = "\n".join(f"- {item}" for item in self.acceptance_criteria)
+            parts.append("### Acceptance Criteria\n" + criteria)
+
+        gate_lines: list[str] = []
+        for gate_name, gate in sorted(self.gate_expectations.items()):
+            if not isinstance(gate, dict):
+                continue
+            verdict = str(gate.get("verdict", "")).strip()
+            failures = ", ".join(str(item) for item in gate.get("failure_classes", []) if item)
+            line = f"- `{gate_name}`: `{verdict}`"
+            if failures:
+                line += f" failure_classes={failures}"
+            gate_lines.append(line)
+        if gate_lines:
+            parts.append("### Gate Expectations\n" + "\n".join(gate_lines))
+
+        context_lines: list[str] = []
+        for role in ("worker", "validator"):
+            policy = self.mission_context_policies.get(role)
+            if not isinstance(policy, dict):
+                continue
+            context_lines.append(
+                "- "
+                + f"`{role}` max_sources={policy.get('max_source_count')} "
+                + f"max_chars={policy.get('max_chars')} "
+                + f"ttl={policy.get('freshness_ttl_seconds')} "
+                + f"transcripts={policy.get('transcript_allowance')}"
+            )
+        if context_lines:
+            parts.append("### Context Policies\n" + "\n".join(context_lines))
+
+        constraint_lines = [
+            f"- Estimated complexity: {self.complexity}",
+            f"- Priority: {self.priority}",
+            f"- Success estimate: {self.success_estimate:.2f}",
+        ]
+        if self.repair_policy:
+            constraint_lines.append(
+                "- Repair budget: "
+                + f"repairs={self.repair_policy.get('max_repair_rounds')} "
+                + f"validators={self.repair_policy.get('max_validator_rounds')} "
+                + f"wall_time_minutes={self.repair_policy.get('max_stage_wall_time_minutes')}"
+            )
+        parts.append("### Constraints\n" + "\n".join(constraint_lines))
+        parts.append(f"<!-- fingerprint:{self.fingerprint} -->")
+        return "\n\n".join(parts)
 
 
 @dataclass
 class StrategicIssueBridgeConfig:
     max_issues: int = 10
     max_per_theme: int = 4
+    categories: list[str] = field(default_factory=list)
     heuristic_only: bool = False
     enable_scanner: bool = True
     enable_llm: bool = False
@@ -353,6 +457,7 @@ class StrategicIssueBridge:
 
         if llm_candidates:
             ranked = self._rank_candidates(llm_candidates, priority_order)
+            ranked = self._filter_candidates(ranked)
             return ranked[: self.config.max_issues]
 
         heuristic_candidates = self._generate_heuristic_candidates(
@@ -361,6 +466,7 @@ class StrategicIssueBridge:
             priority_order,
         )
         ranked = self._rank_candidates(heuristic_candidates, priority_order)
+        ranked = self._filter_candidates(ranked)
         limited = _limit_per_theme(ranked, self.config.max_per_theme)
         return limited[: self.config.max_issues]
 
@@ -373,8 +479,6 @@ class StrategicIssueBridge:
         candidates: list[StrategicIssueCandidate] = []
 
         for item in roadmap_items:
-            if len(candidates) >= self.config.max_issues:
-                break
             candidate = self._candidate_from_roadmap_item(item, context)
             if candidate:
                 candidates.append(candidate)
@@ -406,11 +510,28 @@ class StrategicIssueBridge:
             return None
 
         acceptance = _default_acceptance_criteria(item, validation, file_scope)
-
+        mission_id = _mission_id_for_item(item)
+        stage_id = _stage_id_for_item(item)
+        assertion_ids = _assertion_ids_for_item(item)
+        evidence_expectations = _evidence_expectations_for_item(item)
+        repair_policy = _repair_policy_for_item(item).to_dict()
+        context_policies = normalize_context_policies(
+            None,
+            file_scope=file_scope,
+            evidence_expectations=evidence_expectations,
+        )
         description = _compose_description(item, context)
         priority = _priority_from_rank(item.priority_rank)
         success_estimate = _success_estimate(item, file_scope)
         fingerprint = _fingerprint("roadmap", item.code, item.title, file_scope)
+        draft_gate = _draft_ready_gate(
+            mission_id=mission_id,
+            stage_id=stage_id,
+            assertion_ids=assertion_ids,
+            goal_summary=item.title,
+            file_scope=file_scope,
+            validation_command=validation,
+        )
 
         return StrategicIssueCandidate(
             title=f"{item.code}: {item.title}",
@@ -423,7 +544,14 @@ class StrategicIssueBridge:
             priority=priority,
             success_estimate=success_estimate,
             source="roadmap",
+            mission_id=mission_id,
+            stage_id=stage_id,
+            assertion_ids=assertion_ids,
             roadmap_refs=[item.code],
+            evidence_expectations=evidence_expectations,
+            repair_policy=repair_policy,
+            gate_expectations={GateType.DRAFT_READY.value: draft_gate},
+            mission_context_policies=context_policies,
             metadata={
                 "epic": item.epic,
                 "milestone": item.milestone,
@@ -476,6 +604,23 @@ class StrategicIssueBridge:
         fingerprint = _fingerprint("scanner", finding.file_path, finding.description, file_scope)
         priority = _priority_from_rank(_priority_rank(_theme_label(prefix), priority_order))
         success_estimate = 0.55 if finding.severity in {"high", "critical"} else 0.7
+        mission_id = f"mission-{prefix.lower()}-scanner"
+        stage_id = f"stage-{_slug(finding.category)}-{_slug(Path(finding.file_path).stem)}"
+        assertion_ids = [f"{prefix}-ASSERT-SCANNER-1"]
+        evidence_expectations = ["validation_command", "receipt", "artifact_refs"]
+        draft_gate = _draft_ready_gate(
+            mission_id=mission_id,
+            stage_id=stage_id,
+            assertion_ids=assertion_ids,
+            goal_summary=finding.suggested_action,
+            file_scope=file_scope,
+            validation_command=validation,
+        )
+        context_policies = normalize_context_policies(
+            None,
+            file_scope=file_scope,
+            evidence_expectations=evidence_expectations,
+        )
 
         return StrategicIssueCandidate(
             title=title,
@@ -488,7 +633,14 @@ class StrategicIssueBridge:
             priority=priority,
             success_estimate=success_estimate,
             source="scanner",
+            mission_id=mission_id,
+            stage_id=stage_id,
+            assertion_ids=assertion_ids,
             roadmap_refs=[prefix] if prefix else [],
+            evidence_expectations=evidence_expectations,
+            repair_policy=_repair_policy_for_prefix(prefix).to_dict(),
+            gate_expectations={GateType.DRAFT_READY.value: draft_gate},
+            mission_context_policies=context_policies,
             metadata={
                 "category": finding.category,
                 "severity": finding.severity,
@@ -555,6 +707,28 @@ class StrategicIssueBridge:
             seen.add(candidate.fingerprint)
             result.append(candidate)
         return result
+
+    def _filter_candidates(
+        self, candidates: list[StrategicIssueCandidate]
+    ) -> list[StrategicIssueCandidate]:
+        selected = {
+            str(item).strip().lower() for item in self.config.categories if str(item).strip()
+        }
+        if not selected:
+            return candidates
+
+        filtered: list[StrategicIssueCandidate] = []
+        for candidate in candidates:
+            theme = str(candidate.metadata.get("theme", "")).strip().lower()
+            category = str(candidate.metadata.get("category", "")).strip().lower()
+            refs = {
+                str(ref).split("-", 1)[0].strip().lower()
+                for ref in candidate.roadmap_refs
+                if str(ref).strip()
+            }
+            if theme in selected or category in selected or bool(refs.intersection(selected)):
+                filtered.append(candidate)
+        return filtered
 
 
 def _read_text(path: Path, max_chars: int = 200000) -> str:
@@ -750,6 +924,25 @@ def _candidate_from_goal(
     acceptance = ["Deliver the goal outcome", f"Run and satisfy: {validation}"]
     title = str(getattr(goal, "description", ""))[:80]
     fingerprint = _fingerprint("goal", title, file_scope)
+    roadmap_refs = _match_goal_to_roadmap(title, roadmap_items)
+    prefix = roadmap_refs[0].split("-")[0] if roadmap_refs else "RS"
+    mission_id = f"mission-{_slug(title)}"
+    stage_id = f"stage-{_slug(title)}"
+    assertion_ids = [f"{prefix}-ASSERT-1"]
+    evidence_expectations = ["validation_command", "receipt", "artifact_refs"]
+    draft_gate = _draft_ready_gate(
+        mission_id=mission_id,
+        stage_id=stage_id,
+        assertion_ids=assertion_ids,
+        goal_summary=title,
+        file_scope=file_scope,
+        validation_command=validation,
+    )
+    context_policies = normalize_context_policies(
+        None,
+        file_scope=file_scope,
+        evidence_expectations=evidence_expectations,
+    )
 
     return StrategicIssueCandidate(
         title=title,
@@ -762,7 +955,14 @@ def _candidate_from_goal(
         priority=int(getattr(goal, "priority", 3)),
         success_estimate=0.6,
         source="planner",
-        roadmap_refs=_match_goal_to_roadmap(title, roadmap_items),
+        mission_id=mission_id,
+        stage_id=stage_id,
+        assertion_ids=assertion_ids,
+        roadmap_refs=roadmap_refs,
+        evidence_expectations=evidence_expectations,
+        repair_policy=_repair_policy_for_prefix(prefix).to_dict(),
+        gate_expectations={GateType.DRAFT_READY.value: draft_gate},
+        mission_context_policies=context_policies,
         metadata={"track": getattr(goal, "track", "")},
     )
 
@@ -818,13 +1018,96 @@ def format_candidates_markdown(candidates: list[StrategicIssueCandidate]) -> str
         lines.append(
             f"   Priority: {candidate.priority}  Success: {candidate.success_estimate:.2f}"
         )
+        if candidate.mission_id or candidate.stage_id:
+            lines.append(f"   Mission: {candidate.mission_id}  Stage: {candidate.stage_id}")
+        if candidate.assertion_ids:
+            lines.append(f"   Assertions: {', '.join(candidate.assertion_ids)}")
         lines.append(f"   File scope: {', '.join(candidate.file_scope)}")
         lines.append(f"   Validation: {candidate.validation_command}")
+        if candidate.evidence_expectations:
+            lines.append(f"   Evidence: {', '.join(candidate.evidence_expectations)}")
         lines.append("   Acceptance:")
         for criterion in candidate.acceptance_criteria:
             lines.append(f"   - {criterion}")
         lines.append("")
     return "\n".join(lines).strip()
+
+
+def _slug(text: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", str(text or "").strip().lower())
+    normalized = normalized.strip("-")
+    return normalized[:48] or "stage"
+
+
+def _mission_id_for_item(item: RoadmapItem) -> str:
+    return f"mission-{item.code.lower()}-{_slug(item.title)}"
+
+
+def _stage_id_for_item(item: RoadmapItem) -> str:
+    return f"stage-{item.code.lower()}-{_slug(item.title)}"
+
+
+def _assertion_ids_for_item(item: RoadmapItem) -> list[str]:
+    return [f"{item.code}-ASSERT-1"]
+
+
+def _evidence_expectations_for_item(item: RoadmapItem) -> list[str]:
+    expectations = ["validation_command", "receipt", "artifact_refs"]
+    if item.code.startswith("BC-"):
+        expectations.append("scope_report")
+    if item.code.startswith("RS-"):
+        expectations.append("worker_contract")
+    return list(dict.fromkeys(expectations))
+
+
+def _repair_policy_for_prefix(prefix: str) -> RepairPolicy:
+    wall_time = 90 if prefix in {"RS", "BC"} else 120
+    return RepairPolicy(
+        max_repair_rounds=2,
+        max_validator_rounds=3,
+        max_stage_wall_time_minutes=wall_time,
+        escalate_after_terminal_classes=[
+            "auth_failure",
+            "contract_missing",
+            "unsafe_scope",
+        ],
+    )
+
+
+def _repair_policy_for_item(item: RoadmapItem) -> RepairPolicy:
+    return _repair_policy_for_prefix(item.code.split("-")[0])
+
+
+def _draft_ready_gate(
+    *,
+    mission_id: str,
+    stage_id: str,
+    assertion_ids: list[str],
+    goal_summary: str,
+    file_scope: list[str],
+    validation_command: str,
+) -> dict[str, Any]:
+    failure_classes: list[str] = []
+    if not str(goal_summary or "").strip():
+        failure_classes.append("missing_goal")
+    if not assertion_ids:
+        failure_classes.append("missing_assertions")
+    if not file_scope:
+        failure_classes.append("unbounded_scope")
+    if not str(validation_command or "").strip():
+        failure_classes.append("missing_validation")
+    verdict = GateVerdict.PASS.value if not failure_classes else GateVerdict.BLOCKED.value
+    gate = GateEvaluation(
+        gate_type=GateType.DRAFT_READY.value,
+        verdict=verdict,
+        mission_id=mission_id,
+        stage_id=stage_id,
+        assertion_ids=assertion_ids,
+        failure_classes=failure_classes,
+        repair_eligible=bool(failure_classes),
+        required_evidence=["goal_summary", "file_scope", "validation_command"],
+    )
+    return gate.to_dict()
 
 
 __all__ = [

--- a/aragora/swarm/supervisor.py
+++ b/aragora/swarm/supervisor.py
@@ -2121,6 +2121,15 @@ class SwarmSupervisor:
             target_agent=first.target_agent,
             reviewer_agent=first.reviewer_agent,
             approval_required=True,
+            mission_id=first.mission_id or spec.mission_id,
+            stage_id=first.stage_id or spec.stage_id,
+            assertion_ids=list(first.assertion_ids or spec.assertion_ids),
+            roadmap_refs=list(first.roadmap_refs or spec.roadmap_refs),
+            evidence_expectations=list(first.evidence_expectations or spec.evidence_expectations),
+            gate_expectations=dict(first.gate_expectations or spec.gate_expectations),
+            mission_context_policies=dict(
+                first.mission_context_policies or spec.mission_context_policies
+            ),
             metadata={
                 **dict(first.metadata),
                 "collapsed_redundant_work_orders": [item.work_order_id for item in work_orders],
@@ -2212,6 +2221,30 @@ class SwarmSupervisor:
                         payload.get("approval_required"),
                         default=True,
                     ),
+                    mission_id=str(payload.get("mission_id", "")).strip() or spec.mission_id,
+                    stage_id=str(payload.get("stage_id", "")).strip() or spec.stage_id,
+                    assertion_ids=[
+                        str(item).strip()
+                        for item in payload.get("assertion_ids", [])
+                        if str(item).strip()
+                    ]
+                    or list(spec.assertion_ids),
+                    roadmap_refs=[
+                        str(item).strip()
+                        for item in payload.get("roadmap_refs", [])
+                        if str(item).strip()
+                    ]
+                    or list(spec.roadmap_refs),
+                    evidence_expectations=[
+                        str(item).strip()
+                        for item in payload.get("evidence_expectations", [])
+                        if str(item).strip()
+                    ]
+                    or list(spec.evidence_expectations),
+                    gate_expectations=dict(payload.get("gate_expectations") or {})
+                    or dict(spec.gate_expectations),
+                    mission_context_policies=dict(payload.get("mission_context_policies") or {})
+                    or dict(spec.mission_context_policies),
                     metadata={
                         **dict(payload.get("metadata") or {}),
                         "source": "explicit_spec_work_order",

--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -226,6 +226,12 @@ class TerminalQualification:
     reasons: list[str] = field(default_factory=list)
     receipt_expected: bool = False
     human_intervention_required: bool = False
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] = field(default_factory=list)
+    evidence_expectations: list[str] = field(default_factory=list)
+    gate_evaluations: list[dict[str, Any]] = field(default_factory=list)
+    failure_classes: list[str] = field(default_factory=list)
 
     @property
     def deliverable_type(self) -> str | None:
@@ -249,6 +255,104 @@ class TerminalQualification:
         if self.terminal_outcome in {"crash", "timeout"}:
             return "fail"
         return "unknown"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "terminal_outcome": self.terminal_outcome,
+            "deliverable": dict(self.deliverable) if isinstance(self.deliverable, dict) else None,
+            "worker_outcome": self.worker_outcome,
+            "blocked_reason": self.blocked_reason,
+            "reasons": list(self.reasons),
+            "receipt_expected": self.receipt_expected,
+            "human_intervention_required": self.human_intervention_required,
+            "mission_id": self.mission_id,
+            "stage_id": self.stage_id,
+            "assertion_ids": list(self.assertion_ids),
+            "evidence_expectations": list(self.evidence_expectations),
+            "gate_evaluations": [dict(item) for item in self.gate_evaluations],
+            "failure_classes": list(self.failure_classes),
+            "receipt_outcome": self.receipt_outcome,
+        }
+
+
+def _extract_lineage_mapping(record: dict[str, Any]) -> dict[str, Any]:
+    sources: list[dict[str, Any]] = [record]
+    worker_contract = record.get("worker_contract")
+    if isinstance(worker_contract, dict):
+        sources.append(worker_contract)
+    metadata = record.get("metadata")
+    if isinstance(metadata, dict):
+        sources.append(metadata)
+
+    mission_id = ""
+    stage_id = ""
+    assertion_ids: list[str] = []
+    evidence_expectations: list[str] = []
+    gate_evaluations: list[dict[str, Any]] = []
+
+    for source in sources:
+        if not mission_id:
+            mission_id = _text(source.get("mission_id"))
+        if not stage_id:
+            stage_id = _text(source.get("stage_id"))
+        assertion_ids.extend(_text_list(source.get("assertion_ids")))
+        evidence_expectations.extend(_text_list(source.get("evidence_expectations")))
+        gate_expectations = source.get("gate_expectations")
+        if isinstance(gate_expectations, dict):
+            gate_evaluations.extend(
+                dict(value) for value in gate_expectations.values() if isinstance(value, dict)
+            )
+        direct_gate = source.get("dispatch_gate")
+        if isinstance(direct_gate, dict):
+            gate_evaluations.append(dict(direct_gate))
+        listed_gates = source.get("gate_evaluations")
+        if isinstance(listed_gates, list):
+            gate_evaluations.extend(dict(item) for item in listed_gates if isinstance(item, dict))
+
+    return {
+        "mission_id": mission_id,
+        "stage_id": stage_id,
+        "assertion_ids": _ordered_unique(assertion_ids),
+        "evidence_expectations": _ordered_unique(evidence_expectations),
+        "gate_evaluations": gate_evaluations,
+    }
+
+
+def _terminal_failure_classes(
+    *,
+    terminal_outcome: str,
+    worker_outcome: str | None,
+    blocked_reason: str | None,
+    gate_evaluations: list[dict[str, Any]],
+) -> list[str]:
+    failure_classes: list[str] = []
+    lowered_outcome = _text(terminal_outcome).lower()
+    lowered_worker = _text(worker_outcome).lower()
+    lowered_reason = _text(blocked_reason).lower()
+
+    for gate in gate_evaluations:
+        failure_classes.extend(_text_list(gate.get("failure_classes")))
+
+    if lowered_worker == "scope_violation" or "scope" in lowered_reason:
+        failure_classes.append("scope_violation")
+    if "sanitation" in lowered_reason:
+        failure_classes.append("sanitation_failed")
+    if "runner" in lowered_reason:
+        failure_classes.append("no_fresh_runner")
+    if "auth" in lowered_reason:
+        failure_classes.append("auth_failure")
+    if "crash" in lowered_worker or lowered_outcome == "crash":
+        failure_classes.append("worker_crash")
+    if "timeout" in lowered_worker or lowered_outcome == "timeout":
+        failure_classes.append("timeout")
+    if lowered_outcome == "needs_human":
+        failure_classes.append("needs_human")
+    if lowered_outcome == "blocked" and not failure_classes:
+        failure_classes.append("blocked")
+    if lowered_outcome == "clean_exit_no_deliverable":
+        failure_classes.append("missing_evidence")
+
+    return _ordered_unique(failure_classes)
 
 
 def extract_work_order_deliverable(
@@ -394,6 +498,13 @@ def qualify_work_order_terminal_state(work_order: dict[str, Any]) -> TerminalQua
     receipt_expected = (
         terminal_outcome != "unknown" or deliverable is not None or bool(blocked_reason)
     )
+    lineage = _extract_lineage_mapping(work_order)
+    failure_classes = _terminal_failure_classes(
+        terminal_outcome=terminal_outcome,
+        worker_outcome=worker_outcome,
+        blocked_reason=blocked_reason,
+        gate_evaluations=list(lineage["gate_evaluations"]),
+    )
 
     return TerminalQualification(
         terminal_outcome=terminal_outcome,
@@ -403,6 +514,12 @@ def qualify_work_order_terminal_state(work_order: dict[str, Any]) -> TerminalQua
         reasons=blockers,
         receipt_expected=receipt_expected,
         human_intervention_required=human_intervention_required,
+        mission_id=str(lineage["mission_id"]),
+        stage_id=str(lineage["stage_id"]),
+        assertion_ids=list(lineage["assertion_ids"]),
+        evidence_expectations=list(lineage["evidence_expectations"]),
+        gate_evaluations=list(lineage["gate_evaluations"]),
+        failure_classes=failure_classes,
     )
 
 
@@ -504,6 +621,56 @@ def qualify_run_terminal_state(run_dict: dict[str, Any]) -> TerminalQualificatio
     receipt_expected = (
         terminal_outcome != "unknown" or deliverable is not None or bool(blocked_reason)
     )
+    lineage = _extract_lineage_mapping(run_dict)
+    if not lineage["mission_id"]:
+        lineage["mission_id"] = next(
+            (
+                qualification.mission_id
+                for qualification in work_order_qualifications
+                if qualification.mission_id
+            ),
+            "",
+        )
+    if not lineage["stage_id"]:
+        lineage["stage_id"] = next(
+            (
+                qualification.stage_id
+                for qualification in work_order_qualifications
+                if qualification.stage_id
+            ),
+            "",
+        )
+    lineage["assertion_ids"] = _ordered_unique(
+        list(lineage["assertion_ids"])
+        + [
+            assertion_id
+            for qualification in work_order_qualifications
+            for assertion_id in qualification.assertion_ids
+        ]
+    )
+    lineage["evidence_expectations"] = _ordered_unique(
+        list(lineage["evidence_expectations"])
+        + [
+            expectation
+            for qualification in work_order_qualifications
+            for expectation in qualification.evidence_expectations
+        ]
+    )
+    lineage["gate_evaluations"] = [
+        *list(lineage["gate_evaluations"]),
+        *[
+            dict(gate)
+            for qualification in work_order_qualifications
+            for gate in qualification.gate_evaluations
+            if isinstance(gate, dict)
+        ],
+    ]
+    failure_classes = _terminal_failure_classes(
+        terminal_outcome=terminal_outcome,
+        worker_outcome=worker_outcome,
+        blocked_reason=blocked_reason,
+        gate_evaluations=list(lineage["gate_evaluations"]),
+    )
 
     return TerminalQualification(
         terminal_outcome=terminal_outcome,
@@ -513,6 +680,12 @@ def qualify_run_terminal_state(run_dict: dict[str, Any]) -> TerminalQualificatio
         reasons=blockers,
         receipt_expected=receipt_expected,
         human_intervention_required=human_intervention_required,
+        mission_id=str(lineage["mission_id"]),
+        stage_id=str(lineage["stage_id"]),
+        assertion_ids=list(lineage["assertion_ids"]),
+        evidence_expectations=list(lineage["evidence_expectations"]),
+        gate_evaluations=list(lineage["gate_evaluations"]),
+        failure_classes=failure_classes,
     )
 
 

--- a/aragora/swarm/worker_contract.py
+++ b/aragora/swarm/worker_contract.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.mission import normalize_context_policies
 from aragora.swarm.worker_process import LaunchConfig
 
 
@@ -42,6 +43,11 @@ class WorkerContract:
     gh_api_auth_mode: str
     budget: dict[str, Any]
     env_checksum: str
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] | None = None
+    evidence_expectations: list[str] | None = None
+    mission_context_policy: dict[str, Any] | None = None
     contract_version: str = _CONTRACT_VERSION
 
     def to_dict(self) -> dict[str, Any]:
@@ -56,6 +62,17 @@ class WorkerContract:
             "gh_api_auth_mode": self.gh_api_auth_mode,
             "budget": dict(self.budget),
             "env_checksum": self.env_checksum,
+            "mission_id": str(self.mission_id or "").strip(),
+            "stage_id": str(self.stage_id or "").strip(),
+            "assertion_ids": [
+                str(item).strip() for item in list(self.assertion_ids or []) if str(item).strip()
+            ],
+            "evidence_expectations": [
+                str(item).strip()
+                for item in list(self.evidence_expectations or [])
+                if str(item).strip()
+            ],
+            "mission_context_policy": dict(self.mission_context_policy or {}),
             "contract_version": self.contract_version,
         }
 
@@ -74,11 +91,14 @@ class WorkerContract:
             "gh_api_auth_mode": self.gh_api_auth_mode,
             "budget": self.budget,
             "env_checksum": self.env_checksum,
+            "mission_context_policy": self.mission_context_policy,
             "contract_version": self.contract_version,
         }
         missing = [key for key, value in required.items() if value is None or value == ""]
         if missing:
             raise ValueError(f"Worker contract missing required fields: {', '.join(missing)}")
+        if not dict(self.mission_context_policy or {}):
+            raise ValueError("Worker contract missing required field: mission_context_policy")
 
 
 def _env_checksum(env: Mapping[str, str] | None) -> str:
@@ -128,6 +148,7 @@ def build_worker_contract(
     config: LaunchConfig,
     worktree_path: str,
     env: Mapping[str, str] | None = None,
+    work_order: Mapping[str, Any] | None = None,
 ) -> WorkerContract:
     normalized_agent = str(agent or "").strip() or "unknown"
     if normalized_agent == "claude":
@@ -155,6 +176,30 @@ def build_worker_contract(
         "max_tokens": None,
         "max_retries": None,
     }
+    work_order_data = dict(work_order or {})
+    file_scope = [
+        str(item).strip() for item in work_order_data.get("file_scope", []) if str(item).strip()
+    ]
+    evidence_expectations = [
+        str(item).strip()
+        for item in work_order_data.get("evidence_expectations", [])
+        if str(item).strip()
+    ]
+    if not evidence_expectations:
+        evidence_expectations = [
+            "worker_contract",
+            "worker_contract_checksum",
+            *[
+                str(item).strip()
+                for item in work_order_data.get("expected_tests", [])
+                if str(item).strip()
+            ],
+        ]
+    context_policy = normalize_context_policies(
+        work_order_data.get("mission_context_policies"),
+        file_scope=file_scope,
+        evidence_expectations=evidence_expectations,
+    )["worker"]
 
     execution_mode = (
         config.execution_mode.value
@@ -173,4 +218,13 @@ def build_worker_contract(
         gh_api_auth_mode=_gh_api_auth_mode(env),
         budget=budget,
         env_checksum=_env_checksum(env),
+        mission_id=str(work_order_data.get("mission_id", "") or "").strip(),
+        stage_id=str(work_order_data.get("stage_id", "") or "").strip(),
+        assertion_ids=[
+            str(item).strip()
+            for item in work_order_data.get("assertion_ids", [])
+            if str(item).strip()
+        ],
+        evidence_expectations=evidence_expectations,
+        mission_context_policy=context_policy,
     )

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -170,6 +170,7 @@ class WorkerLauncher:
             config=self.config,
             worktree_path=worktree_path,
             env=worker_env,
+            work_order=work_order,
         )
         contract.validate()
         contract_dict = contract.to_dict()

--- a/scripts/generate_strategic_issues.py
+++ b/scripts/generate_strategic_issues.py
@@ -27,6 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo", default=".", help="Repository root")
     parser.add_argument("--max-issues", type=int, default=10)
     parser.add_argument("--max-per-theme", type=int, default=4)
+    parser.add_argument("--categories", nargs="*", default=[], help="Filter by theme/category")
     parser.add_argument("--dry-run", action="store_true", help="Preview only")
     parser.add_argument("--heuristic-only", action="store_true")
     parser.add_argument("--no-scanner", action="store_true")
@@ -42,6 +43,7 @@ def main() -> int:
     config = StrategicIssueBridgeConfig(
         max_issues=args.max_issues,
         max_per_theme=args.max_per_theme,
+        categories=list(args.categories),
         heuristic_only=args.heuristic_only,
         enable_scanner=not args.no_scanner,
         enable_llm=args.enable_llm,

--- a/tests/nomic/test_pipeline_bridge.py
+++ b/tests/nomic/test_pipeline_bridge.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aragora.nomic.pipeline_bridge import NomicPipelineBridge
+from aragora.nomic.pipeline_bridge import BoundedWorkOrder, NomicPipelineBridge
 from aragora.nomic.task_decomposer import SubTask
 from aragora.pipeline.execution_mode import ExecutionMode
 
@@ -216,6 +216,59 @@ class TestBoundedWorkOrders:
         assert work_order.expected_tests == ["python -m pytest tests/scripts -q"]
         assert work_order.risk_level == "critical"
         assert work_order.approval_required is True
+
+    def test_bounded_work_order_serializes_mission_lineage(self):
+        work_order = BoundedWorkOrder(
+            work_order_id="sub-1",
+            pipeline_task_id="task-1",
+            title="Contract-aware preflight",
+            description="Thread mission lineage into the work order",
+            file_scope=["aragora/swarm/preflight.py"],
+            mission_id="mission-rs-credential-envelope",
+            stage_id="stage-contract-aware-preflight",
+            assertion_ids=["RS-04-ASSERT-1"],
+            roadmap_refs=["RS-04", "RS-05"],
+            evidence_expectations=["validation_command", "worker_contract", "receipt"],
+        )
+
+        payload = work_order.to_dict()
+
+        assert payload["mission_id"] == "mission-rs-credential-envelope"
+        assert payload["stage_id"] == "stage-contract-aware-preflight"
+        assert payload["assertion_ids"] == ["RS-04-ASSERT-1"]
+        assert payload["roadmap_refs"] == ["RS-04", "RS-05"]
+        assert payload["evidence_expectations"] == [
+            "validation_command",
+            "worker_contract",
+            "receipt",
+        ]
+        assert set(payload["mission_context_policies"]) == {"worker", "validator"}
+
+    def test_ralph_manifest_projects_inherit_mission_lineage(self):
+        bridge = NomicPipelineBridge()
+        work_order = BoundedWorkOrder(
+            work_order_id="sub-1",
+            pipeline_task_id="task-1",
+            title="Contract-aware preflight",
+            description="Thread mission lineage into the work order",
+            file_scope=["aragora/swarm/preflight.py"],
+            mission_id="mission-rs-credential-envelope",
+            stage_id="stage-contract-aware-preflight",
+            assertion_ids=["RS-04-ASSERT-1"],
+            roadmap_refs=["RS-04"],
+            evidence_expectations=["validation_command", "worker_contract", "receipt"],
+        )
+
+        manifest = bridge._build_ralph_manifest_for_work_order(
+            "Improve dispatch readiness", work_order
+        )
+        spec = manifest.projects[0].spec
+
+        assert spec.mission_id == "mission-rs-credential-envelope"
+        assert spec.stage_id == "stage-contract-aware-preflight"
+        assert spec.assertion_ids == ["RS-04-ASSERT-1"]
+        assert spec.roadmap_refs == ["RS-04"]
+        assert "worker_contract" in spec.evidence_expectations
 
     def test_write_ralph_handoff_persists_manifest_with_truthful_receipt_metadata(self, tmp_path):
         bridge = NomicPipelineBridge(repo_path=tmp_path)

--- a/tests/scripts/test_generate_strategic_issues.py
+++ b/tests/scripts/test_generate_strategic_issues.py
@@ -31,3 +31,33 @@ def test_cli_dry_run_heuristic_only() -> None:
     assert "RS-01" in result.stdout
     assert "scripts/run_dogfood_benchmark.py" in result.stdout
     assert "scripts/check_benchmark_regression.py" in result.stdout
+
+
+def test_cli_can_filter_categories_and_emit_json() -> None:
+    script_path = REPO_ROOT / "scripts" / "generate_strategic_issues.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script_path.resolve()),
+            "--repo",
+            str(FIXTURE_ROOT),
+            "--dry-run",
+            "--heuristic-only",
+            "--no-scanner",
+            "--categories",
+            "BC",
+            "--max-issues",
+            "4",
+            "--json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert '"mission_id"' in result.stdout
+    assert '"stage_id"' in result.stdout
+    assert '"roadmap_refs": [' in result.stdout
+    assert '"BC-04"' in result.stdout
+    assert '"RS-01"' not in result.stdout

--- a/tests/swarm/test_boss_validation.py
+++ b/tests/swarm/test_boss_validation.py
@@ -243,6 +243,9 @@ class TestCheckPreDispatchGate:
         assert result["method"] == "regex"
         assert result["pass"] is False
         assert result["unresolved_missing"] == ["tests/missing.py"]
+        assert result["gate_evaluation"]["gate_type"] == "dispatch_ready"
+        assert result["gate_evaluation"]["verdict"] == "blocked"
+        assert result["gate_evaluation"]["failure_classes"] == ["validation_target_missing"]
 
     def test_llm_gate_allows_declared_new_file(self, monkeypatch, tmp_path):
         async def fake_parse(_body):
@@ -269,6 +272,7 @@ class TestCheckPreDispatchGate:
         assert result["declared_new_files"] == ["tests/swarm/test_new_gate.py"]
         assert result["missing_targets"] == ["tests/swarm/test_new_gate.py"]
         assert result["unresolved_missing"] == []
+        assert result["gate_evaluation"]["verdict"] == "pass"
 
     def test_llm_gate_falls_back_to_regex(self, monkeypatch, tmp_path):
         async def fake_parse(_body):
@@ -284,6 +288,7 @@ class TestCheckPreDispatchGate:
 
         assert result["method"] == "regex"
         assert result["pass"] is True
+        assert result["gate_evaluation"]["verdict"] == "pass"
 
 
 # -- helpers --

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from aragora.swarm.mission import GateType, GateVerdict
 from aragora.swarm import preflight as mod
 from aragora.swarm.worker_contract import checksum_contract_payload
 from aragora.swarm.worker_process import WorkerProcess
@@ -22,6 +23,20 @@ def _worker(*, branch: str, checksum: str | None = None) -> WorkerProcess:
         "gh_api_auth_mode": "none",
         "budget": {"max_wall_time_seconds": 900.0},
         "env_checksum": "env123",
+        "mission_id": "mission-rs-worker-contract-preflight",
+        "stage_id": "stage-dispatch-ready-preflight",
+        "assertion_ids": ["RS-PREFLIGHT-ASSERT-1"],
+        "evidence_expectations": ["worker_contract", "worker_contract_checksum", "receipt"],
+        "mission_context_policy": {
+            "role": "worker",
+            "allowed_artifact_classes": ["mission_stage", "file_scope", "validation_command"],
+            "max_source_count": 4,
+            "max_chars": 12000,
+            "freshness_ttl_seconds": 3600,
+            "transcript_allowance": "none",
+            "required_sources": ["scratch/preflight_worker_check.txt"],
+            "forbidden_sources": ["raw_worker_transcript"],
+        },
         "contract_version": "1",
     }
     return WorkerProcess(
@@ -83,6 +98,8 @@ def test_run_preflight_returns_structured_result(monkeypatch, tmp_path: Path) ->
     assert result.pull_request_closed is True
     assert result.cleanup_worktree_removed is True
     assert result.cleanup_branch_removed is True
+    assert result.dispatch_gate["gate_type"] == GateType.DISPATCH_READY.value
+    assert result.dispatch_gate["verdict"] == GateVerdict.PASS.value
     assert result.worker["worker_contract_checksum"] == checksum_contract_payload(
         result.worker["worker_contract"]
     )
@@ -135,3 +152,15 @@ def test_run_preflight_fails_closed_on_contract_checksum_mismatch(
     ]
     assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]
     assert cleanup_commands[1] == ["git", "branch", "-D", branch]
+
+
+def test_evaluate_preflight_dispatch_gate_blocks_missing_context_policy() -> None:
+    worker = _worker(branch="preflight/20260411-context-gap")
+    worker.worker_contract.pop("mission_context_policy", None)
+    worker.worker_contract_checksum = checksum_contract_payload(worker.worker_contract)
+
+    gate = mod.evaluate_preflight_dispatch_gate(worker)
+
+    assert gate["gate_type"] == GateType.DISPATCH_READY.value
+    assert gate["verdict"] == GateVerdict.BLOCKED.value
+    assert "context_policy_unresolved" in gate["failure_classes"]

--- a/tests/swarm/test_reporter.py
+++ b/tests/swarm/test_reporter.py
@@ -2222,6 +2222,76 @@ class TestIntegratorView:
         )
         assert payload["summary"]["scope_violation_lanes"] == 1
 
+    def test_build_integrator_view_exposes_mission_and_gate_metadata(self):
+        now = datetime(2026, 3, 30, 12, 0, tzinfo=UTC)
+
+        payload = build_integrator_view(
+            coordination={
+                "integrator": {
+                    "developer_tasks": [
+                        {
+                            "task_key": "run-1:wo-gated",
+                            "task_id": "wo-gated",
+                            "run_id": "run-1",
+                            "status": "blocked",
+                            "title": "Credential envelope gate",
+                            "owner_agent": "codex",
+                            "updated_at": now.isoformat(),
+                            "metadata": {
+                                "mission_id": "mission-rs-credential-envelope",
+                                "stage_id": "stage-contract-aware-preflight",
+                                "assertion_ids": ["ASSERT-001"],
+                                "evidence_expectations": [
+                                    "worker_contract",
+                                    "preflight_result",
+                                ],
+                                "dispatch_gate": {
+                                    "gate_type": "dispatch_ready",
+                                    "verdict": "blocked",
+                                    "mission_id": "mission-rs-credential-envelope",
+                                    "stage_id": "stage-contract-aware-preflight",
+                                    "assertion_ids": ["ASSERT-001"],
+                                    "failure_classes": ["contract_missing"],
+                                    "repair_eligible": False,
+                                    "required_evidence": [
+                                        "worker_contract",
+                                        "preflight_result",
+                                    ],
+                                    "notes": "Credential envelope checksum absent",
+                                },
+                            },
+                        }
+                    ],
+                    "leases": [],
+                    "completion_receipts": [],
+                    "integration_decisions": [],
+                    "salvage_candidates": [],
+                }
+            },
+            now=now,
+        )
+
+        lane = payload["lanes"][0]
+        assert lane["mission_id"] == "mission-rs-credential-envelope"
+        assert lane["stage_id"] == "stage-contract-aware-preflight"
+        assert lane["assertion_ids"] == ["ASSERT-001"]
+        assert lane["evidence_expectations"] == ["worker_contract", "preflight_result"]
+        assert lane["dispatch_gate"] == {
+            "gate_type": "dispatch_ready",
+            "verdict": "blocked",
+            "mission_id": "mission-rs-credential-envelope",
+            "stage_id": "stage-contract-aware-preflight",
+            "assertion_ids": ["ASSERT-001"],
+            "failure_classes": ["contract_missing"],
+            "repair_eligible": False,
+            "required_evidence": ["worker_contract", "preflight_result"],
+            "notes": "Credential envelope checksum absent",
+        }
+        assert lane["gate_evaluations"] == [lane["dispatch_gate"]]
+        assert lane["last_gate_type"] == "dispatch_ready"
+        assert lane["last_gate_verdict"] == "blocked"
+        assert lane["failure_classes"] == ["contract_missing"]
+
     def test_build_integrator_view_excludes_superseded_scope_violation_from_summary(self):
         now = datetime(2026, 3, 30, 12, 0, tzinfo=UTC)
 

--- a/tests/swarm/test_spec.py
+++ b/tests/swarm/test_spec.py
@@ -26,6 +26,12 @@ class TestSwarmSpecCreation:
         assert spec.track_hints == []
         assert spec.file_scope_hints == []
         assert spec.work_orders == []
+        assert spec.mission_id == ""
+        assert spec.stage_id == ""
+        assert spec.assertion_ids == []
+        assert spec.roadmap_refs == []
+        assert spec.evidence_expectations == []
+        assert set(spec.mission_context_policies) == {"worker", "validator"}
 
     def test_creation_with_values(self):
         spec = SwarmSpec(
@@ -36,6 +42,11 @@ class TestSwarmSpecCreation:
             budget_limit_usd=10.0,
             track_hints=["sme", "core"],
             work_orders=[{"work_order_id": "wo-1", "title": "lane"}],
+            mission_id="mission-rs-01",
+            stage_id="stage-rs-01",
+            assertion_ids=["RS-01-ASSERT-1"],
+            roadmap_refs=["RS-01"],
+            evidence_expectations=["validation_command", "receipt"],
             estimated_complexity="high",
             requires_approval=True,
             user_expertise="developer",
@@ -46,6 +57,8 @@ class TestSwarmSpecCreation:
         assert spec.budget_limit_usd == 10.0
         assert spec.track_hints == ["sme", "core"]
         assert spec.work_orders == [{"work_order_id": "wo-1", "title": "lane"}]
+        assert spec.mission_id == "mission-rs-01"
+        assert spec.stage_id == "stage-rs-01"
         assert spec.estimated_complexity == "high"
         assert spec.requires_approval is True
 
@@ -61,6 +74,11 @@ class TestSwarmSpecSerialization:
             constraints=["No breaking changes"],
             budget_limit_usd=7.50,
             track_hints=["qa"],
+            mission_id="mission-rs-credential-envelope",
+            stage_id="stage-contract-aware-preflight",
+            assertion_ids=["RS-04-ASSERT-1"],
+            roadmap_refs=["RS-04", "RS-05"],
+            evidence_expectations=["validation_command", "worker_contract", "receipt"],
             work_orders=[
                 {
                     "work_order_id": "docs-lane",
@@ -81,6 +99,12 @@ class TestSwarmSpecSerialization:
         assert restored.track_hints == spec.track_hints
         assert restored.work_orders == spec.work_orders
         assert restored.id == spec.id
+        assert restored.mission_id == spec.mission_id
+        assert restored.stage_id == spec.stage_id
+        assert restored.assertion_ids == spec.assertion_ids
+        assert restored.roadmap_refs == spec.roadmap_refs
+        assert restored.evidence_expectations == spec.evidence_expectations
+        assert set(restored.mission_context_policies) == {"worker", "validator"}
 
     def test_to_json_and_back(self):
         spec = SwarmSpec(
@@ -151,6 +175,15 @@ class TestSwarmSpecSummary:
         spec = SwarmSpec(work_orders=[{"work_order_id": "docs-lane"}])
         summary = spec.summary()
         assert "Explicit work orders: 1" in summary
+
+    def test_summary_includes_mission_and_stage(self):
+        spec = SwarmSpec(
+            mission_id="mission-rs-credential-envelope",
+            stage_id="stage-contract-aware-preflight",
+        )
+        summary = spec.summary()
+        assert "mission-rs-credential-envelope" in summary
+        assert "stage-contract-aware-preflight" in summary
 
 
 class TestSwarmSpecDispatchBounds:

--- a/tests/swarm/test_strategic_issue_bridge.py
+++ b/tests/swarm/test_strategic_issue_bridge.py
@@ -39,6 +39,12 @@ def test_generate_candidates_heuristic_only() -> None:
         assert candidate.file_scope
         assert candidate.acceptance_criteria
         assert candidate.validation_command
+        assert candidate.mission_id
+        assert candidate.stage_id
+        assert candidate.assertion_ids
+        assert candidate.evidence_expectations
+        assert candidate.gate_expectations["draft_ready"]["verdict"] == "pass"
+        assert set(candidate.mission_context_policies) == {"worker", "validator"}
         assert 0.0 <= candidate.success_estimate <= 1.0
 
 
@@ -105,6 +111,35 @@ def test_generate_candidates_scope_roadmap_items_by_signal() -> None:
     assert (
         len({tuple(by_code[code].file_scope) for code in ("RS-01", "RS-02", "RS-03", "RS-04")}) == 4
     )
+
+
+def test_candidate_formats_boss_ready_mission_body() -> None:
+    bridge = StrategicIssueBridge(repo_root=FIXTURE_ROOT)
+    candidate = bridge.generate_candidates()[0]
+
+    body = candidate.boss_ready_issue_body()
+
+    assert "### Mission" in body
+    assert candidate.mission_id in body
+    assert candidate.stage_id in body
+    assert "### Gate Expectations" in body
+    assert "### Context Policies" in body
+    assert "<!-- fingerprint:" in body
+
+
+def test_generate_candidates_can_filter_by_theme() -> None:
+    config = StrategicIssueBridgeConfig(
+        max_issues=6,
+        heuristic_only=True,
+        enable_scanner=False,
+        categories=["BC"],
+    )
+    bridge = StrategicIssueBridge(repo_root=FIXTURE_ROOT, config=config)
+
+    candidates = bridge.generate_candidates()
+
+    assert candidates
+    assert all(candidate.metadata["theme"] == "BC" for candidate in candidates)
 
 
 def test_llm_fallback_without_keys(monkeypatch) -> None:

--- a/tests/swarm/test_terminal_truth.py
+++ b/tests/swarm/test_terminal_truth.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from aragora.swarm.terminal_truth import (
+    qualify_run_terminal_state,
+    qualify_work_order_terminal_state,
+)
+
+
+def test_qualify_work_order_terminal_state_preserves_mission_lineage() -> None:
+    qualification = qualify_work_order_terminal_state(
+        {
+            "status": "completed",
+            "branch": "feature/mission",
+            "commit_shas": ["deadbeef"],
+            "mission_id": "mission-rs-credential-envelope",
+            "stage_id": "stage-contract-aware-preflight",
+            "assertion_ids": ["RS-04-ASSERT-1"],
+            "evidence_expectations": ["validation_command", "worker_contract", "receipt"],
+            "gate_expectations": {
+                "dispatch_ready": {
+                    "gate_type": "dispatch_ready",
+                    "verdict": "pass",
+                    "failure_classes": [],
+                }
+            },
+        }
+    )
+
+    assert qualification.mission_id == "mission-rs-credential-envelope"
+    assert qualification.stage_id == "stage-contract-aware-preflight"
+    assert qualification.assertion_ids == ["RS-04-ASSERT-1"]
+    assert qualification.evidence_expectations == [
+        "validation_command",
+        "worker_contract",
+        "receipt",
+    ]
+    assert qualification.gate_evaluations[0]["gate_type"] == "dispatch_ready"
+
+
+def test_qualify_run_terminal_state_derives_failure_classes_from_lineage_and_outcome() -> None:
+    qualification = qualify_run_terminal_state(
+        {
+            "status": "needs_human",
+            "work_orders": [
+                {
+                    "status": "needs_human",
+                    "worker_outcome": "scope_violation",
+                    "blockers": ["unsafe scope expansion"],
+                    "mission_id": "mission-bc-admission",
+                    "stage_id": "stage-dispatch-ready",
+                    "assertion_ids": ["BC-04-ASSERT-1"],
+                    "gate_expectations": {
+                        "dispatch_ready": {
+                            "gate_type": "dispatch_ready",
+                            "verdict": "blocked",
+                            "failure_classes": ["unsafe_scope"],
+                        }
+                    },
+                }
+            ],
+        }
+    )
+
+    assert qualification.mission_id == "mission-bc-admission"
+    assert qualification.stage_id == "stage-dispatch-ready"
+    assert qualification.failure_classes == ["unsafe_scope", "scope_violation"]
+    assert qualification.to_dict()["receipt_outcome"] == "blocked"

--- a/tests/swarm/test_worker_contract.py
+++ b/tests/swarm/test_worker_contract.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.worker_contract import build_worker_contract
+from aragora.swarm.worker_process import LaunchConfig
+
+
+def test_build_worker_contract_includes_mission_lineage_and_context_policy(tmp_path) -> None:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    config = LaunchConfig(
+        allow_codex_full_auto=True,
+        execution_mode=ExecutionMode.AUTONOMOUS,
+    )
+
+    contract = build_worker_contract(
+        agent="codex",
+        config=config,
+        worktree_path=str(worktree),
+        env={},
+        work_order={
+            "mission_id": "mission-rs-credential-envelope",
+            "stage_id": "stage-contract-aware-preflight",
+            "assertion_ids": ["RS-04-ASSERT-1"],
+            "file_scope": ["aragora/swarm/preflight.py"],
+            "evidence_expectations": ["validation_command", "worker_contract", "receipt"],
+        },
+    )
+
+    payload = contract.to_dict()
+
+    assert payload["mission_id"] == "mission-rs-credential-envelope"
+    assert payload["stage_id"] == "stage-contract-aware-preflight"
+    assert payload["assertion_ids"] == ["RS-04-ASSERT-1"]
+    assert payload["mission_context_policy"]["role"] == "worker"
+    assert payload["mission_context_policy"]["transcript_allowance"] == "none"
+    contract.validate()


### PR DESCRIPTION
## Summary
- add an additive mission envelope and gate primitives that annotate existing swarm and pipeline contracts
- propagate mission lineage, gate expectations, and context policy metadata through strategic issue generation, worker/preflight flows, terminal truth, and supervisor work orders
- expose mission and gate metadata in reporter integrator lanes so operator-facing payloads explain the current mission stage and failure classes

## Validation
- python3 -m pytest tests/swarm/test_spec.py tests/nomic/test_pipeline_bridge.py tests/swarm/test_preflight.py tests/swarm/test_worker_contract.py tests/swarm/test_terminal_truth.py tests/swarm/test_boss_validation.py tests/swarm/test_strategic_issue_bridge.py tests/scripts/test_generate_strategic_issues.py tests/swarm/test_reporter.py -q
- python3 scripts/generate_strategic_issues.py --dry-run --heuristic-only --max-issues 5
- python3 -m ruff check aragora/swarm/mission.py aragora/swarm/spec.py aragora/nomic/pipeline_bridge.py aragora/swarm/worker_contract.py aragora/swarm/worker_launcher.py aragora/swarm/preflight.py aragora/swarm/terminal_truth.py aragora/swarm/boss_validation.py aragora/swarm/strategic_issue_bridge.py aragora/swarm/supervisor.py aragora/swarm/reporter.py scripts/generate_strategic_issues.py tests/swarm/test_spec.py tests/nomic/test_pipeline_bridge.py tests/swarm/test_preflight.py tests/swarm/test_worker_contract.py tests/swarm/test_terminal_truth.py tests/swarm/test_boss_validation.py tests/swarm/test_strategic_issue_bridge.py tests/scripts/test_generate_strategic_issues.py tests/swarm/test_reporter.py