### PR TITLE
feat(swarm): add task sanitizer admission rules

### DIFF
--- a/aragora/swarm/task_sanitizer.py
+++ b/aragora/swarm/task_sanitizer.py
@@ -1,0 +1,579 @@
+"""Task sanitizer for boss-loop admission decisions.
+
+This module is intentionally standalone: it reuses the existing boss validation
+and spec semantics, but does not create a parallel orchestration path.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from aragora.swarm.boss_validation import (
+    assess_issue_body_sanitation,
+    extract_declared_new_file_paths,
+    extract_issue_validation_contract,
+    extract_pre_dispatch_validation_commands,
+    find_missing_pre_dispatch_validation_targets,
+)
+from aragora.swarm.spec import SwarmSpec
+
+_PATH_RE = re.compile(r"`(?P<path>[^`\n]+/[^`\n]+)`")
+_HEADING_RE = re.compile(r"^\s*#{1,6}\s*(?P<heading>.+?)\s*$")
+_LIST_ITEM_RE = re.compile(r"^\s*(?:[-*]|\d+\.)\s+(?P<text>.+?)\s*$")
+_PR_REF_RE = re.compile(
+    r"(?:\bPR\s*#(?P<short>\d+)\b|\bpull request\s*#(?P<long>\d+)\b|/pull/(?P<url>\d+)\b)",
+    re.IGNORECASE,
+)
+_COMPLEXITY_RE = re.compile(
+    r"\b(?:estimated\s+complexity|complexity)\s*[:=]\s*(?P<value>small|medium|large|high|very high|complex|broad)\b",
+    re.IGNORECASE,
+)
+_MID_SENTENCE_ENDING_RE = re.compile(
+    r"(?:,|:|;|/|\(|\[|with|for|to|and|or|but|because|when|while|after|before)$",
+    re.IGNORECASE,
+)
+_CREATE_KEYWORDS = ("create", "new", "add", "generate", "write")
+_MODIFY_KEYWORDS = ("modify", "edit", "update", "change", "patch", "touch")
+_SCOPE_SECTION_PREFIXES = (
+    "file scope",
+    "allowed write set",
+    "write set",
+    "files",
+    "scope",
+)
+_VALIDATION_SECTION_PREFIXES = (
+    "validation",
+    "validation contract",
+    "acceptance criteria",
+    "acceptance",
+    "test plan",
+    "tests",
+)
+_SEVERITY = {
+    "accepted": 0,
+    "rewritten": 1,
+    "quarantined": 2,
+    "dropped": 3,
+}
+
+
+class SanitizationOutcome(str, Enum):
+    ACCEPTED = "accepted"
+    REWRITTEN = "rewritten"
+    DROPPED = "dropped"
+    QUARANTINED = "quarantined"
+
+
+@dataclass(slots=True)
+class SanitizationResult:
+    outcome: SanitizationOutcome
+    original_text: str
+    sanitized_text: str
+    reason: str
+    confidence: float
+    checks_failed: list[str]
+
+
+@dataclass(slots=True)
+class _CheckFinding:
+    check_name: str
+    outcome: SanitizationOutcome
+    reason: str
+    confidence: float
+    rewritten_body: str | None = None
+
+
+class TaskSanitizer:
+    def __init__(self, *, repo_root: Path | None = None) -> None:
+        self.repo_root = Path(repo_root or Path.cwd()).resolve()
+
+    def sanitize(self, title: str, body: str) -> SanitizationResult:
+        normalized_title = str(title or "").strip()
+        normalized_body = str(body or "").strip()
+        original_text = self._compose_issue_text(normalized_title, normalized_body)
+        working_body = normalized_body
+        findings: list[_CheckFinding] = []
+
+        for finding in (
+            self._check_description_length(working_body),
+            self._check_truncation(working_body),
+            self._check_duplicate_of_merged(working_body),
+            self._check_contradictory_scope(working_body),
+            self._check_impossible_validation(working_body, self.repo_root),
+        ):
+            if finding is not None:
+                findings.append(finding)
+
+        broad_scope = self._check_scope_too_broad(working_body)
+        if broad_scope is not None:
+            rewritten_body = self._rewrite_broad_scope(working_body)
+            findings.append(
+                _CheckFinding(
+                    check_name=broad_scope.check_name,
+                    outcome=broad_scope.outcome,
+                    reason=broad_scope.reason,
+                    confidence=broad_scope.confidence,
+                    rewritten_body=rewritten_body,
+                )
+            )
+            working_body = rewritten_body
+
+        missing_validation = self._check_missing_validation(working_body)
+        if missing_validation is not None:
+            rewritten_body = self._rewrite_missing_validation(working_body)
+            findings.append(
+                _CheckFinding(
+                    check_name=missing_validation.check_name,
+                    outcome=missing_validation.outcome,
+                    reason=missing_validation.reason,
+                    confidence=missing_validation.confidence,
+                    rewritten_body=rewritten_body,
+                )
+            )
+            working_body = rewritten_body
+
+        complexity = self._check_complexity_estimate(normalized_title, working_body)
+        if complexity is not None:
+            findings.append(complexity)
+
+        if not findings:
+            return SanitizationResult(
+                outcome=SanitizationOutcome.ACCEPTED,
+                original_text=original_text,
+                sanitized_text=original_text,
+                reason="task accepted unchanged",
+                confidence=0.98,
+                checks_failed=[],
+            )
+
+        severe = max(
+            findings,
+            key=lambda finding: (_SEVERITY[finding.outcome.value], -findings.index(finding)),
+        )
+        rewritten_body = (
+            working_body if any(f.rewritten_body is not None for f in findings) else normalized_body
+        )
+        return SanitizationResult(
+            outcome=severe.outcome,
+            original_text=original_text,
+            sanitized_text=self._compose_issue_text(normalized_title, rewritten_body),
+            reason=severe.reason,
+            confidence=severe.confidence,
+            checks_failed=[finding.check_name for finding in findings],
+        )
+
+    def _check_description_length(self, body: str) -> _CheckFinding | None:
+        body = str(body or "").strip()
+        if len(body) >= 40:
+            return None
+        return _CheckFinding(
+            check_name="description_length",
+            outcome=SanitizationOutcome.DROPPED,
+            reason="task description is too short to dispatch safely",
+            confidence=0.99,
+        )
+
+    def _check_truncation(self, body: str) -> _CheckFinding | None:
+        sanitized_ok, sanitation_reason = assess_issue_body_sanitation(body)
+        if not sanitized_ok and sanitation_reason in {
+            "task_truncated",
+            "auto_decomposed_missing_task",
+        }:
+            return _CheckFinding(
+                check_name="truncation",
+                outcome=SanitizationOutcome.DROPPED,
+                reason=f"task appears truncated or incomplete ({sanitation_reason})",
+                confidence=0.96,
+            )
+
+        lines = [line.rstrip() for line in str(body or "").splitlines() if line.strip()]
+        if any(line.endswith("\\") for line in lines):
+            return _CheckFinding(
+                check_name="truncation",
+                outcome=SanitizationOutcome.DROPPED,
+                reason="task contains a line continuation marker and appears truncated",
+                confidence=0.97,
+            )
+        if not lines:
+            return None
+        last_line = lines[-1].strip()
+        if _MID_SENTENCE_ENDING_RE.search(last_line):
+            return _CheckFinding(
+                check_name="truncation",
+                outcome=SanitizationOutcome.DROPPED,
+                reason="task ends mid-sentence and appears truncated",
+                confidence=0.9,
+            )
+        return None
+
+    def _check_contradictory_scope(self, body: str) -> _CheckFinding | None:
+        actions_by_path: dict[str, set[str]] = {}
+        for path, action in self._extract_scope_actions(body):
+            actions_by_path.setdefault(path, set()).add(action)
+
+        conflicts = sorted(
+            path
+            for path, actions in actions_by_path.items()
+            if {"create", "modify"}.issubset(actions)
+        )
+        if not conflicts:
+            return None
+        return _CheckFinding(
+            check_name="contradictory_scope",
+            outcome=SanitizationOutcome.QUARANTINED,
+            reason=f"scope contradicts itself for {', '.join(conflicts[:3])}",
+            confidence=0.94,
+        )
+
+    def _check_impossible_validation(
+        self,
+        body: str,
+        repo_root: Path | None,
+    ) -> _CheckFinding | None:
+        repo_path = Path(repo_root or self.repo_root).resolve()
+        commands = extract_pre_dispatch_validation_commands(body)
+        if not commands:
+            return None
+
+        missing = find_missing_pre_dispatch_validation_targets(commands, repo_root=repo_path)
+        if not missing:
+            return None
+
+        declared_new = set(extract_declared_new_file_paths(body))
+        unresolved = [path for path in missing if path not in declared_new]
+        if not unresolved:
+            return None
+
+        return _CheckFinding(
+            check_name="impossible_validation",
+            outcome=SanitizationOutcome.QUARANTINED,
+            reason=f"validation references missing target(s): {', '.join(unresolved)}",
+            confidence=0.98,
+        )
+
+    def _check_scope_too_broad(self, body: str) -> _CheckFinding | None:
+        paths = self._extract_scope_paths(body)
+        if len(paths) <= 5:
+            return None
+        return _CheckFinding(
+            check_name="scope_too_broad",
+            outcome=SanitizationOutcome.QUARANTINED,
+            reason=f"file scope spans {len(paths)} files; quarantine before dispatch",
+            confidence=0.93,
+        )
+
+    def _check_missing_validation(self, body: str) -> _CheckFinding | None:
+        if self._has_validation_contract(body):
+            return None
+        return _CheckFinding(
+            check_name="missing_validation",
+            outcome=SanitizationOutcome.REWRITTEN,
+            reason="task is missing a validation contract; add a default bounded ruff check",
+            confidence=0.91,
+        )
+
+    def _check_duplicate_of_merged(self, body: str) -> _CheckFinding | None:
+        for pr_number in self._extract_pr_references(body):
+            if self._is_pr_merged(pr_number):
+                return _CheckFinding(
+                    check_name="duplicate_merged_pr",
+                    outcome=SanitizationOutcome.DROPPED,
+                    reason=f"task references already-merged PR #{pr_number}",
+                    confidence=0.97,
+                )
+        return None
+
+    def _check_complexity_estimate(self, title: str, body: str) -> _CheckFinding | None:
+        complexity = self._estimate_complexity(title, body)
+        if complexity in {"small", "medium"}:
+            return None
+
+        spec = self._build_spec(title, body)
+        if spec.work_orders:
+            return None
+
+        return _CheckFinding(
+            check_name="complexity_estimate",
+            outcome=SanitizationOutcome.QUARANTINED,
+            reason=f"task complexity is {complexity} without explicit work orders",
+            confidence=0.88,
+        )
+
+    def _rewrite_missing_validation(self, body: str) -> str:
+        if self._has_validation_contract(body):
+            return str(body or "").strip()
+
+        target = self._most_specific_scope_path(body)
+        validation_command = (
+            f"python3 -m ruff check {target}" if target else "python3 -m ruff check aragora/"
+        )
+        base = str(body or "").rstrip()
+        appendix = f"## Validation\n- {validation_command}"
+        if not base:
+            return appendix
+        return f"{base}\n\n{appendix}"
+
+    def _rewrite_broad_scope(self, body: str) -> str:
+        chosen = self._most_specific_scope_path(body)
+        if not chosen:
+            return str(body or "").strip()
+
+        lines = str(body or "").splitlines()
+        rewritten: list[str] = []
+        in_scope_section = False
+        scope_heading_seen = False
+        replaced_scope = False
+
+        for raw_line in lines:
+            heading_match = _HEADING_RE.match(raw_line)
+            if heading_match:
+                heading = heading_match.group("heading").strip().rstrip(":").lower()
+                if in_scope_section and not self._matches_scope_section(heading):
+                    in_scope_section = False
+                if self._matches_scope_section(heading):
+                    in_scope_section = True
+                    scope_heading_seen = True
+                    rewritten.append(raw_line.rstrip())
+                    if not replaced_scope:
+                        rewritten.append(f"- `{chosen}`")
+                        replaced_scope = True
+                    continue
+            if in_scope_section:
+                continue
+            rewritten.append(raw_line.rstrip())
+
+        result = "\n".join(line for line in rewritten).strip()
+        if not scope_heading_seen:
+            suffix = f"## File Scope\n- `{chosen}`"
+            return f"{result}\n\n{suffix}".strip() if result else suffix
+        return result
+
+    def _compose_issue_text(self, title: str, body: str) -> str:
+        title = str(title or "").strip()
+        body = str(body or "").strip()
+        if title and body:
+            return f"{title}\n\n{body}"
+        return title or body
+
+    def _extract_pr_references(self, body: str) -> list[int]:
+        pr_numbers: list[int] = []
+        for match in _PR_REF_RE.finditer(str(body or "")):
+            value = match.group("short") or match.group("long") or match.group("url") or ""
+            try:
+                number = int(value)
+            except ValueError:
+                continue
+            if number not in pr_numbers:
+                pr_numbers.append(number)
+        return pr_numbers
+
+    def _is_pr_merged(self, pr_number: int) -> bool:
+        try:
+            proc = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "state,mergedAt"],
+                cwd=self.repo_root,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except (FileNotFoundError, OSError):
+            return False
+        if proc.returncode != 0:
+            return False
+        try:
+            payload = json.loads(proc.stdout or "{}")
+        except json.JSONDecodeError:
+            return False
+        return bool(payload.get("mergedAt")) or str(payload.get("state", "")).upper() == "MERGED"
+
+    def _build_spec(self, title: str, body: str) -> SwarmSpec:
+        return SwarmSpec(
+            raw_goal=str(title or "").strip(),
+            refined_goal=str(body or "").strip(),
+            acceptance_criteria=extract_pre_dispatch_validation_commands(body),
+            constraints=SwarmSpec.infer_constraints([title, body]),
+            file_scope_hints=self._extract_scope_paths(body),
+            work_orders=self._extract_work_orders(body),
+        )
+
+    def _extract_work_orders(self, body: str) -> list[dict[str, str]]:
+        lines = str(body or "").splitlines()
+        work_orders: list[dict[str, str]] = []
+        in_breakdown = False
+        for raw_line in lines:
+            heading_match = _HEADING_RE.match(raw_line)
+            if heading_match:
+                heading = heading_match.group("heading").strip().rstrip(":").lower()
+                in_breakdown = heading in {"task breakdown", "work orders", "work order", "phases"}
+                continue
+            if re.match(r"^\s*phase\s+\d+\s*:", raw_line, re.IGNORECASE):
+                work_orders.append({"title": raw_line.strip()})
+                continue
+            if not in_breakdown:
+                continue
+            item_match = _LIST_ITEM_RE.match(raw_line)
+            if item_match:
+                work_orders.append({"title": item_match.group("text").strip()})
+        return work_orders
+
+    def _estimate_complexity(self, title: str, body: str) -> str:
+        text = self._compose_issue_text(title, body).lower()
+        explicit = _COMPLEXITY_RE.search(text)
+        if explicit:
+            value = explicit.group("value").lower()
+            if value in {"small"}:
+                return "small"
+            if value in {"medium"}:
+                return "medium"
+            return "high"
+
+        path_count = len(self._extract_scope_paths(body))
+        phase_count = len(
+            re.findall(r"^\s*phase\s+\d+\s*:", str(body or ""), re.IGNORECASE | re.MULTILINE)
+        )
+        if path_count > 5 or phase_count >= 3:
+            return "high"
+        if (
+            any(
+                token in text
+                for token in ("end-to-end", "e2e", "orchestration", "multi-step", "refactor")
+            )
+            and path_count >= 3
+        ):
+            return "high"
+        return "medium"
+
+    def _extract_scope_paths(self, body: str) -> list[str]:
+        lines = str(body or "").splitlines()
+        paths: list[str] = []
+        in_scope_section = False
+        in_validation_section = False
+
+        for raw_line in lines:
+            heading_match = _HEADING_RE.match(raw_line)
+            if heading_match:
+                heading = heading_match.group("heading").strip().rstrip(":").lower()
+                in_scope_section = self._matches_scope_section(heading)
+                in_validation_section = self._matches_validation_section(heading)
+                continue
+
+            if in_validation_section:
+                continue
+            if in_scope_section or any(
+                keyword in raw_line.lower() for keyword in (*_CREATE_KEYWORDS, *_MODIFY_KEYWORDS)
+            ):
+                for path in self._extract_paths_from_line(raw_line):
+                    if path not in paths:
+                        paths.append(path)
+
+        if paths:
+            return paths
+
+        for raw_line in lines:
+            if any(
+                token in raw_line.lower()
+                for token in ("pytest ", "ruff check", "python -m pytest", "python3 -m pytest")
+            ):
+                continue
+            for path in self._extract_paths_from_line(raw_line):
+                if path not in paths:
+                    paths.append(path)
+        return paths
+
+    def _extract_scope_actions(self, body: str) -> list[tuple[str, str]]:
+        actions: list[tuple[str, str]] = []
+        lines = str(body or "").splitlines()
+        in_scope_section = False
+        in_validation_section = False
+
+        for raw_line in lines:
+            heading_match = _HEADING_RE.match(raw_line)
+            if heading_match:
+                heading = heading_match.group("heading").strip().rstrip(":").lower()
+                in_scope_section = self._matches_scope_section(heading)
+                in_validation_section = self._matches_validation_section(heading)
+                continue
+            if in_validation_section:
+                continue
+            if not in_scope_section and not any(
+                keyword in raw_line.lower() for keyword in (*_CREATE_KEYWORDS, *_MODIFY_KEYWORDS)
+            ):
+                continue
+
+            lowered = raw_line.lower()
+            line_actions: set[str] = set()
+            if any(keyword in lowered for keyword in _CREATE_KEYWORDS):
+                line_actions.add("create")
+            if any(keyword in lowered for keyword in _MODIFY_KEYWORDS):
+                line_actions.add("modify")
+            if not line_actions:
+                continue
+            for path in self._extract_paths_from_line(raw_line):
+                for action in sorted(line_actions):
+                    actions.append((path, action))
+        return actions
+
+    def _extract_paths_from_line(self, line: str) -> list[str]:
+        paths: list[str] = []
+        for match in _PATH_RE.finditer(str(line or "")):
+            path = SwarmSpec.sanitize_file_scope_entry(match.group("path"))
+            if path and SwarmSpec.is_concrete_repo_path_hint(path) and path not in paths:
+                paths.append(path)
+        for path in SwarmSpec.infer_file_scope_hints(str(line or "")):
+            if path and SwarmSpec.is_concrete_repo_path_hint(path) and path not in paths:
+                paths.append(path)
+        return paths
+
+    def _most_specific_scope_path(self, body: str) -> str:
+        for path in self._extract_scope_paths(body):
+            if SwarmSpec.is_concrete_repo_path_hint(path) and "(" not in path and ")" not in path:
+                return path
+        return ""
+
+    def _has_validation_contract(self, body: str) -> bool:
+        lines = str(body or "").splitlines()
+        for raw_line in lines:
+            heading_match = _HEADING_RE.match(raw_line)
+            if not heading_match:
+                continue
+            heading = heading_match.group("heading").strip().rstrip(":").lower()
+            if self._matches_validation_section(heading):
+                return True
+        if extract_issue_validation_contract(body):
+            return True
+        lowered = str(body or "").lower()
+        return any(
+            token in lowered
+            for token in (
+                "ruff check",
+                "pytest ",
+                "python -m pytest",
+                "python3 -m pytest",
+            )
+        )
+
+    @staticmethod
+    def _matches_scope_section(heading: str) -> bool:
+        return any(
+            heading == prefix or heading.startswith(f"{prefix} ")
+            for prefix in _SCOPE_SECTION_PREFIXES
+        )
+
+    @staticmethod
+    def _matches_validation_section(heading: str) -> bool:
+        return any(
+            heading == prefix or heading.startswith(f"{prefix} ")
+            for prefix in _VALIDATION_SECTION_PREFIXES
+        )
+
+
+__all__ = [
+    "SanitizationOutcome",
+    "SanitizationResult",
+    "TaskSanitizer",
+]

--- a/tests/swarm/test_task_sanitizer.py
+++ b/tests/swarm/test_task_sanitizer.py
@@ -1,0 +1,399 @@
+"""Tests for task_sanitizer admission rules."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    (tmp_path / "aragora" / "swarm").mkdir(parents=True)
+    (tmp_path / "tests" / "swarm").mkdir(parents=True)
+    (tmp_path / "scripts").mkdir(parents=True)
+    (tmp_path / "aragora" / "swarm" / "boss_loop.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "aragora" / "swarm" / "boss_validation.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "aragora" / "swarm" / "supervisor.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "aragora" / "swarm" / "worker_launcher.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "aragora" / "swarm" / "spec.py").write_text("pass\n", encoding="utf-8")
+    (tmp_path / "tests" / "swarm" / "test_boss_loop.py").write_text(
+        "def test_ok():\n    pass\n", encoding="utf-8"
+    )
+    (tmp_path / "tests" / "swarm" / "test_supervisor.py").write_text(
+        "def test_ok():\n    pass\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+@pytest.fixture()
+def sanitizer(repo_root: Path) -> TaskSanitizer:
+    return TaskSanitizer(repo_root=repo_root)
+
+
+class TestOutcomes:
+    def test_accepted_issue_passes_through_unchanged(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py` (modify)\n\n"
+            "## Validation\n"
+            "- python3 -m ruff check aragora/swarm/boss_loop.py\n"
+        )
+
+        result = sanitizer.sanitize("Narrow boss loop guard", body)
+
+        assert result.outcome is SanitizationOutcome.ACCEPTED
+        assert result.sanitized_text == result.original_text
+        assert result.checks_failed == []
+
+    def test_rewritten_when_validation_missing(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/boss_validation.py` (modify)\n\n"
+            "Tighten the pre-dispatch rule so it rejects incomplete tasks before worker launch."
+        )
+
+        result = sanitizer.sanitize("Add a missing validation contract", body)
+
+        assert result.outcome is SanitizationOutcome.REWRITTEN
+        assert "## Validation" in result.sanitized_text
+        assert "python3 -m ruff check aragora/swarm/boss_validation.py" in result.sanitized_text
+        assert "missing_validation" in result.checks_failed
+
+    def test_dropped_when_description_too_short(self, sanitizer: TaskSanitizer) -> None:
+        result = sanitizer.sanitize("Too short", "Tiny task only.")
+        assert result.outcome is SanitizationOutcome.DROPPED
+        assert result.reason == "task description is too short to dispatch safely"
+        assert "description_length" in result.checks_failed
+
+    def test_quarantined_when_scope_is_too_broad(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## Allowed Write Set\n"
+            "- `aragora/swarm/a.py` (modify)\n"
+            "- `aragora/swarm/b.py` (modify)\n"
+            "- `aragora/swarm/c.py` (modify)\n"
+            "- `aragora/swarm/d.py` (modify)\n"
+            "- `aragora/swarm/e.py` (modify)\n"
+            "- `aragora/swarm/f.py` (modify)\n"
+        )
+
+        result = sanitizer.sanitize("Over-broad lane", body)
+
+        assert result.outcome is SanitizationOutcome.QUARANTINED
+        assert "scope_too_broad" in result.checks_failed
+        assert "- `aragora/swarm/a.py`" in result.sanitized_text
+        assert "- `aragora/swarm/f.py`" not in result.sanitized_text
+
+
+class TestImpossibleValidation:
+    def test_impossible_validation_quarantines_missing_target(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/boss_validation.py` (modify)\n\n"
+            "## Validation\n"
+            "- python3 -m pytest tests/swarm/test_missing.py -q\n"
+        )
+
+        finding = sanitizer._check_impossible_validation(body, sanitizer.repo_root)
+
+        assert finding is not None
+        assert finding.outcome is SanitizationOutcome.QUARANTINED
+        assert "tests/swarm/test_missing.py" in finding.reason
+
+    def test_impossible_validation_allows_existing_target(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py` (modify)\n\n"
+            "## Validation\n"
+            "- python3 -m pytest tests/swarm/test_boss_loop.py -q\n"
+        )
+
+        assert sanitizer._check_impossible_validation(body, sanitizer.repo_root) is None
+
+    def test_impossible_validation_allows_declared_created_file(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `tests/swarm/test_new_lane.py` (create)\n\n"
+            "## Validation\n"
+            "- python3 -m pytest tests/swarm/test_new_lane.py -q\n"
+        )
+
+        assert sanitizer._check_impossible_validation(body, sanitizer.repo_root) is None
+
+    def test_impossible_validation_allows_declared_created_target_with_new_file_marker(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## Files\n"
+            "- `tests/swarm/test_generated_lane.py` (new file)\n\n"
+            "## Validation\n"
+            "- pytest tests/swarm/test_generated_lane.py -q\n"
+        )
+
+        assert sanitizer._check_impossible_validation(body, sanitizer.repo_root) is None
+
+
+class TestScopeTooBroad:
+    def test_scope_too_broad_ignores_five_files(self, sanitizer: TaskSanitizer) -> None:
+        body = "\n".join(
+            [
+                "## File Scope",
+                "- `aragora/swarm/a.py` (modify)",
+                "- `aragora/swarm/b.py` (modify)",
+                "- `aragora/swarm/c.py` (modify)",
+                "- `aragora/swarm/d.py` (modify)",
+                "- `aragora/swarm/e.py` (modify)",
+            ]
+        )
+        assert sanitizer._check_scope_too_broad(body) is None
+
+    def test_scope_too_broad_rejects_six_files(self, sanitizer: TaskSanitizer) -> None:
+        body = "\n".join(
+            [
+                "## File Scope",
+                "- `aragora/swarm/a.py` (modify)",
+                "- `aragora/swarm/b.py` (modify)",
+                "- `aragora/swarm/c.py` (modify)",
+                "- `aragora/swarm/d.py` (modify)",
+                "- `aragora/swarm/e.py` (modify)",
+                "- `aragora/swarm/f.py` (modify)",
+            ]
+        )
+        finding = sanitizer._check_scope_too_broad(body)
+        assert finding is not None
+        assert finding.outcome is SanitizationOutcome.QUARANTINED
+
+    def test_scope_too_broad_deduplicates_duplicate_paths(self, sanitizer: TaskSanitizer) -> None:
+        body = "\n".join(
+            [
+                "## Allowed Write Set",
+                "- `aragora/swarm/a.py` (modify)",
+                "- `aragora/swarm/a.py` (modify)",
+                "- `aragora/swarm/b.py` (modify)",
+                "- `aragora/swarm/c.py` (modify)",
+                "- `aragora/swarm/d.py` (modify)",
+                "- `aragora/swarm/e.py` (modify)",
+            ]
+        )
+        assert sanitizer._check_scope_too_broad(body) is None
+
+    def test_scope_too_broad_uses_scope_section_not_validation_targets(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py` (modify)\n\n"
+            "## Validation\n"
+            "- pytest tests/swarm/test_boss_loop.py -q\n"
+            "- pytest tests/swarm/test_supervisor.py -q\n"
+            "- pytest tests/swarm/test_generated.py -q\n"
+            "- pytest tests/swarm/test_more.py -q\n"
+            "- pytest tests/swarm/test_extra.py -q\n"
+            "- pytest tests/swarm/test_overflow.py -q\n"
+        )
+        assert sanitizer._check_scope_too_broad(body) is None
+
+
+class TestContradictoryScope:
+    def test_contradictory_scope_detects_create_and_modify_same_path(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (create)\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n"
+        )
+        finding = sanitizer._check_contradictory_scope(body)
+        assert finding is not None
+        assert finding.outcome is SanitizationOutcome.QUARANTINED
+
+    def test_contradictory_scope_detects_create_and_update_same_path(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## Files\n"
+            "- create `tests/swarm/test_task_sanitizer.py`\n"
+            "- update `tests/swarm/test_task_sanitizer.py`\n"
+        )
+        finding = sanitizer._check_contradictory_scope(body)
+        assert finding is not None
+        assert "contradicts itself" in finding.reason
+
+    def test_contradictory_scope_ignores_different_paths(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (create)\n"
+            "- `tests/swarm/test_task_sanitizer.py` (modify)\n"
+        )
+        assert sanitizer._check_contradictory_scope(body) is None
+
+    def test_contradictory_scope_ignores_single_create_marker(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        body = "## Allowed Write Set\n- `tests/swarm/test_task_sanitizer.py` (create)\n"
+        assert sanitizer._check_contradictory_scope(body) is None
+
+
+class TestRewriteMissingValidation:
+    def test_rewrite_missing_validation_appends_section(self, sanitizer: TaskSanitizer) -> None:
+        body = "## File Scope\n- `aragora/swarm/task_sanitizer.py` (modify)\n"
+        rewritten = sanitizer._rewrite_missing_validation(body)
+        assert "## Validation" in rewritten
+        assert "python3 -m ruff check aragora/swarm/task_sanitizer.py" in rewritten
+
+    def test_rewrite_missing_validation_uses_most_specific_path(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n"
+            "- `aragora/swarm/worker_launcher.py` (modify)\n"
+        )
+        rewritten = sanitizer._rewrite_missing_validation(body)
+        assert "aragora/swarm/worker_launcher.py" not in rewritten.split("## Validation", 1)[1]
+        assert "aragora/swarm/task_sanitizer.py" in rewritten
+
+    def test_rewrite_missing_validation_falls_back_to_aragora_root(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        rewritten = sanitizer._rewrite_missing_validation(
+            "Investigate crash-heavy overnight tasks."
+        )
+        assert "python3 -m ruff check aragora/" in rewritten
+
+    def test_rewrite_missing_validation_keeps_existing_text(self, sanitizer: TaskSanitizer) -> None:
+        body = "Investigate why rescue_worker_crash dominates the overnight metrics."
+        rewritten = sanitizer._rewrite_missing_validation(body)
+        assert rewritten.startswith(body)
+
+
+class TestDuplicateMerged:
+    def test_duplicate_of_merged_drops_issue(
+        self, sanitizer: TaskSanitizer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sanitizer, "_is_pr_merged", lambda pr_number: pr_number == 1234)
+        finding = sanitizer._check_duplicate_of_merged("Follow-up to PR #1234")
+        assert finding is not None
+        assert finding.outcome is SanitizationOutcome.DROPPED
+
+    def test_duplicate_of_open_pr_is_ignored(
+        self, sanitizer: TaskSanitizer, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(sanitizer, "_is_pr_merged", lambda _pr_number: False)
+        assert sanitizer._check_duplicate_of_merged("Follow-up to PR #1234") is None
+
+
+class TestComplexityEstimate:
+    def test_high_complexity_without_work_orders_is_quarantined(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "Estimated complexity: high\n\n"
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n"
+            "- `aragora/swarm/boss_validation.py` (modify)\n"
+            "- `tests/swarm/test_task_sanitizer.py` (modify)\n"
+        )
+        finding = sanitizer._check_complexity_estimate("Refactor the admission pipeline", body)
+        assert finding is not None
+        assert finding.outcome is SanitizationOutcome.QUARANTINED
+
+    def test_high_complexity_with_explicit_work_orders_is_allowed(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "Estimated complexity: high\n\n"
+            "## Task Breakdown\n"
+            "1. Build the sanitizer helper\n"
+            "2. Add regression tests\n"
+            "3. Validate the new admission gate\n"
+        )
+        assert sanitizer._check_complexity_estimate("Break down the fix", body) is None
+
+
+class TestSanitizePipeline:
+    def test_pipeline_drops_truncated_overnight_issue(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## Task\n"
+            "Investigate why the overnight crash-heavy lane keeps dispatching impossible tasks and \\\n"
+        )
+        result = sanitizer.sanitize("Overnight crash lane", body)
+        assert result.outcome is SanitizationOutcome.DROPPED
+        assert "truncation" in result.checks_failed
+
+    def test_pipeline_quarantines_impossible_validation_issue(
+        self, sanitizer: TaskSanitizer
+    ) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n\n"
+            "## Validation\n"
+            "- pytest tests/swarm/test_nonexistent_retry.py -q\n"
+        )
+        result = sanitizer.sanitize("Fix rescue_worker_crash lane", body)
+        assert result.outcome is SanitizationOutcome.QUARANTINED
+        assert "impossible_validation" in result.checks_failed
+
+    def test_pipeline_rewrites_missing_validation_from_metrics_style_issue(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "## Allowed Write Set\n"
+            "- `aragora/swarm/task_sanitizer.py` (create)\n"
+            "- `tests/swarm/test_task_sanitizer.py` (create)\n\n"
+            "The overnight metrics show 153/205 rescue_worker_crash outcomes. Add a small pre-dispatch sanitizer."
+        )
+        result = sanitizer.sanitize("BC-04 Add sanitizer outcomes", body)
+        assert result.outcome is SanitizationOutcome.REWRITTEN
+        assert "## Validation" in result.sanitized_text
+
+    def test_pipeline_quarantines_high_complexity_without_work_orders(
+        self,
+        sanitizer: TaskSanitizer,
+    ) -> None:
+        body = (
+            "Estimated complexity: large\n\n"
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n"
+            "- `aragora/swarm/boss_validation.py` (modify)\n"
+            "- `aragora/swarm/spec.py` (modify)\n"
+            "- `aragora/swarm/issue_scanner.py` (modify)\n"
+            "- `tests/swarm/test_task_sanitizer.py` (modify)\n"
+            "- `tests/swarm/test_boss_validation.py` (modify)\n"
+        )
+        result = sanitizer.sanitize("Overnight crash reduction pass", body)
+        assert result.outcome is SanitizationOutcome.QUARANTINED
+        assert "complexity_estimate" in result.checks_failed
+
+    def test_pipeline_prefers_dropped_over_rewrite(self, sanitizer: TaskSanitizer) -> None:
+        body = "Tiny task only."
+        result = sanitizer.sanitize("Short and missing validation", body)
+        assert result.outcome is SanitizationOutcome.DROPPED
+        assert "description_length" in result.checks_failed
+
+
+class TestAcceptedUnchanged:
+    def test_accepted_issue_is_returned_unchanged(self, sanitizer: TaskSanitizer) -> None:
+        body = (
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n\n"
+            "## Validation\n"
+            "- python3 -m ruff check aragora/swarm/task_sanitizer.py\n"
+        )
+        result = sanitizer.sanitize("Tighten sanitizer matchers", body)
+        assert result.outcome is SanitizationOutcome.ACCEPTED
+        assert result.original_text == result.sanitized_text


### PR DESCRIPTION
## Summary
- add a standalone task sanitizer for boss-loop admission decisions
- quarantine contradictory, over-broad, truncated, and impossible-to-validate tasks
- rewrite missing validation sections into a bounded default validation contract

## Validation
- `python3 -m pytest tests/swarm/test_task_sanitizer.py -q`
- `python3 -m ruff check aragora/swarm/task_sanitizer.py tests/swarm/test_task_sanitizer.py`
- `python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/swarm/task_sanitizer.py tests/swarm/test_task_sanitizer.py --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`