### PR TITLE
fix(audit): replace silent exception swallowing with debug logging

### DIFF
--- a/aragora/control_plane/audit.py
+++ b/aragora/control_plane/audit.py
@@ -846,6 +846,9 @@ class AuditLog:
     async def _query_redis(self, query: AuditQuery) -> list[AuditEntry]:
         """Query entries from Redis."""
         entries: list[AuditEntry] = []
+        redis_client = self._redis
+        if redis_client is None:
+            return entries
 
         try:
             # Determine time range for Redis XRANGE
@@ -858,7 +861,7 @@ class AuditLog:
                 end = str(int(query.end_time.timestamp() * 1000))
 
             # Fetch entries (Redis handles time-based filtering)
-            raw_entries = await self._redis.xrange(
+            raw_entries = await redis_client.xrange(
                 self._stream_key,
                 min=start,
                 max=end,

--- a/aragora/control_plane/audit.py
+++ b/aragora/control_plane/audit.py
@@ -353,7 +353,7 @@ class AuditLog:
             try:
                 from aragora.storage.production_guards import require_distributed_store, StorageMode
             except ImportError:
-                pass
+                logger.debug("production_guards not available, skipping distributed store check")
             else:
                 require_distributed_store(
                     "control_plane_audit_log",
@@ -368,7 +368,7 @@ class AuditLog:
             try:
                 from aragora.storage.production_guards import require_distributed_store, StorageMode
             except ImportError:
-                pass
+                logger.debug("production_guards not available, skipping distributed store check")
             else:
                 require_distributed_store(
                     "control_plane_audit_log",


### PR DESCRIPTION
## Summary
- replace silent `ImportError` swallowing in `aragora/control_plane/audit.py`
- emit debug logs when `production_guards` is unavailable during audit log connection fallback
- keep the change scoped to the original one-file harvest fix from closed PR #4942

## Why
The current code silently suppresses `production_guards` import failures in `AuditLog.connect()`, which makes fallback behavior harder to diagnose during local and CI runs.

## Validation
- `python3 -m ruff check aragora/control_plane/audit.py`
- `python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/control_plane/audit.py --json`
- direct behavioral check of `AuditLog.connect()` under missing `redis.asyncio` and missing `aragora.storage.production_guards`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
