### PR TITLE
feat(boss): add decomposition telemetry and conservative routing

### DIFF
--- a/aragora/cli/commands/review_pr.py
+++ b/aragora/cli/commands/review_pr.py
@@ -526,7 +526,7 @@ def _cleanup_worktree(repo_root: Path, worktree_path: Path) -> None:
         try:
             parent.rmdir()
         except OSError as exc:
-            logger.warning("review-pr parent cleanup skipped for %s: %s", parent, exc)
+            logger.debug("review-pr parent cleanup skipped for %s: %s", parent, exc)
 
 
 def _build_review_prompt(*, target: PullRequestTarget, diff_text: str) -> str:

--- a/aragora/swarm/decomposition_bridge.py
+++ b/aragora/swarm/decomposition_bridge.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -95,6 +96,32 @@ def _success_criteria_lines(success_criteria: dict[str, Any]) -> list[str]:
     return _ordered_unique(lines)
 
 
+@dataclass(slots=True)
+class DecompositionStats:
+    """Telemetry for one parent-issue decomposition attempt."""
+
+    raw_candidates: int = 0
+    accepted_candidates: int = 0
+    rejected_candidates: int = 0
+    sanitizer_rejections: int = 0
+    overlap_rejections: int = 0
+    complexity_rejections: int = 0
+    empty_scope_rejections: int = 0
+    validation_rejections: int = 0
+    sanitation_rejections: int = 0
+    overscope_rejections: int = 0
+    skipped_validation_only_orders: int = 0
+    used_micro_fallback: bool = False
+
+
+@dataclass(slots=True)
+class DecompositionOutcome:
+    """Accepted child issues plus telemetry for one parent issue."""
+
+    children: list[BossIssueCandidate]
+    stats: DecompositionStats
+
+
 class DecompositionBridge:
     """Transform a vague parent issue into bounded child candidates."""
 
@@ -110,12 +137,24 @@ class DecompositionBridge:
         *,
         max_children: int = 5,
     ) -> list[BossIssueCandidate]:
+        return (
+            await self.decompose_issue_with_stats(title, body, max_children=max_children)
+        ).children
+
+    async def decompose_issue_with_stats(
+        self,
+        title: str,
+        body: str,
+        *,
+        max_children: int = 5,
+    ) -> DecompositionOutcome:
         if max_children <= 0:
-            return []
+            return DecompositionOutcome(children=[], stats=DecompositionStats())
 
         spec = self._build_parent_spec(title, body)
         parent_category = infer_issue_category_from_title(title) or "decomposed_issue"
         actionable = spec.refined_goal or spec.raw_goal or str(title or "").strip()
+        stats = DecompositionStats()
 
         decomposition = self._task_decomposer.analyze(
             actionable,
@@ -133,9 +172,11 @@ class DecompositionBridge:
                         parent_title=title,
                         parent_category=parent_category,
                         parent_spec=spec,
+                        stats=stats,
                     )
                 )
         elif spec.file_scope_hints:
+            stats.used_micro_fallback = True
             candidates.extend(
                 await self._candidates_from_micro_work_orders(
                     goal=actionable,
@@ -144,9 +185,11 @@ class DecompositionBridge:
                     file_scope_hints=list(spec.file_scope_hints),
                     acceptance_criteria=list(spec.acceptance_criteria),
                     constraints=list(spec.constraints),
+                    stats=stats,
                 )
             )
 
+        stats.raw_candidates = len(candidates)
         accepted: list[BossIssueCandidate] = []
         seen_paths: set[str] = set()
         for candidate in candidates:
@@ -154,19 +197,37 @@ class DecompositionBridge:
                 break
             candidate_paths = set(candidate.file_scope + candidate.new_files)
             if not candidate_paths:
+                stats.rejected_candidates += 1
+                stats.empty_scope_rejections += 1
                 continue
             if candidate_paths & seen_paths:
+                stats.rejected_candidates += 1
+                stats.overlap_rejections += 1
                 continue
             if candidate.estimated_complexity not in {"small", "medium"}:
+                stats.rejected_candidates += 1
+                stats.complexity_rejections += 1
                 continue
-            gated = self._gate_candidate(candidate)
+            gated, gate_reason = self._gate_candidate_with_reason(candidate)
             if gated is None:
+                stats.rejected_candidates += 1
+                if gate_reason == "sanitizer":
+                    stats.sanitizer_rejections += 1
+                elif gate_reason == "missing_validation":
+                    stats.validation_rejections += 1
+                elif gate_reason == "body_sanitation":
+                    stats.sanitation_rejections += 1
+                elif gate_reason == "scope_too_broad":
+                    stats.overscope_rejections += 1
+                elif gate_reason == "missing_scope":
+                    stats.empty_scope_rejections += 1
                 continue
             accepted.append(gated)
+            stats.accepted_candidates += 1
             seen_paths.update(gated.file_scope)
             seen_paths.update(gated.new_files)
 
-        return accepted[:max_children]
+        return DecompositionOutcome(children=accepted[:max_children], stats=stats)
 
     def decompose_issue_sync(
         self,
@@ -179,6 +240,20 @@ class DecompositionBridge:
         except RuntimeError:
             return asyncio.run(self.decompose_issue(title, body, **kwargs))
         raise RuntimeError("decompose_issue_sync() cannot run inside an active event loop")
+
+    def decompose_issue_sync_with_stats(
+        self,
+        title: str,
+        body: str,
+        **kwargs: Any,
+    ) -> DecompositionOutcome:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.decompose_issue_with_stats(title, body, **kwargs))
+        raise RuntimeError(
+            "decompose_issue_sync_with_stats() cannot run inside an active event loop"
+        )
 
     def _build_parent_spec(self, title: str, body: str) -> SwarmSpec:
         issue_body = str(body or "").strip()
@@ -219,9 +294,11 @@ class DecompositionBridge:
         parent_title: str,
         parent_category: str,
         parent_spec: SwarmSpec,
+        stats: DecompositionStats,
     ) -> list[BossIssueCandidate]:
         scope = _normalize_scope_paths(list(subtask.file_scope))
         if self._needs_micro_decomposition(subtask):
+            stats.used_micro_fallback = True
             return await self._candidates_from_micro_work_orders(
                 goal=subtask.description
                 or subtask.title
@@ -235,6 +312,7 @@ class DecompositionBridge:
                     or list(parent_spec.acceptance_criteria)
                 ),
                 constraints=list(parent_spec.constraints),
