### PR TITLE
fix: add OSError to narrowed exception handler in crystallizer.py

### DIFF
--- a/aragora/interrogation/crystallizer.py
+++ b/aragora/interrogation/crystallizer.py
@@ -314,6 +314,7 @@ class Crystallizer:
                     ValueError,
                     AttributeError,
                     RuntimeError,
+                    OSError,
                 ):  # pragma: no cover - defensive
                     summary = ""
 


### PR DESCRIPTION
The defensive summary() call in _legacy_crystallize could raise OSError
if the research_result involves I/O. Add it to the specific exception
tuple to keep the handler precise while covering this edge case.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 28291e4cb652ce6b78d7ecdef37e95d304412597)
