### PR TITLE
chore(api): refresh generated OpenAPI artifacts

### DIFF
--- a/docs/api/openapi_generated.json
+++ b/docs/api/openapi_generated.json
@@ -202035,6 +202035,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "id": {
                       "type": "string"
@@ -202092,7 +202093,25 @@
                         "null"
                       ]
                     }
-                  }
+                  },
+                  "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "category",
+                    "author_id",
+                    "version",
+                    "tags",
+                    "status",
+                    "is_verified",
+                    "is_builtin",
+                    "install_count",
+                    "rating_average",
+                    "rating_count",
+                    "created_at",
+                    "updated_at",
+                    "approved_by"
+                  ]
                 }
               }
             }

--- a/docs/api/openapi_generated.yaml
+++ b/docs/api/openapi_generated.yaml
@@ -116092,6 +116092,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: false
                 properties:
                   id:
                     type: string
@@ -116131,6 +116132,23 @@ paths:
                     type:
                     - string
                     - 'null'
+                required:
+                - id
+                - name
+                - description
+                - category
+                - author_id
+                - version
+                - tags
+                - status
+                - is_verified
+                - is_builtin
+                - install_count
+                - rating_average
+                - rating_count
+                - created_at
+                - updated_at
+                - approved_by
         '404':
           description: Not found - The requested resource does not exist
           headers: *id782


### PR DESCRIPTION
## Summary
- regenerate `docs/api/openapi_generated.json` and `docs/api/openapi_generated.yaml`
- bring committed OpenAPI artifacts back in sync with the current generator output
- clear the systemic `Version Alignment` failure affecting unrelated PRs

## Testing
- python3 -m pytest tests/test_openapi_regeneration.py -q