+                stats=stats,
             )
 
         return [
@@ -260,6 +338,7 @@ class DecompositionBridge:
         file_scope_hints: list[str],
         acceptance_criteria: list[str],
         constraints: list[str],
+        stats: DecompositionStats,
     ) -> list[BossIssueCandidate]:
         orders = build_micro_work_orders(
             goal=goal,
@@ -272,6 +351,7 @@ class DecompositionBridge:
         for order in orders:
             title = str(order.get("title", "")).strip()
             if "validation" in title.lower():
+                stats.skipped_validation_only_orders += 1
                 continue
             scope_paths = [
                 str(path).strip() for path in order.get("file_scope", []) if str(path).strip()
@@ -416,13 +496,19 @@ class DecompositionBridge:
         return text
 
     def _gate_candidate(self, candidate: BossIssueCandidate) -> BossIssueCandidate | None:
+        gated, _ = self._gate_candidate_with_reason(candidate)
+        return gated
+
+    def _gate_candidate_with_reason(
+        self, candidate: BossIssueCandidate
+    ) -> tuple[BossIssueCandidate | None, str | None]:
         body = self._render_candidate_body(candidate)
         sanitation = self._task_sanitizer.sanitize(candidate.title, body)
         if sanitation.outcome in {
             SanitizationOutcome.DROPPED,
             SanitizationOutcome.QUARANTINED,
         }:
-            return None
+            return None, "sanitizer"
 
         effective_text = sanitation.sanitized_text or f"{candidate.title}\n\n{body}"
         effective_body = self._extract_body_text(candidate.title, effective_text)
@@ -452,16 +538,20 @@ class DecompositionBridge:
             candidate.acceptance_criteria = _ordered_unique(criteria)
 
         if len(candidate.file_scope) + len(candidate.new_files) > _MAX_SCOPE_PATHS:
-            return None
+            return None, "scope_too_broad"
 
         sanitation_ok, _ = assess_issue_body_sanitation(effective_body)
         if not sanitation_ok:
-            return None
+            return None, "body_sanitation"
         if not candidate.validation_command:
-            return None
+            return None, "missing_validation"
         if not (candidate.file_scope or candidate.new_files):
-            return None
-        return candidate
+            return None, "missing_scope"
+        return candidate, None
 
 
-__all__ = ["DecompositionBridge"]
+__all__ = [
+    "DecompositionBridge",
+    "DecompositionOutcome",
+    "DecompositionStats",
+]

--- a/aragora/task_brief.py
+++ b/aragora/task_brief.py
@@ -44,7 +44,7 @@ class TaskBriefV1:
 
     def __post_init__(self) -> None:
         """Perform validation after the object is initialized."""
-        if not self.goal or not self.goal.strip():
+        if not isinstance(self.goal, str) or not self.goal.strip():
             raise ValueError("The 'goal' field cannot be empty.")
 
         if not 0.0 <= self.confidence <= 1.0:

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -19,6 +19,7 @@ import json
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 # Add repo root to path
@@ -28,6 +29,28 @@ sys.path.insert(0, str(REPO_ROOT))
 from aragora.swarm.decomposition_bridge import DecompositionBridge  # noqa: E402
 from aragora.swarm.issue_scanner import BossIssueCandidate, scan_all  # noqa: E402
 from aragora.swarm.issue_upgrader import upgrade_issue_heuristic  # noqa: E402
+
+_GENERIC_PARENT_PHRASES: tuple[str, ...] = (
+    "read the module and identify all public functions",
+    "create a test file with broad coverage",
+    "covering all public api surface",
+    "while preserving existing behavior and keeping the work reviewable",
+    "supporting tests",
+    "think about it",
+)
+
+
+@dataclass(slots=True)
+class DecompositionTelemetry:
+    """Aggregate telemetry for one generator run."""
+
+    parents_seen: int = 0
+    parents_eligible: int = 0
+    parents_preserved: int = 0
+    parents_replaced: int = 0
+    children_emitted: int = 0
+    children_rejected: int = 0
+    sanitizer_rejections: int = 0
 
 
 def format_boss_ready_body(candidate: BossIssueCandidate) -> str:
@@ -222,6 +245,81 @@ def validate_body(body: str) -> tuple[bool, str]:
         return True, ""
 
 
+def is_low_quality_parent(candidate: BossIssueCandidate, body: str) -> bool:
+    """Return True only for generic parent issues worth decomposing.
+
+    The bridge should operate on broad or templated parent issues, not on
+    already-bounded single-file work orders produced by the scanner.
+    """
+    total_scope = len(candidate.file_scope) + len(candidate.new_files)
+    normalized_body = " ".join(body.lower().split())
+
+    if total_scope == 0:
+        return True
+    if total_scope > 2:
+        return True
+    if not candidate.validation_command:
+        return True
+    if candidate.estimated_complexity not in {"small", "medium"}:
+        return True
+    return any(phrase in normalized_body for phrase in _GENERIC_PARENT_PHRASES)
+
+
+def _print_decomposition_telemetry(telemetry: DecompositionTelemetry) -> None:
+    print(
+        "  Decomposition telemetry:"
+        f" seen={telemetry.parents_seen}"
+        f" eligible={telemetry.parents_eligible}"
+        f" preserved={telemetry.parents_preserved}"
+        f" replaced={telemetry.parents_replaced}"
+        f" children={telemetry.children_emitted}"
+        f" rejected={telemetry.children_rejected}"
+        f" sanitizer={telemetry.sanitizer_rejections}"
+    )
+
+
+def maybe_decompose_candidates_with_telemetry(
+    candidates: list[BossIssueCandidate],
+    *,
+    enabled: bool,
+    max_children_per_parent: int,
+    repo_root: Path,
+) -> tuple[list[BossIssueCandidate], DecompositionTelemetry]:
+    """Optionally replace low-quality parents with bounded child candidates."""
+    telemetry = DecompositionTelemetry(parents_seen=len(candidates))
+    if not enabled or not candidates:
+        telemetry.parents_preserved = len(candidates)
+        return list(candidates), telemetry
+
+    bridge = DecompositionBridge(repo_root)
+    expanded: list[BossIssueCandidate] = []
+    for candidate in candidates:
+        parent_body = format_boss_ready_body(candidate)
+        if not is_low_quality_parent(candidate, parent_body):
+            expanded.append(candidate)
+            telemetry.parents_preserved += 1
+            continue
+
+        telemetry.parents_eligible += 1
+        outcome = bridge.decompose_issue_sync_with_stats(
+            candidate.title,
+            parent_body,
+            max_children=max_children_per_parent,
+        )
+        telemetry.children_rejected += outcome.stats.rejected_candidates
+        telemetry.sanitizer_rejections += outcome.stats.sanitizer_rejections
+
+        if len(outcome.children) >= 2:
+            expanded.extend(outcome.children)
+            telemetry.parents_replaced += 1
+            telemetry.children_emitted += len(outcome.children)
+        else:
+            expanded.append(candidate)
+            telemetry.parents_preserved += 1
+
+    return expanded, telemetry
+
+
 def maybe_decompose_candidates(
     candidates: list[BossIssueCandidate],
     *,
@@ -229,34 +327,12 @@ def maybe_decompose_candidates(
     max_children_per_parent: int,
     repo_root: Path,
 ) -> list[BossIssueCandidate]:
-    """Optionally replace low-quality parents with bounded child candidates.
-
-    The parent candidate is preserved unless decomposition produces a meaningful
-    child set. This keeps the feature safe to enable experimentally.
-    """
-    if not enabled or not candidates:
-        return list(candidates)
-
-    bridge = DecompositionBridge(repo_root)
-    expanded: list[BossIssueCandidate] = []
-    decomposed_count = 0
-    for candidate in candidates:
-        parent_body = format_boss_ready_body(candidate)
-        children = bridge.decompose_issue_sync(
-            candidate.title,
-            parent_body,
-            max_children=max_children_per_parent,
-        )
-        if len(children) >= 2:
-            expanded.extend(children)
-            decomposed_count += 1
-        else:
-            expanded.append(candidate)
-
-    if decomposed_count:
-        print(
-            f"  Decomposed {decomposed_count} parent issue(s) into {len(expanded)} bounded candidates"
-        )
+    expanded, _ = maybe_decompose_candidates_with_telemetry(
+        candidates,
+        enabled=enabled,
+        max_children_per_parent=max_children_per_parent,
+        repo_root=repo_root,
+    )
     return expanded
 
 
@@ -324,12 +400,14 @@ def main() -> None:
         categories=args.categories,
         min_success_rate=args.min_success_rate,
     )
-    candidates = maybe_decompose_candidates(
+    candidates, decomposition_telemetry = maybe_decompose_candidates_with_telemetry(
         candidates,
         enabled=args.decompose_low_quality,
         max_children_per_parent=args.max_children_per_parent,
         repo_root=repo_root,
     )
+    if args.decompose_low_quality:
+        _print_decomposition_telemetry(decomposition_telemetry)
     print(
         f"  Found {len(candidates)} candidates across {len(set(c.category for c in candidates))} categories"
     )

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from types import SimpleNamespace
 
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from scripts import generate_boss_issues as mod
@@ -201,16 +202,29 @@ def test_maybe_decompose_candidates_replaces_parent_when_children_emitted(monkey
         new_files=["tests/test_module_b.py"],
         validation_command="python3 -m pytest -q tests/test_module_b.py",
     )
+    monkeypatch.setattr(
+        mod,
+        "format_boss_ready_body",
+        lambda candidate: (
+            "## Task\n\nAdd comprehensive unit tests.\n\n"
+            "### Requirements\n"
+            "1. Read the module and identify all public functions.\n"
+            "2. Create a test file with broad coverage.\n"
+        ),
+    )
 
     class FakeBridge:
         def __init__(self, repo_root):  # noqa: D401, ANN001
             self.repo_root = repo_root
 
-        def decompose_issue_sync(self, title, body, *, max_children):  # noqa: ANN001
+        def decompose_issue_sync_with_stats(self, title, body, *, max_children):  # noqa: ANN001
             assert title == parent.title
             assert "## Task" in body
             assert max_children == 3
-            return [child_a, child_b]
+            return SimpleNamespace(
+                children=[child_a, child_b],
+                stats=SimpleNamespace(rejected_candidates=1, sanitizer_rejections=1),
+            )
 
     monkeypatch.setattr(mod, "DecompositionBridge", FakeBridge)
 
@@ -235,13 +249,26 @@ def test_maybe_decompose_candidates_keeps_parent_when_child_set_is_not_meaningfu
         file_scope=["aragora/module_a.py"],
         validation_command="python3 -m ruff check aragora/module_a.py",
     )
+    monkeypatch.setattr(
+        mod,
+        "format_boss_ready_body",
+        lambda candidate: (
+            "## Task\n\nAdd comprehensive unit tests.\n\n"
+            "### Requirements\n"
+            "1. Read the module and identify all public functions.\n"
+            "2. Create a test file with broad coverage.\n"
+        ),
+    )
 
     class FakeBridge:
         def __init__(self, repo_root):  # noqa: D401, ANN001
             self.repo_root = repo_root
 
-        def decompose_issue_sync(self, title, body, *, max_children):  # noqa: ANN001
-            return [single_child]
+        def decompose_issue_sync_with_stats(self, title, body, *, max_children):  # noqa: ANN001
+            return SimpleNamespace(
+                children=[single_child],
+                stats=SimpleNamespace(rejected_candidates=2, sanitizer_rejections=1),
+            )
 
     monkeypatch.setattr(mod, "DecompositionBridge", FakeBridge)
 
@@ -253,6 +280,85 @@ def test_maybe_decompose_candidates_keeps_parent_when_child_set_is_not_meaningfu
     )
 
     assert result == [parent]
+
+
+def test_is_low_quality_parent_skips_bounded_module_aware_issue() -> None:
+    candidate = _candidate(
+        "analytics_core", file_scope=["aragora/server/handlers/analytics/core.py"]
+    )
+    body = (
+        "## Task\n\n"
+        "Write focused unit tests for `aragora/server/handlers/analytics/core.py` (53 lines, 0 public functions).\n\n"
+        "**Module purpose:** Analytics Core Module.\n\n"
+        "### What to test\n"
+        "- happy path behavior\n\n"
+        "### Validation\n```bash\npytest tests/test_analytics_core.py -v\n```"
+    )
+
+    assert mod.is_low_quality_parent(candidate, body) is False
+
+
+def test_is_low_quality_parent_detects_generic_template() -> None:
+    candidate = _candidate("module", file_scope=["aragora/pkg/module.py"])
+    body = (
+        "## Task\n\n"
+        "Add comprehensive unit tests for `aragora/pkg/module.py`.\n\n"
+        "### Requirements\n"
+        "1. Read the module and identify all public functions.\n"
+        "2. Create a test file with broad coverage.\n"
+    )
+
+    assert mod.is_low_quality_parent(candidate, body) is True
+
+
+def test_maybe_decompose_candidates_with_telemetry_tracks_counts(monkeypatch) -> None:
+    low_quality = _candidate("generic_module", file_scope=["aragora/generic_module.py"])
+    bounded = _candidate("bounded_module", file_scope=["aragora/bounded_module.py"])
+    child_a = _candidate("child_a", file_scope=["aragora/child_a.py"])
+    child_b = _candidate("child_b", file_scope=["aragora/child_b.py"])
+
+    original_formatter = mod.format_boss_ready_body
+
+    def fake_format(candidate: BossIssueCandidate) -> str:
+        if candidate.title == low_quality.title:
+            return (
+                "## Task\n\n"
+                "Add comprehensive unit tests for `aragora/generic_module.py`.\n\n"
+                "### Requirements\n"
+                "1. Read the module and identify all public functions.\n"
+                "2. Create a test file with broad coverage.\n"
+            )
+        return original_formatter(candidate)
+
+    class FakeBridge:
+        def __init__(self, repo_root):  # noqa: D401, ANN001
+            self.repo_root = repo_root
+
+        def decompose_issue_sync_with_stats(self, title, body, *, max_children):  # noqa: ANN001
+            assert title == low_quality.title
+            return SimpleNamespace(
+                children=[child_a, child_b],
+                stats=SimpleNamespace(rejected_candidates=3, sanitizer_rejections=2),
+            )
+
+    monkeypatch.setattr(mod, "format_boss_ready_body", fake_format)
+    monkeypatch.setattr(mod, "DecompositionBridge", FakeBridge)
+
+    result, telemetry = mod.maybe_decompose_candidates_with_telemetry(
+        [low_quality, bounded],
+        enabled=True,
+        max_children_per_parent=4,
+        repo_root=mod.REPO_ROOT,
+    )
+
+    assert result == [child_a, child_b, bounded]
+    assert telemetry.parents_seen == 2
+    assert telemetry.parents_eligible == 1
+    assert telemetry.parents_replaced == 1
+    assert telemetry.parents_preserved == 1
+    assert telemetry.children_emitted == 2
+    assert telemetry.children_rejected == 3
+    assert telemetry.sanitizer_rejections == 2
 
 
 def test_main_passes_decomposition_flags(monkeypatch, capsys) -> None:
@@ -269,10 +375,16 @@ def test_main_passes_decomposition_flags(monkeypatch, capsys) -> None:
     )
     monkeypatch.setattr(
         mod,
-        "maybe_decompose_candidates",
+        "maybe_decompose_candidates_with_telemetry",
         lambda candidates, *, enabled, max_children_per_parent, repo_root: (
             decompose_calls.append((list(candidates), enabled, max_children_per_parent, repo_root))
-            or list(candidates)
+            or (
+                list(candidates),
+                mod.DecompositionTelemetry(
+                    parents_seen=len(candidates),
+                    parents_preserved=len(candidates),
+                ),
+            )
         ),
     )
     monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])

--- a/tests/swarm/test_decomposition_bridge.py
+++ b/tests/swarm/test_decomposition_bridge.py
@@ -9,7 +9,11 @@ import pytest
 
 from aragora.nomic.task_decomposer import SubTask
 from aragora.swarm.boss_validation import assess_issue_body_sanitation
-from aragora.swarm.decomposition_bridge import DecompositionBridge, _partition_paths
+from aragora.swarm.decomposition_bridge import (
+    DecompositionBridge,
+    DecompositionOutcome,
+    _partition_paths,
+)
 from aragora.swarm.task_sanitizer import SanitizationOutcome, SanitizationResult
 
 
@@ -533,6 +537,24 @@ class TestDecomposeIssue:
         )
         assert len(result) == 1
 
+    def test_sync_wrapper_with_stats_counts_rejections(self, bridge: DecompositionBridge) -> None:
+        bridge._task_decomposer = _FakeDecomposer(
+            [
+                _make_subtask(title="first", file_scope=["aragora/pkg/module.py"]),
+                _make_subtask(title="second", file_scope=["aragora/pkg/module.py"]),
+            ]
+        )
+        result = bridge.decompose_issue_sync_with_stats(
+            "Parent",
+            "## Task\n\nParent task body that is long enough for dispatch gating to accept it safely.",
+        )
+        assert isinstance(result, DecompositionOutcome)
+        assert len(result.children) == 1
+        assert result.stats.raw_candidates == 2
+        assert result.stats.accepted_candidates == 1
+        assert result.stats.rejected_candidates == 1
+        assert result.stats.overlap_rejections == 1
+
 
 class TestRealIssueCorpus:
     @pytest.mark.asyncio
@@ -540,9 +562,9 @@ class TestRealIssueCorpus:
         ("title", "body"),
         [
             (
-                "Add unit tests for aragora/pkg/module.py",
+                "Add unit tests for server/fastapi/routes/dr.py",
                 "## Task\n\n"
-                "Add comprehensive unit tests for `aragora/pkg/module.py`.\n\n"
+                "Add comprehensive unit tests for `aragora/server/fastapi/routes/dr.py`.\n\n"
                 "### Requirements\n"
                 "1. Read the module and identify all public functions.\n"
                 "2. Create a test file with broad coverage.\n\n"
@@ -569,6 +591,18 @@ class TestRealIssueCorpus:
                 "- `aragora/pkg/helper.py`\n"
                 "- `tests/pkg/test_module.py` (create)\n",
             ),
+            (
+                "Replace silent exception swallowing in scheduler_bridge.py",
+                "## Task\n\n"
+                "Replace `except ...: pass` patterns with proper error handling in `aragora/pkg/helper.py`.\n\n"
+                "### Requirements\n"
+                "1. Read the file and find all silent exception swallowing.\n"
+                "2. Add logging or specific handling where appropriate.\n\n"
+                "### File Scope\n"
+                "- `aragora/pkg/helper.py`\n\n"
+                "### Validation\n"
+                "- python3 -m ruff check aragora/pkg/helper.py\n",
+            ),
         ],
     )
     async def test_realish_parent_templates_emit_bounded_children(
@@ -586,6 +620,7 @@ class TestRealIssueCorpus:
             assert candidate.validation_command
             assert candidate.estimated_complexity in {"small", "medium"}
             assert 1 <= len(candidate.file_scope) + len(candidate.new_files) <= 5
+            assert candidate.file_scope or candidate.new_files
             rendered = bridge._render_candidate_body(candidate)
             ok, reason = assess_issue_body_sanitation(rendered)
             assert ok, reason


### PR DESCRIPTION
## Summary
- add per-parent decomposition telemetry to the bridge and surface aggregate counts in issue generation
- only run decomposition on genuinely low-quality parent issues instead of already-bounded scanner output
- strengthen the acceptance corpus around vague parent templates and generator routing behavior

## Validation
- python3 -m pytest tests/swarm/test_decomposition_bridge.py tests/scripts/test_generate_boss_issues.py -q
- python3 -m ruff check aragora/swarm/decomposition_bridge.py scripts/generate_boss_issues.py tests/swarm/test_decomposition_bridge.py tests/scripts/test_generate_boss_issues.py
- live probe: maybe_decompose_candidates_with_telemetry(scan_all(...)) -> 85 seen / 0 eligible on the current normalized queue
