### PR TITLE
fix(server): reconcile baseline handler contracts

### DIFF
--- a/aragora/server/handlers/admin/feature_flags.py
+++ b/aragora/server/handlers/admin/feature_flags.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 __all__ = ["FeatureFlagAdminHandler"]
 
+import json
 import logging
 from typing import Any
 
@@ -232,8 +233,8 @@ class FeatureFlagAdminHandler(BaseHandler):
         if not definition:
             return error_response(f"Flag not found: {name}", 404)
 
-        body = self.read_json_body(handler)
-        if body is None:
+        body, parsed = self._read_json_body_value(handler)
+        if not parsed:
             return error_response("Invalid JSON body", 400)
         if not isinstance(body, dict):
             return error_response("JSON body must deserialize to an object", 400)
@@ -266,3 +267,45 @@ class FeatureFlagAdminHandler(BaseHandler):
                 "updated": True,
             }
         )
+
+    def _read_json_body_value(
+        self,
+        handler: Any,
+        max_size: int | None = None,
+    ) -> tuple[Any | None, bool]:
+        """Read JSON while distinguishing parse failures from non-object payloads."""
+        max_size = max_size or self.MAX_BODY_SIZE
+        try:
+            for raw_body in (
+                getattr(handler, "body", None),
+                getattr(getattr(handler, "request", None), "body", None),
+            ):
+                if isinstance(raw_body, str):
+                    raw_body = raw_body.encode("utf-8")
+                if isinstance(raw_body, (bytes, bytearray)):
+                    if len(raw_body) > max_size:
+                        return None, False
+                    if not raw_body:
+                        return {}, True
+                    return json.loads(bytes(raw_body)), True
+
+            content_length = int(handler.headers.get("Content-Length", 0))
+            is_chunked = "chunked" in (handler.headers.get("Transfer-Encoding", "") or "").lower()
+
+            if content_length > max_size:
+                return None, False
+
+            if content_length > 0:
+                body = handler.rfile.read(content_length)
+            elif is_chunked or content_length == 0:
+                body = handler.rfile.read(max_size)
+            else:
+                return {}, True
+
+            if not body:
+                return {}, True
+            if len(body) > max_size:
+                return None, False
+            return json.loads(body), True
+        except (AttributeError, json.JSONDecodeError, TypeError, ValueError):
+            return None, False

--- a/tests/server/handlers/test_runs_handler.py
+++ b/tests/server/handlers/test_runs_handler.py
@@ -51,6 +51,18 @@ def _make_http_handler() -> Any:
     return handler
 
 
+def _assert_stage_payload(
+    actual: list[dict[str, Any]],
+    expected: list[tuple[str, str]],
+) -> None:
+    assert [(stage["stage"], stage["status"]) for stage in actual] == expected
+    for stage in actual:
+        assert isinstance(stage.get("event_id"), str)
+        assert "created_at" in stage
+        assert stage.get("artifact_ref") == ""
+        assert stage.get("details") == {}
+
+
 @pytest.fixture(autouse=True)
 def isolated_plan_store(tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> PlanStore:
     store = PlanStore(db_path=str(tmp_path / "runs_handler.db"))
@@ -100,21 +112,21 @@ def test_handle_runs_list_returns_compact_backbone_payload(
     parsed = _parse(result)
 
     assert parsed["status"] == 200
-    assert parsed["body"] == {
-        "runs": [
-            {
-                "run_id": "run-001",
-                "status": "plan_ready",
-                "stages": [
-                    {"stage": BackboneStage.INTAKE.value, "status": "received"},
-                    {"stage": BackboneStage.PLAN.value, "status": "completed"},
-                ],
-                "execution_id": "exec-001",
-                "receipt_id": "receipt-001",
-                "safety_mode": ExecutionMode.INTERACTIVE.value,
-            }
-        ]
-    }
+    assert len(parsed["body"]["runs"]) == 1
+    payload = parsed["body"]["runs"][0]
+    assert payload["run_id"] == "run-001"
+    assert payload["status"] == "plan_ready"
+    assert payload["execution_id"] == "exec-001"
+    assert payload["receipt_id"] == "receipt-001"
+    assert payload["safety_mode"] == ExecutionMode.INTERACTIVE.value
+    _assert_stage_payload(
+        payload["stages"],
+        [
+            (BackboneStage.INTAKE.value, "received"),
+            (BackboneStage.PLAN.value, "completed"),
+        ],
+    )
+    assert payload["stage_timeline"] == payload["stages"]
 
 
 def test_handle_runs_list_prefers_backbone_lister() -> None:
@@ -146,9 +158,11 @@ def test_handle_runs_list_prefers_backbone_lister() -> None:
     assert parsed["status"] == 200
     assert store.calls == [("receipt_ready", 5, 2)]
     assert parsed["body"]["runs"][0]["run_id"] == "run-compat"
-    assert parsed["body"]["runs"][0]["stages"] == [
-        {"stage": BackboneStage.RECEIPT.value, "status": "completed"}
-    ]
+    _assert_stage_payload(
+        parsed["body"]["runs"][0]["stages"],
+        [(BackboneStage.RECEIPT.value, "completed")],
+    )
+    assert parsed["body"]["runs"][0]["stage_timeline"] == parsed["body"]["runs"][0]["stages"]
 
 
 def test_handle_run_detail_prefers_get_backbone_run() -> None:
@@ -174,18 +188,17 @@ def test_handle_run_detail_prefers_get_backbone_run() -> None:
 
     assert parsed["status"] == 200
     assert store.seen == ["run-detail"]
-    assert parsed["body"] == {
-        "run": {
-            "run_id": "run-detail",
-            "status": "execution_started",
-            "stages": [
-                {"stage": BackboneStage.EXECUTION.value, "status": "running"},
-            ],
-            "execution_id": "exec-detail",
-            "receipt_id": None,
-            "safety_mode": ExecutionMode.AUTONOMOUS.value,
-        }
-    }
+    payload = parsed["body"]["run"]
+    assert payload["run_id"] == "run-detail"
+    assert payload["status"] == "execution_started"
+    assert payload["execution_id"] == "exec-detail"
+    assert payload["receipt_id"] is None
+    assert payload["safety_mode"] == ExecutionMode.AUTONOMOUS.value
+    _assert_stage_payload(
+        payload["stages"],
+        [(BackboneStage.EXECUTION.value, "running")],
+    )
+    assert payload["stage_timeline"] == payload["stages"]
 
 
 def test_handle_run_detail_returns_404_when_missing() -> None:


### PR DESCRIPTION
## Summary
- distinguish malformed JSON from valid non-object JSON in the feature-flags set handler
- keep the handler returning the documented object-only validation error for scalar and array bodies
- update runs-handler expectations to match the current richer stage payload contract

## Validation
- python3 -m pytest -q tests/server/handlers/test_runs_handler.py
- python3 -m pytest -q tests/handlers/admin/test_feature_flags.py
- python3 -m ruff check aragora/server/handlers/admin/feature_flags.py tests/server/handlers/test_runs_handler.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
