### PR TITLE
fix(preflight): fail closed on ambiguous draft capture

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -752,6 +752,7 @@ def run_remote_publish_validation_receipt(
     worktree_created = False
     pushed = False
     draft_created = False
+    draft_capture_ambiguous = False
     scratch_file = _scratch_validation_file(worktree_path)
 
     try:
@@ -829,6 +830,7 @@ def run_remote_publish_validation_receipt(
                                     base_ref=normalized_base_ref,
                                 )
                             if pr_number is None or not pr_url:
+                                draft_capture_ambiguous = True
                                 _append_check(
                                     checks,
                                     name="gh_pr_capture",
@@ -869,17 +871,29 @@ def run_remote_publish_validation_receipt(
                 checks,
                 name="gh_pr_close",
                 passed=True,
-                detail="skipped (draft PR not created)",
+                detail=(
+                    "skipped (draft PR existence ambiguous)"
+                    if draft_capture_ambiguous
+                    else "skipped (draft PR not created)"
+                ),
             )
 
         if pushed:
-            _run_check(
-                checks,
-                name="cleanup_remote_branch_delete",
-                cmd=["git", "push", "origin", "--delete", branch],
-                cwd=worktree_path if worktree_created else resolved_repo_root,
-                env=git_safe_env(),
-            )
+            if draft_capture_ambiguous:
+                _append_check(
+                    checks,
+                    name="cleanup_remote_branch_delete",
+                    passed=True,
+                    detail="skipped (draft PR existence ambiguous; remote branch preserved)",
+                )
+            else:
+                _run_check(
+                    checks,
+                    name="cleanup_remote_branch_delete",
+                    cmd=["git", "push", "origin", "--delete", branch],
+                    cwd=worktree_path if worktree_created else resolved_repo_root,
+                    env=git_safe_env(),
+                )
         else:
             _append_check(
                 checks,

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -498,6 +498,70 @@ def test_run_remote_publish_validation_receipt_closes_draft_when_create_output_u
     )
 
 
+def test_run_remote_publish_validation_receipt_preserves_remote_branch_when_pr_capture_is_ambiguous(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 13, 1, 5, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "deadbeef")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="draft created successfully\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+    )
+
+    assert receipt.passed is False
+    assert receipt.artifacts["draft_pr_number"] is None
+    assert receipt.artifacts["draft_pr_url"] == ""
+    assert any(
+        check["name"] == "gh_pr_capture"
+        and check["passed"] is False
+        and "fallback lookup by branch did not find an open PR" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "gh_pr_close"
+        and check["passed"] is True
+        and check["detail"] == "skipped (draft PR existence ambiguous)"
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "cleanup_remote_branch_delete"
+        and check["passed"] is True
+        and check["detail"] == "skipped (draft PR existence ambiguous; remote branch preserved)"
+        for check in receipt.checks
+    )
+    assert any(cmd[:3] == ["gh", "pr", "create"] for cmd in commands)
+    assert any(cmd[:3] == ["gh", "pr", "list"] for cmd in commands)
+    assert not any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
+    assert not any(
+        cmd == ["git", "push", "origin", "--delete", receipt.artifacts["branch"]]
+        for cmd in commands
+    )
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- preserve the remote validation branch when gh pr create succeeds but PR capture remains ambiguous
- record explicit skip details for PR close and remote branch cleanup in that fail-closed path
- cover the ambiguous capture case in preflight receipt tests

## Validation
- python3 -m pytest -q tests/swarm/test_preflight.py -k 'remote_publish_validation_receipt'
- python3 -m ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/preflight.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD