### PR TITLE
Narrow deterministic issue upgrader heuristic

### DIFF
--- a/aragora/swarm/issue_upgrader.py
+++ b/aragora/swarm/issue_upgrader.py
@@ -11,13 +11,36 @@ from vague inputs, so workers succeed instead of crashing.
 
 from __future__ import annotations
 
+import ast
 import logging
 import os
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+_PATH_RE = re.compile(r"`(?P<path>aragora/[^\s`]+\.py)`")
+_TEST_PATH_PREFIX = Path("tests")
+_MAX_SIMPLE_LOC = 120
+_MAX_SIMPLE_PUBLIC_API = 8
+_MAX_SIMPLE_EXTERNAL_WEIGHT = 2
+_SKIP_SENTINELS = frozenset({"__init__.py", "__main__.py"})
+_CONCRETE_MOCK_GUIDANCE: dict[str, str] = {
+    "httpx": "Patch `httpx` clients or request helpers to return deterministic responses.",
+    "requests": "Monkeypatch `requests` calls so tests do not hit the network.",
+    "aiohttp": "Use async fakes for `aiohttp` sessions and responses.",
+    "anthropic": "Stub Anthropic client calls and assert the prompt contract only.",
+    "openai": "Stub OpenAI client calls and assert the request payload only.",
+    "boto3": "Stub `boto3` clients/resources so tests never reach AWS.",
+    "redis": "Replace Redis clients with an in-memory fake or monkeypatched methods.",
+    "sqlalchemy": "Mock SQLAlchemy sessions/engines instead of opening a real database.",
+    "asyncpg": "Patch asyncpg connection helpers with deterministic fakes.",
+    "psycopg": "Stub psycopg connections/cursors so tests stay local.",
+    "subprocess": "Patch `subprocess` invocations and assert command construction only.",
+}
+_KNOWN_LOCAL_IMPORT_PREFIXES = ("aragora", "tests")
+_STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", set()))
 
 
 @dataclass
@@ -36,80 +59,217 @@ class UpgradedIssue:
     upgrade_method: str  # "llm" or "heuristic"
 
 
+@dataclass(slots=True)
+class _ModuleAnalysis:
+    docstring: str
+    public_functions: list[str]
+    public_classes: list[str]
+    public_methods: dict[str, list[str]]
+    imports: list[str]
+    external_imports: list[str]
+    mock_hints: list[str]
+    loc: int
+    complexity: str
+    has_async: bool
+    has_useful_public_api: bool
+    is_obvious_reexport_or_empty: bool
+    external_dependency_weight: int
+
+
 def _read_module(path: Path) -> str | None:
-    """Read a module file, return content or None."""
     try:
         return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
 
 
