### PR TITLE
fix: replace broad exception handler with specific OSError in bug_detector.py (#4878)

### DIFF
--- a/aragora/audit/bug_detector.py
+++ b/aragora/audit/bug_detector.py
@@ -936,7 +936,7 @@ class BugDetector:
                 report.bugs.extend(bugs)
                 report.files_scanned += 1
 
-            except (ValueError, OSError) as e:
+            except OSError as e:
                 logger.warning("[%s] Error analyzing %s: %s", scan_id, file_path, e)
 
         report.lines_scanned = total_lines
@@ -945,7 +945,7 @@ class BugDetector:
 
         elapsed = (report.completed_at - start_time).total_seconds()
         logger.info(
-            f"[{scan_id}] Completed in {elapsed:.2f}s: {report.total_bugs} potential bugs found"
+            "[%s] Completed in %.2fs: %d potential bugs found", scan_id, elapsed, report.total_bugs
         )
 
         return report


### PR DESCRIPTION
- Narrow `except (ValueError, OSError)` to `except OSError` in
  detect_in_directory since ValueError is not expected in file I/O path
- Convert f-string logging to %-formatting for consistency

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e5633b8ad256ffbae9b62d1de0ed29c4637489ad)
