### PR TITLE
feat(swarm): gate boss dispatch on contract admission

### DIFF
--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -29,8 +30,11 @@ from typing import Any
 
 from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
+from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.worker_contract import build_worker_contract
+from aragora.swarm.worker_process import LaunchConfig
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     TerminalClass,
@@ -623,6 +627,7 @@ class BossLoop:
         self._recent_elapsed: list[float] = []
         # Deferred publish retry queue: (issue, worker_result) pairs
         self._deferred_publish_queue: list[tuple[Any, dict[str, Any]]] = []
+        self._github_cli_auth_available: bool | None = None
 
     def _git_cmd(self, args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -4760,6 +4765,294 @@ class BossLoop:
             worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
         )
 
+    def _dispatch_contract_target_agent(
+        self,
+        *,
+        selected_runner: dict[str, Any] | None,
+        requested_target_agent: str | None,
+    ) -> str:
+        requested = str(requested_target_agent or "").strip().lower()
+        if requested:
+            return requested
+        if isinstance(selected_runner, dict):
+            runner_type = str(selected_runner.get("runner_type", "")).strip().lower()
+            if runner_type:
+                return runner_type
+        default_target = str(self.config.default_target_agent or "").strip().lower()
+        if default_target:
+            return default_target
+        return "codex"
+
+    def _dispatch_contract_preview_env(
+        self,
+        *,
+        selected_runner: dict[str, Any] | None,
+        requested_target_agent: str | None,
+        worker_env: dict[str, str] | None,
+    ) -> tuple[str, dict[str, str]]:
+        env = dict(os.environ)
+        if isinstance(self._env, dict):
+            env.update(
+                {str(key): str(value) for key, value in self._env.items() if str(key).strip()}
+            )
+        if worker_env:
+            env.update(
+                {str(key): str(value) for key, value in worker_env.items() if str(key).strip()}
+            )
+
+        target_agent = self._dispatch_contract_target_agent(
+            selected_runner=selected_runner,
+            requested_target_agent=requested_target_agent,
+        )
+        runner_type = (
+            str((selected_runner or {}).get("runner_type", "")).strip().lower() or target_agent
+        )
+        runner_command = str((selected_runner or {}).get("command_path", "")).strip()
+        runner_profile = str((selected_runner or {}).get("profile", "")).strip()
+
+        if runner_type == "claude":
+            env.setdefault("ARAGORA_CLAUDE_PROFILE", runner_profile or "default")
+            env.setdefault("CLAUDE_COMMAND", runner_command or shutil.which("claude") or "claude")
+            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "profile")
+        elif runner_type == "codex":
+            env.setdefault("CODEX_COMMAND", runner_command or shutil.which("codex") or "codex")
+            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
+        elif runner_command:
+            env.setdefault("ARAGORA_RUNNER_COMMAND", runner_command)
+            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
+
+        pytest_path = shutil.which("pytest")
+        if pytest_path and not (
+            env.get("ARAGORA_CAN_RUN_PYTEST")
+            or env.get("PYTEST_AVAILABLE")
+            or env.get("PYTEST_PATH")
+        ):
+            env["PYTEST_PATH"] = pytest_path
+        ruff_path = shutil.which("ruff")
+        if ruff_path and not (
+            env.get("ARAGORA_CAN_RUN_RUFF") or env.get("RUFF_AVAILABLE") or env.get("RUFF_PATH")
+        ):
+            env["RUFF_PATH"] = ruff_path
+        return target_agent, env
+
+    def _dispatch_contract_preview_work_orders(self, spec: Any) -> list[dict[str, Any]]:
+        preview_orders: list[dict[str, Any]] = []
+        raw_orders = getattr(spec, "work_orders", None)
+        if isinstance(raw_orders, list):
+            for item in raw_orders:
+                if not isinstance(item, dict):
+                    continue
+                preview_orders.append(
+                    {
+                        "file_scope": [
+                            str(path).strip()
+                            for path in item.get("file_scope", [])
+                            if str(path).strip()
+                        ],
+                        "expected_tests": [
+                            str(test).strip()
+                            for test in item.get("expected_tests", [])
+                            if str(test).strip()
+                        ],
+                        "mission_id": str(item.get("mission_id", "") or "").strip(),
+                        "stage_id": str(item.get("stage_id", "") or "").strip(),
+                        "assertion_ids": [
+                            str(entry).strip()
+                            for entry in item.get("assertion_ids", [])
+                            if str(entry).strip()
+                        ],
+                        "evidence_expectations": [
+                            str(entry).strip()
+                            for entry in item.get("evidence_expectations", [])
+                            if str(entry).strip()
+                        ],
+                        "mission_context_policies": dict(
+                            item.get("mission_context_policies") or {}
+                        ),
+                    }
+                )
+        if preview_orders:
+            return preview_orders
+        return [
+            {
+                "file_scope": [
+                    str(path).strip()
+                    for path in getattr(spec, "file_scope_hints", [])
+                    if str(path).strip()
+                ],
+                "expected_tests": [],
+                "mission_context_policies": dict(
+                    getattr(spec, "mission_context_policies", {}) or {}
+                ),
+            }
+        ]
+
+    def _github_cli_authenticated(self) -> bool:
+        if self._github_cli_auth_available is not None:
+            return self._github_cli_auth_available
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "status"],
+                cwd=Path.cwd(),
+                env=git_safe_env(self._env),
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            self._github_cli_auth_available = False
+            return False
+        self._github_cli_auth_available = result.returncode == 0
+        return self._github_cli_auth_available
+
+    def _dispatch_contract_missing_slices(
+        self,
+        *,
+        envelope: CredentialEnvelope,
+        target_agent: str,
+    ) -> list[str]:
+        missing = list(envelope.missing_slices())
+        requires_git = bool(self.config.auto_publish_deliverables)
+        requires_github_api = bool(
+            self.config.auto_publish_deliverables or self.config.auto_close_already_done_issues
+        )
+        if not requires_git and "git" in missing:
+            missing.remove("git")
+        if target_agent in {"claude", "codex"} and "provider" in missing:
+            missing.remove("provider")
+        if "github_api" in missing and (
+            not requires_github_api or self._github_cli_authenticated()
+        ):
+            missing.remove("github_api")
+        if target_agent in {"claude", "codex"}:
+            return [
+                item for item in missing if item in {"runner", "git", "github_api", "verification"}
+            ]
+        return [
+            item
+            for item in missing
+            if item in {"runner", "git", "github_api", "provider", "verification"}
+        ]
+
+    def _dispatch_contract_gate_reason(
+        self,
+        *,
+        issue_number: int,
+        target_agent: str,
+        missing_slices: list[str],
+        contract_valid: bool,
+    ) -> tuple[list[str], list[str]]:
+        reasons: list[str] = []
+        next_actions: list[str] = []
+        if not contract_valid:
+            reasons.append(
+                f"Issue #{issue_number} failed worker contract admission before dispatch."
+            )
+            next_actions.append(
+                "Refresh the dispatch contract inputs so runner, scope, and mission context policy resolve cleanly before redispatch."
+            )
+        slice_messages = {
+            "runner": (
+                f"Issue #{issue_number} is missing a runner slice for `{target_agent}` dispatch."
+            ),
+            "git": (
+                f"Issue #{issue_number} is missing git publish credentials for branch-scoped worktree dispatch."
+            ),
+            "github_api": (
+                f"Issue #{issue_number} is missing GitHub API authentication required for full-auto publication."
+            ),
+            "provider": (
+                f"Issue #{issue_number} is missing provider credentials for `{target_agent}` dispatch."
+            ),
+            "verification": (
+                f"Issue #{issue_number} is missing verification tool capability (pytest and/or ruff)."
+            ),
+        }
+        slice_actions = {
+            "runner": "Select a runner with a resolvable command/profile before redispatch.",
+            "git": "Restore SSH agent or HTTPS git credentials before redispatch.",
+            "github_api": "Restore `gh` authentication or a GitHub token before redispatch.",
+            "provider": "Restore the provider API key or choose a CLI-backed target agent before redispatch.",
+            "verification": "Ensure pytest and ruff are installed and discoverable before redispatch.",
+        }
+        for missing in missing_slices:
+            reasons.append(slice_messages[missing])
+            next_actions.append(slice_actions[missing])
+        return reasons, list(dict.fromkeys(next_actions))
+
+    def _dispatch_contract_gate(
+        self,
+        *,
+        issue: GitHubIssue,
+        spec: Any,
+        selected_runner: dict[str, Any] | None,
+        requested_target_agent: str | None,
+        worker_env: dict[str, str] | None,
+    ) -> dict[str, Any] | None:
+        target_agent, preview_env = self._dispatch_contract_preview_env(
+            selected_runner=selected_runner,
+            requested_target_agent=requested_target_agent,
+            worker_env=worker_env,
+        )
+        envelope = CredentialEnvelope.from_environment(preview_env)
+        missing_slices = self._dispatch_contract_missing_slices(
+            envelope=envelope,
+            target_agent=target_agent,
+        )
+        launch_config = LaunchConfig(
+            base_branch=self.config.target_branch,
+            execution_mode=self.config.execution_mode,
+            claude_profile=(
+                str((selected_runner or {}).get("profile", "")).strip() or None
+                if target_agent == "claude"
+                else None
+            ),
+            allow_claude_dangerously_skip_permissions=(
+                self.config.allow_claude_dangerously_skip_permissions
+            ),
+            allow_codex_full_auto=self.config.allow_codex_full_auto,
+        )
+        contract_valid = True
+        for work_order in self._dispatch_contract_preview_work_orders(spec):
+            try:
+                contract = build_worker_contract(
+                    agent=target_agent,
+                    config=launch_config,
+                    worktree_path=str(Path.cwd()),
+                    env=preview_env,
+                    work_order=work_order,
+                )
+                contract.validate()
+                if not contract.admission_check():
+                    contract_valid = False
+                    break
+            except ValueError:
+                contract_valid = False
+                break
+
+        if contract_valid and not missing_slices:
+            return None
+
+        reasons, next_actions = self._dispatch_contract_gate_reason(
+            issue_number=issue.number,
+            target_agent=target_agent,
+            missing_slices=missing_slices,
+            contract_valid=contract_valid,
+        )
+        return {
+            "status": "needs_human",
+            "outcome": "blocked_auth_failure" if missing_slices else "blocked",
+            "reasons": reasons,
+            "next_actions": next_actions,
+            "dispatch_contract": {
+                "target_agent": target_agent,
+                "contract_valid": contract_valid,
+                "missing_slices": missing_slices,
+                "credential_envelope": envelope.preflight_cache_payload(),
+            },
+        }
+
     async def _dispatch_issue(
         self,
         issue: GitHubIssue,
@@ -5099,6 +5392,19 @@ class BossLoop:
                 freshness,
                 requested_target_agent=requested_target_agent,
             )
