### PR TITLE
fix: include exception detail in health check JSON parse log

### DIFF
--- a/aragora/agents/devops/agent.py
+++ b/aragora/agents/devops/agent.py
@@ -552,8 +552,8 @@ class DevOpsAgent:
                             "date": releases[0].get("publishedAt"),
                         }
                     )
-            except json.JSONDecodeError:
-                logger.debug("Failed to parse release JSON for health check")
+            except json.JSONDecodeError as exc:
+                logger.debug("Failed to parse release JSON for health check: %s", exc)
 
         result.details = checks
         result.items_processed = len(checks)


### PR DESCRIPTION
Add exception value to the JSONDecodeError debug log in health_check()
for consistent error visibility across all exception handlers in agent.py.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 618eacb826b2ea6b24d0a7d0d081b4e183a400cf)
