### PR TITLE
feat(swarm): enrich issue specs and gate dispatch admission

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -634,6 +635,117 @@ class BossLoop:
             check=False,
             timeout=timeout,
         )
+
+    def _gh_cli_authenticated(self) -> bool:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status", "--hostname", "github.com"],
+                cwd=Path.cwd(),
+                env=git_safe_env(self._env),
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5.0,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+    def _dispatch_capability_env(
+        self,
+        *,
+        target_agent: str,
+        selected_runner: dict[str, Any] | None,
+    ) -> dict[str, str]:
+        env_snapshot = dict(self._env or os.environ)
+        runner_profile = str((selected_runner or {}).get("profile", "") or "").strip()
+
+        if runner_profile and "ARAGORA_RUNNER_PROFILE" not in env_snapshot:
+            env_snapshot["ARAGORA_RUNNER_PROFILE"] = runner_profile
+        if target_agent == "claude":
+            if runner_profile and "ARAGORA_CLAUDE_PROFILE" not in env_snapshot:
+                env_snapshot["ARAGORA_CLAUDE_PROFILE"] = runner_profile
+            env_snapshot.setdefault("ARAGORA_RUNNER_COMMAND", "claude")
+        elif target_agent == "codex":
+            if runner_profile and "ARAGORA_CODEX_PROFILE" not in env_snapshot:
+                env_snapshot["ARAGORA_CODEX_PROFILE"] = runner_profile
+            env_snapshot.setdefault("ARAGORA_RUNNER_COMMAND", "codex")
+
+        if "ARAGORA_RUNNER_AUTH_MODE" not in env_snapshot:
+            env_snapshot["ARAGORA_RUNNER_AUTH_MODE"] = "profile" if runner_profile else "command"
+        env_snapshot.setdefault(
+            "PYTEST_AVAILABLE",
+            "true" if shutil.which("pytest") else "false",
+        )
+        env_snapshot.setdefault(
+            "RUFF_AVAILABLE",
+            "true" if shutil.which("ruff") else "false",
+        )
+        return env_snapshot
+
+    def _dispatch_contract_gate(
+        self,
+        *,
+        issue: GitHubIssue,
+        spec: Any,
+        target_agent: str,
+        selected_runner: dict[str, Any] | None,
+    ) -> dict[str, Any] | None:
+        from aragora.swarm.credential_envelope import CredentialEnvelope
+        from aragora.swarm.worker_contract import build_worker_contract
+        from aragora.swarm.worker_process import LaunchConfig
+
+        env_snapshot = self._dispatch_capability_env(
+            target_agent=target_agent,
+            selected_runner=selected_runner,
+        )
+        envelope = CredentialEnvelope.from_environment(env_snapshot)
+        missing_slices = envelope.missing_slices()
+        if "github_api" in missing_slices and self._gh_cli_authenticated():
+            missing_slices = [item for item in missing_slices if item != "github_api"]
+        if missing_slices:
+            missing_text = ", ".join(missing_slices)
+            return {
+                "status": "needs_human",
+                "outcome": "blocked_auth_failure",
+                "credential_missing_slices": missing_slices,
+                "reasons": [
+                    f"Issue #{issue.number} cannot dispatch until credential slices are complete: {missing_text}"
+                ],
+                "next_actions": [
+                    f"Restore the missing credential slices: {missing_text}.",
+                    "Rerun dispatch after the runner, Git/GitHub, provider, and verification capabilities are restored.",
+                ],
+            }
+
+        launch_config = LaunchConfig(
+            base_branch=self.config.target_branch,
+            claude_profile=str((selected_runner or {}).get("profile", "") or "").strip() or None,
+            allow_claude_dangerously_skip_permissions=self.config.allow_claude_dangerously_skip_permissions,
+            allow_codex_full_auto=self.config.allow_codex_full_auto,
+            execution_mode=self.config.execution_mode,
+        )
+        contract = build_worker_contract(
+            agent=target_agent,
+            config=launch_config,
+            worktree_path=str(Path.cwd()),
+            env=env_snapshot,
+            work_order={
+                "file_scope": list(getattr(spec, "file_scope_hints", []) or []),
+                "expected_tests": list(getattr(spec, "acceptance_criteria", []) or []),
+            },
+        )
+        if not contract.admission_check():
+            return {
+                "status": "needs_human",
+                "outcome": "blocked_auth_failure",
+                "credential_missing_slices": [],
+                "reasons": [f"Issue #{issue.number} failed worker contract admission checks."],
+                "next_actions": [
+                    "Refresh the selected runner contract and verify the dispatch environment before retrying.",
+                ],
+            }
+        return None
 
     def _git_rev_parse(self, ref: str) -> str | None:
         try:
@@ -5099,6 +5211,22 @@ class BossLoop:
                 freshness,
                 requested_target_agent=requested_target_agent,
             )
