### PR TITLE
fix: replace broad except Exception with specific error types in quickstart.py

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -1989,8 +1989,8 @@ def cmd_quickstart(args: argparse.Namespace) -> None:
             state="CREATED",
         )
         logger.info("receipt_persisted id=%s", canonical_result.get("receipt_id", ""))
-    except Exception:  # noqa: BLE001 - best-effort, local file is primary
-        logger.debug("receipt_store_persist_skipped", exc_info=True)
+    except (ImportError, OSError, RuntimeError, ValueError, TypeError) as exc:
+        logger.debug("receipt_store_persist_skipped: %s", exc, exc_info=True)
 
     # Step 6b: Report KM ingestion status truthfully
     if result.get("mode") == "live":


### PR DESCRIPTION
Narrows the blind `except Exception` (with noqa: BLE001) in receipt store
persistence to specific exception types (ImportError, OSError, RuntimeError,
ValueError, TypeError), matching the pattern used elsewhere in the file.
Also includes the exception detail in the debug log message.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit bcb7edc84ee7b68f3cfa17b98accf570803194b8)
