### PR TITLE
fix(cli): include JSON decode detail in review PR debug logging

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -614,8 +614,8 @@ def _extract_first_json_object(text: str) -> dict[str, Any]:
             continue
         try:
             payload, _ = decoder.raw_decode(text[index:])
-        except json.JSONDecodeError:
-            logger.debug("skipping non-JSON fragment at offset %d", index)
+        except json.JSONDecodeError as exc:
+            logger.debug("skipping non-JSON fragment at offset %d: %s", index, exc)
             continue
         if isinstance(payload, dict):
             return payload


### PR DESCRIPTION
## Summary
- bind `json.JSONDecodeError` in `aragora/cli/commands/review_pr.py`
- include the parse error details in the existing debug log when scanning non-JSON fragments
- keep the change scoped to the original one-file salvage from closed PR #4908

## Why
The existing handler swallowed the concrete decode error details, which made malformed-fragment debugging harder during PR review artifact parsing.

## Validation
- `python3 -m ruff check aragora/cli/commands/review_pr.py`
- `python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/cli/commands/review_pr.py --json`
- `python3 - <<'PY' ... functional check for _extract_first_json_object logging detail ... PY`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- `python3 -m pytest tests/cli/commands/test_review_pr.py -q` currently has an unrelated pre-existing failure in `test_cleanup_worktree_logs_parent_cleanup_failure` on `main`; this PR does not touch that path.
