### PR TITLE
fix(scripts): paginate open PR conflict detection

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -38,6 +38,10 @@ _GENERIC_PARENT_PHRASES: tuple[str, ...] = (
     "supporting tests",
     "think about it",
 )
+_OPEN_PR_PAGE_SIZE = 100
+_OPEN_PR_MAX_PAGES = 10
+_OPEN_PR_FILES_PAGE_SIZE = 100
+_OPEN_PR_FILES_MAX_PAGES = 10
 
 
 @dataclass(slots=True)
@@ -142,33 +146,61 @@ def fetch_existing_boss_issues(repo: str) -> list[dict]:
 def fetch_open_pr_files(repo: str) -> set[str]:
     """Fetch file paths changed in open PRs."""
     try:
-        result = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repo,
-                "--state",
-                "open",
-                "--limit",
-                "50",
-                "--json",
-                "files",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-        if result.returncode == 0:
-            prs = json.loads(result.stdout or "[]")
-            files: set[str] = set()
+        files: set[str] = set()
+        for page in range(1, _OPEN_PR_MAX_PAGES + 1):
+            prs_result = subprocess.run(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo}/pulls?state=open&per_page={_OPEN_PR_PAGE_SIZE}&page={page}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if prs_result.returncode != 0:
+                return set()
+            prs = json.loads(prs_result.stdout or "[]")
+            if not isinstance(prs, list):
+                return set()
+            if not prs:
+                return files
             for pr in prs:
-                for f in pr.get("files", []):
-                    path = f.get("path", "") if isinstance(f, dict) else str(f)
-                    if path:
-                        files.add(path)
-            return files
+                if not isinstance(pr, dict):
+                    continue
+                number = pr.get("number")
+                if not isinstance(number, int):
+                    continue
+                for files_page in range(1, _OPEN_PR_FILES_MAX_PAGES + 1):
+                    files_result = subprocess.run(
+                        [
+                            "gh",
+                            "api",
+                            (
+                                f"repos/{repo}/pulls/{number}/files"
+                                f"?per_page={_OPEN_PR_FILES_PAGE_SIZE}&page={files_page}"
+                            ),
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                    )
+                    if files_result.returncode != 0:
+                        return set()
+                    payload = json.loads(files_result.stdout or "[]")
+                    if not isinstance(payload, list):
+                        return set()
+                    if not payload:
+                        break
+                    for item in payload:
+                        path = item.get("filename", "") if isinstance(item, dict) else str(item)
+                        if path:
+                            files.add(path)
+                    if len(payload) < _OPEN_PR_FILES_PAGE_SIZE:
+                        break
+            if len(prs) < _OPEN_PR_PAGE_SIZE:
+                return files
+        return files
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         pass
     return set()

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from types import SimpleNamespace
 
@@ -409,3 +410,64 @@ def test_main_passes_decomposition_flags(monkeypatch, capsys) -> None:
     assert decompose_calls
     assert decompose_calls[0][1] is True
     assert decompose_calls[0][2] == 4
+
+
+def test_fetch_open_pr_files_paginates_open_prs_and_pr_files(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_PAGE_SIZE", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        endpoint = cmd[-1]
+        calls.append(endpoint)
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"number": 101}, {"number": 102}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [{"filename": "aragora/first.py"}, {"filename": "aragora/second.py"}]
+                ),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=2"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/third.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/102/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/fourth.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=2"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 103}]), stderr="")
+        if endpoint.endswith("/pulls/103/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/fifth.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=3"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    files = mod.fetch_open_pr_files("org/repo")
+
+    assert files == {
+        "aragora/first.py",
+        "aragora/second.py",
+        "aragora/third.py",
+        "aragora/fourth.py",
+        "aragora/fifth.py",
+    }
+    assert "repos/org/repo/pulls?state=open&per_page=2&page=2" in calls
+    assert "repos/org/repo/pulls/101/files?per_page=2&page=2" in calls


### PR DESCRIPTION
## Summary
- paginate open PR discovery in `scripts/generate_boss_issues.py` instead of stopping at the first 50 PRs
- paginate per-PR file listing so changed-path conflict detection remains truthful on large open-PR sets
- add a focused regression that exercises both open-PR pagination and per-PR file pagination

## Validation
- `python3 -m ruff check scripts/generate_boss_issues.py tests/scripts/test_generate_boss_issues.py`
- `python3 -m pytest tests/scripts/test_generate_boss_issues.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
