### PR TITLE
feat(swarm): add terminal truth benchmark fixtures

### DIFF
--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -102,6 +102,8 @@ def classify_from_metrics(row: dict[str, Any]) -> TerminalClass:
         return TerminalClass.BLOCKED_NO_RUNNER
     if "auth" in outcome:
         return TerminalClass.BLOCKED_AUTH_FAILURE
+    if "decomposition_limit" in outcome:
+        return TerminalClass.BLOCKED_DECOMPOSITION_LIMIT
 
     if "crash" in outcome:
         return TerminalClass.RESCUE_WORKER_CRASH

--- a/tests/swarm/test_terminal_truth.py
+++ b/tests/swarm/test_terminal_truth.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 from aragora.swarm.terminal_truth import (
+    classify_from_metrics,
     qualify_run_terminal_state,
     qualify_work_order_terminal_state,
 )
@@ -65,3 +69,23 @@ def test_qualify_run_terminal_state_derives_failure_classes_from_lineage_and_out
     assert qualification.stage_id == "stage-dispatch-ready"
     assert qualification.failure_classes == ["unsafe_scope", "scope_violation"]
     assert qualification.to_dict()["receipt_outcome"] == "blocked"
+
+
+def test_terminal_truth_fixtures_match_expected_classes() -> None:
+    fixture_dir = (
+        Path(__file__).resolve().parents[2] / "benchmarks" / "fixtures" / "swarm" / "terminal_truth"
+    )
+    fixture_files = sorted(fixture_dir.glob("*.json"))
+
+    assert fixture_files, "expected terminal-truth fixtures to exist"
+
+    for fixture_file in fixture_files:
+        rows = json.loads(fixture_file.read_text(encoding="utf-8"))
+        assert isinstance(rows, list), f"{fixture_file.name} must contain a list of examples"
+
+        for row in rows:
+            expected = row["expected_class"]
+            observed = classify_from_metrics(row).value
+            assert observed == expected, (
+                f"{fixture_file.name}: expected {expected!r}, observed {observed!r} for row {row!r}"
+            )


### PR DESCRIPTION
## Summary
- add benchmark fixtures for every `TerminalClass` case under `benchmarks/fixtures/swarm/terminal_truth`
- complete `classify_from_metrics` handling for `blocked_decomposition_limit`
- add a regression test that verifies every fixture row classifies to its expected terminal class

## Testing
- python3 -m pytest tests/swarm/test_terminal_truth.py -q
- python3 -m ruff check aragora/swarm/terminal_truth.py tests/swarm/test_terminal_truth.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
