### PR TITLE
fix: harden preflight cache and cohort guardrails

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -78,6 +78,7 @@ class PreflightReceipt:
     started_at: str
     finished_at: str
     passed: bool
+    base_ref: str = ""
     checks: list[dict[str, Any]] = field(default_factory=list)
     schema_version: int = _PREFLIGHT_RECEIPT_SCHEMA_VERSION
     cache_key: str = ""
@@ -92,6 +93,7 @@ class PreflightReceipt:
             "envelope_seal": self.envelope_seal,
             "repo_root": self.repo_root,
             "check_type": self.check_type,
+            "base_ref": self.base_ref,
             "started_at": self.started_at,
             "finished_at": self.finished_at,
             "passed": self.passed,
@@ -110,6 +112,7 @@ class PreflightReceipt:
             envelope_seal=str(data.get("envelope_seal", "") or ""),
             repo_root=str(data.get("repo_root", "") or ""),
             check_type=str(data.get("check_type", "") or ""),
+            base_ref=str(data.get("base_ref", "") or ""),
             started_at=str(data.get("started_at", "") or ""),
             finished_at=str(data.get("finished_at", "") or ""),
             passed=bool(data.get("passed", False)),
@@ -142,6 +145,13 @@ def _validate_check_type(check_type: str) -> str:
     if normalized not in _PREFLIGHT_TTL_SECONDS:
         raise ValueError(f"Unsupported preflight check type: {normalized or '<empty>'}")
     return normalized
+
+
+def _normalize_base_ref(check_type: str, base_ref: str | None = None) -> str:
+    normalized_check_type = _validate_check_type(check_type)
+    if normalized_check_type != "remote_publish":
+        return ""
+    return str(base_ref or "main").strip() or "main"
 
 
 def _receipt_token() -> str:
@@ -250,6 +260,8 @@ def _preflight_cache_key(
     repo_root: Path,
     envelope: CredentialEnvelope,
     check_type: str,
+    *,
+    base_ref: str | None = None,
 ) -> str:
     normalized = _validate_check_type(check_type)
     payload = json.dumps(
@@ -258,6 +270,7 @@ def _preflight_cache_key(
             "repo_root": str(repo_root.resolve()),
             "envelope_seal": envelope.preflight_cache_seal(),
             "check_type": normalized,
+            "base_ref": _normalize_base_ref(normalized, base_ref),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -280,9 +293,11 @@ def _receipt_is_cacheable(
     repo_root: Path,
     envelope: CredentialEnvelope,
     check_type: str,
+    base_ref: str | None = None,
     now: datetime | None = None,
 ) -> bool:
     normalized = _validate_check_type(check_type)
+    normalized_base_ref = _normalize_base_ref(normalized, base_ref)
     if receipt.schema_version != _PREFLIGHT_RECEIPT_SCHEMA_VERSION:
         return False
     if not receipt.passed:
@@ -291,9 +306,16 @@ def _receipt_is_cacheable(
         return False
     if receipt.check_type != normalized:
         return False
+    if str(receipt.base_ref or "") != normalized_base_ref:
+        return False
     if receipt.envelope_seal != envelope.preflight_cache_seal():
         return False
-    expected_cache_key = _preflight_cache_key(repo_root, envelope, normalized)
+    expected_cache_key = _preflight_cache_key(
+        repo_root,
+        envelope,
+        normalized,
+        base_ref=normalized_base_ref,
+    )
     if receipt.cache_key != expected_cache_key:
         return False
     if any(not bool(item.get("passed")) for item in receipt.checks):
@@ -310,10 +332,12 @@ def _load_cached_preflight_receipt(
     envelope: CredentialEnvelope,
     check_type: str,
     *,
+    base_ref: str | None = None,
     now: datetime | None = None,
 ) -> PreflightReceipt | None:
     normalized = _validate_check_type(check_type)
-    cache_key = _preflight_cache_key(repo_root, envelope, normalized)
+    normalized_base_ref = _normalize_base_ref(normalized, base_ref)
+    cache_key = _preflight_cache_key(repo_root, envelope, normalized, base_ref=normalized_base_ref)
     path = _preflight_receipt_path(repo_root, check_type=normalized, cache_key=cache_key)
     if not path.exists():
         return None
@@ -327,6 +351,7 @@ def _load_cached_preflight_receipt(
         repo_root=repo_root,
         envelope=envelope,
         check_type=normalized,
+        base_ref=normalized_base_ref,
         now=now,
     ):
         return None
@@ -350,21 +375,29 @@ def _finalize_preflight_receipt(
     repo_root: Path,
     envelope: CredentialEnvelope,
     check_type: str,
+    base_ref: str | None,
     started_at: datetime,
     finished_at: datetime,
     checks: list[dict[str, Any]],
     artifacts: dict[str, Any],
 ) -> PreflightReceipt:
     normalized = _validate_check_type(check_type)
+    normalized_base_ref = _normalize_base_ref(normalized, base_ref)
     ttl_seconds = _PREFLIGHT_TTL_SECONDS[normalized]
     passed = all(bool(item.get("passed")) for item in checks)
-    cache_key = _preflight_cache_key(repo_root, envelope, normalized)
+    cache_key = _preflight_cache_key(
+        repo_root,
+        envelope,
+        normalized,
+        base_ref=normalized_base_ref,
+    )
     return PreflightReceipt(
         schema_version=_PREFLIGHT_RECEIPT_SCHEMA_VERSION,
         receipt_id=_preflight_receipt_id(normalized, now=finished_at),
         envelope_seal=envelope.preflight_cache_seal(),
         repo_root=str(repo_root.resolve()),
         check_type=normalized,
+        base_ref=normalized_base_ref,
         started_at=_isoformat_utc(started_at),
         finished_at=_isoformat_utc(finished_at),
         passed=passed,
@@ -382,6 +415,48 @@ def _parse_pr_create_output(stdout: str, stderr: str) -> tuple[int | None, str]:
     if match is None:
         return None, ""
     return int(match.group("number")), match.group(0)
+
+
+def _lookup_open_pr_by_head(cwd: Path, branch: str) -> tuple[int | None, str]:
+    try:
+        result = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "list",
+                "--head",
+                branch,
+                "--state",
+                "open",
+                "--json",
+                "number,url",
+                "--limit",
+                "10",
+            ],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, ""
+    if result.returncode != 0:
+        return None, ""
+    try:
+        payload = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return None, ""
+    if not isinstance(payload, list):
+        return None, ""
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        number = item.get("number")
+        url = str(item.get("url") or "").strip()
+        if isinstance(number, int) and url:
+            return number, url
+    return None, ""
 
 
 def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
@@ -625,6 +700,7 @@ def run_scratch_validation_receipt(
         repo_root=resolved_repo_root,
         envelope=envelope,
         check_type="scratch",
+        base_ref=None,
         started_at=started_at,
         finished_at=finished_at,
         checks=checks,
@@ -642,11 +718,13 @@ def run_remote_publish_validation_receipt(
     force_refresh: bool = False,
 ) -> PreflightReceipt:
     resolved_repo_root = repo_root.resolve()
+    normalized_base_ref = _normalize_base_ref("remote_publish", base_ref)
     if not force_refresh:
         cached = _load_cached_preflight_receipt(
             resolved_repo_root,
             envelope,
             "remote_publish",
+            base_ref=normalized_base_ref,
         )
         if cached is not None:
             return cached
@@ -718,7 +796,7 @@ def run_remote_publish_validation_receipt(
                                 "pr",
                                 "create",
                                 "--base",
-                                str(base_ref or "main"),
+                                normalized_base_ref,
                                 "--head",
                                 branch,
                                 "--title",
@@ -735,13 +813,8 @@ def run_remote_publish_validation_receipt(
                                 pr_result.stderr,
                             )
                             if pr_number is None or not pr_url:
-                                _append_check(
-                                    checks,
-                                    name="gh_pr_capture",
-                                    passed=False,
-                                    detail="Draft PR create output did not include a parseable PR URL.",
-                                )
-                            else:
+                                pr_number, pr_url = _lookup_open_pr_by_head(worktree_path, branch)
+                            if pr_number is not None and pr_url:
                                 draft_created = True
                                 artifacts["draft_pr_number"] = pr_number
                                 artifacts["draft_pr_url"] = pr_url
@@ -751,7 +824,29 @@ def run_remote_publish_validation_receipt(
                                     passed=True,
                                     detail=pr_url,
                                 )
+                            else:
+                                _append_check(
+                                    checks,
+                                    name="gh_pr_capture",
+                                    passed=False,
+                                    detail="Draft PR create output did not include a parseable PR URL.",
+                                )
     finally:
+        if pushed and not draft_created:
+            pr_number, pr_url = _lookup_open_pr_by_head(
+                worktree_path if worktree_created else resolved_repo_root,
+                branch,
+            )
+            if pr_number is not None and pr_url:
+                draft_created = True
+                artifacts["draft_pr_number"] = pr_number
+                artifacts["draft_pr_url"] = pr_url
+                _append_check(
+                    checks,
+                    name="gh_pr_capture_recovery",
+                    passed=True,
+                    detail=pr_url,
+                )
         if draft_created:
             close_target = str(artifacts.get("draft_pr_number") or branch)
             _run_check(
@@ -810,6 +905,7 @@ def run_remote_publish_validation_receipt(
         repo_root=resolved_repo_root,
         envelope=envelope,
         check_type="remote_publish",
+        base_ref=normalized_base_ref,
         started_at=started_at,
         finished_at=finished_at,
         checks=checks,

--- a/aragora/swarm/tranche.py
+++ b/aragora/swarm/tranche.py
@@ -59,8 +59,6 @@ def _issue_text_metadata(result: dict[str, Any]) -> dict[str, Any]:
         return {}
 
     payload: dict[str, Any] = {}
-    if original_body is not None:
-        payload["original_body"] = original_body
     if sanitized_body is not None:
         payload["sanitized_body"] = sanitized_body
     if original_body is not None and sanitized_body is not None:

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -38,6 +38,10 @@ _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "supporting tests",
     "think about it",
 )
+_OPEN_PR_PAGE_SIZE = 100
+_OPEN_PR_MAX_PAGES = 10
+_OPEN_PR_FILES_PAGE_SIZE = 100
+_OPEN_PR_FILES_MAX_PAGES = 10
 
 
 @dataclass(slots=True)
@@ -142,33 +146,61 @@ def fetch_existing_boss_issues(repo: str) -> list[dict]:
 def fetch_open_pr_files(repo: str) -> set[str]:
     """Fetch file paths changed in open PRs."""
     try:
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "open",
-                "--limit",
-                "50",
-                "--json",
-                "files",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            prs = json.loads(result.stdout or "[]")
-            files: set[str] = set()
+        files: set[str] = set()
+        for page in range(1, _OPEN_PR_MAX_PAGES + 1):
+            prs_result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls?state=open&per_page={_OPEN_PR_PAGE_SIZE}&page={page}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if prs_result.returncode != 0:
+                return set()
+            prs = json.loads(prs_result.stdout or "[]")
+            if not isinstance(prs, list):
+                return set()
+            if not prs:
+                return files
             for pr in prs:
-                for f in pr.get("files", []):
-                    path = f.get("path", "") if isinstance(f, dict) else str(f)
-                    if path:
-                        files.add(path)
-            return files
+                if not isinstance(pr, dict):
+                    continue
+                number = pr.get("number")
+                if not isinstance(number, int):
+                    continue
+                for files_page in range(1, _OPEN_PR_FILES_MAX_PAGES + 1):
+                    files_result = subprocess.run(
+                        [
+                            "gh",
+                            "api",
+                            (
+                                f"repos/{repo}/pulls/{number}/files"
+                                f"?per_page={_OPEN_PR_FILES_PAGE_SIZE}&page={files_page}"
+                            ),
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    if files_result.returncode != 0:
+                        return set()
+                    payload = json.loads(files_result.stdout or "[]")
+                    if not isinstance(payload, list):
+                        return set()
+                    if not payload:
+                        break
+                    for item in payload:
+                        path = item.get("filename", "") if isinstance(item, dict) else str(item)
+                        if path:
+                            files.add(path)
+                    if len(payload) < _OPEN_PR_FILES_PAGE_SIZE:
+                        break
+            if len(prs) < _OPEN_PR_PAGE_SIZE:
+                return files
+        return files
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         pass
     return set()

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from types import SimpleNamespace
 
@@ -409,3 +410,64 @@ def test_main_passes_decomposition_flags(monkeypatch, capsys) -> None:
     assert decompose_calls
     assert decompose_calls[0][1] is True
     assert decompose_calls[0][2] == 4
+
+
+def test_fetch_open_pr_files_paginates_open_prs_and_pr_files(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_PAGE_SIZE", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        calls.append(cmd[-1])
+        endpoint = cmd[-1]
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"number": 101}, {"number": 102}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [{"filename": "aragora/first.py"}, {"filename": "aragora/second.py"}]
+                ),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=2"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/third.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/102/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/fourth.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=2"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 103}]), stderr="")
+        if endpoint.endswith("/pulls/103/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/fifth.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=3"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    files = mod.fetch_open_pr_files("org/repo")
+
+    assert files == {
+        "aragora/first.py",
+        "aragora/second.py",
+        "aragora/third.py",
+        "aragora/fourth.py",
+        "aragora/fifth.py",
+    }
+    assert "repos/org/repo/pulls?state=open&per_page=2&page=2" in calls
+    assert "repos/org/repo/pulls/101/files?per_page=2&page=2" in calls

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -434,6 +434,49 @@ def test_run_remote_publish_validation_receipt_records_pr_artifacts(
     assert any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
 
 
+def test_run_remote_publish_validation_receipt_recovers_pr_when_create_output_is_unparseable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 13, 1, 5, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "ef56aa12")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(returncode=0, stdout="created draft\n", stderr="")
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [{"number": 5124, "url": "https://github.com/synaptent/aragora/pull/5124"}]
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+        force_refresh=True,
+    )
+
+    assert receipt.passed is True
+    assert receipt.artifacts["draft_pr_number"] == 5124
+    assert any(check["name"] == "gh_pr_capture" and check["passed"] for check in receipt.checks)
+    assert any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -453,6 +496,7 @@ def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
         started_at="2026-04-12T20:00:00Z",
         finished_at="2026-04-12T20:00:05Z",
         passed=True,
+        base_ref="",
         checks=[{"name": "git_commit", "passed": True, "detail": "ok"}],
         cache_key=cache_key,
         ttl_seconds=86400,
@@ -474,7 +518,7 @@ def test_load_cached_preflight_receipt_misses_when_ttl_expired(monkeypatch, tmp_
     now = datetime(2026, 4, 12, 20, 0, 0, tzinfo=timezone.utc)
     monkeypatch.setattr(mod, "_utc_now", lambda: now)
 
-    cache_key = mod._preflight_cache_key(repo_root, envelope, "remote_publish")
+    cache_key = mod._preflight_cache_key(repo_root, envelope, "remote_publish", base_ref="main")
     receipt = mod.PreflightReceipt(
         schema_version=1,
         receipt_id="preflight-remote_publish-20260412T190000Z-expired1",
@@ -484,6 +528,7 @@ def test_load_cached_preflight_receipt_misses_when_ttl_expired(monkeypatch, tmp_
         started_at="2026-04-12T19:00:00Z",
         finished_at="2026-04-12T19:00:10Z",
         passed=True,
+        base_ref="main",
         checks=[{"name": "git_push", "passed": True, "detail": "ok"}],
         cache_key=cache_key,
         ttl_seconds=3600,
@@ -497,6 +542,42 @@ def test_load_cached_preflight_receipt_misses_when_ttl_expired(monkeypatch, tmp_
         envelope,
         "remote_publish",
         now=now,
+    )
+
+    assert loaded is None
+
+
+def test_load_cached_preflight_receipt_misses_when_remote_publish_base_ref_changes(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+
+    cache_key = mod._preflight_cache_key(repo_root, envelope, "remote_publish", base_ref="main")
+    receipt = mod.PreflightReceipt(
+        schema_version=1,
+        receipt_id="preflight-remote_publish-20260412T200000Z-base1",
+        envelope_seal=envelope.preflight_cache_seal(),
+        repo_root=str(repo_root.resolve()),
+        check_type="remote_publish",
+        started_at="2026-04-12T20:00:00Z",
+        finished_at="2026-04-12T20:00:05Z",
+        passed=True,
+        base_ref="main",
+        checks=[{"name": "git_push", "passed": True, "detail": "ok"}],
+        cache_key=cache_key,
+        ttl_seconds=3600,
+        expires_at="2026-04-12T21:00:05Z",
+        artifacts={"branch": "preflight/remote/test", "worktree_path": "/tmp/worktree"},
+    )
+    mod._save_preflight_receipt(repo_root, receipt)
+
+    loaded = mod._load_cached_preflight_receipt(
+        repo_root,
+        envelope,
+        "remote_publish",
+        base_ref="release/2026-04-13",
     )
 
     assert loaded is None
@@ -529,6 +610,7 @@ def test_load_cached_preflight_receipt_misses_when_envelope_changes(
         started_at="2026-04-12T20:00:00Z",
         finished_at="2026-04-12T20:00:05Z",
         passed=True,
+        base_ref="",
         checks=[{"name": "git_commit", "passed": True, "detail": "ok"}],
         cache_key=cache_key,
         ttl_seconds=86400,
@@ -557,6 +639,7 @@ def test_failed_receipts_are_not_reused(tmp_path: Path) -> None:
         started_at="2026-04-12T20:00:00Z",
         finished_at="2026-04-12T20:00:05Z",
         passed=False,
+        base_ref="",
         checks=[{"name": "git_commit", "passed": False, "detail": "failed"}],
         cache_key=cache_key,
         ttl_seconds=86400,

--- a/tests/swarm/test_tranche.py
+++ b/tests/swarm/test_tranche.py
@@ -872,12 +872,12 @@ async def test_artifact_from_run_result_persists_issue_text_audit_metadata(tmp_p
     )
 
     assert artifact.metadata["issue_text"] == {
-        "original_body": "raw body",
         "sanitized_body": "rewritten body",
         "changed": True,
         "sanitizer_outcome": "rewritten",
         "checks_failed": ["missing_validation"],
     }
+    assert "original_body" not in artifact.metadata["issue_text"]
 
 
 def test_lane_spec_from_manifest_emits_explicit_single_work_order() -> None:


### PR DESCRIPTION
## Summary
- include `base_ref` in remote-publish preflight receipt identity so cached receipts do not cross base branches
- recover and close draft validation PRs even when `gh pr create` output is not parseable
- persist only the sanitized issue-text surface in tranche artifacts and drop the unsanitized original body
- paginate open-PR conflict detection in `scripts/generate_boss_issues.py` so file-overlap checks do not stop at the first 50 PRs

## Validation
- `python3 -m ruff check aragora/swarm/preflight.py aragora/swarm/tranche.py scripts/generate_boss_issues.py tests/swarm/test_preflight.py tests/swarm/test_tranche.py tests/scripts/test_generate_boss_issues.py`
- `python3 -m pytest tests/swarm/test_preflight.py tests/swarm/test_tranche.py tests/scripts/test_generate_boss_issues.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
