### PR TITLE
feat(ci): enforce code quality ratchet for hotspot size

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -157,6 +157,9 @@ jobs:
       - name: Validate Prometheus rule syntax with promtool
         run: ${{ steps.lint_python.outputs.python_bin }} scripts/check_prometheus_rules.py
 
+      - name: Enforce code quality ratchet
+        run: ${{ steps.lint_python.outputs.python_bin }} scripts/report_code_quality.py --check
+
       - name: Run ruff format check (all Python files)
         run: ${{ steps.lint_python.outputs.python_bin }} -m ruff format --check aragora/ tests/ scripts/
         shell: bash

--- a/scripts/report_code_quality.py
+++ b/scripts/report_code_quality.py
@@ -39,7 +39,7 @@ SUBSYSTEMS = {
 
 # Ratchet thresholds — these should only go DOWN over time
 RATCHET = {
-    "max_file_loc": 6000,  # No single file above this
+    "max_file_loc": 5400,  # No single file above this
     "max_except_exception": 900,  # Total across aragora/
     "max_type_ignore": 700,  # Total across aragora/
     "max_noqa": 2800,  # Total across aragora/

--- a/tests/scripts/test_report_code_quality.py
+++ b/tests/scripts/test_report_code_quality.py
@@ -1,0 +1,56 @@
+"""Tests for scripts/report_code_quality.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _scripts_dir not in sys.path:
+    sys.path.insert(0, _scripts_dir)
+
+import report_code_quality  # noqa: E402
+
+
+def test_default_file_loc_ratchet_is_tighter_than_legacy_ceiling() -> None:
+    assert report_code_quality.RATCHET["max_file_loc"] <= 5400
+
+
+def test_check_ratchet_flags_files_above_file_loc_ceiling() -> None:
+    violations = report_code_quality.check_ratchet(
+        {"except_exception": 0, "type_ignore": 0, "noqa": 0},
+        [
+            {
+                "top5_largest": [
+                    {
+                        "file": "aragora/nomic/dev_coordination.py",
+                        "loc": report_code_quality.RATCHET["max_file_loc"] + 1,
+                    }
+                ]
+            }
+        ],
+    )
+
+    assert violations == [
+        "aragora/nomic/dev_coordination.py: "
+        f"{report_code_quality.RATCHET['max_file_loc'] + 1} LOC > "
+        f"{report_code_quality.RATCHET['max_file_loc']}"
+    ]
+
+
+def test_check_ratchet_allows_files_at_file_loc_ceiling() -> None:
+    violations = report_code_quality.check_ratchet(
+        {"except_exception": 0, "type_ignore": 0, "noqa": 0},
+        [
+            {
+                "top5_largest": [
+                    {
+                        "file": "aragora/swarm/boss_loop.py",
+                        "loc": report_code_quality.RATCHET["max_file_loc"],
+                    }
+                ]
+            }
+        ],
+    )
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- add a required lint-step that runs the code quality ratchet in CI
- tighten the maximum hotspot file-size threshold from 6000 LOC to 5400 LOC
- add focused tests covering the tighter file-size ceiling behavior

## Stack
This PR stacks on #4863 so the new 5400-LOC budget starts from the extracted dev_coordination baseline.

## Validation
- python -m pytest -p no:cacheprovider -q tests/scripts/test_report_code_quality.py
- python -m ruff format --check scripts/report_code_quality.py tests/scripts/test_report_code_quality.py
- python -m ruff check scripts/report_code_quality.py tests/scripts/test_report_code_quality.py
- bash scripts/test_tiers.sh typecheck
- python scripts/report_code_quality.py --check
- local YAML parse of .github/workflows/lint.yml