### PR TITLE
fix: add justification comment to CancelledError pass in arena_bridge.py

### DIFF
--- a/aragora/control_plane/arena_bridge.py
+++ b/aragora/control_plane/arena_bridge.py
@@ -724,7 +724,7 @@ class ArenaControlPlaneBridge:
                 try:
                     await sla_task
                 except asyncio.CancelledError:
-                    pass
+                    pass  # Expected: SLA task was intentionally cancelled
 
         except asyncio.TimeoutError:
             task.metrics.completed_at = time.time()


### PR DESCRIPTION
The only bare `except: pass` pattern in arena_bridge.py is the
asyncio.CancelledError handler during SLA task cleanup — this is
intentional (the task is explicitly cancelled). Added an inline
comment to document the intent, satisfying the no-silent-swallowing
policy without changing behavior.

Addresses #4938

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit ffdeb5b2dba024ffbbf0cbd9486e4130d5d57383)
