### PR TITLE
fix: fail closed on unresolved draft cleanup and PR pagination caps

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -752,6 +752,7 @@ def run_remote_publish_validation_receipt(
     worktree_created = False
     pushed = False
     draft_created = False
+    unresolved_remote_pr_state = False
     scratch_file = _scratch_validation_file(worktree_path)
 
     try:
@@ -849,6 +850,25 @@ def run_remote_publish_validation_receipt(
                                     detail=pr_url,
                                 )
     finally:
+        if pushed and not draft_created:
+            pr_number, pr_url = _find_open_pr_by_branch(
+                cwd=worktree_path if worktree_created else resolved_repo_root,
+                branch=branch,
+                base_ref=normalized_base_ref,
+            )
+            if pr_number is not None and pr_url:
+                draft_created = True
+                artifacts["draft_pr_number"] = pr_number
+                artifacts["draft_pr_url"] = pr_url
+                _append_check(
+                    checks,
+                    name="gh_pr_capture_recovery",
+                    passed=True,
+                    detail=pr_url,
+                )
+            else:
+                unresolved_remote_pr_state = True
+
         if draft_created:
             close_target = str(artifacts.get("draft_pr_number") or branch)
             _run_check(
@@ -864,6 +884,16 @@ def run_remote_publish_validation_receipt(
                 ],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
             )
+        elif pushed and unresolved_remote_pr_state:
+            _append_check(
+                checks,
+                name="gh_pr_close",
+                passed=False,
+                detail=(
+                    "unable to confirm whether a draft PR exists after gh pr create; "
+                    "remote branch retained for manual cleanup"
+                ),
+            )
         elif pushed:
             _append_check(
                 checks,
@@ -872,13 +902,20 @@ def run_remote_publish_validation_receipt(
                 detail="skipped (draft PR not created)",
             )
 
-        if pushed:
+        if pushed and not unresolved_remote_pr_state:
             _run_check(
                 checks,
                 name="cleanup_remote_branch_delete",
                 cmd=["git", "push", "origin", "--delete", branch],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
                 env=git_safe_env(),
+            )
+        elif pushed:
+            _append_check(
+                checks,
+                name="cleanup_remote_branch_delete",
+                passed=False,
+                detail=("skipped because draft PR state could not be confirmed after gh pr create"),
             )
         else:
             _append_check(

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -198,9 +198,16 @@ def fetch_open_pr_files(repo: str) -> set[str]:
                             files.add(path)
                     if len(payload) < _OPEN_PR_FILES_PAGE_SIZE:
                         break
+                else:
+                    raise RuntimeError(
+                        "open PR file pagination exceeded configured cap "
+                        f"({_OPEN_PR_FILES_MAX_PAGES} pages) for PR #{number}"
+                    )
             if len(prs) < _OPEN_PR_PAGE_SIZE:
                 return files
-        return files
+        raise RuntimeError(
+            f"open PR pagination exceeded configured cap ({_OPEN_PR_MAX_PAGES} pages) for {repo}"
+        )
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         pass
     return set()
@@ -458,7 +465,11 @@ def main() -> None:
 
     # 3. Check PR conflicts (always fetch, even in dry-run)
     print("Fetching open PR files...")
-    pr_files = fetch_open_pr_files(args.repo)
+    try:
+        pr_files = fetch_open_pr_files(args.repo)
+    except RuntimeError as exc:
+        print(f"Error: {exc}")
+        return 1
     print(f"  {len(pr_files)} files in open PRs")
 
     # 4. Filter

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -4,6 +4,8 @@ import json
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from scripts import generate_boss_issues as mod
 
@@ -471,3 +473,73 @@ def test_fetch_open_pr_files_paginates_open_prs_and_pr_files(monkeypatch) -> Non
     }
     assert "repos/org/repo/pulls?state=open&per_page=2&page=2" in calls
     assert "repos/org/repo/pulls/101/files?per_page=2&page=2" in calls
+
+
+def test_fetch_open_pr_files_raises_when_open_pr_pagination_cap_exhausted(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_PR_MAX_PAGES", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        endpoint = cmd[-1]
+        if endpoint.endswith("/pulls?state=open&per_page=1&page=1"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 101}]), stderr="")
+        if endpoint.endswith("/pulls/101/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        if endpoint.endswith("/pulls?state=open&per_page=1&page=2"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 102}]), stderr="")
+        if endpoint.endswith("/pulls/102/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="open PR pagination exceeded configured cap"):
+        mod.fetch_open_pr_files("org/repo")
+
+
+def test_fetch_open_pr_files_raises_when_pr_files_pagination_cap_exhausted(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_PAGE_SIZE", 1)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_MAX_PAGES", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        endpoint = cmd[-1]
+        if endpoint.endswith("/pulls?state=open&per_page=1&page=1"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 101}]), stderr="")
+        if endpoint.endswith("/pulls/101/files?per_page=1&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/first.py"}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=1&page=2"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"filename": "aragora/second.py"}]),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="open PR file pagination exceeded configured cap"):
+        mod.fetch_open_pr_files("org/repo")
+
+
+def test_main_returns_error_when_open_pr_pagination_exhausted(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        mod,
+        "scan_all",
+        lambda repo_root, categories=None, min_success_rate=0.3: [],
+    )
+    monkeypatch.setattr(mod, "fetch_existing_boss_issues", lambda repo: [])
+
+    def raise_pagination_error(repo: str) -> set[str]:
+        raise RuntimeError("open PR pagination exceeded configured cap (10 pages) for org/repo")
+
+    monkeypatch.setattr(mod, "fetch_open_pr_files", raise_pagination_error)
+    monkeypatch.setattr(sys, "argv", ["generate_boss_issues.py", "--repo", "org/repo"])
+
+    assert mod.main() == 1
+    out = capsys.readouterr().out
+    assert "Error: open PR pagination exceeded configured cap (10 pages) for org/repo" in out

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -498,6 +498,64 @@ def test_run_remote_publish_validation_receipt_closes_draft_when_create_output_u
     )
 
 
