### PR TITLE
fix: replace silent except-pass with logging in computer_use orchestrator

### DIFF
--- a/aragora/computer_use/orchestrator.py
+++ b/aragora/computer_use/orchestrator.py
@@ -559,7 +559,9 @@ class ComputerUseOrchestrator:
                 if is_receipt_enforcement_enabled("computer_use"):
                     transition_receipt_executed(receipt_id)
             except ImportError:
-                pass
+                logger.debug(
+                    "Receipt enforcement module not available, skipping post-task transition"
+                )
 
         return result
 


### PR DESCRIPTION
Replace bare `except ImportError: pass` with a debug log message for
the receipt enforcement post-task transition, improving error visibility
without changing behavior.

Addresses #4929.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c9e7af0e61a8ab2e9236159956a0920dfefd4eb8)
