### PR TITLE
fix: replace silent exception swallowing in auto_scaling.py

### DIFF
--- a/aragora/control_plane/auto_scaling.py
+++ b/aragora/control_plane/auto_scaling.py
@@ -253,7 +253,7 @@ class AutoScaler:
             try:
                 await self._task
             except asyncio.CancelledError:
-                pass
+                logger.debug("Auto-scaler task cancelled during shutdown")
             self._task = None
 
         logger.info("Auto-scaler stopped")


### PR DESCRIPTION
Replace bare `except CancelledError: pass` with a debug log message
so shutdown cancellation is observable rather than silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 8de1b87732aca984affd93e3dea05c1e377f09d8)
