### PR TITLE
fix: replace silent exception swallowing in feature_flags.py

### DIFF
--- a/aragora/config/feature_flags.py
+++ b/aragora/config/feature_flags.py
@@ -437,7 +437,7 @@ class FeatureFlagRegistry:
                 }
                 return mappings.get(name)
         except ImportError:
-            pass
+            logger.debug("Tenancy module not available; skipping tenant flag lookup for %s", name)
         return None
 
     def _register_builtin_flags(self) -> None:


### PR DESCRIPTION
Replace bare `except ImportError: pass` in _get_tenant_value() with a
logger.debug() call so optional-dependency skips are visible in debug
logs instead of silently swallowed.

Addresses #4930.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 4ce1875756a7330aad144e9a634abec07ce9c6b6)
