### PR TITLE
fix(b0): clarify proxy labels and paginate truth reconciliation

### DIFF
--- a/scripts/measure_b0_progress.py
+++ b/scripts/measure_b0_progress.py
@@ -29,13 +29,13 @@ class CohortSummary:
     name: str
     rows: int
     unique_issues_attempted: int
-    unique_issues_with_mergeable_pr_signal: int
+    unique_issues_with_proxy_pr_signal: int
     unique_issues_with_completed_iteration: int
     deferred_publish_issue_count: int
     deferred_publish_event_count: int
     deferred_publish_issue_rate: float
     average_iterations_per_issue: float
-    success_rate: float
+    proxy_pr_signal_issue_rate: float
     completed_issue_rate: float
     terminal_class_distribution: dict[str, int]
 
@@ -44,13 +44,13 @@ class CohortSummary:
             "name": self.name,
             "rows": self.rows,
             "unique_issues_attempted": self.unique_issues_attempted,
-            "unique_issues_with_mergeable_pr_signal": self.unique_issues_with_mergeable_pr_signal,
+            "unique_issues_with_proxy_pr_signal": self.unique_issues_with_proxy_pr_signal,
             "unique_issues_with_completed_iteration": self.unique_issues_with_completed_iteration,
             "deferred_publish_issue_count": self.deferred_publish_issue_count,
             "deferred_publish_event_count": self.deferred_publish_event_count,
             "deferred_publish_issue_rate": round(self.deferred_publish_issue_rate, 4),
             "average_iterations_per_issue": round(self.average_iterations_per_issue, 4),
-            "success_rate": round(self.success_rate, 4),
+            "proxy_pr_signal_issue_rate": round(self.proxy_pr_signal_issue_rate, 4),
             "completed_issue_rate": round(self.completed_issue_rate, 4),
             "terminal_class_distribution": self.terminal_class_distribution,
         }
@@ -59,7 +59,7 @@ class CohortSummary:
 @dataclass
 class IssueAggregate:
     iterations: int = 0
-    has_mergeable_pr_signal: bool = False
+    has_proxy_pr_signal: bool = False
     has_completed_iteration: bool = False
     has_deferred_publish: bool = False
 
@@ -139,7 +139,7 @@ def resolve_terminal_class(row: dict[str, Any]) -> TerminalClass:
     return classify_from_metrics(row)
 
 
-def has_mergeable_pr_signal(row: dict[str, Any], terminal_class: TerminalClass) -> bool:
+def has_proxy_pr_signal(row: dict[str, Any], terminal_class: TerminalClass) -> bool:
     if terminal_class is TerminalClass.DELIVERABLE_PR_CREATED:
         return True
     publish_action = _normalize_text(row.get("publish_action"))
@@ -170,15 +170,15 @@ def summarize_cohort(name: str, rows: list[dict[str, Any]]) -> CohortSummary:
 
         aggregate = issues.setdefault(issue_key, IssueAggregate())
         aggregate.iterations += 1
-        if has_mergeable_pr_signal(row, terminal_class):
-            aggregate.has_mergeable_pr_signal = True
+        if has_proxy_pr_signal(row, terminal_class):
+            aggregate.has_proxy_pr_signal = True
         if has_completed_iteration(row):
             aggregate.has_completed_iteration = True
         if is_deferred_publish(row, terminal_class):
             aggregate.has_deferred_publish = True
 
     issue_count = len(issues)
-    success_count = sum(1 for issue in issues.values() if issue.has_mergeable_pr_signal)
+    proxy_signal_count = sum(1 for issue in issues.values() if issue.has_proxy_pr_signal)
     completed_count = sum(1 for issue in issues.values() if issue.has_completed_iteration)
     deferred_issue_count = sum(1 for issue in issues.values() if issue.has_deferred_publish)
     deferred_event_count = sum(
@@ -190,13 +190,13 @@ def summarize_cohort(name: str, rows: list[dict[str, Any]]) -> CohortSummary:
         name=name,
         rows=len(rows),
         unique_issues_attempted=issue_count,
-        unique_issues_with_mergeable_pr_signal=success_count,
+        unique_issues_with_proxy_pr_signal=proxy_signal_count,
         unique_issues_with_completed_iteration=completed_count,
         deferred_publish_issue_count=deferred_issue_count,
         deferred_publish_event_count=deferred_event_count,
         deferred_publish_issue_rate=(deferred_issue_count / issue_count if issue_count else 0.0),
         average_iterations_per_issue=(total_iterations / issue_count if issue_count else 0.0),
-        success_rate=(success_count / issue_count if issue_count else 0.0),
+        proxy_pr_signal_issue_rate=(proxy_signal_count / issue_count if issue_count else 0.0),
         completed_issue_rate=(completed_count / issue_count if issue_count else 0.0),
         terminal_class_distribution=dict(sorted(terminal_counts.items())),
     )
@@ -217,8 +217,8 @@ def render_table(report: dict[str, CohortSummary]) -> str:
         "Cohort",
         "Rows",
         "Issues",
-        "PR signal",
-        "Success",
+        "PR signal (proxy)",
+        "Proxy rate",
         "Completed",
         "Deferred",
         "Avg iters",
@@ -230,8 +230,8 @@ def render_table(report: dict[str, CohortSummary]) -> str:
                 name,
                 str(summary.rows),
                 str(summary.unique_issues_attempted),
-                str(summary.unique_issues_with_mergeable_pr_signal),
-                f"{summary.success_rate:.1%}",
+                str(summary.unique_issues_with_proxy_pr_signal),
+                f"{summary.proxy_pr_signal_issue_rate:.1%}",
                 str(summary.unique_issues_with_completed_iteration),
                 f"{summary.deferred_publish_issue_count} ({summary.deferred_publish_issue_rate:.1%})",
                 f"{summary.average_iterations_per_issue:.2f}",
@@ -263,6 +263,9 @@ def render_table(report: dict[str, CohortSummary]) -> str:
 def report_to_json(metrics_file: Path, report: dict[str, CohortSummary]) -> str:
     payload = {
         "metrics_file": str(metrics_file),
+        "proxy_metric_note": (
+            "PR signal is a proxy from metrics, not GitHub truth or merged-PR truth."
+        ),
         "cohorts": {name: summary.to_dict() for name, summary in report.items()},
     }
     return json.dumps(payload, indent=2, sort_keys=True)

--- a/scripts/reconcile_b0_pr_truth.py
+++ b/scripts/reconcile_b0_pr_truth.py
@@ -47,6 +47,45 @@ PR_SIGNAL_OUTCOMES = frozenset({"pr_adopted"})
 MERGEABLE_STATES = frozenset({"MERGEABLE"})
 MERGED_STATES = frozenset({"MERGED"})
 OPEN_STATES = frozenset({"OPEN"})
+ISSUE_COMMENTS_PER_PAGE = 100
+ISSUE_COMMENTS_MAX_PAGES = 5
+CROSS_REFS_PER_PAGE = 100
+CROSS_REFS_MAX_PAGES = 5
+
+
+def _git_common_repo_root() -> Path | None:
+    proc = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    if proc.returncode != 0:
+        return None
+    common_dir = Path(proc.stdout.strip())
+    if common_dir.name != ".git":
+        return None
+    return common_dir.parent.resolve()
+
+
+def resolve_metrics_path(candidate: Path) -> Path:
+    if candidate.exists():
+        return candidate.resolve()
+    if candidate.is_absolute():
+        return candidate
+
+    repo_relative = (REPO_ROOT / candidate).resolve()
+    if repo_relative.exists():
+        return repo_relative
+
+    common_root = _git_common_repo_root()
+    if common_root is not None:
+        common_relative = (common_root / candidate).resolve()
+        if common_relative.exists():
+            return common_relative
+
+    return candidate.resolve()
 
 
 @dataclass(frozen=True)
@@ -139,7 +178,7 @@ class TruthSummary:
 class GitHubTruthClient:
     """Minimal GitHub reader backed by the gh CLI."""
 
