### PR TITLE
chore(sdk): refresh generated TypeScript SDK types

### DIFF
--- a/sdk/typescript/src/openapi-types.ts
+++ b/sdk/typescript/src/openapi-types.ts
@@ -163635,24 +163635,24 @@ export interface operations {
                 };
                 content: {
                     "application/json": {
-                        id?: string;
-                        name?: string;
-                        description?: string;
-                        category?: string;
-                        author_id?: string;
-                        version?: string;
-                        tags?: string[];
-                        status?: string;
-                        is_verified?: boolean;
-                        is_builtin?: boolean;
-                        install_count?: number;
-                        rating_average?: number;
-                        rating_count?: number;
+                        id: string;
+                        name: string;
+                        description: string;
+                        category: string;
+                        author_id: string;
+                        version: string;
+                        tags: string[];
+                        status: string;
+                        is_verified: boolean;
+                        is_builtin: boolean;
+                        install_count: number;
+                        rating_average: number;
+                        rating_count: number;
                         /** Format: date-time */
-                        created_at?: string;
+                        created_at: string;
                         /** Format: date-time */
-                        updated_at?: string;
-                        approved_by?: string | null;
+                        updated_at: string;
+                        approved_by: string | null;
                     };
                 };
             };


### PR DESCRIPTION
## Summary
- refresh `sdk/typescript/src/openapi-types.ts` from the current checked-in OpenAPI spec
- unblock `Version Alignment` for unrelated PRs that currently fail on stale generated SDK types
- keep the change to the single generated artifact that the CI check compares

## Why
`Version Alignment` is currently failing on PRs that do not touch API surfaces because the generated TypeScript SDK types no longer match `docs/api/openapi_generated.json` on `main`.

## Validation
- `python3 scripts/generate_sdk_types.py --openapi docs/api/openapi_generated.json --check`
- `python3 -m pytest tests/scripts/test_generate_sdk_types.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
