### PR TITLE
feat(boss): filter issue generation by historical success rate

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -256,6 +256,12 @@ def main() -> None:
     parser.add_argument("--max-issues", type=int, default=20, help="Max issues to create")
     parser.add_argument("--categories", nargs="*", help="Filter to specific categories")
     parser.add_argument("--label", default="boss-ready", help="Label for created issues")
+    parser.add_argument(
+        "--min-success-rate",
+        type=float,
+        default=0.3,
+        help="Drop candidate categories below this historical success rate",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     args = parser.parse_args()
 
@@ -263,9 +269,11 @@ def main() -> None:
 
     # 1. Scan
     print(f"Scanning {repo_root}...")
-    # Use min_success_rate=0.0 when upgrader is active — the upgrader transforms
-    # low-quality issues into high-quality ones, so historical rates don't apply
-    candidates = scan_all(repo_root, categories=args.categories, min_success_rate=0.0)
+    candidates = scan_all(
+        repo_root,
+        categories=args.categories,
+        min_success_rate=args.min_success_rate,
+    )
     print(
         f"  Found {len(candidates)} candidates across {len(set(c.category for c in candidates))} categories"
     )

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -26,7 +26,7 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
     pr_conflict = _candidate("pr_conflict_module", file_scope=["aragora/pr_conflict_module.py"])
     eligible = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
 
-    scan_calls: list[tuple[object, object]] = []
+    scan_calls: list[tuple[object, object, object]] = []
     fetch_existing_calls: list[str] = []
     fetch_pr_calls: list[str] = []
     create_calls: list[tuple[str, str, str, str]] = []
@@ -34,8 +34,9 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
     monkeypatch.setattr(
         mod,
         "scan_all",
-        lambda repo_root, categories=None: (
-            scan_calls.append((repo_root, categories)) or [duplicate, pr_conflict, eligible]
+        lambda repo_root, categories=None, min_success_rate=0.3: (
+            scan_calls.append((repo_root, categories, min_success_rate))
+            or [duplicate, pr_conflict, eligible]
         ),
     )
     monkeypatch.setattr(
@@ -74,6 +75,7 @@ def test_main_dry_run_fetches_and_filters_like_real_mode(
 
     out = capsys.readouterr().out
     assert scan_calls
+    assert scan_calls[0][2] == 0.3
     assert fetch_existing_calls == ["org/repo"]
     assert fetch_pr_calls == ["org/repo"]
     assert "DRY RUN — would create 1 issues" in out
@@ -90,7 +92,11 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     second = _candidate("second_module", file_scope=["aragora/second_module.py"])
 
     created: list[tuple[str, str, str, str]] = []
-    monkeypatch.setattr(mod, "scan_all", lambda repo_root, categories=None: [first, second])
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [first, second],
+    )
     monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
     monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
     monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
@@ -124,3 +130,35 @@ def test_main_create_mode_trims_to_max_and_writes_fingerprint(
     assert title == first.title
     assert label == "boss-ready"
     assert f"<!-- fingerprint:{first.fingerprint} -->" in body
+
+
+def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
+    eligible = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+    scan_calls: list[tuple[object, object, object]] = []
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: (
+            scan_calls.append((repo_root, categories, min_success_rate)) or [eligible]
+        ),
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--dry-run",
+            "--min-success-rate",
+            "0.5",
+        ],
+    )
+
+    mod.main()
+
+    _ = capsys.readouterr()
+    assert scan_calls
+    assert scan_calls[0][2] == 0.5


### PR DESCRIPTION
## Summary
- add an explicit `--min-success-rate` flag to `scripts/generate_boss_issues.py`
- stop forcing `min_success_rate=0.0` so generator dry-runs and refill runs respect historical scanner performance by default
- add generator tests proving the default and explicit threshold values are passed through to `scan_all()`

## Validation
- `python3 -m pytest tests/scripts/test_generate_boss_issues.py tests/swarm/test_issue_scanner.py tests/scripts/test_analyze_crash_patterns.py -q`
- `python3 -m ruff check scripts/generate_boss_issues.py scripts/analyze_crash_patterns.py aragora/swarm/issue_scanner.py tests/scripts/test_generate_boss_issues.py tests/swarm/test_issue_scanner.py tests/scripts/test_analyze_crash_patterns.py`
- `python3 scripts/analyze_crash_patterns.py --metrics-file .aragora/overnight/boss_metrics.jsonl`
- `python3 scripts/generate_boss_issues.py --dry-run --max-issues 5 --min-success-rate 0.3`

## Live Note
The current overnight metrics show the queue is now the real problem, not the flag wiring. On the latest run, categories below `0.30` are:
- `broad_exception`
- `handler_validation`
- `silent_exception`
- `test_coverage`

At the current threshold, the generator dry-run found only one surviving category and all 10 candidates in that lane were already duplicates of open issues.