-    def _run_json(self, args: list[str]) -> dict[str, Any]:
+    def _run_json_object(self, args: list[str]) -> dict[str, Any]:
         proc = subprocess.run(
             ["gh", *args],
             capture_output=True,
@@ -153,8 +192,22 @@ class GitHubTruthClient:
             raise RuntimeError("gh command did not return a JSON object")
         return payload
 
+    def _run_json_list(self, args: list[str]) -> list[dict[str, Any]]:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(proc.stderr.strip() or proc.stdout.strip() or "gh command failed")
+        payload = json.loads(proc.stdout or "[]")
+        if not isinstance(payload, list):
+            raise RuntimeError("gh command did not return a JSON array")
+        return [item for item in payload if isinstance(item, dict)]
+
     def get_issue(self, repo: str, number: int) -> dict[str, Any]:
-        return self._run_json(
+        payload = self._run_json_object(
             [
                 "issue",
                 "view",
@@ -162,12 +215,14 @@ class GitHubTruthClient:
                 "--repo",
                 repo,
                 "--json",
-                "number,title,url,comments",
+                "number,title,url",
             ]
         )
+        payload["comments"] = self.get_issue_comments(repo, number)
+        return payload
 
     def get_pr(self, repo: str, number: int) -> dict[str, Any]:
-        return self._run_json(
+        return self._run_json_object(
             [
                 "pr",
                 "view",
@@ -179,14 +234,40 @@ class GitHubTruthClient:
             ]
         )
 
+    def get_issue_comments(self, repo: str, number: int) -> list[dict[str, Any]]:
+        comments: list[dict[str, Any]] = []
+        for page in range(1, ISSUE_COMMENTS_MAX_PAGES + 1):
+            payload = self._run_json_list(
+                [
+                    "api",
+                    f"repos/{repo}/issues/{number}/comments?per_page={ISSUE_COMMENTS_PER_PAGE}&page={page}",
+                ]
+            )
+            comments.extend(payload)
+            if len(payload) < ISSUE_COMMENTS_PER_PAGE:
+                return comments
+        raise RuntimeError(
+            f"issue comment pagination exceeded bound for {repo}#{number} "
+            f"after {ISSUE_COMMENTS_MAX_PAGES} pages"
+        )
+
     def get_cross_referenced_pr_numbers(self, repo: str, number: int) -> list[int]:
         owner, name = repo.split("/", 1)
-        payload = self._run_json(
-            [
+        pr_numbers: list[int] = []
+        cursor: str | None = None
+
+        for _page in range(CROSS_REFS_MAX_PAGES):
+            args = [
                 "api",
                 "graphql",
                 "-f",
-                "query=query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { issue(number:$number) { timelineItems(itemTypes:[CROSS_REFERENCED_EVENT], first:100) { nodes { ... on CrossReferencedEvent { source { __typename ... on PullRequest { number } } } } } } } }",
+                (
+                    "query=query($owner:String!, $name:String!, $number:Int!, $after:String) "
+                    "{ repository(owner:$owner, name:$name) { issue(number:$number) { "
+                    f"timelineItems(itemTypes:[CROSS_REFERENCED_EVENT], first:{CROSS_REFS_PER_PAGE}, after:$after) "
+                    "{ nodes { ... on CrossReferencedEvent { source { __typename ... on PullRequest { number } } } } "
+                    "pageInfo { hasNextPage endCursor } } } } }"
+                ),
                 "-F",
                 f"owner={owner}",
                 "-F",
@@ -194,25 +275,40 @@ class GitHubTruthClient:
                 "-F",
                 f"number={number}",
             ]
+            if cursor is not None:
+                args.extend(["-F", f"after={cursor}"])
+            payload = self._run_json_object(args)
+            timeline = (
+                payload.get("data", {})
+                .get("repository", {})
+                .get("issue", {})
+                .get("timelineItems", {})
+            )
+            nodes = timeline.get("nodes", [])
+            for node in nodes:
+                source = node.get("source") if isinstance(node, dict) else None
+                if not isinstance(source, dict):
+                    continue
+                if source.get("__typename") != "PullRequest":
+                    continue
+                pr_number = source.get("number")
+                if isinstance(pr_number, int):
+                    pr_numbers.append(pr_number)
+
+            page_info = timeline.get("pageInfo", {})
+            has_next = bool(page_info.get("hasNextPage"))
+            if not has_next:
+                return pr_numbers
+            cursor = str(page_info.get("endCursor") or "").strip() or None
+            if cursor is None:
+                raise RuntimeError(
+                    f"cross-reference pagination missing endCursor for {repo}#{number}"
+                )
+
+        raise RuntimeError(
+            f"cross-reference pagination exceeded bound for {repo}#{number} "
+            f"after {CROSS_REFS_MAX_PAGES} pages"
         )
-        nodes = (
-            payload.get("data", {})
-            .get("repository", {})
-            .get("issue", {})
-            .get("timelineItems", {})
-            .get("nodes", [])
-        )
-        pr_numbers: list[int] = []
-        for node in nodes:
-            source = node.get("source") if isinstance(node, dict) else None
-            if not isinstance(source, dict):
-                continue
-            if source.get("__typename") != "PullRequest":
-                continue
-            pr_number = source.get("number")
-            if isinstance(pr_number, int):
-                pr_numbers.append(pr_number)
-        return pr_numbers
 
 
 def load_metrics_rows(metrics_file: Path) -> list[dict[str, Any]]:
@@ -506,7 +602,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    metrics_file = args.metrics_file.resolve()
+    metrics_file = resolve_metrics_path(args.metrics_file)
     if not metrics_file.exists():
         parser.error(f"metrics file not found: {metrics_file}")
 

--- a/tests/scripts/test_measure_b0_progress.py
+++ b/tests/scripts/test_measure_b0_progress.py
@@ -27,18 +27,18 @@ def test_measure_b0_progress_cohorts_and_unique_issue_aggregation() -> None:
     all_summary = report["all"]
     assert all_summary.rows == 6
     assert all_summary.unique_issues_attempted == 5
-    assert all_summary.unique_issues_with_mergeable_pr_signal == 1
+    assert all_summary.unique_issues_with_proxy_pr_signal == 1
     assert all_summary.unique_issues_with_completed_iteration == 3
     assert all_summary.deferred_publish_issue_count == 1
     assert all_summary.deferred_publish_event_count == 1
     assert all_summary.deferred_publish_issue_rate == 0.2
     assert all_summary.average_iterations_per_issue == 1.2
-    assert all_summary.success_rate == 0.2
+    assert all_summary.proxy_pr_signal_issue_rate == 0.2
 
     v2_summary = report["v2"]
     assert v2_summary.rows == 5
     assert v2_summary.unique_issues_attempted == 4
-    assert v2_summary.unique_issues_with_mergeable_pr_signal == 1
+    assert v2_summary.unique_issues_with_proxy_pr_signal == 1
     assert v2_summary.unique_issues_with_completed_iteration == 2
     assert v2_summary.deferred_publish_issue_count == 1
     assert v2_summary.average_iterations_per_issue == 1.25
@@ -46,7 +46,7 @@ def test_measure_b0_progress_cohorts_and_unique_issue_aggregation() -> None:
     decomposed_summary = report["decomposed"]
     assert decomposed_summary.rows == 2
     assert decomposed_summary.unique_issues_attempted == 1
-    assert decomposed_summary.unique_issues_with_mergeable_pr_signal == 1
+    assert decomposed_summary.unique_issues_with_proxy_pr_signal == 1
     assert decomposed_summary.unique_issues_with_completed_iteration == 1
     assert decomposed_summary.average_iterations_per_issue == 2.0
 
@@ -61,7 +61,7 @@ def test_b0_tagged_cohort_detects_title_and_metadata_tags() -> None:
     assert tagged_numbers == [101, 101, 102]
     assert tagged_summary.rows == 3
     assert tagged_summary.unique_issues_attempted == 2
-    assert tagged_summary.unique_issues_with_mergeable_pr_signal == 1
+    assert tagged_summary.unique_issues_with_proxy_pr_signal == 1
     assert tagged_summary.deferred_publish_issue_count == 1
     assert tagged_summary.average_iterations_per_issue == 1.5
 
@@ -85,7 +85,7 @@ def test_b0_tagged_cohort_detects_explicit_cohort_tag_field() -> None:
 
     assert tagged_summary.rows == 1
     assert tagged_summary.unique_issues_attempted == 1
-    assert tagged_summary.unique_issues_with_mergeable_pr_signal == 1
+    assert tagged_summary.unique_issues_with_proxy_pr_signal == 1
 
 
 def test_terminal_class_distribution_uses_existing_or_fallback_classification() -> None:
@@ -109,8 +109,10 @@ def test_json_output_contains_machine_readable_report() -> None:
     payload = json.loads(report_to_json(FIXTURE_PATH, report))
 
     assert payload["metrics_file"].endswith("mixed_metrics.jsonl")
+    assert "proxy_metric_note" in payload
     assert payload["cohorts"]["all"]["unique_issues_attempted"] == 5
-    assert payload["cohorts"]["b0_tagged"]["unique_issues_with_mergeable_pr_signal"] == 1
+    assert payload["cohorts"]["b0_tagged"]["unique_issues_with_proxy_pr_signal"] == 1
+    assert payload["cohorts"]["all"]["proxy_pr_signal_issue_rate"] == 0.2
 
 
 def test_table_output_contains_comparison_rows_and_terminal_classes() -> None:
@@ -122,6 +124,8 @@ def test_table_output_contains_comparison_rows_and_terminal_classes() -> None:
     assert "Cohort" in table
     assert "all" in table
     assert "b0_tagged" in table
+    assert "PR signal (proxy)" in table
+    assert "Proxy rate" in table
     assert "Terminal class distribution:" in table
     assert "deliverable_pr_created" in table
     assert "rescue_publish_deferred" in table

--- a/tests/scripts/test_reconcile_b0_pr_truth.py
+++ b/tests/scripts/test_reconcile_b0_pr_truth.py
@@ -3,7 +3,14 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.reconcile_b0_pr_truth import (
+    CROSS_REFS_MAX_PAGES,
+    CROSS_REFS_PER_PAGE,
+    ISSUE_COMMENTS_MAX_PAGES,
+    ISSUE_COMMENTS_PER_PAGE,
+    GitHubTruthClient,
     IssueMetricsAggregate,
     IssueTruthRecord,
     LinkedPullRequest,
@@ -14,6 +21,7 @@ from scripts.reconcile_b0_pr_truth import (
     reconcile_issue_truth,
     render_table,
     report_to_json,
+    resolve_metrics_path,
     summarize_truth,
 )
 
@@ -38,6 +46,33 @@ class FakeGitHubTruthClient:
 
     def get_cross_referenced_pr_numbers(self, repo: str, number: int) -> list[int]:
         return list(self.cross_refs.get(number, []))
+
+
+class PaginatedGitHubTruthClient(GitHubTruthClient):
+    def __init__(
+        self,
+        *,
+        comment_pages: list[list[dict]] | None = None,
+        cross_ref_pages: list[dict] | None = None,
+    ) -> None:
+        self.comment_pages = comment_pages or []
+        self.cross_ref_pages = cross_ref_pages or []
+        self.comment_calls = 0
+        self.cross_ref_calls = 0
+
+    def _run_json_object(self, args: list[str]) -> dict:
+        if args[:2] == ["api", "graphql"]:
+            payload = self.cross_ref_pages[self.cross_ref_calls]
+            self.cross_ref_calls += 1
+            return payload
+        raise AssertionError(f"unexpected object args: {args}")
+
+    def _run_json_list(self, args: list[str]) -> list[dict]:
+        if args and args[0] == "api" and "/comments?" in args[1]:
+            payload = self.comment_pages[self.comment_calls]
+            self.comment_calls += 1
+            return payload
+        raise AssertionError(f"unexpected list args: {args}")
 
 
 def _write_metrics(tmp_path: Path, rows: list[dict]) -> Path:
@@ -183,6 +218,97 @@ def test_reconcile_issue_truth_falls_back_to_cross_refs() -> None:
     assert record.no_rescue_truth_success is False
 
 
+def test_issue_comment_pagination_collects_multiple_pages() -> None:
+    client = PaginatedGitHubTruthClient(
+        comment_pages=[
+            [{"body": "page1"}] * ISSUE_COMMENTS_PER_PAGE,
+            [{"body": "page2"}],
+        ]
+    )
+
+    comments = client.get_issue_comments("synaptent/aragora", 5102)
+
+    assert len(comments) == ISSUE_COMMENTS_PER_PAGE + 1
+    assert client.comment_calls == 2
+
+
+def test_issue_comment_pagination_raises_when_bound_exceeded() -> None:
+    client = PaginatedGitHubTruthClient(
+        comment_pages=[
+            [{"body": f"page-{idx}"}] * ISSUE_COMMENTS_PER_PAGE
+            for idx in range(ISSUE_COMMENTS_MAX_PAGES)
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="issue comment pagination exceeded bound"):
+        client.get_issue_comments("synaptent/aragora", 5102)
+
+
+def test_cross_reference_pagination_collects_multiple_pages() -> None:
+    client = PaginatedGitHubTruthClient(
+        cross_ref_pages=[
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "timelineItems": {
+                                "nodes": [
+                                    {"source": {"__typename": "PullRequest", "number": 5107}}
+                                ],
+                                "pageInfo": {"hasNextPage": True, "endCursor": "cursor-1"},
+                            }
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "timelineItems": {
+                                "nodes": [
+                                    {"source": {"__typename": "PullRequest", "number": 5108}}
+                                ],
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            }
+                        }
+                    }
+                }
+            },
+        ]
+    )
+
+    pr_numbers = client.get_cross_referenced_pr_numbers("synaptent/aragora", 5102)
+
+    assert pr_numbers == [5107, 5108]
+    assert client.cross_ref_calls == 2
+
+
+def test_cross_reference_pagination_raises_when_bound_exceeded() -> None:
+    client = PaginatedGitHubTruthClient(
+        cross_ref_pages=[
+            {
+                "data": {
+                    "repository": {
+                        "issue": {
+                            "timelineItems": {
+                                "nodes": [
+                                    {"source": {"__typename": "PullRequest", "number": 6000 + idx}}
+                                ],
+                                "pageInfo": {"hasNextPage": True, "endCursor": f"cursor-{idx}"},
+                            }
+                        }
+                    }
+                }
+            }
+            for idx in range(CROSS_REFS_MAX_PAGES)
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="cross-reference pagination exceeded bound"):
+        client.get_cross_referenced_pr_numbers("synaptent/aragora", 5102)
+
+
 def test_reconcile_issue_truth_preserves_closed_unmerged_pr() -> None:
     aggregate = IssueMetricsAggregate(
         issue_number=5104,
@@ -279,6 +405,23 @@ def test_summary_and_renderers_include_proxy_vs_truth_language() -> None:
     assert "#5105:open_pr:UNKNOWN" in table
     assert payload["summary"]["truth_success_issue_count"] == 1
     assert payload["issues"][0]["truth_state"] == "open_pr"
+
+
+def test_resolve_metrics_path_falls_back_to_git_common_root(tmp_path: Path, monkeypatch) -> None:
+    shared_root = tmp_path / "shared-root"
+    metrics_file = shared_root / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    metrics_file.parent.mkdir(parents=True)
+    metrics_file.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr("scripts.reconcile_b0_pr_truth.REPO_ROOT", tmp_path / "worktree-root")
+    monkeypatch.setattr(
+        "scripts.reconcile_b0_pr_truth._git_common_repo_root",
+        lambda: shared_root,
+    )
+
+    resolved = resolve_metrics_path(Path(".aragora/overnight/boss_metrics.jsonl"))
+
+    assert resolved == metrics_file.resolve()
 
 
 def test_main_json_output_with_mocked_github_client(tmp_path: Path, monkeypatch, capsys) -> None:


### PR DESCRIPTION
## Summary\n- rename issue-level proxy fields in measure_b0_progress so they are explicitly proxy metrics\n- add bounded pagination for B0 truth reconciliation issue comments and cross-references\n- fail loudly instead of silently truncating GitHub-linked PR truth\n\n## Validation\n- pytest tests/scripts/test_measure_b0_progress.py tests/scripts/test_reconcile_b0_pr_truth.py -q\n- ruff check scripts/measure_b0_progress.py scripts/reconcile_b0_pr_truth.py tests/scripts/test_measure_b0_progress.py tests/scripts/test_reconcile_b0_pr_truth.py\n- bash scripts/automation_pr_preflight.sh origin/main HEAD