+        target_agent = (
+            str((selected_runner or {}).get("runner_type", "") or "").strip().lower()
+            or str(requested_target_agent or "").strip().lower()
+            or str(self.config.default_target_agent or "").strip().lower()
+            or "claude"
+        )
+        contract_gate_failure = self._dispatch_contract_gate(
+            issue=issue,
+            spec=spec,
+            target_agent=target_agent,
+            selected_runner=selected_runner,
+        )
+        if contract_gate_failure is not None:
+            if claimed_runner_id:
+                self._release_runner_claim(claimed_runner_id)
+            return _with_sanitizer_metadata(contract_gate_failure)
         try:
             result = await dispatch_bounded_spec(
                 spec,

--- a/aragora/swarm/issue_upgrader.py
+++ b/aragora/swarm/issue_upgrader.py
@@ -41,6 +41,44 @@ _CONCRETE_MOCK_GUIDANCE: dict[str, str] = {
 }
 _KNOWN_LOCAL_IMPORT_PREFIXES = ("aragora", "tests")
 _STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", set()))
+_FILE_IO_HINTS = (
+    "open(",
+    "read_text(",
+    "write_text(",
+    "mkdir(",
+    "unlink(",
+    "rename(",
+    "replace(",
+    "iterdir(",
+)
+_VALUE_ERROR_HINTS = (
+    "int(",
+    "float(",
+    "decimal(",
+    "fromisoformat(",
+    "strptime(",
+    "uuid(",
+)
+_KEY_ERROR_HINTS = (
+    "payload[",
+    "data[",
+    "mapping[",
+    "headers[",
+    "meta[",
+    "config[",
+)
+_CLEANUP_CONTEXT_HINTS = (
+    "close(",
+    "cleanup",
+    "shutdown",
+    "teardown",
+    "best effort",
+    "best-effort",
+    "release(",
+    "cancel(",
+    "unlink(",
+    "remove(",
+)
 
 
 @dataclass
@@ -74,6 +112,26 @@ class _ModuleAnalysis:
     has_useful_public_api: bool
     is_obvious_reexport_or_empty: bool
     external_dependency_weight: int
+
+
+@dataclass(slots=True)
+class _BroadExceptSite:
+    line_number: int
+    suggestions: list[str]
+    rationale: str
+
+
+@dataclass(slots=True)
+class _SilentExceptionSite:
+    line_number: int
+    guidance: str
+
+
+@dataclass(slots=True)
+class _MissingReturnAnnotation:
+    line_number: int
+    name: str
+    suggested_type: str
 
 
 def _read_module(path: Path) -> str | None:
@@ -272,31 +330,201 @@ def _render_mock_guidance(analysis: _ModuleAnalysis) -> str:
     return "\n".join(f"- {hint}" for hint in analysis.mock_hints[:5])
 
 
-def upgrade_issue_heuristic(
+def _module_upgrade_title(module_rel: str, *, prefix: str) -> str:
+    parts = Path(module_rel).parts
+    rendered = "/".join(parts[1:]) if len(parts) > 1 else module_rel
+    return f"{prefix} {rendered}"
+
+
+def _content_line(content: str, line_number: int) -> str:
+    lines = content.splitlines()
+    if 1 <= line_number <= len(lines):
+        return lines[line_number - 1]
+    return ""
+
+
+def _segment_for_node(content: str, node: ast.AST) -> str:
+    segment = ast.get_source_segment(content, node)
+    return str(segment or "").strip()
+
+
+def _infer_broad_exception_suggestions(try_source: str) -> tuple[list[str], str]:
+    normalized = try_source.lower()
+    suggestions: list[str] = []
+    rationale: list[str] = []
+
+    if any(token in normalized for token in _FILE_IO_HINTS):
+        suggestions.append("OSError")
+        rationale.append("file or path operations are present")
+    if "json.loads(" in normalized:
+        suggestions.append("json.JSONDecodeError")
+        rationale.append("JSON parsing is present")
+    if any(token in normalized for token in _VALUE_ERROR_HINTS):
+        suggestions.append("ValueError")
+        rationale.append("value parsing/conversion is present")
+    if any(token in normalized for token in _KEY_ERROR_HINTS):
+        suggestions.append("KeyError")
+        rationale.append("mapping lookups are present")
+
+    if suggestions:
+        return list(dict.fromkeys(suggestions)), "; ".join(rationale)
+    return [], "no deterministic narrow type was inferred from the try block"
+
+
+def _collect_broad_exception_sites(content: str) -> list[_BroadExceptSite]:
+    try:
+        module = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    sites: list[_BroadExceptSite] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Try):
+            continue
+        try_source = _segment_for_node(content, node)
+        for handler in node.handlers:
+            if not isinstance(handler.type, ast.Name) or handler.type.id != "Exception":
+                continue
+            line = _content_line(content, handler.lineno)
+            if "# noqa" in line:
+                continue
+            suggestions, rationale = _infer_broad_exception_suggestions(try_source)
+            sites.append(
+                _BroadExceptSite(
+                    line_number=handler.lineno,
+                    suggestions=suggestions,
+                    rationale=rationale,
+                )
+            )
+    return sites
+
+
+def _classify_silent_exception_guidance(handler_line: str, try_source: str) -> str:
+    normalized = f"{handler_line}\n{try_source}".lower()
+    if any(token in normalized for token in _CLEANUP_CONTEXT_HINTS):
+        return (
+            "If this is truly best-effort cleanup, keep the silence only with an explicit "
+            "`# noqa` justification. Otherwise surface a minimal debug log."
+        )
+    return (
+        "Replace the silent swallow with `logger.warning(...)` or `logger.debug(...)` so "
+        "failures become visible without changing control flow."
+    )
+
+
+def _collect_silent_exception_sites(content: str) -> list[_SilentExceptionSite]:
+    try:
+        module = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    sites: list[_SilentExceptionSite] = []
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Try):
+            continue
+        try_source = _segment_for_node(content, node)
+        for handler in node.handlers:
+            if len(handler.body) != 1 or not isinstance(handler.body[0], ast.Pass):
+                continue
+            line = _content_line(content, handler.lineno)
+            if "# noqa" in line or "# intentional" in line.lower():
+                continue
+            sites.append(
+                _SilentExceptionSite(
+                    line_number=handler.lineno,
+                    guidance=_classify_silent_exception_guidance(line, try_source),
+                )
+            )
+    return sites
+
+
+def _infer_return_annotation(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    returns = [child.value for child in ast.walk(node) if isinstance(child, ast.Return)]
+    if not returns or all(value is None for value in returns):
+        return "None"
+
+    inferred: list[str] = []
+    for value in returns:
+        if value is None:
+            inferred.append("None")
+        elif isinstance(value, ast.Constant):
+            if value.value is None:
+                inferred.append("None")
+            elif isinstance(value.value, bool):
+                inferred.append("bool")
+            elif isinstance(value.value, int):
+                inferred.append("int")
+            elif isinstance(value.value, float):
+                inferred.append("float")
+            elif isinstance(value.value, str):
+                inferred.append("str")
+            else:
+                inferred.append("Any")
+        elif isinstance(value, ast.Dict):
+            inferred.append("dict[str, Any]")
+        elif isinstance(value, ast.List | ast.ListComp):
+            inferred.append("list[Any]")
+        elif isinstance(value, ast.Tuple):
+            inferred.append("tuple[Any, ...]")
+        elif isinstance(value, ast.Set):
+            inferred.append("set[Any]")
+        else:
+            inferred.append("Any")
+
+    unique = list(dict.fromkeys(inferred))
+    if len(unique) == 1:
+        return unique[0]
+    if set(unique) <= {"None", "Any"}:
+        return "Any"
+    return "Any"
+
+
+def _collect_missing_return_annotations(content: str) -> list[_MissingReturnAnnotation]:
+    try:
+        module = ast.parse(content)
+    except SyntaxError:
+        return []
+
+    missing: list[_MissingReturnAnnotation] = []
+    for node in module.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and not node.name.startswith(
+            "_"
+        ):
+            if node.returns is None:
+                missing.append(
+                    _MissingReturnAnnotation(
+                        line_number=node.lineno,
+                        name=node.name,
+                        suggested_type=_infer_return_annotation(node),
+                    )
+                )
+        elif isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+            for child in node.body:
+                if isinstance(
+                    child, (ast.FunctionDef, ast.AsyncFunctionDef)
+                ) and not child.name.startswith("_"):
+                    if child.returns is None:
+                        missing.append(
+                            _MissingReturnAnnotation(
+                                line_number=child.lineno,
+                                name=f"{node.name}.{child.name}",
+                                suggested_type=_infer_return_annotation(child),
+                            )
+                        )
+                    if len(missing) >= 10:
+                        break
+        if len(missing) >= 10:
+            break
+    return missing
+
+
+def _upgrade_test_coverage_issue(
+    *,
     title: str,
     body: str,
-    *,
-    repo_root: Path,
+    module_rel: str,
+    analysis: _ModuleAnalysis,
 ) -> UpgradedIssue | None:
-    """Upgrade an issue using deterministic heuristic module analysis.
-
-    This prototype is intentionally narrow: only trivial/simple modules with a
-    useful public API are upgraded.
-    """
-    module_rel = _primary_module_path(body)
-    if not module_rel:
-        return None
-
-    if Path(module_rel).name in _SKIP_SENTINELS:
-        return None
-    module_path = repo_root / module_rel
-    content = _read_module(module_path)
-    if content is None:
-        return None
-
-    analysis = _analyze_module(content)
-    if analysis is None:
-        return None
     if analysis.is_obvious_reexport_or_empty or not analysis.has_useful_public_api:
         return None
     if analysis.complexity not in {"trivial", "simple"}:
@@ -339,14 +567,10 @@ def upgrade_issue_heuristic(
         f"- Estimated complexity: {analysis.complexity}\n"
         "- Do not broaden into decomposition or cross-module planning."
     )
-
-    parts = Path(module_rel).parts
-    upgraded_title = f"Add unit tests for {'/'.join(parts[1:])}" if len(parts) > 1 else title
-
     return UpgradedIssue(
         original_title=title,
         original_body=body,
-        upgraded_title=upgraded_title,
+        upgraded_title=_module_upgrade_title(module_rel, prefix="Add unit tests for"),
         upgraded_body=upgraded_body,
         module_summary=analysis.docstring,
         functions_found=list(analysis.public_functions),
@@ -355,6 +579,223 @@ def upgrade_issue_heuristic(
         complexity=analysis.complexity,
         upgrade_method="heuristic",
     )
+
+
+def _upgrade_broad_exception_issue(
+    *,
+    title: str,
+    body: str,
+    module_rel: str,
+    content: str,
+    analysis: _ModuleAnalysis,
+) -> UpgradedIssue | None:
+    if analysis.complexity not in {"trivial", "simple"}:
+        return None
+    sites = _collect_broad_exception_sites(content)
+    if not sites:
+        return None
+
+    site_lines: list[str] = []
+    for site in sites[:8]:
+        if site.suggestions:
+            rendered = ", ".join(f"`{item}`" for item in site.suggestions)
+            site_lines.append(
+                f"- Line {site.line_number}: likely narrow to {rendered} ({site.rationale})."
+            )
+        else:
+            site_lines.append(
+                f"- Line {site.line_number}: no deterministic narrow type; keep `BLE001` only with an explicit boundary justification."
+            )
+
+    upgraded_body = (
+        "## Task\n\n"
+        f"Narrow the broad `except Exception` handlers in `{module_rel}`.\n\n"
+        "### Catch sites to inspect\n"
+        f"{chr(10).join(site_lines)}\n\n"
+        "### File Scope\n"
+        f"- `{module_rel}`\n\n"
+        "### Validation\n"
+        "```bash\n"
+        f"ruff check {module_rel}\n"
+        "```\n\n"
+        "### Acceptance Criteria\n"
+        "- Each broad catch is replaced with a specific exception type, or carries `# noqa: BLE001` with a boundary justification.\n"
+        "- Keep behavior unchanged beyond narrowing the catch.\n"
+        f"- `ruff check {module_rel}` passes.\n\n"
+        "### Constraints\n"
+        f"- Estimated complexity: {analysis.complexity}\n"
+        "- Keep the lane scoped to this module only."
+    )
+    return UpgradedIssue(
+        original_title=title,
+        original_body=body,
+        upgraded_title=_module_upgrade_title(module_rel, prefix="Narrow broad except handlers in"),
+        upgraded_body=upgraded_body,
+        module_summary=analysis.docstring,
+        functions_found=[f"line {site.line_number}" for site in sites[:10]],
+        loc=analysis.loc,
+        imports=list(analysis.external_imports[:10]),
+        complexity=analysis.complexity,
+        upgrade_method="heuristic",
+    )
+
+
+def _upgrade_silent_exception_issue(
+    *,
+    title: str,
+    body: str,
+    module_rel: str,
+    content: str,
+    analysis: _ModuleAnalysis,
+) -> UpgradedIssue | None:
+    sites = _collect_silent_exception_sites(content)
+    if not sites:
+        return None
+
+    site_lines = "\n".join(f"- Line {site.line_number}: {site.guidance}" for site in sites[:8])
+    upgraded_body = (
+        "## Task\n\n"
+        f"Replace silent exception swallowing in `{module_rel}` with visible, bounded handling.\n\n"
+        "### Catch sites to inspect\n"
+        f"{site_lines}\n\n"
+        "### File Scope\n"
+        f"- `{module_rel}`\n\n"
+        "### Validation\n"
+        "```bash\n"
+        f"ruff check {module_rel}\n"
+        "```\n\n"
+        "### Acceptance Criteria\n"
+        "- Each `except ...: pass` either logs at debug/warning level or carries an explicit intentional-silence justification.\n"
+        "- Do not broaden the behavior or change control flow.\n"
+        f"- `ruff check {module_rel}` passes.\n\n"
+        "### Constraints\n"
+        f"- Estimated complexity: {analysis.complexity}\n"
+        "- Keep the lane scoped to this module only."
+    )
+    return UpgradedIssue(
+        original_title=title,
+        original_body=body,
+        upgraded_title=_module_upgrade_title(
+            module_rel, prefix="Replace silent exception swallowing in"
+        ),
+        upgraded_body=upgraded_body,
+        module_summary=analysis.docstring,
+        functions_found=[f"line {site.line_number}" for site in sites[:10]],
+        loc=analysis.loc,
+        imports=list(analysis.external_imports[:10]),
+        complexity=analysis.complexity,
+        upgrade_method="heuristic",
+    )
+
+
+def _upgrade_type_annotation_issue(
+    *,
+    title: str,
+    body: str,
+    module_rel: str,
+    content: str,
+    analysis: _ModuleAnalysis,
+) -> UpgradedIssue | None:
+    missing = _collect_missing_return_annotations(content)
+    if not missing:
+        return None
+
+    suggestion_lines = "\n".join(
+        f"- Line {item.line_number}: `{item.name}` -> suggest `-> {item.suggested_type}`"
+        for item in missing[:10]
+    )
+    upgraded_body = (
+        "## Task\n\n"
+        f"Add explicit return type annotations for the missing public callables in `{module_rel}`.\n\n"
+        "### Suggested annotations\n"
+        f"{suggestion_lines}\n\n"
+        "### File Scope\n"
+        f"- `{module_rel}`\n\n"
+        "### Validation\n"
+        "```bash\n"
+        f"ruff check {module_rel}\n"
+        "```\n\n"
+        "### Acceptance Criteria\n"
+        "- Annotate the listed public callables first and keep the lane bounded.\n"
+        "- Use `None` when a callable does not return a value; use `Any` only when inference is genuinely ambiguous.\n"
+        f"- `ruff check {module_rel}` passes.\n\n"
+        "### Constraints\n"
+        f"- Estimated complexity: {analysis.complexity}\n"
+        "- Limit the change to this module."
+    )
+    return UpgradedIssue(
+        original_title=title,
+        original_body=body,
+        upgraded_title=_module_upgrade_title(module_rel, prefix="Add return type annotations for"),
+        upgraded_body=upgraded_body,
+        module_summary=analysis.docstring,
+        functions_found=[item.name for item in missing[:10]],
+        loc=analysis.loc,
+        imports=list(analysis.external_imports[:10]),
+        complexity=analysis.complexity,
+        upgrade_method="heuristic",
+    )
+
+
+def upgrade_issue_heuristic(
+    title: str,
+    body: str,
+    *,
+    repo_root: Path,
+    category: str = "test_coverage",
+) -> UpgradedIssue | None:
+    """Upgrade an issue using deterministic heuristic module analysis.
+
+    This prototype stays deterministic and bounded. It upgrades only the issue
+    categories that can be made more concrete from local module analysis.
+    """
+    module_rel = _primary_module_path(body)
+    if not module_rel:
+        return None
+
+    if Path(module_rel).name in _SKIP_SENTINELS:
+        return None
+    module_path = repo_root / module_rel
+    content = _read_module(module_path)
+    if content is None:
+        return None
+
+    analysis = _analyze_module(content)
+    if analysis is None:
+        return None
+
+    if category == "test_coverage":
+        return _upgrade_test_coverage_issue(
+            title=title,
+            body=body,
+            module_rel=module_rel,
+            analysis=analysis,
+        )
+    if category == "broad_exception":
+        return _upgrade_broad_exception_issue(
+            title=title,
+            body=body,
+            module_rel=module_rel,
+            content=content,
+            analysis=analysis,
+        )
+    if category == "silent_exception":
+        return _upgrade_silent_exception_issue(
+            title=title,
+            body=body,
+            module_rel=module_rel,
+            content=content,
+            analysis=analysis,
+        )
+    if category == "type_annotation":
+        return _upgrade_type_annotation_issue(
+            title=title,
+            body=body,
+            module_rel=module_rel,
+            content=content,
+            analysis=analysis,
+        )
+    return None
 
 
 async def upgrade_issue_llm(

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -60,16 +60,21 @@ class DecompositionTelemetry:
 def format_boss_ready_body(candidate: BossIssueCandidate) -> str:
     """Format a candidate into the proven boss-ready issue body.
 
-    For test_coverage candidates, uses the issue upgrader to generate
-    concrete, module-aware issue bodies instead of generic templates.
+    For supported categories, uses the issue upgrader to generate concrete,
+    module-aware issue bodies instead of generic templates.
     """
-    # Try to upgrade test_coverage issues with module-specific guidance
-    if candidate.category == "test_coverage":
+    if candidate.category in {
+        "test_coverage",
+        "broad_exception",
+        "silent_exception",
+        "type_annotation",
+    }:
         upgraded = upgrade_issue_heuristic(
             candidate.title,
             f"## Task\n\n{candidate.description}\n\n### File Scope\n"
             + "\n".join(f"- `{f}`" for f in candidate.file_scope),
             repo_root=REPO_ROOT,
+            category=candidate.category,
         )
         if upgraded:
             body = upgraded.upgraded_body

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from aragora.swarm.issue_upgrader import UpgradedIssue
 from aragora.swarm.issue_scanner import BossIssueCandidate
 from scripts import generate_boss_issues as mod
 
@@ -166,6 +167,109 @@ def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
     _ = capsys.readouterr()
     assert scan_calls
     assert scan_calls[0][2] == 0.5
+
+
+def test_format_boss_ready_body_uses_upgrader_for_broad_exception(monkeypatch) -> None:
+    candidate = BossIssueCandidate(
+        category="broad_exception",
+        title="Narrow broad except Exception in sample.py",
+        description="Replace broad handlers in `aragora/sample.py`.",
+        file_scope=["aragora/sample.py"],
+        validation_command="ruff check aragora/sample.py",
+    )
+    upgraded = UpgradedIssue(
+        original_title=candidate.title,
+        original_body=candidate.description,
+        upgraded_title=candidate.title,
+        upgraded_body="## Task\n\nUse a narrower catch.",
+        module_summary="summary",
+        functions_found=["line 10"],
+        loc=42,
+        imports=[],
+        complexity="simple",
+        upgrade_method="heuristic",
+    )
+    seen: list[str] = []
+
+    def fake_upgrade(title: str, body: str, *, repo_root, category: str = "test_coverage"):  # noqa: ANN001
+        seen.append(category)
+        return upgraded
+
+    monkeypatch.setattr(mod, "upgrade_issue_heuristic", fake_upgrade)
+
+    body = mod.format_boss_ready_body(candidate)
+
+    assert seen == ["broad_exception"]
+    assert body.startswith("## Task\n\nUse a narrower catch.")
+    assert f"<!-- fingerprint:{candidate.fingerprint} -->" in body
+
+
+def test_format_boss_ready_body_uses_upgrader_for_silent_exception(monkeypatch) -> None:
+    candidate = BossIssueCandidate(
+        category="silent_exception",
+        title="Replace silent exception swallowing in sample.py",
+        description="Replace `except ...: pass` in `aragora/sample.py`.",
+        file_scope=["aragora/sample.py"],
+        validation_command="ruff check aragora/sample.py",
+    )
+    upgraded = UpgradedIssue(
+        original_title=candidate.title,
+        original_body=candidate.description,
+        upgraded_title=candidate.title,
+        upgraded_body="## Task\n\nAdd visibility.",
+        module_summary="summary",
+        functions_found=["line 12"],
+        loc=42,
+        imports=[],
+        complexity="simple",
+        upgrade_method="heuristic",
+    )
+    seen: list[str] = []
+
+    def fake_upgrade(title: str, body: str, *, repo_root, category: str = "test_coverage"):  # noqa: ANN001
+        seen.append(category)
+        return upgraded
+
+    monkeypatch.setattr(mod, "upgrade_issue_heuristic", fake_upgrade)
+
+    body = mod.format_boss_ready_body(candidate)
+
+    assert seen == ["silent_exception"]
+    assert body.startswith("## Task\n\nAdd visibility.")
+
+
+def test_format_boss_ready_body_uses_upgrader_for_type_annotation(monkeypatch) -> None:
+    candidate = BossIssueCandidate(
+        category="type_annotation",
+        title="Add return type annotations to sample.py",
+        description="Add return annotations in `aragora/sample.py`.",
+        file_scope=["aragora/sample.py"],
+        validation_command="ruff check aragora/sample.py",
+    )
+    upgraded = UpgradedIssue(
+        original_title=candidate.title,
+        original_body=candidate.description,
+        upgraded_title=candidate.title,
+        upgraded_body="## Task\n\nAnnotate the missing methods.",
+        module_summary="summary",
+        functions_found=["Thing.run"],
+        loc=42,
+        imports=[],
+        complexity="simple",
+        upgrade_method="heuristic",
+    )
+    seen: list[str] = []
+
+    def fake_upgrade(title: str, body: str, *, repo_root, category: str = "test_coverage"):  # noqa: ANN001
+        seen.append(category)
+        return upgraded
+
+    monkeypatch.setattr(mod, "upgrade_issue_heuristic", fake_upgrade)
+
+    body = mod.format_boss_ready_body(candidate)
+
+    assert seen == ["type_annotation"]
+    assert body.startswith("## Task\n\nAnnotate the missing methods.")
 
 
 def test_maybe_decompose_candidates_noop_when_disabled(monkeypatch) -> None:

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3245,6 +3245,207 @@ async def test_dispatch_issue_drops_short_task_before_dispatch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_issue_blocks_when_credential_slices_are_incomplete() -> None:
+    issue = _make_issue(
+        2463,
+        "Add dispatch contract gate",
+        body=(
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py`\n\n"
+            "## Validation\n"
+            "```bash\n"
+            "ruff check aragora/swarm/boss_loop.py\n"
+            "```\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="codex"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+        "profile": "default",
+    }
+
+    dispatch_mock = AsyncMock(return_value={"status": "completed", "run_id": "run-2463"})
+    fake_envelope = SimpleNamespace(missing_slices=lambda: ["github_api", "verification"])
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.check_pre_dispatch_gate",
+            new=AsyncMock(
+                return_value={
+                    "method": "deterministic",
+                    "pass": True,
+                    "sanitation_ok": True,
+                    "unresolved_missing": [],
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.credential_envelope.CredentialEnvelope.from_environment",
+            return_value=fake_envelope,
+        ),
+        patch("aragora.swarm.boss_loop.dispatch_bounded_spec", new=dispatch_mock),
+        patch("aragora.swarm.boss_loop.BossLoop._gh_cli_authenticated", return_value=False),
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked_auth_failure"
+    assert result["credential_missing_slices"] == ["github_api", "verification"]
+    assert "credential slices are complete" in result["reasons"][0]
+    assert dispatch_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_blocks_when_worker_contract_fails_admission() -> None:
+    issue = _make_issue(
+        2464,
+        "Add dispatch contract gate",
+        body=(
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py`\n\n"
+            "## Validation\n"
+            "```bash\n"
+            "ruff check aragora/swarm/boss_loop.py\n"
+            "```\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="codex"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+        "profile": "default",
+    }
+
+    dispatch_mock = AsyncMock(return_value={"status": "completed", "run_id": "run-2464"})
+    fake_envelope = SimpleNamespace(missing_slices=lambda: [])
+    fake_contract = SimpleNamespace(admission_check=lambda: False)
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.check_pre_dispatch_gate",
+            new=AsyncMock(
+                return_value={
+                    "method": "deterministic",
+                    "pass": True,
+                    "sanitation_ok": True,
+                    "unresolved_missing": [],
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.credential_envelope.CredentialEnvelope.from_environment",
+            return_value=fake_envelope,
+        ),
+        patch(
+            "aragora.swarm.worker_contract.build_worker_contract",
+            return_value=fake_contract,
+        ),
+        patch("aragora.swarm.boss_loop.dispatch_bounded_spec", new=dispatch_mock),
+        patch("aragora.swarm.boss_loop.BossLoop._gh_cli_authenticated", return_value=True),
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked_auth_failure"
+    assert "worker contract admission checks" in result["reasons"][0]
+    assert dispatch_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_accepts_gh_cli_auth_for_contract_gate() -> None:
+    issue = _make_issue(
+        2465,
+        "Add dispatch contract gate",
+        body=(
+            "## File Scope\n"
+            "- `aragora/swarm/boss_loop.py`\n\n"
+            "## Validation\n"
+            "```bash\n"
+            "ruff check aragora/swarm/boss_loop.py\n"
+            "```\n"
+        ),
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="codex"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+        "profile": "default",
+    }
+
+    fake_envelope = SimpleNamespace(missing_slices=lambda: ["github_api"])
+    fake_contract = SimpleNamespace(admission_check=lambda: True)
+    dispatch_mock = AsyncMock(return_value={"status": "completed", "run_id": "run-2465"})
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(
+                return_value={
+                    "refined_prompt": "",
+                    "files_to_change": [],
+                    "test_patterns": [],
+                    "constraints": [],
+                    "context_gathered": False,
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.check_pre_dispatch_gate",
+            new=AsyncMock(
+                return_value={
+                    "method": "deterministic",
+                    "pass": True,
+                    "sanitation_ok": True,
+                    "unresolved_missing": [],
+                }
+            ),
+        ),
+        patch(
+            "aragora.swarm.credential_envelope.CredentialEnvelope.from_environment",
+            return_value=fake_envelope,
+        ),
+        patch(
+            "aragora.swarm.worker_contract.build_worker_contract",
+            return_value=fake_contract,
+        ),
+        patch("aragora.swarm.boss_loop.dispatch_bounded_spec", new=dispatch_mock),
+        patch("aragora.swarm.boss_loop.BossLoop._gh_cli_authenticated", return_value=True),
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    assert dispatch_mock.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_sanitizer_failed_issue_is_not_retried_in_same_run() -> None:
     dropped = _make_issue(2601, "Too short", body="Tiny task only.", labels=["boss-ready"])
     follow_up = _make_issue(2602, "Fix bounded queue state", labels=["boss-ready"])

--- a/tests/swarm/test_issue_upgrader.py
+++ b/tests/swarm/test_issue_upgrader.py
@@ -27,6 +27,13 @@ def _upgrade(repo_root: Path, rel: str) -> UpgradedIssue | None:
     return upgrade_issue_heuristic(f"Add tests for {Path(rel).name}", body, repo_root=repo_root)
 
 
+def _upgrade_category(
+    repo_root: Path, rel: str, *, category: str, title: str
+) -> UpgradedIssue | None:
+    body = f"Focus on `{rel}` with a mirrored focused test file."
+    return upgrade_issue_heuristic(title, body, repo_root=repo_root, category=category)
+
+
 class TestUpgradeAdmission:
     def test_upgrades_trivial_public_function_module(self, repo_root: Path) -> None:
         _write_module(
@@ -336,3 +343,154 @@ class TestOutputShape:
 
         assert result is not None
         assert "PublicTool" in result.upgraded_body
+
+
+class TestBroadExceptionUpgrade:
+    def test_broad_exception_upgrade_lists_specific_exception_hints(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/broad_except_module.py",
+            '"""Broad exception example."""\n\n'
+            "import json\n\n"
+            "def load_count(path: str) -> int:\n"
+            "    try:\n"
+            "        payload = json.loads(Path(path).read_text())\n"
+            "        return int(payload['count'])\n"
+            "    except Exception:\n"
+            "        return 0\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            "aragora/swarm/broad_except_module.py",
+            category="broad_exception",
+            title="Narrow broad except Exception in broad_except_module.py",
+        )
+
+        assert result is not None
+        assert "OSError" in result.upgraded_body
+        assert "json.JSONDecodeError" in result.upgraded_body
+        assert "ValueError" in result.upgraded_body
+        assert "KeyError" in result.upgraded_body
+        assert "ruff check aragora/swarm/broad_except_module.py" in result.upgraded_body
+
+    def test_broad_exception_upgrade_skips_medium_modules(self, repo_root: Path) -> None:
+        body_lines = ['"""Too broad for deterministic narrowing."""', ""]
+        for idx in range(10):
+            body_lines.extend(
+                [
+                    f"def public_fn_{idx}(value: int) -> int:",
+                    "    try:",
+                    "        return int(str(value))",
+                    "    except Exception:",
+                    "        return 0",
+                    "",
+                ]
+            )
+        _write_module(repo_root, "aragora/swarm/medium_broad_except.py", "\n".join(body_lines))
+
+        assert (
+            _upgrade_category(
+                repo_root,
+                "aragora/swarm/medium_broad_except.py",
+                category="broad_exception",
+                title="Narrow broad except Exception in medium_broad_except.py",
+            )
+            is None
+        )
+
+
+class TestSilentExceptionUpgrade:
+    def test_silent_exception_upgrade_recommends_visibility_for_regular_paths(
+        self,
+        repo_root: Path,
+    ) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/silent_swallow.py",
+            '"""Swallowing example."""\n\n'
+            "def refresh(payload: dict[str, str]) -> None:\n"
+            "    try:\n"
+            "        payload['token']\n"
+            "    except KeyError:\n"
+            "        pass\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            "aragora/swarm/silent_swallow.py",
+            category="silent_exception",
+            title="Replace silent exception swallowing in silent_swallow.py",
+        )
+
+        assert result is not None
+        assert "logger.warning" in result.upgraded_body or "logger.debug" in result.upgraded_body
+        assert "Line 6" in result.upgraded_body
+
+    def test_silent_exception_upgrade_detects_cleanup_context(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/cleanup_swallow.py",
+            '"""Cleanup swallow example."""\n\n'
+            "def cleanup(handle) -> None:\n"
+            "    try:\n"
+            "        handle.close()\n"
+            "    except OSError:\n"
+            "        pass\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            "aragora/swarm/cleanup_swallow.py",
+            category="silent_exception",
+            title="Replace silent exception swallowing in cleanup_swallow.py",
+        )
+
+        assert result is not None
+        assert "# noqa" in result.upgraded_body
+        assert "best-effort cleanup" in result.upgraded_body
+
+
+class TestTypeAnnotationUpgrade:
+    def test_type_annotation_upgrade_lists_suggested_return_types(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/annotation_gaps.py",
+            '"""Missing annotations example."""\n\n'
+            "def as_text():\n"
+            "    return 'ok'\n\n"
+            "class Counter:\n"
+            "    def total(self):\n"
+            "        return 3\n\n"
+            "    def reset(self):\n"
+            "        return None\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            "aragora/swarm/annotation_gaps.py",
+            category="type_annotation",
+            title="Add return type annotations to annotation_gaps.py",
+        )
+
+        assert result is not None
+        assert "`as_text` -> suggest `-> str`" in result.upgraded_body
+        assert "`Counter.total` -> suggest `-> int`" in result.upgraded_body
+        assert "`Counter.reset` -> suggest `-> None`" in result.upgraded_body
+
+    def test_type_annotation_upgrade_uses_any_for_mixed_returns(self, repo_root: Path) -> None:
+        _write_module(
+            repo_root,
+            "aragora/swarm/mixed_annotations.py",
+            "def unstable(flag: bool):\n    if flag:\n        return 'ok'\n    return 3\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            "aragora/swarm/mixed_annotations.py",
+            category="type_annotation",
+            title="Add return type annotations to mixed_annotations.py",
+        )
+
+        assert result is not None
+        assert "`unstable` -> suggest `-> Any`" in result.upgraded_body


### PR DESCRIPTION
## Summary
- expand the heuristic issue upgrader beyond `test_coverage` to emit richer boss-ready work orders for `broad_exception`, `silent_exception`, and `type_annotation`
- wire generator formatting to use those upgraded bodies instead of the generic template when available
- add a pre-dispatch credential-envelope / worker-contract gate in `BossLoop._dispatch_issue()` so missing capability slices block truthfully before worker launch

## Validation
- `pytest tests/swarm/test_issue_upgrader.py tests/scripts/test_generate_boss_issues.py -q`
- `pytest tests/swarm/test_boss_loop.py -k "credential_slices_are_incomplete or worker_contract_fails_admission or accepts_gh_cli_auth_for_contract_gate" -q`
- `ruff check aragora/swarm/issue_upgrader.py scripts/generate_boss_issues.py tests/swarm/test_issue_upgrader.py aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py tests/scripts/test_generate_boss_issues.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

## Notes
- The live overnight boss loop was left running; this PR is the bounded strategic lane from the overnight autonomy plan.
- I intentionally stopped after Batch A/B and did not widen the optional decomposition-trigger changes.