### PR TITLE
docs(status): reconcile landed reliability substrate work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,7 +167,7 @@ Aragora is the **Decision Integrity Platform** -- orchestrating 43 agent types t
 
 **Five Pillars:** (1) SMB-ready with enterprise-grade security, (2) leading-edge memory and context processing, (3) extensible/modular with broad connectors and SDKs, (4) multi-agent robustness via heterogeneous model consensus, (5) self-healing and self-extending via the Nomic Loop.
 
-**Codebase Scale:** 3,000+ Python modules | 153,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
+**Codebase Scale:** 3,000+ Python modules | 154,000+ tests | 5,000+ test files | 210+ debate modules | 3,000+ API operations across 2,700+ paths | 42 registered KM adapters | 185 Python / 183 TypeScript SDK namespaces
 
 ## Architecture
 
@@ -415,7 +415,7 @@ See `docs/reference/ENVIRONMENT.md` for full reference.
 
 ## Feature Status
 
-**Test Suite:** 153,000+ tests across 5,000+ test files
+**Test Suite:** 154,000+ tests across 5,000+ test files
 
 **Core (stable):**
 - Debate orchestration (Arena, consensus, convergence)

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ aragora/
 └── workflow/       # DAG-based automation engine
 ```
 
-**Scale:** 3,000+ Python modules | 153,000+ tests across 5,000+ test files
+**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files
 
 ### Performance and Costs
 

--- a/docs-site/docs/contributing/active-execution-issues.md
+++ b/docs-site/docs/contributing/active-execution-issues.md
@@ -5,7 +5,7 @@ description: Active Execution Issues
 
 # Active Execution Issues
 
-Last updated: 2026-04-09
+Last updated: 2026-04-12
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -47,14 +47,14 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 1.1 — Failure Taxonomy & Benchmark Corpus `[30d]`
 
-- [ ] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
-- [ ] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
-- [ ] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
+- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
+- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
+- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
 
 ### Milestone 1.2 — Worker Contracts & Credential Envelopes `[30-90d]`
 
-- [ ] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
-- [ ] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
+- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
+- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
 - [ ] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
@@ -81,8 +81,8 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
-- [ ] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
-- [ ] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
+- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
+- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
 - [ ] **BC-06** Preserve original versus sanitized task text for audit
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`

--- a/docs-site/docs/contributing/next-steps-canonical.md
+++ b/docs-site/docs/contributing/next-steps-canonical.md
@@ -5,7 +5,7 @@ description: Next Steps (Canonical)
 
 # Next Steps (Canonical)
 
-Last updated: 2026-04-09
+Last updated: 2026-04-12
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](./canonical-goals) defines what Aragora is and why.
@@ -23,13 +23,17 @@ What is already true:
 - host-side install and preflight scripts exist
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
+- terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
+- `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
+- launcher-side contract admission and module-level contract-aware preflight are on `main`
+- task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 
 What is still missing:
 
 - honest benchmarked proof of semi-autonomous success
-- contract-backed worker admission on the safest classes of work
-- production-equivalent preflight on those classes
-- truthful failure taxonomy and repair loops
+- contract-backed worker admission across launcher, supervisor, and tranche queue on the safest classes of work
+- top-level production-equivalent preflight on those classes
+- broader repair-loop coverage and persisted original-versus-sanitized task audit
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”

--- a/docs/EXTENDED_README.md
+++ b/docs/EXTENDED_README.md
@@ -336,7 +336,7 @@ aragora/
 └── cli/              # Command-line interface
 ```
 
-**Scale:** 3,000+ Python modules | 153,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
+**Scale:** 3,000+ Python modules | 154,000+ tests across 5,000+ test files | 185 Python / 186 TypeScript SDK namespaces
 
 ---
 

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-09
+Last updated: 2026-04-12
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -42,14 +42,14 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 1.1 — Failure Taxonomy & Benchmark Corpus `[30d]`
 
-- [ ] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
-- [ ] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
-- [ ] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
+- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
+- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
+- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
 
 ### Milestone 1.2 — Worker Contracts & Credential Envelopes `[30-90d]`
 
-- [ ] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
-- [ ] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
+- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
+- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
 - [ ] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
@@ -76,8 +76,8 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
-- [ ] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
-- [ ] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
+- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
+- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
 - [ ] **BC-06** Preserve original versus sanitized task text for audit
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-09
+Last updated: 2026-04-12
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -18,13 +18,17 @@ What is already true:
 - host-side install and preflight scripts exist
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
+- terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
+- `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
+- launcher-side contract admission and module-level contract-aware preflight are on `main`
+- task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 
 What is still missing:
 
 - honest benchmarked proof of semi-autonomous success
-- contract-backed worker admission on the safest classes of work
-- production-equivalent preflight on those classes
-- truthful failure taxonomy and repair loops
+- contract-backed worker admission across launcher, supervisor, and tranche queue on the safest classes of work
+- top-level production-equivalent preflight on those classes
+- broader repair-loop coverage and persisted original-versus-sanitized task audit
 - lower-rescue unattended operation on bounded backlogs
 
 The work now is not “add more speculative autonomy.” It is “make bounded unattended execution boring.”


### PR DESCRIPTION
## Summary
- update the active execution map to reflect landed reliability substrate and sanitizer work
- reconcile the canonical next-steps doc with what is now actually true on main
- keep RS-06..09 and BC-06 explicitly open where the full guarded path is not finished

## Validation
- python3 scripts/reconcile_status_docs.py --strict
- bash scripts/automation_pr_preflight.sh origin/main HEAD