### PR TITLE
fix(b0): fast-path bounded cohort seeding

### DIFF
--- a/scripts/create_b0_cohort.py
+++ b/scripts/create_b0_cohort.py
@@ -25,6 +25,7 @@ from aragora.swarm.task_sanitizer import (  # noqa: E402
 DEFAULT_CATEGORY = "test_coverage"
 DEFAULT_MIN_SUCCESS_RATE = 0.3
 DEFAULT_MAX_CHILDREN = 5
+DEFAULT_LABEL = "boss-ready"
 
 
 @dataclass(frozen=True)
@@ -102,6 +103,19 @@ def _evaluate_candidate(
     )
 
 
+def _candidate_is_ready_for_cohort(child: ChildReview) -> bool:
+    candidate = child.candidate
+    declared_scope = len(candidate.file_scope) + len(candidate.new_files)
+    return (
+        declared_scope > 0
+        and declared_scope <= DEFAULT_MAX_CHILDREN
+        and bool(str(candidate.validation_command or "").strip())
+        and str(candidate.estimated_complexity or "").strip().lower() in {"small", "medium"}
+        and _task_sanitizer_ok(child.task_sanitizer)
+        and child.body_sanitation_ok
+    )
+
+
 def _select_cohort(
     candidates: list[BossIssueCandidate],
     *,
@@ -114,6 +128,13 @@ def _select_cohort(
     for candidate in candidates:
         if total_selected >= max_issues:
             break
+
+        parent_review = _evaluate_candidate(candidate, candidate.title, sanitizer=sanitizer)
+        if _candidate_is_ready_for_cohort(parent_review):
+            reviews.append(ParentReview(parent_title=candidate.title, children=[parent_review]))
+            total_selected += 1
+            continue
+
         parent_body = _format_parent_body(candidate)
         children = bridge.decompose_issue_sync(
             candidate.title,
@@ -144,10 +165,22 @@ def _all_candidates_pass(reviews: list[ParentReview]) -> bool:
     return True
 
 
-def _create_issue(repo: str, title: str, body: str) -> bool:
+def _create_issue(repo: str, title: str, body: str, *, label: str) -> bool:
     try:
         result = subprocess.run(
-            ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
+            [
+                "gh",
+                "issue",
+                "create",
+                "--repo",
+                repo,
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                label,
+            ],
             capture_output=True,
             text=True,
             timeout=30,
@@ -211,6 +244,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=[DEFAULT_CATEGORY],
         help="Scanner categories to include (default: test_coverage)",
     )
+    parser.add_argument(
+        "--label",
+        default=DEFAULT_LABEL,
+        help="Label applied to created cohort issues (default: boss-ready)",
+    )
     return parser
 
 
@@ -267,7 +305,7 @@ def main(argv: list[str] | None = None) -> int:
         failed = 0
         for review in reviews:
             for child in review.children:
-                ok = _create_issue(args.repo, child.prefixed_title, child.body)
+                ok = _create_issue(args.repo, child.prefixed_title, child.body, label=args.label)
                 if ok:
                     created += 1
                 else:

--- a/tests/scripts/test_create_b0_cohort.py
+++ b/tests/scripts/test_create_b0_cohort.py
@@ -39,15 +39,21 @@ def _install_dummy_sanitizer(monkeypatch, outcome: SanitizationOutcome) -> None:
     monkeypatch.setattr(create_b0_cohort, "TaskSanitizer", DummySanitizer)
 
 
-def _install_dummy_bridge(monkeypatch, children: list[BossIssueCandidate] | None = None) -> None:
+def _install_dummy_bridge(
+    monkeypatch, children: list[BossIssueCandidate] | None = None
+) -> SimpleNamespace:
+    calls = SimpleNamespace(count=0)
+
     class DummyBridge:
         def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
             self._children = list(children or [])
 
         def decompose_issue_sync(self, *args, **kwargs) -> list[BossIssueCandidate]:  # noqa: ANN002, ANN003
+            calls.count += 1
             return list(self._children)
 
     monkeypatch.setattr(create_b0_cohort, "DecompositionBridge", DummyBridge)
+    return calls
 
 
 def test_dry_run_outputs_required_fields(monkeypatch, capsys) -> None:
@@ -66,6 +72,29 @@ def test_dry_run_outputs_required_fields(monkeypatch, capsys) -> None:
     assert "Validation command: pytest tests/test_foo.py -v" in output
     assert "TaskSanitizer accepts: yes" in output
     assert "assess_issue_body_sanitation accepts: yes" in output
+
+
+def test_bounded_candidate_skips_bridge(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        create_b0_cohort, "scan_all", lambda *args, **kwargs: [_candidate("Add unit tests for foo")]
+    )
+    calls = _install_dummy_bridge(monkeypatch, children=[])
+    _install_dummy_sanitizer(monkeypatch, SanitizationOutcome.ACCEPTED)
+    monkeypatch.setattr(create_b0_cohort, "assess_issue_body_sanitation", lambda *_: (True, ""))
+
+    exit_code = create_b0_cohort.main(["--dry-run", "--max-issues", "1"])
+
+    assert exit_code == 0
+    assert calls.count == 0
+    assert "Dry run only; no issues created." in capsys.readouterr().out
+
+
+def test_rendered_body_contains_required_sections() -> None:
+    body = create_b0_cohort._render_issue_body(_candidate("Add unit tests for foo"))
+
+    assert "## Task" in body
+    assert "### File Scope" in body
+    assert "### Validation" in body
 
 
 def test_publish_requires_all_candidates_pass(monkeypatch, capsys) -> None:
@@ -88,6 +117,30 @@ def test_publish_requires_all_candidates_pass(monkeypatch, capsys) -> None:
     assert exit_code == 1
     assert "Publish aborted" in output
     assert calls.count == 0
+
+
+def test_publish_passes_boss_ready_label(monkeypatch) -> None:
+    monkeypatch.setattr(
+        create_b0_cohort, "scan_all", lambda *args, **kwargs: [_candidate("Add unit tests for foo")]
+    )
+    _install_dummy_bridge(monkeypatch, children=[])
+    _install_dummy_sanitizer(monkeypatch, SanitizationOutcome.ACCEPTED)
+    monkeypatch.setattr(create_b0_cohort, "assess_issue_body_sanitation", lambda *_: (True, ""))
+
+    seen = []
+
+    def _fake_create_issue(repo: str, title: str, body: str, *, label: str) -> bool:
+        seen.append((repo, title, label, body))
+        return True
+
+    monkeypatch.setattr(create_b0_cohort, "_create_issue", _fake_create_issue)
+    exit_code = create_b0_cohort.main(["--publish", "--max-issues", "1"])
+
+    assert exit_code == 0
+    assert len(seen) == 1
+    assert seen[0][2] == "boss-ready"
+    assert seen[0][1].startswith("[B0-cohort] ")
+    assert "### Validation" in seen[0][3]
 
 
 def test_requires_exact_count(monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- skip decomposition for candidates that are already bounded and already pass the cohort sanitation gates
- label published cohort issues with `boss-ready` so the live boss loop can see them
- add tests for the bounded fast path, output guarantees, and publish labeling

## Validation
- pytest tests/scripts/test_create_b0_cohort.py -q
- python scripts/create_b0_cohort.py --dry-run --max-issues 5 --min-success-rate 0
- ruff check scripts/create_b0_cohort.py tests/scripts/test_create_b0_cohort.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD