### PR TITLE
fix: narrow broad except-Exception to specific types in cv.py (#4812)

### DIFF
--- a/aragora/agents/cv.py
+++ b/aragora/agents/cv.py
@@ -523,7 +523,7 @@ def get_cv_builder() -> CVBuilder:
             elo_system = get_elo_store()
         except ImportError:
             logger.debug("ELO system not available for CV builder")
-        except Exception as e:
+        except (RuntimeError, OSError, ValueError, TypeError) as e:
             logger.warning("Failed to initialise ELO system for CV builder: %s", e)
 
         try:
@@ -532,7 +532,7 @@ def get_cv_builder() -> CVBuilder:
             calibration_tracker = CalibrationTracker()
         except ImportError:
             logger.debug("CalibrationTracker not available for CV builder")
-        except Exception as e:
+        except (RuntimeError, OSError, ValueError, TypeError) as e:
             logger.warning("Failed to initialise CalibrationTracker for CV builder: %s", e)
 
         _cv_builder = CVBuilder(


### PR DESCRIPTION
Replace `except Exception` with `except (RuntimeError, OSError, ValueError,
TypeError)` in get_cv_builder() to avoid silently catching unexpected errors
like KeyboardInterrupt or SystemExit.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 4c2fc5966d4b6ee9f673866b75921afb13b64be3)
