### PR TITLE
fix: convert f-string logging to %-formatting in metering.py

### DIFF
--- a/aragora/billing/metering.py
+++ b/aragora/billing/metering.py
@@ -473,10 +473,11 @@ class UsageMeter:
         for event in events_to_flush:
             if self.config.detailed_logging:
                 logger.info(
-                    f"billing_event tenant={event.tenant_id} "
-                    f"type={event.event_type.value} "
-                    f"quantity={event.quantity} "
-                    f"cost=${event.total_cost:.4f}"
+                    "billing_event tenant=%s type=%s quantity=%s cost=$%.4f",
+                    event.tenant_id,
+                    event.event_type.value,
+                    event.quantity,
+                    event.total_cost,
                 )
 
     def _get_tenant_id(self) -> str | None:


### PR DESCRIPTION
All except-pass patterns were already resolved in prior commits.
Remaining issue was f-string logging in _flush_events which should
use %-formatting per project convention.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 96da883ad1f10fc332a48cb42c8b0478bf572da0)
