### PR TITLE
fix: share semantic extraction across boss and triage

### DIFF
--- a/aragora/inbox/triage_runner.py
+++ b/aragora/inbox/triage_runner.py
@@ -41,6 +41,7 @@ from aragora.inbox.triage_diagnostics import (
     TriageRunDiagnostics,
     record_triage_diagnostic,
 )
+from aragora.utils.semantic_extraction import ExtractionProvider, extract_json_object_llm_first
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +60,36 @@ _DEGRADED_DIAGNOSTIC_SEVERITIES = {
     DiagnosticSeverity.DEGRADED.value,
 }
 _FAST_TIER_JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+_FAST_TRIAGE_PROVIDERS = (
+    ExtractionProvider(
+        agent_type="gemini",
+        model="gemini-2.0-flash",
+        role="analyst",
+        name="triage-fast",
+        env_vars=("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    ),
+    ExtractionProvider(
+        agent_type="openai-api",
+        model="gpt-4.1-mini",
+        role="analyst",
+        name="triage-fast",
+        env_vars=("OPENAI_API_KEY",),
+    ),
+    ExtractionProvider(
+        agent_type="anthropic-api",
+        model="claude-haiku-4-5-20251001",
+        role="analyst",
+        name="triage-fast",
+        env_vars=("ANTHROPIC_API_KEY",),
+    ),
+    ExtractionProvider(
+        agent_type="openrouter",
+        model="deepseek/deepseek-chat",
+        role="analyst",
+        name="triage-fast",
+        env_vars=("OPENROUTER_API_KEY",),
+    ),
+)
 
 _ACTION_PATTERNS = {
     AllowedAction.ARCHIVE: re.compile(r"\barchiv(?:e|ed|ing)\b", re.IGNORECASE),
@@ -221,32 +252,21 @@ def _build_fast_tier_prompt(*, sender: str, subject: str, body: str) -> str:
     )
 
 
-def _create_fast_triage_agent() -> Any | None:
-    from aragora.agents.base import create_agent
+def _normalize_fast_tier_payload(parsed: dict[str, Any]) -> dict[str, Any] | None:
+    action = str(parsed.get("action", "")).strip().lower()
+    if action not in {member.value for member in AllowedAction}:
+        return None
 
-    candidates = [
-        ("GEMINI_API_KEY", "gemini", "gemini-2.0-flash"),
-        ("GOOGLE_API_KEY", "gemini", "gemini-2.0-flash"),
-        ("OPENAI_API_KEY", "openai-api", "gpt-4.1-mini"),
-        ("ANTHROPIC_API_KEY", "anthropic-api", "claude-haiku-4-5-20251001"),
-        ("OPENROUTER_API_KEY", "openrouter", "deepseek/deepseek-chat"),
-    ]
+    try:
+        confidence = max(0.0, min(1.0, float(parsed.get("confidence", 0.0))))
+    except (TypeError, ValueError):
+        confidence = 0.0
 
-    seen_providers: set[str] = set()
-    for env_var, provider, model in candidates:
-        if not os.environ.get(env_var) or provider in seen_providers:
-            continue
-        seen_providers.add(provider)
-        try:
-            return create_agent(
-                provider,
-                name="triage-fast",
-                role="analyst",
-                model=model,
-            )
-        except (ImportError, RuntimeError, ValueError, OSError):
-            logger.debug("Fast triage agent unavailable: provider=%s", provider)
-    return None
+    return {
+        "action": action,
+        "confidence": confidence,
+        "rationale": str(parsed.get("rationale", "")).strip(),
+    }
 
 
 def _normalize_triage_profile(profile: str | None) -> str:
@@ -862,31 +882,31 @@ class InboxTriageRunner:
         subject = msg.get("subject", "(no subject)")
         sender = msg.get("from_address", msg.get("sender", "(unknown)"))
         body = msg.get("body_text", msg.get("body", msg.get("snippet", "")))
-        agent = _create_fast_triage_agent()
-        if agent is None:
-            logger.warning("No fast triage agent available; returning blocked fast-tier result")
-            return {
-                "final_answer": "",
-                "confidence": 0.0,
-                "debate_id": f"fast-no-agent-{uuid.uuid4().hex[:8]}",
-                "status": "insufficient_participation",
-            }
-
         prompt = _build_fast_tier_prompt(sender=sender, subject=subject, body=body)
-        try:
-            raw = await agent.generate(prompt)
-        except (RuntimeError, OSError, ValueError, TypeError) as exc:
-            logger.warning("Fast triage failed, returning blocked fast-tier result: %s", exc)
-            return {
-                "final_answer": "",
-                "confidence": 0.0,
-                "debate_id": f"fast-err-{uuid.uuid4().hex[:8]}",
-                "status": "failed",
-            }
-
-        parsed = _extract_fast_tier_json(str(raw))
-        if parsed is None:
-            logger.warning("Fast triage returned non-JSON output; returning blocked result")
+        extraction = await extract_json_object_llm_first(
+            prompt,
+            providers=_FAST_TRIAGE_PROVIDERS,
+            normalizer=_normalize_fast_tier_payload,
+            timeout=_FAST_TIER_TIMEOUT_SECONDS,
+            logger=logger,
+            context="fast triage",
+        )
+        if extraction.value is None:
+            if extraction.error == "no_available_providers":
+                logger.warning(
+                    "No fast triage provider available; returning blocked fast-tier result"
+                )
+                return {
+                    "final_answer": "",
+                    "confidence": 0.0,
+                    "debate_id": f"fast-no-agent-{uuid.uuid4().hex[:8]}",
+                    "status": "insufficient_participation",
+                }
+            logger.warning(
+                "Fast triage semantic extraction failed; source=%s error=%s",
+                extraction.source,
+                extraction.error,
+            )
             return {
                 "final_answer": "",
                 "confidence": 0.0,
@@ -894,23 +914,12 @@ class InboxTriageRunner:
                 "status": "failed",
             }
 
-        action = str(parsed.get("action", "")).strip().lower()
-        if action not in {member.value for member in AllowedAction}:
-            logger.warning("Fast triage returned unsupported action '%s'", action)
-            return {
-                "final_answer": "",
-                "confidence": 0.0,
-                "debate_id": f"fast-action-{uuid.uuid4().hex[:8]}",
-                "status": "failed",
-            }
-
-        try:
-            confidence = max(0.0, min(1.0, float(parsed.get("confidence", 0.0))))
-        except (TypeError, ValueError):
-            confidence = 0.0
-        rationale = str(parsed.get("rationale", "")).strip()
+        parsed = extraction.value
+        action = str(parsed["action"]).strip()
+        confidence = float(parsed["confidence"])
+        rationale = str(parsed["rationale"]).strip()
         final_answer = f"{action}: {rationale}" if rationale else action
-        provider = getattr(agent, "model_type", None) or getattr(agent, "name", "fast-triage")
+        provider = extraction.provider.agent_type if extraction.provider else extraction.source
         return {
             "final_answer": final_answer,
             "confidence": confidence,

--- a/aragora/swarm/boss_validation.py
+++ b/aragora/swarm/boss_validation.py
@@ -4,15 +4,14 @@ Provides utilities for sanitizing GitHub issue bodies for worker dispatch,
 extracting explicit validation contracts (acceptance criteria, test commands),
 running pre-dispatch validation commands, and discovering focused test files.
 
-When an Anthropic API key is available, semantic parsing uses a fast LLM call
-(Haiku) to extract structured data from the issue body.  This avoids the
+When a configured fast agent provider is available, semantic parsing uses an
+LLM to extract structured data from the issue body.  This avoids the
 brittleness of regex-only parsing.  On any LLM failure the module falls back
 to the original regex pipeline transparently.
 """
 
 from __future__ import annotations
 
-import json as _json
 import logging
 import re
 import subprocess
@@ -20,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict
+from aragora.utils.semantic_extraction import ExtractionProvider, extract_json_object_llm_first
 
 logger = logging.getLogger(__name__)
 
@@ -488,50 +488,30 @@ Issue body:
 {issue_body}
 """
 
+_ISSUE_PARSE_OPENROUTER_MODEL = "anthropic/claude-haiku-4-5-20251001"
 
-async def _call_anthropic(prompt: str, model: str, timeout: float) -> str | None:
-    """Try Anthropic API directly."""
-    import os
 
-    if not os.environ.get("ANTHROPIC_API_KEY"):
-        return None
-    import anthropic
-
-    client = anthropic.AsyncAnthropic()
-    response = await client.messages.create(
-        model=model,
-        max_tokens=512,
-        messages=[{"role": "user", "content": prompt}],
-        timeout=timeout,
+def _issue_parse_providers(model: str) -> tuple[ExtractionProvider, ...]:
+    return (
+        ExtractionProvider(
+            agent_type="anthropic-api",
+            model=model,
+            role="critic",
+            name="boss-issue-parser",
+            env_vars=("ANTHROPIC_API_KEY",),
+        ),
+        ExtractionProvider(
+            agent_type="openrouter",
+            model=_ISSUE_PARSE_OPENROUTER_MODEL,
+            role="critic",
+            name="boss-issue-parser",
+            env_vars=("OPENROUTER_API_KEY",),
+        ),
     )
-    return response.content[0].text.strip()
 
 
-async def _call_openrouter(prompt: str, timeout: float) -> str | None:
-    """Try OpenRouter as fallback (supports Haiku via anthropic/claude-haiku-4.5)."""
-    import os
-
-    api_key = os.environ.get("OPENROUTER_API_KEY")
-    if not api_key:
-        return None
-    import httpx
-
-    async with httpx.AsyncClient(timeout=timeout) as http:
-        resp = await http.post(
-            "https://openrouter.ai/api/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {api_key}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": "anthropic/claude-haiku-4.5",
-                "max_tokens": 512,
-                "messages": [{"role": "user", "content": prompt}],
-            },
-        )
-        resp.raise_for_status()
-        data = resp.json()
-        return data["choices"][0]["message"]["content"].strip()
+def _normalize_issue_parse_payload(parsed: dict[str, Any]) -> dict[str, Any] | None:
+    return parsed if isinstance(parsed, dict) else None
 
 
 async def parse_issue_with_llm(
@@ -542,8 +522,8 @@ async def parse_issue_with_llm(
 ) -> dict[str, Any] | None:
     """Parse an issue body using a fast LLM call.
 
-    Tries Anthropic API first, then OpenRouter, then returns ``None``
-    so callers fall back to the regex pipeline.
+    Tries configured agent providers in order, then returns ``None`` so
+    callers fall back to the regex pipeline.
     """
     body = str(issue_body or "").strip()
     if not body:
@@ -551,37 +531,23 @@ async def parse_issue_with_llm(
 
     prompt = _ISSUE_PARSE_PROMPT.format(issue_body=body[:3000])
 
-    text: str | None = None
-    try:
-        text = await _call_anthropic(prompt, model, timeout)
-        if text:
-            logger.debug("LLM issue parsing via Anthropic API")
-    except Exception as exc:
-        logger.debug("Anthropic API unavailable for issue parsing: %s", exc)
-
-    if text is None:
-        try:
-            text = await _call_openrouter(prompt, timeout)
-            if text:
-                logger.debug("LLM issue parsing via OpenRouter")
-        except Exception as exc:
-            logger.debug("OpenRouter unavailable for issue parsing: %s", exc)
-
-    if text is None:
-        logger.debug("LLM issue parsing unavailable, falling back to regex")
+    result = await extract_json_object_llm_first(
+        prompt,
+        providers=_issue_parse_providers(model),
+        normalizer=_normalize_issue_parse_payload,
+        timeout=timeout,
+        logger=logger,
+        context="LLM issue parsing",
+    )
+    if result.value is None:
+        logger.debug(
+            "LLM issue parsing unavailable, falling back to regex: source=%s error=%s",
+            result.source,
+            result.error,
+        )
         return None
-
-    try:
-        # Strip markdown fences if the model wraps JSON
-        if text.startswith("```"):
-            text = text.split("\n", 1)[1].rsplit("```", 1)[0].strip()
-        data = _json.loads(text)
-        if not isinstance(data, dict):
-            return None
-        return data
-    except (_json.JSONDecodeError, IndexError, ValueError) as exc:
-        logger.debug("LLM returned unparseable response: %s", exc)
-        return None
+    logger.debug("LLM issue parsing via %s", result.source)
+    return result.value
 
 
 def llm_result_to_declared_new_files(parsed: dict[str, Any]) -> list[str]:

--- a/aragora/utils/semantic_extraction.py
+++ b/aragora/utils/semantic_extraction.py
@@ -1,0 +1,155 @@
+"""Shared LLM-first semantic extraction helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
+
+from aragora.utils.json_helpers import extract_json_from_text
+
+if TYPE_CHECKING:
+    from aragora.agents.base import AgentType
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionProvider:
+    agent_type: AgentType
+    model: str | None = None
+    role: str = "critic"
+    name: str = "semantic-extractor"
+    env_vars: tuple[str, ...] = ()
+
+    def is_available(self) -> bool:
+        return not self.env_vars or any(os.environ.get(env_var) for env_var in self.env_vars)
+
+
+@dataclass(frozen=True, slots=True)
+class ExtractionResult(Generic[T]):
+    value: T | None
+    source: str
+    provider: ExtractionProvider | None = None
+    raw_response: str | None = None
+    error: str | None = None
+
+    @property
+    def succeeded(self) -> bool:
+        return self.value is not None
+
+
+def _parse_json_object(raw_response: str) -> dict[str, Any] | None:
+    text = extract_json_from_text(str(raw_response or "").strip()).strip()
+    if not text.startswith("{"):
+        return None
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _format_provider_error(
+    provider: ExtractionProvider,
+    category: str,
+    detail: str | None = None,
+) -> str:
+    base = f"{provider.agent_type}:{category}"
+    return f"{base}:{detail}" if detail else base
+
+
+async def extract_json_object_llm_first(
+    prompt: str,
+    *,
+    providers: Sequence[ExtractionProvider],
+    normalizer: Callable[[dict[str, Any]], T | None],
+    timeout: float | None = None,
+    logger: logging.Logger | None = None,
+    context: str = "semantic extraction",
+) -> ExtractionResult[T]:
+    text = str(prompt or "").strip()
+    if not text:
+        return ExtractionResult(value=None, source="none", error="empty_prompt")
+
+    log = logger or logging.getLogger(__name__)
+    available_providers = [provider for provider in providers if provider.is_available()]
+    if not available_providers:
+        return ExtractionResult(value=None, source="none", error="no_available_providers")
+
+    from aragora.agents.base import create_agent
+
+    errors: list[str] = []
+    last_provider: ExtractionProvider | None = None
+    last_raw_response: str | None = None
+
+    for provider in available_providers:
+        last_provider = provider
+        try:
+            kwargs: dict[str, Any] = {
+                "name": provider.name,
+                "role": provider.role,
+            }
+            if provider.model is not None:
+                kwargs["model"] = provider.model
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            agent = create_agent(provider.agent_type, **kwargs)
+            raw_response = await agent.generate(text)
+        except Exception as exc:
+            errors.append(_format_provider_error(provider, "generate_failed", type(exc).__name__))
+            log.debug(
+                "%s generate failed via %s (%s)",
+                context,
+                provider.agent_type,
+                type(exc).__name__,
+            )
+            continue
+
+        raw_text = str(raw_response or "").strip()
+        last_raw_response = raw_text or None
+        parsed = _parse_json_object(raw_text)
+        if parsed is None:
+            errors.append(_format_provider_error(provider, "invalid_json"))
+            log.debug("%s returned non-JSON object via %s", context, provider.agent_type)
+            continue
+
+        try:
+            value = normalizer(parsed)
+        except Exception as exc:
+            errors.append(
+                _format_provider_error(provider, "normalization_failed", type(exc).__name__)
+            )
+            log.debug(
+                "%s normalization failed via %s (%s)",
+                context,
+                provider.agent_type,
+                type(exc).__name__,
+            )
+            continue
+
+        if value is None:
+            errors.append(_format_provider_error(provider, "normalization_failed"))
+            log.debug("%s normalization rejected payload via %s", context, provider.agent_type)
+            continue
+
+        return ExtractionResult(
+            value=value,
+            source=provider.agent_type,
+            provider=provider,
+            raw_response=raw_text or None,
+            error=None,
+        )
+
+    return ExtractionResult(
+        value=None,
+        source=last_provider.agent_type if last_provider else "none",
+        provider=last_provider,
+        raw_response=last_raw_response,
+        error="; ".join(errors[-3:]) if errors else "exhausted_without_result",
+    )

--- a/tests/inbox/test_triage_runner.py
+++ b/tests/inbox/test_triage_runner.py
@@ -24,6 +24,7 @@ from aragora.inbox.trust_wedge import (
     TriageDecision,
     compute_content_hash,
 )
+from aragora.utils.semantic_extraction import ExtractionResult
 
 
 class _DummyGmail:
@@ -92,6 +93,97 @@ def test_extract_fast_tier_json_parses_fenced_payload():
         "confidence": 0.95,
         "rationale": "Promotional email.",
     }
+
+
+@pytest.mark.asyncio
+async def test_run_fast_tier_once_uses_shared_semantic_extraction(monkeypatch):
+    runner = InboxTriageRunner(gmail_connector=None)
+
+    async def fake_extract(prompt, **kwargs):
+        assert "Test subject" in prompt
+        return ExtractionResult(
+            value={
+                "action": "archive",
+                "confidence": 0.95,
+                "rationale": "Promotional email.",
+            },
+            source="openai-api",
+        )
+
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner.extract_json_object_llm_first",
+        fake_extract,
+    )
+
+    result = await runner._run_fast_tier_once(
+        {
+            "subject": "Test subject",
+            "from_address": "sender@example.com",
+            "body_text": "Promotional body",
+        }
+    )
+
+    assert result["final_answer"] == "archive: Promotional email."
+    assert result["confidence"] == pytest.approx(0.95)
+    assert result["status"] == "completed"
+    assert result["metadata"]["triage_fast_provider"] == "openai-api"
+
+
+@pytest.mark.asyncio
+async def test_run_fast_tier_once_returns_blocked_when_no_provider_available(monkeypatch):
+    runner = InboxTriageRunner(gmail_connector=None)
+
+    async def fake_extract(_prompt, **kwargs):
+        return ExtractionResult(
+            value=None,
+            source="none",
+            error="no_available_providers",
+        )
+
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner.extract_json_object_llm_first",
+        fake_extract,
+    )
+
+    result = await runner._run_fast_tier_once(
+        {
+            "subject": "Test subject",
+            "from_address": "sender@example.com",
+            "body_text": "Promotional body",
+        }
+    )
+
+    assert result["confidence"] == 0.0
+    assert result["status"] == "insufficient_participation"
+
+
+@pytest.mark.asyncio
+async def test_run_fast_tier_once_returns_failed_when_semantic_extraction_fails(monkeypatch):
+    runner = InboxTriageRunner(gmail_connector=None)
+
+    async def fake_extract(_prompt, **kwargs):
+        return ExtractionResult(
+            value=None,
+            source="openai-api",
+            raw_response="not-json",
+            error="openai-api:invalid_json",
+        )
+
+    monkeypatch.setattr(
+        "aragora.inbox.triage_runner.extract_json_object_llm_first",
+        fake_extract,
+    )
+
+    result = await runner._run_fast_tier_once(
+        {
+            "subject": "Test subject",
+            "from_address": "sender@example.com",
+            "body_text": "Promotional body",
+        }
+    )
+
+    assert result["confidence"] == 0.0
+    assert result["status"] == "failed"
 
 
 @pytest.mark.asyncio

--- a/tests/swarm/test_boss_validation.py
+++ b/tests/swarm/test_boss_validation.py
@@ -12,6 +12,7 @@ import pytest
 from aragora.swarm.boss_validation import (
     assess_issue_body_sanitation,
     check_pre_dispatch_gate,
+    parse_issue_with_llm,
     extract_declared_new_file_paths,
     extract_issue_validation_contract,
     extract_pre_dispatch_validation_commands,
@@ -23,6 +24,7 @@ from aragora.swarm.boss_validation import (
     _ordered_unique_strings,
     _extract_task_block,
 )
+from aragora.utils.semantic_extraction import ExtractionResult
 
 
 # -- assess_issue_body_sanitation --
@@ -216,6 +218,60 @@ class TestRunPreDispatchValidationCommands:
         )
         assert result["satisfied"] is False
         assert result["results"][0]["status"] == "timeout"
+
+
+# -- parse_issue_with_llm --
+
+
+class TestParseIssueWithLLM:
+    def test_uses_shared_semantic_extraction_helper(self, monkeypatch):
+        async def fake_extract(prompt, **kwargs):
+            assert "Implement a comprehensive feature" in prompt
+            return ExtractionResult(
+                value={
+                    "task_summary": "Implement a comprehensive feature with enough detail here.",
+                    "is_well_formed": True,
+                },
+                source="anthropic-api",
+            )
+
+        monkeypatch.setattr(
+            "aragora.swarm.boss_validation.extract_json_object_llm_first",
+            fake_extract,
+        )
+
+        result = asyncio.run(
+            parse_issue_with_llm(
+                "## Task\nImplement a comprehensive feature with enough detail here."
+            )
+        )
+
+        assert result == {
+            "task_summary": "Implement a comprehensive feature with enough detail here.",
+            "is_well_formed": True,
+        }
+
+    def test_returns_none_when_shared_extraction_fails(self, monkeypatch):
+        async def fake_extract(_prompt, **kwargs):
+            return ExtractionResult(
+                value=None,
+                source="openrouter",
+                raw_response="not-json",
+                error="openrouter:invalid_json",
+            )
+
+        monkeypatch.setattr(
+            "aragora.swarm.boss_validation.extract_json_object_llm_first",
+            fake_extract,
+        )
+
+        result = asyncio.run(
+            parse_issue_with_llm(
+                "## Task\nImplement a comprehensive feature with enough detail here."
+            )
+        )
+
+        assert result is None
 
 
 # -- check_pre_dispatch_gate --

--- a/tests/utils/test_semantic_extraction.py
+++ b/tests/utils/test_semantic_extraction.py
@@ -1,0 +1,86 @@
+"""Tests for shared semantic extraction helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from aragora.utils.semantic_extraction import (
+    ExtractionProvider,
+    extract_json_object_llm_first,
+)
+
+
+class _DummyAgent:
+    def __init__(self, response: str | Exception) -> None:
+        self._response = response
+
+    async def generate(self, prompt: str) -> str:
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+@pytest.mark.asyncio
+async def test_extract_json_object_llm_first_falls_back_to_second_provider(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-openrouter")
+
+    providers = (
+        ExtractionProvider(agent_type="anthropic-api", env_vars=("ANTHROPIC_API_KEY",)),
+        ExtractionProvider(agent_type="openrouter", env_vars=("OPENROUTER_API_KEY",)),
+    )
+
+    def fake_create_agent(model_type: str, **kwargs):
+        if model_type == "anthropic-api":
+            return _DummyAgent("not json")
+        return _DummyAgent('```json\n{"result":"ok"}\n```')
+
+    monkeypatch.setattr("aragora.agents.base.create_agent", fake_create_agent)
+
+    result = await extract_json_object_llm_first(
+        "Summarize this issue.",
+        providers=providers,
+        normalizer=lambda data: str(data.get("result", "")) or None,
+    )
+
+    assert result.value == "ok"
+    assert result.source == "openrouter"
+    assert result.provider is not None
+    assert result.provider.agent_type == "openrouter"
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_extract_json_object_llm_first_returns_no_available_providers(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    result = await extract_json_object_llm_first(
+        "Summarize this issue.",
+        providers=(ExtractionProvider(agent_type="openai-api", env_vars=("OPENAI_API_KEY",)),),
+        normalizer=lambda data: data,
+    )
+
+    assert result.value is None
+    assert result.source == "none"
+    assert result.error == "no_available_providers"
+
+
+@pytest.mark.asyncio
+async def test_extract_json_object_llm_first_reports_normalization_failure(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+
+    monkeypatch.setattr(
+        "aragora.agents.base.create_agent",
+        lambda model_type, **kwargs: _DummyAgent('{"action":"unsupported"}'),
+    )
+
+    result = await extract_json_object_llm_first(
+        "Summarize this issue.",
+        providers=(ExtractionProvider(agent_type="openai-api", env_vars=("OPENAI_API_KEY",)),),
+        normalizer=lambda data: None,
+    )
+
+    assert result.value is None
+    assert result.source == "openai-api"
+    assert result.raw_response == '{"action":"unsupported"}'
+    assert result.error == "openai-api:normalization_failed"


### PR DESCRIPTION
## Summary
- add a shared LLM-first semantic extraction helper with provider fallback, JSON parsing, and normalization telemetry
- route boss issue parsing through the shared helper instead of direct provider-specific calls
- route fast inbox triage through the same helper and add focused helper + consumer tests

## Testing
- python3 -m pytest tests/utils/test_semantic_extraction.py tests/swarm/test_boss_validation.py tests/inbox/test_triage_runner.py -q
- python3 -m ruff check aragora/utils/semantic_extraction.py aragora/swarm/boss_validation.py aragora/inbox/triage_runner.py tests/utils/test_semantic_extraction.py tests/swarm/test_boss_validation.py tests/inbox/test_triage_runner.py
- python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/utils/semantic_extraction.py aragora/swarm/boss_validation.py aragora/inbox/triage_runner.py tests/utils/test_semantic_extraction.py tests/swarm/test_boss_validation.py tests/inbox/test_triage_runner.py --json
