### PR TITLE
fix: replace silent except-pass with httpx sentinel in teams _files.py

### DIFF
--- a/aragora/connectors/chat/teams/_files.py
+++ b/aragora/connectors/chat/teams/_files.py
@@ -17,8 +17,8 @@ import aragora.connectors.chat.teams._constants as _tc
 
 try:
     import httpx
-except ImportError:
-    pass
+except ImportError:  # pragma: no cover – httpx is optional; _tc.HTTPX_AVAILABLE gates usage
+    httpx = None  # type: ignore[assignment]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
The bare `except ImportError: pass` swallowed the missing-httpx case
silently. Assign `httpx = None` instead so the name is always bound
and the pattern is no longer a silent pass. Runtime gating already
happens via `_tc.HTTPX_AVAILABLE`.

Refs #4932

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 1982862795dea7d4a689eebe0b75d381acf137d9)
