### PR TITLE
fix: update triage.py (#4824)

### DIFF
--- a/aragora/cli/commands/triage.py
+++ b/aragora/cli/commands/triage.py
@@ -430,8 +430,10 @@ async def _run_triage(
 
                     loop = CLIReviewLoop(review_fn=wedge_service.review_receipt)
                     loop.review_batch(decisions)
-                except ImportError:
-                    logger.debug("CLIReviewLoop not available, skipping interactive review")
+                except ImportError as exc:
+                    logger.debug(
+                        "CLIReviewLoop not available, skipping interactive review: %s", exc
+                    )
                     return
         finally:
             await _shutdown_triage_storage()


### PR DESCRIPTION
Capture ImportError exception in CLIReviewLoop import handler to
include exception details in debug log, replacing the last uncaptured
exception pattern.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f30aa8d3c58bd74c412aa1372c9265091a6f98f8)
