### PR TITLE
fix(b0): unblock cohort seeding and tag measurement

### DIFF
--- a/scripts/create_b0_cohort.py
+++ b/scripts/create_b0_cohort.py
@@ -25,6 +25,7 @@ from aragora.swarm.task_sanitizer import (  # noqa: E402
 DEFAULT_CATEGORY = "test_coverage"
 DEFAULT_MIN_SUCCESS_RATE = 0.3
 DEFAULT_MAX_CHILDREN = 5
+DEFAULT_LABEL = "boss-ready"
 
 
 @dataclass(frozen=True)
@@ -108,6 +109,7 @@ def _select_cohort(
     max_issues: int,
     bridge: DecompositionBridge,
     sanitizer: TaskSanitizer,
+    skip_decomposition: bool = False,
 ) -> list[ParentReview]:
     reviews: list[ParentReview] = []
     total_selected = 0
@@ -115,11 +117,13 @@ def _select_cohort(
         if total_selected >= max_issues:
             break
         parent_body = _format_parent_body(candidate)
-        children = bridge.decompose_issue_sync(
-            candidate.title,
-            parent_body,
-            max_children=DEFAULT_MAX_CHILDREN,
-        )
+        children: list[BossIssueCandidate] = []
+        if not skip_decomposition:
+            children = bridge.decompose_issue_sync(
+                candidate.title,
+                parent_body,
+                max_children=DEFAULT_MAX_CHILDREN,
+            )
         final_children = children or [candidate]
         remaining = max_issues - total_selected
         final_children = final_children[:remaining]
@@ -145,9 +149,17 @@ def _all_candidates_pass(reviews: list[ParentReview]) -> bool:
 
 
 def _create_issue(repo: str, title: str, body: str) -> bool:
+    return _create_issue_with_label(repo, title, body, label=DEFAULT_LABEL)
+
+
+def _create_issue_with_label(repo: str, title: str, body: str, *, label: str) -> bool:
     try:
+        cmd = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+        normalized_label = str(label or "").strip()
+        if normalized_label:
+            cmd.extend(["--label", normalized_label])
         result = subprocess.run(
-            ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body],
+            cmd,
             capture_output=True,
             text=True,
             timeout=30,
@@ -211,6 +223,16 @@ def build_parser() -> argparse.ArgumentParser:
         default=[DEFAULT_CATEGORY],
         help="Scanner categories to include (default: test_coverage)",
     )
+    parser.add_argument(
+        "--skip-decomposition",
+        action="store_true",
+        help="Use raw scanner candidates instead of decomposition-bridge children",
+    )
+    parser.add_argument(
+        "--label",
+        default=DEFAULT_LABEL,
+        help="GitHub label applied to created issues (default: boss-ready)",
+    )
     return parser
 
 
@@ -243,6 +265,7 @@ def main(argv: list[str] | None = None) -> int:
         max_issues=args.max_issues,
         bridge=bridge,
         sanitizer=sanitizer,
+        skip_decomposition=args.skip_decomposition,
     )
     selected_count = sum(len(review.children) for review in reviews)
     if selected_count < args.max_issues:
@@ -267,7 +290,12 @@ def main(argv: list[str] | None = None) -> int:
         failed = 0
         for review in reviews:
             for child in review.children:
-                ok = _create_issue(args.repo, child.prefixed_title, child.body)
+                ok = _create_issue_with_label(
+                    args.repo,
+                    child.prefixed_title,
+                    child.body,
+                    label=args.label,
+                )
                 if ok:
                     created += 1
                 else:

--- a/scripts/measure_b0_progress.py
+++ b/scripts/measure_b0_progress.py
@@ -18,6 +18,7 @@ from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics  #
 
 DEFAULT_METRICS_PATH = REPO_ROOT / ".aragora" / "overnight" / "boss_metrics.jsonl"
 COHORT_TAG = "[b0-cohort]"
+COHORT_TAG_PLAIN = "b0-cohort"
 PR_SIGNAL_ACTIONS = frozenset({"pr_created", "existing_pr", "discovered_after_push"})
 PR_SIGNAL_OUTCOMES = frozenset({"pr_adopted"})
 COMPLETED_STATUS = "completed"
@@ -96,7 +97,8 @@ def _normalize_text(value: Any) -> str:
 
 def _contains_cohort_tag(value: Any) -> bool:
     if isinstance(value, str):
-        return COHORT_TAG in value.lower()
+        normalized = value.lower()
+        return COHORT_TAG in normalized or COHORT_TAG_PLAIN in normalized
     if isinstance(value, dict):
         return any(_contains_cohort_tag(item) for item in value.values())
     if isinstance(value, (list, tuple, set)):
@@ -105,6 +107,8 @@ def _contains_cohort_tag(value: Any) -> bool:
 
 
 def is_b0_cohort_row(row: dict[str, Any]) -> bool:
+    if _contains_cohort_tag(row.get("cohort_tag")):
+        return True
     for key in ("issue_title", "title"):
         if _contains_cohort_tag(row.get(key)):
             return True

--- a/tests/scripts/test_create_b0_cohort.py
+++ b/tests/scripts/test_create_b0_cohort.py
@@ -90,6 +90,50 @@ def test_publish_requires_all_candidates_pass(monkeypatch, capsys) -> None:
     assert calls.count == 0
 
 
+def test_skip_decomposition_bypasses_bridge(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        create_b0_cohort, "scan_all", lambda *args, **kwargs: [_candidate("Add unit tests for foo")]
+    )
+
+    class ExplodingBridge:
+        def __init__(self, *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+            pass
+
+        def decompose_issue_sync(self, *args, **kwargs) -> list[BossIssueCandidate]:  # noqa: ANN002, ANN003
+            raise AssertionError("bridge should not run when --skip-decomposition is set")
+
+    monkeypatch.setattr(create_b0_cohort, "DecompositionBridge", ExplodingBridge)
+    _install_dummy_sanitizer(monkeypatch, SanitizationOutcome.ACCEPTED)
+    monkeypatch.setattr(create_b0_cohort, "assess_issue_body_sanitation", lambda *_: (True, ""))
+
+    exit_code = create_b0_cohort.main(["--dry-run", "--max-issues", "1", "--skip-decomposition"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "[B0-cohort]" in output
+
+
+def test_publish_applies_requested_label(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        create_b0_cohort, "scan_all", lambda *args, **kwargs: [_candidate("Add unit tests for foo")]
+    )
+    _install_dummy_bridge(monkeypatch, children=[])
+    _install_dummy_sanitizer(monkeypatch, SanitizationOutcome.ACCEPTED)
+    monkeypatch.setattr(create_b0_cohort, "assess_issue_body_sanitation", lambda *_: (True, ""))
+
+    calls = []
+
+    def _fake_create_issue(repo: str, title: str, body: str, *, label: str) -> bool:
+        calls.append((repo, title, body, label))
+        return True
+
+    monkeypatch.setattr(create_b0_cohort, "_create_issue_with_label", _fake_create_issue)
+    exit_code = create_b0_cohort.main(["--publish", "--max-issues", "1", "--label", "boss-ready"])
+    assert exit_code == 0
+    capsys.readouterr()
+    assert len(calls) == 1
+    assert calls[0][3] == "boss-ready"
+
+
 def test_requires_exact_count(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         create_b0_cohort, "scan_all", lambda *args, **kwargs: [_candidate("Add unit tests for foo")]

--- a/tests/scripts/test_measure_b0_progress.py
+++ b/tests/scripts/test_measure_b0_progress.py
@@ -66,6 +66,28 @@ def test_b0_tagged_cohort_detects_title_and_metadata_tags() -> None:
     assert tagged_summary.average_iterations_per_issue == 1.5
 
 
+def test_b0_tagged_cohort_detects_explicit_cohort_tag_field() -> None:
+    rows = [
+        {
+            "issue_number": 777,
+            "cohort_tag": "B0-cohort",
+            "prompt_chars": 123,
+            "publish_action": "pr_created",
+            "worker_status": "completed",
+            "terminal_class": "deliverable_pr_created",
+        }
+    ]
+
+    assert is_b0_cohort_row(rows[0]) is True
+
+    report = measure_b0_progress(rows)
+    tagged_summary = report["b0_tagged"]
+
+    assert tagged_summary.rows == 1
+    assert tagged_summary.unique_issues_attempted == 1
+    assert tagged_summary.unique_issues_with_mergeable_pr_signal == 1
+
+
 def test_terminal_class_distribution_uses_existing_or_fallback_classification() -> None:
     rows = load_metrics_rows(FIXTURE_PATH)
 


### PR DESCRIPTION
## Summary\n- add a fast seeding path that skips decomposition for controlled B0 cohort creation\n- apply the boss-ready label when creating cohort issues so the live loop can consume them\n- teach B0 measurement to detect the emitted cohort_tag field in metrics\n\n## Validation\n- python3 -m pytest tests/scripts/test_create_b0_cohort.py tests/scripts/test_measure_b0_progress.py -q\n- python3 -m ruff check scripts/create_b0_cohort.py scripts/measure_b0_progress.py tests/scripts/test_create_b0_cohort.py tests/scripts/test_measure_b0_progress.py\n- python3 scripts/create_b0_cohort.py --dry-run --max-issues 5 --min-success-rate 0 --skip-decomposition\n- bash scripts/automation_pr_preflight.sh origin/main HEAD