### PR TITLE
feat(boss): decompose vague parent issues into bounded children

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -31,6 +31,7 @@ from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     TerminalClass,
     classify_from_metrics,
@@ -2836,7 +2837,9 @@ class BossLoop:
     @staticmethod
     def _published_deliverable_comment(worker_result: dict[str, Any]) -> str | None:
         publish_result = worker_result.get("publish_result")
-        if not BossLoop._publish_result_succeeded(publish_result):
+        if not isinstance(publish_result, dict) or not BossLoop._publish_result_succeeded(
+            publish_result
+        ):
             return None
         pr_url = BossLoop._published_pr_url(worker_result)
         if pr_url is None:
@@ -4760,6 +4763,64 @@ class BossLoop:
         """
         from aragora.swarm.spec import SwarmSpec
 
+        original_issue_body = str(issue.body or "").strip()
+        sanitizer = TaskSanitizer(repo_root=Path.cwd())
+        sanitization = sanitizer.sanitize(issue.title, original_issue_body)
+        sanitized_issue_body = str(sanitization.sanitized_text or "").strip()
+        issue_title_text = str(issue.title or "").strip()
+        if issue_title_text and sanitized_issue_body.startswith(issue_title_text):
+            sanitized_issue_body = sanitized_issue_body[len(issue_title_text) :].strip()
+        if not sanitized_issue_body:
+            sanitized_issue_body = original_issue_body
+
+        logger.info(
+            "task_sanitizer issue=#%s outcome=%s checks=%s",
+            issue.number,
+            sanitization.outcome.value,
+            ",".join(sanitization.checks_failed) if sanitization.checks_failed else "-",
+        )
+        if sanitization.outcome in {
+            SanitizationOutcome.DROPPED,
+            SanitizationOutcome.QUARANTINED,
+        }:
+            if "impossible_validation" in sanitization.checks_failed:
+                outcome = "verification_target_missing"
+                missing_targets_text = sanitization.reason.partition(":")[2].strip()
+                if not missing_targets_text:
+                    missing_targets_text = "unknown targets"
+                next_actions = [
+                    "Refresh the issue's Acceptance Criteria or Test Plan so validation commands reference current repo paths.",
+                    "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
+                ]
+                reasons = [
+                    f"Issue #{issue.number} references missing validation targets: {missing_targets_text}"
+                ]
+            else:
+                outcome = "sanitation_failed"
+                next_actions = (
+                    [
+                        "Rewrite the issue body so it contains a complete bounded task description before redispatch.",
+                    ]
+                    if sanitization.outcome is SanitizationOutcome.DROPPED
+                    else [
+                        "Narrow the write scope, validation targets, or task breakdown before redispatch.",
+                    ]
+                )
+                reasons = [
+                    (
+                        f"Issue #{issue.number} was {sanitization.outcome.value} by task sanitizer: "
+                        f"{sanitization.reason}"
+                    )
+                ]
+            return {
+                "status": "needs_human",
+                "outcome": outcome,
+                "sanitizer_outcome": sanitization.outcome.value,
+                "checks_failed": list(sanitization.checks_failed),
+                "reasons": reasons,
+                "next_actions": next_actions,
+            }
+
         refinement: dict[str, Any] = {}
         refined_prompt = ""
         pending_handoff = self._pending_handoff_prompts.get(issue.number)
@@ -4774,7 +4835,7 @@ class BossLoop:
 
             refinement = await refine_worker_prompt(
                 issue.title,
-                issue.body or "",
+                sanitized_issue_body,
                 repo_path=Path.cwd(),
             )
             refinement_worker_env = build_refinement_worker_env(refinement)
@@ -4791,7 +4852,7 @@ class BossLoop:
             logger.debug("Prompt refinement skipped: %s", exc)
             refinement_worker_env = {}
 
-        body_lines = [str(line).strip() for line in str(issue.body or "").splitlines()]
+        body_lines = [str(line).strip() for line in sanitized_issue_body.splitlines()]
         scope_hints = list(
             dict.fromkeys(
                 [
@@ -4800,7 +4861,7 @@ class BossLoop:
                         for path in refinement.get("files_to_change", [])
                         if str(path).strip()
                     ],
-                    *SwarmSpec.infer_file_scope_hints(issue.body or ""),
+                    *SwarmSpec.infer_file_scope_hints(sanitized_issue_body),
                 ]
             )
         )
@@ -4819,7 +4880,7 @@ class BossLoop:
         goal = _compose_issue_dispatch_goal(
             issue.number,
             issue.title,
-            issue_body=issue.body or "",
+            issue_body=sanitized_issue_body,
             refined_prompt=refined_prompt,
         )
         if "git add -A && git commit" not in goal:
@@ -4847,7 +4908,7 @@ class BossLoop:
             try:
                 from aragora.swarm.micro_decomposer import build_micro_work_orders
 
-                validation_contract_raw = extract_issue_validation_contract(issue.body)
+                validation_contract_raw = extract_issue_validation_contract(sanitized_issue_body)
                 micro_orders = build_micro_work_orders(
                     goal=goal,
                     file_scope_hints=scope_hints,
@@ -4870,7 +4931,7 @@ class BossLoop:
             except Exception as exc:
                 logger.debug("Micro-decomposition skipped: %s", exc)
 
-        validation_contract = extract_issue_validation_contract(issue.body)
+        validation_contract = extract_issue_validation_contract(sanitized_issue_body)
         if validation_contract and self.config.use_focused_verification:
             # Replace broad test suite commands with focused verification
             # that only tests files related to the worker's changes
@@ -4908,7 +4969,7 @@ class BossLoop:
         self._attach_issue_handoff_metadata(spec, issue)
 
         gate = await check_pre_dispatch_gate(
-            issue.body or "",
+            sanitized_issue_body,
             repo_root=Path.cwd(),
             use_llm=self.config.use_llm_pre_dispatch_gate,
         )

--- a/aragora/swarm/decomposition_bridge.py
+++ b/aragora/swarm/decomposition_bridge.py
@@ -1,0 +1,467 @@
+"""Bridge vague boss issues into bounded child candidates.
+
+This module intentionally reuses existing swarm/nomic primitives instead of
+introducing a parallel decomposition stack:
+
+1. Parent issue text is normalized into a ``SwarmSpec``.
+2. ``TaskDecomposer`` extracts subtasks when possible.
+3. Broad subtasks fall back to ``build_micro_work_orders``.
+4. Each child is converted into a ``BossIssueCandidate``.
+5. Each child is gated through ``TaskSanitizer`` and boss-validation.
+
+The output is a bounded list of child candidates suitable for queueing as
+worker-friendly follow-up issues.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any
+
+from aragora.nomic.task_decomposer import SubTask, TaskDecomposer
+from aragora.swarm.boss_validation import (
+    assess_issue_body_sanitation,
+    extract_declared_new_file_paths,
+    extract_issue_validation_contract,
+    extract_pre_dispatch_validation_commands,
+    sanitize_issue_body_for_dispatch,
+)
+from aragora.swarm.issue_scanner import BossIssueCandidate, infer_issue_category_from_title
+from aragora.swarm.micro_decomposer import build_micro_work_orders
+from aragora.swarm.prompt_refiner import refine_worker_prompt
+from aragora.swarm.spec import SwarmSpec
+from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
+
+logger = logging.getLogger(__name__)
+
+_MAX_SCOPE_PATHS = 5
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for raw in values:
+        value = str(raw or "").strip()
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered
+
+
+def _normalize_scope_paths(values: list[str]) -> list[str]:
+    return _ordered_unique(
+        [
+            normalized
+            for normalized in (SwarmSpec.sanitize_file_scope_entry(value) for value in values)
+            if normalized
+        ]
+    )
+
+
+def _partition_paths(
+    repo_root: Path,
+    paths: list[str],
+    *,
+    declared_new: list[str] | None = None,
+) -> tuple[list[str], list[str]]:
+    declared = set(_normalize_scope_paths(list(declared_new or [])))
+    file_scope: list[str] = []
+    new_files: list[str] = []
+    for path in _normalize_scope_paths(paths):
+        if path in declared or not (repo_root / path).exists():
+            new_files.append(path)
+        else:
+            file_scope.append(path)
+    return file_scope[:_MAX_SCOPE_PATHS], new_files[:_MAX_SCOPE_PATHS]
+
+
+def _normalized_complexity(value: str) -> str:
+    lowered = str(value or "").strip().lower()
+    if lowered in {"low", "small", "trivial"}:
+        return "small"
+    return "medium"
+
+
+def _success_criteria_lines(success_criteria: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    for key, value in dict(success_criteria or {}).items():
+        left = str(key or "").strip()
+        right = str(value or "").strip()
+        if left and right:
+            lines.append(f"{left} {right}")
+    return _ordered_unique(lines)
+
+
+class DecompositionBridge:
+    """Transform a vague parent issue into bounded child candidates."""
+
+    def __init__(self, repo_root: Path):
+        self.repo_root = Path(repo_root).resolve()
+        self._task_decomposer = TaskDecomposer()
+        self._task_sanitizer = TaskSanitizer(repo_root=self.repo_root)
+
+    async def decompose_issue(
+        self,
+        title: str,
+        body: str,
+        *,
+        max_children: int = 5,
+    ) -> list[BossIssueCandidate]:
+        if max_children <= 0:
+            return []
+
+        spec = self._build_parent_spec(title, body)
+        parent_category = infer_issue_category_from_title(title) or "decomposed_issue"
+        actionable = spec.refined_goal or spec.raw_goal or str(title or "").strip()
+
+        decomposition = self._task_decomposer.analyze(
+            actionable,
+            file_scope_hints=list(spec.file_scope_hints),
+            acceptance_criteria=list(spec.acceptance_criteria),
+            constraints=list(spec.constraints),
+        )
+
+        candidates: list[BossIssueCandidate] = []
+        if decomposition.subtasks:
+            for subtask in decomposition.subtasks:
+                candidates.extend(
+                    await self._candidates_for_subtask(
+                        subtask,
+                        parent_title=title,
+                        parent_category=parent_category,
+                        parent_spec=spec,
+                    )
+                )
+        elif spec.file_scope_hints:
+            candidates.extend(
+                await self._candidates_from_micro_work_orders(
+                    goal=actionable,
+                    parent_title=title,
+                    parent_category=parent_category,
+                    file_scope_hints=list(spec.file_scope_hints),
+                    acceptance_criteria=list(spec.acceptance_criteria),
+                    constraints=list(spec.constraints),
+                )
+            )
+
+        accepted: list[BossIssueCandidate] = []
+        seen_paths: set[str] = set()
+        for candidate in candidates:
+            if len(accepted) >= max_children:
+                break
+            candidate_paths = set(candidate.file_scope + candidate.new_files)
+            if not candidate_paths:
+                continue
+            if candidate_paths & seen_paths:
+                continue
+            if candidate.estimated_complexity not in {"small", "medium"}:
+                continue
+            gated = self._gate_candidate(candidate)
+            if gated is None:
+                continue
+            accepted.append(gated)
+            seen_paths.update(gated.file_scope)
+            seen_paths.update(gated.new_files)
+
+        return accepted[:max_children]
+
+    def decompose_issue_sync(
+        self,
+        title: str,
+        body: str,
+        **kwargs: Any,
+    ) -> list[BossIssueCandidate]:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.decompose_issue(title, body, **kwargs))
+        raise RuntimeError("decompose_issue_sync() cannot run inside an active event loop")
+
+    def _build_parent_spec(self, title: str, body: str) -> SwarmSpec:
+        issue_body = str(body or "").strip()
+        raw_goal = "\n\n".join(
+            part for part in [str(title or "").strip(), issue_body] if part
+        ).strip()
+        spec = SwarmSpec.from_direct_goal(
+            raw_goal,
+            budget_limit_usd=None,
+            requires_approval=True,
+            user_expertise="developer",
+            use_llm=False,
+        )
+        dispatch_body = sanitize_issue_body_for_dispatch(issue_body)
+        if dispatch_body:
+            spec.refined_goal = dispatch_body
+        validation_contract = extract_issue_validation_contract(issue_body)
+        if validation_contract:
+            spec.acceptance_criteria = _ordered_unique(
+                [*spec.acceptance_criteria, *validation_contract]
+            )
+        spec.constraints = _ordered_unique(
+            [*spec.constraints, *SwarmSpec.infer_constraints([title, issue_body])]
+        )
+        spec.file_scope_hints = _ordered_unique(
+            [
+                *spec.file_scope_hints,
+                *SwarmSpec.infer_file_scope_hints(issue_body),
+                *extract_declared_new_file_paths(issue_body),
+            ]
+        )
+        return spec
+
+    async def _candidates_for_subtask(
+        self,
+        subtask: SubTask,
+        *,
+        parent_title: str,
+        parent_category: str,
+        parent_spec: SwarmSpec,
+    ) -> list[BossIssueCandidate]:
+        scope = _normalize_scope_paths(list(subtask.file_scope))
+        if self._needs_micro_decomposition(subtask):
+            return await self._candidates_from_micro_work_orders(
+                goal=subtask.description
+                or subtask.title
+                or parent_spec.refined_goal
+                or parent_title,
+                parent_title=subtask.title or parent_title,
+                parent_category=parent_category,
+                file_scope_hints=scope or list(parent_spec.file_scope_hints),
+                acceptance_criteria=(
+                    _success_criteria_lines(subtask.success_criteria)
+                    or list(parent_spec.acceptance_criteria)
+                ),
+                constraints=list(parent_spec.constraints),
+            )
+
+        return [
+            await self._candidate_from_parts(
+                title=subtask.title or parent_title,
+                category=parent_category,
+                description=subtask.description or parent_spec.refined_goal or parent_title,
+                scope_paths=scope or list(parent_spec.file_scope_hints),
+                acceptance_criteria=(
+                    _success_criteria_lines(subtask.success_criteria)
+                    or list(parent_spec.acceptance_criteria)
+                ),
+                estimated_complexity=_normalized_complexity(subtask.estimated_complexity),
+            )
+        ]
+
+    async def _candidates_from_micro_work_orders(
+        self,
+        *,
+        goal: str,
+        parent_title: str,
+        parent_category: str,
+        file_scope_hints: list[str],
+        acceptance_criteria: list[str],
+        constraints: list[str],
+    ) -> list[BossIssueCandidate]:
+        orders = build_micro_work_orders(
+            goal=goal,
+            file_scope_hints=file_scope_hints,
+            acceptance_criteria=acceptance_criteria,
+            constraints=constraints,
+            repo_root=self.repo_root,
+        )
+        candidates: list[BossIssueCandidate] = []
+        for order in orders:
+            title = str(order.get("title", "")).strip()
+            if "validation" in title.lower():
+                continue
+            scope_paths = [
+                str(path).strip() for path in order.get("file_scope", []) if str(path).strip()
+            ]
+            if not scope_paths:
+                continue
+            candidates.append(
+                await self._candidate_from_parts(
+                    title=title or parent_title,
+                    category=parent_category,
+                    description=str(order.get("description", "")).strip() or goal,
+                    scope_paths=scope_paths,
+                    acceptance_criteria=acceptance_criteria,
+                    estimated_complexity=_normalized_complexity(
+                        str(order.get("estimated_complexity", "low"))
+                    ),
+                )
+            )
+        return candidates
+
+    async def _candidate_from_parts(
+        self,
+        *,
+        title: str,
+        category: str,
+        description: str,
+        scope_paths: list[str],
+        acceptance_criteria: list[str],
+        estimated_complexity: str,
+    ) -> BossIssueCandidate:
+        normalized_scope = _normalize_scope_paths(scope_paths)
+        file_scope, new_files = _partition_paths(self.repo_root, normalized_scope)
+
+        refinement = await refine_worker_prompt(
+            title,
+            description,
+            repo_path=self.repo_root,
+        )
+        refined_description = (
+            str(refinement.get("refined_prompt", "")).strip() or str(description or "").strip()
+        )
+        validation_command = self._choose_validation_command(
+            description=refined_description,
+            file_scope=file_scope,
+            new_files=new_files,
+            acceptance_criteria=acceptance_criteria,
+            refinement=refinement,
+        )
+        acceptance = _ordered_unique(
+            [
+                *acceptance_criteria,
+                *(extract_issue_validation_contract(refined_description) or []),
+                *([f"`{validation_command}` passes"] if validation_command else []),
+            ]
+        )
+        return BossIssueCandidate(
+            category=category,
+            title=title.strip() or "Decomposed child issue",
+            description=refined_description,
+            file_scope=file_scope,
+            new_files=new_files,
+            validation_command=validation_command,
+            acceptance_criteria=acceptance,
+            estimated_complexity=estimated_complexity,
+        )
+
+    def _needs_micro_decomposition(self, subtask: SubTask) -> bool:
+        scope = _normalize_scope_paths(list(subtask.file_scope))
+        if not scope:
+            return False
+        if len(scope) > 1:
+            return True
+        if any(path.endswith("/") for path in scope):
+            return True
+        lowered = str(subtask.estimated_complexity or "").strip().lower()
+        return lowered not in {"low", "small", "trivial"}
+
+    def _choose_validation_command(
+        self,
+        *,
+        description: str,
+        file_scope: list[str],
+        new_files: list[str],
+        acceptance_criteria: list[str],
+        refinement: dict[str, Any],
+    ) -> str:
+        command_sources = [
+            *extract_pre_dispatch_validation_commands(description),
+            *extract_pre_dispatch_validation_commands("\n".join(acceptance_criteria)),
+        ]
+        if command_sources:
+            return command_sources[0]
+
+        test_patterns = [
+            str(item).strip() for item in refinement.get("test_patterns", []) if str(item).strip()
+        ]
+        if test_patterns:
+            return f"python3 -m pytest -q {test_patterns[0]}"
+
+        test_targets = [
+            path
+            for path in [*file_scope, *new_files]
+            if path.startswith("tests/") and path.endswith(".py")
+        ]
+        if test_targets:
+            return f"python3 -m pytest -q {test_targets[0]}"
+
+        lint_targets = [*file_scope, *new_files]
+        if lint_targets:
+            return "python3 -m ruff check " + " ".join(lint_targets[:_MAX_SCOPE_PATHS])
+        return "python3 -m ruff check aragora/"
+
+    def _render_candidate_body(self, candidate: BossIssueCandidate) -> str:
+        parts = [f"## Task\n\n{candidate.description.strip()}"]
+        scope_lines = [f"- `{path}`" for path in candidate.file_scope]
+        scope_lines.extend(f"- `{path}` (create)" for path in candidate.new_files)
+        if scope_lines:
+            parts.append("### File Scope\n" + "\n".join(scope_lines))
+        if candidate.validation_command:
+            parts.append(f"### Validation\n- {candidate.validation_command}")
+        if candidate.acceptance_criteria:
+            parts.append(
+                "### Acceptance Criteria\n"
+                + "\n".join(f"- {item}" for item in candidate.acceptance_criteria)
+            )
+        parts.append(
+            "### Constraints\n"
+            f"- Estimated complexity: {candidate.estimated_complexity}\n"
+            "- Child issue emitted by decomposition bridge\n"
+            "- Keep changes focused to the declared file scope"
+        )
+        return "\n\n".join(parts).strip()
+
+    def _extract_body_text(self, title: str, composed_text: str) -> str:
+        text = str(composed_text or "").strip()
+        stripped_title = str(title or "").strip()
+        if stripped_title and text.startswith(stripped_title):
+            remainder = text[len(stripped_title) :].lstrip()
+            if remainder.startswith("\n"):
+                remainder = remainder.lstrip()
+            return remainder.strip()
+        return text
+
+    def _gate_candidate(self, candidate: BossIssueCandidate) -> BossIssueCandidate | None:
+        body = self._render_candidate_body(candidate)
+        sanitation = self._task_sanitizer.sanitize(candidate.title, body)
+        if sanitation.outcome in {
+            SanitizationOutcome.DROPPED,
+            SanitizationOutcome.QUARANTINED,
+        }:
+            return None
+
+        effective_text = sanitation.sanitized_text or f"{candidate.title}\n\n{body}"
+        effective_body = self._extract_body_text(candidate.title, effective_text)
+
+        commands = extract_pre_dispatch_validation_commands(effective_body)
+        if commands:
+            candidate.validation_command = commands[0]
+
+        paths = _normalize_scope_paths(
+            [
+                *SwarmSpec.infer_file_scope_hints(effective_body),
+                *extract_declared_new_file_paths(effective_body),
+            ]
+        )
+        if paths:
+            file_scope, new_files = _partition_paths(
+                self.repo_root,
+                paths,
+                declared_new=extract_declared_new_file_paths(effective_body),
+            )
+            if file_scope or new_files:
+                candidate.file_scope = file_scope
+                candidate.new_files = new_files
+
+        criteria = extract_issue_validation_contract(effective_body)
+        if criteria:
+            candidate.acceptance_criteria = _ordered_unique(criteria)
+
+        if len(candidate.file_scope) + len(candidate.new_files) > _MAX_SCOPE_PATHS:
+            return None
+
+        sanitation_ok, _ = assess_issue_body_sanitation(effective_body)
+        if not sanitation_ok:
+            return None
+        if not candidate.validation_command:
+            return None
+        if not (candidate.file_scope or candidate.new_files):
+            return None
+        return candidate
+
+
+__all__ = ["DecompositionBridge"]

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -25,6 +25,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
+from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
 
