### PR TITLE
refactor(nomic): extract dev coordination verification helpers

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Validate Prometheus rule syntax with promtool
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_prometheus_rules.py
 
+      - name: Enforce code quality ratchet
+        run: ${{ steps.lint_python.outputs.python_bin }} scripts/report_code_quality.py --check
+
       - name: Run ruff format check (all Python files)
         run: ${{ steps.lint_python.outputs.python_bin }} -m ruff format --check aragora/ tests/ scripts/
         shell: bash

--- a/aragora/nomic/dev_coordination.py
+++ b/aragora/nomic/dev_coordination.py
@@ -37,6 +37,7 @@ from aragora.docs_only import (
     is_docs_safe_path,
     is_docs_safe_top_level_file,
 )
+from aragora.nomic import dev_coordination_verification as _verification_helpers
 from aragora.nomic.event_bus import EventBus
 from aragora.nomic.global_work_queue import GlobalWorkQueue, WorkItem, WorkStatus, WorkType
 from aragora.worktree.fleet import FleetCoordinationStore
@@ -86,7 +87,16 @@ _QUEUEABLE_DEVELOPER_TASK_STATUSES = {
 }
 _REAPED_NO_RECEIPT_ARCHIVE_GRACE_HOURS = 6.0
 _REAPED_NO_RECEIPT_BLOCKERS = {"stale_lease_reaped", "expired_lease_reaped"}
-_TEST_FILE_PATTERN = re.compile(r"(tests/[\w./-]+\.py)")
+_TEST_FILE_PATTERN = _verification_helpers._TEST_FILE_PATTERN
+_canonical_verification_command = _verification_helpers._canonical_verification_command
+_extract_tests_value = _verification_helpers._extract_tests_value
+_inferred_expected_tests_for_work_order = (
+    _verification_helpers._inferred_expected_tests_for_work_order
+)
+_is_overbroad_pytest_command = _verification_helpers._is_overbroad_pytest_command
+_pytest_command_targets = _verification_helpers._pytest_command_targets
+_verification_command_covers_expected = _verification_helpers._verification_command_covers_expected
+_verification_timeout_for_command = _verification_helpers._verification_timeout_for_command
 _DOCS_ONLY_GENERATE_CAPABILITY_MATRIX_COMMANDS = (
     "python3 scripts/generate_capability_matrix.py",
     "python3 scripts/generate_capability_matrix.py --out docs-site/docs/contributing/capability-matrix.md",
@@ -2584,69 +2594,6 @@ def _developer_task_acceptance_checks(work_order: dict[str, Any]) -> list[str]:
     return checks
 
 
-def _extract_tests_value(value: Any) -> list[str]:
-    if isinstance(value, str):
-        text = value.strip()
-        return [text] if text else []
-    if isinstance(value, list):
-        return [str(item).strip() for item in value if str(item).strip()]
-    return []
-
-
-def _inferred_expected_tests_for_work_order(work_order: dict[str, Any]) -> list[str]:
-    inferred: list[str] = []
-    seen: set[str] = set()
-    deferred_overbroad: list[str] = []
-    deferred_seen: set[str] = set()
-
-    def _append(command: str) -> None:
-        normalized = str(command).strip()
-        canonical = _canonical_verification_command(normalized)
-        dedupe_key = canonical or normalized
-        if not normalized or dedupe_key in seen:
-            return
-        if _is_overbroad_pytest_command(normalized):
-            if dedupe_key in deferred_seen:
-                return
-            deferred_seen.add(dedupe_key)
-            deferred_overbroad.append(normalized)
-            return
-        seen.add(dedupe_key)
-        inferred.append(normalized)
-
-    for entry in work_order.get("expected_tests", []):
-        _append(str(entry))
-
-    success_criteria = work_order.get("success_criteria")
-    if isinstance(success_criteria, dict):
-        for entry in _extract_tests_value(success_criteria.get("tests")):
-            _append(entry)
-
-    metadata = work_order.get("metadata")
-    if isinstance(metadata, dict):
-        for entry in metadata.get("acceptance_criteria", []):
-            text = str(entry).strip()
-            if text.startswith("python -m pytest") or text.startswith("pytest"):
-                _append(text)
-            for match in _TEST_FILE_PATTERN.findall(text):
-                _append(f"python -m pytest {match} -q")
-
-    for path in work_order.get("file_scope", []):
-        normalized = str(path).strip()
-        if normalized.startswith("tests/") and normalized.endswith(".py"):
-            _append(f"python -m pytest {normalized} -q")
-
-    for path in work_order.get("changed_paths", []):
-        normalized = str(path).strip()
-        if normalized.startswith("tests/") and normalized.endswith(".py"):
-            _append(f"python -m pytest {normalized} -q")
-
-    if not inferred:
-        inferred.extend(deferred_overbroad)
-
-    return inferred
-
-
 def _merge_gate_state_for_work_order(work_order: dict[str, Any]) -> dict[str, Any]:
     expected_checks = _inferred_expected_tests_for_work_order(work_order)
     verification_results = [
@@ -2743,96 +2690,6 @@ def _merge_gate_state_for_work_order(work_order: dict[str, Any]) -> dict[str, An
         "merge_eligible": checks_passed,
         "blocked_reasons": blocked_reasons,
     }
-
-
-def _canonical_verification_command(command: Any) -> str:
-    text = str(command or "").strip()
-    if not text:
-        return ""
-    for prefix in ("bash -lc ", "/bin/bash -lc "):
-        if text.startswith(prefix):
-            text = text[len(prefix) :].strip()
-            if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
-                text = text[1:-1]
-            break
-    from aragora.swarm.worker_launcher import WorkerLauncher
-
-    text = re.sub(r"^(?P<prefix>\s*)python3(?=\s|$)", r"\g<prefix>python", text)
-    return WorkerLauncher._normalize_verification_command(text).strip()
-
-
-def _pytest_command_targets(command: Any) -> list[str]:
-    text = _canonical_verification_command(command)
-    if not text:
-        return []
-    try:
-        tokens = shlex.split(text)
-    except ValueError:
-        return []
-    if not tokens:
-        return []
-    start = 0
-    if len(tokens) >= 3 and tokens[1] == "-m" and tokens[2] == "pytest":
-        start = 3
-    elif tokens[0].endswith("pytest"):
-        start = 1
-    else:
-        return []
-
-    targets: list[str] = []
-    skip_next = False
-    options_with_values = {"-k", "-m", "--maxfail", "--timeout", "--tb", "-c", "--rootdir"}
-    for token in tokens[start:]:
-        if skip_next:
-            skip_next = False
-            continue
-        if token in options_with_values:
-            skip_next = True
-            continue
-        if token.startswith("-"):
-            continue
-        normalized = _normalize_claim(token.rstrip("/"))
-        if token.endswith("/") or "/" in normalized or normalized.endswith(".py"):
-            targets.append(normalized)
-    return targets
-
-
-def _is_overbroad_pytest_command(command: Any) -> bool:
-    targets = _pytest_command_targets(command)
-    if not targets:
-        return False
-    return any(not target.endswith(".py") for target in targets)
-
-
-def _verification_command_covers_expected(recorded_command: Any, expected_command: Any) -> bool:
-    recorded = _canonical_verification_command(recorded_command)
-    expected = _canonical_verification_command(expected_command)
-    if not recorded or not expected:
-        return False
-    if recorded == expected:
-        return True
-    recorded_targets = _pytest_command_targets(recorded)
-    expected_targets = _pytest_command_targets(expected)
-    if not recorded_targets or not expected_targets:
-        return False
-    for expected_target in expected_targets:
-        if not any(
-            expected_target == recorded_target
-            or expected_target.startswith(recorded_target.rstrip("/") + "/")
-            for recorded_target in recorded_targets
-        ):
-            return False
-    return True
-
-
-def _verification_timeout_for_command(command: Any, default_timeout: float) -> float:
-    canonical = _canonical_verification_command(command)
-    if not canonical:
-        return default_timeout
-    targets = _pytest_command_targets(canonical)
-    if len(targets) == 1 and targets[0].endswith(".py"):
-        return max(default_timeout, 300.0)
-    return default_timeout
 
 
 def _developer_task_blockers(work_order: dict[str, Any]) -> list[str]:

--- a/aragora/nomic/dev_coordination_verification.py
+++ b/aragora/nomic/dev_coordination_verification.py
@@ -1,0 +1,166 @@
+"""Verification helpers extracted from ``dev_coordination``."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from typing import Any
+
+_TEST_FILE_PATTERN = re.compile(r"(tests/[\w./-]+\.py)")
+
+
+def _normalize_claim(value: str) -> str:
+    return value.strip().strip("/")
+
+
+def _extract_tests_value(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = value.strip()
+        return [text] if text else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _canonical_verification_command(command: Any) -> str:
+    text = str(command or "").strip()
+    if not text:
+        return ""
+    for prefix in ("bash -lc ", "/bin/bash -lc "):
+        if text.startswith(prefix):
+            text = text[len(prefix) :].strip()
+            if len(text) >= 2 and text[0] == text[-1] and text[0] in {"'", '"'}:
+                text = text[1:-1]
+            break
+    from aragora.swarm.worker_launcher import WorkerLauncher
+
+    text = re.sub(r"^(?P<prefix>\s*)python3(?=\s|$)", r"\g<prefix>python", text)
+    return WorkerLauncher._normalize_verification_command(text).strip()
+
+
+def _pytest_command_targets(command: Any) -> list[str]:
+    text = _canonical_verification_command(command)
+    if not text:
+        return []
+    try:
+        tokens = shlex.split(text)
+    except ValueError:
+        return []
+    if not tokens:
+        return []
+    start = 0
+    if len(tokens) >= 3 and tokens[1] == "-m" and tokens[2] == "pytest":
+        start = 3
+    elif tokens[0].endswith("pytest"):
+        start = 1
+    else:
+        return []
+
+    targets: list[str] = []
+    skip_next = False
+    options_with_values = {"-k", "-m", "--maxfail", "--timeout", "--tb", "-c", "--rootdir"}
+    for token in tokens[start:]:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in options_with_values:
+            skip_next = True
+            continue
+        if token.startswith("-"):
+            continue
+        normalized = _normalize_claim(token.rstrip("/"))
+        if token.endswith("/") or "/" in normalized or normalized.endswith(".py"):
+            targets.append(normalized)
+    return targets
+
+
+def _is_overbroad_pytest_command(command: Any) -> bool:
+    targets = _pytest_command_targets(command)
+    if not targets:
+        return False
+    return any(not target.endswith(".py") for target in targets)
+
+
+def _verification_command_covers_expected(recorded_command: Any, expected_command: Any) -> bool:
+    recorded = _canonical_verification_command(recorded_command)
+    expected = _canonical_verification_command(expected_command)
+    if not recorded or not expected:
+        return False
+    if recorded == expected:
+        return True
+    recorded_targets = _pytest_command_targets(recorded)
+    expected_targets = _pytest_command_targets(expected)
+    if not recorded_targets or not expected_targets:
+        return False
+    for expected_target in expected_targets:
+        if not any(
+            expected_target == recorded_target
+            or expected_target.startswith(recorded_target.rstrip("/") + "/")
+            for recorded_target in recorded_targets
+        ):
+            return False
+    return True
+
+
+def _verification_timeout_for_command(command: Any, default_timeout: float) -> float:
+    canonical = _canonical_verification_command(command)
+    if not canonical:
+        return default_timeout
+    targets = _pytest_command_targets(canonical)
+    if len(targets) == 1 and targets[0].endswith(".py"):
+        return max(default_timeout, 300.0)
+    return default_timeout
+
+
+def _inferred_expected_tests_for_work_order(work_order: dict[str, Any]) -> list[str]:
+    inferred: list[str] = []
+    seen: set[str] = set()
+    deferred_overbroad: list[str] = []
+    deferred_seen: set[str] = set()
+
+    def _append(command: str) -> None:
+        normalized = str(command).strip()
+        canonical = _canonical_verification_command(normalized)
+        dedupe_key = canonical or normalized
+        if not normalized or dedupe_key in seen:
+            return
+        if _is_overbroad_pytest_command(normalized):
+            if dedupe_key in deferred_seen:
+                return
+            deferred_seen.add(dedupe_key)
+            deferred_overbroad.append(normalized)
+            return
+        seen.add(dedupe_key)
+        inferred.append(normalized)
+
+    for entry in work_order.get("expected_tests", []):
+        _append(str(entry))
+
+    success_criteria = work_order.get("success_criteria")
+    if isinstance(success_criteria, dict):
+        for entry in _extract_tests_value(success_criteria.get("tests")):
+            _append(entry)
+
+    metadata = work_order.get("metadata")
+    if isinstance(metadata, dict):
+        for entry in metadata.get("acceptance_criteria", []):
+            text = str(entry).strip()
+            if text.startswith("python -m pytest") or text.startswith("pytest"):
+                _append(text)
+            for match in _TEST_FILE_PATTERN.findall(text):
+                _append(f"python -m pytest {match} -q")
+
+    for path in work_order.get("file_scope", []):
+        normalized = str(path).strip()
+        if normalized.startswith("tests/") and normalized.endswith(".py"):
+            _append(f"python -m pytest {normalized} -q")
+
+    for path in work_order.get("changed_paths", []):
+        normalized = str(path).strip()
+        if normalized.startswith("tests/") and normalized.endswith(".py"):
+            _append(f"python -m pytest {normalized} -q")
+
+    if not inferred:
+        inferred.extend(deferred_overbroad)
+
+    return inferred

--- a/scripts/report_code_quality.py
+++ b/scripts/report_code_quality.py
@@ -39,7 +39,7 @@ SUBSYSTEMS = {
 
 # Ratchet thresholds — these should only go DOWN over time
 RATCHET = {
-    "max_file_loc": 6000,  # No single file above this
+    "max_file_loc": 5400,  # No single file above this
     "max_except_exception": 900,  # Total across aragora/
     "max_type_ignore": 700,  # Total across aragora/
     "max_noqa": 2800,  # Total across aragora/

--- a/tests/nomic/test_dev_coordination_verification.py
+++ b/tests/nomic/test_dev_coordination_verification.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from aragora.nomic.dev_coordination_verification import (
+    _inferred_expected_tests_for_work_order,
+    _pytest_command_targets,
+    _verification_command_covers_expected,
+)
+
+
+def test_pytest_command_targets_ignores_options() -> None:
+    targets = _pytest_command_targets(
+        "python -m pytest tests/nomic/test_dev_coordination.py -k merge_gate --maxfail 1 -q"
+    )
+
+    assert targets == ["tests/nomic/test_dev_coordination.py"]
+
+
+def test_verification_command_covers_directory_level_pytest_target() -> None:
+    assert _verification_command_covers_expected(
+        "python -m pytest tests/nomic -q",
+        "python -m pytest tests/nomic/test_dev_coordination.py -q",
+    )
+
+
+def test_inferred_expected_tests_prefers_specific_pytest_targets() -> None:
+    work_order = {
+        "expected_tests": ["python -m pytest tests/nomic -q"],
+        "metadata": {
+            "acceptance_criteria": [
+                "Run python -m pytest tests/nomic/test_dev_coordination.py -q before merge."
+            ]
+        },
+    }
+
+    assert _inferred_expected_tests_for_work_order(work_order) == [
+        "python -m pytest tests/nomic/test_dev_coordination.py -q"
+    ]

--- a/tests/scripts/test_report_code_quality.py
+++ b/tests/scripts/test_report_code_quality.py
@@ -1,0 +1,56 @@
+"""Tests for scripts/report_code_quality.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import report_code_quality  # noqa: E402
+
+
+def test_default_file_loc_ratchet_is_tighter_than_legacy_ceiling() -> None:
+    assert report_code_quality.RATCHET["max_file_loc"] <= 5400
+
+
+def test_check_ratchet_flags_files_above_file_loc_ceiling() -> None:
+    violations = report_code_quality.check_ratchet(
+        {"except_exception": 0, "type_ignore": 0, "noqa": 0},
+        [
+            {
+                "top5_largest": [
+                    {
+                        "file": "aragora/nomic/dev_coordination.py",
+                        "loc": report_code_quality.RATCHET["max_file_loc"] + 1,
+                    }
+                ]
+            }
+        ],
+    )
+
+    assert violations == [
+        "aragora/nomic/dev_coordination.py: "
+        f"{report_code_quality.RATCHET['max_file_loc'] + 1} LOC > "
+        f"{report_code_quality.RATCHET['max_file_loc']}"
+    ]
+
+
+def test_check_ratchet_allows_files_at_file_loc_ceiling() -> None:
+    violations = report_code_quality.check_ratchet(
+        {"except_exception": 0, "type_ignore": 0, "noqa": 0},
+        [
+            {
+                "top5_largest": [
+                    {
+                        "file": "aragora/swarm/boss_loop.py",
+                        "loc": report_code_quality.RATCHET["max_file_loc"],
+                    }
+                ]
+            }
+        ],
+    )
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- extract reusable verification-command parsing and expected-test inference helpers from dev_coordination into a focused module
- preserve the existing dev_coordination call sites through top-level aliases while reducing the hotspot file size
- add focused tests for the extracted helper module and keep the existing dev_coordination replay coverage green

## Validation
- python -m pytest -p no:cacheprovider -q tests/nomic/test_dev_coordination_verification.py tests/nomic/test_dev_coordination.py::test_verification_timeout_for_command_extends_single_file_pytest tests/nomic/test_dev_coordination.py::test_backfill_missing_verification_plans_infers_test_from_scope tests/nomic/test_dev_coordination.py::test_backfill_missing_verification_plans_infers_test_from_changed_paths tests/nomic/test_dev_coordination.py::test_backfill_missing_verification_plans_infers_test_from_acceptance_text tests/nomic/test_dev_coordination.py::test_replay_narrow_pytest_merge_gate_failures_marks_lane_completed tests/nomic/test_dev_coordination.py::test_replay_narrow_pytest_merge_gate_failures_skips_overbroad_commands
- python -m ruff format --check aragora/nomic/dev_coordination.py aragora/nomic/dev_coordination_verification.py tests/nomic/test_dev_coordination_verification.py
- python -m ruff check aragora/nomic/dev_coordination.py aragora/nomic/dev_coordination_verification.py tests/nomic/test_dev_coordination_verification.py
- bash scripts/test_tiers.sh typecheck