### PR TITLE
fix: update monitor.py (#4827)

### DIFF
--- a/aragora/compliance/monitor.py
+++ b/aragora/compliance/monitor.py
@@ -191,7 +191,7 @@ class ComplianceMonitor:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                logger.debug("Compliance monitor task cancelled")
         logger.info("Compliance monitor stopped")
 
     async def _monitoring_loop(self) -> None:


### PR DESCRIPTION
Replace silent `except asyncio.CancelledError: pass` with debug logging
for visibility during task cancellation in compliance monitor shutdown.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d3b504d6ddba7d291db1c78110ef04d19d09b815)