@@ -221,6 +222,44 @@ def validate_body(body: str) -> tuple[bool, str]:
         return True, ""
 
 
+def maybe_decompose_candidates(
+    candidates: list[BossIssueCandidate],
+    *,
+    enabled: bool,
+    max_children_per_parent: int,
+    repo_root: Path,
+) -> list[BossIssueCandidate]:
+    """Optionally replace low-quality parents with bounded child candidates.
+
+    The parent candidate is preserved unless decomposition produces a meaningful
+    child set. This keeps the feature safe to enable experimentally.
+    """
+    if not enabled or not candidates:
+        return list(candidates)
+
+    bridge = DecompositionBridge(repo_root)
+    expanded: list[BossIssueCandidate] = []
+    decomposed_count = 0
+    for candidate in candidates:
+        parent_body = format_boss_ready_body(candidate)
+        children = bridge.decompose_issue_sync(
+            candidate.title,
+            parent_body,
+            max_children=max_children_per_parent,
+        )
+        if len(children) >= 2:
+            expanded.extend(children)
+            decomposed_count += 1
+        else:
+            expanded.append(candidate)
+
+    if decomposed_count:
+        print(
+            f"  Decomposed {decomposed_count} parent issue(s) into {len(expanded)} bounded candidates"
+        )
+    return expanded
+
+
 def create_github_issue(repo: str, title: str, body: str, label: str) -> bool:
     """Create a GitHub issue and return success."""
     try:
@@ -262,6 +301,17 @@ def main() -> None:
         default=0.3,
         help="Drop candidate categories below this historical success rate",
     )
+    parser.add_argument(
+        "--decompose-low-quality",
+        action="store_true",
+        help="Use the decomposition bridge to replace vague parent issues with bounded child issues",
+    )
+    parser.add_argument(
+        "--max-children-per-parent",
+        type=int,
+        default=5,
+        help="Maximum child issues to emit for one decomposed parent",
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
     args = parser.parse_args()
 
@@ -273,6 +323,12 @@ def main() -> None:
         repo_root,
         categories=args.categories,
         min_success_rate=args.min_success_rate,
+    )
+    candidates = maybe_decompose_candidates(
+        candidates,
+        enabled=args.decompose_low_quality,
+        max_children_per_parent=args.max_children_per_parent,
+        repo_root=repo_root,
     )
     print(
         f"  Found {len(candidates)} candidates across {len(set(c.category for c in candidates))} categories"

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -162,3 +162,138 @@ def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
     _ = capsys.readouterr()
     assert scan_calls
     assert scan_calls[0][2] == 0.5
+
+
+def test_maybe_decompose_candidates_noop_when_disabled(monkeypatch) -> None:
+    parent = _candidate("parent_module", file_scope=["aragora/parent_module.py"])
+
+    class UnexpectedBridge:
+        def __init__(self, repo_root):  # noqa: D401, ANN001
+            raise AssertionError("bridge should not be constructed when disabled")
+
+    monkeypatch.setattr(mod, "DecompositionBridge", UnexpectedBridge)
+
+    result = mod.maybe_decompose_candidates(
+        [parent],
+        enabled=False,
+        max_children_per_parent=5,
+        repo_root=mod.REPO_ROOT,
+    )
+
+    assert result == [parent]
+
+
+def test_maybe_decompose_candidates_replaces_parent_when_children_emitted(monkeypatch) -> None:
+    parent = _candidate("parent_module", file_scope=["aragora/parent_module.py"])
+    child_a = BossIssueCandidate(
+        category="test_coverage",
+        title="Child A",
+        description="Write focused tests for module A with bounded scope and validation.",
+        file_scope=["aragora/module_a.py"],
+        new_files=["tests/test_module_a.py"],
+        validation_command="python3 -m pytest -q tests/test_module_a.py",
+    )
+    child_b = BossIssueCandidate(
+        category="test_coverage",
+        title="Child B",
+        description="Write focused tests for module B with bounded scope and validation.",
+        file_scope=["aragora/module_b.py"],
+        new_files=["tests/test_module_b.py"],
+        validation_command="python3 -m pytest -q tests/test_module_b.py",
+    )
+
+    class FakeBridge:
+        def __init__(self, repo_root):  # noqa: D401, ANN001
+            self.repo_root = repo_root
+
+        def decompose_issue_sync(self, title, body, *, max_children):  # noqa: ANN001
+            assert title == parent.title
+            assert "## Task" in body
+            assert max_children == 3
+            return [child_a, child_b]
+
+    monkeypatch.setattr(mod, "DecompositionBridge", FakeBridge)
+
+    result = mod.maybe_decompose_candidates(
+        [parent],
+        enabled=True,
+        max_children_per_parent=3,
+        repo_root=mod.REPO_ROOT,
+    )
+
+    assert result == [child_a, child_b]
+
+
+def test_maybe_decompose_candidates_keeps_parent_when_child_set_is_not_meaningful(
+    monkeypatch,
+) -> None:
+    parent = _candidate("parent_module", file_scope=["aragora/parent_module.py"])
+    single_child = BossIssueCandidate(
+        category="test_coverage",
+        title="Only child",
+        description="Only child with bounded scope and validation command.",
+        file_scope=["aragora/module_a.py"],
+        validation_command="python3 -m ruff check aragora/module_a.py",
+    )
+
+    class FakeBridge:
+        def __init__(self, repo_root):  # noqa: D401, ANN001
+            self.repo_root = repo_root
+
+        def decompose_issue_sync(self, title, body, *, max_children):  # noqa: ANN001
+            return [single_child]
+
+    monkeypatch.setattr(mod, "DecompositionBridge", FakeBridge)
+
+    result = mod.maybe_decompose_candidates(
+        [parent],
+        enabled=True,
+        max_children_per_parent=5,
+        repo_root=mod.REPO_ROOT,
+    )
+
+    assert result == [parent]
+
+
+def test_main_passes_decomposition_flags(monkeypatch, capsys) -> None:
+    eligible = _candidate("eligible_module", file_scope=["aragora/eligible_module.py"])
+    scan_calls: list[tuple[object, object, object]] = []
+    decompose_calls: list[tuple[list[BossIssueCandidate], bool, int, object]] = []
+
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: (
+            scan_calls.append((repo_root, categories, min_success_rate)) or [eligible]
+        ),
+    )
+    monkeypatch.setattr(
+        mod,
+        "maybe_decompose_candidates",
+        lambda candidates, *, enabled, max_children_per_parent, repo_root: (
+            decompose_calls.append((list(candidates), enabled, max_children_per_parent, repo_root))
+            or list(candidates)
+        ),
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+    monkeypatch.setattr(mod, "fetch_open_pr_files", lambda repo: set())
+    monkeypatch.setattr(mod, "validate_body", lambda body: (True, ""))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_boss_issues.py",
+            "--dry-run",
+            "--decompose-low-quality",
+            "--max-children-per-parent",
+            "4",
+        ],
+    )
+
+    mod.main()
+
+    _ = capsys.readouterr()
+    assert scan_calls
+    assert decompose_calls
+    assert decompose_calls[0][1] is True
+    assert decompose_calls[0][2] == 4

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2964,6 +2964,146 @@ async def test_dispatch_issue_allows_missing_validation_target_for_explicit_new_
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_rewrites_missing_validation_before_dispatch() -> None:
+    issue = _make_issue(
+        2460,
+        "Add sanitizer admission wiring",
+        body=(
+            "## File Scope\n"
+            "- `aragora/swarm/task_sanitizer.py` (modify)\n\n"
+            "Tighten the admission path so broad or contradictory tasks stop before worker launch."
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    fake_run = MagicMock()
+    fake_run.to_dict.return_value = {
+        "status": "completed",
+        "run_id": "run-2460",
+        "work_orders": [
+            {"status": "completed", "branch": "codex/task-sanitizer", "commit_shas": ["abc123"]}
+        ],
+    }
+    refinement_mock = AsyncMock(
+        return_value={
+            "refined_prompt": "",
+            "files_to_change": [],
+            "test_patterns": [],
+            "constraints": [],
+            "context_gathered": False,
+        }
+    )
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=refinement_mock,
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        mock_commander_cls.return_value.run_supervised_from_spec = AsyncMock(return_value=fake_run)
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    spec = mock_commander_cls.return_value.run_supervised_from_spec.await_args.args[0]
+    assert spec.acceptance_criteria == ["python3 -m ruff check aragora/swarm/task_sanitizer.py"]
+    assert "## Validation" in refinement_mock.await_args.args[1]
+    assert (
+        "python3 -m ruff check aragora/swarm/task_sanitizer.py"
+        in refinement_mock.await_args.args[1]
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_quarantines_broad_scope_before_dispatch() -> None:
+    issue = _make_issue(
+        2461,
+        "Over-broad crash cleanup lane",
+        body=(
+            "## Allowed Write Set\n"
+            "- `aragora/swarm/a.py` (modify)\n"
+            "- `aragora/swarm/b.py` (modify)\n"
+            "- `aragora/swarm/c.py` (modify)\n"
+            "- `aragora/swarm/d.py` (modify)\n"
+            "- `aragora/swarm/e.py` (modify)\n"
+            "- `aragora/swarm/f.py` (modify)\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "sanitation_failed"
+    assert result["sanitizer_outcome"] == "quarantined"
+    assert "scope_too_broad" in result["checks_failed"]
+    mock_commander_cls.return_value.run_supervised_from_spec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_drops_short_task_before_dispatch() -> None:
+    issue = _make_issue(
+        2462,
+        "Too short",
+        body="Tiny task only.",
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch("aragora.swarm.commander.SwarmCommander") as mock_commander_cls,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "sanitation_failed"
+    assert result["sanitizer_outcome"] == "dropped"
+    assert "description_length" in result["checks_failed"]
+    mock_commander_cls.return_value.run_supervised_from_spec.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_dispatch_issue_consumes_pending_handoff_prompt_and_target_agent() -> None:
     issue = _make_issue(1701, "Retry same issue with handoff")
     loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="claude"))

--- a/tests/swarm/test_decomposition_bridge.py
+++ b/tests/swarm/test_decomposition_bridge.py
@@ -1,0 +1,591 @@
+"""Tests for decomposition_bridge orchestration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from aragora.nomic.task_decomposer import SubTask
+from aragora.swarm.boss_validation import assess_issue_body_sanitation
+from aragora.swarm.decomposition_bridge import DecompositionBridge, _partition_paths
+from aragora.swarm.task_sanitizer import SanitizationOutcome, SanitizationResult
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    (tmp_path / "aragora" / "pkg").mkdir(parents=True)
+    (tmp_path / "tests" / "pkg").mkdir(parents=True)
+    (tmp_path / "aragora" / "pkg" / "module.py").write_text(
+        '"""module docs"""\n\ndef run() -> None:\n    pass\n'
+    )
+    (tmp_path / "aragora" / "pkg" / "helper.py").write_text("def helper() -> int:\n    return 1\n")
+    (tmp_path / "tests" / "pkg" / "test_module.py").write_text("def test_run():\n    assert True\n")
+    return tmp_path
+
+
+@pytest.fixture
+def bridge(repo_root: Path, monkeypatch: pytest.MonkeyPatch) -> DecompositionBridge:
+    async def fake_refiner(
+        title: str, body: str, *, repo_path: Path | None = None, timeout_seconds: float = 45.0
+    ):  # noqa: ARG001
+        return {
+            "refined_prompt": body,
+            "files_to_change": [],
+            "test_patterns": [],
+            "constraints": [],
+            "context_gathered": True,
+        }
+
+    class PassSanitizer:
+        def sanitize(self, title: str, body: str) -> SanitizationResult:
+            composed = f"{title}\n\n{body}"
+            return SanitizationResult(
+                outcome=SanitizationOutcome.ACCEPTED,
+                original_text=composed,
+                sanitized_text=composed,
+                reason="accepted",
+                confidence=0.99,
+                checks_failed=[],
+            )
+
+    monkeypatch.setattr("aragora.swarm.decomposition_bridge.refine_worker_prompt", fake_refiner)
+    result = DecompositionBridge(repo_root)
+    result._task_sanitizer = PassSanitizer()
+    return result
+
+
+def _make_subtask(
+    *,
+    title: str = "Target module",
+    description: str = "Update the module safely and keep the change tightly scoped.",
+    file_scope: list[str] | None = None,
+    estimated_complexity: str = "low",
+    success_criteria: dict[str, str] | None = None,
+) -> SubTask:
+    return SubTask(
+        id="st-1",
+        title=title,
+        description=description,
+        file_scope=list(file_scope or []),
+        estimated_complexity=estimated_complexity,
+        success_criteria=dict(success_criteria or {}),
+    )
+
+
+class _FakeDecomposer:
+    def __init__(self, subtasks: list[SubTask] | None = None) -> None:
+        self.subtasks = list(subtasks or [])
+        self.calls: list[dict[str, object]] = []
+
+    def analyze(self, task_description: str, **kwargs: object) -> SimpleNamespace:
+        self.calls.append({"task_description": task_description, **kwargs})
+        return SimpleNamespace(subtasks=list(self.subtasks))
+
+
+class TestHelpers:
+    def test_partition_paths_marks_missing_files_as_new(self, repo_root: Path) -> None:
+        file_scope, new_files = _partition_paths(
+            repo_root,
+            ["aragora/pkg/module.py", "tests/pkg/test_new.py"],
+        )
+        assert file_scope == ["aragora/pkg/module.py"]
+        assert new_files == ["tests/pkg/test_new.py"]
+
+    def test_partition_paths_respects_declared_new(self, repo_root: Path) -> None:
+        file_scope, new_files = _partition_paths(
+            repo_root,
+            ["aragora/pkg/module.py", "tests/pkg/test_module.py"],
+            declared_new=["tests/pkg/test_module.py"],
+        )
+        assert file_scope == ["aragora/pkg/module.py"]
+        assert new_files == ["tests/pkg/test_module.py"]
+
+    def test_build_parent_spec_extracts_file_scope_and_validation(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        spec = bridge._build_parent_spec(
+            "Add tests for module",
+            "## Task\n\nCover the module.\n\n### File Scope\n- `aragora/pkg/module.py`\n- `tests/pkg/test_module.py` (create)\n\n### Validation\n- python3 -m pytest -q tests/pkg/test_module.py",
+        )
+        assert "aragora/pkg/module.py" in spec.file_scope_hints
+        assert "tests/pkg/test_module.py" in spec.file_scope_hints
+        assert "python3 -m pytest -q tests/pkg/test_module.py" in spec.acceptance_criteria
+
+    def test_build_parent_spec_extracts_constraints(self, bridge: DecompositionBridge) -> None:
+        spec = bridge._build_parent_spec(
+            "Add tests",
+            "## Task\n\nDo the thing.\n\n### Constraints\n- Do not modify other files",
+        )
+        assert any("Do not modify other files" in item for item in spec.constraints)
+
+    def test_render_candidate_body_has_required_sections(self, bridge: DecompositionBridge) -> None:
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Write tests for module.py",
+            description="Add focused tests.",
+            file_scope=["aragora/pkg/module.py"],
+            new_files=["tests/pkg/test_module.py"],
+            validation_command="python3 -m pytest -q tests/pkg/test_module.py",
+            acceptance_criteria=["Tests pass"],
+        )
+        body = bridge._render_candidate_body(candidate)
+        assert "## Task" in body
+        assert "### File Scope" in body
+        assert "### Validation" in body
+        assert "### Acceptance Criteria" in body
+
+
+class TestCandidateConstruction:
+    @pytest.mark.asyncio
+    async def test_candidate_prefers_explicit_validation_command(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        candidate = await bridge._candidate_from_parts(
+            title="Write tests",
+            category="test_coverage",
+            description="Use `python3 -m pytest -q tests/pkg/test_module.py` after changes.",
+            scope_paths=["aragora/pkg/module.py", "tests/pkg/test_module.py"],
+            acceptance_criteria=[],
+            estimated_complexity="small",
+        )
+        assert candidate.validation_command == "python3 -m pytest -q tests/pkg/test_module.py"
+
+    @pytest.mark.asyncio
+    async def test_candidate_uses_refiner_test_pattern_fallback(
+        self, bridge: DecompositionBridge, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_refiner(
+            title: str, body: str, *, repo_path: Path | None = None, timeout_seconds: float = 45.0
+        ):  # noqa: ARG001
+            return {
+                "refined_prompt": body,
+                "files_to_change": [],
+                "test_patterns": ["tests/pkg/test_module.py"],
+                "constraints": [],
+                "context_gathered": True,
+            }
+
+        monkeypatch.setattr("aragora.swarm.decomposition_bridge.refine_worker_prompt", fake_refiner)
+        candidate = await bridge._candidate_from_parts(
+            title="Write tests",
+            category="test_coverage",
+            description="Add focused tests.",
+            scope_paths=["aragora/pkg/module.py"],
+            acceptance_criteria=[],
+            estimated_complexity="small",
+        )
+        assert candidate.validation_command == "python3 -m pytest -q tests/pkg/test_module.py"
+
+    @pytest.mark.asyncio
+    async def test_candidate_uses_pytest_for_test_file_scope(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        candidate = await bridge._candidate_from_parts(
+            title="Write tests",
+            category="test_coverage",
+            description="Add focused tests.",
+            scope_paths=["tests/pkg/test_module.py"],
+            acceptance_criteria=[],
+            estimated_complexity="small",
+        )
+        assert candidate.validation_command == "python3 -m pytest -q tests/pkg/test_module.py"
+
+    @pytest.mark.asyncio
+    async def test_candidate_uses_ruff_fallback_for_source_files(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        candidate = await bridge._candidate_from_parts(
+            title="Update module",
+            category="decomposed_issue",
+            description="Make a tiny change.",
+            scope_paths=["aragora/pkg/module.py"],
+            acceptance_criteria=[],
+            estimated_complexity="small",
+        )
+        assert candidate.validation_command == "python3 -m ruff check aragora/pkg/module.py"
+
+    @pytest.mark.asyncio
+    async def test_candidate_complexity_is_bounded(self, bridge: DecompositionBridge) -> None:
+        candidate = await bridge._candidate_from_parts(
+            title="Update module",
+            category="decomposed_issue",
+            description="Make a tiny change.",
+            scope_paths=["aragora/pkg/module.py"],
+            acceptance_criteria=[],
+            estimated_complexity="medium",
+        )
+        assert candidate.estimated_complexity in {"small", "medium"}
+
+
+class TestGateCandidate:
+    def test_gate_candidate_rejects_quarantined_child(self, bridge: DecompositionBridge) -> None:
+        class RejectSanitizer:
+            def sanitize(self, title: str, body: str) -> SanitizationResult:
+                return SanitizationResult(
+                    outcome=SanitizationOutcome.QUARANTINED,
+                    original_text=body,
+                    sanitized_text=body,
+                    reason="bad",
+                    confidence=0.99,
+                    checks_failed=["scope_too_broad"],
+                )
+
+        bridge._task_sanitizer = RejectSanitizer()
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Bad child",
+            description="Bad child description long enough to pass.",
+            file_scope=["aragora/pkg/module.py"],
+            validation_command="python3 -m ruff check aragora/pkg/module.py",
+        )
+        assert bridge._gate_candidate(candidate) is None
+
+    def test_gate_candidate_rejects_dropped_child(self, bridge: DecompositionBridge) -> None:
+        class DropSanitizer:
+            def sanitize(self, title: str, body: str) -> SanitizationResult:
+                return SanitizationResult(
+                    outcome=SanitizationOutcome.DROPPED,
+                    original_text=body,
+                    sanitized_text=body,
+                    reason="duplicate",
+                    confidence=0.99,
+                    checks_failed=["duplicate"],
+                )
+
+        bridge._task_sanitizer = DropSanitizer()
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Dropped child",
+            description="Bad child description long enough to pass.",
+            file_scope=["aragora/pkg/module.py"],
+            validation_command="python3 -m ruff check aragora/pkg/module.py",
+        )
+        assert bridge._gate_candidate(candidate) is None
+
+    def test_gate_candidate_adopts_rewritten_validation(self, bridge: DecompositionBridge) -> None:
+        class RewriteSanitizer:
+            def sanitize(self, title: str, body: str) -> SanitizationResult:
+                rewritten = (
+                    f"{title}\n\n"
+                    "## Task\n\nRefined task body that is long enough for dispatch gating to accept it safely.\n\n"
+                    "### File Scope\n- `aragora/pkg/module.py`\n\n"
+                    "### Validation\n- python3 -m pytest -q tests/pkg/test_module.py"
+                )
+                return SanitizationResult(
+                    outcome=SanitizationOutcome.REWRITTEN,
+                    original_text=body,
+                    sanitized_text=rewritten,
+                    reason="added validation",
+                    confidence=0.9,
+                    checks_failed=["missing_validation"],
+                )
+
+        bridge._task_sanitizer = RewriteSanitizer()
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Rewritten child",
+            description="Refined task body that is long enough for dispatch gating to accept it safely.",
+            file_scope=["aragora/pkg/module.py"],
+            validation_command="",
+        )
+        gated = bridge._gate_candidate(candidate)
+        assert gated is not None
+        assert gated.validation_command == "python3 -m pytest -q tests/pkg/test_module.py"
+
+    def test_gate_candidate_adopts_rewritten_scope(self, bridge: DecompositionBridge) -> None:
+        class RewriteScopeSanitizer:
+            def sanitize(self, title: str, body: str) -> SanitizationResult:
+                rewritten = (
+                    f"{title}\n\n"
+                    "## Task\n\nRefined task body that is long enough for dispatch gating to accept it safely.\n\n"
+                    "### File Scope\n- `aragora/pkg/helper.py`\n\n"
+                    "### Validation\n- python3 -m ruff check aragora/pkg/helper.py"
+                )
+                return SanitizationResult(
+                    outcome=SanitizationOutcome.REWRITTEN,
+                    original_text=body,
+                    sanitized_text=rewritten,
+                    reason="narrowed scope",
+                    confidence=0.9,
+                    checks_failed=["scope_too_broad"],
+                )
+
+        bridge._task_sanitizer = RewriteScopeSanitizer()
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Rewritten scope",
+            description="Refined task body that is long enough for dispatch gating to accept it safely.",
+            file_scope=["aragora/pkg/module.py", "aragora/pkg/helper.py"],
+            validation_command="python3 -m ruff check aragora/pkg/module.py",
+        )
+        gated = bridge._gate_candidate(candidate)
+        assert gated is not None
+        assert gated.file_scope == ["aragora/pkg/helper.py"]
+
+    def test_gate_candidate_requires_sanitation_ok(
+        self, bridge: DecompositionBridge, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "aragora.swarm.decomposition_bridge.assess_issue_body_sanitation",
+            lambda body: (False, "task_truncated"),
+        )
+        candidate = pytest.importorskip("aragora.swarm.issue_scanner").BossIssueCandidate(
+            category="decomposed_issue",
+            title="Bad child",
+            description="Refined task body that is long enough for dispatch gating to accept it safely.",
+            file_scope=["aragora/pkg/module.py"],
+            validation_command="python3 -m ruff check aragora/pkg/module.py",
+        )
+        assert bridge._gate_candidate(candidate) is None
+
+
+class TestDecomposeIssue:
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_subtasks_and_no_scope(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer([])
+        result = await bridge.decompose_issue("Vague parent", "## Task\n\nThink about it.")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_direct_child_from_subtask(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(
+                    file_scope=["aragora/pkg/module.py"], success_criteria={"pytest": "passes"}
+                )
+            ]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nImprove the module with a tightly scoped change that preserves existing behavior.\n\n### File Scope\n- `aragora/pkg/module.py`",
+        )
+        assert len(result) == 1
+        assert result[0].file_scope == ["aragora/pkg/module.py"]
+        assert result[0].validation_command
+
+    @pytest.mark.asyncio
+    async def test_micro_decomposer_used_for_broad_subtask(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(
+                    title="Broad child",
+                    file_scope=["aragora/pkg/module.py", "tests/pkg/test_module.py"],
+                    estimated_complexity="high",
+                )
+            ]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nImprove the module with a tightly scoped change that preserves existing behavior.\n\n### File Scope\n- `aragora/pkg/module.py`\n- `tests/pkg/test_module.py`",
+        )
+        assert len(result) >= 1
+        assert all("validation" not in candidate.title.lower() for candidate in result)
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_micro_decomposer_without_subtasks(
+        self, bridge: DecompositionBridge
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer([])
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nImprove the module with a tightly scoped change that preserves existing behavior.\n\n### File Scope\n- `aragora/pkg/module.py`\n- `tests/pkg/test_module.py`",
+        )
+        assert len(result) >= 1
+        assert any(
+            "aragora/pkg/module.py" in candidate.file_scope
+            or "tests/pkg/test_module.py" in candidate.file_scope
+            for candidate in result
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_validation_only_work_orders(
+        self, bridge: DecompositionBridge, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(
+                    file_scope=["aragora/pkg/module.py", "tests/pkg/test_module.py"],
+                    estimated_complexity="high",
+                )
+            ]
+        )
+
+        def fake_micro(
+            *,
+            goal: str,
+            file_scope_hints: list[str],
+            acceptance_criteria: list[str] | None = None,
+            constraints: list[str] | None = None,
+            repo_root: Path | None = None,
+        ):  # noqa: ARG001
+            return [
+                {
+                    "title": "Update module.py",
+                    "description": "Refined task body that is long enough for dispatch gating to accept it safely.",
+                    "file_scope": ["aragora/pkg/module.py"],
+                    "estimated_complexity": "low",
+                },
+                {
+                    "title": "Run validation and fix failures",
+                    "description": "Validation lane that should be skipped because it is not an actionable child issue.",
+                    "file_scope": ["aragora/pkg/module.py"],
+                    "estimated_complexity": "low",
+                },
+            ]
+
+        monkeypatch.setattr(
+            "aragora.swarm.decomposition_bridge.build_micro_work_orders", fake_micro
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert len(result) == 1
+        assert result[0].title == "Update module.py"
+
+    @pytest.mark.asyncio
+    async def test_max_children_cap_works(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(title="one", file_scope=["aragora/pkg/module.py"]),
+                _make_subtask(title="two", file_scope=["aragora/pkg/helper.py"]),
+                _make_subtask(title="three", file_scope=["tests/pkg/test_module.py"]),
+            ]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+            max_children=2,
+        )
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_file_scope_is_preserved(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [_make_subtask(file_scope=["aragora/pkg/helper.py"])]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert result[0].file_scope == ["aragora/pkg/helper.py"]
+
+    @pytest.mark.asyncio
+    async def test_suppresses_overlapping_paths(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(title="first", file_scope=["aragora/pkg/module.py"]),
+                _make_subtask(title="second", file_scope=["aragora/pkg/module.py"]),
+            ]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_rejects_children_without_validation_after_gate(
+        self, bridge: DecompositionBridge, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [_make_subtask(file_scope=["aragora/pkg/module.py"])]
+        )
+        monkeypatch.setattr(
+            bridge,
+            "_choose_validation_command",
+            lambda **kwargs: "",
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_fingerprints_are_unique(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(title="first", file_scope=["aragora/pkg/module.py"]),
+                _make_subtask(title="second", file_scope=["aragora/pkg/helper.py"]),
+            ]
+        )
+        result = await bridge.decompose_issue(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert len(result) == 2
+        assert result[0].fingerprint != result[1].fingerprint
+
+    def test_sync_wrapper(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [_make_subtask(file_scope=["aragora/pkg/module.py"])]
+        )
+        result = bridge.decompose_issue_sync(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert len(result) == 1
+
+
+class TestRealIssueCorpus:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("title", "body"),
+        [
+            (
+                "Add unit tests for aragora/pkg/module.py",
+                "## Task\n\n"
+                "Add comprehensive unit tests for `aragora/pkg/module.py`.\n\n"
+                "### Requirements\n"
+                "1. Read the module and identify all public functions.\n"
+                "2. Create a test file with broad coverage.\n\n"
+                "### File Scope\n"
+                "- `aragora/pkg/module.py`\n"
+                "- `tests/pkg/test_module.py` (create)\n",
+            ),
+            (
+                "Add request body validation to handler-like endpoints",
+                "## Task\n\n"
+                "Add request body validation to `aragora/pkg/module.py` and supporting tests.\n\n"
+                "### File Scope\n"
+                "- `aragora/pkg/module.py`\n"
+                "- `tests/pkg/test_module.py` (create)\n\n"
+                "### Acceptance Criteria\n"
+                "- invalid input is rejected clearly\n",
+            ),
+            (
+                "Improve module and helper together",
+                "## Task\n\n"
+                "Improve the implementation while preserving existing behavior and keeping the work reviewable.\n\n"
+                "### File Scope\n"
+                "- `aragora/pkg/module.py`\n"
+                "- `aragora/pkg/helper.py`\n"
+                "- `tests/pkg/test_module.py` (create)\n",
+            ),
+        ],
+    )
+    async def test_realish_parent_templates_emit_bounded_children(
+        self,
+        bridge: DecompositionBridge,
+        title: str,
+        body: str,
+    ) -> None:
+        bridge._task_decomposer = _FakeDecomposer([])
+
+        result = await bridge.decompose_issue(title, body, max_children=4)
+
+        assert result
+        for candidate in result:
+            assert candidate.validation_command
+            assert candidate.estimated_complexity in {"small", "medium"}
+            assert 1 <= len(candidate.file_scope) + len(candidate.new_files) <= 5
+            rendered = bridge._render_candidate_body(candidate)
+            ok, reason = assess_issue_body_sanitation(rendered)
+            assert ok, reason


### PR DESCRIPTION
## Summary
- add a decomposition bridge that converts vague parent issues into bounded child `BossIssueCandidate`s
- wire the bridge into `generate_boss_issues.py` behind `--decompose-low-quality` and `--max-children-per-parent`
- add focused bridge tests plus generator integration tests and a small real-issue corpus

## Validation
- python3 -m pytest tests/swarm/test_decomposition_bridge.py tests/scripts/test_generate_boss_issues.py -q
- python3 -m ruff check aragora/swarm/decomposition_bridge.py tests/swarm/test_decomposition_bridge.py scripts/generate_boss_issues.py tests/scripts/test_generate_boss_issues.py
- python3 -c "from aragora.swarm.decomposition_bridge import DecompositionBridge; print("OK")"

## Notes
- current live scanner output for the first sampled `test_coverage` parents was already bounded, so the bridge preserved them unchanged in the dry-run comparison
- the bridge only replaces a parent when decomposition yields a meaningful child set; otherwise the parent candidate is preserved