### PR TITLE
feat(swarm): filter low-signal boss issues from metrics

### DIFF
--- a/aragora/swarm/issue_scanner.py
+++ b/aragora/swarm/issue_scanner.py
@@ -9,10 +9,27 @@ and creates GitHub issues with the ``boss-ready`` label.
 
 from __future__ import annotations
 
+import json
 import hashlib
 import re
+import subprocess
+from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
+
+from aragora.swarm.terminal_truth import classify_from_metrics
+
+
+DEFAULT_BOSS_METRICS_PATH = Path(".aragora/overnight/boss_metrics.jsonl")
+_CATEGORY_TITLE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"^narrow broad except", re.IGNORECASE), "broad_exception"),
+    (re.compile(r"^replace silent", re.IGNORECASE), "silent_exception"),
+    (re.compile(r"^add unit tests", re.IGNORECASE), "test_coverage"),
+    (re.compile(r"^add request body", re.IGNORECASE), "handler_validation"),
+    (re.compile(r"^add return type", re.IGNORECASE), "type_annotation"),
+    (re.compile(r"^address todo", re.IGNORECASE), "actionable_todo"),
+)
 
 
 @dataclass
@@ -34,6 +51,172 @@ class BossIssueCandidate:
         if not self.fingerprint:
             raw = f"{self.category}:{':'.join(sorted(self.file_scope + self.new_files))}"
             self.fingerprint = hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def infer_issue_category_from_title(title: str | None) -> str | None:
