### PR TITLE
fix: add missing org_id validation in list workspaces handler

### DIFF
--- a/aragora/server/handlers/workspace/crud.py
+++ b/aragora/server/handlers/workspace/crud.py
@@ -155,6 +155,8 @@ class WorkspaceCrudMixin:
 
         # SECURITY: Only list workspaces from user's own organization
         org_id = auth_ctx.org_id
+        if not org_id:
+            return m.error_response("organization_id is required", 400)
 
         # Reject requests that attempt to access another organization's workspaces
         requested_org_id = query_params.get("organization_id")


### PR DESCRIPTION
Add org_id null check in _handle_list_workspaces to match the existing
security pattern in _handle_create_workspace, preventing list operations
when the authenticated user has no organization context.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
(cherry picked from commit 5c20a5fc912a71fff56f0dd1793945f0b809f1f5)
