### PR TITLE
fix: narrow broad except Exception in canonical_execution.py

### DIFF
--- a/aragora/pipeline/canonical_execution.py
+++ b/aragora/pipeline/canonical_execution.py
@@ -426,7 +426,7 @@ def _ensure_backbone_run(
                 safety_mode=safety_mode,
                 message=f"Failed to record plan stage for backbone run {run_id}",
             )
-        except Exception as exc:
+        except (BackbonePersistenceError, OSError, TypeError, ValueError, KeyError) as exc:
             _backbone_write_failed(
                 safety_mode,
                 f"Failed to seed backbone run {run_id}",
@@ -446,7 +446,7 @@ def _ensure_backbone_run(
                 safety_mode=safety_mode,
                 message=f"Failed to update backbone run {run_id}",
             )
-        except Exception as exc:
+        except (BackbonePersistenceError, OSError, TypeError, ValueError, KeyError) as exc:
             _backbone_write_failed(
                 safety_mode,
                 f"Failed to update backbone run {run_id}",


### PR DESCRIPTION
Replace two `except Exception` handlers in `_ensure_backbone_run()` with
specific exception types: `BackbonePersistenceError | OSError | TypeError |
ValueError | KeyError`. These cover persistence errors, I/O failures, and
data serialization issues while avoiding silent swallowing of unexpected
errors like KeyboardInterrupt or SystemExit.

Closes #4928

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit d600569d49f1a13d616582beb37477b94d9ed041)
