### PR TITLE
fix(scripts): fail closed on PR pagination caps

### DIFF
--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -44,6 +44,10 @@ _OPEN_PR_FILES_PAGE_SIZE = 100
 _OPEN_PR_FILES_MAX_PAGES = 10
 
 
+class OpenPRPaginationExhaustedError(RuntimeError):
+    """Conflict detection cannot trust partial GitHub pagination results."""
+
+
 @dataclass(slots=True)
 class DecompositionTelemetry:
     """Aggregate telemetry for one generator run."""
@@ -198,9 +202,18 @@ def fetch_open_pr_files(repo: str) -> set[str]:
                             files.add(path)
                     if len(payload) < _OPEN_PR_FILES_PAGE_SIZE:
                         break
+                else:
+                    raise OpenPRPaginationExhaustedError(
+                        "Open PR file pagination exceeded "
+                        f"{_OPEN_PR_FILES_MAX_PAGES} pages for PR #{number} in {repo}; "
+                        "refusing partial conflict data."
+                    )
             if len(prs) < _OPEN_PR_PAGE_SIZE:
                 return files
-        return files
+        raise OpenPRPaginationExhaustedError(
+            "Open PR pagination exceeded "
+            f"{_OPEN_PR_MAX_PAGES} pages for {repo}; refusing partial conflict data."
+        )
     except (subprocess.TimeoutExpired, json.JSONDecodeError, OSError):
         pass
     return set()
@@ -458,7 +471,10 @@ def main() -> None:
 
     # 3. Check PR conflicts (always fetch, even in dry-run)
     print("Fetching open PR files...")
-    pr_files = fetch_open_pr_files(args.repo)
+    try:
+        pr_files = fetch_open_pr_files(args.repo)
+    except OpenPRPaginationExhaustedError as exc:
+        raise SystemExit(str(exc)) from exc
     print(f"  {len(pr_files)} files in open PRs")
 
     # 4. Filter

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -4,6 +4,8 @@ import json
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from scripts import generate_boss_issues as mod
 
@@ -471,3 +473,75 @@ def test_fetch_open_pr_files_paginates_open_prs_and_pr_files(monkeypatch) -> Non
     }
     assert "repos/org/repo/pulls?state=open&per_page=2&page=2" in calls
     assert "repos/org/repo/pulls/101/files?per_page=2&page=2" in calls
+
+
+def test_fetch_open_pr_files_fails_closed_when_open_pr_page_cap_exhausted(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_MAX_PAGES", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        endpoint = cmd[-1]
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"number": 101}, {"number": 102}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        if endpoint.endswith("/pulls/102/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=2"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps([{"number": 103}, {"number": 104}]),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/103/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        if endpoint.endswith("/pulls/104/files?per_page=100&page=1"):
+            return SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        mod.OpenPRPaginationExhaustedError, match="Open PR pagination exceeded 2 pages"
+    ):
+        mod.fetch_open_pr_files("org/repo")
+
+
+def test_fetch_open_pr_files_fails_closed_when_pr_files_page_cap_exhausted(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "_OPEN_PR_PAGE_SIZE", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_PAGE_SIZE", 2)
+    monkeypatch.setattr(mod, "_OPEN_PR_FILES_MAX_PAGES", 2)
+
+    def fake_run(cmd: list[str], **_: object) -> SimpleNamespace:
+        endpoint = cmd[-1]
+        if endpoint.endswith("/pulls?state=open&per_page=2&page=1"):
+            return SimpleNamespace(returncode=0, stdout=json.dumps([{"number": 101}]), stderr="")
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=1"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [{"filename": "aragora/first.py"}, {"filename": "aragora/second.py"}]
+                ),
+                stderr="",
+            )
+        if endpoint.endswith("/pulls/101/files?per_page=2&page=2"):
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps(
+                    [{"filename": "aragora/third.py"}, {"filename": "aragora/fourth.py"}]
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected gh api call: {endpoint}")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    with pytest.raises(
+        mod.OpenPRPaginationExhaustedError,
+        match=r"Open PR file pagination exceeded 2 pages for PR #101",
+    ):
+        mod.fetch_open_pr_files("org/repo")


### PR DESCRIPTION
## Summary
- raise an explicit pagination error when open PR listing exhausts its page cap
- raise an explicit pagination error when a PR's files listing exhausts its page cap
- add focused tests for both cap-exhaustion paths while keeping normal pagination coverage

## Validation
- python3 -m pytest -q tests/scripts/test_generate_boss_issues.py
- python3 -m ruff check scripts/generate_boss_issues.py tests/scripts/test_generate_boss_issues.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD