### PR TITLE
feat(swarm): expand heuristic issue upgrades

### DIFF
--- a/aragora/swarm/issue_upgrader.py
+++ b/aragora/swarm/issue_upgrader.py
@@ -417,11 +417,11 @@ def upgrade_issue_heuristic(
         return None
 
     if category == "test_coverage":
-        test_rel = (
-            str(new_files[0]).strip()
-            if list(new_files or []) and str(list(new_files or [])[0]).strip()
-            else _generated_test_path(module_rel)
+        first_new_file = next(
+            (str(path).strip() for path in (new_files or []) if str(path).strip()),
+            None,
         )
+        test_rel = first_new_file or _generated_test_path(module_rel)
         public_api_section = _render_public_api_section(analysis)
         module_purpose = (
             f"**Module purpose:** {analysis.docstring}\n\n" if analysis.docstring else ""

--- a/aragora/swarm/issue_upgrader.py
+++ b/aragora/swarm/issue_upgrader.py
@@ -26,6 +26,9 @@ _MAX_SIMPLE_LOC = 120
 _MAX_SIMPLE_PUBLIC_API = 8
 _MAX_SIMPLE_EXTERNAL_WEIGHT = 2
 _SKIP_SENTINELS = frozenset({"__init__.py", "__main__.py"})
+_SUPPORTED_UPGRADE_CATEGORIES = frozenset(
+    {"test_coverage", "broad_exception", "silent_exception", "type_annotation"}
+)
 _CONCRETE_MOCK_GUIDANCE: dict[str, str] = {
     "httpx": "Patch `httpx` clients or request helpers to return deterministic responses.",
     "requests": "Monkeypatch `requests` calls so tests do not hit the network.",
@@ -272,17 +275,124 @@ def _render_mock_guidance(analysis: _ModuleAnalysis) -> str:
     return "\n".join(f"- {hint}" for hint in analysis.mock_hints[:5])
 
 
+def _render_acceptance_criteria(
+    category: str,
+    *,
+    module_rel: str,
+    validation_command: str,
+    acceptance_criteria: list[str] | None,
+) -> list[str]:
+    normalized = [
+        str(item).strip() for item in list(acceptance_criteria or []) if str(item).strip()
+    ]
+    if normalized:
+        return normalized
+    if category == "broad_exception":
+        return [
+            "Broad exception handlers are narrowed or justified explicitly.",
+            f"`{validation_command}` passes",
+            f"Keep the lane scoped to `{module_rel}`.",
+        ]
+    if category == "silent_exception":
+        return [
+            "Silent exception swallowing is removed or justified explicitly.",
+            f"`{validation_command}` passes",
+            f"Keep the lane scoped to `{module_rel}`.",
+        ]
+    if category == "type_annotation":
+        return [
+            "Public functions and methods have precise return type annotations.",
+            f"`{validation_command}` passes",
+            f"Keep the lane scoped to `{module_rel}`.",
+        ]
+    return [
+        "Tests cover the listed public API directly.",
+        "External dependencies stay mocked or faked.",
+        "The test file runs with a single focused pytest command.",
+        "Keep the lane scoped to this module and its mirrored test file.",
+    ]
+
+
+def _render_non_test_upgrade_body(
+    *,
+    category: str,
+    module_rel: str,
+    analysis: _ModuleAnalysis,
+    validation_command: str,
+    acceptance_criteria: list[str] | None,
+) -> str:
+    task_lines = {
+        "broad_exception": [
+            f"Narrow broad exception handling in `{module_rel}` without changing public behavior.",
+            "Replace `except Exception:` with specific exception types where the failure mode is known.",
+            "If a broad boundary must remain, keep it explicit with `# noqa: BLE001` and a short justification comment.",
+        ],
+        "silent_exception": [
+            f"Replace silent exception swallowing in `{module_rel}` while preserving current behavior.",
+            "Convert `except ...: pass` paths into explicit handling, visible logging, or documented intentional silence.",
+            "Do not broaden scope beyond the current module.",
+        ],
+        "type_annotation": [
+            f"Add precise return type annotations in `{module_rel}` without broadening scope.",
+            "Annotate public functions and methods first, using `None` for no-return paths.",
+            "Avoid unrelated refactors or signature changes outside return annotations.",
+        ],
+    }[category]
+    module_purpose = f"**Module purpose:** {analysis.docstring}\n\n" if analysis.docstring else ""
+    public_api_section = _render_public_api_section(analysis)
+    acceptance_lines = _render_acceptance_criteria(
+        category,
+        module_rel=module_rel,
+        validation_command=validation_command,
+        acceptance_criteria=acceptance_criteria,
+    )
+    async_note = (
+        "- Preserve async call boundaries and await behavior while making this change.\n"
+        if analysis.has_async
+        else ""
+    )
+    return (
+        "## Task\n\n"
+        + "\n".join(f"- {line}" for line in task_lines)
+        + "\n\n"
+        + module_purpose
+        + "### Public API / behavior to preserve\n"
+        + f"{public_api_section}\n\n"
+        + "### File Scope\n"
+        + f"- `{module_rel}`\n\n"
+        + "### Validation\n"
+        + "```bash\n"
+        + f"{validation_command}\n"
+        + "```\n\n"
+        + "### Acceptance Criteria\n"
+        + "\n".join(f"- {criterion}" for criterion in acceptance_lines)
+        + "\n\n"
+        + "### Constraints\n"
+        + f"- Estimated complexity: {analysis.complexity}\n"
+        + async_note
+        + "- Keep the change limited to the current module.\n"
+        + "- Do not broaden into decomposition or cross-module planning."
+    )
+
+
 def upgrade_issue_heuristic(
     title: str,
     body: str,
     *,
     repo_root: Path,
+    category: str = "test_coverage",
+    validation_command: str = "",
+    acceptance_criteria: list[str] | None = None,
+    new_files: list[str] | None = None,
 ) -> UpgradedIssue | None:
     """Upgrade an issue using deterministic heuristic module analysis.
 
     This prototype is intentionally narrow: only trivial/simple modules with a
     useful public API are upgraded.
     """
+    if category not in _SUPPORTED_UPGRADE_CATEGORIES:
+        return None
+
     module_rel = _primary_module_path(body)
     if not module_rel:
         return None
@@ -306,42 +416,63 @@ def upgrade_issue_heuristic(
     if analysis.external_imports and len(analysis.mock_hints) < len(analysis.external_imports):
         return None
 
-    test_rel = _generated_test_path(module_rel)
-    public_api_section = _render_public_api_section(analysis)
-    module_purpose = f"**Module purpose:** {analysis.docstring}\n\n" if analysis.docstring else ""
-    async_note = (
-        "\n### Async handling\n- Use `pytest.mark.asyncio` for async entrypoints or wrap them with `asyncio.run()` in focused unit tests.\n"
-        if analysis.has_async
-        else ""
-    )
-    upgraded_body = (
-        "## Task\n\n"
-        f"Add focused unit tests for `{module_rel}`.\n\n"
-        f"{module_purpose}"
-        "### Public API to cover\n"
-        f"{public_api_section}\n\n"
-        "### Mock guidance\n"
-        f"{_render_mock_guidance(analysis)}\n"
-        f"{async_note}"
-        "### File Scope\n"
-        f"- `{module_rel}`\n"
-        f"- `{test_rel}` (create)\n\n"
-        "### Validation\n"
-        "```bash\n"
-        f"pytest {test_rel} -q\n"
-        "```\n\n"
-        "### Acceptance Criteria\n"
-        "- Tests cover the listed public API directly.\n"
-        "- External dependencies stay mocked or faked.\n"
-        "- The test file runs with a single focused pytest command.\n"
-        "- Keep the lane scoped to this module and its mirrored test file.\n\n"
-        "### Constraints\n"
-        f"- Estimated complexity: {analysis.complexity}\n"
-        "- Do not broaden into decomposition or cross-module planning."
-    )
-
-    parts = Path(module_rel).parts
-    upgraded_title = f"Add unit tests for {'/'.join(parts[1:])}" if len(parts) > 1 else title
+    if category == "test_coverage":
+        test_rel = (
+            str(new_files[0]).strip()
+            if list(new_files or []) and str(list(new_files or [])[0]).strip()
+            else _generated_test_path(module_rel)
+        )
+        public_api_section = _render_public_api_section(analysis)
+        module_purpose = (
+            f"**Module purpose:** {analysis.docstring}\n\n" if analysis.docstring else ""
+        )
+        async_note = (
+            "\n### Async handling\n- Use `pytest.mark.asyncio` for async entrypoints or wrap them with `asyncio.run()` in focused unit tests.\n"
+            if analysis.has_async
+            else ""
+        )
+        validation_text = validation_command or f"pytest {test_rel} -q"
+        acceptance_lines = _render_acceptance_criteria(
+            category,
+            module_rel=module_rel,
+            validation_command=validation_text,
+            acceptance_criteria=acceptance_criteria,
+        )
+        upgraded_body = (
+            "## Task\n\n"
+            f"Add focused unit tests for `{module_rel}`.\n\n"
+            f"{module_purpose}"
+            "### Public API to cover\n"
+            f"{public_api_section}\n\n"
+            "### Mock guidance\n"
+            f"{_render_mock_guidance(analysis)}\n"
+            f"{async_note}"
+            "### File Scope\n"
+            f"- `{module_rel}`\n"
+            f"- `{test_rel}` (create)\n\n"
+            "### Validation\n"
+            "```bash\n"
+            f"{validation_text}\n"
+            "```\n\n"
+            "### Acceptance Criteria\n"
+            + "\n".join(f"- {criterion}" for criterion in acceptance_lines)
+            + "\n\n"
+            + "### Constraints\n"
+            + f"- Estimated complexity: {analysis.complexity}\n"
+            + "- Do not broaden into decomposition or cross-module planning."
+        )
+        parts = Path(module_rel).parts
+        upgraded_title = f"Add unit tests for {'/'.join(parts[1:])}" if len(parts) > 1 else title
+    else:
+        validation_text = validation_command or f"ruff check {module_rel}"
+        upgraded_body = _render_non_test_upgrade_body(
+            category=category,
+            module_rel=module_rel,
+            analysis=analysis,
+            validation_command=validation_text,
+            acceptance_criteria=acceptance_criteria,
+        )
+        upgraded_title = title
 
     return UpgradedIssue(
         original_title=title,

--- a/scripts/generate_boss_issues.py
+++ b/scripts/generate_boss_issues.py
@@ -42,6 +42,9 @@ _OPEN_PR_PAGE_SIZE = 100
 _OPEN_PR_MAX_PAGES = 10
 _OPEN_PR_FILES_PAGE_SIZE = 100
 _OPEN_PR_FILES_MAX_PAGES = 10
+_UPGRADEABLE_CATEGORIES = frozenset(
+    {"test_coverage", "broad_exception", "silent_exception", "type_annotation"}
+)
 
 
 @dataclass(slots=True)
@@ -60,16 +63,19 @@ class DecompositionTelemetry:
 def format_boss_ready_body(candidate: BossIssueCandidate) -> str:
     """Format a candidate into the proven boss-ready issue body.
 
-    For test_coverage candidates, uses the issue upgrader to generate
-    concrete, module-aware issue bodies instead of generic templates.
+    For supported categories, use the issue upgrader to generate concrete,
+    module-aware issue bodies instead of the generic template.
     """
-    # Try to upgrade test_coverage issues with module-specific guidance
-    if candidate.category == "test_coverage":
+    if candidate.category in _UPGRADEABLE_CATEGORIES:
         upgraded = upgrade_issue_heuristic(
             candidate.title,
             f"## Task\n\n{candidate.description}\n\n### File Scope\n"
             + "\n".join(f"- `{f}`" for f in candidate.file_scope),
             repo_root=REPO_ROOT,
+            category=candidate.category,
+            validation_command=candidate.validation_command,
+            acceptance_criteria=list(candidate.acceptance_criteria),
+            new_files=list(candidate.new_files),
         )
         if upgraded:
             body = upgraded.upgraded_body

--- a/tests/scripts/test_generate_boss_issues.py
+++ b/tests/scripts/test_generate_boss_issues.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -19,6 +20,24 @@ def _candidate(name: str, *, file_scope: list[str]) -> BossIssueCandidate:
         new_files=[f"tests/test_{name}.py"],
         validation_command=f"pytest tests/test_{name}.py -v",
         acceptance_criteria=["All tests pass"],
+    )
+
+
+def _category_candidate(category: str, *, rel: str) -> BossIssueCandidate:
+    validation_command = (
+        f"pytest tests/test_{Path(rel).stem}.py -v"
+        if category == "test_coverage"
+        else f"ruff check {rel}"
+    )
+    new_files = [f"tests/test_{Path(rel).stem}.py"] if category == "test_coverage" else []
+    return BossIssueCandidate(
+        category=category,
+        title=f"Candidate for {category}",
+        description=f"Improve `{rel}` in a bounded way.",
+        file_scope=[rel],
+        new_files=new_files,
+        validation_command=validation_command,
+        acceptance_criteria=[f"`{validation_command}` passes"],
     )
 
 
@@ -166,6 +185,48 @@ def test_main_passes_explicit_min_success_rate(monkeypatch, capsys) -> None:
     _ = capsys.readouterr()
     assert scan_calls
     assert scan_calls[0][2] == 0.5
+
+
+@pytest.mark.parametrize(
+    "category",
+    ["test_coverage", "broad_exception", "silent_exception", "type_annotation"],
+)
+def test_format_boss_ready_body_uses_upgrader_for_supported_categories(
+    monkeypatch,
+    category: str,
+) -> None:
+    candidate = _category_candidate(category, rel="aragora/swarm/example_module.py")
+    calls: list[dict[str, object]] = []
+
+    def _upgrade(title, body, **kwargs):  # noqa: ANN001
+        calls.append({"title": title, "body": body, **kwargs})
+        return SimpleNamespace(upgraded_body="## Task\n\nUpgraded body")
+
+    monkeypatch.setattr(mod, "upgrade_issue_heuristic", _upgrade)
+
+    body = mod.format_boss_ready_body(candidate)
+
+    assert body.startswith("## Task\n\nUpgraded body")
+    assert f"<!-- fingerprint:{candidate.fingerprint} -->" in body
+    assert calls[0]["category"] == category
+    assert calls[0]["validation_command"] == candidate.validation_command
+    assert calls[0]["acceptance_criteria"] == candidate.acceptance_criteria
+    assert calls[0]["new_files"] == candidate.new_files
+
+
+def test_format_boss_ready_body_falls_back_when_non_test_upgrade_is_unavailable(
+    monkeypatch,
+) -> None:
+    candidate = _category_candidate("type_annotation", rel="aragora/swarm/example_module.py")
+    monkeypatch.setattr(mod, "upgrade_issue_heuristic", lambda *args, **kwargs: None)
+
+    body = mod.format_boss_ready_body(candidate)
+
+    assert candidate.description in body
+    assert "### File Scope" in body
+    assert "`aragora/swarm/example_module.py`" in body
+    assert candidate.validation_command in body
+    assert f"<!-- fingerprint:{candidate.fingerprint} -->" in body
 
 
 def test_maybe_decompose_candidates_noop_when_disabled(monkeypatch) -> None:

--- a/tests/swarm/test_issue_upgrader.py
+++ b/tests/swarm/test_issue_upgrader.py
@@ -27,6 +27,25 @@ def _upgrade(repo_root: Path, rel: str) -> UpgradedIssue | None:
     return upgrade_issue_heuristic(f"Add tests for {Path(rel).name}", body, repo_root=repo_root)
 
 
+def _upgrade_category(
+    repo_root: Path,
+    rel: str,
+    *,
+    category: str,
+    validation_command: str | None = None,
+    acceptance_criteria: list[str] | None = None,
+) -> UpgradedIssue | None:
+    body = f"Focus on `{rel}` with bounded scope."
+    return upgrade_issue_heuristic(
+        f"Upgrade {Path(rel).name}",
+        body,
+        repo_root=repo_root,
+        category=category,
+        validation_command=validation_command or f"ruff check {rel}",
+        acceptance_criteria=acceptance_criteria or [f"`ruff check {rel}` passes"],
+    )
+
+
 class TestUpgradeAdmission:
     def test_upgrades_trivial_public_function_module(self, repo_root: Path) -> None:
         _write_module(
@@ -336,3 +355,73 @@ class TestOutputShape:
 
         assert result is not None
         assert "PublicTool" in result.upgraded_body
+
+    @pytest.mark.parametrize(
+        ("category", "expected_snippet"),
+        [
+            ("broad_exception", "Narrow broad exception handling"),
+            ("silent_exception", "Replace silent exception swallowing"),
+            ("type_annotation", "Add precise return type annotations"),
+        ],
+    )
+    def test_non_test_categories_get_module_aware_upgrade_body(
+        self,
+        repo_root: Path,
+        category: str,
+        expected_snippet: str,
+    ) -> None:
+        rel = "aragora/swarm/non_test_upgrade.py"
+        _write_module(
+            repo_root,
+            rel,
+            '"""Preserve user-visible behavior."""\n\n'
+            "def normalize_name(value: str) -> str:\n"
+            "    return value.strip().lower()\n",
+        )
+
+        result = _upgrade_category(
+            repo_root,
+            rel,
+            category=category,
+            acceptance_criteria=["Keep behavior stable", "ruff stays green"],
+        )
+
+        assert result is not None
+        assert expected_snippet in result.upgraded_body
+        assert "### Public API / behavior to preserve" in result.upgraded_body
+        assert "`normalize_name()`" in result.upgraded_body
+        assert f"ruff check {rel}" in result.upgraded_body
+        assert f"- `{rel}`" in result.upgraded_body
+        assert "tests/swarm/test_non_test_upgrade.py" not in result.upgraded_body
+
+    @pytest.mark.parametrize(
+        "category",
+        ["broad_exception", "silent_exception", "type_annotation"],
+    )
+    def test_non_test_categories_skip_medium_modules(self, repo_root: Path, category: str) -> None:
+        body_lines = ['"""Module with too much surface."""', ""]
+        for idx in range(10):
+            body_lines.extend(
+                [
+                    f"def public_fn_{idx}(value: int) -> int:",
+                    f"    return value + {idx}",
+                    "",
+                ]
+            )
+        rel = "aragora/swarm/medium_non_test.py"
+        _write_module(repo_root, rel, "\n".join(body_lines))
+
+        assert _upgrade_category(repo_root, rel, category=category) is None
+
+    def test_non_test_category_output_is_stable(self, repo_root: Path) -> None:
+        rel = "aragora/swarm/stable_type_annotations.py"
+        _write_module(
+            repo_root,
+            rel,
+            "def normalize() -> str:\n    return 'ok'\n",
+        )
+
+        first = _upgrade_category(repo_root, rel, category="type_annotation")
+        second = _upgrade_category(repo_root, rel, category="type_annotation")
+
+        assert first == second


### PR DESCRIPTION
## Summary
- extend heuristic issue upgrades beyond `test_coverage` to `broad_exception`, `silent_exception`, and `type_annotation`
- route those supported categories through `scripts/generate_boss_issues.py` while preserving generic fallback when an upgrade is unavailable
- add focused upgrader and generator coverage for the new category-aware output paths

## Validation
- `ruff check aragora/swarm/issue_upgrader.py scripts/generate_boss_issues.py tests/swarm/test_issue_upgrader.py tests/scripts/test_generate_boss_issues.py`
- `pytest -q tests/swarm/test_issue_upgrader.py tests/scripts/test_generate_boss_issues.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`
