### PR TITLE
fix: narrow broad except Exception in trust_wedge.py execute_receipt

### DIFF
--- a/aragora/inbox/trust_wedge.py
+++ b/aragora/inbox/trust_wedge.py
@@ -1579,7 +1579,7 @@ class InboxTrustWedgeService:
             if updated is None or updated.receipt.state is not ReceiptState.EXECUTED:
                 raise ValueError("receipt execution state not persisted")
             return result
-        except Exception as exc:  # noqa: BLE001 — release claim on any error before re-raise
+        except (ValueError, OSError, sqlite3.Error, RuntimeError) as exc:
             self.store.release_execution_claim(receipt_id, claim_token, error=str(exc))
             raise
 


### PR DESCRIPTION
Replace `except Exception` with specific `(ValueError, OSError, sqlite3.Error,
RuntimeError)` in execute_receipt's claim-release guard. The _cursor context
manager retains its broad catch with noqa since it's a yield-based rollback
guard where any caller exception must trigger rollback.

Closes #4810

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 8571c6ff2678a019d57125c74288f082e0ca57bf)
