### PR TITLE
feat(swarm): apply task sanitizer before boss dispatch

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -31,6 +31,7 @@ from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     TerminalClass,
     classify_from_metrics,
@@ -2836,7 +2837,9 @@ class BossLoop:
     @staticmethod
     def _published_deliverable_comment(worker_result: dict[str, Any]) -> str | None:
         publish_result = worker_result.get("publish_result")
-        if not BossLoop._publish_result_succeeded(publish_result):
+        if not isinstance(publish_result, dict) or not BossLoop._publish_result_succeeded(
+            publish_result
+        ):
             return None
         pr_url = BossLoop._published_pr_url(worker_result)
         if pr_url is None:
@@ -4760,6 +4763,64 @@ class BossLoop:
         """
         from aragora.swarm.spec import SwarmSpec
 
+        original_issue_body = str(issue.body or "").strip()
+        sanitizer = TaskSanitizer(repo_root=Path.cwd())
+        sanitization = sanitizer.sanitize(issue.title, original_issue_body)
+        sanitized_issue_body = str(sanitization.sanitized_text or "").strip()
+        issue_title_text = str(issue.title or "").strip()
+        if issue_title_text and sanitized_issue_body.startswith(issue_title_text):
+            sanitized_issue_body = sanitized_issue_body[len(issue_title_text) :].strip()
+        if not sanitized_issue_body:
+            sanitized_issue_body = original_issue_body
+
+        logger.info(
+            "task_sanitizer issue=#%s outcome=%s checks=%s",
+            issue.number,
+            sanitization.outcome.value,
+            ",".join(sanitization.checks_failed) if sanitization.checks_failed else "-",
+        )
+        if sanitization.outcome in {
+            SanitizationOutcome.DROPPED,
+            SanitizationOutcome.QUARANTINED,
+        }:
+            if "impossible_validation" in sanitization.checks_failed:
+                outcome = "verification_target_missing"
+                missing_targets_text = sanitization.reason.partition(":")[2].strip()
+                if not missing_targets_text:
+                    missing_targets_text = "unknown targets"
+                next_actions = [
+                    "Refresh the issue's Acceptance Criteria or Test Plan so validation commands reference current repo paths.",
+                    "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
+                ]
+                reasons = [
+                    f"Issue #{issue.number} references missing validation targets: {missing_targets_text}"
+                ]
+            else:
+                outcome = "sanitation_failed"
+                next_actions = (
+                    [
+                        "Rewrite the issue body so it contains a complete bounded task description before redispatch.",
+                    ]
+                    if sanitization.outcome is SanitizationOutcome.DROPPED
+                    else [
+                        "Narrow the write scope, validation targets, or task breakdown before redispatch.",
+                    ]
+                )
+                reasons = [
+                    (
+                        f"Issue #{issue.number} was {sanitization.outcome.value} by task sanitizer: "
+                        f"{sanitization.reason}"
+                    )
+                ]
+            return {
+                "status": "needs_human",
+                "outcome": outcome,
+                "sanitizer_outcome": sanitization.outcome.value,
+                "checks_failed": list(sanitization.checks_failed),
+                "reasons": reasons,
+                "next_actions": next_actions,
+            }
+
         refinement: dict[str, Any] = {}
         refined_prompt = ""
         pending_handoff = self._pending_handoff_prompts.get(issue.number)
@@ -4774,7 +4835,7 @@ class BossLoop:
 
             refinement = await refine_worker_prompt(
                 issue.title,
-                issue.body or "",
+                sanitized_issue_body,
                 repo_path=Path.cwd(),
             )
             refinement_worker_env = build_refinement_worker_env(refinement)
@@ -4791,7 +4852,7 @@ class BossLoop:
             logger.debug("Prompt refinement skipped: %s", exc)
             refinement_worker_env = {}
 
-        body_lines = [str(line).strip() for line in str(issue.body or "").splitlines()]
+        body_lines = [str(line).strip() for line in sanitized_issue_body.splitlines()]
         scope_hints = list(
             dict.fromkeys(
                 [
@@ -4800,7 +4861,7 @@ class BossLoop:
                         for path in refinement.get("files_to_change", [])
                         if str(path).strip()
                     ],
-                    *SwarmSpec.infer_file_scope_hints(issue.body or ""),
+                    *SwarmSpec.infer_file_scope_hints(sanitized_issue_body),
                 ]
             )
         )
@@ -4819,7 +4880,7 @@ class BossLoop:
         goal = _compose_issue_dispatch_goal(
             issue.number,
             issue.title,
-            issue_body=issue.body or "",
+            issue_body=sanitized_issue_body,
             refined_prompt=refined_prompt,
         )
         if "git add -A && git commit" not in goal:
@@ -4847,7 +4908,7 @@ class BossLoop:
             try:
                 from aragora.swarm.micro_decomposer import build_micro_work_orders
 
-                validation_contract_raw = extract_issue_validation_contract(issue.body)
+                validation_contract_raw = extract_issue_validation_contract(sanitized_issue_body)
                 micro_orders = build_micro_work_orders(
                     goal=goal,
                     file_scope_hints=scope_hints,
@@ -4870,7 +4931,7 @@ class BossLoop:
             except Exception as exc:
                 logger.debug("Micro-decomposition skipped: %s", exc)
 
-        validation_contract = extract_issue_validation_contract(issue.body)
+        validation_contract = extract_issue_validation_contract(sanitized_issue_body)
         if validation_contract and self.config.use_focused_verification:
             # Replace broad test suite commands with focused verification
             # that only tests files related to the worker's changes
@@ -4908,7 +4969,7 @@ class BossLoop:
         self._attach_issue_handoff_metadata(spec, issue)
 
         gate = await check_pre_dispatch_gate(
-            issue.body or "",
+            sanitized_issue_body,
             repo_root=Path.cwd(),
             use_llm=self.config.use_llm_pre_dispatch_gate,
         )

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2964,6 +2964,146 @@ async def test_dispatch_issue_allows_missing_validation_target_for_explicit_new_
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_rewrites_missing_validation_before_dispatch() -> None:
+    issue = _make_issue(
+        2460,
+        "Add sanitizer admission wiring",
+        body=(
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n\n"
+            "Tighten the admission path so broad or contradictory tasks stop before worker launch."
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "status": "completed",
+        "run_id": "run-2460",
+        "work_orders": [
+            {"status": "completed", "branch": "codex/task-sanitizer", "commit_shas": ["abc123"]}
+        ],
+    }
+    refinement_mock = AsyncMock(
+        return_value={
+            "refined_prompt": "",
+            "files_to_change": [],
+            "test_patterns": [],
+            "constraints": [],
+            "context_gathered": False,
+        }
+    )
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=refinement_mock,
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(return_value=fake_run)
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    spec = mock_commander_cls.return_value.run_supervised_from_spec.await_args.args[0]
+    assert spec.acceptance_criteria == ["python3 -m ruff check aragora/swarm/task_sanitizer.py"]
+    assert "## Validation" in refinement_mock.await_args.args[1]
+    assert (
+        "python3 -m ruff check aragora/swarm/task_sanitizer.py"
+        in refinement_mock.await_args.args[1]
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_quarantines_broad_scope_before_dispatch() -> None:
+    issue = _make_issue(
+        2461,
+        "Over-broad crash cleanup lane",
+        body=(
+            "## Allowed Write Set\n"
+            "- `aragora/swarm/a.py` (modify)\n"
+            "- `aragora/swarm/b.py` (modify)\n"
+            "- `aragora/swarm/c.py` (modify)\n"
+            "- `aragora/swarm/d.py` (modify)\n"
+            "- `aragora/swarm/e.py` (modify)\n"
+            "- `aragora/swarm/f.py` (modify)\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "sanitation_failed"
+    assert result["sanitizer_outcome"] == "quarantined"
+    assert "scope_too_broad" in result["checks_failed"]
+    mock_commander_cls.return_value.run_supervised_from_spec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_drops_short_task_before_dispatch() -> None:
+    issue = _make_issue(
+        2462,
+        "Too short",
+        body="Tiny task only.",
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "sanitation_failed"
+    assert result["sanitizer_outcome"] == "dropped"
+    assert "description_length" in result["checks_failed"]
+    mock_commander_cls.return_value.run_supervised_from_spec.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_consumes_pending_handoff_prompt_and_target_agent() -> None:
     issue = _make_issue(1701, "Retry same issue with handoff")
     loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="claude"))


### PR DESCRIPTION
## Summary
- run TaskSanitizer at the start of boss-loop dispatch and feed rewritten issue bodies into refinement, scope inference, validation extraction, and the pre-dispatch gate
- preserve the existing verification-target-missing blocked outcome while adding sanitizer metadata for dropped and quarantined tasks
- add boss-loop regression tests for rewritten, quarantined, and dropped admission cases

## Validation
- python3 -m pytest tests/swarm/test_boss_loop.py -k 'missing_validation_target or task_before_dispatch or rewrites_missing_validation or quarantines_broad_scope or drops_short_task' -q
- python3 -m pytest tests/swarm/test_task_sanitizer.py -q
- python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/boss_loop.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD