### PR TITLE
docs(CLAUDE.md): add worktree cleanup safety guardrail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,23 @@ repo — editing files in the main directory causes concurrent overwrites.
 3. **Background cleanup** — A LaunchAgent runs every 5 minutes, reconciling worktrees with main
    (merge strategy) and cleaning up stale ones after 24h. Branches are auto-deleted after merge.
 
+### Worktree cleanup (IMPORTANT)
+
+**NEVER** use raw `find .worktrees -exec rm -rf` or similar ad-hoc deletion.
+This destroys active worktrees with uncommitted work. Always use the safe helpers:
+
+```bash
+# Safe cleanup (preferred) — respects TTL, checks merge status
+python3 scripts/codex_worktree_autopilot.py cleanup --base main --ttl-hours 24
+
+# Per-worktree safe removal — checks for blockers first
+python3 scripts/safe_worktree_cleanup.py inspect <worktree-path>
+python3 scripts/safe_worktree_cleanup.py remove <worktree-path>
+
+# Minimal safe option — only prunes already-deleted directories
+git worktree prune --expire=now
+```
+
 ### Manual worktree commands
 
 - `./scripts/codex_session.sh` — Legacy session bootstrap (creates worktree + metadata)


### PR DESCRIPTION
## Summary
- Add explicit safety rule to CLAUDE.md: never use raw `rm -rf` on worktrees
- Document the three safe alternatives (autopilot cleanup, safe_worktree_cleanup, git worktree prune)
- Prevents accidental destruction of active worktrees with uncommitted work

## Context
Claude B used raw `find .worktrees -exec rm -rf` which destroyed 336 worktrees indiscriminately. Some may have had uncommitted work. This guardrail ensures all agents use the safe helpers.

## Test plan
- [x] Docs-only change, preflight passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)