### PR TITLE
feat(swarm): RS-01 wire terminal_class into boss loop metrics

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -32,6 +32,8 @@ from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.terminal_truth import (
+    TerminalClass,
+    classify_from_metrics,
     extract_run_deliverable,
     extract_run_worker_outcome,
     qualify_work_order_terminal_state,
@@ -913,6 +915,14 @@ class BossLoop:
                 "has_deliverable": has_deliverable,
                 "publish_action": publish_action,
             }
+
+            # RS-01: classify into canonical terminal-truth taxonomy
+            try:
+                tc = classify_from_metrics(payload)
+                payload["terminal_class"] = tc.value
+            except Exception:
+                payload["terminal_class"] = TerminalClass.RESCUE_NO_DELIVERABLE.value
+
             with metrics_path.open("a", encoding="utf-8") as handle:
                 handle.write(json.dumps(payload, sort_keys=True))
                 handle.write("\n")


### PR DESCRIPTION
## Summary

Wires the RS-01 terminal truth taxonomy into the boss loop metrics JSONL.

Every iteration now gets a `terminal_class` field (e.g., `deliverable_pr_created`, `rescue_worker_crash`, `blocked_sanitation_failed`) from the canonical `TerminalClass` enum.

**One file changed**: `boss_loop.py` — 2 imports added, 6 lines in metrics emission.

## Test plan
- [x] `pytest tests/swarm/test_boss_loop.py -k metric` — 1 passed
- [x] Syntax check clean
- [x] Fail-safe: classification errors default to `RESCUE_NO_DELIVERABLE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)