### PR TITLE
fix(swarm): preserve timeout salvage outcome

### DIFF
--- a/aragora/swarm/supervisor_probes.py
+++ b/aragora/swarm/supervisor_probes.py
@@ -317,6 +317,7 @@ def _finalize_completed_work_order_result(
     worker_type_circuit_breaker_policy: dict[str, Any] | None = None,
 ) -> bool:
     merge_gate = self._merge_gate_state(item)
+    preserved_outcome = str(item.get("worker_outcome", "")).strip()
     item["merge_gate"] = merge_gate
     if merge_gate.get("verification_missing_reason"):
         item["verification_missing_reason"] = merge_gate["verification_missing_reason"]
@@ -342,7 +343,11 @@ def _finalize_completed_work_order_result(
             _append_repair_journal(self, item, result, reason="merge_gate_failed")
             item["review_status"] = "changes_requested"
             item["receipt_id"] = None
-            item["worker_outcome"] = WorkerOutcome.MERGE_GATE_FAILED.value
+            if preserved_outcome not in {
+                WorkerOutcome.CRASH_WITH_SALVAGE.value,
+                WorkerOutcome.TIMEOUT_WITH_SALVAGE.value,
+            }:
+                item["worker_outcome"] = WorkerOutcome.MERGE_GATE_FAILED.value
             self._release_terminal_lease(item)
             return False
 


### PR DESCRIPTION
## Summary
- preserve salvage-specific `worker_outcome` values when merge-gate checks later block approval
- keep merge-gate failures surfaced through lane status and blocking metadata instead of clobbering the worker terminal classification

## Validation
- `python3 -m pytest tests/swarm/test_worker_outcome_classification.py -q -o cache_dir=/tmp/pytest-cache-worker-outcome-full`
- `python3 -m pytest tests/swarm/test_supervisor.py::test_collect_finished_results_recovers_commit_backed_timeout_without_marker -q -o cache_dir=/tmp/pytest-cache-timeout-recovery-exact`
- `python3 -m pytest tests/swarm/test_supervisor.py -q -k 'collect_results_blocks_merge_gate_without_verification_plan' -o cache_dir=/tmp/pytest-cache-timeout-salvage-supervisor`
- `python3 -m ruff check aragora/swarm/supervisor_probes.py tests/swarm/test_worker_outcome_classification.py tests/swarm/test_supervisor.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