+
+        gate_result = self._dispatch_contract_gate(
+            issue=issue,
+            spec=spec,
+            selected_runner=selected_runner,
+            requested_target_agent=requested_target_agent,
+            worker_env=refinement_worker_env or None,
+        )
+        if gate_result is not None:
+            if claimed_runner_id:
+                self._release_runner_claim(claimed_runner_id)
+            return _with_sanitizer_metadata(gate_result)
+
         try:
             result = await dispatch_bounded_spec(
                 spec,

--- a/aragora/swarm/boss_loop.py
+++ b/aragora/swarm/boss_loop.py
@@ -3,11 +3,6 @@
 Pulls candidate work from GitHub issues, selects one eligible task at a time,
 requires fresh eligible runners, runs supervised worker execution with bounded
 retries, and emits periodic status reports with truthful stop conditions.
-
-Usage:
-    loop = BossLoop(config=BossLoopConfig(max_iterations=20))
-    final_status = await loop.run()
-    print(json.dumps(final_status.to_dict(), indent=2))
 """
 
 from __future__ import annotations
@@ -16,7 +11,6 @@ import json
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 import tempfile
@@ -30,11 +24,9 @@ from typing import Any
 
 from aragora.nomic.dev_coordination import DevCoordinationStore
 from aragora.pipeline.execution_mode import ExecutionMode
-from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.debate_gate import DebateGate, DebateGateConfig, DebateGateRequest
+from aragora.swarm.dispatch_contract_gate import dispatch_contract_gate
 from aragora.swarm.env_utils import git_safe_env
-from aragora.swarm.worker_contract import build_worker_contract
-from aragora.swarm.worker_process import LaunchConfig
 from aragora.swarm.task_sanitizer import SanitizationOutcome, TaskSanitizer
 from aragora.swarm.terminal_truth import (
     TerminalClass,
@@ -627,7 +619,6 @@ class BossLoop:
         self._recent_elapsed: list[float] = []
         # Deferred publish retry queue: (issue, worker_result) pairs
         self._deferred_publish_queue: list[tuple[Any, dict[str, Any]]] = []
-        self._github_cli_auth_available: bool | None = None
 
     def _git_cmd(self, args: list[str], *, timeout: float = 30.0) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -4765,303 +4756,12 @@ class BossLoop:
             worker_outcome=str(worker_result.get("outcome", "")).strip() or None,
         )
 
-    def _dispatch_contract_target_agent(
-        self,
-        *,
-        selected_runner: dict[str, Any] | None,
-        requested_target_agent: str | None,
-    ) -> str:
-        requested = str(requested_target_agent or "").strip().lower()
-        if requested:
-            return requested
-        if isinstance(selected_runner, dict):
-            runner_type = str(selected_runner.get("runner_type", "")).strip().lower()
-            if runner_type:
-                return runner_type
-        default_target = str(self.config.default_target_agent or "").strip().lower()
-        if default_target:
-            return default_target
-        return "codex"
-
-    def _dispatch_contract_preview_env(
-        self,
-        *,
-        selected_runner: dict[str, Any] | None,
-        requested_target_agent: str | None,
-        worker_env: dict[str, str] | None,
-    ) -> tuple[str, dict[str, str]]:
-        env = dict(os.environ)
-        if isinstance(self._env, dict):
-            env.update(
-                {str(key): str(value) for key, value in self._env.items() if str(key).strip()}
-            )
-        if worker_env:
-            env.update(
-                {str(key): str(value) for key, value in worker_env.items() if str(key).strip()}
-            )
-
-        target_agent = self._dispatch_contract_target_agent(
-            selected_runner=selected_runner,
-            requested_target_agent=requested_target_agent,
-        )
-        runner_type = (
-            str((selected_runner or {}).get("runner_type", "")).strip().lower() or target_agent
-        )
-        runner_command = str((selected_runner or {}).get("command_path", "")).strip()
-        runner_profile = str((selected_runner or {}).get("profile", "")).strip()
-
-        if runner_type == "claude":
-            env.setdefault("ARAGORA_CLAUDE_PROFILE", runner_profile or "default")
-            env.setdefault("CLAUDE_COMMAND", runner_command or shutil.which("claude") or "claude")
-            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "profile")
-        elif runner_type == "codex":
-            env.setdefault("CODEX_COMMAND", runner_command or shutil.which("codex") or "codex")
-            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
-        elif runner_command:
-            env.setdefault("ARAGORA_RUNNER_COMMAND", runner_command)
-            env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
-
-        pytest_path = shutil.which("pytest")
-        if pytest_path and not (
-            env.get("ARAGORA_CAN_RUN_PYTEST")
-            or env.get("PYTEST_AVAILABLE")
-            or env.get("PYTEST_PATH")
-        ):
-            env["PYTEST_PATH"] = pytest_path
-        ruff_path = shutil.which("ruff")
-        if ruff_path and not (
-            env.get("ARAGORA_CAN_RUN_RUFF") or env.get("RUFF_AVAILABLE") or env.get("RUFF_PATH")
-        ):
-            env["RUFF_PATH"] = ruff_path
-        return target_agent, env
-
-    def _dispatch_contract_preview_work_orders(self, spec: Any) -> list[dict[str, Any]]:
-        preview_orders: list[dict[str, Any]] = []
-        raw_orders = getattr(spec, "work_orders", None)
-        if isinstance(raw_orders, list):
-            for item in raw_orders:
-                if not isinstance(item, dict):
-                    continue
-                preview_orders.append(
-                    {
-                        "file_scope": [
-                            str(path).strip()
-                            for path in item.get("file_scope", [])
-                            if str(path).strip()
-                        ],
-                        "expected_tests": [
-                            str(test).strip()
-                            for test in item.get("expected_tests", [])
-                            if str(test).strip()
-                        ],
-                        "mission_id": str(item.get("mission_id", "") or "").strip(),
-                        "stage_id": str(item.get("stage_id", "") or "").strip(),
-                        "assertion_ids": [
-                            str(entry).strip()
-                            for entry in item.get("assertion_ids", [])
-                            if str(entry).strip()
-                        ],
-                        "evidence_expectations": [
-                            str(entry).strip()
-                            for entry in item.get("evidence_expectations", [])
-                            if str(entry).strip()
-                        ],
-                        "mission_context_policies": dict(
-                            item.get("mission_context_policies") or {}
-                        ),
-                    }
-                )
-        if preview_orders:
-            return preview_orders
-        return [
-            {
-                "file_scope": [
-                    str(path).strip()
-                    for path in getattr(spec, "file_scope_hints", [])
-                    if str(path).strip()
-                ],
-                "expected_tests": [],
-                "mission_context_policies": dict(
-                    getattr(spec, "mission_context_policies", {}) or {}
-                ),
-            }
-        ]
-
-    def _github_cli_authenticated(self) -> bool:
-        if self._github_cli_auth_available is not None:
-            return self._github_cli_auth_available
-        try:
-            result = subprocess.run(
-                ["gh", "auth", "status"],
-                cwd=Path.cwd(),
-                env=git_safe_env(self._env),
-                capture_output=True,
-                text=True,
-                timeout=5,
-                check=False,
-            )
-        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-            self._github_cli_auth_available = False
-            return False
-        self._github_cli_auth_available = result.returncode == 0
-        return self._github_cli_auth_available
-
-    def _dispatch_contract_missing_slices(
-        self,
-        *,
-        envelope: CredentialEnvelope,
-        target_agent: str,
-    ) -> list[str]:
-        missing = list(envelope.missing_slices())
-        requires_git = bool(self.config.auto_publish_deliverables)
-        requires_github_api = bool(
-            self.config.auto_publish_deliverables or self.config.auto_close_already_done_issues
-        )
-        if not requires_git and "git" in missing:
-            missing.remove("git")
-        if target_agent in {"claude", "codex"} and "provider" in missing:
-            missing.remove("provider")
-        if "github_api" in missing and (
-            not requires_github_api or self._github_cli_authenticated()
-        ):
-            missing.remove("github_api")
-        if target_agent in {"claude", "codex"}:
-            return [
-                item for item in missing if item in {"runner", "git", "github_api", "verification"}
-            ]
-        return [
-            item
-            for item in missing
-            if item in {"runner", "git", "github_api", "provider", "verification"}
-        ]
-
-    def _dispatch_contract_gate_reason(
-        self,
-        *,
-        issue_number: int,
-        target_agent: str,
-        missing_slices: list[str],
-        contract_valid: bool,
-    ) -> tuple[list[str], list[str]]:
-        reasons: list[str] = []
-        next_actions: list[str] = []
-        if not contract_valid:
-            reasons.append(
-                f"Issue #{issue_number} failed worker contract admission before dispatch."
-            )
-            next_actions.append(
-                "Refresh the dispatch contract inputs so runner, scope, and mission context policy resolve cleanly before redispatch."
-            )
-        slice_messages = {
-            "runner": (
-                f"Issue #{issue_number} is missing a runner slice for `{target_agent}` dispatch."
-            ),
-            "git": (
-                f"Issue #{issue_number} is missing git publish credentials for branch-scoped worktree dispatch."
-            ),
-            "github_api": (
-                f"Issue #{issue_number} is missing GitHub API authentication required for full-auto publication."
-            ),
-            "provider": (
-                f"Issue #{issue_number} is missing provider credentials for `{target_agent}` dispatch."
-            ),
-            "verification": (
-                f"Issue #{issue_number} is missing verification tool capability (pytest and/or ruff)."
-            ),
-        }
-        slice_actions = {
-            "runner": "Select a runner with a resolvable command/profile before redispatch.",
-            "git": "Restore SSH agent or HTTPS git credentials before redispatch.",
-            "github_api": "Restore `gh` authentication or a GitHub token before redispatch.",
-            "provider": "Restore the provider API key or choose a CLI-backed target agent before redispatch.",
-            "verification": "Ensure pytest and ruff are installed and discoverable before redispatch.",
-        }
-        for missing in missing_slices:
-            reasons.append(slice_messages[missing])
-            next_actions.append(slice_actions[missing])
-        return reasons, list(dict.fromkeys(next_actions))
-
-    def _dispatch_contract_gate(
-        self,
-        *,
-        issue: GitHubIssue,
-        spec: Any,
-        selected_runner: dict[str, Any] | None,
-        requested_target_agent: str | None,
-        worker_env: dict[str, str] | None,
-    ) -> dict[str, Any] | None:
-        target_agent, preview_env = self._dispatch_contract_preview_env(
-            selected_runner=selected_runner,
-            requested_target_agent=requested_target_agent,
-            worker_env=worker_env,
-        )
-        envelope = CredentialEnvelope.from_environment(preview_env)
-        missing_slices = self._dispatch_contract_missing_slices(
-            envelope=envelope,
-            target_agent=target_agent,
-        )
-        launch_config = LaunchConfig(
-            base_branch=self.config.target_branch,
-            execution_mode=self.config.execution_mode,
-            claude_profile=(
-                str((selected_runner or {}).get("profile", "")).strip() or None
-                if target_agent == "claude"
-                else None
-            ),
-            allow_claude_dangerously_skip_permissions=(
-                self.config.allow_claude_dangerously_skip_permissions
-            ),
-            allow_codex_full_auto=self.config.allow_codex_full_auto,
-        )
-        contract_valid = True
-        for work_order in self._dispatch_contract_preview_work_orders(spec):
-            try:
-                contract = build_worker_contract(
-                    agent=target_agent,
-                    config=launch_config,
-                    worktree_path=str(Path.cwd()),
-                    env=preview_env,
-                    work_order=work_order,
-                )
-                contract.validate()
-                if not contract.admission_check():
-                    contract_valid = False
-                    break
-            except ValueError:
-                contract_valid = False
-                break
-
-        if contract_valid and not missing_slices:
-            return None
-
-        reasons, next_actions = self._dispatch_contract_gate_reason(
-            issue_number=issue.number,
-            target_agent=target_agent,
-            missing_slices=missing_slices,
-            contract_valid=contract_valid,
-        )
-        return {
-            "status": "needs_human",
-            "outcome": "blocked_auth_failure" if missing_slices else "blocked",
-            "reasons": reasons,
-            "next_actions": next_actions,
-            "dispatch_contract": {
-                "target_agent": target_agent,
-                "contract_valid": contract_valid,
-                "missing_slices": missing_slices,
-                "credential_envelope": envelope.preflight_cache_payload(),
-            },
-        }
-
     async def _dispatch_issue(
         self,
         issue: GitHubIssue,
         freshness: RunnerFreshnessResult,
     ) -> dict[str, Any]:
-        """Dispatch a supervised worker for the given issue.
-
-        Returns a dict with at minimum ``{"status": "completed"|"failed"|"needs_human"}``.
-        """
+        """Dispatch a supervised worker for the given issue."""
         from aragora.swarm.spec import SwarmSpec
 
         original_issue_body = str(issue.body or "").strip()
@@ -5073,7 +4773,6 @@ class BossLoop:
             sanitized_issue_body = sanitized_issue_body[len(issue_title_text) :].strip()
         if not sanitized_issue_body:
             sanitized_issue_body = original_issue_body
-
         logger.info(
             "task_sanitizer issue=#%s outcome=%s checks=%s",
             issue.number,
@@ -5393,16 +5092,16 @@ class BossLoop:
                 requested_target_agent=requested_target_agent,
             )
 
-        gate_result = self._dispatch_contract_gate(
-            issue=issue,
-            spec=spec,
-            selected_runner=selected_runner,
-            requested_target_agent=requested_target_agent,
-            worker_env=refinement_worker_env or None,
+        gate_result = dispatch_contract_gate(
+            self,
+            issue,
+            spec,
+            selected_runner,
+            requested_target_agent,
+            refinement_worker_env,
+            claimed_runner_id,
         )
         if gate_result is not None:
-            if claimed_runner_id:
-                self._release_runner_claim(claimed_runner_id)
             return _with_sanitizer_metadata(gate_result)
 
         try:
@@ -5414,9 +5113,6 @@ class BossLoop:
                 wait_for_completion=True,
                 default_target_agent=requested_target_agent,
                 default_reviewer_agent=self.config.default_reviewer_agent,
-                # The supervisor already provisions the worktree, so the session
-                # script wrapper is redundant and crashes on bash 3.2 (macOS
-                # default) due to ${VAR,,} syntax.  Matches tranche_queue.py.
                 use_managed_session_script=False,
                 selected_runner=selected_runner,
                 worker_env=refinement_worker_env or None,
@@ -5428,7 +5124,6 @@ class BossLoop:
             if claimed_runner_id:
                 self._release_runner_claim(claimed_runner_id)
 
-        # --- Backbone ledger: record dispatch outcome ---
         if backbone_run_id and runtime is not None:
             try:
                 runtime.update_run(

--- a/aragora/swarm/dispatch_contract_gate.py
+++ b/aragora/swarm/dispatch_contract_gate.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, Mapping
+
+from aragora.swarm.boss_feed import GitHubIssue
+from aragora.swarm.credential_envelope import CredentialEnvelope
+from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.worker_contract import build_worker_contract
+from aragora.swarm.worker_process import LaunchConfig
+
+
+def _target_agent(
+    loop: Any,
+    *,
+    selected_runner: dict[str, Any] | None,
+    requested_target_agent: str | None,
+) -> str:
+    requested = str(requested_target_agent or "").strip().lower()
+    if requested:
+        return requested
+    if isinstance(selected_runner, dict):
+        runner_type = str(selected_runner.get("runner_type", "")).strip().lower()
+        if runner_type:
+            return runner_type
+    default_target = str(loop.config.default_target_agent or "").strip().lower()
+    if default_target:
+        return default_target
+    return "codex"
+
+
+def _preview_env(
+    loop: Any,
+    *,
+    selected_runner: dict[str, Any] | None,
+    requested_target_agent: str | None,
+    worker_env: Mapping[str, str] | None,
+) -> tuple[str, dict[str, str]]:
+    env = dict(os.environ)
+    if isinstance(loop._env, dict):
+        env.update({str(key): str(value) for key, value in loop._env.items() if str(key).strip()})
+    if worker_env:
+        env.update({str(key): str(value) for key, value in worker_env.items() if str(key).strip()})
+
+    target_agent = _target_agent(
+        loop,
+        selected_runner=selected_runner,
+        requested_target_agent=requested_target_agent,
+    )
+    runner_type = (
+        str((selected_runner or {}).get("runner_type", "")).strip().lower() or target_agent
+    )
+    runner_command = str((selected_runner or {}).get("command_path", "")).strip()
+    runner_profile = str((selected_runner or {}).get("profile", "")).strip()
+
+    if runner_type == "claude":
+        env.setdefault("ARAGORA_CLAUDE_PROFILE", runner_profile or "default")
+        env.setdefault("CLAUDE_COMMAND", runner_command or shutil.which("claude") or "claude")
+        env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "profile")
+    elif runner_type == "codex":
+        env.setdefault("CODEX_COMMAND", runner_command or shutil.which("codex") or "codex")
+        env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
+    elif runner_command:
+        env.setdefault("ARAGORA_RUNNER_COMMAND", runner_command)
+        env.setdefault("ARAGORA_RUNNER_AUTH_MODE", "command")
+
+    pytest_path = shutil.which("pytest")
+    if pytest_path and not (
+        env.get("ARAGORA_CAN_RUN_PYTEST") or env.get("PYTEST_AVAILABLE") or env.get("PYTEST_PATH")
+    ):
+        env["PYTEST_PATH"] = pytest_path
+    ruff_path = shutil.which("ruff")
+    if ruff_path and not (
+        env.get("ARAGORA_CAN_RUN_RUFF") or env.get("RUFF_AVAILABLE") or env.get("RUFF_PATH")
+    ):
+        env["RUFF_PATH"] = ruff_path
+    return target_agent, env
+
+
+def _preview_work_orders(spec: Any) -> list[dict[str, Any]]:
+    preview_orders: list[dict[str, Any]] = []
+    raw_orders = getattr(spec, "work_orders", None)
+    if isinstance(raw_orders, list):
+        for item in raw_orders:
+            if not isinstance(item, dict):
+                continue
+            preview_orders.append(
+                {
+                    "file_scope": [
+                        str(path).strip()
+                        for path in item.get("file_scope", [])
+                        if str(path).strip()
+                    ],
+                    "expected_tests": [
+                        str(test).strip()
+                        for test in item.get("expected_tests", [])
+                        if str(test).strip()
+                    ],
+                    "mission_id": str(item.get("mission_id", "") or "").strip(),
+                    "stage_id": str(item.get("stage_id", "") or "").strip(),
+                    "assertion_ids": [
+                        str(entry).strip()
+                        for entry in item.get("assertion_ids", [])
+                        if str(entry).strip()
+                    ],
+                    "evidence_expectations": [
+                        str(entry).strip()
+                        for entry in item.get("evidence_expectations", [])
+                        if str(entry).strip()
+                    ],
+                    "mission_context_policies": dict(item.get("mission_context_policies") or {}),
+                }
+            )
+    if preview_orders:
+        return preview_orders
+    return [
+        {
+            "file_scope": [
+                str(path).strip()
+                for path in getattr(spec, "file_scope_hints", [])
+                if str(path).strip()
+            ],
+            "expected_tests": [],
+            "mission_context_policies": dict(getattr(spec, "mission_context_policies", {}) or {}),
+        }
+    ]
+
+
+def _github_cli_authenticated(loop: Any) -> bool:
+    cached = getattr(loop, "_dispatch_contract_github_cli_auth_available", None)
+    if cached is not None:
+        return bool(cached)
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            cwd=Path.cwd(),
+            env=git_safe_env(loop._env),
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        setattr(loop, "_dispatch_contract_github_cli_auth_available", False)
+        return False
+    authenticated = result.returncode == 0
+    setattr(loop, "_dispatch_contract_github_cli_auth_available", authenticated)
+    return authenticated
+
+
+def _missing_slices(loop: Any, *, envelope: CredentialEnvelope, target_agent: str) -> list[str]:
+    missing = list(envelope.missing_slices())
+    requires_git = bool(loop.config.auto_publish_deliverables)
+    requires_github_api = bool(
+        loop.config.auto_publish_deliverables or loop.config.auto_close_already_done_issues
+    )
+    if not requires_git and "git" in missing:
+        missing.remove("git")
+    if target_agent in {"claude", "codex"} and "provider" in missing:
+        missing.remove("provider")
+    if "github_api" in missing and (not requires_github_api or _github_cli_authenticated(loop)):
+        missing.remove("github_api")
+    allowed = {"runner", "git", "github_api", "verification"}
+    if target_agent not in {"claude", "codex"}:
+        allowed.add("provider")
+    return [item for item in missing if item in allowed]
+
+
+def _gate_reason(
+    *,
+    issue_number: int,
+    target_agent: str,
+    missing_slices: list[str],
+    contract_valid: bool,
+) -> tuple[list[str], list[str]]:
+    reasons: list[str] = []
+    next_actions: list[str] = []
+    if not contract_valid:
+        reasons.append(f"Issue #{issue_number} failed worker contract admission before dispatch.")
+        next_actions.append(
+            "Refresh the dispatch contract inputs so runner, scope, and mission context policy resolve cleanly before redispatch."
+        )
+    slice_messages = {
+        "runner": f"Issue #{issue_number} is missing a runner slice for `{target_agent}` dispatch.",
+        "git": f"Issue #{issue_number} is missing git publish credentials for branch-scoped worktree dispatch.",
+        "github_api": f"Issue #{issue_number} is missing GitHub API authentication required for full-auto publication.",
+        "provider": f"Issue #{issue_number} is missing provider credentials for `{target_agent}` dispatch.",
+        "verification": f"Issue #{issue_number} is missing verification tool capability (pytest and/or ruff).",
+    }
+    slice_actions = {
+        "runner": "Select a runner with a resolvable command/profile before redispatch.",
+        "git": "Restore SSH agent or HTTPS git credentials before redispatch.",
+        "github_api": "Restore `gh` authentication or a GitHub token before redispatch.",
+        "provider": "Restore the provider API key or choose a CLI-backed target agent before redispatch.",
+        "verification": "Ensure pytest and ruff are installed and discoverable before redispatch.",
+    }
+    for missing in missing_slices:
+        reasons.append(slice_messages[missing])
+        next_actions.append(slice_actions[missing])
+    return reasons, list(dict.fromkeys(next_actions))
+
+
+def dispatch_contract_gate(
+    loop: Any,
+    issue: GitHubIssue,
+    spec: Any,
+    selected_runner: dict[str, Any] | None,
+    requested_target_agent: str | None,
+    worker_env: Mapping[str, str] | None,
+    claimed_runner_id: str | None,
+) -> dict[str, Any] | None:
+    target_agent, preview_env = _preview_env(
+        loop,
+        selected_runner=selected_runner,
+        requested_target_agent=requested_target_agent,
+        worker_env=worker_env,
+    )
+    envelope = CredentialEnvelope.from_environment(preview_env)
+    missing_slices = _missing_slices(loop, envelope=envelope, target_agent=target_agent)
+    launch_config = LaunchConfig(
+        base_branch=loop.config.target_branch,
+        execution_mode=loop.config.execution_mode,
+        claude_profile=(
+            str((selected_runner or {}).get("profile", "")).strip() or None
+            if target_agent == "claude"
+            else None
+        ),
+        allow_claude_dangerously_skip_permissions=(
+            loop.config.allow_claude_dangerously_skip_permissions
+        ),
+        allow_codex_full_auto=loop.config.allow_codex_full_auto,
+    )
+    contract_valid = True
+    for work_order in _preview_work_orders(spec):
+        try:
+            contract = build_worker_contract(
+                agent=target_agent,
+                config=launch_config,
+                worktree_path=str(Path.cwd()),
+                env=preview_env,
+                work_order=work_order,
+            )
+            contract.validate()
+            if not contract.admission_check():
+                contract_valid = False
+                break
+        except ValueError:
+            contract_valid = False
+            break
+
+    if contract_valid and not missing_slices:
+        return None
+
+    reasons, next_actions = _gate_reason(
+        issue_number=issue.number,
+        target_agent=target_agent,
+        missing_slices=missing_slices,
+        contract_valid=contract_valid,
+    )
+    if claimed_runner_id:
+        loop._release_runner_claim(claimed_runner_id)
+    return {
+        "status": "needs_human",
+        "outcome": "blocked_auth_failure" if missing_slices else "blocked",
+        "reasons": reasons,
+        "next_actions": next_actions,
+        "dispatch_contract": {
+            "target_agent": target_agent,
+            "contract_valid": contract_valid,
+            "missing_slices": missing_slices,
+            "credential_envelope": envelope.preflight_cache_payload(),
+        },
+    }

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -3280,9 +3280,8 @@ async def test_dispatch_issue_sanitizer_failure_skips_contract_gate() -> None:
 
     with (
         patch("aragora.swarm.boss_loop.subprocess.run", side_effect=_run),
-        patch.object(
-            loop,
-            "_dispatch_contract_preview_env",
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
             side_effect=AssertionError("contract gate should not run after sanitation failure"),
         ),
     ):
@@ -3307,9 +3306,8 @@ async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> No
             "aragora.swarm.prompt_refiner.refine_worker_prompt",
             new=AsyncMock(side_effect=RuntimeError("skip refinement")),
         ),
-        patch.object(
-            loop,
-            "_dispatch_contract_preview_env",
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
             return_value=(
                 "codex",
                 {
@@ -3352,9 +3350,8 @@ async def test_dispatch_issue_contract_gate_blocks_missing_publish_auth_slices()
             "aragora.swarm.prompt_refiner.refine_worker_prompt",
             new=AsyncMock(side_effect=RuntimeError("skip refinement")),
         ),
-        patch.object(
-            loop,
-            "_dispatch_contract_preview_env",
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
             return_value=(
                 "codex",
                 {
@@ -3365,7 +3362,7 @@ async def test_dispatch_issue_contract_gate_blocks_missing_publish_auth_slices()
                 },
             ),
         ),
-        patch.object(loop, "_github_cli_authenticated", return_value=False),
+        patch("aragora.swarm.dispatch_contract_gate._github_cli_authenticated", return_value=False),
         patch(
             "aragora.swarm.boss_loop.dispatch_bounded_spec",
             new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
@@ -3396,9 +3393,8 @@ async def test_dispatch_issue_contract_gate_blocks_missing_provider_for_api_agen
             "aragora.swarm.prompt_refiner.refine_worker_prompt",
             new=AsyncMock(side_effect=RuntimeError("skip refinement")),
         ),
-        patch.object(
-            loop,
-            "_dispatch_contract_preview_env",
+        patch(
+            "aragora.swarm.dispatch_contract_gate._preview_env",
             return_value=(
                 "openai-api",
                 {

--- a/tests/swarm/test_boss_loop.py
+++ b/tests/swarm/test_boss_loop.py
@@ -50,6 +50,7 @@ from aragora.swarm.boss_loop import (
     sanitize_issue_body_for_dispatch,
     select_eligible_issue,
 )
+from aragora.swarm.task_sanitizer import SanitizationOutcome
 
 UTC = timezone.utc
 
@@ -2248,26 +2249,42 @@ class TestBossLoop:
         payload = json.loads((tmp_path / "boss_metrics.jsonl").read_text(encoding="utf-8"))
         assert payload["terminal_class"] == TerminalClass.RESCUE_NO_DELIVERABLE.value
 
-    def test_missing_validation_contract_stops_with_needs_human(self):
-        feed = MagicMock(spec=GitHubIssueFeed)
-        feed.fetch.return_value = [
-            _make_issue(
-                7,
-                "Issue missing validation",
-                body="Tighten the boss loop selection logic in aragora/swarm/boss_loop.py",
-            )
-        ]
-
-        loop = BossLoop(
-            config=_boss_config(max_iterations=1),
-            issue_feed=feed,
-            freshness_checker=lambda **kw: _fresh_result(fresh=True),
+    @pytest.mark.asyncio
+    async def test_missing_validation_contract_stops_with_needs_human(self):
+        issue = _make_issue(
+            7,
+            "Issue missing validation",
+            body="Tighten the boss loop selection logic in aragora/swarm/boss_loop.py",
         )
+        loop = BossLoop(config=_boss_config(max_iterations=1))
+        loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (
+            None,
+            None,
+        )
+        loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+            "runner_id": "codex-runner-1",
+            "runner_type": "codex",
+        }
 
-        result = asyncio.run(loop.run())
+        with (
+            patch(
+                "aragora.swarm.prompt_refiner.refine_worker_prompt",
+                new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+            ),
+            patch(
+                "aragora.swarm.boss_loop.TaskSanitizer.sanitize",
+                return_value=SimpleNamespace(
+                    outcome=SanitizationOutcome.ACCEPTED,
+                    sanitized_text=issue.body,
+                    checks_failed=[],
+                    reason="",
+                ),
+            ),
+        ):
+            result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
 
-        assert result.stop_reason == BossStopReason.NEEDS_HUMAN.value
-        assert "lacks an explicit validation contract" in result.needs_human_reasons[0]
+        assert result["status"] == "needs_human"
+        assert "lacks an explicit validation contract" in result["reasons"][0]
 
     def test_bold_markdown_validation_contract_allows_dispatch(self):
         feed = MagicMock(spec=GitHubIssueFeed)
@@ -3242,6 +3259,168 @@ async def test_dispatch_issue_drops_short_task_before_dispatch() -> None:
     assert "description_length" in comments[-1]
     assert any(cmd[:3] == ["gh", "issue", "edit"] for cmd in commands)
     assert any(cmd[:3] == ["gh", "issue", "close"] for cmd in commands)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_sanitizer_failure_skips_contract_gate() -> None:
+    issue = _make_issue(
+        2463,
+        "Too short for contract gate",
+        body="Tiny task only.",
+        labels=["boss-ready"],
+    )
+    loop = BossLoop(config=_boss_config(max_iterations=1, repo="synaptent/aragora"))
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    with (
+        patch("aragora.swarm.boss_loop.subprocess.run", side_effect=_run),
+        patch.object(
+            loop,
+            "_dispatch_contract_preview_env",
+            side_effect=AssertionError("contract gate should not run after sanitation failure"),
+        ),
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "sanitation_failed"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_contract_gate_allows_complete_cli_dispatch() -> None:
+    issue = _make_issue(2464, "Dispatch with complete CLI contract")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="codex"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch.object(
+            loop,
+            "_dispatch_contract_preview_env",
+            return_value=(
+                "codex",
+                {
+                    "ARAGORA_RUNNER_AUTH_MODE": "command",
+                    "CODEX_COMMAND": "/usr/local/bin/codex",
+                    "PYTEST_PATH": "/usr/local/bin/pytest",
+                    "RUFF_PATH": "/usr/local/bin/ruff",
+                },
+            ),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "completed"
+    dispatch_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_contract_gate_blocks_missing_publish_auth_slices() -> None:
+    issue = _make_issue(2465, "Dispatch requires publish auth")
+    loop = BossLoop(
+        config=_boss_config(
+            max_iterations=1,
+            default_target_agent="codex",
+            auto_publish_deliverables=True,
+        )
+    )
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "codex-runner-1",
+        "runner_type": "codex",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch.object(
+            loop,
+            "_dispatch_contract_preview_env",
+            return_value=(
+                "codex",
+                {
+                    "ARAGORA_RUNNER_AUTH_MODE": "command",
+                    "CODEX_COMMAND": "/usr/local/bin/codex",
+                    "PYTEST_PATH": "/usr/local/bin/pytest",
+                    "RUFF_PATH": "/usr/local/bin/ruff",
+                },
+            ),
+        ),
+        patch.object(loop, "_github_cli_authenticated", return_value=False),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked_auth_failure"
+    assert result["dispatch_contract"]["missing_slices"] == ["git", "github_api"]
+    assert "missing git publish credentials" in result["reasons"][0]
+    assert "missing GitHub API authentication" in result["reasons"][1]
+    dispatch_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatch_issue_contract_gate_blocks_missing_provider_for_api_agent() -> None:
+    issue = _make_issue(2466, "Dispatch requires provider auth")
+    loop = BossLoop(config=_boss_config(max_iterations=1, default_target_agent="openai-api"))
+    loop._claim_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: (None, None)
+    loop._selected_runner_for_dispatch = lambda freshness, *, requested_target_agent=None: {
+        "runner_id": "openai-api-runner-1",
+        "runner_type": "openai-api",
+    }
+
+    with (
+        patch(
+            "aragora.swarm.prompt_refiner.refine_worker_prompt",
+            new=AsyncMock(side_effect=RuntimeError("skip refinement")),
+        ),
+        patch.object(
+            loop,
+            "_dispatch_contract_preview_env",
+            return_value=(
+                "openai-api",
+                {
+                    "ARAGORA_RUNNER_AUTH_MODE": "command",
+                    "ARAGORA_RUNNER_COMMAND": "/usr/local/bin/openai",
+                    "PYTEST_PATH": "/usr/local/bin/pytest",
+                    "RUFF_PATH": "/usr/local/bin/ruff",
+                },
+            ),
+        ),
+        patch(
+            "aragora.swarm.boss_loop.dispatch_bounded_spec",
+            new=AsyncMock(return_value={"status": "completed", "run": {"work_orders": []}}),
+        ) as dispatch_mock,
+    ):
+        result = await loop._dispatch_issue(issue, _fresh_result(fresh=True))
+
+    assert result["status"] == "needs_human"
+    assert result["outcome"] == "blocked_auth_failure"
+    assert result["dispatch_contract"]["missing_slices"] == ["provider"]
+    assert "missing provider credentials" in result["reasons"][0]
+    dispatch_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a pre-dispatch boss-loop contract gate that reuses `build_worker_contract()` before worker launch
- block dispatch truthfully when required runner, git, GitHub, provider, or verification capability is missing
- cover the new admission path with focused boss-loop tests and harden the missing-validation test against ambient repo state

## Validation
- `ruff check aragora/swarm/boss_loop.py tests/swarm/test_boss_loop.py`
- `pytest -q tests/swarm/test_boss_loop.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
