### PR TITLE
fix: replace except-pass with debug logging for httpx import in teams _files.py

### DIFF
--- a/aragora/connectors/chat/teams/_files.py
+++ b/aragora/connectors/chat/teams/_files.py
@@ -15,12 +15,13 @@ from aragora.connectors.chat.models import FileAttachment
 
 import aragora.connectors.chat.teams._constants as _tc
 
+logger = logging.getLogger(__name__)
+
 try:
     import httpx
 except ImportError:
-    pass
-
-logger = logging.getLogger(__name__)
+    httpx = None  # type: ignore[assignment]
+    logger.debug("httpx not installed; Teams file operations will be unavailable")
 
 
 class _TeamsConnectorProtocol(Protocol):


### PR DESCRIPTION
Assigns httpx=None sentinel on ImportError and logs a debug message
instead of silently swallowing the exception.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e2eb2683db3ca8e192f36cdc57ef738481ca4837)
