### PR TITLE
feat(swarm): RS-03 benchmark scoring lane with regression tests

### DIFF
--- a/scripts/score_benchmark.py
+++ b/scripts/score_benchmark.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Score terminal-truth benchmark fixtures against classify_from_metrics().
+
+RS-03 scoring lane — loads JSON fixture files produced by RS-02, runs
+``classify_from_metrics()`` on every example, and reports per-file and
+aggregate pass/fail results.
+
+Exit codes:
+    0  — all examples classified correctly
+    1  — one or more mismatches detected
+    2  — fixtures directory missing or empty
+
+Usage:
+    python scripts/score_benchmark.py
+    python scripts/score_benchmark.py --fixtures-dir path/to/fixtures
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure the local repo takes precedence over any editable install so that
+# worktree-local changes to aragora are picked up when the script is invoked
+# directly (sys.path[0] defaults to the *scripts/* directory, not the repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.terminal_truth import classify_from_metrics  # noqa: E402
+
+DEFAULT_FIXTURES_DIR = REPO_ROOT / "benchmarks" / "fixtures" / "swarm" / "terminal_truth"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Score terminal-truth benchmark fixtures against classify_from_metrics().",
+    )
+    parser.add_argument(
+        "--fixtures-dir",
+        type=Path,
+        default=DEFAULT_FIXTURES_DIR,
+        help=(
+            f"Path to directory containing .json fixture files (default: {DEFAULT_FIXTURES_DIR})"
+        ),
+    )
+    return parser
+
+
+def score_fixtures(fixtures_dir: Path) -> tuple[bool, str]:
+    """Load and score all fixture files.
+
+    Returns ``(all_passed, report_text)``.
+    """
+    if not fixtures_dir.is_dir():
+        return False, f"ERROR: fixtures directory does not exist: {fixtures_dir}"
+
+    fixture_files = sorted(fixtures_dir.glob("*.json"))
+    if not fixture_files:
+        return False, f"ERROR: no .json files found in {fixtures_dir}"
+
+    total_examples = 0
+    total_pass = 0
+    total_fail = 0
+    lines: list[str] = []
+
+    for fixture_file in fixture_files:
+        with fixture_file.open() as fh:
+            examples = json.load(fh)
+
+        file_pass = 0
+        file_fail = 0
+        file_errors: list[str] = []
+
+        for idx, row in enumerate(examples):
+            expected = row.get("expected_class", "")
+            result = classify_from_metrics(row)
+            if result.value == expected:
+                file_pass += 1
+            else:
+                file_fail += 1
+                file_errors.append(f"  [{idx}] expected {expected!r}, got {result.value!r}")
+
+        total_examples += file_pass + file_fail
+        total_pass += file_pass
+        total_fail += file_fail
+
+        status = "PASS" if file_fail == 0 else "FAIL"
+        lines.append(f"  {status}  {fixture_file.name} ({file_pass}/{file_pass + file_fail})")
+        for err in file_errors:
+            lines.append(err)
+
+    # Aggregate summary
+    all_passed = total_fail == 0
+    summary_status = "PASS" if all_passed else "FAIL"
+    header = (
+        f"Terminal-truth benchmark: {summary_status}\n"
+        f"Files: {len(fixture_files)}  |  "
+        f"Examples: {total_examples}  |  "
+        f"Pass: {total_pass}  |  Fail: {total_fail}\n"
+    )
+    report = header + "\n".join(lines)
+    return all_passed, report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    fixtures_dir: Path = args.fixtures_dir
+
+    all_passed, report = score_fixtures(fixtures_dir)
+    print(report)
+
+    if not fixtures_dir.is_dir():
+        return 2
+    fixture_files = sorted(fixtures_dir.glob("*.json"))
+    if not fixture_files:
+        return 2
+
+    return 0 if all_passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/swarm/test_terminal_truth_benchmark.py
+++ b/tests/swarm/test_terminal_truth_benchmark.py
@@ -1,0 +1,284 @@
+"""RS-03 regression tests — terminal truth benchmark scoring.
+
+Parametrizes over all 14 fixture files and validates that
+``classify_from_metrics()`` returns the expected class for every example.
+Also tests the ``score_benchmark.py`` script's ``score_fixtures()`` helper
+directly and verifies error handling for missing/empty directories.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.terminal_truth import (
+    TerminalClass,
+    classify_from_metrics,
+    score_benchmark,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+FIXTURES_DIR = REPO_ROOT / "benchmarks" / "fixtures" / "swarm" / "terminal_truth"
+SCORE_SCRIPT = REPO_ROOT / "scripts" / "score_benchmark.py"
+
+# Collect fixture files for parametrization
+_fixture_files = sorted(FIXTURES_DIR.glob("*.json")) if FIXTURES_DIR.is_dir() else []
+
+
+# ---------------------------------------------------------------------------
+# Parametrized per-fixture classification tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture_file",
+    _fixture_files,
+    ids=[f.stem for f in _fixture_files],
+)
+def test_fixture_classifies_correctly(fixture_file: Path) -> None:
+    """Each example in a fixture file must classify to its expected_class."""
+    with fixture_file.open() as fh:
+        examples = json.load(fh)
+
+    assert isinstance(examples, list), f"{fixture_file.name}: root must be a JSON array"
+    assert 3 <= len(examples) <= 5, (
+        f"{fixture_file.name}: expected 3-5 examples, got {len(examples)}"
+    )
+
+    for idx, row in enumerate(examples):
+        expected = row["expected_class"]
+        result = classify_from_metrics(row)
+        assert result.value == expected, (
+            f"{fixture_file.name}[{idx}]: expected {expected!r}, got {result.value!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "fixture_file",
+    _fixture_files,
+    ids=[f.stem for f in _fixture_files],
+)
+def test_fixture_schema_valid(fixture_file: Path) -> None:
+    """Every example must contain the required metric fields plus expected_class."""
+    required_keys = {
+        "worker_status",
+        "worker_outcome",
+        "elapsed_seconds",
+        "files_changed",
+        "has_deliverable",
+        "publish_action",
+        "expected_class",
+    }
+    with fixture_file.open() as fh:
+        examples = json.load(fh)
+
+    for idx, row in enumerate(examples):
+        missing = required_keys - set(row.keys())
+        assert not missing, f"{fixture_file.name}[{idx}]: missing keys {missing}"
+
+
+def test_all_14_terminal_classes_covered() -> None:
+    """There must be exactly one fixture file per TerminalClass value."""
+    expected_stems = {tc.value for tc in TerminalClass}
+    actual_stems = {f.stem for f in _fixture_files}
+    assert actual_stems == expected_stems, (
+        f"Missing: {expected_stems - actual_stems}, Extra: {actual_stems - expected_stems}"
+    )
+
+
+def test_fixtures_cover_all_families() -> None:
+    """Fixtures span success, rescue, and blocked families."""
+    families = set()
+    for fixture_file in _fixture_files:
+        with fixture_file.open() as fh:
+            examples = json.load(fh)
+        for row in examples:
+            tc = classify_from_metrics(row)
+            families.add(tc.family)
+    assert families == {"success", "rescue", "blocked"}
+
+
+# ---------------------------------------------------------------------------
+# score_benchmark() function tests
+# ---------------------------------------------------------------------------
+
+
+def test_score_benchmark_with_fixture_rows() -> None:
+    """score_benchmark() returns a correct summary when given all fixture rows."""
+    all_rows: list[dict] = []
+    for fixture_file in _fixture_files:
+        with fixture_file.open() as fh:
+            all_rows.extend(json.load(fh))
+
+    summary = score_benchmark(all_rows)
+
+    assert summary["total"] == len(all_rows)
+    assert isinstance(summary["successes"], int)
+    assert 0.0 <= summary["no_rescue_rate"] <= 1.0
+    assert isinstance(summary["meets_30d_target"], bool)
+    assert isinstance(summary["families"], dict)
+    assert isinstance(summary["classes"], dict)
+    # All three families must be represented
+    assert set(summary["families"].keys()) == {"success", "rescue", "blocked"}
+    # Family counts must sum to total
+    assert sum(summary["families"].values()) == summary["total"]
+    # Class counts must sum to total
+    assert sum(summary["classes"].values()) == summary["total"]
+    assert isinstance(summary["actionable_failures"], int)
+    assert summary["actionable_failures"] >= 0
+
+
+def test_score_benchmark_empty_input() -> None:
+    """score_benchmark() handles an empty list gracefully."""
+    summary = score_benchmark([])
+    assert summary["total"] == 0
+    assert summary["no_rescue_rate"] == 0.0
+
+
+def test_score_benchmark_single_success_row() -> None:
+    """score_benchmark() correctly scores a single success row."""
+    row = {
+        "worker_status": "completed",
+        "worker_outcome": "pr_adopted",
+        "elapsed_seconds": 120.0,
+        "files_changed": 5,
+        "has_deliverable": True,
+        "publish_action": "merged",
+    }
+    summary = score_benchmark([row])
+    assert summary["total"] == 1
+    assert summary["successes"] == 1
+    assert summary["no_rescue_rate"] == 1.0
+    assert summary["meets_30d_target"] is True
+    assert summary["families"]["success"] == 1
+
+
+def test_score_benchmark_mixed_rows() -> None:
+    """score_benchmark() correctly computes rates for mixed success/failure rows."""
+    success_row = {
+        "worker_status": "completed",
+        "worker_outcome": "pr_adopted",
+        "elapsed_seconds": 120.0,
+        "files_changed": 5,
+        "has_deliverable": True,
+        "publish_action": "merged",
+    }
+    rescue_row = {
+        "worker_status": "running",
+        "worker_outcome": "timeout",
+        "elapsed_seconds": 3600.0,
+        "files_changed": 0,
+        "has_deliverable": False,
+        "publish_action": "",
+    }
+    summary = score_benchmark([success_row, rescue_row])
+    assert summary["total"] == 2
+    assert summary["successes"] == 1
+    assert summary["no_rescue_rate"] == 0.5
+    assert summary["meets_30d_target"] is True
+
+
+# ---------------------------------------------------------------------------
+# Script CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_score_script_help_exits_zero() -> None:
+    """``python3 scripts/score_benchmark.py --help`` must exit 0."""
+    result = subprocess.run(
+        [sys.executable, str(SCORE_SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, f"--help exited {result.returncode}: {result.stderr}"
+
+
+def test_score_script_default_run_exits_zero() -> None:
+    """Default invocation must load all fixtures and exit 0."""
+    result = subprocess.run(
+        [sys.executable, str(SCORE_SCRIPT)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"Default run exited {result.returncode}:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "PASS" in result.stdout or "pass" in result.stdout.lower()
+
+
+def test_score_script_missing_dir_exits_nonzero() -> None:
+    """Missing fixtures directory must cause non-zero exit."""
+    result = subprocess.run(
+        [sys.executable, str(SCORE_SCRIPT), "--fixtures-dir", "/tmp/nonexistent_dir_rs03"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode != 0, "Should exit non-zero for missing dir"
+
+
+def test_score_script_empty_dir_exits_nonzero() -> None:
+    """Empty fixtures directory must cause non-zero exit."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        result = subprocess.run(
+            [sys.executable, str(SCORE_SCRIPT), "--fixtures-dir", tmpdir],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0, "Should exit non-zero for empty dir"
+
+
+def test_score_script_mismatch_exits_nonzero() -> None:
+    """A fixture with wrong expected_class must cause non-zero exit."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        bad_fixture = Path(tmpdir) / "bad_fixture.json"
+        bad_fixture.write_text(
+            json.dumps(
+                [
+                    {
+                        "worker_status": "completed",
+                        "worker_outcome": "pr_adopted",
+                        "elapsed_seconds": 100.0,
+                        "files_changed": 5,
+                        "has_deliverable": True,
+                        "publish_action": "merged",
+                        "expected_class": "rescue_timeout",  # wrong!
+                    },
+                    {
+                        "worker_status": "completed",
+                        "worker_outcome": "pr_adopted",
+                        "elapsed_seconds": 200.0,
+                        "files_changed": 3,
+                        "has_deliverable": True,
+                        "publish_action": "merged",
+                        "expected_class": "rescue_timeout",  # wrong!
+                    },
+                    {
+                        "worker_status": "completed",
+                        "worker_outcome": "pr_adopted",
+                        "elapsed_seconds": 300.0,
+                        "files_changed": 7,
+                        "has_deliverable": True,
+                        "publish_action": "merged",
+                        "expected_class": "rescue_timeout",  # wrong!
+                    },
+                ]
+            )
+        )
+        result = subprocess.run(
+            [sys.executable, str(SCORE_SCRIPT), "--fixtures-dir", tmpdir],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode != 0, (
+            f"Should exit non-zero for mismatch:\n{result.stdout}\n{result.stderr}"
+        )


### PR DESCRIPTION
## Summary
- `scripts/score_benchmark.py` — loads fixtures, classifies, asserts correctness
- `tests/swarm/test_terminal_truth_benchmark.py` — 39 tests covering all 14 classes

## Test plan
- [x] 39 passed in 30s
- [x] score_benchmark.py syntax clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)