### PR TITLE
fix: replace silent CancelledError pass with debug logging in scheduler.py (#4817)

### DIFF
--- a/aragora/backup/scheduler.py
+++ b/aragora/backup/scheduler.py
@@ -367,7 +367,7 @@ class BackupScheduler:
             try:
                 await task
             except asyncio.CancelledError:
-                pass  # Expected during shutdown — task was intentionally cancelled
+                logger.debug("Task cancelled during scheduler shutdown")
 
         self._tasks.clear()
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 668ab8d17476cc8a2b90d7ec347a9e36b95e70ca)
