### PR TITLE
fix: replace silent exception swallowing in computer_use/orchestrator.py

### DIFF
--- a/aragora/computer_use/orchestrator.py
+++ b/aragora/computer_use/orchestrator.py
@@ -559,7 +559,7 @@ class ComputerUseOrchestrator:
                 if is_receipt_enforcement_enabled("computer_use"):
                     transition_receipt_executed(receipt_id)
             except ImportError:
-                pass
+                logger.debug("Receipt enforcement module not available, skipping transition")
 
         return result
 


### PR DESCRIPTION
Replace bare `except ImportError: pass` with a debug log message for
the receipt enforcement transition, matching the pattern already used
elsewhere in the file.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 09571f8814e5c52a3674721d24889982c79980f7)
