### PR TITLE
fix(ci): use changed-file typecheck for branch pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -389,11 +389,20 @@ jobs:
               --base-ref "${{ github.base_ref }}" \
               --github-output "$GITHUB_OUTPUT" \
               --targets-file "$TARGETS_FILE"
-          else
+          elif [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            # Direct push to main: run full typecheck
             echo "mode=full" >> "$GITHUB_OUTPUT"
             echo "target_count=0" >> "$GITHUB_OUTPUT"
-            echo "summary=Run the full typecheck tier on non-pull_request events." >> "$GITHUB_OUTPUT"
+            echo "summary=Run the full typecheck tier on direct main push." >> "$GITHUB_OUTPUT"
             : > "$TARGETS_FILE"
+          else
+            # Branch push (e.g., boss loop harvest): check only changed files
+            git fetch --no-tags origin main --depth=1 2>/dev/null || true
+            "${{ steps.typecheck_python.outputs.python_bin }}" scripts/run_typecheck_gate.py \
+              --repo-root . \
+              --base-ref "origin/main" \
+              --github-output "$GITHUB_OUTPUT" \
+              --targets-file "$TARGETS_FILE"
           fi
           echo "targets_file=$TARGETS_FILE" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

Boss loop PRs all fail typecheck because branch pushes trigger full-codebase mypy (3,364 pre-existing errors). Workers' changes are type-correct but the gate rejects the whole PR.

Fix: Branch pushes now use the changed-file gate (same as PRs), checking only touched files. Full typecheck only runs on direct main pushes.

## Root cause

Line 393 of lint.yml: `echo "mode=full"` for all non-pull_request events. Boss loop pushes branches → triggers push event → full mypy → 3,364 errors → PR blocked.

## Test plan
- Boss loop PRs should now pass typecheck if the worker's changes are type-correct
- Direct pushes to main still get full typecheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)