+def test_run_remote_publish_validation_receipt_retains_branch_when_draft_state_unresolved(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 12, 20, 7, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "ca11ab1e")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="draft created successfully\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "list"]:
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+        base_ref="main",
+    )
+
+    assert receipt.passed is False
+    assert receipt.artifacts["draft_pr_number"] is None
+    assert receipt.artifacts["draft_pr_url"] == ""
+    assert any(
+        check["name"] == "gh_pr_close"
+        and check["passed"] is False
+        and "remote branch retained for manual cleanup" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "cleanup_remote_branch_delete"
+        and check["passed"] is False
+        and "draft PR state could not be confirmed" in check["detail"]
+        for check in receipt.checks
+    )
+    assert sum(1 for cmd in commands if cmd[:3] == ["gh", "pr", "list"]) == 2
+    assert not any(cmd[:3] == ["gh", "pr", "close"] for cmd in commands)
+    assert not any(
+        cmd == ["git", "push", "origin", "--delete", receipt.artifacts["branch"]]
+        for cmd in commands
+    )
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when remote publish cannot confirm whether gh pr create actually opened a draft PR
- retain the remote branch for manual cleanup instead of deleting it in the unresolved path
- raise loudly when open-PR pagination or per-PR file pagination exceeds configured caps
- add focused regressions for the unresolved draft path and both pagination-cap exhaustion paths

## Validation
- python3 -m ruff check aragora/swarm/preflight.py scripts/generate_boss_issues.py tests/swarm/test_preflight.py tests/scripts/test_generate_boss_issues.py
- python3 -m pytest tests/swarm/test_preflight.py tests/scripts/test_generate_boss_issues.py -q
- bash scripts/automation_pr_preflight.sh origin/main HEAD