### PR TITLE
fix(swarm): fail-closed orphan-draft cleanup + generator pagination warning

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -872,13 +872,26 @@ def run_remote_publish_validation_receipt(
                 detail="skipped (draft PR not created)",
             )
 
-        if pushed:
+        if pushed and draft_created:
+            # Safe: we know the PR was captured and closed above
             _run_check(
                 checks,
                 name="cleanup_remote_branch_delete",
                 cmd=["git", "push", "origin", "--delete", branch],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
                 env=git_safe_env(),
+            )
+        elif pushed and not draft_created:
+            # Fail-closed: PR may exist on this branch but we couldn't
+            # capture it. Do NOT delete the branch — it may orphan a PR.
+            _append_check(
+                checks,
+                name="cleanup_remote_branch_delete",
+                passed=False,
+                detail=(
+                    "skipped (branch pushed but draft PR not captured — "
+                    "refusing to delete branch to avoid orphaning a PR)"
+                ),
             )
         else:
             _append_check(

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -137,7 +137,14 @@ def fetch_existing_boss_issues(repo: str) -> list[dict]:
             timeout=30,
         )
         if result.returncode == 0:
-            return json.loads(result.stdout or "[]")
+            issues = json.loads(result.stdout or "[]")
+            if len(issues) >= 200:
+                print(
+                    "WARNING: fetched 200 issues (hard cap). "
+                    "Dedup may miss issues beyond this limit.",
+                    file=sys.stderr,
+                )
+            return issues
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         pass
     return []


### PR DESCRIPTION
## Summary

Two findings from Codex review of current origin/main:

1. **preflight.py orphan-draft path**: When `gh pr create` succeeded but parse+lookup both missed the PR, cleanup deleted the remote branch — orphaning the draft PR. Fix: fail-closed — refuse to delete when draft wasn't captured.

2. **generate_boss_issues.py pagination**: Silently stopped at `--limit 200`. Fix: warn to stderr when count hits the cap.

## Test plan
- [x] `pytest tests/swarm/test_preflight.py -q` — 18 passed
- [x] `ruff check` — clean
- [x] Syntax check — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)