+    """Infer scanner category from a boss-issue title."""
+    if not title:
+        return None
+
+    normalized = title.strip()
+    for pattern, category in _CATEGORY_TITLE_PATTERNS:
+        if pattern.match(normalized):
+            return category
+    return None
+
+
+def _load_prompt_metric_rows(metrics_path: Path) -> list[dict[str, Any]]:
+    if not metrics_path.exists():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    try:
+        with metrics_path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if float(row.get("prompt_chars", 0) or 0) <= 0:
+                    continue
+                rows.append(row)
+    except OSError:
+        return []
+    return rows
+
+
+def _fetch_issue_titles(
+    issue_numbers: set[int], *, repo: str = "synaptent/aragora"
+) -> dict[int, str]:
+    """Fetch GitHub issue titles in batches via gh GraphQL.
+
+    Returns an empty mapping if gh is unavailable or the call fails.
+    """
+    if not issue_numbers:
+        return {}
+
+    owner, sep, name = repo.partition("/")
+    if not sep or not owner or not name:
+        return {}
+
+    titles: dict[int, str] = {}
+    batch_size = 25
+    sorted_numbers = sorted(issue_numbers)
+    for idx in range(0, len(sorted_numbers), batch_size):
+        batch = sorted_numbers[idx : idx + batch_size]
+        aliases = "\n".join(
+            f"issue_{number}: issue(number: {number}) {{ number title }}" for number in batch
+        )
+        query = f'query {{ repository(owner: "{owner}", name: "{name}") {{\n{aliases}\n}} }}'
+        try:
+            result = subprocess.run(
+                ["gh", "api", "graphql", "-f", f"query={query}"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return {}
+
+        if result.returncode != 0:
+            return {}
+
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            return {}
+
+        repository = payload.get("data", {}).get("repository", {})
+        if not isinstance(repository, dict):
+            return {}
+
+        for issue in repository.values():
+            if not isinstance(issue, dict):
+                continue
+            number = issue.get("number")
+            title = issue.get("title")
+            if isinstance(number, int) and isinstance(title, str) and title.strip():
+                titles[number] = title.strip()
+
+    return titles
+
+
+def historical_category_stats(metrics_path: Path) -> dict[str, dict[str, float]]:
+    """Compute per-category success and crash rates from prompt-era boss metrics."""
+    rows = _load_prompt_metric_rows(metrics_path)
+    if not rows:
+        return {}
+
+    title_by_issue: dict[int, str] = {}
+    missing_titles: set[int] = set()
+    for row in rows:
+        issue_number = row.get("issue_number")
+        if not isinstance(issue_number, int):
+            continue
+        issue_title = row.get("issue_title")
+        if isinstance(issue_title, str) and issue_title.strip():
+            title_by_issue[issue_number] = issue_title.strip()
+        else:
+            missing_titles.add(issue_number)
+
+    title_by_issue.update(
+        {
+            number: title
+            for number, title in _fetch_issue_titles(missing_titles).items()
+            if title.strip()
+        }
+    )
+
+    totals: dict[str, dict[str, float]] = defaultdict(
+        lambda: {
+            "total": 0.0,
+            "successes": 0.0,
+            "crashes": 0.0,
+            "elapsed_seconds": 0.0,
+            "success_rate": 0.0,
+            "crash_rate": 0.0,
+            "avg_elapsed_seconds": 0.0,
+        }
+    )
+    for row in rows:
+        issue_number = row.get("issue_number")
+        if not isinstance(issue_number, int):
+            continue
+        category = infer_issue_category_from_title(title_by_issue.get(issue_number))
+        if not category:
+            continue
+
+        terminal_class = classify_from_metrics(row)
+        entry = totals[category]
+        entry["total"] += 1.0
+        entry["elapsed_seconds"] += float(row.get("elapsed_seconds", 0.0) or 0.0)
+        if terminal_class.family == "success":
+            entry["successes"] += 1.0
+        if terminal_class.value == "rescue_worker_crash":
+            entry["crashes"] += 1.0
+
+    finalized: dict[str, dict[str, float]] = {}
+    for category, entry in totals.items():
+        total = entry["total"]
+        if total <= 0:
+            continue
+        finalized[category] = {
+            **entry,
+            "success_rate": entry["successes"] / total,
+            "crash_rate": entry["crashes"] / total,
+            "avg_elapsed_seconds": entry["elapsed_seconds"] / total,
+        }
+    return finalized
+
+
+def historical_success_rates(metrics_path: Path) -> dict[str, float]:
+    """Return real success rates per scanner category from boss metrics."""
+    return {
+        category: stats["success_rate"]
+        for category, stats in historical_category_stats(metrics_path).items()
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -544,6 +727,8 @@ def scan_all(
     repo_root: Path,
     *,
     categories: list[str] | None = None,
+    metrics_path: Path | None = None,
+    min_success_rate: float = 0.3,
 ) -> list[BossIssueCandidate]:
     """Run all scanners and return merged, prioritized candidates."""
     all_scanners = {
@@ -562,6 +747,19 @@ def scan_all(
         scanner = all_scanners.get(cat)
         if scanner:
             candidates.extend(scanner(repo_root))
+
+    resolved_metrics_path = metrics_path or repo_root / DEFAULT_BOSS_METRICS_PATH
+    historical_rates = historical_success_rates(resolved_metrics_path)
+    for candidate in candidates:
+        if candidate.category in historical_rates:
+            candidate.expected_success_rate = historical_rates[candidate.category]
+
+    if min_success_rate > 0:
+        candidates = [
+            candidate
+            for candidate in candidates
+            if candidate.expected_success_rate >= min_success_rate
+        ]
 
     # Sort: highest success rate first, then by category priority
     candidates.sort(

--- a/scripts/analyze_crash_patterns.py
+++ b/scripts/analyze_crash_patterns.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Analyze boss-loop crash patterns from prompt-era metrics rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.issue_scanner import (  # noqa: E402
+    DEFAULT_BOSS_METRICS_PATH,
+    historical_category_stats,
+)
+from aragora.swarm.terminal_truth import classify_from_metrics  # noqa: E402
+
+
+def load_prompt_rows(metrics_file: Path) -> list[dict[str, Any]]:
+    """Load prompt-era rows only (`prompt_chars > 0`)."""
+    if not metrics_file.exists():
+        return []
+
+    rows: list[dict[str, Any]] = []
+    with metrics_file.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            if float(row.get("prompt_chars", 0) or 0) <= 0:
+                continue
+            rows.append(row)
+    return rows
+
+
+def terminal_class_counts(rows: list[dict[str, Any]]) -> Counter[str]:
+    """Count prompt-era rows by terminal class."""
+    return Counter(classify_from_metrics(row).value for row in rows)
+
+
+def low_success_categories(
+    category_stats: dict[str, dict[str, float]],
+    *,
+    threshold: float,
+) -> list[str]:
+    """Return categories whose historical success rate is below the threshold."""
+    return sorted(
+        category
+        for category, stats in category_stats.items()
+        if stats.get("success_rate", 0.0) < threshold
+    )
+
+
+def render_report(
+    rows: list[dict[str, Any]],
+    counts: Counter[str],
+    category_stats: dict[str, dict[str, float]],
+    *,
+    threshold: float,
+) -> str:
+    """Render a human-readable crash analysis report."""
+    lines = [
+        f"Prompt-era rows analyzed: {len(rows)}",
+        "",
+        "Terminal class counts:",
+    ]
+    for terminal_class, count in counts.most_common():
+        lines.append(f"  {terminal_class}: {count}")
+
+    if not category_stats:
+        lines.extend(
+            [
+                "",
+                "Category analysis:",
+                "  No category stats available. Metrics rows are missing issue titles and title lookup returned no data.",
+            ]
+        )
+        return "\n".join(lines)
+
+    lines.extend(["", "Per-category stats:"])
+    for category in sorted(category_stats):
+        stats = category_stats[category]
+        lines.append(
+            "  "
+            f"{category}: success_rate={stats['success_rate']:.3f} "
+            f"crash_rate={stats['crash_rate']:.3f} "
+            f"avg_elapsed={stats['avg_elapsed_seconds']:.1f}s "
+            f"total={int(stats['total'])}"
+        )
+
+    deprioritized = low_success_categories(category_stats, threshold=threshold)
+    lines.extend(["", f"Categories below success threshold ({threshold:.2f}):"])
+    if deprioritized:
+        lines.extend(f"  - {category}" for category in deprioritized)
+    else:
+        lines.append("  none")
+
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Analyze boss-loop crash patterns.")
+    parser.add_argument(
+        "--metrics-file",
+        type=Path,
+        default=REPO_ROOT / DEFAULT_BOSS_METRICS_PATH,
+        help="Path to boss_metrics.jsonl",
+    )
+    parser.add_argument(
+        "--min-success-rate",
+        type=float,
+        default=0.3,
+        help="Threshold below which categories should be deprioritized",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    rows = load_prompt_rows(args.metrics_file)
+    if not rows:
+        print(f"No prompt-era rows found in {args.metrics_file}")
+        return 1
+
+    counts = terminal_class_counts(rows)
+    category_stats = historical_category_stats(args.metrics_file)
+    print(
+        render_report(
+            rows,
+            counts,
+            category_stats,
+            threshold=args.min_success_rate,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_analyze_crash_patterns.py
+++ b/tests/scripts/test_analyze_crash_patterns.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.analyze_crash_patterns import (
+    load_prompt_rows,
+    low_success_categories,
+    render_report,
+    terminal_class_counts,
+)
+
+
+def test_load_prompt_rows_filters_prompt_versions(tmp_path: Path) -> None:
+    metrics_path = tmp_path / "boss_metrics.jsonl"
+    metrics_path.write_text(
+        "\n".join(
+            [
+                json.dumps({"issue_number": 1, "prompt_chars": 0, "worker_status": "completed"}),
+                json.dumps({"issue_number": 2, "prompt_chars": 10, "worker_status": "completed"}),
+            ]
+        )
+        + "\n"
+    )
+
+    rows = load_prompt_rows(metrics_path)
+
+    assert [row["issue_number"] for row in rows] == [2]
+
+
+def test_terminal_class_counts_and_report(tmp_path: Path) -> None:
+    rows = [
+        {
+            "issue_number": 101,
+            "issue_title": "Narrow broad except Exception in foo.py",
+            "prompt_chars": 1000,
+            "worker_status": "completed",
+            "worker_outcome": "pr_adopted",
+            "publish_action": "pr_created",
+            "elapsed_seconds": 120.0,
+            "files_changed": 1,
+            "has_deliverable": True,
+        },
+        {
+            "issue_number": 102,
+            "issue_title": "Narrow broad except Exception in bar.py",
+            "prompt_chars": 1000,
+            "worker_status": "failed",
+            "worker_outcome": "worker_crash",
+            "publish_action": "",
+            "elapsed_seconds": 180.0,
+            "files_changed": 0,
+            "has_deliverable": False,
+        },
+    ]
+
+    counts = terminal_class_counts(rows)
+    category_stats = {
+        "broad_exception": {
+            "total": 2.0,
+            "success_rate": 0.5,
+            "crash_rate": 0.5,
+            "avg_elapsed_seconds": 150.0,
+        }
+    }
+
+    report = render_report(rows, counts, category_stats, threshold=0.6)
+
+    assert counts["deliverable_pr_created"] == 1
+    assert counts["rescue_worker_crash"] == 1
+    assert (
+        "broad_exception: success_rate=0.500 crash_rate=0.500 avg_elapsed=150.0s total=2" in report
+    )
+    assert "Categories below success threshold (0.60):" in report
+    assert "  - broad_exception" in report
+
+
+def test_low_success_categories_sorts_threshold_breaches() -> None:
+    stats = {
+        "broad_exception": {"success_rate": 0.9},
+        "handler_validation": {"success_rate": 0.1},
+        "type_annotation": {"success_rate": 0.2},
+    }
+
+    assert low_success_categories(stats, threshold=0.3) == [
+        "handler_validation",
+        "type_annotation",
+    ]
+
+
+def test_render_report_handles_missing_category_stats() -> None:
+    rows = [
+        {
+            "issue_number": 201,
+            "prompt_chars": 1000,
+            "worker_status": "failed",
+            "worker_outcome": "worker_crash",
+            "publish_action": "",
+            "elapsed_seconds": 33.0,
+            "files_changed": 0,
+            "has_deliverable": False,
+        }
+    ]
+    report = render_report(
+        rows,
+        terminal_class_counts(rows),
+        {},
+        threshold=0.3,
+    )
+
+    assert "No category stats available" in report

--- a/tests/swarm/test_issue_scanner.py
+++ b/tests/swarm/test_issue_scanner.py
@@ -9,6 +9,8 @@ import pytest
 
 from aragora.swarm.issue_scanner import (
     BossIssueCandidate,
+    historical_success_rates,
+    infer_issue_category_from_title,
     scan_all,
     scan_bare_except_handlers,
     scan_silent_exception_swallowing,
@@ -200,12 +202,12 @@ class TestScannersOnRealRepo:
         return Path(__file__).resolve().parent.parent.parent
 
     def test_scan_all_returns_candidates(self, repo_root):
-        candidates = scan_all(repo_root)
+        candidates = scan_all(repo_root, metrics_path=repo_root / ".missing-boss-metrics.jsonl")
         assert len(candidates) > 0
         assert all(isinstance(c, BossIssueCandidate) for c in candidates)
 
     def test_candidates_have_required_fields(self, repo_root):
-        candidates = scan_all(repo_root)
+        candidates = scan_all(repo_root, metrics_path=repo_root / ".missing-boss-metrics.jsonl")
         for c in candidates[:10]:
             assert len(c.title) > 20, f"Title too short: {c.title}"
             assert len(c.description) > 40, f"Description too short for {c.title}"
@@ -215,7 +217,7 @@ class TestScannersOnRealRepo:
             assert 0 < c.expected_success_rate <= 1.0
 
     def test_scan_all_sorted_by_success_rate(self, repo_root):
-        candidates = scan_all(repo_root)
+        candidates = scan_all(repo_root, metrics_path=repo_root / ".missing-boss-metrics.jsonl")
         rates = [c.expected_success_rate for c in candidates]
         # Should be roughly descending (within same rate, category order matters)
         for i in range(len(rates) - 1):
@@ -248,3 +250,115 @@ class TestScannersOnRealRepo:
         for c in results:
             assert c.category == "actionable_todo"
             assert "TODO" in c.description or "FIXME" in c.description
+
+
+class TestHistoricalSuccessRates:
+    def test_infer_issue_category_from_title(self) -> None:
+        assert infer_issue_category_from_title("Narrow broad except Exception in foo.py")
+        assert infer_issue_category_from_title("Replace silent exception swallowing in foo.py")
+        assert infer_issue_category_from_title("Add unit tests for swarm/foo.py")
+        assert infer_issue_category_from_title("Add request body validation to foo.py handlers")
+        assert infer_issue_category_from_title("Add return type annotations to foo.py")
+        assert infer_issue_category_from_title("Address TODO/FIXME items in foo.py")
+        assert infer_issue_category_from_title("Unrelated issue title") is None
+
+    def test_historical_success_rates_uses_inline_issue_titles(self, tmp_path: Path) -> None:
+        metrics_path = tmp_path / "boss_metrics.jsonl"
+        rows = [
+            {
+                "issue_number": 101,
+                "issue_title": "Narrow broad except Exception in foo.py",
+                "prompt_chars": 1000,
+                "worker_status": "completed",
+                "worker_outcome": "pr_adopted",
+                "publish_action": "pr_created",
+                "elapsed_seconds": 120.0,
+                "files_changed": 1,
+                "has_deliverable": True,
+            },
+            {
+                "issue_number": 102,
+                "issue_title": "Narrow broad except Exception in bar.py",
+                "prompt_chars": 1200,
+                "worker_status": "failed",
+                "worker_outcome": "worker_crash",
+                "publish_action": "",
+                "elapsed_seconds": 240.0,
+                "files_changed": 0,
+                "has_deliverable": False,
+            },
+            {
+                "issue_number": 201,
+                "issue_title": "Add request body validation to baz.py handlers",
+                "prompt_chars": 1500,
+                "worker_status": "needs_human",
+                "worker_outcome": "blocked",
+                "publish_action": "",
+                "elapsed_seconds": 90.0,
+                "files_changed": 0,
+                "has_deliverable": False,
+            },
+        ]
+        metrics_path.write_text("\n".join(__import__("json").dumps(row) for row in rows) + "\n")
+
+        rates = historical_success_rates(metrics_path)
+
+        assert rates["broad_exception"] == pytest.approx(0.5)
+        assert rates["handler_validation"] == pytest.approx(0.0)
+
+    def test_scan_all_overrides_rates_and_filters(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        candidate = BossIssueCandidate(
+            category="handler_validation",
+            title="Add request body validation to foo.py handlers",
+            description="desc",
+            file_scope=["aragora/server/handlers/foo.py"],
+            expected_success_rate=0.5,
+        )
+
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_handler_validation_gaps",
+            lambda repo_root, limit=15: [candidate],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_bare_except_handlers",
+            lambda repo_root, limit=20: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_silent_exception_swallowing",
+            lambda repo_root, limit=20: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_untested_modules",
+            lambda repo_root, min_loc=50, max_loc=300, limit=30: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_actionable_todos",
+            lambda repo_root, min_length=25, limit=15: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_type_annotation_gaps",
+            lambda repo_root, limit=10: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.historical_success_rates",
+            lambda metrics_path: {"handler_validation": 0.2},
+        )
+
+        filtered = scan_all(
+            tmp_path,
+            categories=["handler_validation"],
+            metrics_path=tmp_path / "boss_metrics.jsonl",
+            min_success_rate=0.3,
+        )
+        assert filtered == []
+
+        unfiltered = scan_all(
+            tmp_path,
+            categories=["handler_validation"],
+            metrics_path=tmp_path / "boss_metrics.jsonl",
+            min_success_rate=0.0,
+        )
+        assert len(unfiltered) == 1
+        assert unfiltered[0].expected_success_rate == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- add a crash-pattern analysis script for prompt-era boss metrics rows
- teach `issue_scanner` to derive historical category stats from terminal-truth classified metrics
- deprioritize low-success categories from boss-ready issue generation instead of overfeeding low-signal lanes

## Validation
- `python3 -m pytest tests/swarm/test_issue_scanner.py tests/scripts/test_analyze_crash_patterns.py -q`
- `python3 -m ruff check aragora/swarm/issue_scanner.py tests/swarm/test_issue_scanner.py scripts/analyze_crash_patterns.py tests/scripts/test_analyze_crash_patterns.py`
- `python3 scripts/run_typecheck_gate.py --repo-root . --files aragora/swarm/issue_scanner.py scripts/analyze_crash_patterns.py --json`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`