### PR TITLE
feat(swarm): RS-02 benchmark fixtures for terminal truth taxonomy

### DIFF
--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_auth_failure.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_auth_failure.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "failed",
+    "worker_outcome": "auth_failure",
+    "elapsed_seconds": 5.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_auth_failure"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "github_auth_expired",
+    "elapsed_seconds": 10.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_auth_failure"
+  },
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "auth_token_invalid",
+    "elapsed_seconds": 3.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_auth_failure"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_decomposition_limit.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_decomposition_limit.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "decomposition_limit_reached",
+    "elapsed_seconds": 10.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_decomposition_limit"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "decomposition_limit",
+    "elapsed_seconds": 5.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_decomposition_limit"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "hit_decomposition_limit",
+    "elapsed_seconds": 15.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_decomposition_limit"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_no_runner.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_no_runner.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "no_fresh_runner_available",
+    "elapsed_seconds": 0.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_no_runner"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "no_eligible_workers",
+    "elapsed_seconds": 5.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_no_runner"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "no_fresh_runner",
+    "elapsed_seconds": 12.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_no_runner"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_not_dispatch_bounded.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_not_dispatch_bounded.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "blocked",
+    "elapsed_seconds": 0.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_not_dispatch_bounded"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "blocked",
+    "elapsed_seconds": 10.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_not_dispatch_bounded"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "blocked",
+    "elapsed_seconds": 300.0,
+    "files_changed": 2,
+    "has_deliverable": true,
+    "publish_action": "skipped",
+    "expected_class": "blocked_not_dispatch_bounded"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_sanitation_failed.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_sanitation_failed.json
@@ -1,0 +1,47 @@
+[
+  {
+    "worker_status": "failed",
+    "worker_outcome": "sanitation_failed",
+    "elapsed_seconds": 5.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_sanitation_failed"
+  },
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "sanitation_failed",
+    "elapsed_seconds": 15.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_sanitation_failed"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "sanitation_failed",
+    "elapsed_seconds": 60.0,
+    "files_changed": 2,
+    "has_deliverable": true,
+    "publish_action": "",
+    "expected_class": "blocked_sanitation_failed"
+  },
+  {
+    "worker_status": "",
+    "worker_outcome": "",
+    "elapsed_seconds": 29.9,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_sanitation_failed"
+  },
+  {
+    "worker_status": "unknown",
+    "worker_outcome": "",
+    "elapsed_seconds": 25.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_sanitation_failed"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/blocked_validation_target_missing.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/blocked_validation_target_missing.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "failed",
+    "worker_outcome": "verification_target_missing",
+    "elapsed_seconds": 10.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_validation_target_missing"
+  },
+  {
+    "worker_status": "blocked",
+    "worker_outcome": "verification_target_missing",
+    "elapsed_seconds": 30.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "blocked_validation_target_missing"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "verification_target_missing",
+    "elapsed_seconds": 5.5,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "skipped",
+    "expected_class": "blocked_validation_target_missing"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/deliverable_branch_pushed.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/deliverable_branch_pushed.json
@@ -1,0 +1,38 @@
+[
+  {
+    "worker_status": "completed",
+    "worker_outcome": "deliverable_created",
+    "elapsed_seconds": 210.7,
+    "files_changed": 7,
+    "has_deliverable": true,
+    "publish_action": "branch_pushed",
+    "expected_class": "deliverable_branch_pushed"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "success",
+    "elapsed_seconds": 155.0,
+    "files_changed": 3,
+    "has_deliverable": true,
+    "publish_action": "none",
+    "expected_class": "deliverable_branch_pushed"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "deliverable_created",
+    "elapsed_seconds": 90.2,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "deliverable_branch_pushed"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "",
+    "elapsed_seconds": 248.0,
+    "files_changed": 5,
+    "has_deliverable": true,
+    "publish_action": "branch_only",
+    "expected_class": "deliverable_branch_pushed"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/deliverable_pr_created.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/deliverable_pr_created.json
@@ -1,0 +1,38 @@
+[
+  {
+    "worker_status": "completed",
+    "worker_outcome": "pr_adopted",
+    "elapsed_seconds": 342.5,
+    "files_changed": 12,
+    "has_deliverable": true,
+    "publish_action": "merged",
+    "expected_class": "deliverable_pr_created"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "success",
+    "elapsed_seconds": 185.0,
+    "files_changed": 5,
+    "has_deliverable": true,
+    "publish_action": "pr_created",
+    "expected_class": "deliverable_pr_created"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "pr_adopted",
+    "elapsed_seconds": 120.3,
+    "files_changed": 3,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "deliverable_pr_created"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "",
+    "elapsed_seconds": 450.0,
+    "files_changed": 8,
+    "has_deliverable": false,
+    "publish_action": "pr_created_and_merged",
+    "expected_class": "deliverable_pr_created"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/issue_already_resolved.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/issue_already_resolved.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "completed",
+    "worker_outcome": "issue_already_resolved",
+    "elapsed_seconds": 45.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "issue_already_resolved"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "issue_already_resolved",
+    "elapsed_seconds": 15.8,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "skipped",
+    "expected_class": "issue_already_resolved"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "issue_already_resolved",
+    "elapsed_seconds": 62.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "none",
+    "expected_class": "issue_already_resolved"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/rescue_no_deliverable.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/rescue_no_deliverable.json
@@ -1,0 +1,38 @@
+[
+  {
+    "worker_status": "completed",
+    "worker_outcome": "no_output",
+    "elapsed_seconds": 300.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_no_deliverable"
+  },
+  {
+    "worker_status": "completed",
+    "worker_outcome": "",
+    "elapsed_seconds": 120.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "none",
+    "expected_class": "rescue_no_deliverable"
+  },
+  {
+    "worker_status": "stalled",
+    "worker_outcome": "",
+    "elapsed_seconds": 500.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_no_deliverable"
+  },
+  {
+    "worker_status": "",
+    "worker_outcome": "",
+    "elapsed_seconds": 30.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_no_deliverable"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/rescue_publish_deferred.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/rescue_publish_deferred.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "pending",
+    "worker_outcome": "",
+    "elapsed_seconds": 300.0,
+    "files_changed": 2,
+    "has_deliverable": false,
+    "publish_action": "publish_deferred",
+    "expected_class": "rescue_publish_deferred"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "partial",
+    "elapsed_seconds": 600.0,
+    "files_changed": 5,
+    "has_deliverable": true,
+    "publish_action": "deferred_pending_review",
+    "expected_class": "rescue_publish_deferred"
+  },
+  {
+    "worker_status": "stalled",
+    "worker_outcome": "",
+    "elapsed_seconds": 200.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "deferred",
+    "expected_class": "rescue_publish_deferred"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/rescue_timeout.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/rescue_timeout.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "timed_out",
+    "worker_outcome": "timeout",
+    "elapsed_seconds": 3600.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_timeout"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "timeout",
+    "elapsed_seconds": 1800.0,
+    "files_changed": 2,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_timeout"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "timeout",
+    "elapsed_seconds": 7200.0,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_timeout"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/rescue_verification_failed.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/rescue_verification_failed.json
@@ -1,0 +1,38 @@
+[
+  {
+    "worker_status": "failed",
+    "worker_outcome": "verification_failed",
+    "elapsed_seconds": 125.0,
+    "files_changed": 5,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_verification_failed"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "tests_failed",
+    "elapsed_seconds": 200.3,
+    "files_changed": 3,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_verification_failed"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "lint_failed",
+    "elapsed_seconds": 310.0,
+    "files_changed": 8,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_verification_failed"
+  },
+  {
+    "worker_status": "unknown",
+    "worker_outcome": "",
+    "elapsed_seconds": 180.0,
+    "files_changed": 2,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_verification_failed"
+  }
+]

--- a/benchmarks/fixtures/swarm/terminal_truth/rescue_worker_crash.json
+++ b/benchmarks/fixtures/swarm/terminal_truth/rescue_worker_crash.json
@@ -1,0 +1,29 @@
+[
+  {
+    "worker_status": "failed",
+    "worker_outcome": "crash",
+    "elapsed_seconds": 45.2,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_worker_crash"
+  },
+  {
+    "worker_status": "error",
+    "worker_outcome": "worker_crash_with_salvage",
+    "elapsed_seconds": 180.0,
+    "files_changed": 3,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_worker_crash"
+  },
+  {
+    "worker_status": "failed",
+    "worker_outcome": "process_crash",
+    "elapsed_seconds": 10.5,
+    "files_changed": 0,
+    "has_deliverable": false,
+    "publish_action": "",
+    "expected_class": "rescue_worker_crash"
+  }
+]


### PR DESCRIPTION
## Summary

Purely additive: 14 JSON fixture files, one per TerminalClass. 48 examples total.

No code changes. These fixtures are consumed by `score_benchmark()` in `terminal_truth.py` and will be used by the RS-03 benchmark scoring lane.

## Test plan
- [x] All fixture files are valid JSON
- [x] Every example's `expected_class` matches `classify_from_metrics(row).value`

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Factory Droid