### PR TITLE
fix: update registry.py (#4819)

### DIFF
--- a/aragora/channels/registry.py
+++ b/aragora/channels/registry.py
@@ -238,5 +238,5 @@ def _register_builtin_docks(registry: DockRegistry) -> None:
             registry.register(dock_class)
         except ImportError:
             logger.debug("%s dock not available (missing dependencies)", label)
-        except Exception:
-            logger.warning("Failed to register %s dock", label, exc_info=True)
+        except Exception as exc:
+            logger.warning("Failed to register %s dock: %s", label, exc, exc_info=True)


### PR DESCRIPTION
Bind exception variable in broad except clause and include error
details in the warning message for better diagnostics.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 970a160b1152e9acfad3c97fc7714d1537943149)
