### PR TITLE
fix: update review_pr.py (#4823)

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -619,6 +619,7 @@ def _extract_first_json_object(text: str) -> dict[str, Any]:
             continue
         if isinstance(payload, dict):
             return payload
+    logger.warning("no valid JSON object found in response text (%d chars)", len(text))
     return {}
 
 


### PR DESCRIPTION
Add warning log when _extract_first_json_object fails to find any valid
JSON in the response text, replacing the silent empty-dict return with
observable failure reporting while keeping per-offset debug logs quiet.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit cdf058cdd9963f1f9578058cfc9d588db34dcd0e)