-def _extract_functions(content: str) -> list[str]:
-    """Extract public function and method names."""
-    return [
-        m.group(1)
-        for m in re.finditer(r"(?:def|async def)\s+(\w+)\s*\(", content)
-        if not m.group(1).startswith("_")
-    ]
+def _primary_module_path(issue_body: str) -> str | None:
+    match = _PATH_RE.search(str(issue_body or ""))
+    if not match:
+        return None
+    return str(match.group("path")).strip()
 
 
-def _extract_classes(content: str) -> list[str]:
-    """Extract class names."""
-    return [m.group(1) for m in re.finditer(r"class\s+(\w+)\s*[:(]", content)]
+def _iter_code_lines(content: str) -> list[str]:
+    lines: list[str] = []
+    for raw_line in content.splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    return lines
 
 
-def _extract_imports(content: str) -> list[str]:
-    """Extract import statements."""
-    imports: list[str] = []
-    for line in content.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("import ") or stripped.startswith("from "):
-            imports.append(stripped)
-    return imports
+def _normalized_import_root(node: ast.AST) -> str:
+    if isinstance(node, ast.Import):
+        if not node.names:
+            return ""
+        return str(node.names[0].name.split(".", 1)[0]).strip()
+    if isinstance(node, ast.ImportFrom):
+        if node.level and not node.module:
+            return ""
+        return str((node.module or "").split(".", 1)[0]).strip()
+    return ""
 
 
-def _needs_mocking(imports: list[str]) -> list[str]:
-    """Identify imports that likely need mocking in tests."""
-    mock_hints: list[str] = []
-    mock_patterns = [
-        "redis",
-        "postgres",
-        "sqlite",
-        "database",
-        "db",
-        "httpx",
-        "requests",
-        "aiohttp",
-        "subprocess",
-        "os.environ",
-        "anthropic",
-        "openai",
-        "boto3",
-        "s3",
-    ]
-    for imp in imports:
-        imp_lower = imp.lower()
-        for pattern in mock_patterns:
-            if pattern in imp_lower:
-                mock_hints.append(f"Mock `{imp.split()[-1]}` — external dependency")
-                break
-    return mock_hints
+def _is_external_import(root: str) -> bool:
+    if not root:
+        return False
+    if root in _STDLIB_MODULES:
+        return False
+    if any(
+        root == prefix or root.startswith(f"{prefix}.") for prefix in _KNOWN_LOCAL_IMPORT_PREFIXES
+    ):
+        return False
+    return True
+
+
+def _mock_hint_for_import(root: str) -> str | None:
+    return _CONCRETE_MOCK_GUIDANCE.get(root)
 
 
 def _estimate_complexity(
+    *,
     loc: int,
-    num_functions: int,
-    num_imports: int,
+    public_api_size: int,
+    external_dependency_weight: int,
     has_async: bool,
 ) -> str:
-    """Estimate testing complexity."""
-    if loc < 30 and num_functions <= 3:
+    if loc <= 40 and public_api_size <= 3 and external_dependency_weight == 0 and not has_async:
         return "trivial"
-    if loc < 100 and num_functions <= 7 and num_imports < 5:
+    if (
+        loc <= _MAX_SIMPLE_LOC
+        and public_api_size <= _MAX_SIMPLE_PUBLIC_API
+        and external_dependency_weight <= _MAX_SIMPLE_EXTERNAL_WEIGHT
+    ):
         return "simple"
-    if loc < 300 and num_functions <= 15:
+    if loc <= 260 and public_api_size <= 16 and external_dependency_weight <= 4:
         return "medium"
     return "complex"
+
+
+def _is_obvious_reexport_or_empty(module: ast.Module) -> bool:
+    body = list(module.body)
+    if (
+        body
+        and isinstance(body[0], ast.Expr)
+        and isinstance(body[0].value, ast.Constant)
+        and isinstance(body[0].value.value, str)
+    ):
+        body = body[1:]
+    if not body:
+        return True
+
+    allowed_assign_targets = {"__all__", "__version__"}
+    for node in body:
+        if isinstance(node, (ast.Import, ast.ImportFrom, ast.Pass)):
+            continue
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            targets = []
+            if isinstance(node, ast.Assign):
+                targets = [target.id for target in node.targets if isinstance(target, ast.Name)]
+            elif isinstance(node.target, ast.Name):
+                targets = [node.target.id]
+            if targets and all(target in allowed_assign_targets for target in targets):
+                continue
+        return False
+    return True
+
+
+def _analyze_module(content: str) -> _ModuleAnalysis | None:
+    try:
+        module = ast.parse(content)
+    except SyntaxError:
+        return None
+
+    public_functions: list[str] = []
+    public_classes: list[str] = []
+    public_methods: dict[str, list[str]] = {}
+    imports: list[str] = []
+    external_imports: list[str] = []
+    mock_hints: list[str] = []
+    has_async = False
+
+    for node in module.body:
+        if isinstance(node, ast.FunctionDef) and not node.name.startswith("_"):
+            public_functions.append(node.name)
+        elif isinstance(node, ast.AsyncFunctionDef) and not node.name.startswith("_"):
+            public_functions.append(node.name)
+            has_async = True
+        elif isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+            public_classes.append(node.name)
+            methods: list[str] = []
+            for child in node.body:
+                if isinstance(child, ast.AsyncFunctionDef):
+                    has_async = True
+                if isinstance(
+                    child, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and not child.name.startswith("_"):
+                    methods.append(child.name)
+            public_methods[node.name] = methods
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            rendered = ast.unparse(node).strip()
+            imports.append(rendered)
+            root = _normalized_import_root(node)
+            if _is_external_import(root) and root not in external_imports:
+                external_imports.append(root)
+                hint = _mock_hint_for_import(root)
+                if hint:
+                    mock_hints.append(hint)
+
+    public_api_size = len(public_functions) + len(public_classes)
+    return _ModuleAnalysis(
+        docstring=(ast.get_docstring(module) or "").strip()[:200],
+        public_functions=public_functions,
+        public_classes=public_classes,
+        public_methods=public_methods,
+        imports=imports,
+        external_imports=external_imports,
+        mock_hints=mock_hints,
+        loc=len(_iter_code_lines(content)),
+        complexity=_estimate_complexity(
+            loc=len(_iter_code_lines(content)),
+            public_api_size=public_api_size,
+            external_dependency_weight=len(external_imports),
+            has_async=has_async,
+        ),
+        has_async=has_async,
+        has_useful_public_api=(public_api_size > 0),
+        is_obvious_reexport_or_empty=_is_obvious_reexport_or_empty(module),
+        external_dependency_weight=len(external_imports),
+    )
+
+
+def _generated_test_path(module_rel: str) -> str:
+    parts = Path(module_rel).parts
+    if parts and parts[0] == "aragora" and len(parts) >= 2:
+        return str(_TEST_PATH_PREFIX / Path(*parts[1:-1]) / f"test_{parts[-1]}")
+    return str(_TEST_PATH_PREFIX / f"test_{Path(module_rel).name}")
+
+
+def _render_public_api_section(analysis: _ModuleAnalysis) -> str:
+    lines: list[str] = []
+    if analysis.public_functions:
+        lines.append("Public functions:")
+        lines.extend(f"- `{name}()`" for name in analysis.public_functions[:12])
+    if analysis.public_classes:
+        if lines:
+            lines.append("")
+        lines.append("Public classes:")
+        for class_name in analysis.public_classes[:8]:
+            methods = analysis.public_methods.get(class_name, [])
+            if methods:
+                method_bits = ", ".join(f"`{method}()`" for method in methods[:5])
+                lines.append(f"- `{class_name}` with methods {method_bits}")
+            else:
+                lines.append(f"- `{class_name}`")
+    return "\n".join(lines).strip()
+
+
+def _render_mock_guidance(analysis: _ModuleAnalysis) -> str:
+    if not analysis.mock_hints:
+        return "- No external dependency mocking required."
+    return "\n".join(f"- {hint}" for hint in analysis.mock_hints[:5])
 
 
 def upgrade_issue_heuristic(
@@ -118,96 +278,69 @@ def upgrade_issue_heuristic(
     *,
     repo_root: Path,
 ) -> UpgradedIssue | None:
-    """Upgrade an issue using heuristic module analysis (no LLM needed)."""
-    # Extract the target module path from the issue
-    path_match = re.search(r"`(aragora/\S+\.py)`", body)
-    if not path_match:
+    """Upgrade an issue using deterministic heuristic module analysis.
+
+    This prototype is intentionally narrow: only trivial/simple modules with a
+    useful public API are upgraded.
+    """
+    module_rel = _primary_module_path(body)
+    if not module_rel:
         return None
 
-    module_rel = path_match.group(1)
+    if Path(module_rel).name in _SKIP_SENTINELS:
+        return None
     module_path = repo_root / module_rel
     content = _read_module(module_path)
     if content is None:
         return None
 
-    lines = content.splitlines()
-    loc = len(lines)
-    functions = _extract_functions(content)
-    classes = _extract_classes(content)
-    imports = _extract_imports(content)
-    has_async = "async def" in content
-    mock_hints = _needs_mocking(imports)
-    complexity = _estimate_complexity(loc, len(functions), len(imports), has_async)
+    analysis = _analyze_module(content)
+    if analysis is None:
+        return None
+    if analysis.is_obvious_reexport_or_empty or not analysis.has_useful_public_api:
+        return None
+    if analysis.complexity not in {"trivial", "simple"}:
+        return None
+    if analysis.external_dependency_weight > _MAX_SIMPLE_EXTERNAL_WEIGHT:
+        return None
+    if analysis.external_imports and len(analysis.mock_hints) < len(analysis.external_imports):
+        return None
 
-    # Extract docstring
-    docstring = ""
-    if '"""' in content:
-        ds_match = re.search(r'"""(.*?)"""', content, re.DOTALL)
-        if ds_match:
-            docstring = ds_match.group(1).strip()[:200]
+    test_rel = _generated_test_path(module_rel)
+    public_api_section = _render_public_api_section(analysis)
+    module_purpose = f"**Module purpose:** {analysis.docstring}\n\n" if analysis.docstring else ""
+    async_note = (
+        "\n### Async handling\n- Use `pytest.mark.asyncio` for async entrypoints or wrap them with `asyncio.run()` in focused unit tests.\n"
+        if analysis.has_async
+        else ""
+    )
+    upgraded_body = (
+        "## Task\n\n"
+        f"Add focused unit tests for `{module_rel}`.\n\n"
+        f"{module_purpose}"
+        "### Public API to cover\n"
+        f"{public_api_section}\n\n"
+        "### Mock guidance\n"
+        f"{_render_mock_guidance(analysis)}\n"
+        f"{async_note}"
+        "### File Scope\n"
+        f"- `{module_rel}`\n"
+        f"- `{test_rel}` (create)\n\n"
+        "### Validation\n"
+        "```bash\n"
+        f"pytest {test_rel} -q\n"
+        "```\n\n"
+        "### Acceptance Criteria\n"
+        "- Tests cover the listed public API directly.\n"
+        "- External dependencies stay mocked or faked.\n"
+        "- The test file runs with a single focused pytest command.\n"
+        "- Keep the lane scoped to this module and its mirrored test file.\n\n"
+        "### Constraints\n"
+        f"- Estimated complexity: {analysis.complexity}\n"
+        "- Do not broaden into decomposition or cross-module planning."
+    )
 
-    # Build the test file path
     parts = Path(module_rel).parts
-    if parts[0] == "aragora" and len(parts) >= 2:
-        test_rel = str(Path("tests") / Path(*parts[1:-1]) / f"test_{parts[-1]}")
-    else:
-        test_rel = f"tests/test_{parts[-1]}"
-
-    # Build upgraded body with concrete guidance
-    func_list = (
-        "\n".join(f"   - `{f}()`" for f in functions[:15])
-        if functions
-        else "   - (no public functions found)"
-    )
-    class_list = "\n".join(f"   - `{c}`" for c in classes) if classes else ""
-    mock_list = (
-        "\n".join(f"   - {m}" for m in mock_hints)
-        if mock_hints
-        else "   - No external dependencies to mock"
-    )
-
-    async_note = ""
-    if has_async:
-        async_note = "\n\n**Note:** This module uses `async def`. Use `pytest-asyncio` or wrap calls in `asyncio.run()` for testing."
-
-    upgraded_body = f"""## Task
-
-Write focused unit tests for `{module_rel}` ({loc} lines, {len(functions)} public functions).
-
-{f"**Module purpose:** {docstring}" if docstring else ""}
-
-### What to test
-
-Public functions:
-{func_list}
-{f"{chr(10)}Classes:{chr(10)}{class_list}" if class_list else ""}
-
-### Mocking requirements
-{mock_list}
-{async_note}
-
-### Complexity: {complexity}
-{f"This is a {complexity} module. " if complexity == "trivial" else ""}{f"Focus on the {len(functions)} public functions — keep tests simple and direct." if complexity in ("trivial", "simple") else f"This module has {len(functions)} functions and {len(imports)} imports. Prioritize the most important public API surface."}
-
-### File Scope
-- `{module_rel}`
-- `{test_rel}` (create)
-
-### Validation
-```bash
-pytest {test_rel} -v
-```
-
-### Acceptance Criteria
-- All tests pass
-- At least {min(len(functions) * 2, 12)} test functions
-- No external service calls (mock all dependencies)
-- Tests complete in under 10 seconds
-
-### Constraints
-- Single-file change preferred
-- Estimated complexity: {complexity}"""
-
     upgraded_title = f"Add unit tests for {'/'.join(parts[1:])}" if len(parts) > 1 else title
 
     return UpgradedIssue(
@@ -215,11 +348,11 @@ pytest {test_rel} -v
         original_body=body,
         upgraded_title=upgraded_title,
         upgraded_body=upgraded_body,
-        module_summary=docstring,
-        functions_found=functions,
-        loc=loc,
-        imports=[i.split()[-1] for i in imports[:10]],
-        complexity=complexity,
+        module_summary=analysis.docstring,
+        functions_found=list(analysis.public_functions),
+        loc=analysis.loc,
+        imports=list(analysis.external_imports[:10]),
+        complexity=analysis.complexity,
         upgrade_method="heuristic",
     )
 

--- a/tests/swarm/test_issue_upgrader.py
+++ b/tests/swarm/test_issue_upgrader.py
@@ -1,0 +1,338 @@
+"""Tests for the narrow heuristic issue upgrader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from aragora.swarm.issue_upgrader import UpgradedIssue, upgrade_issue_heuristic
+
+
+@pytest.fixture()
+def repo_root(tmp_path: Path) -> Path:
+    (tmp_path / "aragora" / "swarm").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_module(repo_root: Path, rel: str, content: str) -> Path:
+    path = repo_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _upgrade(repo_root: Path, rel: str) -> UpgradedIssue | None:
+    body = f"Focus on `{rel}` with a mirrored focused test file."
+    return upgrade_issue_heuristic(f"Add tests for {Path(rel).name}", body, repo_root=repo_root)
+
+
+class TestUpgradeAdmission:
+    def test_upgrades_trivial_public_function_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/trivial_module.py",
+            '"""Small helper module."""\n\n'
+            "def normalize_name(value: str) -> str:\n"
+            "    return value.strip().lower()\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/trivial_module.py")
+
+        assert result is not None
+        assert result.complexity == "trivial"
+        assert result.upgrade_method == "heuristic"
+        assert result.functions_found == ["normalize_name"]
+
+    def test_upgrades_simple_class_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/simple_module.py",
+            '"""Simple state holder."""\n\n'
+            "class IssueState:\n"
+            "    def status(self) -> str:\n"
+            "        return 'ok'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/simple_module.py")
+
+        assert result is not None
+        assert result.complexity in {"trivial", "simple"}
+        assert "IssueState" in result.upgraded_body
+
+    def test_skips_medium_module(self, repo_root: Path) -> None:
+        body_lines = ['"""Module with too much surface."""', ""]
+        for idx in range(10):
+            body_lines.extend(
+                [
+                    f"def public_fn_{idx}(value: int) -> int:",
+                    f"    return value + {idx}",
+                    "",
+                ]
+            )
+        _write_module(repo_root, "aragora/swarm/medium_module.py", "\n".join(body_lines))
+
+        assert _upgrade(repo_root, "aragora/swarm/medium_module.py") is None
+
+    def test_skips_complex_module(self, repo_root: Path) -> None:
+        body_lines = ['"""Complex module."""', ""]
+        for idx in range(18):
+            body_lines.extend(
+                [
+                    f"def public_fn_{idx}(value: int) -> int:",
+                    f"    return value + {idx}",
+                    "",
+                ]
+            )
+        _write_module(repo_root, "aragora/swarm/complex_module.py", "\n".join(body_lines))
+
+        assert _upgrade(repo_root, "aragora/swarm/complex_module.py") is None
+
+    def test_skips_private_only_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/private_only.py",
+            "def _helper() -> str:\n    return 'x'\n",
+        )
+
+        assert _upgrade(repo_root, "aragora/swarm/private_only.py") is None
+
+    def test_skips_constant_only_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/constants_only.py",
+            '"""Constants only."""\n\nDEFAULT_TIMEOUT = 5\n',
+        )
+
+        assert _upgrade(repo_root, "aragora/swarm/constants_only.py") is None
+
+    def test_skips_reexport_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/reexport_only.py",
+            "from aragora.swarm.simple_module import IssueState\n\n__all__ = ['IssueState']\n",
+        )
+
+        assert _upgrade(repo_root, "aragora/swarm/reexport_only.py") is None
+
+    def test_skips_empty_module(self, repo_root: Path) -> None:
+        _write_module(repo_root, "aragora/swarm/empty_module.py", "")
+
+        assert _upgrade(repo_root, "aragora/swarm/empty_module.py") is None
+
+    def test_skips_init_modules(self, repo_root: Path) -> None:
+        _write_module(repo_root, "aragora/swarm/__init__.py", "from .x import y\n")
+
+        assert _upgrade(repo_root, "aragora/swarm/__init__.py") is None
+
+    def test_skips_when_body_has_no_module_reference(self, repo_root: Path) -> None:
+        result = upgrade_issue_heuristic(
+            "No path", "This issue body names no module.", repo_root=repo_root
+        )
+        assert result is None
+
+    def test_skips_when_module_is_missing(self, repo_root: Path) -> None:
+        result = _upgrade(repo_root, "aragora/swarm/missing_module.py")
+        assert result is None
+
+
+class TestAsyncHandling:
+    def test_async_module_is_upgraded_with_async_note(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/async_module.py",
+            '"""Async helper."""\n\nasync def fetch_status() -> str:\n    return \'ready\'\n',
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/async_module.py")
+
+        assert result is not None
+        assert "pytest.mark.asyncio" in result.upgraded_body
+        assert "fetch_status()" in result.upgraded_body
+
+    def test_async_class_method_is_handled_sensibly(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/async_class_module.py",
+            '"""Async class helper."""\n\n'
+            "class AsyncRunner:\n"
+            "    async def run(self) -> str:\n"
+            "        return 'done'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/async_class_module.py")
+
+        assert result is not None
+        assert "AsyncRunner" in result.upgraded_body
+        assert "pytest.mark.asyncio" in result.upgraded_body
+
+
+class TestDependencyWeight:
+    def test_low_external_dependency_weight_with_concrete_guidance_is_allowed(
+        self,
+        repo_root: Path,
+    ) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/http_client.py",
+            '"""HTTP helper."""\n\nimport httpx\n\ndef fetch() -> str:\n    return \'ok\'\n',
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/http_client.py")
+
+        assert result is not None
+        assert "Patch `httpx` clients" in result.upgraded_body
+        assert result.imports == ["httpx"]
+
+    def test_high_external_dependency_weight_is_skipped(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/heavy_external.py",
+            '"""Heavy external module."""\n\n'
+            "import httpx\n"
+            "import requests\n"
+            "import boto3\n\n"
+            "def fetch_all() -> str:\n"
+            "    return 'ok'\n",
+        )
+
+        assert _upgrade(repo_root, "aragora/swarm/heavy_external.py") is None
+
+    def test_unknown_external_dependency_is_skipped(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/unknown_external.py",
+            '"""Unknown external dep."""\n\n'
+            "import vendorlib\n\n"
+            "def run() -> str:\n"
+            "    return 'ok'\n",
+        )
+
+        assert _upgrade(repo_root, "aragora/swarm/unknown_external.py") is None
+
+    def test_local_imports_do_not_count_as_external_weight(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/local_imports.py",
+            '"""Local helper."""\n\n'
+            "from aragora.swarm.spec import SwarmSpec\n\n"
+            "def build() -> str:\n"
+            "    return SwarmSpec.__name__\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/local_imports.py")
+
+        assert result is not None
+        assert result.imports == []
+
+
+class TestOutputShape:
+    def test_generated_test_path_is_correct_for_nested_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/nested/example_module.py",
+            "def helper() -> str:\n    return 'x'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/nested/example_module.py")
+
+        assert result is not None
+        assert "`tests/swarm/nested/test_example_module.py` (create)" in result.upgraded_body
+
+    def test_upgraded_body_contains_concrete_file_scope_and_validation(
+        self, repo_root: Path
+    ) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/output_shape.py",
+            "def helper() -> str:\n    return 'x'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/output_shape.py")
+
+        assert result is not None
+        assert "### File Scope" in result.upgraded_body
+        assert "### Validation" in result.upgraded_body
+        assert "pytest tests/swarm/test_output_shape.py -q" in result.upgraded_body
+
+    def test_upgraded_body_includes_public_api_section(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/public_api.py",
+            "def alpha() -> str:\n    return 'a'\n\ndef beta() -> str:\n    return 'b'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/public_api.py")
+
+        assert result is not None
+        assert "`alpha()`" in result.upgraded_body
+        assert "`beta()`" in result.upgraded_body
+
+    def test_module_docstring_is_used_in_summary(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/with_docstring.py",
+            '"""Normalize worker-ready issue bodies into bounded specs."""\n\n'
+            "def normalize() -> str:\n"
+            "    return 'ok'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/with_docstring.py")
+
+        assert result is not None
+        assert "Normalize worker-ready issue bodies" in result.module_summary
+        assert "**Module purpose:** Normalize worker-ready issue bodies" in result.upgraded_body
+
+    def test_output_is_stable_for_same_module(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/stable_module.py",
+            "def normalize() -> str:\n    return 'ok'\n",
+        )
+
+        first = _upgrade(repo_root, "aragora/swarm/stable_module.py")
+        second = _upgrade(repo_root, "aragora/swarm/stable_module.py")
+
+        assert first == second
+
+    def test_title_is_rewritten_to_nested_module_path(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/nested/title_module.py",
+            "def normalize() -> str:\n    return 'ok'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/nested/title_module.py")
+
+        assert result is not None
+        assert result.upgraded_title == "Add unit tests for swarm/nested/title_module.py"
+
+    def test_simple_module_reports_simple_complexity(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/simple_complexity.py",
+            "\n".join(
+                ['"""Simple but not trivial."""', ""]
+                + [
+                    f"def fn_{idx}(value: int) -> int:\n    return value + {idx}\n"
+                    for idx in range(5)
+                ]
+            ),
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/simple_complexity.py")
+
+        assert result is not None
+        assert result.complexity == "simple"
+
+    def test_class_only_public_api_is_supported(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/class_only.py",
+            "class PublicTool:\n    def run(self) -> str:\n        return 'ok'\n",
+        )
+
+        result = _upgrade(repo_root, "aragora/swarm/class_only.py")
+
+        assert result is not None
+        assert "PublicTool" in result.upgraded_body


### PR DESCRIPTION
## Summary
- harden the existing issue upgrader into a deterministic heuristic-first lane
- only upgrade trivial/simple modules with useful public API and concrete mock guidance
- add focused regression coverage for upgrade admission, skip rules, async handling, test path generation, and stable output

## Validation
- pytest tests/swarm/test_issue_upgrader.py -q
- ruff check aragora/swarm/issue_upgrader.py tests/swarm/test_issue_upgrader.py
- python -c "from aragora.swarm.issue_upgrader import upgrade_issue_heuristic; print("OK")"
- bash scripts/automation_pr_preflight.sh origin/main HEAD