### PR TITLE
feat(ci): add truthful changed-file typecheck gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -307,6 +307,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Verify checkout integrity
         shell: bash
@@ -371,10 +373,49 @@ jobs:
           "${{ steps.typecheck_python.outputs.python_bin }}" -m pip install --user -e .
           "${{ steps.typecheck_python.outputs.python_bin }}" -m pip install --user mypy types-requests types-redis types-python-dateutil types-setuptools
 
-      - name: Run typecheck tier
+      - name: Resolve phase-1 typecheck plan
+        id: typecheck_plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS_FILE="${RUNNER_TEMP}/typecheck-targets.txt"
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            git fetch --no-tags origin "${{ github.base_ref }}" --depth=1
+            "${{ steps.typecheck_python.outputs.python_bin }}" scripts/run_typecheck_gate.py \
+              --repo-root . \
+              --base-ref "${{ github.base_ref }}" \
+              --github-output "$GITHUB_OUTPUT" \
+              --targets-file "$TARGETS_FILE"
+          else
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "target_count=0" >> "$GITHUB_OUTPUT"
+            echo "summary=Run the full typecheck tier on non-pull_request events." >> "$GITHUB_OUTPUT"
+            : > "$TARGETS_FILE"
+          fi
+          echo "targets_file=$TARGETS_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Run full typecheck tier
+        if: steps.typecheck_plan.outputs.mode == 'full'
         run: PATH="$HOME/.local/bin:$PATH" bash scripts/test_tiers.sh typecheck
         shell: bash
         # Phase 5: mypy now REQUIRED (43→0 errors fixed Jan 2026)
+
+      - name: Run changed-file typecheck gate
+        if: steps.typecheck_plan.outputs.mode == 'changed'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t TARGETS < "${{ steps.typecheck_plan.outputs.targets_file }}"
+          echo "Running mypy on ${#TARGETS[@]} touched aragora file(s)"
+          PATH="$HOME/.local/bin:$PATH" \
+            "${{ steps.typecheck_python.outputs.python_bin }}" -m mypy \
+            --ignore-missing-imports \
+            --show-error-codes \
+            "${TARGETS[@]}"
+
+      - name: Skip typecheck gate
+        if: steps.typecheck_plan.outputs.mode == 'skip'
+        run: echo "${{ steps.typecheck_plan.outputs.summary }}"
 
   typecheck:
     needs: [changes, typecheck-run]

