### PR TITLE
fix(preflight): fail closed on ambiguous draft cleanup

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -747,6 +747,7 @@ def run_remote_publish_validation_receipt(
         "target_ref": normalized_base_ref,
         "draft_pr_number": None,
         "draft_pr_url": "",
+        "manual_reconciliation_required": False,
     }
     checks: list[dict[str, Any]] = []
     worktree_created = False
@@ -829,13 +830,16 @@ def run_remote_publish_validation_receipt(
                                     base_ref=normalized_base_ref,
                                 )
                             if pr_number is None or not pr_url:
+                                artifacts["manual_reconciliation_required"] = True
                                 _append_check(
                                     checks,
                                     name="gh_pr_capture",
                                     passed=False,
                                     detail=(
-                                        "Draft PR create output did not include a parseable PR URL "
-                                        "and fallback lookup by branch did not find an open PR."
+                                        "Draft PR create command succeeded, but output did not "
+                                        "include a parseable PR URL and fallback lookup by branch "
+                                        "did not find an open PR. Remote branch preserved for "
+                                        "manual reconciliation."
                                     ),
                                 )
                             else:
@@ -849,6 +853,7 @@ def run_remote_publish_validation_receipt(
                                     detail=pr_url,
                                 )
     finally:
+        manual_reconciliation_required = bool(artifacts.get("manual_reconciliation_required"))
         if draft_created:
             close_target = str(artifacts.get("draft_pr_number") or branch)
             _run_check(
@@ -865,21 +870,43 @@ def run_remote_publish_validation_receipt(
                 cwd=worktree_path if worktree_created else resolved_repo_root,
             )
         elif pushed:
-            _append_check(
-                checks,
-                name="gh_pr_close",
-                passed=True,
-                detail="skipped (draft PR not created)",
-            )
+            if manual_reconciliation_required:
+                _append_check(
+                    checks,
+                    name="gh_pr_close",
+                    passed=False,
+                    detail=(
+                        "Skipped because draft PR creation may have succeeded but could not be "
+                        "reconciled. Manual cleanup required."
+                    ),
+                )
+            else:
+                _append_check(
+                    checks,
+                    name="gh_pr_close",
+                    passed=True,
+                    detail="skipped (draft PR not created)",
+                )
 
         if pushed:
-            _run_check(
-                checks,
-                name="cleanup_remote_branch_delete",
-                cmd=["git", "push", "origin", "--delete", branch],
-                cwd=worktree_path if worktree_created else resolved_repo_root,
-                env=git_safe_env(),
-            )
+            if manual_reconciliation_required:
+                _append_check(
+                    checks,
+                    name="cleanup_remote_branch_delete",
+                    passed=False,
+                    detail=(
+                        "Skipped to preserve the remote branch because draft PR creation may "
+                        "have succeeded but could not be reconciled. Manual cleanup required."
+                    ),
+                )
+            else:
+                _run_check(
+                    checks,
+                    name="cleanup_remote_branch_delete",
+                    cmd=["git", "push", "origin", "--delete", branch],
+                    cwd=worktree_path if worktree_created else resolved_repo_root,
+                    env=git_safe_env(),
+                )
         else:
             _append_check(
                 checks,

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -498,6 +498,71 @@ def test_run_remote_publish_validation_receipt_closes_draft_when_create_output_u
     )
 
 
+def test_run_remote_publish_validation_receipt_fails_closed_when_pr_capture_is_ambiguous(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 12, 19, 53, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "f0e1d2c3")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="draft created successfully\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+    )
+
+    assert receipt.passed is False
+    assert receipt.artifacts["draft_pr_number"] is None
+    assert receipt.artifacts["draft_pr_url"] == ""
+    assert receipt.artifacts["manual_reconciliation_required"] is True
+    assert any(
+        check["name"] == "gh_pr_capture"
+        and check["passed"] is False
+        and "Remote branch preserved for manual reconciliation." in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "gh_pr_close"
+        and check["passed"] is False
+        and "Manual cleanup required." in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "cleanup_remote_branch_delete"
+        and check["passed"] is False
+        and "preserve the remote branch" in check["detail"]
+        for check in receipt.checks
+    )
+    assert not any(
+        cmd == ["git", "push", "origin", "--delete", receipt.artifacts["branch"]]
+        for cmd in commands
+    )
+    assert not any(
+        cmd[:4] == ["gh", "pr", "close", receipt.artifacts["branch"]] for cmd in commands
+    )
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when draft PR creation succeeds but capture remains ambiguous
- preserve the remote branch for manual reconciliation instead of deleting it
- add a regression test for the orphan-draft path

## Validation
- python3 -m pytest tests/swarm/test_preflight.py -q
- python3 -m ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD