### PR TITLE
fix: bind JSONDecodeError in review_pr.py for proper error visibility

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -614,8 +614,8 @@ def _extract_first_json_object(text: str) -> dict[str, Any]:
             continue
         try:
             payload, _ = decoder.raw_decode(text[index:])
-        except json.JSONDecodeError:
-            logger.debug("skipping non-JSON fragment at offset %d", index)
+        except json.JSONDecodeError as exc:
+            logger.debug("skipping non-JSON fragment at offset %d: %s", index, exc)
             continue
         if isinstance(payload, dict):
             return payload


### PR DESCRIPTION
The except clause in _extract_first_json_object was catching
json.JSONDecodeError without binding the exception variable, so the
debug log message lacked error details. Bind the exception and include
it in the log output.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c008a63770e13b67c63ee6c35c0b87b621100c93)
