### PR TITLE
fix(interrogation): replace broad exception handler with specific types in researcher.py

### DIFF
--- a/aragora/interrogation/researcher.py
+++ b/aragora/interrogation/researcher.py
@@ -118,8 +118,23 @@ class UnifiedResearcher:
                 results = await self._query_source(source, query, max_results_per_source)
                 ctx.results.extend(results)
                 ctx.sources_queried.append(source)
-            except Exception:
-                logger.warning("Research source %s failed for query: %s", source, query)
+            except (OSError, TimeoutError, ConnectionError) as exc:
+                logger.warning(
+                    "Research source %s failed (network/IO) for query: %s: %s", source, query, exc
+                )
+                ctx.sources_failed.append(source)
+            except (ValueError, TypeError, KeyError, AttributeError) as exc:
+                logger.warning(
+                    "Research source %s returned bad data for query: %s: %s", source, query, exc
+                )
+                ctx.sources_failed.append(source)
+            except RuntimeError as exc:
+                logger.error(
+                    "Research source %s hit unexpected runtime error for query: %s: %s",
+                    source,
+                    query,
+                    exc,
+                )
                 ctx.sources_failed.append(source)
         return ctx
 


### PR DESCRIPTION
Replace the catch-all `except Exception` in UnifiedResearcher.research() with
specific exception types: OSError/TimeoutError/ConnectionError for network/IO
failures, ValueError/TypeError/KeyError/AttributeError for bad data from
sources, and RuntimeError for unexpected runtime errors.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 70fc2ed5aca2fe14b51109165997125f6c7c79b4)
