### PR TITLE
feat(b0): add GitHub truth reconciliation for cohort PRs

### DIFF
--- a/scripts/reconcile_b0_pr_truth.py
+++ b/scripts/reconcile_b0_pr_truth.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Reconcile B0 cohort PR truth against live GitHub state.
+
+This script is intentionally narrow. It does not replace the existing B0
+measurement script. Instead it adds GitHub-truth reconciliation for the B0
+cohort by:
+- reading boss metrics JSONL
+- identifying B0 cohort issues from `cohort_tag` or `[B0-cohort]` titles
+- computing issue-level proxy success from metrics
+- resolving linked PRs for each issue via GitHub issue comments and PR metadata
+- reporting truth states per issue: no linked PR, open PR, mergeable PR, merged PR
+
+Proxy metric:
+- an issue has a PR signal in metrics
+
+Truth metrics:
+- open PR: at least one linked PR exists on GitHub and is open
+- mergeable PR: at least one linked PR is open and GitHub reports MERGEABLE
+- merged PR: at least one linked PR is merged
+- no-rescue truth success: the issue reached mergeable or merged truth without any
+  rescue_worker_crash rows in the metrics file
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics  # noqa: E402
+
+DEFAULT_METRICS_PATH = REPO_ROOT / ".aragora" / "overnight" / "boss_metrics.jsonl"
+B0_TAG = "b0-cohort"
+PR_URL_RE = re.compile(r"https://github\.com/([^/]+/[^/]+)/pull/(\d+)")
+PR_SIGNAL_ACTIONS = frozenset({"pr_created", "existing_pr", "discovered_after_push"})
+PR_SIGNAL_OUTCOMES = frozenset({"pr_adopted"})
+MERGEABLE_STATES = frozenset({"MERGEABLE"})
+MERGED_STATES = frozenset({"MERGED"})
+OPEN_STATES = frozenset({"OPEN"})
+
+
+def _git_common_repo_root() -> Path | None:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if proc.returncode != 0:
+        return None
+    common_dir = Path(proc.stdout.strip())
+    if common_dir.name != ".git":
+        return None
+    return common_dir.parent.resolve()
+
+
+def resolve_metrics_path(candidate: Path) -> Path:
+    if candidate.exists():
+        return candidate.resolve()
+    if candidate.is_absolute():
+        return candidate
+
+    repo_relative = (REPO_ROOT / candidate).resolve()
+    if repo_relative.exists():
+        return repo_relative
+
+    common_root = _git_common_repo_root()
+    if common_root is not None:
+        common_relative = (common_root / candidate).resolve()
+        if common_relative.exists():
+            return common_relative
+
+    return candidate.resolve()
+
+
+@dataclass(frozen=True)
+class LinkedPullRequest:
+    number: int
+    title: str
+    url: str
+    state: str
+    mergeable: str
+    merge_state_status: str
+    merged_at: str | None
+    is_draft: bool
+
+    @property
+    def truth_state(self) -> str:
+        if self.state in MERGED_STATES or self.merged_at:
+            return "merged_pr"
+        if self.state in OPEN_STATES and self.mergeable in MERGEABLE_STATES:
+            return "mergeable_pr"
+        if self.state in OPEN_STATES:
+            return "open_pr"
+        return "closed_unmerged_pr"
+
+
+@dataclass
+class IssueMetricsAggregate:
+    issue_number: int
+    title: str = ""
+    row_count: int = 0
+    proxy_pr_signal: bool = False
+    had_rescue: bool = False
+
+
+@dataclass(frozen=True)
+class IssueTruthRecord:
+    issue_number: int
+    issue_title: str
+    proxy_pr_signal: bool
+    had_rescue: bool
+    truth_state: str
+    truth_success: bool
+    no_rescue_truth_success: bool
+    linked_prs: list[LinkedPullRequest] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "issue_number": self.issue_number,
+            "issue_title": self.issue_title,
+            "proxy_pr_signal": self.proxy_pr_signal,
+            "had_rescue": self.had_rescue,
+            "truth_state": self.truth_state,
+            "truth_success": self.truth_success,
+            "no_rescue_truth_success": self.no_rescue_truth_success,
+            "linked_prs": [asdict(pr) | {"truth_state": pr.truth_state} for pr in self.linked_prs],
+        }
+
+
+@dataclass(frozen=True)
+class TruthSummary:
+    attempted_issue_count: int
+    proxy_success_issue_count: int
+    proxy_success_rate: float
+    linked_pr_issue_count: int
+    linked_pr_issue_rate: float
+    truth_success_issue_count: int
+    truth_success_rate: float
+    merged_issue_count: int
+    merged_issue_rate: float
+    no_rescue_truth_success_issue_count: int
+    no_rescue_truth_success_rate: float
+    truth_state_counts: dict[str, int]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "attempted_issue_count": self.attempted_issue_count,
+            "proxy_success_issue_count": self.proxy_success_issue_count,
+            "proxy_success_rate": round(self.proxy_success_rate, 4),
+            "linked_pr_issue_count": self.linked_pr_issue_count,
+            "linked_pr_issue_rate": round(self.linked_pr_issue_rate, 4),
+            "truth_success_issue_count": self.truth_success_issue_count,
+            "truth_success_rate": round(self.truth_success_rate, 4),
+            "merged_issue_count": self.merged_issue_count,
+            "merged_issue_rate": round(self.merged_issue_rate, 4),
+            "no_rescue_truth_success_issue_count": self.no_rescue_truth_success_issue_count,
+            "no_rescue_truth_success_rate": round(self.no_rescue_truth_success_rate, 4),
+            "truth_state_counts": self.truth_state_counts,
+        }
+
+
+class GitHubTruthClient:
+    """Minimal GitHub reader backed by the gh CLI."""
+
+    def _run_json(self, args: list[str]) -> dict[str, Any]:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh command failed")
+        payload = json.loads(proc.stdout or "{}")
+        if not isinstance(payload, dict):
+            raise RuntimeError("gh command did not return a JSON object")
+        return payload
+
+    def get_issue(self, repo: str, number: int) -> dict[str, Any]:
+        return self._run_json(
+            [
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,url,comments",
+            ]
+        )
+
+    def get_pr(self, repo: str, number: int) -> dict[str, Any]:
+        return self._run_json(
+            [
+                "pr",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,title,url,state,mergeable,mergeStateStatus,mergedAt,isDraft",
+            ]
+        )
+
+    def get_cross_referenced_pr_numbers(self, repo: str, number: int) -> list[int]:
+        owner, name = repo.split("/", 1)
+        payload = self._run_json(
+            [
+                "api",
+                "graphql",
+                "-f",
+                "query=query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { issue(number:$number) { timelineItems(itemTypes:[CROSS_REFERENCED_EVENT], first:100) { nodes { ... on CrossReferencedEvent { source { __typename ... on PullRequest { number } } } } } } } }",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={number}",
+            ]
+        )
+        nodes = (
+            payload.get("data", {})
+            .get("repository", {})
+            .get("issue", {})
+            .get("timelineItems", {})
+            .get("nodes", [])
+        )
+        pr_numbers: list[int] = []
+        for node in nodes:
+            source = node.get("source") if isinstance(node, dict) else None
+            if not isinstance(source, dict):
+                continue
+            if source.get("__typename") != "PullRequest":
+                continue
+            pr_number = source.get("number")
+            if isinstance(pr_number, int):
+                pr_numbers.append(pr_number)
+        return pr_numbers
+
+
+def load_metrics_rows(metrics_file: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with metrics_file.open(encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return rows
+
+
+def _normalize_issue_number(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_text(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _contains_b0_tag(value: Any) -> bool:
+    if isinstance(value, str):
+        return B0_TAG in value.lower()
+    if isinstance(value, dict):
+        return any(_contains_b0_tag(item) for item in value.values())
+    if isinstance(value, (list, tuple, set)):
+        return any(_contains_b0_tag(item) for item in value)
+    return False
+
+
+def is_b0_issue_row(row: dict[str, Any]) -> bool:
+    cohort_tag = _normalize_text(row.get("cohort_tag"))
+    if cohort_tag == B0_TAG:
+        return True
+    for key in ("issue_title", "title", "metadata", "issue_metadata"):
+        if _contains_b0_tag(row.get(key)):
+            return True
+    return False
+
+
+def resolve_terminal_class(row: dict[str, Any]) -> TerminalClass:
+    existing = row.get("terminal_class")
+    if isinstance(existing, str) and existing.strip():
+        try:
+            return TerminalClass(existing.strip())
+        except ValueError:
+            pass
+    return classify_from_metrics(row)
+
+
+def has_proxy_pr_signal(row: dict[str, Any], terminal_class: TerminalClass) -> bool:
+    if terminal_class is TerminalClass.DELIVERABLE_PR_CREATED:
+        return True
+    publish_action = _normalize_text(row.get("publish_action"))
+    worker_outcome = _normalize_text(row.get("worker_outcome"))
+    return publish_action in PR_SIGNAL_ACTIONS or worker_outcome in PR_SIGNAL_OUTCOMES
+
+
+def aggregate_b0_issues(rows: list[dict[str, Any]]) -> list[IssueMetricsAggregate]:
+    issues: dict[int, IssueMetricsAggregate] = {}
+    for row in rows:
+        if not is_b0_issue_row(row):
+            continue
+        issue_number = _normalize_issue_number(row.get("issue_number"))
+        if issue_number is None:
+            continue
+        aggregate = issues.setdefault(
+            issue_number, IssueMetricsAggregate(issue_number=issue_number)
+        )
+        aggregate.row_count += 1
+        if not aggregate.title:
+            aggregate.title = str(row.get("issue_title") or row.get("title") or "").strip()
+        terminal_class = resolve_terminal_class(row)
+        if has_proxy_pr_signal(row, terminal_class):
+            aggregate.proxy_pr_signal = True
+        if terminal_class is TerminalClass.RESCUE_WORKER_CRASH:
+            aggregate.had_rescue = True
+    return [issues[number] for number in sorted(issues)]
+
+
+def extract_pr_numbers_from_issue(repo: str, issue_payload: dict[str, Any]) -> list[int]:
+    expected_repo = repo.lower()
+    found: set[int] = set()
+    for comment in issue_payload.get("comments", []):
+        if not isinstance(comment, dict):
+            continue
+        body = str(comment.get("body") or "")
+        for match in PR_URL_RE.finditer(body):
+            if match.group(1).lower() != expected_repo:
+                continue
+            found.add(int(match.group(2)))
+    return sorted(found)
+
+
+def classify_issue_truth_state(linked_prs: list[LinkedPullRequest]) -> str:
+    states = {pr.truth_state for pr in linked_prs}
+    if "merged_pr" in states:
+        return "merged_pr"
+    if "mergeable_pr" in states:
+        return "mergeable_pr"
+    if "open_pr" in states:
+        return "open_pr"
+    return "no_linked_pr"
+
+
+def reconcile_issue_truth(
+    repo: str,
+    aggregate: IssueMetricsAggregate,
+    client: GitHubTruthClient,
+) -> IssueTruthRecord:
+    issue_payload = client.get_issue(repo, aggregate.issue_number)
+    issue_title = aggregate.title or str(issue_payload.get("title") or "").strip()
+
+    pr_numbers = extract_pr_numbers_from_issue(repo, issue_payload)
+    if not pr_numbers:
+        pr_numbers = sorted(
+            set(client.get_cross_referenced_pr_numbers(repo, aggregate.issue_number))
+        )
+
+    linked_prs: list[LinkedPullRequest] = []
+    for pr_number in pr_numbers:
+        pr_payload = client.get_pr(repo, pr_number)
+        linked_prs.append(
+            LinkedPullRequest(
+                number=int(pr_payload.get("number", pr_number)),
+                title=str(pr_payload.get("title") or "").strip(),
+                url=str(pr_payload.get("url") or "").strip(),
+                state=str(pr_payload.get("state") or "").strip().upper(),
+                mergeable=str(pr_payload.get("mergeable") or "").strip().upper(),
+                merge_state_status=str(pr_payload.get("mergeStateStatus") or "").strip().upper(),
+                merged_at=pr_payload.get("mergedAt"),
+                is_draft=bool(pr_payload.get("isDraft", False)),
+            )
+        )
+
+    truth_state = classify_issue_truth_state(linked_prs)
+    truth_success = truth_state in {"mergeable_pr", "merged_pr"}
+    no_rescue_truth_success = truth_success and not aggregate.had_rescue
+    return IssueTruthRecord(
+        issue_number=aggregate.issue_number,
+        issue_title=issue_title,
+        proxy_pr_signal=aggregate.proxy_pr_signal,
+        had_rescue=aggregate.had_rescue,
+        truth_state=truth_state,
+        truth_success=truth_success,
+        no_rescue_truth_success=no_rescue_truth_success,
+        linked_prs=linked_prs,
+    )
+
+
+def summarize_truth(records: list[IssueTruthRecord]) -> TruthSummary:
+    attempted = len(records)
+    proxy_success = sum(1 for record in records if record.proxy_pr_signal)
+    linked_pr = sum(1 for record in records if record.truth_state != "no_linked_pr")
+    truth_success = sum(1 for record in records if record.truth_success)
+    merged = sum(1 for record in records if record.truth_state == "merged_pr")
+    no_rescue_truth_success = sum(1 for record in records if record.no_rescue_truth_success)
+    state_counts = Counter(record.truth_state for record in records)
+    return TruthSummary(
+        attempted_issue_count=attempted,
+        proxy_success_issue_count=proxy_success,
+        proxy_success_rate=(proxy_success / attempted if attempted else 0.0),
+        linked_pr_issue_count=linked_pr,
+        linked_pr_issue_rate=(linked_pr / attempted if attempted else 0.0),
+        truth_success_issue_count=truth_success,
+        truth_success_rate=(truth_success / attempted if attempted else 0.0),
+        merged_issue_count=merged,
+        merged_issue_rate=(merged / attempted if attempted else 0.0),
+        no_rescue_truth_success_issue_count=no_rescue_truth_success,
+        no_rescue_truth_success_rate=(no_rescue_truth_success / attempted if attempted else 0.0),
+        truth_state_counts=dict(sorted(state_counts.items())),
+    )
+
+
+def render_table(
+    repo: str, metrics_file: Path, records: list[IssueTruthRecord], summary: TruthSummary
+) -> str:
+    headers = ["Issue", "Proxy", "Truth", "No rescue", "Linked PRs", "Title"]
+    body_rows: list[list[str]] = []
+    for record in records:
+        pr_cell = (
+            ", ".join(
+                f"#{pr.number}:{pr.truth_state}:{pr.mergeable or '-'}" for pr in record.linked_prs
+            )
+            or "-"
+        )
+        body_rows.append(
+            [
+                str(record.issue_number),
+                "yes" if record.proxy_pr_signal else "no",
+                record.truth_state,
+                "yes" if record.no_rescue_truth_success else "no",
+                pr_cell,
+                record.issue_title,
+            ]
+        )
+
+    widths = [len(header) for header in headers]
+    for row in body_rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], len(value))
+
+    def fmt(row: list[str]) -> str:
+        return " | ".join(value.ljust(widths[idx]) for idx, value in enumerate(row))
+
+    lines = [
+        f"Repo: {repo}",
+        f"Metrics file: {metrics_file}",
+        "",
+        "Rates are issue-level. Proxy success is metrics-derived. Truth success is GitHub-derived (mergeable or merged PR).",
+        "When GitHub reports an open PR with mergeable=UNKNOWN, this script reports open_pr because mergeability is not proven.",
+        f"Attempted issues: {summary.attempted_issue_count}",
+        (
+            "Proxy success (proxy): "
+            f"{summary.proxy_success_issue_count}/{summary.attempted_issue_count} "
+            f"({summary.proxy_success_rate:.1%})"
+        ),
+        (
+            "Linked PR issues (truth): "
+            f"{summary.linked_pr_issue_count}/{summary.attempted_issue_count} "
+            f"({summary.linked_pr_issue_rate:.1%})"
+        ),
+        (
+            "Mergeable or merged issues (truth success): "
+            f"{summary.truth_success_issue_count}/{summary.attempted_issue_count} "
+            f"({summary.truth_success_rate:.1%})"
+        ),
+        (
+            "Merged issues (truth): "
+            f"{summary.merged_issue_count}/{summary.attempted_issue_count} "
+            f"({summary.merged_issue_rate:.1%})"
+        ),
+        (
+            "No-rescue truth success (truth + metrics): "
+            f"{summary.no_rescue_truth_success_issue_count}/{summary.attempted_issue_count} "
+            f"({summary.no_rescue_truth_success_rate:.1%})"
+        ),
+        f"Truth state counts: {summary.truth_state_counts}",
+        "",
+        fmt(headers),
+        "-+-".join("-" * width for width in widths),
+    ]
+    lines.extend(fmt(row) for row in body_rows)
+    return "\n".join(lines)
+
+
+def report_to_json(
+    repo: str,
+    metrics_file: Path,
+    records: list[IssueTruthRecord],
+    summary: TruthSummary,
+) -> str:
+    payload = {
+        "repo": repo,
+        "metrics_file": str(metrics_file),
+        "issue_level_only": True,
+        "proxy_metric_note": "PR signal is metrics-derived proxy, not GitHub truth.",
+        "truth_metric_note": "Truth success requires at least one linked PR with state mergeable_pr or merged_pr.",
+        "summary": summary.to_dict(),
+        "issues": [record.to_dict() for record in records],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--metrics-file",
+        type=Path,
+        default=DEFAULT_METRICS_PATH,
+        help=f"Metrics JSONL file (default: {DEFAULT_METRICS_PATH})",
+    )
+    parser.add_argument("--repo", default="synaptent/aragora", help="GitHub repo owner/name")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    metrics_file = resolve_metrics_path(args.metrics_file)
+    if not metrics_file.exists():
+        parser.error(f"metrics file not found: {metrics_file}")
+
+    rows = load_metrics_rows(metrics_file)
+    aggregates = aggregate_b0_issues(rows)
+    client = GitHubTruthClient()
+    records = [reconcile_issue_truth(args.repo, aggregate, client) for aggregate in aggregates]
+    summary = summarize_truth(records)
+
+    if args.json:
+        print(report_to_json(args.repo, metrics_file, records, summary))
+    else:
+        print(render_table(args.repo, metrics_file, records, summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_reconcile_b0_pr_truth.py
+++ b/tests/scripts/test_reconcile_b0_pr_truth.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts.reconcile_b0_pr_truth import (
+    IssueMetricsAggregate,
+    IssueTruthRecord,
+    LinkedPullRequest,
+    TruthSummary,
+    aggregate_b0_issues,
+    extract_pr_numbers_from_issue,
+    main,
+    reconcile_issue_truth,
+    render_table,
+    report_to_json,
+    resolve_metrics_path,
+    summarize_truth,
+)
+
+
+class FakeGitHubTruthClient:
+    def __init__(
+        self,
+        *,
+        issues: dict[int, dict],
+        prs: dict[int, dict],
+        cross_refs: dict[int, list[int]] | None = None,
+    ) -> None:
+        self.issues = issues
+        self.prs = prs
+        self.cross_refs = cross_refs or {}
+
+    def get_issue(self, repo: str, number: int) -> dict:
+        return self.issues[number]
+
+    def get_pr(self, repo: str, number: int) -> dict:
+        return self.prs[number]
+
+    def get_cross_referenced_pr_numbers(self, repo: str, number: int) -> list[int]:
+        return list(self.cross_refs.get(number, []))
+
+
+def _write_metrics(tmp_path: Path, rows: list[dict]) -> Path:
+    path = tmp_path / "boss_metrics.jsonl"
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
+    return path
+
+
+def test_aggregate_b0_issues_detects_cohort_tag_and_title() -> None:
+    rows = [
+        {
+            "issue_number": 101,
+            "cohort_tag": "B0-cohort",
+            "issue_title": "Add tests for alpha.py",
+            "terminal_class": "deliverable_pr_created",
+            "publish_action": "pr_created",
+        },
+        {
+            "issue_number": 101,
+            "cohort_tag": "B0-cohort",
+            "issue_title": "Add tests for alpha.py",
+            "terminal_class": "blocked_not_dispatch_bounded",
+        },
+        {
+            "issue_number": 102,
+            "issue_title": "[B0-cohort] Add tests for beta.py",
+            "terminal_class": "rescue_worker_crash",
+        },
+        {
+            "issue_number": 103,
+            "issue_title": "Non cohort issue",
+            "terminal_class": "deliverable_pr_created",
+        },
+    ]
+
+    aggregates = aggregate_b0_issues(rows)
+
+    assert [item.issue_number for item in aggregates] == [101, 102]
+    assert aggregates[0].proxy_pr_signal is True
+    assert aggregates[0].row_count == 2
+    assert aggregates[1].had_rescue is True
+
+
+def test_extract_pr_numbers_from_issue_filters_repo() -> None:
+    issue_payload = {
+        "comments": [
+            {
+                "body": (
+                    "PR: https://github.com/synaptent/aragora/pull/5107\n"
+                    "Other repo: https://github.com/other/repo/pull/99"
+                )
+            }
+        ]
+    }
+
+    result = extract_pr_numbers_from_issue("synaptent/aragora", issue_payload)
+
+    assert result == [5107]
+
+
+def test_reconcile_issue_truth_prefers_merged_pr() -> None:
+    aggregate = IssueMetricsAggregate(
+        issue_number=5102,
+        title="[B0-cohort] Add tests for protocols.py",
+        row_count=2,
+        proxy_pr_signal=True,
+        had_rescue=False,
+    )
+    client = FakeGitHubTruthClient(
+        issues={
+            5102: {
+                "title": aggregate.title,
+                "comments": [
+                    {
+                        "body": (
+                            "PR: https://github.com/synaptent/aragora/pull/5107\n"
+                            "PR: https://github.com/synaptent/aragora/pull/5108"
+                        )
+                    }
+                ],
+            }
+        },
+        prs={
+            5107: {
+                "number": 5107,
+                "title": "draft pr",
+                "url": "https://github.com/synaptent/aragora/pull/5107",
+                "state": "OPEN",
+                "mergeable": "UNKNOWN",
+                "mergeStateStatus": "UNKNOWN",
+                "mergedAt": None,
+                "isDraft": True,
+            },
+            5108: {
+                "number": 5108,
+                "title": "merged pr",
+                "url": "https://github.com/synaptent/aragora/pull/5108",
+                "state": "MERGED",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": "2026-04-12T20:40:00Z",
+                "isDraft": False,
+            },
+        },
+    )
+
+    record = reconcile_issue_truth("synaptent/aragora", aggregate, client)
+
+    assert record.truth_state == "merged_pr"
+    assert record.truth_success is True
+    assert record.no_rescue_truth_success is True
+    assert [pr.number for pr in record.linked_prs] == [5107, 5108]
+
+
+def test_reconcile_issue_truth_falls_back_to_cross_refs() -> None:
+    aggregate = IssueMetricsAggregate(
+        issue_number=5103,
+        title="[B0-cohort] Add tests for connector.py",
+        proxy_pr_signal=False,
+        had_rescue=True,
+    )
+    client = FakeGitHubTruthClient(
+        issues={5103: {"title": aggregate.title, "comments": []}},
+        prs={
+            5111: {
+                "number": 5111,
+                "title": "active pr",
+                "url": "https://github.com/synaptent/aragora/pull/5111",
+                "state": "OPEN",
+                "mergeable": "MERGEABLE",
+                "mergeStateStatus": "CLEAN",
+                "mergedAt": None,
+                "isDraft": False,
+            }
+        },
+        cross_refs={5103: [5111]},
+    )
+
+    record = reconcile_issue_truth("synaptent/aragora", aggregate, client)
+
+    assert record.truth_state == "mergeable_pr"
+    assert record.truth_success is True
+    assert record.no_rescue_truth_success is False
+
+
+def test_summary_and_renderers_include_proxy_vs_truth_language() -> None:
+    records = [
+        IssueTruthRecord(
+            issue_number=5098,
+            issue_title="[B0-cohort] alpha",
+            proxy_pr_signal=True,
+            had_rescue=False,
+            truth_state="open_pr",
+            truth_success=False,
+            no_rescue_truth_success=False,
+            linked_prs=[
+                LinkedPullRequest(
+                    number=5105,
+                    title="alpha pr",
+                    url="https://github.com/synaptent/aragora/pull/5105",
+                    state="OPEN",
+                    mergeable="UNKNOWN",
+                    merge_state_status="UNKNOWN",
+                    merged_at=None,
+                    is_draft=True,
+                )
+            ],
+        ),
+        IssueTruthRecord(
+            issue_number=5099,
+            issue_title="[B0-cohort] beta",
+            proxy_pr_signal=True,
+            had_rescue=False,
+            truth_state="merged_pr",
+            truth_success=True,
+            no_rescue_truth_success=True,
+            linked_prs=[
+                LinkedPullRequest(
+                    number=5106,
+                    title="beta pr",
+                    url="https://github.com/synaptent/aragora/pull/5106",
+                    state="MERGED",
+                    mergeable="MERGEABLE",
+                    merge_state_status="CLEAN",
+                    merged_at="2026-04-12T20:41:00Z",
+                    is_draft=False,
+                )
+            ],
+        ),
+    ]
+
+    summary = summarize_truth(records)
+    table = render_table("synaptent/aragora", Path("metrics.jsonl"), records, summary)
+    payload = json.loads(
+        report_to_json("synaptent/aragora", Path("metrics.jsonl"), records, summary)
+    )
+
+    assert summary.proxy_success_issue_count == 2
+    assert summary.truth_success_issue_count == 1
+    assert summary.truth_state_counts == {"merged_pr": 1, "open_pr": 1}
+    assert "Proxy success (proxy): 2/2 (100.0%)" in table
+    assert "Mergeable or merged issues (truth success): 1/2 (50.0%)" in table
+    assert "mergeability is not proven" in table
+    assert "#5105:open_pr:UNKNOWN" in table
+    assert payload["summary"]["truth_success_issue_count"] == 1
+    assert payload["issues"][0]["truth_state"] == "open_pr"
+
+
+def test_resolve_metrics_path_falls_back_to_git_common_root(tmp_path: Path, monkeypatch) -> None:
+    shared_root = tmp_path / "shared-root"
+    metrics_file = shared_root / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    metrics_file.parent.mkdir(parents=True)
+    metrics_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr("scripts.reconcile_b0_pr_truth.REPO_ROOT", tmp_path / "worktree-root")
+    monkeypatch.setattr(
+        "scripts.reconcile_b0_pr_truth._git_common_repo_root",
+        lambda: shared_root,
+    )
+
+    resolved = resolve_metrics_path(Path(".aragora/overnight/boss_metrics.jsonl"))
+
+    assert resolved == metrics_file.resolve()
+
+
+def test_main_json_output_with_mocked_github_client(tmp_path: Path, monkeypatch, capsys) -> None:
+    metrics_file = _write_metrics(
+        tmp_path,
+        [
+            {
+                "issue_number": 5102,
+                "cohort_tag": "B0-cohort",
+                "issue_title": "[B0-cohort] Add tests for protocols.py",
+                "terminal_class": "deliverable_pr_created",
+                "publish_action": "pr_created",
+            }
+        ],
+    )
+
+    client = FakeGitHubTruthClient(
+        issues={
+            5102: {
+                "title": "[B0-cohort] Add tests for protocols.py",
+                "comments": [{"body": "PR: https://github.com/synaptent/aragora/pull/5107"}],
+            }
+        },
+        prs={
+            5107: {
+                "number": 5107,
+                "title": "draft pr",
+                "url": "https://github.com/synaptent/aragora/pull/5107",
+                "state": "OPEN",
+                "mergeable": "UNKNOWN",
+                "mergeStateStatus": "UNKNOWN",
+                "mergedAt": None,
+                "isDraft": True,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "scripts.reconcile_b0_pr_truth.GitHubTruthClient",
+        lambda: client,
+    )
+
+    assert main(["--metrics-file", str(metrics_file), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+
+    assert payload["summary"]["attempted_issue_count"] == 1
+    assert payload["summary"]["proxy_success_issue_count"] == 1
+    assert payload["summary"]["truth_success_issue_count"] == 0
+    assert payload["issues"][0]["issue_number"] == 5102
+    assert payload["issues"][0]["truth_state"] == "open_pr"


### PR DESCRIPTION
## Summary\n- add a narrow B0 truth reconciler that reads boss metrics, detects B0 cohort issues, and resolves linked PR state from GitHub\n- report issue-level proxy success separately from GitHub-truth states: no PR, open PR, mergeable PR, merged PR\n- add focused tests with mocked GitHub responses and worktree-relative metrics path coverage\n\n## Validation\n- pytest tests/scripts/test_reconcile_b0_pr_truth.py -q\n- python scripts/reconcile_b0_pr_truth.py --metrics-file .aragora/overnight/boss_metrics.jsonl\n- ruff check scripts/reconcile_b0_pr_truth.py tests/scripts/test_reconcile_b0_pr_truth.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD