### PR TITLE
fix(tranche): keep only sanitized issue text in artifacts

### DIFF
--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -55,16 +55,17 @@ def _issue_text_metadata(result: dict[str, Any]) -> dict[str, Any]:
     sanitized_body = _optional_text(result.get("sanitized_issue_body"))
     sanitizer_outcome = _optional_text(result.get("sanitizer_outcome"))
     checks_failed = _string_list(result.get("checks_failed"), field_name="checks_failed")
-    if not any((original_body, sanitized_body, sanitizer_outcome, checks_failed)):
+    kept_body = sanitized_body or original_body
+    if not any((kept_body, sanitizer_outcome, checks_failed)):
         return {}
 
+    changed = bool(
+        original_body is not None and sanitized_body is not None and original_body != sanitized_body
+    )
     payload: dict[str, Any] = {}
-    if original_body is not None:
-        payload["original_body"] = original_body
-    if sanitized_body is not None:
-        payload["sanitized_body"] = sanitized_body
-    if original_body is not None and sanitized_body is not None:
-        payload["changed"] = original_body != sanitized_body
+    if kept_body is not None:
+        payload["sanitized_body"] = kept_body
+    payload["changed"] = changed
     if sanitizer_outcome is not None:
         payload["sanitizer_outcome"] = sanitizer_outcome
     if checks_failed:

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -808,7 +808,7 @@ async def test_artifact_from_run_result_persists_receipt_and_lease_ids(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_artifact_from_run_result_persists_issue_text_audit_metadata(tmp_path: Path) -> None:
+async def test_artifact_from_run_result_omits_raw_issue_text_when_sanitized(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     manifest = TrancheManifest.from_dict(
         {
@@ -872,11 +872,83 @@ async def test_artifact_from_run_result_persists_issue_text_audit_metadata(tmp_p
     )
 
     assert artifact.metadata["issue_text"] == {
-        "original_body": "raw body",
         "sanitized_body": "rewritten body",
         "changed": True,
         "sanitizer_outcome": "rewritten",
         "checks_failed": ["missing_validation"],
+    }
+    assert "original_body" not in artifact.metadata["issue_text"]
+
+
+@pytest.mark.asyncio
+async def test_artifact_from_run_result_keeps_single_copy_when_text_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    repo = _init_repo(tmp_path)
+    manifest = TrancheManifest.from_dict(
+        {
+            "manifest_id": "pmf-tranche",
+            "repo": {"name": "synaptent/aragora", "root": str(repo), "base_ref": "origin/main"},
+            "references": {
+                "source_refs": {
+                    "issue_1046": {
+                        "kind": "issue",
+                        "url": "https://github.com/synaptent/aragora/issues/1046",
+                        "state": "open",
+                    }
+                }
+            },
+            "gates": {},
+            "lanes": [
+                {
+                    "lane_id": "pmf_impl",
+                    "owner_role": "critical_path_engineer",
+                    "title": "Implement PMF path",
+                    "prompt": "Make the end-to-end PMF flow work.",
+                    "target_agent": "codex",
+                    "review_model": "claude",
+                    "source_refs": ["https://github.com/synaptent/aragora/issues/1046"],
+                    "allowed_write_scope": ["aragora/api/**"],
+                    "dependencies": ["issue_1046"],
+                    "verification_commands": ["pytest tests/api/test_pmf.py -q"],
+                    "stop_conditions": ["needs_human returned"],
+                    "expected_receipts_artifacts": ["PR URL"],
+                }
+            ],
+            "terminal_outcomes": {"success": {"definition": "done"}},
+        }
+    )
+    executor = TrancheExecutor(repo_root=repo, artifact_store=TrancheArtifactStore(repo))
+    prepared = TrancheLaneArtifact(
+        lane_id="pmf_impl",
+        source_ref="issue_1046",
+        status="prepared",
+        worktree_path="/tmp/controller-worktree",
+        metadata={"branch": "codex/pmf-impl", "target_agent": "codex"},
+    )
+
+    artifact = await executor._artifact_from_run_result(
+        manifest,
+        manifest.lane("pmf_impl"),
+        prepared=prepared,
+        result={
+            "status": "needs_human",
+            "outcome": "sanitation_checked",
+            "run_id": "run-123",
+            "sanitizer_outcome": "accepted",
+            "original_issue_body": "same body",
+            "sanitized_issue_body": "same body",
+            "reasons": ["needs update"],
+            "next_actions": ["fix it"],
+        },
+        review_model="claude",
+        skip_review=True,
+    )
+
+    assert artifact.metadata["issue_text"] == {
+        "sanitized_body": "same body",
+        "changed": False,
+        "sanitizer_outcome": "accepted",
     }
 
 


### PR DESCRIPTION
## Summary
- stop persisting raw original issue text in long-lived tranche artifact metadata when sanitization rewrites the body
- keep the sanitized body plus audit fields (, , )
- retain one safe copy when original and sanitized text are identical

## Validation
- pytest tests/swarm/test_boss_loop.py -k 'sanitizer or rewrites_missing_validation_before_dispatch' -q
- pytest tests/swarm/test_tranche.py -k 'issue_text' -q
- python3 -m ruff check aragora/swarm/boss_loop.py aragora/swarm/tranche.py tests/swarm/test_boss_loop.py tests/swarm/test_tranche.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/boss_loop.py aragora/swarm/tranche.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD