### PR TITLE
fix: update monitor.py (#4855)

### DIFF
--- a/aragora/compliance/monitor.py
+++ b/aragora/compliance/monitor.py
@@ -317,11 +317,7 @@ class ComplianceMonitor:
             Summary dict of relevant audit findings, or None
         """
         try:
-            # Try to get the audit log for recent findings
-            try:
-                from aragora.audit.log import AuditQuery, get_audit_log
-            except ImportError:
-                return None
+            from aragora.audit.log import AuditQuery, get_audit_log
 
             audit_log = get_audit_log()
             if not audit_log:


### PR DESCRIPTION
Remove nested try/except for ImportError in _fetch_audit_context that
silently returned None without logging. The outer handler already catches
ImportError with proper debug logging.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 98a52634fb4bea7db257751e55ed15157515fabf)
