### PR TITLE
fix: upgrade silent debug-level exception logging to warning in auto_scaling.py

### DIFF
--- a/aragora/control_plane/auto_scaling.py
+++ b/aragora/control_plane/auto_scaling.py
@@ -323,7 +323,7 @@ class AutoScaler:
                 metrics.pending_tasks = stats.get("pending_tasks", 0)
                 metrics.running_tasks = stats.get("running_tasks", 0)
             except (OSError, ConnectionError, RuntimeError) as e:
-                logger.debug("Failed to get scheduler stats: %s", e)
+                logger.warning("Failed to get scheduler stats: %s", e)
 
         # Get registry stats
         if self._registry:
@@ -337,7 +337,7 @@ class AutoScaler:
                 if metrics.total_agents > 0:
                     metrics.utilization = metrics.busy_agents / metrics.total_agents
             except (OSError, ConnectionError, RuntimeError) as e:
-                logger.debug("Failed to get registry stats: %s", e)
+                logger.warning("Failed to get registry stats: %s", e)
 
         # Calculate p99 latency from samples
         if self._latency_samples:


### PR DESCRIPTION
The _collect_metrics method caught exceptions from scheduler and registry
stats but logged them at debug level, which is effectively silent in
production. Upgraded to warning level so failures in metrics collection
are visible without needing debug logging enabled.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit e6953efd9e6d15f12b7e58d0db3e5cdb588de8cc)
