### PR TITLE
feat(swarm): add session state persistence skeleton

### DIFF
--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+_SESSION_ID_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _optional_text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        return (
+            value.astimezone(timezone.utc) if value.tzinfo else value.replace(tzinfo=timezone.utc)
+        )
+    text = _optional_text(value)
+    if not text:
+        return _utcnow()
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return _utcnow()
+
+
+def _coerce_issue_number(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _sanitize_session_id(session_id: str) -> str:
+    cleaned = _SESSION_ID_PATTERN.sub("-", str(session_id).strip()).strip("-")
+    if not cleaned:
+        raise ValueError("session_id must contain at least one filename-safe character")
+    return cleaned
+
+
+@dataclass(slots=True)
+class SessionState:
+    """Durable local session metadata for future retry/repair orchestration."""
+
+    session_id: str
+    status: str = "created"
+    issue_number: int | None = None
+    target_agent: str | None = None
+    runner_type: str | None = None
+    worktree_path: str | None = None
+    branch_name: str | None = None
+    pr_url: str | None = None
+    resume_hint: str | None = None
+    retry_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+    created_at: datetime = field(default_factory=_utcnow)
+    updated_at: datetime = field(default_factory=_utcnow)
+
+    def __post_init__(self) -> None:
+        self.session_id = _sanitize_session_id(self.session_id)
+        self.status = str(self.status or "created").strip() or "created"
+        self.issue_number = _coerce_issue_number(self.issue_number)
+        self.target_agent = _optional_text(self.target_agent)
+        self.runner_type = _optional_text(self.runner_type)
+        self.worktree_path = _optional_text(self.worktree_path)
+        self.branch_name = _optional_text(self.branch_name)
+        self.pr_url = _optional_text(self.pr_url)
+        self.resume_hint = _optional_text(self.resume_hint)
+        self.retry_count = max(0, int(self.retry_count or 0))
+        self.created_at = _coerce_datetime(self.created_at)
+        self.updated_at = _coerce_datetime(self.updated_at)
+        self.metadata = dict(self.metadata or {})
+
+    def touch(self) -> None:
+        self.updated_at = _utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "status": self.status,
+            "issue_number": self.issue_number,
+            "target_agent": self.target_agent,
+            "runner_type": self.runner_type,
+            "worktree_path": self.worktree_path,
+            "branch_name": self.branch_name,
+            "pr_url": self.pr_url,
+            "resume_hint": self.resume_hint,
+            "retry_count": self.retry_count,
+            "metadata": dict(self.metadata),
+            "created_at": self.created_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any] | None) -> "SessionState":
+        data = dict(payload or {})
+        return cls(
+            session_id=str(data.get("session_id", "")).strip(),
+            status=data.get("status", "created"),
+            issue_number=data.get("issue_number"),
+            target_agent=data.get("target_agent"),
+            runner_type=data.get("runner_type"),
+            worktree_path=data.get("worktree_path"),
+            branch_name=data.get("branch_name"),
+            pr_url=data.get("pr_url"),
+            resume_hint=data.get("resume_hint"),
+            retry_count=data.get("retry_count", 0),
+            metadata=dict(data.get("metadata") or {}),
+            created_at=_coerce_datetime(data.get("created_at")),
+            updated_at=_coerce_datetime(data.get("updated_at")),
+        )
+
+
+class SessionStateStore:
+    """Local JSON store for persisted swarm session state."""
+
+    def __init__(self, *, state_dir: Path | None = None) -> None:
+        self._state_dir = (
+            Path(state_dir).resolve()
+            if state_dir is not None
+            else Path.home() / ".aragora" / "sessions"
+        )
+        self._state_dir.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def state_dir(self) -> Path:
+        return self._state_dir
+
+    def path_for(self, session_id: str) -> Path:
+        return self._state_dir / f"{_sanitize_session_id(session_id)}.json"
+
+    def save(self, state: SessionState) -> Path:
+        state.touch()
+        destination = self.path_for(state.session_id)
+        tmp_path = destination.with_suffix(".json.tmp")
+        payload = json.dumps(state.to_dict(), indent=2, sort_keys=False) + "\n"
+        tmp_path.write_text(payload, encoding="utf-8")
+        tmp_path.replace(destination)
+        return destination
+
+    def load(self, session_id: str) -> SessionState | None:
+        path = self.path_for(session_id)
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("session state payload must be a JSON object")
+        return SessionState.from_dict(payload)
+
+    def list_sessions(self, *, issue_number: int | None = None) -> list[SessionState]:
+        items: list[SessionState] = []
+        issue_filter = _coerce_issue_number(issue_number)
+        for path in sorted(self._state_dir.glob("*.json")):
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(payload, dict):
+                    continue
+                state = SessionState.from_dict(payload)
+            except (OSError, json.JSONDecodeError, TypeError, ValueError):
+                continue
+            if issue_filter is not None and state.issue_number != issue_filter:
+                continue
+            items.append(state)
+        items.sort(
+            key=lambda state: (state.updated_at, state.created_at, state.session_id),
+            reverse=True,
+        )
+        return items
+
+    def cleanup_old(
+        self,
+        *,
+        older_than: datetime | None = None,
+        max_age: timedelta | None = None,
+        now: datetime | None = None,
+    ) -> list[Path]:
+        reference = _coerce_datetime(now) if now is not None else _utcnow()
+        cutoff = (
+            _coerce_datetime(older_than)
+            if older_than is not None
+            else reference - (max_age or timedelta(days=7))
+        )
+        removed: list[Path] = []
+        for state in self.list_sessions():
+            if state.updated_at >= cutoff:
+                continue
+            path = self.path_for(state.session_id)
+            if path.exists():
+                path.unlink()
+                removed.append(path)
+        return removed

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from aragora.swarm.session_state import SessionState, SessionStateStore
+
+
+def _dt(text: str) -> datetime:
+    return datetime.fromisoformat(text).astimezone(timezone.utc)
+
+
+def test_session_state_roundtrip_serialization() -> None:
+    created_at = _dt("2026-04-13T09:30:00+00:00")
+    updated_at = _dt("2026-04-13T10:00:00+00:00")
+    state = SessionState(
+        session_id="bc01-repair-session",
+        status="needs_human",
+        issue_number=5247,
+        target_agent="codex",
+        runner_type="codex",
+        worktree_path="/tmp/aragora-bc01",
+        branch_name="codex/bc01-session-state",
+        pr_url="https://github.com/synaptent/aragora/pull/9999",
+        resume_hint="resume after review",
+        retry_count=2,
+        metadata={"receipt_id": "rcpt-123", "phase": "skeleton"},
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+    restored = SessionState.from_dict(state.to_dict())
+
+    assert restored.to_dict() == state.to_dict()
+
+
+def test_session_state_store_save_and_load(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+    state = SessionState(
+        session_id="save-load",
+        issue_number=6001,
+        target_agent="codex",
+        worktree_path="/tmp/worktree",
+    )
+
+    saved = store.save(state)
+    loaded = store.load("save-load")
+
+    assert saved == tmp_path / "save-load.json"
+    assert loaded is not None
+    assert loaded.session_id == "save-load"
+    assert loaded.issue_number == 6001
+    assert loaded.target_agent == "codex"
+
+
+def test_session_state_store_lists_by_issue_number(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+    older = SessionState(
+        session_id="older",
+        issue_number=7001,
+        updated_at=_dt("2026-04-13T08:00:00+00:00"),
+    )
+    newer = SessionState(
+        session_id="newer",
+        issue_number=7001,
+        updated_at=_dt("2026-04-13T09:00:00+00:00"),
+    )
+    other = SessionState(
+        session_id="other",
+        issue_number=7002,
+        updated_at=_dt("2026-04-13T10:00:00+00:00"),
+    )
+
+    store.save(older)
+    store.save(newer)
+    store.save(other)
+
+    items = store.list_sessions(issue_number=7001)
+
+    assert [item.session_id for item in items] == ["newer", "older"]
+
+
+def test_session_state_store_cleanup_old_removes_stale_files(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+    stale = SessionState(
+        session_id="stale",
+        updated_at=_dt("2026-04-10T10:00:00+00:00"),
+    )
+    fresh = SessionState(
+        session_id="fresh",
+        updated_at=_dt("2026-04-13T10:00:00+00:00"),
+    )
+
+    stale_path = store.save(stale)
+    fresh_path = store.save(fresh)
+    stale.updated_at = _dt("2026-04-10T10:00:00+00:00")
+    fresh.updated_at = _dt("2026-04-13T10:00:00+00:00")
+    stale_path.write_text(json.dumps(stale.to_dict(), indent=2) + "\n", encoding="utf-8")
+    fresh_path.write_text(json.dumps(fresh.to_dict(), indent=2) + "\n", encoding="utf-8")
+    removed = store.cleanup_old(
+        older_than=_dt("2026-04-12T00:00:00+00:00"),
+        now=_dt("2026-04-13T12:00:00+00:00"),
+    )
+
+    assert removed == [stale_path]
+    assert not stale_path.exists()
+    assert fresh_path.exists()
+
+
+def test_session_state_store_load_missing_file_returns_none(tmp_path: Path) -> None:
+    store = SessionStateStore(state_dir=tmp_path)
+
+    assert store.load("missing-session") is None
+
+
+def test_session_state_store_default_path_uses_home(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    store = SessionStateStore()
+
+    assert store.state_dir == tmp_path / ".aragora" / "sessions"


### PR DESCRIPTION
## Summary
- add a small `SessionState` dataclass for durable local swarm session metadata
- add a JSON-backed `SessionStateStore` under `~/.aragora/sessions` with save/load/list/cleanup
- add focused BC-01 tests for serialization, persistence, filtering, cleanup, and missing files

## Validation
- `pytest tests/swarm/test_session_state.py -q`
- `ruff check aragora/swarm/session_state.py tests/swarm/test_session_state.py`
- `python3 -m mypy --ignore-missing-imports --follow-imports=skip --show-error-codes aragora/swarm/session_state.py`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`