### PR TITLE
fix(preflight): fail closed on ambiguous draft cleanup

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -747,11 +747,13 @@ def run_remote_publish_validation_receipt(
         "target_ref": normalized_base_ref,
         "draft_pr_number": None,
         "draft_pr_url": "",
+        "draft_pr_cleanup_state": "not_created",
     }
     checks: list[dict[str, Any]] = []
     worktree_created = False
     pushed = False
     draft_created = False
+    draft_pr_ambiguous = False
     scratch_file = _scratch_validation_file(worktree_path)
 
     try:
@@ -829,6 +831,8 @@ def run_remote_publish_validation_receipt(
                                     base_ref=normalized_base_ref,
                                 )
                             if pr_number is None or not pr_url:
+                                draft_pr_ambiguous = True
+                                artifacts["draft_pr_cleanup_state"] = "ambiguous"
                                 _append_check(
                                     checks,
                                     name="gh_pr_capture",
@@ -840,6 +844,7 @@ def run_remote_publish_validation_receipt(
                                 )
                             else:
                                 draft_created = True
+                                artifacts["draft_pr_cleanup_state"] = "identified"
                                 artifacts["draft_pr_number"] = pr_number
                                 artifacts["draft_pr_url"] = pr_url
                                 _append_check(
@@ -864,6 +869,17 @@ def run_remote_publish_validation_receipt(
                 ],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
             )
+            artifacts["draft_pr_cleanup_state"] = "closed"
+        elif pushed and draft_pr_ambiguous:
+            _append_check(
+                checks,
+                name="gh_pr_close",
+                passed=False,
+                detail=(
+                    "gh pr create succeeded, but draft PR identity remained ambiguous after "
+                    "output parsing and fallback lookup; draft PR may still be open."
+                ),
+            )
         elif pushed:
             _append_check(
                 checks,
@@ -872,7 +888,17 @@ def run_remote_publish_validation_receipt(
                 detail="skipped (draft PR not created)",
             )
 
-        if pushed:
+        if pushed and draft_pr_ambiguous:
+            _append_check(
+                checks,
+                name="cleanup_remote_branch_delete",
+                passed=False,
+                detail=(
+                    "Skipped remote branch deletion because gh pr create succeeded but draft PR "
+                    "identity is ambiguous; remote branch retained for manual review."
+                ),
+            )
+        elif pushed:
             _run_check(
                 checks,
                 name="cleanup_remote_branch_delete",

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -498,6 +498,73 @@ def test_run_remote_publish_validation_receipt_closes_draft_when_create_output_u
     )
 
 
+def test_run_remote_publish_validation_receipt_retains_remote_branch_when_draft_pr_identity_is_ambiguous(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 12, 19, 53, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "0rph4n42")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="draft created successfully\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+        base_ref="main",
+    )
+
+    assert receipt.passed is False
+    assert receipt.artifacts["draft_pr_number"] is None
+    assert receipt.artifacts["draft_pr_url"] == ""
+    assert receipt.artifacts["draft_pr_cleanup_state"] == "ambiguous"
+    assert any(
+        check["name"] == "gh_pr_capture"
+        and check["passed"] is False
+        and "fallback lookup by branch did not find an open PR" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "gh_pr_close"
+        and check["passed"] is False
+        and "draft PR may still be open" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "cleanup_remote_branch_delete"
+        and check["passed"] is False
+        and "remote branch retained for manual review" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        cmd[:5] == ["gh", "pr", "list", "--head", receipt.artifacts["branch"]] for cmd in commands
+    )
+    assert not any(
+        cmd == ["git", "push", "origin", "--delete", receipt.artifacts["branch"]]
+        for cmd in commands
+    )
+    assert not any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when gh pr create succeeds but draft PR identity remains ambiguous
- retain the remote branch for manual review instead of deleting it in that orphan-draft path
- add a regression test covering the ambiguous draft cleanup path

## Validation
- pytest tests/swarm/test_preflight.py -q
- ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/preflight.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD