### PR TITLE
fix: update metrics_export.py

### DIFF
--- a/aragora/rlm/metrics_export.py
+++ b/aragora/rlm/metrics_export.py
@@ -71,7 +71,7 @@ class MetricsCollector:
     - Rate calculations (calls per second)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._last_snapshot: MetricsSnapshot | None = None
         self._last_collect_time: float = 0
         self._callbacks: list[Callable[[MetricsSnapshot], None]] = []
@@ -219,7 +219,7 @@ def export_to_prometheus(
             pass
 
     # Update metrics with current values
-    def update_prometheus_metrics():
+    def update_prometheus_metrics() -> None:
         current = get_factory_metrics()
         for name, counter in metrics_map.items():
             if name in current:
@@ -349,7 +349,7 @@ def create_periodic_exporter(
 
     stop_event = threading.Event()
 
-    def run():
+    def run() -> None:
         while not stop_event.is_set():
             try:
                 export_fn()
@@ -360,7 +360,7 @@ def create_periodic_exporter(
     thread = threading.Thread(target=run, daemon=True)
     thread.start()
 
-    def stop():
+    def stop() -> None:
         stop_event.set()
         thread.join(timeout=5.0)
 


### PR DESCRIPTION
Add return type annotations to all methods missing them:
- MetricsCollector.__init__
- update_prometheus_metrics (nested)
- run (nested in create_periodic_exporter)
- stop (nested in create_periodic_exporter)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit c2f986772b0ea4f5b5ab5e6cbbff97068490dc92)
