### PR TITLE
fix(swarm): restore worker contract mission lineage

### DIFF
--- a/aragora/swarm/worker_contract.py
+++ b/aragora/swarm/worker_contract.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import Any, Mapping
 
 from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.mission import normalize_context_policies
 from aragora.swarm.worker_process import LaunchConfig
 
 
@@ -42,6 +43,11 @@ class WorkerContract:
     gh_api_auth_mode: str
     budget: dict[str, Any]
     env_checksum: str
+    mission_id: str = ""
+    stage_id: str = ""
+    assertion_ids: list[str] | None = None
+    evidence_expectations: list[str] | None = None
+    mission_context_policy: dict[str, Any] | None = None
     contract_version: str = _CONTRACT_VERSION
     _expected_checksum: str = field(default="", init=False, repr=False)
 
@@ -60,6 +66,17 @@ class WorkerContract:
             "gh_api_auth_mode": self.gh_api_auth_mode,
             "budget": dict(self.budget),
             "env_checksum": self.env_checksum,
+            "mission_id": str(self.mission_id or "").strip(),
+            "stage_id": str(self.stage_id or "").strip(),
+            "assertion_ids": [
+                str(item).strip() for item in list(self.assertion_ids or []) if str(item).strip()
+            ],
+            "evidence_expectations": [
+                str(item).strip()
+                for item in list(self.evidence_expectations or [])
+                if str(item).strip()
+            ],
+            "mission_context_policy": dict(self.mission_context_policy or {}),
             "contract_version": self.contract_version,
         }
 
@@ -78,11 +95,14 @@ class WorkerContract:
             "gh_api_auth_mode": self.gh_api_auth_mode,
             "budget": self.budget,
             "env_checksum": self.env_checksum,
+            "mission_context_policy": self.mission_context_policy,
             "contract_version": self.contract_version,
         }
         missing = [key for key, value in required.items() if value is None or value == ""]
         if missing:
             raise ValueError(f"Worker contract missing required fields: {', '.join(missing)}")
