### PR TITLE
fix: broaden alert callback error handling in replication_monitor.py

### DIFF
--- a/aragora/backup/replication_monitor.py
+++ b/aragora/backup/replication_monitor.py
@@ -389,7 +389,7 @@ class ReplicationHealthMonitor:
         if self._alert_callback:
             try:
                 self._alert_callback(alert_type, health)
-            except (OSError, RuntimeError, ValueError) as e:
+            except (OSError, RuntimeError, ValueError, TypeError, AttributeError) as e:
                 logger.error("Failed to invoke alert callback: %s", e)
 
     def _update_metrics(self) -> None:


### PR DESCRIPTION
Add TypeError and AttributeError to the alert callback exception handler
to properly catch user-provided callback failures (wrong signature,
None attribute access) instead of letting them propagate silently.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit a0fc48e8c9abd0a893e5f3a0384c45640a107ea5)
