### PR TITLE
fix: update action_store.py (#4800)

### DIFF
--- a/aragora/blockchain/action_store.py
+++ b/aragora/blockchain/action_store.py
@@ -58,7 +58,7 @@ def _parse_json(value: str | None) -> dict[str, Any]:
         return {}
     try:
         data = json.loads(value)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, TypeError):
         return {}
     return data if isinstance(data, dict) else {}
 


### PR DESCRIPTION
Widen _parse_json exception handler to also catch TypeError, which
json.loads can raise on non-string/bytes input, complementing the
existing JSONDecodeError catch.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit f6bb5e20d443ab111f97b1736fa2497474d4c823)
