### PR TITLE
fix(preflight): retain branch when draft close fails

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -753,6 +753,7 @@ def run_remote_publish_validation_receipt(
     pushed = False
     draft_created = False
     unresolved_remote_pr_state = False
+    draft_close_succeeded = False
     scratch_file = _scratch_validation_file(worktree_path)
 
     try:
@@ -871,7 +872,7 @@ def run_remote_publish_validation_receipt(
 
         if draft_created:
             close_target = str(artifacts.get("draft_pr_number") or branch)
-            _run_check(
+            close_result = _run_check(
                 checks,
                 name="gh_pr_close",
                 cmd=[
@@ -884,6 +885,7 @@ def run_remote_publish_validation_receipt(
                 ],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
             )
+            draft_close_succeeded = close_result is not None and close_result.returncode == 0
         elif pushed and unresolved_remote_pr_state:
             _append_check(
                 checks,
@@ -902,13 +904,24 @@ def run_remote_publish_validation_receipt(
                 detail="skipped (draft PR not created)",
             )
 
-        if pushed and not unresolved_remote_pr_state:
+        if (
+            pushed
+            and not unresolved_remote_pr_state
+            and (not draft_created or draft_close_succeeded)
+        ):
             _run_check(
                 checks,
                 name="cleanup_remote_branch_delete",
                 cmd=["git", "push", "origin", "--delete", branch],
                 cwd=worktree_path if worktree_created else resolved_repo_root,
                 env=git_safe_env(),
+            )
+        elif pushed and draft_created and not draft_close_succeeded:
+            _append_check(
+                checks,
+                name="cleanup_remote_branch_delete",
+                passed=False,
+                detail="skipped because draft PR close failed; remote branch retained for manual cleanup",
             )
         elif pushed:
             _append_check(

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -556,6 +556,67 @@ def test_run_remote_publish_validation_receipt_retains_branch_when_draft_state_u
     )
 
 
+def test_run_remote_publish_validation_receipt_retains_branch_when_draft_close_fails(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    envelope = _envelope()
+    now = datetime(2026, 4, 12, 20, 8, 0, tzinfo=timezone.utc)
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "_utc_now", lambda: now)
+    monkeypatch.setattr(mod, "_receipt_token", lambda: "deadbeef")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
+        commands.append(list(cmd))
+        if cmd[:3] == ["git", "worktree", "add"]:
+            Path(cmd[5]).mkdir(parents=True, exist_ok=True)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="https://github.com/synaptent/aragora/pull/7777\n",
+                stderr="",
+            )
+        if cmd[:3] == ["gh", "pr", "close"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout="",
+                stderr="close failed",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    receipt = mod.run_remote_publish_validation_receipt(
+        repo_root=repo_root,
+        envelope=envelope,
+        base_ref="main",
+    )
+
+    assert receipt.passed is False
+    assert receipt.artifacts["draft_pr_number"] == 7777
+    assert receipt.artifacts["draft_pr_url"] == "https://github.com/synaptent/aragora/pull/7777"
+    assert any(
+        check["name"] == "gh_pr_close"
+        and check["passed"] is False
+        and "close failed" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(
+        check["name"] == "cleanup_remote_branch_delete"
+        and check["passed"] is False
+        and "draft PR close failed" in check["detail"]
+        for check in receipt.checks
+    )
+    assert any(cmd[:4] == ["gh", "pr", "close", "7777"] for cmd in commands)
+    assert not any(
+        cmd == ["git", "push", "origin", "--delete", receipt.artifacts["branch"]]
+        for cmd in commands
+    )
+
+
 def test_load_cached_preflight_receipt_reuses_fresh_successful_receipt(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- gate remote branch deletion on successful draft PR close
- retain the branch for manual cleanup when gh pr close fails
- add a regression that forces gh_pr_close to fail after draft capture

## Validation
- python3 -m pytest tests/swarm/test_preflight.py -q
- python3 -m ruff check aragora/swarm/preflight.py tests/swarm/test_preflight.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD