### PR TITLE
feat(boss): add B0 metrics instrumentation

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -882,11 +882,11 @@ class BossLoop:
             prompt_chars = 0
             enriched_context_chars = 0
             prompt_version = "v2"  # Context-first prompt (post a11848eac)
-            issue_title = ""
-            if isinstance(receipt_metadata, dict):
-                issue_title = str(receipt_metadata.get("issue_title", "")).strip()
-            if not issue_title:
-                issue_title = str(worker_result.get("issue_title", "")).strip()
+            issue_title = (
+                str(receipt_metadata.get("issue_title", "")).strip()
+                if isinstance(receipt_metadata, dict)
+                else ""
+            ) or str(worker_result.get("issue_title", "")).strip()
             is_decomposed = bool(re.search(r"\[from #\d+\]", issue_title))
             cohort_tag = "B0-cohort" if issue_title.startswith("[B0-cohort]") else None
             worker_outcome = str(worker_result.get("outcome", "")).strip()
@@ -4834,8 +4834,6 @@ class BossLoop:
                 {
                     "status": "needs_human",
                     "outcome": outcome,
-                    "sanitizer_outcome": sanitization.outcome.value,
-                    "checks_failed": list(sanitization.checks_failed),
                     "reasons": reasons,
                     "next_actions": next_actions,
                 }

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -878,20 +878,26 @@ class BossLoop:
 
             # Extract prompt/context instrumentation from work order data
             run_dict = worker_result.get("run")
+            receipt_metadata = worker_result.get("receipt_metadata")
             prompt_chars = 0
             enriched_context_chars = 0
             prompt_version = "v2"  # Context-first prompt (post a11848eac)
-            is_decomposed = bool(
-                re.search(
-                    r"\[from #\d+\]",
-                    str((worker_result.get("receipt_metadata") or {}).get("issue_title", "")),
-                )
-            )
+            issue_title = ""
+            if isinstance(receipt_metadata, dict):
+                issue_title = str(receipt_metadata.get("issue_title", "")).strip()
+            if not issue_title:
+                issue_title = str(worker_result.get("issue_title", "")).strip()
+            is_decomposed = bool(re.search(r"\[from #\d+\]", issue_title))
+            cohort_tag = "B0-cohort" if issue_title.startswith("[B0-cohort]") else None
             worker_outcome = str(worker_result.get("outcome", "")).strip()
             has_deliverable = bool(worker_result.get("deliverable"))
             publish_action = (
                 str((worker_result.get("publish_result") or {}).get("action", "")).strip() or None
             )
+            sanitizer_outcome = str(worker_result.get("sanitizer_outcome", "")).strip() or None
+            checks_failed = worker_result.get("checks_failed")
+            if not isinstance(checks_failed, list):
+                checks_failed = []
 
             # Read prompt size from persisted WorkerProcess fields
             if isinstance(run_dict, dict):
@@ -913,6 +919,12 @@ class BossLoop:
                 "prompt_chars": prompt_chars,
                 "enriched_context_chars": enriched_context_chars,
                 "is_decomposed_issue": is_decomposed,
+                "deferred_queue_depth": len(self._deferred_publish_queue),
+                "sanitizer_outcome": sanitizer_outcome,
+                "sanitizer_checks_failed_count": len(
+                    [str(item).strip() for item in checks_failed if str(item).strip()]
+                ),
+                "cohort_tag": cohort_tag,
                 "has_deliverable": has_deliverable,
                 "publish_action": publish_action,
             }
@@ -4779,6 +4791,12 @@ class BossLoop:
             sanitization.outcome.value,
             ",".join(sanitization.checks_failed) if sanitization.checks_failed else "-",
         )
+
+        def _with_sanitizer_metadata(result: dict[str, Any]) -> dict[str, Any]:
+            result.setdefault("sanitizer_outcome", sanitization.outcome.value)
+            result.setdefault("checks_failed", list(sanitization.checks_failed))
+            return result
+
         if sanitization.outcome in {
             SanitizationOutcome.DROPPED,
             SanitizationOutcome.QUARANTINED,
@@ -4812,14 +4830,16 @@ class BossLoop:
                         f"{sanitization.reason}"
                     )
                 ]
-            return {
-                "status": "needs_human",
-                "outcome": outcome,
-                "sanitizer_outcome": sanitization.outcome.value,
-                "checks_failed": list(sanitization.checks_failed),
-                "reasons": reasons,
-                "next_actions": next_actions,
-            }
+            return _with_sanitizer_metadata(
+                {
+                    "status": "needs_human",
+                    "outcome": outcome,
+                    "sanitizer_outcome": sanitization.outcome.value,
+                    "checks_failed": list(sanitization.checks_failed),
+                    "reasons": reasons,
+                    "next_actions": next_actions,
+                }
+            )
 
         refinement: dict[str, Any] = {}
         refined_prompt = ""
@@ -4955,16 +4975,18 @@ class BossLoop:
         if self.config.require_validation_contract and not bool(
             getattr(spec, "acceptance_criteria", None)
         ):
-            return {
-                "status": "needs_human",
-                "reasons": [
-                    f"Issue #{issue.number} lacks an explicit validation contract or acceptance criteria."
-                ],
-                "next_actions": [
-                    "Add an Acceptance Criteria, Validation, Definition of Done, or Test Plan section to the issue body.",
-                    "Include at least one concrete verification step such as a pytest command or observable success criterion.",
-                ],
-            }
+            return _with_sanitizer_metadata(
+                {
+                    "status": "needs_human",
+                    "reasons": [
+                        f"Issue #{issue.number} lacks an explicit validation contract or acceptance criteria."
+                    ],
+                    "next_actions": [
+                        "Add an Acceptance Criteria, Validation, Definition of Done, or Test Plan section to the issue body.",
+                        "Include at least one concrete verification step such as a pytest command or observable success criterion.",
+                    ],
+                }
+            )
 
         self._attach_issue_handoff_metadata(spec, issue)
 
@@ -4982,16 +5004,18 @@ class BossLoop:
             gate.get("unresolved_missing", []),
         )
         if not gate["sanitation_ok"]:
-            return {
-                "status": "needs_human",
-                "outcome": "sanitation_failed",
-                "reasons": [
-                    f"Issue #{issue.number} failed sanitation: {gate.get('sanitation_reason', 'unknown')}"
-                ],
-                "next_actions": [
-                    "Rewrite the issue body with a clear task description.",
-                ],
-            }
+            return _with_sanitizer_metadata(
+                {
+                    "status": "needs_human",
+                    "outcome": "sanitation_failed",
+                    "reasons": [
+                        f"Issue #{issue.number} failed sanitation: {gate.get('sanitation_reason', 'unknown')}"
+                    ],
+                    "next_actions": [
+                        "Rewrite the issue body with a clear task description.",
+                    ],
+                }
+            )
         if gate.get("unresolved_missing"):
             if gate.get("missing_targets") and not gate["unresolved_missing"]:
                 logger.info(
@@ -5001,41 +5025,47 @@ class BossLoop:
                 )
             else:
                 targets_text = ", ".join(gate["unresolved_missing"])
-                return {
-                    "status": "needs_human",
-                    "outcome": "verification_target_missing",
-                    "reasons": [
-                        f"Issue #{issue.number} references missing validation targets: {targets_text}"
-                    ],
-                    "next_actions": [
-                        "Refresh the issue's Acceptance Criteria or Test Plan so pytest points at current repo paths.",
-                        "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
-                    ],
-                }
+                return _with_sanitizer_metadata(
+                    {
+                        "status": "needs_human",
+                        "outcome": "verification_target_missing",
+                        "reasons": [
+                            f"Issue #{issue.number} references missing validation targets: {targets_text}"
+                        ],
+                        "next_actions": [
+                            "Refresh the issue's Acceptance Criteria or Test Plan so pytest points at current repo paths.",
+                            "Update the Files/Reference section or add explicit work orders before rerunning Boss dispatch.",
+                        ],
+                    }
+                )
 
         if not spec.is_dispatch_bounded():
-            return {
-                "status": "needs_human",
-                "reasons": [
-                    f"Issue #{issue.number} is not safely dispatchable: {spec.dispatch_gate_reason()}"
-                ],
-                "next_actions": [
-                    "Add file-scope hints, constraints, acceptance criteria, or explicit work orders before dispatch.",
-                ],
-            }
+            return _with_sanitizer_metadata(
+                {
+                    "status": "needs_human",
+                    "reasons": [
+                        f"Issue #{issue.number} is not safely dispatchable: {spec.dispatch_gate_reason()}"
+                    ],
+                    "next_actions": [
+                        "Add file-scope hints, constraints, acceptance criteria, or explicit work orders before dispatch.",
+                    ],
+                }
+            )
 
         if not self.config.dispatch_enabled:
-            return {
-                "status": "needs_human",
-                "outcome": "preview_only",
-                "reasons": [
-                    f"No-dispatch preview only for issue #{issue.number}; supervised execution was intentionally skipped."
-                ],
-                "next_actions": [
-                    "Review the selected issue and derived validation contract.",
-                    "Rerun without --no-dispatch to execute the bounded Boss loop lane.",
-                ],
-            }
+            return _with_sanitizer_metadata(
+                {
+                    "status": "needs_human",
+                    "outcome": "preview_only",
+                    "reasons": [
+                        f"No-dispatch preview only for issue #{issue.number}; supervised execution was intentionally skipped."
+                    ],
+                    "next_actions": [
+                        "Review the selected issue and derived validation contract.",
+                        "Rerun without --no-dispatch to execute the bounded Boss loop lane.",
+                    ],
+                }
+            )
 
         requested_target_agent = (
             str(pending_handoff[1]).strip().lower()
@@ -5110,6 +5140,7 @@ class BossLoop:
             dispatch_started = _dispatch_result_started(result)
             if result.get("status") != "failed" or dispatch_started:
                 self._pending_handoff_prompts.pop(issue.number, None)
+        result = _with_sanitizer_metadata(result)
         result["receipt_metadata"] = self._receipt_metadata_for_result(
             result,
             issue=issue,
@@ -5209,6 +5240,7 @@ class BossLoop:
 
         return {
             "issue_number": issue.number,
+            "issue_title": issue.title,
             "requested_target_agent": requested_target_agent,
             "requested_reviewer_agent": self.config.default_reviewer_agent,
             "actual_target_agent": actual_target_agent,

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -2010,6 +2010,10 @@ class TestBossLoop:
         assert payload["prompt_version"] == "v2"
         assert payload["prompt_chars"] == 2048
         assert payload["enriched_context_chars"] == 1536
+        assert payload["deferred_queue_depth"] == 0
+        assert payload["sanitizer_outcome"] is None
+        assert payload["sanitizer_checks_failed_count"] == 0
+        assert payload["cohort_tag"] is None
         assert payload["has_deliverable"] is True
         assert payload["publish_action"] == "opened_pr"
         assert payload["elapsed_seconds"] >= 0.0
@@ -2068,6 +2072,10 @@ class TestBossLoop:
         assert "prompt_chars" in payload
         assert "enriched_context_chars" in payload
         assert "is_decomposed_issue" in payload
+        assert "deferred_queue_depth" in payload
+        assert "sanitizer_outcome" in payload
+        assert "sanitizer_checks_failed_count" in payload
+        assert "cohort_tag" in payload
         assert "has_deliverable" in payload
         assert "publish_action" in payload
         # New terminal_class field
@@ -2075,6 +2083,134 @@ class TestBossLoop:
         assert payload["terminal_class"] in valid_values, (
             f"terminal_class value {payload['terminal_class']!r} is not a valid TerminalClass"
         )
+
+    @pytest.mark.parametrize(
+        ("title", "body", "expected_outcome"),
+        [
+            (
+                "Too short",
+                "Tiny task only.",
+                "dropped",
+            ),
+            (
+                "Broad scope",
+                (
+                    "Implement the reliability substrate end-to-end.\n\n"
+                    "Allowed write set:\n"
+                    "- `aragora/swarm/a.py` (modify)\n"
+                    "- `aragora/swarm/b.py` (modify)\n"
+                    "- `aragora/swarm/c.py` (modify)\n"
+                    "- `aragora/swarm/d.py` (modify)\n"
+                    "- `aragora/swarm/e.py` (modify)\n"
+                    "- `aragora/swarm/f.py` (modify)\n"
+                ),
+                "quarantined",
+            ),
+        ],
+    )
+    def test_metrics_emit_sanitizer_outcome_for_filtered_issues(
+        self,
+        tmp_path: Path,
+        title: str,
+        body: str,
+        expected_outcome: str,
+    ) -> None:
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.return_value = [_make_issue(2420, title, body=body)]
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                metrics_jsonl_path=str(tmp_path / "boss_metrics.jsonl"),
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
+        payload = json.loads((tmp_path / "boss_metrics.jsonl").read_text(encoding="utf-8"))
+        assert payload["worker_status"] == "needs_human"
+        assert payload["sanitizer_outcome"] == expected_outcome
+        assert payload["sanitizer_checks_failed_count"] >= 1
+
+    def test_metrics_emit_deferred_queue_depth_when_publish_deferred(self, tmp_path: Path) -> None:
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                metrics_jsonl_path=str(tmp_path / "boss_metrics.jsonl"),
+                auto_publish_deliverables=True,
+            ),
+        )
+        issue = _make_issue(123, "Deferred publish metrics")
+        worker_result = {
+            "status": "completed",
+            "outcome": "deliverable_created",
+            "deliverable": {
+                "type": "branch",
+                "branch": "codex/issue-123",
+                "commit_shas": ["abc123"],
+            },
+            "receipt_metadata": {"issue_title": issue.title},
+            "run": {"work_orders": []},
+        }
+
+        with patch.object(
+            loop,
+            "_maybe_publish_deliverable",
+            return_value={
+                "action": "deferred_due_to_open_boss_prs",
+                "reason": "open_boss_harvest_pr_limit",
+                "branch": "codex/issue-123",
+                "max_open_prs": 20,
+                "open_prs": [],
+            },
+        ):
+            processed = loop._postprocess_issue_result(issue, worker_result)
+
+        loop._append_iteration_metrics(
+            iteration=1,
+            issue_number=issue.number,
+            worker_result=processed,
+            elapsed_seconds=0.25,
+        )
+
+        payload = json.loads((tmp_path / "boss_metrics.jsonl").read_text(encoding="utf-8"))
+        assert payload["publish_action"] == "deferred_due_to_open_boss_prs"
+        assert payload["deferred_queue_depth"] == 1
+        assert len(loop._deferred_publish_queue) == 1
+
+    def test_metrics_emit_cohort_tag_from_issue_title(self, tmp_path: Path) -> None:
+        feed = MagicMock(spec=GitHubIssueFeed)
+        issue = _make_issue(77, "[B0-cohort] Measure clean publish path")
+        feed.fetch.return_value = [issue]
+
+        loop = BossLoop(
+            config=_boss_config(
+                max_iterations=1,
+                metrics_jsonl_path=str(tmp_path / "boss_metrics.jsonl"),
+            ),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        async def _completed_dispatch(issue, freshness):
+            return {
+                "status": "completed",
+                "outcome": "deliverable_created",
+                "deliverable": {"branch": "codex/test-branch"},
+                "receipt_metadata": {"issue_title": issue.title},
+                "run": {"work_orders": []},
+            }
+
+        loop._dispatch_issue = _completed_dispatch
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        payload = json.loads((tmp_path / "boss_metrics.jsonl").read_text(encoding="utf-8"))
+        assert payload["cohort_tag"] == "B0-cohort"
 
     def test_terminal_class_fallback_on_classification_error(self, tmp_path: Path):
         """terminal_class uses fallback value when classify_from_metrics raises."""
@@ -4514,6 +4650,28 @@ class TestRunnerHeartbeatRefresh:
         assert len(refresh_calls) == 2, (
             f"Expected 2 heartbeat refreshes (one per iteration), got {len(refresh_calls)}"
         )
+
+    def test_deferred_publish_queue_drained_each_iteration(self) -> None:
+        feed = MagicMock(spec=GitHubIssueFeed)
+        feed.fetch.side_effect = [
+            [_make_issue(1, "First issue")],
+            [_make_issue(2, "Second issue")],
+        ]
+
+        loop = BossLoop(
+            config=_boss_config(max_iterations=2),
+            issue_feed=feed,
+            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+        )
+
+        drain_calls: list[int] = []
+        loop._drain_deferred_publish_queue = lambda: drain_calls.append(1) or 0
+        loop._dispatch_issue = AsyncMock(return_value={"status": "completed"})
+
+        result = asyncio.run(loop.run())
+
+        assert result.stop_reason == BossStopReason.MAX_ITERATIONS.value
+        assert len(drain_calls) == 2
 
     def test_heartbeat_refresh_skipped_without_owner_context(self, tmp_path):
         """Without ARAGORA_USER_ID, heartbeat refresh is a no-op (no crash)."""


### PR DESCRIPTION
## Summary
- add narrow boss-loop metrics fields for deferred publish depth, sanitizer outcome, sanitizer check count, and B0 cohort tagging
- thread sanitizer metadata and issue title through existing worker-result metadata paths without changing publish or sanitizer policy
- add focused boss-loop coverage for deferred queue drain timing and the new metrics fields

## Validation
- pytest tests/swarm/test_boss_loop.py -k 'sanitizer or deferred or cohort or metrics' -q
- python3 -m ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/boss_loop.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
