### PR TITLE
fix(interrogation): narrow broad except Exception in executor.py

### DIFF
--- a/aragora/interrogation/executor.py
+++ b/aragora/interrogation/executor.py
@@ -77,10 +77,10 @@ class InterrogationExecutor:
                 subtasks_completed=getattr(result, "completed_subtasks", 0),
                 subtasks_failed=getattr(result, "failed_subtasks", 0),
             )
-        except Exception:
+        except (RuntimeError, ValueError, TypeError, OSError) as exc:
             logger.exception("Execution failed")
             return ExecutionResult(
                 success=False,
                 goal_text=goal_text,
-                error="Execution failed",
+                error=f"Execution failed: {exc}",
             )


### PR DESCRIPTION
Replace broad `except Exception:` with specific exception types
(RuntimeError, ValueError, TypeError, OSError) to satisfy BLE001
and improve error reporting by including the exception message.

Refs: #4924

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 858a73477af2855e6695b854109a2a3e1736fc4f)