+        if not dict(self.mission_context_policy or {}):
+            raise ValueError("Worker contract missing required field: mission_context_policy")
 
     def admission_check(self) -> bool:
         """Check contract completeness and integrity for dispatch admission.
@@ -112,6 +132,8 @@ class WorkerContract:
             for value in required_fields:
                 if value is None or value == "":
                     return False
+            if not dict(self.mission_context_policy or {}):
+                return False
 
             # 2. Detect checksum drift.
             current_checksum = checksum_contract_payload(self.to_dict())
@@ -170,6 +192,7 @@ def build_worker_contract(
     config: LaunchConfig,
     worktree_path: str,
     env: Mapping[str, str] | None = None,
+    work_order: Mapping[str, Any] | None = None,
 ) -> WorkerContract:
     normalized_agent = str(agent or "").strip() or "unknown"
     if normalized_agent == "claude":
@@ -197,6 +220,30 @@ def build_worker_contract(
         "max_tokens": None,
         "max_retries": None,
     }
+    work_order_data = dict(work_order or {})
+    file_scope = [
+        str(item).strip() for item in work_order_data.get("file_scope", []) if str(item).strip()
+    ]
+    evidence_expectations = [
+        str(item).strip()
+        for item in work_order_data.get("evidence_expectations", [])
+        if str(item).strip()
+    ]
+    if not evidence_expectations:
+        evidence_expectations = [
+            "worker_contract",
+            "worker_contract_checksum",
+            *[
+                str(item).strip()
+                for item in work_order_data.get("expected_tests", [])
+                if str(item).strip()
+            ],
+        ]
+    context_policy = normalize_context_policies(
+        work_order_data.get("mission_context_policies"),
+        file_scope=file_scope,
+        evidence_expectations=evidence_expectations,
+    )["worker"]
 
     execution_mode = (
         config.execution_mode.value
@@ -215,4 +262,13 @@ def build_worker_contract(
         gh_api_auth_mode=_gh_api_auth_mode(env),
         budget=budget,
         env_checksum=_env_checksum(env),
+        mission_id=str(work_order_data.get("mission_id", "") or "").strip(),
+        stage_id=str(work_order_data.get("stage_id", "") or "").strip(),
+        assertion_ids=[
+            str(item).strip()
+            for item in work_order_data.get("assertion_ids", [])
+            if str(item).strip()
+        ],
+        evidence_expectations=evidence_expectations,
+        mission_context_policy=context_policy,
     )

--- a/tests/swarm/test_worker_contract.py
+++ b/tests/swarm/test_worker_contract.py
@@ -15,12 +15,45 @@ from unittest.mock import patch
 
 import pytest
 
+from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.worker_contract import (
     WorkerContract,
     build_worker_contract,
     checksum_contract_payload,
 )
 from aragora.swarm.worker_process import LaunchConfig
+
+
+def test_build_worker_contract_includes_mission_lineage_and_context_policy(tmp_path) -> None:
+    worktree = tmp_path / "repo"
+    worktree.mkdir()
+    config = LaunchConfig(
+        allow_codex_full_auto=True,
+        execution_mode=ExecutionMode.AUTONOMOUS,
+    )
+
+    contract = build_worker_contract(
+        agent="codex",
+        config=config,
+        worktree_path=str(worktree),
+        env={},
+        work_order={
+            "mission_id": "mission-rs-credential-envelope",
+            "stage_id": "stage-contract-aware-preflight",
+            "assertion_ids": ["RS-04-ASSERT-1"],
+            "file_scope": ["aragora/swarm/preflight.py"],
+            "evidence_expectations": ["validation_command", "worker_contract", "receipt"],
+        },
+    )
+
+    payload = contract.to_dict()
+
+    assert payload["mission_id"] == "mission-rs-credential-envelope"
+    assert payload["stage_id"] == "stage-contract-aware-preflight"
+    assert payload["assertion_ids"] == ["RS-04-ASSERT-1"]
+    assert payload["mission_context_policy"]["role"] == "worker"
+    assert payload["mission_context_policy"]["transcript_allowance"] == "none"
+    contract.validate()
 
 
 def _make_valid_contract() -> WorkerContract:
@@ -42,6 +75,17 @@ def _make_valid_contract() -> WorkerContract:
             "max_retries": None,
         },
         env_checksum="abc123",
+        mission_id="mission-rs04-worker-contract",
+        stage_id="stage-admission-check",
+        assertion_ids=["RS-04-ASSERT-1"],
+        evidence_expectations=["worker_contract", "worker_contract_checksum"],
+        mission_context_policy={
+            "role": "worker",
+            "allowed_artifact_classes": ["worker_contract", "receipt"],
+            "max_source_count": 4,
+            "max_chars": 2000,
+            "transcript_allowance": "none",
+        },
     )
 
 
@@ -151,6 +195,16 @@ class TestAdmissionCheckMissingFieldsParametrized:
         """Empty dict budget is still structurally valid — admission checks for None/''."""
         contract = _make_valid_contract()
         contract.budget = ""  # type: ignore[assignment]
+        assert contract.admission_check() is False
+
+    def test_none_mission_context_policy_rejected(self) -> None:
+        contract = _make_valid_contract()
+        contract.mission_context_policy = None  # type: ignore[assignment]
+        assert contract.admission_check() is False
+
+    def test_empty_mission_context_policy_rejected(self) -> None:
+        contract = _make_valid_contract()
+        contract.mission_context_policy = {}
         assert contract.admission_check() is False
 
 


### PR DESCRIPTION
## Summary
- restore mission lineage and mission context policy fields on `WorkerContract`
- restore `build_worker_contract(..., work_order=...)` so `worker_launcher` and preflight callers match the contract builder again
- restore focused test coverage for mission lineage and context policy in worker contract construction and admission checks

## Why
`#4920` merged the RS-04 admission check but dropped mission/context envelope fields and the `work_order` parameter from `build_worker_contract()`. Current `worker_launcher.py` and `preflight.py` still depend on those fields, so mainline contract shape drifted away from its live callers.

## Validation
- `python3 -m pytest tests/swarm/test_worker_contract.py tests/swarm/test_preflight.py -q`
- `python3 -m pytest tests/swarm/test_worker_launcher.py -k launch_creates_worker -q`
- `python3 -m ruff check aragora/swarm/worker_contract.py tests/swarm/test_worker_contract.py`
- `python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/swarm/worker_contract.py aragora/swarm/worker_launcher.py aragora/swarm/preflight.py --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`