### PR TITLE
fix(audit): replace silent exception swallowing with debug logging

### DIFF
--- a/aragora/control_plane/audit.py
+++ b/aragora/control_plane/audit.py
@@ -353,7 +353,7 @@ class AuditLog:
             try:
                 from aragora.storage.production_guards import require_distributed_store, StorageMode
             except ImportError:
-                pass
+                logger.debug("production_guards not available, skipping distributed store check")
             else:
                 require_distributed_store(
                     "control_plane_audit_log",
@@ -368,7 +368,7 @@ class AuditLog:
             try:
                 from aragora.storage.production_guards import require_distributed_store, StorageMode
             except ImportError:
-                pass
+                logger.debug("production_guards not available, skipping distributed store check")
             else:
                 require_distributed_store(
                     "control_plane_audit_log",


### PR DESCRIPTION
Replace bare `except ImportError: pass` in AuditLog.connect() with
logger.debug() calls so suppressed import failures are visible in
debug logs instead of being silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 10c850273ab7434d25d9a77d6c540e12eb27eedf)
