### PR TITLE
fix(ci): add --follow-imports=skip to changed-file typecheck

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -422,6 +422,7 @@ jobs:
           PATH="$HOME/.local/bin:$PATH" \
             "${{ steps.typecheck_python.outputs.python_bin }}" -m mypy \
             --ignore-missing-imports \
+            --follow-imports=skip \
             --show-error-codes \
             "${TARGETS[@]}"
 


### PR DESCRIPTION
## Summary

Second part of the typecheck gate fix. #4914 added branch-push changed-file mode, but mypy still follows imports and finds 2,500 errors in dependencies. `--follow-imports=skip` limits checking to explicitly listed files only.

## Root cause

`mypy aragora/cli/review.py` checks that file but also follows every `import` and finds errors in `shared_inbox/`, `notifications/`, etc. With 2,500+ pre-existing errors in the dependency graph, every single-file PR fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)