### PR TITLE
feat(swarm): align preflight scratch path and classify failures

### DIFF
--- a/aragora/swarm/preflight.py
+++ b/aragora/swarm/preflight.py
@@ -18,6 +18,7 @@ from typing import Any
 from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.env_utils import git_safe_env
 from aragora.swarm.mission import GateEvaluation, GateType, GateVerdict, MissionContextPolicy
+from aragora.swarm.terminal_truth import TerminalClass, classify_preflight_failure
 from aragora.swarm.worker_contract import WorkerContract, checksum_contract_payload
 from aragora.swarm.worker_launcher import LaunchConfig, WorkerLauncher, WorkerProcess
 
@@ -47,6 +48,14 @@ class PreflightResult:
     checks: list[dict[str, Any]] = field(default_factory=list)
     duration_seconds: float = 0.0
     envelope: CredentialEnvelope | None = None
+
+    @property
+    def failure_terminal_class(self) -> TerminalClass | None:
+        return classify_preflight_failure(
+            passed=self.passed,
+            checks=list(self.checks),
+            dispatch_gate=dict(self.dispatch_gate),
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -84,6 +93,14 @@ class PreflightReceipt:
     ttl_seconds: int = 0
     expires_at: str = ""
     artifacts: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def failure_terminal_class(self) -> TerminalClass | None:
+        return classify_preflight_failure(
+            passed=self.passed,
+            checks=list(self.checks),
+            dispatch_gate=None,
+        )
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -637,6 +654,7 @@ def run_scratch_validation_receipt(
     force_refresh: bool = False,
 ) -> PreflightReceipt:
     resolved_repo_root = repo_root.resolve()
+    normalized_base_ref = "main"
     if not force_refresh:
         cached = _load_cached_preflight_receipt(resolved_repo_root, envelope, "scratch")
         if cached is not None:
@@ -648,6 +666,7 @@ def run_scratch_validation_receipt(
     artifacts: dict[str, Any] = {
         "branch": branch,
         "worktree_path": str(worktree_path),
+        "target_ref": normalized_base_ref,
         "draft_pr_number": None,
         "draft_pr_url": "",
     }
@@ -660,7 +679,15 @@ def run_scratch_validation_receipt(
         worktree_result = _run_check(
             checks,
             name="git_worktree_add",
-            cmd=["git", "worktree", "add", "-b", branch, str(worktree_path), "HEAD"],
+            cmd=[
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                str(worktree_path),
+                normalized_base_ref,
+            ],
             cwd=resolved_repo_root,
             env=git_safe_env(),
         )

--- a/aragora/swarm/terminal_truth.py
+++ b/aragora/swarm/terminal_truth.py
@@ -74,6 +74,35 @@ class TerminalClass(str, Enum):
         }
 
 
+_PREFLIGHT_AUTH_HINTS: tuple[str, ...] = (
+    "auth",
+    "authentication",
+    "not logged",
+    "permission denied",
+    "forbidden",
+    "http 401",
+    "http 403",
+    "requires authentication",
+)
+
+_PREFLIGHT_SCOPE_HINTS: tuple[str, ...] = (
+    "already exists",
+    "would be overwritten",
+    "checkout conflict",
+    "scope conflict",
+    "scope_violation",
+    "worktree has uncommitted changes",
+)
+
+_PREFLIGHT_NO_RUNNER_HINTS: tuple[str, ...] = (
+    "runner command not configured",
+    "command failed",
+    "not found",
+    "no such file",
+    "executable file not found",
+)
+
+
 def classify_from_metrics(row: dict[str, Any]) -> TerminalClass:
     """Classify a boss_metrics.jsonl row into the canonical taxonomy."""
     status = str(row.get("worker_status", "")).strip().lower()
@@ -117,6 +146,60 @@ def classify_from_metrics(row: dict[str, Any]) -> TerminalClass:
         return TerminalClass.BLOCKED_SANITATION_FAILED
 
     return TerminalClass.RESCUE_NO_DELIVERABLE
+
+
+def classify_preflight_failure(
+    *,
+    passed: bool,
+    checks: list[dict[str, Any]] | None = None,
+    dispatch_gate: dict[str, Any] | None = None,
+) -> TerminalClass | None:
+    """Map failed preflight outcomes into canonical blocked terminal truth."""
+    if passed:
+        return None
+
+    failed_checks = [
+        dict(item)
+        for item in list(checks or [])
+        if isinstance(item, dict) and not bool(item.get("passed", False))
+    ]
+    gate = dict(dispatch_gate or {})
+    gate_failure_classes = {
+        _text(item).lower() for item in _text_list(gate.get("failure_classes")) if _text(item)
+    }
+    gate_notes = _text(gate.get("notes")).lower()
+
+    if gate_failure_classes.intersection({"contract_missing", "context_policy_unresolved"}):
+        return TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+
+    def _failed_check_text(check: dict[str, Any]) -> str:
+        return " ".join(
+            part
+            for part in [
+                _text(check.get("name")).lower(),
+                _text(check.get("detail")).lower(),
+            ]
+            if part
+        )
+
+    failed_texts = [_failed_check_text(check) for check in failed_checks]
+    if any(any(hint in text for hint in _PREFLIGHT_AUTH_HINTS) for text in failed_texts):
+        return TerminalClass.BLOCKED_AUTH_FAILURE
+
+    if any(
+        _text(check.get("name")).lower() == "runner_cli"
+        and any(hint in _text(check.get("detail")).lower() for hint in _PREFLIGHT_NO_RUNNER_HINTS)
+        for check in failed_checks
+    ):
+        return TerminalClass.BLOCKED_NO_RUNNER
+
+    if any(any(hint in text for hint in _PREFLIGHT_SCOPE_HINTS) for text in failed_texts):
+        return TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+
+    if "dispatch" in gate_notes or "bounded" in gate_notes or gate_failure_classes:
+        return TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+
+    return TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
 
 
 def score_benchmark(rows: list[dict[str, Any]]) -> dict[str, Any]:

--- a/tests/swarm/test_preflight.py
+++ b/tests/swarm/test_preflight.py
@@ -10,6 +10,7 @@ import pytest
 from aragora.swarm.credential_envelope import CredentialEnvelope
 from aragora.swarm.mission import GateType, GateVerdict
 from aragora.swarm import preflight as mod
+from aragora.swarm.terminal_truth import TerminalClass
 from aragora.swarm.worker_contract import checksum_contract_payload
 from aragora.swarm.worker_process import WorkerProcess
 
@@ -380,6 +381,7 @@ def test_run_scratch_validation_receipt_persists_success(monkeypatch, tmp_path: 
     assert receipt.check_type == "scratch"
     assert receipt.passed is True
     assert receipt.ttl_seconds == 86400
+    assert receipt.artifacts["target_ref"] == "main"
     assert receipt.artifacts["draft_pr_number"] is None
     assert receipt.artifacts["draft_pr_url"] == ""
     assert any(check["name"] == "git_commit" for check in receipt.checks)
@@ -389,7 +391,116 @@ def test_run_scratch_validation_receipt_persists_success(monkeypatch, tmp_path: 
     assert receipt_path.exists()
     payload = json.loads(receipt_path.read_text(encoding="utf-8"))
     assert payload["receipt_id"] == receipt.receipt_id
-    assert commands[0][:3] == ["git", "worktree", "add"]
+    assert commands[0] == [
+        "git",
+        "worktree",
+        "add",
+        "-b",
+        receipt.artifacts["branch"],
+        str(
+            repo_root / ".worktrees" / f"preflight-{receipt.artifacts['branch'].replace('/', '-')}"
+        ),
+        "main",
+    ]
+
+
+def test_preflight_result_failure_terminal_class_maps_runner_auth_failure() -> None:
+    result = mod.PreflightResult(
+        repo_root="/tmp/repo",
+        base_ref="main",
+        branch="",
+        worktree_path="/tmp/repo",
+        agent="codex",
+        published=False,
+        pull_request_created=False,
+        pull_request_closed=False,
+        cleanup_worktree_removed=False,
+        cleanup_branch_removed=False,
+        passed=False,
+        checks=[
+            {
+                "name": "runner_cli",
+                "passed": False,
+                "detail": "authentication required for codex runner",
+            }
+        ],
+    )
+
+    assert result.failure_terminal_class == TerminalClass.BLOCKED_AUTH_FAILURE
+
+
+def test_preflight_result_failure_terminal_class_maps_no_runner() -> None:
+    result = mod.PreflightResult(
+        repo_root="/tmp/repo",
+        base_ref="main",
+        branch="",
+        worktree_path="/tmp/repo",
+        agent="codex",
+        published=False,
+        pull_request_created=False,
+        pull_request_closed=False,
+        cleanup_worktree_removed=False,
+        cleanup_branch_removed=False,
+        passed=False,
+        checks=[
+            {
+                "name": "runner_cli",
+                "passed": False,
+                "detail": "runner command not configured",
+            }
+        ],
+    )
+
+    assert result.failure_terminal_class == TerminalClass.BLOCKED_NO_RUNNER
+
+
+def test_preflight_result_failure_terminal_class_maps_scope_conflict() -> None:
+    result = mod.PreflightResult(
+        repo_root="/tmp/repo",
+        base_ref="main",
+        branch="",
+        worktree_path="/tmp/repo",
+        agent="codex",
+        published=False,
+        pull_request_created=False,
+        pull_request_closed=False,
+        cleanup_worktree_removed=False,
+        cleanup_branch_removed=False,
+        passed=False,
+        checks=[
+            {
+                "name": "git_worktree_add",
+                "passed": False,
+                "detail": "fatal: worktree path already exists and scope conflict was detected",
+            }
+        ],
+    )
+
+    assert result.failure_terminal_class == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
+
+
+def test_preflight_result_failure_terminal_class_maps_dispatch_gate_block() -> None:
+    result = mod.PreflightResult(
+        repo_root="/tmp/repo",
+        base_ref="main",
+        branch="",
+        worktree_path="/tmp/repo",
+        agent="codex",
+        published=False,
+        pull_request_created=False,
+        pull_request_closed=False,
+        cleanup_worktree_removed=False,
+        cleanup_branch_removed=False,
+        passed=False,
+        checks=[],
+        dispatch_gate={
+            "verdict": GateVerdict.BLOCKED.value,
+            "failure_classes": ["context_policy_unresolved"],
+            "notes": "Dispatch gate failed because the worker is not dispatch bounded.",
+        },
+    )
+
+    assert result.failure_terminal_class == TerminalClass.BLOCKED_NOT_DISPATCH_BOUNDED
 
 
 def test_run_remote_publish_validation_receipt_records_pr_artifacts(


### PR DESCRIPTION
## Summary
- align scratch preflight validation to the explicit production-like base ref path instead of ambient HEAD
- add canonical terminal-truth classification for preflight failures on results and receipts
- cover runner auth, missing runner, scope conflict, dispatch-bounded failure, and scratch-base-ref behavior

## Validation
- python3 -m pytest -q tests/swarm/test_preflight.py
- python3 -m ruff check aragora/swarm/preflight.py aragora/swarm/terminal_truth.py tests/swarm/test_preflight.py
- python3 -m mypy --follow-imports=skip --hide-error-context --no-error-summary aragora/swarm/preflight.py aragora/swarm/terminal_truth.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD