### PR TITLE
feat(swarm): add contract-aware preflight admission

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -14,7 +14,7 @@ from typing import Any
 from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict, MissionContextPolicy
-from aragora.swarm.worker_contract import checksum_contract_payload
+from aragora.swarm.worker_contract import WorkerContract, checksum_contract_payload
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
 
 
@@ -233,22 +233,59 @@ def _worktree_path(repo_root: Path, branch: str) -> Path:
     return repo_root / ".worktrees" / f"preflight-{branch.replace('/', '-')}"
 
 
-def _work_order(agent: str) -> dict[str, object]:
-    filename = "scratch/preflight_worker_check.txt"
+def _preflight_filename(contract: WorkerContract | None = None) -> str:
+    if contract is not None:
+        policy = dict(contract.mission_context_policy or {})
+        required_sources = [
+            str(item).strip()
+            for item in list(policy.get("required_sources", []) or [])
+            if str(item).strip()
+        ]
+        if required_sources:
+            return required_sources[0]
+    return "scratch/preflight_worker_check.txt"
+
+
+def _work_order(agent: str, *, contract: WorkerContract | None = None) -> dict[str, object]:
+    filename = _preflight_filename(contract)
+    mission_id = "mission-rs-worker-contract-preflight"
+    stage_id = "stage-dispatch-ready-preflight"
+    assertion_ids = ["RS-PREFLIGHT-ASSERT-1"]
+    evidence_expectations = [
+        "worker_contract",
+        "worker_contract_checksum",
+        "receipt",
+    ]
+    if contract is not None:
+        mission_id = str(contract.mission_id or "").strip() or mission_id
+        stage_id = str(contract.stage_id or "").strip() or stage_id
+        assertion_ids = [
+            str(item).strip() for item in list(contract.assertion_ids or []) if str(item).strip()
+        ]
+        if not assertion_ids:
+            assertion_ids = ["RS-PREFLIGHT-ASSERT-1"]
+        evidence_expectations = [
+            str(item).strip()
+            for item in list(contract.evidence_expectations or [])
+            if str(item).strip()
+        ] or evidence_expectations
     return {
         "work_order_id": f"preflight-{int(time.time())}",
         "target_agent": agent,
-        "mission_id": "mission-rs-worker-contract-preflight",
-        "stage_id": "stage-dispatch-ready-preflight",
-        "assertion_ids": ["RS-PREFLIGHT-ASSERT-1"],
-        "evidence_expectations": [
-            "worker_contract",
-            "worker_contract_checksum",
-            "receipt",
-        ],
-        "title": "Preflight worker check",
+        "mission_id": mission_id,
+        "stage_id": stage_id,
+        "assertion_ids": assertion_ids,
+        "evidence_expectations": evidence_expectations,
+        "mission_context_policies": (
+            {"worker": dict(contract.mission_context_policy or {})}
+            if contract is not None
+            else None
+        ),
+        "title": "Contract-aware preflight worker check"
+        if contract is not None
+        else "Preflight worker check",
         "description": (
-            "Create a file named `scratch/preflight_worker_check.txt` with a single line "
+            f"Create a file named `{filename}` with a single line "
             "timestamp. Commit it with message `chore: preflight worker check`. "
             "Do not modify any other files."
         ),
@@ -264,13 +301,14 @@ async def _run_worker(
     worktree_path: Path,
     branch: str,
     agent: str,
+    contract: WorkerContract | None = None,
 ) -> WorkerProcess:
     config = LaunchConfig(
         allow_claude_dangerously_skip_permissions=True,
         allow_codex_full_auto=True,
     )
     launcher = WorkerLauncher(config=config)
-    work_order = _work_order(agent)
+    work_order = _work_order(agent, contract=contract)
     return await launcher.launch_and_wait(
         work_order,
         worktree_path=str(worktree_path),
@@ -344,6 +382,42 @@ def _validate_worker_contract(worker: WorkerProcess) -> dict[str, Any]:
     return gate
 
 
+def _load_contract_payload(contract_path: Path) -> tuple[WorkerContract, str]:
+    payload = json.loads(contract_path.read_text(encoding="utf-8"))
+    worker_contract_payload: Any = payload
+    expected_checksum = ""
+    if isinstance(payload, dict) and isinstance(payload.get("worker_contract"), dict):
+        worker_contract_payload = payload.get("worker_contract")
+        expected_checksum = str(payload.get("worker_contract_checksum", "") or "").strip()
+    if not isinstance(worker_contract_payload, dict):
+        raise RuntimeError("Worker contract file must contain a JSON object payload.")
+    contract = WorkerContract.from_dict(worker_contract_payload)
+    contract_checksum = contract.checksum()
+    if expected_checksum and expected_checksum != contract_checksum:
+        raise RuntimeError("Worker contract file checksum does not match the contract payload.")
+    if not contract.admission_check():
+        raise RuntimeError("Worker contract file failed dispatch admission check.")
+    return contract, expected_checksum or contract_checksum
+
+
+def _enforce_expected_contract(
+    worker: WorkerProcess,
+    *,
+    expected_contract: WorkerContract,
+    expected_checksum: str,
+) -> None:
+    actual_contract = WorkerContract.from_dict(worker.worker_contract or {})
+    actual_checksum = str(worker.worker_contract_checksum or "").strip()
+    if actual_contract.to_dict() != expected_contract.to_dict():
+        raise RuntimeError(
+            "Preflight worker emitted a contract that drifted from the expected contract."
+        )
+    if actual_checksum != expected_checksum:
+        raise RuntimeError(
+            "Preflight worker emitted a contract checksum that drifted from the expected contract."
+        )
+
+
 def _create_pr(repo_root: Path, branch: str, base_ref: str) -> None:
     _run(
         [
@@ -390,13 +464,21 @@ def run_preflight(
     base_ref: str = "main",
     skip_publication: bool = False,
     envelope: CredentialEnvelope | None = None,
+    contract_path: Path | None = None,
 ) -> PreflightResult:
     if envelope is not None:
         return run_preflight_checks(envelope, repo_root=repo_root)
 
     start = time.monotonic()
     resolved_repo_root = repo_root.resolve()
-    normalized_agent = str(agent or "").strip() or "claude"
+    expected_contract: WorkerContract | None = None
+    expected_contract_checksum = ""
+    if contract_path is not None:
+        expected_contract, expected_contract_checksum = _load_contract_payload(contract_path)
+    if expected_contract is not None and str(expected_contract.agent or "").strip():
+        normalized_agent = str(expected_contract.agent).strip()
+    else:
+        normalized_agent = str(agent or "").strip() or "claude"
     normalized_base_ref = str(base_ref or "main").strip() or "main"
     branch = _branch_name()
     worktree_path = _worktree_path(resolved_repo_root, branch)
@@ -424,9 +506,16 @@ def run_preflight(
                 worktree_path=worktree_path,
                 branch=branch,
                 agent=normalized_agent,
+                contract=expected_contract,
             )
         )
         dispatch_gate = _validate_worker_contract(worker)
+        if expected_contract is not None:
+            _enforce_expected_contract(
+                worker,
+                expected_contract=expected_contract,
+                expected_checksum=expected_contract_checksum,
+            )
         if not worker.commit_shas:
             raise RuntimeError("Preflight worker did not produce a commit.")
 
@@ -503,6 +592,11 @@ def main() -> int:
         help="Skip push/PR steps (debug only).",
     )
     parser.add_argument(
+        "--contract",
+        default=None,
+        help="Path to a JSON worker contract file for contract-aware preflight.",
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Emit a structured result payload.",
@@ -514,6 +608,7 @@ def main() -> int:
         agent=str(args.agent),
         base_ref=str(args.base_ref),
         skip_publication=bool(args.skip_publication),
+        contract_path=Path(args.contract) if args.contract else None,
     )
     if args.json:
         _write_stdout_line(json.dumps(result.to_dict(), indent=2))

--- a/aragora/swarm/worker_contract.py
+++ b/aragora/swarm/worker_contract.py
@@ -80,6 +80,35 @@ class WorkerContract:
             "contract_version": self.contract_version,
         }
 
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "WorkerContract":
+        return cls(
+            runner_type=str(data.get("runner_type", "") or ""),
+            agent=str(data.get("agent", "") or ""),
+            model=str(data.get("model", "") or ""),
+            profile=str(data.get("profile", "") or ""),
+            permissions=dict(data.get("permissions", {}) or {}),
+            execution_mode=str(data.get("execution_mode", "") or ""),
+            git_auth_mode=str(data.get("git_auth_mode", "") or ""),
+            gh_api_auth_mode=str(data.get("gh_api_auth_mode", "") or ""),
+            budget=dict(data.get("budget", {}) or {}),
+            env_checksum=str(data.get("env_checksum", "") or ""),
+            mission_id=str(data.get("mission_id", "") or ""),
+            stage_id=str(data.get("stage_id", "") or ""),
+            assertion_ids=[
+                str(item).strip()
+                for item in list(data.get("assertion_ids", []) or [])
+                if str(item).strip()
+            ],
+            evidence_expectations=[
+                str(item).strip()
+                for item in list(data.get("evidence_expectations", []) or [])
+                if str(item).strip()
+            ],
+            mission_context_policy=dict(data.get("mission_context_policy", {}) or {}),
+            contract_version=str(data.get("contract_version", _CONTRACT_VERSION) or ""),
+        )
+
     def checksum(self) -> str:
         return checksum_contract_payload(self.to_dict())
 

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -173,6 +173,8 @@ class WorkerLauncher:
             work_order=work_order,
         )
         contract.validate()
+        if not contract.admission_check():
+            raise RuntimeError("Worker contract failed dispatch admission check.")
         contract_dict = contract.to_dict()
         contract_checksum = contract.checksum()
         work_order["worker_contract"] = dict(contract_dict)
@@ -538,6 +540,7 @@ class WorkerLauncher:
         *,
         worktree_path: str,
         branch: str = "main",
+        timeout: float | None = None,
     ) -> WorkerProcess:
         """Launch a worker and wait for it to complete."""
         worker = await self.launch(
@@ -545,7 +548,7 @@ class WorkerLauncher:
             worktree_path=worktree_path,
             branch=branch,
         )
-        return await self.wait(worker.work_order_id)
+        return await self.wait(worker.work_order_id, timeout=timeout)
 
     def get_worker(self, work_order_id: str) -> WorkerProcess | None:
         return self._workers.get(work_order_id)

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -233,3 +234,109 @@ def test_preflight_result_serializes_envelope(monkeypatch, tmp_path: Path) -> No
     result = mod.run_preflight(envelope=envelope, repo_root=tmp_path)
     payload = result.to_dict()
     assert payload["envelope"]["provider"]["provider_name"] == "openai"
+
+
+def test_run_preflight_uses_contract_file_and_enforces_expected_contract(
+    monkeypatch, tmp_path: Path
+) -> None:
+    branch = "preflight/20260412-contract"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    commands: list[list[str]] = []
+    cleanup_commands: list[list[str]] = []
+    contract_payload = _worker(branch=branch).worker_contract
+    contract_path = tmp_path / "worker_contract.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "worker_contract": contract_payload,
+                "worker_contract_checksum": checksum_contract_payload(contract_payload),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def fake_run_worker(**kwargs: object) -> WorkerProcess:
+        assert kwargs["agent"] == "codex"
+        return _worker(branch=branch)
+
+    def fake_run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+        commands.append(list(cmd))
+
+    def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        cleanup_commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "_branch_name", lambda: branch)
+    monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    result = mod.run_preflight(
+        repo_root=repo_root,
+        skip_publication=True,
+        contract_path=contract_path,
+    )
+
+    assert result.passed is True
+    assert result.agent == "codex"
+    assert result.worker["worker_contract"] == contract_payload
+    assert commands[0][:4] == ["git", "worktree", "add", "-b"]
+    assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]
+
+
+def test_run_preflight_rejects_contract_file_checksum_mismatch(tmp_path: Path) -> None:
+    contract_payload = _worker(branch="preflight/20260412-contract-bad").worker_contract
+    contract_path = tmp_path / "worker_contract_bad.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "worker_contract": contract_payload,
+                "worker_contract_checksum": "bad-checksum",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(RuntimeError, match="checksum"):
+        mod.run_preflight(
+            repo_root=tmp_path,
+            contract_path=contract_path,
+        )
+
+
+def test_run_preflight_rejects_emitted_contract_drift(monkeypatch, tmp_path: Path) -> None:
+    branch = "preflight/20260412-contract-drift"
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    cleanup_commands: list[list[str]] = []
+    contract_payload = _worker(branch=branch).worker_contract
+    contract_path = tmp_path / "worker_contract_drift.json"
+    contract_path.write_text(json.dumps(contract_payload), encoding="utf-8")
+
+    async def fake_run_worker(**_: object) -> WorkerProcess:
+        worker = _worker(branch=branch)
+        worker.worker_contract["model"] = "tampered-model"
+        worker.worker_contract_checksum = checksum_contract_payload(worker.worker_contract)
+        return worker
+
+    def fake_run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
+        return None
+
+    def fake_subprocess_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        cleanup_commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod, "_branch_name", lambda: branch)
+    monkeypatch.setattr(mod, "_run_worker", fake_run_worker)
+    monkeypatch.setattr(mod, "_run", fake_run)
+    monkeypatch.setattr(mod.subprocess, "run", fake_subprocess_run)
+
+    with pytest.raises(RuntimeError, match="drifted from the expected contract"):
+        mod.run_preflight(
+            repo_root=repo_root,
+            skip_publication=True,
+            contract_path=contract_path,
+        )
+
+    assert cleanup_commands[0][:4] == ["git", "worktree", "remove", "--force"]

--- a/tests/swarm/test_worker_contract.py
+++ b/tests/swarm/test_worker_contract.py
@@ -56,6 +56,15 @@ def test_build_worker_contract_includes_mission_lineage_and_context_policy(tmp_p
     contract.validate()
 
 
+def test_worker_contract_from_dict_round_trips_valid_contract() -> None:
+    contract = _make_valid_contract()
+
+    restored = WorkerContract.from_dict(contract.to_dict())
+
+    assert restored.to_dict() == contract.to_dict()
+    assert restored.admission_check() is True
+
+
 def _make_valid_contract() -> WorkerContract:
     """Create a valid WorkerContract with all required fields populated."""
     return WorkerContract(

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -548,6 +548,37 @@ class TestLaunch:
                 await launcher.launch(wo, worktree_path="/tmp/wt")
 
     @pytest.mark.asyncio
+    async def test_launch_fails_closed_when_contract_fails_admission(self, tmp_path: Path):
+        launcher = WorkerLauncher()
+        worktree = tmp_path / "wt"
+        (worktree / "scripts").mkdir(parents=True)
+        (worktree / "scripts" / "codex_session.sh").write_text(
+            "#!/usr/bin/env bash\n", encoding="utf-8"
+        )
+        wo = {
+            "work_order_id": "wo-admission-fail",
+            "target_agent": "claude",
+            "title": "Admission failure",
+            "metadata": {"admin_approved": True},
+        }
+        fake_contract = MagicMock()
+        fake_contract.validate.return_value = None
+        fake_contract.admission_check.return_value = False
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/claude"),
+            patch.object(WorkerLauncher, "_git_output", return_value=""),
+            patch(
+                "aragora.swarm.worker_launcher.build_worker_contract", return_value=fake_contract
+            ),
+            patch("asyncio.create_subprocess_exec") as mock_exec,
+        ):
+            with pytest.raises(RuntimeError, match="dispatch admission check"):
+                await launcher.launch(wo, worktree_path=str(worktree), branch="feat")
+
+        mock_exec.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_launch_merges_metadata_worker_env(self, tmp_path: Path):
         launcher = WorkerLauncher(LaunchConfig(detach=False))
         mock_proc = AsyncMock()


### PR DESCRIPTION
## Summary
- add worker-contract deserialization and fail-closed admission enforcement in the launcher
- add contract-aware preflight loading for raw or wrapped JSON worker contracts
- verify preflight launch output matches the expected contract and cover the new paths with focused swarm tests

## Validation
- python3 -m pytest tests/swarm/test_preflight.py tests/swarm/test_worker_contract.py tests/swarm/test_worker_launcher.py -q
- python3 -m ruff check aragora/swarm/preflight.py aragora/swarm/worker_contract.py aragora/swarm/worker_launcher.py tests/swarm/test_preflight.py tests/swarm/test_worker_contract.py tests/swarm/test_worker_launcher.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/preflight.py aragora/swarm/worker_contract.py aragora/swarm/worker_launcher.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD