### PR TITLE
fix: replace silent exception swallowing in agent_factory.py with debug logging

### DIFF
--- a/aragora/control_plane/agent_factory.py
+++ b/aragora/control_plane/agent_factory.py
@@ -242,8 +242,10 @@ class AgentFactory:
                             credentials_missing=True,
                         )
             except ImportError:
-                # Credential validator not available, proceed without validation
-                pass
+                logger.debug(
+                    "credential_validator_unavailable",
+                    extra={"agent_id": agent_info.agent_id, "agent_type": agent_type},
+                )
 
         # Load API key from environment
         api_key = self._get_api_key(agent_type)
@@ -359,7 +361,7 @@ class AgentFactory:
                 if value:
                     return value
         except ImportError:
-            pass
+            logger.debug("secrets_module_unavailable", extra={"agent_type": agent_type})
 
         # Fallback to environment variables
         import os


### PR DESCRIPTION
Replace bare `except ImportError: pass` patterns with `logger.debug()` calls
so that missing optional modules (credential_validator, config.secrets) are
visible in debug logs instead of silently swallowed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit bcffe5d53ada58943f203b7bd4082e918bd1252f)
