### PR TITLE
fix: replace empty except blocks with debug logging in quickstart.py

### DIFF
--- a/aragora/cli/commands/quickstart.py
+++ b/aragora/cli/commands/quickstart.py
@@ -395,6 +395,7 @@ def _clamp_confidence(raw_confidence: Any) -> float:
     try:
         confidence = float(raw_confidence or 0.0)
     except (TypeError, ValueError):
+        logger.debug("clamp_confidence_invalid_value: %r", raw_confidence)
         return 0.0
     return max(0.0, min(1.0, confidence))
 
@@ -606,6 +607,7 @@ def _coerce_positive_int(value: Any, *, default: int) -> int:
     try:
         parsed = int(value)
     except (TypeError, ValueError):
+        logger.debug("coerce_positive_int_invalid_value: %r, using default=%d", value, default)
         return default
     return parsed if parsed > 0 else default
 


### PR DESCRIPTION
Add logger.debug calls in _clamp_confidence and _coerce_positive_int
so invalid input values are logged instead of silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 992171ad9d6d569b156b91a604f7fcd98829c629)