--- a/scripts/run_typecheck_gate.py
+++ b/scripts/run_typecheck_gate.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Plan the phase-1 typecheck gate for changed Aragora Python files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+PlanMode = Literal["skip", "changed", "full"]
+
+FORCE_FULL_EXACT_PATHS = {
+    "pyproject.toml",
+    ".github/workflows/lint.yml",
+    "scripts/run_typecheck_gate.py",
+    "scripts/test_tiers.sh",
+}
+FORCE_FULL_PREFIXES = (".github/actions/pr-scope-classifier/",)
+
+
+@dataclass(frozen=True)
+class TypecheckPlan:
+    mode: PlanMode
+    targets: list[str]
+    changed_files: list[str]
+    reasons: list[str]
+
+    @property
+    def summary(self) -> str:
+        if self.mode == "changed":
+            return f"Run mypy on {len(self.targets)} touched aragora Python file(s)."
+        if self.mode == "full":
+            return "Run the full typecheck tier due to config or structural changes."
+        return "Skip typecheck: no touched aragora Python files require the phase-1 gate."
+
+
+def _normalize_paths(paths: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        value = raw.strip().replace("\\", "/")
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        normalized.append(value)
+    return normalized
+
+
+def _is_requirement_file(path: str) -> bool:
+    name = Path(path).name
+    return name.startswith("requirements") and name.endswith(".txt")
+
+
+def _forces_full_typecheck(path: str) -> bool:
+    if path in FORCE_FULL_EXACT_PATHS or _is_requirement_file(path):
+        return True
+    return any(path.startswith(prefix) for prefix in FORCE_FULL_PREFIXES)
+
+
+def _is_aragora_python_target(path: str) -> bool:
+    return path.startswith("aragora/") and path.endswith(".py")
+
+
+def build_typecheck_plan(*, repo_root: Path, changed_files: list[str]) -> TypecheckPlan:
+    normalized = _normalize_paths(changed_files)
+    reasons: list[str] = []
+
+    force_full_paths = [path for path in normalized if _forces_full_typecheck(path)]
+    if force_full_paths:
+        reasons.extend(f"force_full:{path}" for path in force_full_paths)
+        return TypecheckPlan(
+            mode="full",
+            targets=[],
+            changed_files=normalized,
+            reasons=reasons,
+        )
+
+    deleted_targets = [
+        path
+        for path in normalized
+        if _is_aragora_python_target(path) and not (repo_root / path).exists()
+    ]
+    if deleted_targets:
+        reasons.extend(f"deleted_target:{path}" for path in deleted_targets)
+        return TypecheckPlan(
+            mode="full",
+            targets=[],
+            changed_files=normalized,
+            reasons=reasons,
+        )
+
+    targets = [
+        path
+        for path in normalized
+        if _is_aragora_python_target(path) and (repo_root / path).exists()
+    ]
+    if targets:
+        reasons.extend(f"target:{path}" for path in targets)
+        return TypecheckPlan(
+            mode="changed",
+            targets=targets,
+            changed_files=normalized,
+            reasons=reasons,
+        )
+
+    reasons.append("no_aragora_python_targets")
+    return TypecheckPlan(
+        mode="skip",
+        targets=[],
+        changed_files=normalized,
+        reasons=reasons,
+    )
+
+
+def get_changed_files(*, repo_root: Path, base_ref: str, head_ref: str = "HEAD") -> list[str]:
+    base = base_ref if base_ref.startswith("origin/") else f"origin/{base_ref}"
+    proc = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...{head_ref}"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+def write_github_outputs(*, plan: TypecheckPlan, output_path: Path) -> None:
+    with output_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"mode={plan.mode}\n")
+        handle.write(f"target_count={len(plan.targets)}\n")
+        handle.write(f"summary={plan.summary}\n")
+        handle.write("reasons<<EOF\n")
+        handle.write("\n".join(plan.reasons))
+        handle.write("\nEOF\n")
+
+
+def write_targets_file(*, plan: TypecheckPlan, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "\n".join(plan.targets)
+    output_path.write_text(f"{payload}\n" if payload else "", encoding="utf-8")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plan the truthful phase-1 typecheck gate for changed Aragora Python files.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root (default: current working directory).",
+    )
+    parser.add_argument(
+        "--base-ref",
+        help="Base git ref for diff planning (example: main). Required unless --files is supplied.",
+    )
+    parser.add_argument(
+        "--head-ref",
+        default="HEAD",
+        help="Head git ref for diff planning (default: HEAD).",
+    )
+    parser.add_argument(
+        "--files",
+        nargs="*",
+        help="Explicit changed files to classify instead of querying git.",
+    )
+    parser.add_argument(
+        "--github-output",
+        type=Path,
+        help="Optional GitHub Actions output file to append plan metadata to.",
+    )
+    parser.add_argument(
+        "--targets-file",
+        type=Path,
+        help="Optional file path for newline-delimited mypy targets.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the computed plan as JSON.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+
+    if args.files is not None:
+        changed_files = list(args.files)
+    else:
+        if not args.base_ref:
+            raise SystemExit("--base-ref is required unless --files is provided.")
+        changed_files = get_changed_files(
+            repo_root=repo_root,
+            base_ref=args.base_ref,
+            head_ref=args.head_ref,
+        )
+
+    plan = build_typecheck_plan(repo_root=repo_root, changed_files=changed_files)
+
+    if args.github_output is not None:
+        write_github_outputs(plan=plan, output_path=args.github_output)
+    if args.targets_file is not None:
+        write_targets_file(plan=plan, output_path=args.targets_file)
+
+    if args.json:
+        print(json.dumps(asdict(plan), indent=2, sort_keys=True))
+    else:
+        print(plan.summary)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_run_typecheck_gate.py
+++ b/tests/scripts/test_run_typecheck_gate.py
@@ -1,0 +1,125 @@
+"""Tests for scripts/run_typecheck_gate.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import run_typecheck_gate  # noqa: E402
+
+
+def test_build_typecheck_plan_targets_only_touched_aragora_python_files(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "aragora" / "cli").mkdir(parents=True)
+    (repo_root / "aragora" / "cli" / "main.py").write_text("print('ok')\n", encoding="utf-8")
+    (repo_root / "tests").mkdir()
+    (repo_root / "tests" / "test_sample.py").write_text("def test_ok(): pass\n", encoding="utf-8")
+
+    plan = run_typecheck_gate.build_typecheck_plan(
+        repo_root=repo_root,
+        changed_files=["aragora/cli/main.py", "tests/test_sample.py"],
+    )
+
+    assert plan.mode == "changed"
+    assert plan.targets == ["aragora/cli/main.py"]
+    assert "target:aragora/cli/main.py" in plan.reasons
+
+
+def test_build_typecheck_plan_forces_full_on_config_changes(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "aragora").mkdir()
+    (repo_root / "aragora" / "__init__.py").write_text("", encoding="utf-8")
+    (repo_root / "pyproject.toml").write_text("[tool.pytest.ini_options]\n", encoding="utf-8")
+
+    plan = run_typecheck_gate.build_typecheck_plan(
+        repo_root=repo_root,
+        changed_files=["pyproject.toml", "aragora/__init__.py"],
+    )
+
+    assert plan.mode == "full"
+    assert plan.targets == []
+    assert "force_full:pyproject.toml" in plan.reasons
+
+
+def test_build_typecheck_plan_forces_full_on_deleted_aragora_target(tmp_path: Path) -> None:
+    repo_root = tmp_path
+    (repo_root / "aragora").mkdir()
+
+    plan = run_typecheck_gate.build_typecheck_plan(
+        repo_root=repo_root,
+        changed_files=["aragora/deleted_module.py"],
+    )
+
+    assert plan.mode == "full"
+    assert "deleted_target:aragora/deleted_module.py" in plan.reasons
+
+
+def test_get_changed_files_uses_git_diff(monkeypatch: object, tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(
+        cmd: list[str],
+        cwd: Path,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+    ) -> SimpleNamespace:
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["capture_output"] = capture_output
+        captured["text"] = text
+        captured["check"] = check
+        return SimpleNamespace(stdout="aragora/cli/main.py\ntests/test_cli.py\n")
+
+    monkeypatch.setattr(run_typecheck_gate.subprocess, "run", _fake_run)
+
+    changed = run_typecheck_gate.get_changed_files(
+        repo_root=tmp_path,
+        base_ref="main",
+        head_ref="HEAD",
+    )
+
+    assert changed == ["aragora/cli/main.py", "tests/test_cli.py"]
+    assert captured["cmd"] == ["git", "diff", "--name-only", "origin/main...HEAD"]
+    assert captured["cwd"] == tmp_path
+
+
+def test_main_writes_github_outputs_and_targets_file(tmp_path: Path, capsys: object) -> None:
+    repo_root = tmp_path
+    (repo_root / "aragora" / "inbox").mkdir(parents=True)
+    (repo_root / "aragora" / "inbox" / "triage_runner.py").write_text(
+        "from __future__ import annotations\n",
+        encoding="utf-8",
+    )
+    github_output = repo_root / "github_output.txt"
+    targets_file = repo_root / "targets.txt"
+
+    exit_code = run_typecheck_gate.main(
+        [
+            "--repo-root",
+            str(repo_root),
+            "--files",
+            "aragora/inbox/triage_runner.py",
+            "tests/inbox/test_triage_runner.py",
+            "--github-output",
+            str(github_output),
+            "--targets-file",
+            str(targets_file),
+            "--json",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["mode"] == "changed"
+    assert payload["targets"] == ["aragora/inbox/triage_runner.py"]
+    assert targets_file.read_text(encoding="utf-8") == "aragora/inbox/triage_runner.py\n"
+    output = github_output.read_text(encoding="utf-8")
+    assert "mode=changed" in output
+    assert "target_count=1" in output


### PR DESCRIPTION
## Summary
- add a planning script that classifies PR diffs into changed, full, or skip typecheck modes
- update the required typecheck workflow to run mypy only on touched Aragora Python files when safe
- add focused tests for the planner and keep full typecheck on config or structural changes

## Validation
- python -m pytest -p no:cacheprovider -q tests/scripts/test_run_typecheck_gate.py
- python -m ruff format --check scripts/run_typecheck_gate.py tests/scripts/test_run_typecheck_gate.py
- python -m ruff check scripts/run_typecheck_gate.py tests/scripts/test_run_typecheck_gate.py
- bash scripts/test_tiers.sh typecheck
- python scripts/run_typecheck_gate.py --repo-root . --files aragora/cli/main.py tests/cli/test_main.py --json
- local YAML parse of .github/workflows/lint.yml