### PR TITLE
fix: replace silent CancelledError swallow with debug log in arena_bridge.py

### DIFF
--- a/aragora/control_plane/arena_bridge.py
+++ b/aragora/control_plane/arena_bridge.py
@@ -724,7 +724,7 @@ class ArenaControlPlaneBridge:
                 try:
                     await sla_task
                 except asyncio.CancelledError:
-                    pass
+                    logger.debug("SLA monitor task cancelled for task %s", task.task_id)
 
         except asyncio.TimeoutError:
             task.metrics.completed_at = time.time()


### PR DESCRIPTION
Replace bare `except asyncio.CancelledError: pass` with a debug log
message for SLA monitor task cancellation, adding visibility without
changing behavior.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 623e79db9d88bc436bd0648ca1b09f9ba278dbaa)
