### PR TITLE
feat(swarm): route issue scanning from outcome learner calibration

### DIFF
--- a/aragora/swarm/issue_scanner.py
+++ b/aragora/swarm/issue_scanner.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from aragora.swarm.outcome_learner import load_category_success_rates
 from aragora.swarm.terminal_truth import classify_from_metrics
 
 
@@ -217,6 +218,19 @@ def historical_success_rates(metrics_path: Path) -> dict[str, float]:
         category: stats["success_rate"]
         for category, stats in historical_category_stats(metrics_path).items()
     }
+
+
+def expected_success_rates(
+    metrics_path: Path,
+    *,
+    signal_log_path: Path | None = None,
+) -> dict[str, float]:
+    """Return category success rates, preferring learner calibration when available."""
+    rates = historical_success_rates(metrics_path)
+    calibrated_rates = load_category_success_rates(log_path=signal_log_path)
+    for category, success_rate in calibrated_rates.items():
+        rates[category] = success_rate
+    return rates
 
 
 # ---------------------------------------------------------------------------
@@ -728,6 +742,7 @@ def scan_all(
     *,
     categories: list[str] | None = None,
     metrics_path: Path | None = None,
+    signal_log_path: Path | None = None,
     min_success_rate: float = 0.3,
 ) -> list[BossIssueCandidate]:
     """Run all scanners and return merged, prioritized candidates."""
@@ -749,10 +764,13 @@ def scan_all(
             candidates.extend(scanner(repo_root))
 
     resolved_metrics_path = metrics_path or repo_root / DEFAULT_BOSS_METRICS_PATH
-    historical_rates = historical_success_rates(resolved_metrics_path)
+    calibrated_rates = expected_success_rates(
+        resolved_metrics_path,
+        signal_log_path=signal_log_path,
+    )
     for candidate in candidates:
-        if candidate.category in historical_rates:
-            candidate.expected_success_rate = historical_rates[candidate.category]
+        if candidate.category in calibrated_rates:
+            candidate.expected_success_rate = calibrated_rates[candidate.category]
 
     if min_success_rate > 0:
         candidates = [

--- a/aragora/swarm/outcome_learner.py
+++ b/aragora/swarm/outcome_learner.py
@@ -11,11 +11,14 @@ from __future__ import annotations
 from collections import Counter, deque
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
+import json
+from pathlib import Path
 from typing import Any, Iterable
 
 from aragora.swarm.outcome_signals import OutcomeSignal
 
 UTC = timezone.utc
+_DEFAULT_OUTCOME_SIGNAL_LOG = Path("~/.aragora/outcome_signals.jsonl").expanduser()
 
 
 @dataclass
@@ -106,6 +109,7 @@ class OutcomeLearner:
         signals = list(self._signals)
         by_loop: dict[str, OutcomeAggregate] = {}
         by_agent: dict[str, OutcomeAggregate] = {}
+        by_category: dict[str, OutcomeAggregate] = {}
         failure_reasons: Counter[str] = Counter()
         blocker_kinds: Counter[str] = Counter()
 
@@ -133,13 +137,34 @@ class OutcomeLearner:
                         agg.blocker_kinds.get(signal.blocker_kind, 0) + 1
                     )
 
+            category_key = _infer_signal_category(signal)
+            if category_key:
+                category_agg = by_category.setdefault(category_key, OutcomeAggregate())
+                category_agg.total += 1
+                if signal.is_success:
+                    category_agg.successes += 1
+                if signal.is_failure:
+                    category_agg.failures += 1
+                if signal.did_merge:
+                    category_agg.merge_count += 1
+                if signal.needed_human_rescue:
+                    category_agg.rescue_count += 1
+                if signal.failure_reason:
+                    category_agg.failure_reasons[signal.failure_reason] = (
+                        category_agg.failure_reasons.get(signal.failure_reason, 0) + 1
+                    )
+                if signal.blocker_kind:
+                    category_agg.blocker_kinds[signal.blocker_kind] = (
+                        category_agg.blocker_kinds.get(signal.blocker_kind, 0) + 1
+                    )
+
             if signal.failure_reason:
                 failure_reasons[signal.failure_reason] += 1
             if signal.blocker_kind:
                 blocker_kinds[signal.blocker_kind] += 1
 
         recommendations = self._recommendations(by_loop, by_agent, failure_reasons, blocker_kinds)
-        routing_hints = self._routing_hints(by_loop, by_agent)
+        routing_hints = self._routing_hints(by_loop, by_agent, by_category)
 
         return OutcomeLearnerSnapshot(
             timestamp=datetime.now(UTC).isoformat(),
@@ -206,16 +231,89 @@ class OutcomeLearner:
         self,
         by_loop: dict[str, OutcomeAggregate],
         by_agent: dict[str, OutcomeAggregate],
+        by_category: dict[str, OutcomeAggregate],
     ) -> dict[str, Any]:
         deprioritize_loops: list[str] = []
         deprioritize_agents: list[str] = []
+        deprioritize_categories: list[str] = []
+        category_success_rates: dict[str, float] = {}
         for loop, agg in sorted(by_loop.items()):
             if agg.total >= self._min_samples and agg.merge_rate < self._merge_rate_threshold:
                 deprioritize_loops.append(loop)
         for agent, agg in sorted(by_agent.items()):
             if agg.total >= self._min_samples and agg.success_rate < self._merge_rate_threshold:
                 deprioritize_agents.append(agent)
+        for category, agg in sorted(by_category.items()):
+            if agg.total < self._min_samples:
+                continue
+            category_success_rates[category] = agg.success_rate
+            if agg.success_rate < self._merge_rate_threshold:
+                deprioritize_categories.append(category)
         return {
             "deprioritize_loops": deprioritize_loops,
             "deprioritize_agents": deprioritize_agents,
+            "deprioritize_categories": deprioritize_categories,
+            "category_success_rates": category_success_rates,
         }
+
+
+def _infer_signal_category(signal: OutcomeSignal) -> str | None:
+    title = str(signal.entity_title or "").strip()
+    if not title:
+        return None
+    from aragora.swarm.issue_scanner import infer_issue_category_from_title
+
+    return infer_issue_category_from_title(title)
+
+
+def _parse_signal_row(data: dict[str, Any]) -> OutcomeSignal | None:
+    if not isinstance(data, dict):
+        return None
+    fields = OutcomeSignal.__dataclass_fields__.keys()
+    try:
+        return OutcomeSignal(**{key: value for key, value in data.items() if key in fields})
+    except (TypeError, ValueError):
+        return None
+
+
+def load_category_success_rates(
+    *,
+    log_path: Path | None = None,
+    window_size: int = 500,
+    min_samples: int = 3,
+) -> dict[str, float]:
+    """Load deterministic per-category success rates from the outcome signal log."""
+    path = log_path or _DEFAULT_OUTCOME_SIGNAL_LOG
+    if window_size <= 0:
+        raise ValueError("window_size must be positive")
+    if min_samples <= 0:
+        raise ValueError("min_samples must be positive")
+    if not path.exists():
+        return {}
+
+    rows: deque[OutcomeSignal] = deque(maxlen=window_size)
+    try:
+        with path.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                signal = _parse_signal_row(payload)
+                if signal is not None:
+                    rows.append(signal)
+    except OSError:
+        return {}
+
+    if not rows:
+        return {}
+
+    learner = OutcomeLearner(window_size=window_size, min_samples=min_samples)
+    learner.ingest_many(rows)
+    snapshot = learner.snapshot()
+    hints = snapshot.routing_hints.get("category_success_rates", {})
+    return {
+        str(category): float(rate)
+        for category, rate in sorted(hints.items())
+        if isinstance(category, str)
+    }

--- a/tests/swarm/test_issue_scanner.py
+++ b/tests/swarm/test_issue_scanner.py
@@ -9,6 +9,7 @@ import pytest
 
 from aragora.swarm.issue_scanner import (
     BossIssueCandidate,
+    expected_success_rates,
     historical_success_rates,
     infer_issue_category_from_title,
     scan_all,
@@ -306,6 +307,43 @@ class TestHistoricalSuccessRates:
         assert rates["broad_exception"] == pytest.approx(0.5)
         assert rates["handler_validation"] == pytest.approx(0.0)
 
+    def test_expected_success_rates_prefers_learner_calibration(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        metrics_path = tmp_path / "boss_metrics.jsonl"
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.historical_success_rates",
+            lambda path: {"handler_validation": 0.8, "broad_exception": 0.6},
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.load_category_success_rates",
+            lambda log_path=None: {"handler_validation": 0.25},
+        )
+
+        rates = expected_success_rates(metrics_path)
+
+        assert rates == {
+            "broad_exception": 0.6,
+            "handler_validation": 0.25,
+        }
+
+    def test_expected_success_rates_falls_back_when_learner_calibration_absent(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        metrics_path = tmp_path / "boss_metrics.jsonl"
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.historical_success_rates",
+            lambda path: {"handler_validation": 0.2},
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.load_category_success_rates",
+            lambda log_path=None: {},
+        )
+
+        rates = expected_success_rates(metrics_path)
+
+        assert rates == {"handler_validation": 0.2}
+
     def test_scan_all_overrides_rates_and_filters(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
@@ -345,6 +383,10 @@ class TestHistoricalSuccessRates:
             "aragora.swarm.issue_scanner.historical_success_rates",
             lambda metrics_path: {"handler_validation": 0.2},
         )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.load_category_success_rates",
+            lambda log_path=None: {},
+        )
 
         filtered = scan_all(
             tmp_path,
@@ -362,3 +404,132 @@ class TestHistoricalSuccessRates:
         )
         assert len(unfiltered) == 1
         assert unfiltered[0].expected_success_rate == pytest.approx(0.2)
+
+    def test_scan_all_uses_learner_calibration_to_deprioritize_low_value_categories(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        low_value = BossIssueCandidate(
+            category="type_annotation",
+            title="Add return type annotations to low.py",
+            description="desc",
+            file_scope=["aragora/low.py"],
+            expected_success_rate=0.4,
+        )
+        high_value = BossIssueCandidate(
+            category="broad_exception",
+            title="Narrow broad except Exception in high.py",
+            description="desc",
+            file_scope=["aragora/high.py"],
+            expected_success_rate=0.9,
+        )
+
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_type_annotation_gaps",
+            lambda repo_root, limit=10: [low_value],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_bare_except_handlers",
+            lambda repo_root, limit=20: [high_value],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_silent_exception_swallowing",
+            lambda repo_root, limit=20: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_untested_modules",
+            lambda repo_root, min_loc=50, max_loc=300, limit=30: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_handler_validation_gaps",
+            lambda repo_root, limit=15: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_actionable_todos",
+            lambda repo_root, min_length=25, limit=15: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.historical_success_rates",
+            lambda metrics_path: {"type_annotation": 0.7, "broad_exception": 0.4},
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.load_category_success_rates",
+            lambda log_path=None: {"type_annotation": 0.1, "broad_exception": 0.8},
+        )
+
+        candidates = scan_all(
+            tmp_path,
+            categories=["type_annotation", "broad_exception"],
+            metrics_path=tmp_path / "boss_metrics.jsonl",
+            min_success_rate=0.0,
+        )
+
+        assert [candidate.category for candidate in candidates] == [
+            "broad_exception",
+            "type_annotation",
+        ]
+        assert candidates[0].expected_success_rate == pytest.approx(0.8)
+        assert candidates[1].expected_success_rate == pytest.approx(0.1)
+
+    def test_scan_all_preserves_historical_for_uncalibrated_categories(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        calibrated = BossIssueCandidate(
+            category="handler_validation",
+            title="Add request body validation to foo.py handlers",
+            description="desc",
+            file_scope=["aragora/server/handlers/foo.py"],
+            expected_success_rate=0.5,
+        )
+        fallback = BossIssueCandidate(
+            category="actionable_todo",
+            title="Address TODO/FIXME items in foo.py",
+            description="desc",
+            file_scope=["aragora/foo.py"],
+            expected_success_rate=0.5,
+        )
+
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_handler_validation_gaps",
+            lambda repo_root, limit=15: [calibrated],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_actionable_todos",
+            lambda repo_root, min_length=25, limit=15: [fallback],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_bare_except_handlers",
+            lambda repo_root, limit=20: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_silent_exception_swallowing",
+            lambda repo_root, limit=20: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_untested_modules",
+            lambda repo_root, min_loc=50, max_loc=300, limit=30: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.scan_type_annotation_gaps",
+            lambda repo_root, limit=10: [],
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.historical_success_rates",
+            lambda metrics_path: {"handler_validation": 0.2, "actionable_todo": 0.6},
+        )
+        monkeypatch.setattr(
+            "aragora.swarm.issue_scanner.load_category_success_rates",
+            lambda log_path=None: {"handler_validation": 0.75},
+        )
+
+        candidates = scan_all(
+            tmp_path,
+            categories=["handler_validation", "actionable_todo"],
+            metrics_path=tmp_path / "boss_metrics.jsonl",
+            min_success_rate=0.0,
+        )
+
+        rates = {candidate.category: candidate.expected_success_rate for candidate in candidates}
+        assert rates == {
+            "actionable_todo": pytest.approx(0.6),
+            "handler_validation": pytest.approx(0.75),
+        }

--- a/tests/swarm/test_outcome_learner.py
+++ b/tests/swarm/test_outcome_learner.py
@@ -1,6 +1,8 @@
 """Tests for OutcomeLearner rolling summaries."""
 
-from aragora.swarm.outcome_learner import OutcomeLearner
+from pathlib import Path
+
+from aragora.swarm.outcome_learner import OutcomeLearner, load_category_success_rates
 from aragora.swarm.outcome_signals import OutcomeSignal
 
 
@@ -46,3 +48,80 @@ def test_recommendations_and_routing_hints_are_deterministic():
     assert "deprioritize_loops" in snap.routing_hints
     assert "boss" in snap.routing_hints["deprioritize_loops"]
     assert "claude" in snap.routing_hints["deprioritize_agents"]
+
+
+def test_snapshot_exposes_category_success_rates_from_issue_titles():
+    learner = OutcomeLearner(window_size=10, min_samples=1, merge_rate_threshold=0.5)
+    learner.ingest(
+        _signal(
+            entity_title="Narrow broad except Exception in foo.py",
+            did_merge=True,
+        )
+    )
+    learner.ingest(
+        _signal(
+            signal_type="failed",
+            entity_title="Add return type annotations to bar.py",
+            failure_reason="worker_crash",
+        )
+    )
+
+    snap = learner.snapshot()
+
+    assert snap.routing_hints["category_success_rates"]["broad_exception"] == 1.0
+    assert snap.routing_hints["category_success_rates"]["type_annotation"] == 0.0
+    assert "type_annotation" in snap.routing_hints["deprioritize_categories"]
+    assert "broad_exception" not in snap.routing_hints["deprioritize_categories"]
+
+
+def test_snapshot_ignores_unclassified_issue_titles():
+    learner = OutcomeLearner(window_size=10, min_samples=1, merge_rate_threshold=0.5)
+    learner.ingest(_signal(entity_title="Unclassified task title", did_merge=True))
+
+    snap = learner.snapshot()
+
+    assert snap.routing_hints["category_success_rates"] == {}
+    assert snap.routing_hints["deprioritize_categories"] == []
+
+
+def test_load_category_success_rates_reads_recent_signal_log(tmp_path: Path):
+    log_path = tmp_path / "outcome_signals.jsonl"
+    rows = [
+        _signal(
+            entity_id="1",
+            entity_title="Replace silent exception swallowing in foo.py",
+            signal_type="completed",
+        ).to_dict(),
+        _signal(
+            entity_id="2",
+            entity_title="Replace silent exception swallowing in foo.py",
+            signal_type="failed",
+        ).to_dict(),
+        _signal(
+            entity_id="3",
+            entity_title="Add request body validation to bar.py handlers",
+            signal_type="completed",
+        ).to_dict(),
+    ]
+    log_path.write_text("\n".join(__import__("json").dumps(row) for row in rows) + "\n")
+
+    rates = load_category_success_rates(log_path=log_path, window_size=10, min_samples=1)
+
+    assert rates == {
+        "handler_validation": 1.0,
+        "silent_exception": 0.5,
+    }
+
+
+def test_load_category_success_rates_respects_min_samples(tmp_path: Path):
+    log_path = tmp_path / "outcome_signals.jsonl"
+    row = _signal(
+        entity_id="1",
+        entity_title="Add unit tests for foo.py",
+        signal_type="completed",
+    ).to_dict()
+    log_path.write_text(__import__("json").dumps(row) + "\n")
+
+    rates = load_category_success_rates(log_path=log_path, window_size=10, min_samples=2)
+
+    assert rates == {}


### PR DESCRIPTION
## Summary
- add deterministic category calibration output to `OutcomeLearner` from existing issue-title outcomes
- feed `issue_scanner` expected success rates from learner calibration when available, with historical fallback otherwise
- add focused regressions for calibration precedence, fallback behavior, deprioritization, and current scanner stability

## Validation
- `pytest tests/swarm/test_outcome_learner.py tests/swarm/test_issue_scanner.py -q`
- `ruff check aragora/swarm/outcome_learner.py aragora/swarm/issue_scanner.py tests/swarm/test_outcome_learner.py tests/swarm/test_issue_scanner.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`