### PR TITLE
feat: continue roadmap with BC-02/03, status CLI, docs, and ratchet

### DIFF
--- a/aragora/cli/commands/swarm.py
+++ b/aragora/cli/commands/swarm.py
@@ -3082,6 +3082,7 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                 print(render_boss_text(payload))
             return
     if action == "status":
+        from aragora.cli.commands.swarm_status import load_operator_status, render_operator_status
         from aragora.swarm.session_coordinator import read_directives as coord_read
 
         repo_root = resolve_repo_root(Path.cwd())
@@ -3106,6 +3107,11 @@ def cmd_swarm(args: argparse.Namespace) -> None:
         payload["coordination_view"] = coord_read(
             repo_root,
             findings_limit=max(1, int(getattr(args, "findings_limit", 10))),
+        )
+        payload["operator_status"] = load_operator_status(
+            repo_root,
+            limit=10,
+            boss_repo=_optional_text(getattr(args, "boss_repo", None)),
         )
         if as_json:
             print(json.dumps(payload, indent=2))
@@ -3139,6 +3145,8 @@ def cmd_swarm(args: argparse.Namespace) -> None:
                     _print_supervisor_run(run)
             print("---")
             _render_coordination_view(payload["coordination_view"])
+            print("---")
+            print(render_operator_status(payload["operator_status"]))
         return
 
     if action == "reconcile":

--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from aragora.swarm.terminal_truth import TerminalClass, classify_from_metrics
+
+DEFAULT_METRICS_PATH = Path(".aragora") / "overnight" / "boss_metrics.jsonl"
+_SANITIZER_REJECTION_OUTCOMES = frozenset({"dropped", "quarantined"})
+
+
+def _optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: object) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_elapsed_seconds(value: object) -> str:
+    elapsed = _optional_float(value)
+    if elapsed is None:
+        return "-"
+    if elapsed < 60:
+        return f"{elapsed:.1f}s"
+    minutes = int(elapsed // 60)
+    seconds = int(elapsed % 60)
+    return f"{minutes}m {seconds}s"
+
+
+def _load_metrics_rows(metrics_path: Path) -> list[dict[str, Any]]:
+    if not metrics_path.exists():
+        return []
+    rows: list[dict[str, Any]] = []
+    with metrics_path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(payload, dict):
+                rows.append(payload)
+    return rows
+
+
+def _resolve_terminal_class(row: dict[str, Any]) -> str:
+    existing = _optional_text(row.get("terminal_class"))
+    if existing:
+        return existing
+    try:
+        return classify_from_metrics(row).value
+    except Exception:
+        return TerminalClass.RESCUE_NO_DELIVERABLE.value
+
+
+def _infer_repo_name(repo_root: Path) -> str | None:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "remote", "get-url", "origin"],
+            text=True,
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        return None
+    remote = (proc.stdout or "").strip()
+    if remote.startswith("git@github.com:"):
+        return remote.removeprefix("git@github.com:").removesuffix(".git")
+    marker = "github.com/"
+    if marker in remote:
+        return remote.split(marker, 1)[1].removesuffix(".git")
+    return None
+
+
+def _boss_ready_queue_depth(repo_root: Path, *, boss_repo: str | None = None) -> int | None:
+    gh = shutil.which("gh")
+    repo = _optional_text(boss_repo) or _infer_repo_name(repo_root)
+    if not gh or not repo:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                gh,
+                "issue",
+                "list",
+                "--repo",
+                repo,
+                "--label",
+                "boss-ready",
+                "--state",
+                "open",
+                "--limit",
+                "500",
+                "--json",
+                "number",
+            ],
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads(proc.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    return len(payload) if isinstance(payload, list) else None
+
+
+def load_operator_status(
+    repo_root: Path,
+    *,
+    limit: int = 10,
+    boss_repo: str | None = None,
+    metrics_path: Path | None = None,
+) -> dict[str, Any]:
+    metrics_file = metrics_path or (repo_root / DEFAULT_METRICS_PATH)
+    rows = _load_metrics_rows(metrics_file)
+    queue_depth = _boss_ready_queue_depth(repo_root, boss_repo=boss_repo)
+
+    attempted_issues = {
+        issue_number
+        for row in rows
+        if (issue_number := _optional_int(row.get("issue_number"))) is not None
+    }
+    completed_issues = {
+        issue_number
+        for row in rows
+        if (issue_number := _optional_int(row.get("issue_number"))) is not None
+        and _optional_text(row.get("worker_status")) == "completed"
+    }
+    deferred_publish_count = sum(
+        1
+        for row in rows
+        if "deferred" in str(row.get("publish_action") or "").lower()
+        or _resolve_terminal_class(row) == TerminalClass.RESCUE_PUBLISH_DEFERRED.value
+    )
+    sanitizer_rejection_count = sum(
+        1
+        for row in rows
+        if _optional_text(row.get("sanitizer_outcome")) in _SANITIZER_REJECTION_OUTCOMES
+    )
+    rejection_rate = sanitizer_rejection_count / len(rows) if rows else 0.0
+
+    per_issue: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        issue_number = _optional_int(row.get("issue_number"))
+        if issue_number is None:
+            continue
+        bucket = per_issue.setdefault(
+            issue_number,
+            {
+                "issue_number": issue_number,
+                "attempts": 0,
+                "completed_iterations": 0,
+            },
+        )
+        bucket["attempts"] += 1
+        if _optional_text(row.get("worker_status")) == "completed":
+            bucket["completed_iterations"] += 1
+
+    per_issue_success = []
+    for item in per_issue.values():
+        attempts = int(item["attempts"])
+        completed_iterations = int(item["completed_iterations"])
+        item["success_rate"] = round(completed_iterations / attempts, 4) if attempts else 0.0
+        per_issue_success.append(item)
+    per_issue_success.sort(
+        key=lambda item: (-float(item["success_rate"]), int(item["issue_number"]))
+    )
+
+    last_iterations = []
+    for row in rows[-max(1, int(limit)) :]:
+        last_iterations.append(
+            {
+                "iteration": _optional_int(row.get("iteration")),
+                "issue_number": _optional_int(row.get("issue_number")),
+                "terminal_class": _resolve_terminal_class(row),
+                "elapsed_seconds": _optional_float(row.get("elapsed_seconds")),
+                "worker_status": _optional_text(row.get("worker_status")) or "unknown",
+            }
+        )
+
+    return {
+        "available": metrics_file.exists(),
+        "metrics_path": str(metrics_file),
+        "summary": {
+            "unique_issues_attempted": len(attempted_issues),
+            "unique_issues_completed": len(completed_issues),
+            "sanitizer_rejection_rate": round(rejection_rate, 4),
+            "sanitizer_rejection_count": sanitizer_rejection_count,
+            "deferred_publish_count": deferred_publish_count,
+            "queue_depth": queue_depth if queue_depth is not None else "unknown",
+        },
+        "last_iterations": last_iterations,
+        "per_issue_success": per_issue_success,
+    }
+
+
+def render_operator_status(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary", {}) if isinstance(payload.get("summary"), dict) else {}
+    lines = [
+        "operator attempted={attempted} completed={completed} sanitizer_rejection_rate={rate:.1%} "
+        "deferred_publish={deferred} queue_depth={queue_depth}".format(
+            attempted=summary.get("unique_issues_attempted", 0),
+            completed=summary.get("unique_issues_completed", 0),
+            rate=float(summary.get("sanitizer_rejection_rate", 0.0) or 0.0),
+            deferred=summary.get("deferred_publish_count", 0),
+            queue_depth=summary.get("queue_depth", "unknown"),
+        )
+    ]
+
+    iterations = [item for item in payload.get("last_iterations", []) if isinstance(item, dict)]
+    if iterations:
+        lines.append("recent iterations:")
+        for item in iterations[-10:]:
+            issue_text = item.get("issue_number")
+            lines.append(
+                "  #{issue} {terminal} elapsed={elapsed} status={status}".format(
+                    issue=issue_text if issue_text not in (None, "") else "-",
+                    terminal=item.get("terminal_class", "unknown"),
+                    elapsed=_format_elapsed_seconds(item.get("elapsed_seconds")),
+                    status=item.get("worker_status", "unknown"),
+                )
+            )
+
+    per_issue_success = [
+        item for item in payload.get("per_issue_success", []) if isinstance(item, dict)
+    ]
+    if per_issue_success:
+        lines.append("per-issue success:")
+        for item in per_issue_success[:10]:
+            lines.append(
+                "  #{issue} {completed}/{attempts} ({rate:.0%})".format(
+                    issue=item.get("issue_number", "-"),
+                    completed=item.get("completed_iterations", 0),
+                    attempts=item.get("attempts", 0),
+                    rate=float(item.get("success_rate", 0.0) or 0.0),
+                )
+            )
+
+    return "\n".join(lines)

--- a/aragora/cli/commands/swarm_status.py
+++ b/aragora/cli/commands/swarm_status.py
@@ -20,18 +20,32 @@ def _optional_text(value: object) -> str | None:
 def _optional_int(value: object) -> int | None:
     if value is None or value == "":
         return None
-    try:
+    if isinstance(value, bool):
         return int(value)
-    except (TypeError, ValueError):
+    if isinstance(value, int):
+        return value
+    text = _optional_text(value)
+    if text is None:
+        return None
+    try:
+        return int(text)
+    except ValueError:
         return None
 
 
 def _optional_float(value: object) -> float | None:
     if value is None or value == "":
         return None
-    try:
+    if isinstance(value, bool):
         return float(value)
-    except (TypeError, ValueError):
+    if isinstance(value, int | float):
+        return float(value)
+    text = _optional_text(value)
+    if text is None:
+        return None
+    try:
+        return float(text)
+    except ValueError:
         return None
 
 

--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -19,6 +19,10 @@ def _optional_text(value: Any) -> str | None:
     return text or None
 
 
+def _coerce_phase(value: Any) -> str:
+    return str(value or "").strip() or "explore"
+
+
 def _coerce_datetime(value: Any) -> datetime:
     if isinstance(value, datetime):
         return (
@@ -50,11 +54,28 @@ def _sanitize_session_id(session_id: str) -> str:
     return cleaned
 
 
+def _coerce_dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    items: list[dict[str, Any]] = []
+    for item in value:
+        if isinstance(item, Mapping):
+            items.append(dict(item))
+    return items
+
+
+def _coerce_path_list(value: Any) -> list[str]:
+    if not isinstance(value, (list, tuple, set)):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
 @dataclass(slots=True)
 class SessionState:
     """Durable local session metadata for future retry/repair orchestration."""
 
     session_id: str
+    phase: str = "explore"
     status: str = "created"
     issue_number: int | None = None
     target_agent: str | None = None
@@ -64,12 +85,15 @@ class SessionState:
     pr_url: str | None = None
     resume_hint: str | None = None
     retry_count: int = 0
+    attempts: list[dict[str, Any]] = field(default_factory=list)
+    repair_journal: list[dict[str, Any]] = field(default_factory=list)
     metadata: dict[str, Any] = field(default_factory=dict)
     created_at: datetime = field(default_factory=_utcnow)
     updated_at: datetime = field(default_factory=_utcnow)
 
     def __post_init__(self) -> None:
         self.session_id = _sanitize_session_id(self.session_id)
+        self.phase = _coerce_phase(self.phase)
         self.status = str(self.status or "created").strip() or "created"
         self.issue_number = _coerce_issue_number(self.issue_number)
         self.target_agent = _optional_text(self.target_agent)
@@ -79,6 +103,8 @@ class SessionState:
         self.pr_url = _optional_text(self.pr_url)
         self.resume_hint = _optional_text(self.resume_hint)
         self.retry_count = max(0, int(self.retry_count or 0))
+        self.attempts = _coerce_dict_list(self.attempts)
+        self.repair_journal = _coerce_dict_list(self.repair_journal)
         self.created_at = _coerce_datetime(self.created_at)
         self.updated_at = _coerce_datetime(self.updated_at)
         self.metadata = dict(self.metadata or {})
@@ -89,6 +115,7 @@ class SessionState:
     def to_dict(self) -> dict[str, Any]:
         return {
             "session_id": self.session_id,
+            "phase": self.phase,
             "status": self.status,
             "issue_number": self.issue_number,
             "target_agent": self.target_agent,
@@ -98,6 +125,8 @@ class SessionState:
             "pr_url": self.pr_url,
             "resume_hint": self.resume_hint,
             "retry_count": self.retry_count,
+            "attempts": [dict(item) for item in self.attempts],
+            "repair_journal": [dict(item) for item in self.repair_journal],
             "metadata": dict(self.metadata),
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
@@ -108,6 +137,7 @@ class SessionState:
         data = dict(payload or {})
         return cls(
             session_id=str(data.get("session_id", "")).strip(),
+            phase=data.get("phase", "explore"),
             status=data.get("status", "created"),
             issue_number=data.get("issue_number"),
             target_agent=data.get("target_agent"),
@@ -117,10 +147,80 @@ class SessionState:
             pr_url=data.get("pr_url"),
             resume_hint=data.get("resume_hint"),
             retry_count=data.get("retry_count", 0),
+            attempts=_coerce_dict_list(data.get("attempts")),
+            repair_journal=_coerce_dict_list(data.get("repair_journal")),
             metadata=dict(data.get("metadata") or {}),
             created_at=_coerce_datetime(data.get("created_at")),
             updated_at=_coerce_datetime(data.get("updated_at")),
         )
+
+    def record_attempt(
+        self,
+        exit_code: int | None,
+        changed_files: list[str] | tuple[str, ...] | set[str] | None,
+        test_output: str | None,
+        worker_outcome: str | None,
+    ) -> dict[str, Any]:
+        attempt = {
+            "at": _utcnow().isoformat(),
+            "exit_code": int(exit_code) if exit_code is not None else None,
+            "changed_files": _coerce_path_list(changed_files),
+            "test_output": _optional_text(test_output),
+            "worker_outcome": _optional_text(worker_outcome),
+        }
+        self.attempts.append(attempt)
+        self.retry_count = max(self.retry_count, len(self.attempts))
+        self.touch()
+        return dict(attempt)
+
+    def last_attempt(self) -> dict[str, Any] | None:
+        if not self.attempts:
+            return None
+        return dict(self.attempts[-1])
+
+    def should_resume(self) -> bool:
+        last = self.last_attempt()
+        if last is not None:
+            if last.get("changed_files"):
+                return True
+            if _optional_text(last.get("test_output")):
+                return True
+            if _optional_text(last.get("worker_outcome")) not in {None, "completed"}:
+                return True
+        return bool(self.repair_journal) or self.phase not in {"explore", "plan"}
+
+    def resume_context(self) -> str:
+        if not self.should_resume():
+            return ""
+
+        lines = [f"Resume from phase: {self.phase}"]
+        if self.resume_hint:
+            lines.append(f"Resume hint: {self.resume_hint}")
+
+        if self.attempts:
+            lines.append("Prior attempts:")
+            for index, attempt in enumerate(
+                self.attempts[-3:], start=max(1, len(self.attempts) - 2)
+            ):
+                summary: list[str] = []
+                exit_code = attempt.get("exit_code")
+                if exit_code is not None:
+                    summary.append(f"exit={exit_code}")
+                worker_outcome = _optional_text(attempt.get("worker_outcome"))
+                if worker_outcome:
+                    summary.append(worker_outcome)
+                changed = _coerce_path_list(attempt.get("changed_files"))
+                if changed:
+                    summary.append(f"changed={', '.join(changed[:5])}")
+                lines.append(f"- Attempt {index}: {', '.join(summary) if summary else 'recorded'}")
+                test_output = _optional_text(attempt.get("test_output"))
+                if test_output:
+                    lines.append(f"  Test output: {test_output[-240:]}")
+
+        if self.repair_journal:
+            lines.append(f"Repair journal entries available: {len(self.repair_journal)}")
+
+        return "\n".join(lines).strip()
 
 
 class SessionStateStore:

--- a/aragora/swarm/session_state.py
+++ b/aragora/swarm/session_state.py
@@ -8,6 +8,17 @@ from pathlib import Path
 from typing import Any, Mapping
 
 _SESSION_ID_PATTERN = re.compile(r"[^A-Za-z0-9._-]+")
+_IMPORT_ERROR_RE = re.compile(r"\b(module(notfounderror)?|importerror|cannot import name)\b", re.I)
+_DEPENDENCY_MISSING_RE = re.compile(
+    r"(command not found|executable file not found|not installed|missing dependency|no such file or directory)",
+    re.I,
+)
+_TIMEOUT_RE = re.compile(r"\b(time[ -]?out|timed out)\b", re.I)
+_SCOPE_TOO_BROAD_RE = re.compile(
+    r"(scope too broad|too broad|outside file scope|file scope spans|task sanitizer|quarantined)",
+    re.I,
+)
+_TEST_FAILURE_RE = re.compile(r"(assertionerror|\bfailed\b|\btraceback\b|\bpytest\b)", re.I)
 
 
 def _utcnow() -> datetime:
@@ -84,6 +95,7 @@ class SessionState:
     branch_name: str | None = None
     pr_url: str | None = None
     resume_hint: str | None = None
+    blocker_evidence: str | None = None
     retry_count: int = 0
     attempts: list[dict[str, Any]] = field(default_factory=list)
     repair_journal: list[dict[str, Any]] = field(default_factory=list)
@@ -102,6 +114,7 @@ class SessionState:
         self.branch_name = _optional_text(self.branch_name)
         self.pr_url = _optional_text(self.pr_url)
         self.resume_hint = _optional_text(self.resume_hint)
+        self.blocker_evidence = _optional_text(self.blocker_evidence)
         self.retry_count = max(0, int(self.retry_count or 0))
         self.attempts = _coerce_dict_list(self.attempts)
         self.repair_journal = _coerce_dict_list(self.repair_journal)
@@ -124,6 +137,7 @@ class SessionState:
             "branch_name": self.branch_name,
             "pr_url": self.pr_url,
             "resume_hint": self.resume_hint,
+            "blocker_evidence": self.blocker_evidence,
             "retry_count": self.retry_count,
             "attempts": [dict(item) for item in self.attempts],
             "repair_journal": [dict(item) for item in self.repair_journal],
@@ -146,6 +160,7 @@ class SessionState:
             branch_name=data.get("branch_name"),
             pr_url=data.get("pr_url"),
             resume_hint=data.get("resume_hint"),
+            blocker_evidence=data.get("blocker_evidence"),
             retry_count=data.get("retry_count", 0),
             attempts=_coerce_dict_list(data.get("attempts")),
             repair_journal=_coerce_dict_list(data.get("repair_journal")),
@@ -221,6 +236,14 @@ class SessionState:
             lines.append(f"Repair journal entries available: {len(self.repair_journal)}")
 
         return "\n".join(lines).strip()
+
+    def set_blocker(self, evidence: str) -> None:
+        self.blocker_evidence = _optional_text(evidence)
+        self.touch()
+
+    def clear_blocker(self) -> None:
+        self.blocker_evidence = None
+        self.touch()
 
 
 class SessionStateStore:
@@ -301,3 +324,59 @@ class SessionStateStore:
                 path.unlink()
                 removed.append(path)
         return removed
+
+
+def _attempt_evidence(state: SessionState) -> list[tuple[dict[str, Any], str]]:
+    evidence: list[tuple[dict[str, Any], str]] = []
+    for attempt in reversed(state.attempts):
+        text_parts = [
+            str(attempt.get("worker_outcome") or "").strip(),
+            str(attempt.get("test_output") or "").strip(),
+        ]
+        combined = "\n".join(part for part in text_parts if part).strip()
+        evidence.append((attempt, combined))
+    if state.blocker_evidence:
+        evidence.append(({}, state.blocker_evidence))
+    return evidence
+
+
+def _suggested_action(blocker_type: str) -> str:
+    actions = {
+        "test_failure": "Run the failing validation locally, fix the assertion or regression, and retry.",
+        "import_error": "Repair the import/module path, then rerun the targeted validation command.",
+        "timeout": "Narrow the validation scope or add progress checkpoints before retrying.",
+        "scope_too_broad": "Split the task into a smaller bounded write scope before another retry.",
+        "dependency_missing": "Install or provision the missing dependency or command before retrying.",
+    }
+    return actions[blocker_type]
+
+
+def classify_session_blocker(state: SessionState) -> dict[str, str]:
+    evidence_rows = _attempt_evidence(state)
+    for attempt, text in evidence_rows:
+        normalized = text.strip()
+        exit_code = attempt.get("exit_code")
+        if exit_code in {-1, 124, 137} or _TIMEOUT_RE.search(normalized):
+            blocker_type = "timeout"
+        elif _IMPORT_ERROR_RE.search(normalized):
+            blocker_type = "import_error"
+        elif _DEPENDENCY_MISSING_RE.search(normalized):
+            blocker_type = "dependency_missing"
+        elif _SCOPE_TOO_BROAD_RE.search(normalized):
+            blocker_type = "scope_too_broad"
+        elif _TEST_FAILURE_RE.search(normalized):
+            blocker_type = "test_failure"
+        else:
+            continue
+        return {
+            "blocker_type": blocker_type,
+            "evidence": normalized or "session contains blocker evidence",
+            "suggested_action": _suggested_action(blocker_type),
+        }
+
+    fallback = state.blocker_evidence or "Latest retry failed without structured blocker evidence."
+    return {
+        "blocker_type": "test_failure",
+        "evidence": fallback,
+        "suggested_action": _suggested_action("test_failure"),
+    }

--- a/aragora/swarm/worker_launcher.py
+++ b/aragora/swarm/worker_launcher.py
@@ -28,6 +28,7 @@ from aragora.security.capability_gate import (
     ensure_capability_approval_id,
 )
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.session_state import SessionState
 from aragora.swarm.worker_contract import build_worker_contract
 from aragora.swarm.worker_process import (
     DEFAULT_VERIFICATION_TIMEOUT_SECONDS,
@@ -1037,6 +1038,18 @@ class WorkerLauncher:
         return "\n".join(lines).strip()
 
     @staticmethod
+    def _format_session_resume_context(value: Any) -> str:
+        if isinstance(value, SessionState):
+            return value.resume_context()
+        if not isinstance(value, dict):
+            return ""
+        try:
+            state = SessionState.from_dict(value)
+        except ValueError:
+            return ""
+        return state.resume_context()
+
+    @staticmethod
     def _build_prompt(work_order: dict[str, Any]) -> str:
         """Build the task prompt from a work order dict.
 
@@ -1061,6 +1074,12 @@ class WorkerLauncher:
         repair_notes = WorkerLauncher._format_repair_journal(metadata.get("repair_journal"))
         if repair_notes:
             parts.append("## What was tried before (and why it failed)\n\n" + repair_notes)
+
+        resume_context = WorkerLauncher._format_session_resume_context(
+            metadata.get("session_state") or work_order.get("session_state")
+        )
+        if resume_context:
+            parts.append("## Resume context\n\n" + resume_context)
 
         # --- Section 3: Code context (the bulk of the prompt) ---
         enriched_context = work_order.get("_enriched_context", "")

--- a/docs/status/ACTIVE_EXECUTION_ISSUES.md
+++ b/docs/status/ACTIVE_EXECUTION_ISSUES.md
@@ -1,6 +1,6 @@
 # Active Execution Issues
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This document is the canonical epic, milestone, and execution-issue tree for the current roadmap tranche.
 
@@ -36,25 +36,27 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 | **B3 — Repair** | Productize retry, salvage, quarantine, and session reuse | `BC-01..03`, `RS-10..11` |
 | **B4 — Multi** | Extend proven loops across hosts with truthful state | `BC-07..12`, `UDW-01..03` |
 
+Status note: B0 is above target at 86.7% no-rescue success on the tracked cohort as of 2026-04-13. The remaining gate is production guard proof, not inflating the benchmark story.
+
 ## Epic 1 — Reliability Substrate
 
 **Outcome:** make bounded unattended execution trustworthy on real multi-host backlogs.
 
 ### Milestone 1.1 — Failure Taxonomy & Benchmark Corpus `[30d]`
 
-- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures
-- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts
-- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI
+- [x] **RS-01** Define canonical terminal-truth classes for auth, publication, validation, runtime, and task-shape failures _(Done 2026-04-10)_
+- [x] **RS-02** Harvest benchmark fixtures from real `needs_human` and publication-failure receipts _(Done 2026-04-10)_
+- [x] **RS-03** Add a benchmark scoring lane and regression guardrails in CI _(Done 2026-04-11)_
 
 ### Milestone 1.2 — Worker Contracts & Credential Envelopes `[30-90d]`
 
-- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules
-- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth
-- [ ] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts
+- [x] **RS-04** Introduce persisted `WorkerContract` objects with checksum and admission rules _(Done 2026-04-11)_
+- [x] **RS-05** Introduce `CredentialEnvelope` slices for runner, git, GitHub API, provider, and verification auth _(Done 2026-04-12)_
+- [x] **RS-06** Require launcher, supervisor, and tranche queue to dispatch only from complete contracts _(Done 2026-04-13)_
 
 ### Milestone 1.3 — Contract-Aware Preflight `[30-90d]`
 
-- [ ] **RS-07** Build `aragora swarm preflight run --contract ...`
+- [ ] **RS-07** Build `aragora swarm preflight run --contract ...` _(Partial as of 2026-04-13: module preflight plus scratch/draft-PR validation exist, but the top-level operator surface is still incomplete)_
 - [ ] **RS-08** Validate scratch read/write/commit/push/draft-PR flow through the production code path
 - [ ] **RS-09** Replace shell-only host checks with receipt-backed preflight wrappers
 
@@ -76,8 +78,8 @@ This is the near-term sequencing layer across the full task tree. Do not treat a
 
 ### Milestone 2.2 — Task Sanitizer & Admission Gate `[30-90d]`
 
-- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined
-- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch
+- [x] **BC-04** Add sanitizer outcomes: accepted, rewritten, dropped, quarantined _(Done 2026-04-12)_
+- [x] **BC-05** Detect truncated, contradictory, or impossible tasks before dispatch _(Done 2026-04-13)_
 - [ ] **BC-06** Preserve original versus sanitized task text for audit
 
 ### Milestone 2.3 — Truthful Lane / Integrator State `[90d]`

--- a/docs/status/NEXT_STEPS_CANONICAL.md
+++ b/docs/status/NEXT_STEPS_CANONICAL.md
@@ -1,6 +1,6 @@
 # Next Steps (Canonical)
 
-Last updated: 2026-04-12
+Last updated: 2026-04-13
 
 This is the single source of truth for short-horizon execution priorities.
 [CANONICAL_GOALS](../CANONICAL_GOALS.md) defines what Aragora is and why.
@@ -10,7 +10,7 @@ This is the single source of truth for short-horizon execution priorities.
 
 ## Current Gate
 
-The current gate is the transition from early `Teammate` behavior to reliable `Foreman` behavior across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
+The current gate is to finish `RS-08/09` and `BC-01..03`, then prove the `B2` guard on the safest execution classes across the current execution epics [#804](https://github.com/synaptent/aragora/issues/804), [#805](https://github.com/synaptent/aragora/issues/805), and [#806](https://github.com/synaptent/aragora/issues/806).
 
 What is already true:
 
@@ -19,15 +19,16 @@ What is already true:
 - bounded product wedges such as prompt-to-spec and inbox workflows exist
 - the approved reliability substrate spec identifies the missing layer clearly
 - terminal-truth taxonomy, benchmark fixtures, and the benchmark scoring lane are now on `main`
+- the 30-day B0 target is already exceeded on the tracked cohort at **86.7%** no-rescue success
 - `WorkerContract` and `CredentialEnvelope` primitives exist on the live swarm path
-- launcher-side contract admission and module-level contract-aware preflight are on `main`
+- launcher-side contract admission, dispatch gating, and module-level contract-aware preflight are on `main`
 - task sanitizer outcomes and success-rate filtering are shaping safer boss-loop intake
 
 What is still missing:
 
-- honest benchmarked proof of semi-autonomous success
-- contract-backed worker admission across launcher, supervisor, and tranche queue on the safest classes of work
-- top-level production-equivalent preflight on those classes
+- production-equivalent preflight through the operator surface on the safest classes
+- resumable session state, retry context, and precise blocker evidence on the live swarm loop
+- proof that the B2 guard holds under repeated bounded runs instead of one-off success stories
 - broader repair-loop coverage and persisted original-versus-sanitized task audit
 - lower-rescue unattended operation on bounded backlogs
 
@@ -42,13 +43,15 @@ The 30-day target is intentionally narrow:
 - **100%** of failures land in truthful canonical buckets
 - repeated rescue classes become explicit product work
 
+Current status: the tracked B0 cohort is running at **86.7%** no-rescue success as of 2026-04-13. The benchmark target is no longer the blocker; truthful guard completion is.
+
 If a task does not improve that metric, it is not first-tranche work.
 
 ## Reverse-Staged Rocket Bootstrap
 
 ### Booster 0 — Corpus
 
-Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This is the smallest booster and the only one that must clearly work in the first 30 days.
+Build the fixed benchmark corpus, enrich worker context, and record rescues honestly. This booster is already above target, so the remaining work is to keep it truthful while the guard layers catch up.
 
 ### Booster 1 — Assist
 

--- a/scripts/report_code_quality.py
+++ b/scripts/report_code_quality.py
@@ -45,6 +45,13 @@ RATCHET = {
     "max_noqa": 2800,  # Total across aragora/
 }
 
+LAST_RECORDED_BASELINE = {
+    "date": "2026-04-12",
+    "global_suppressions": {
+        "except_exception": 770,
+    },
+}
+
 _SUPPRESSION_PATTERNS = {
     "except_exception": re.compile(r"except\s+Exception\b"),
     "type_ignore": re.compile(r"#\s*type:\s*ignore"),
@@ -199,16 +206,38 @@ def check_ratchet(global_suppressions: dict[str, int], subsystems: list[dict]) -
     return violations
 
 
+def build_comparison(global_suppressions: dict[str, int]) -> dict[str, object]:
+    baseline = dict(LAST_RECORDED_BASELINE)
+    compared: dict[str, dict[str, int]] = {}
+    for key, baseline_value in dict(baseline.get("global_suppressions", {})).items():
+        current_value = int(global_suppressions.get(key, 0) or 0)
+        compared[key] = {
+            "baseline": int(baseline_value),
+            "current": current_value,
+            "delta": current_value - int(baseline_value),
+        }
+    return {
+        "baseline_date": str(baseline.get("date", "")).strip() or None,
+        "global_suppressions": compared,
+    }
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Report codebase quality metrics")
     parser.add_argument("--json", action="store_true", help="JSON output")
     parser.add_argument("--check", action="store_true", help="Exit 1 if ratchet violated")
+    parser.add_argument(
+        "--compare",
+        action="store_true",
+        help="Show deltas versus the last recorded suppression baseline",
+    )
     args = parser.parse_args()
 
     subsystems = [scan_subsystem(name, path) for name, path in SUBSYSTEMS.items()]
     global_suppressions = scan_all_aragora()
     boss_metrics = scan_boss_metrics()
     violations = check_ratchet(global_suppressions, subsystems)
+    comparison = build_comparison(global_suppressions) if args.compare else None
 
     report = {
         "subsystems": subsystems,
@@ -217,6 +246,8 @@ def main() -> None:
         "ratchet_thresholds": RATCHET,
         "ratchet_violations": violations,
     }
+    if comparison is not None:
+        report["baseline_comparison"] = comparison
 
     if args.json:
         print(json.dumps(report, indent=2))
@@ -244,6 +275,25 @@ def main() -> None:
             print(f"  Issues completed: {boss_metrics['issues_completed']}")
             print(f"  Per-issue success rate: {boss_metrics['per_issue_success_rate']:.1%}")
             print(f"  Meets B0 target (>=50%): {boss_metrics['meets_b0_target']}")
+
+        if comparison is not None:
+            print(
+                "\nBaseline Comparison:"
+                f"\n  baseline_date: {comparison.get('baseline_date') or 'unknown'}"
+            )
+            compared = comparison.get("global_suppressions", {})
+            if isinstance(compared, dict):
+                for name, values in sorted(compared.items()):
+                    if not isinstance(values, dict):
+                        continue
+                    print(
+                        "  {name:20s} baseline={baseline:4d} current={current:4d} delta={delta:+d}".format(
+                            name=name,
+                            baseline=int(values.get("baseline", 0) or 0),
+                            current=int(values.get("current", 0) or 0),
+                            delta=int(values.get("delta", 0) or 0),
+                        )
+                    )
 
         if violations:
             print(f"\nRatchet Violations ({len(violations)}):")

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from aragora.cli.commands.swarm import cmd_swarm
+from aragora.cli.commands.swarm_status import load_operator_status, render_operator_status
+
+
+def _write_metrics(metrics_path: Path, rows: list[dict[str, object]]) -> None:
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _swarm_status_args(**overrides: object) -> argparse.Namespace:
+    defaults: dict[str, object] = {
+        "swarm_action_or_goal": "status",
+        "swarm_goal": None,
+        "swarm_campaign_target": None,
+        "json": False,
+        "run_id": None,
+        "status_limit": 20,
+        "findings_limit": 10,
+        "refresh_scaling": False,
+        "target_branch": "main",
+        "boss_repo": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+def test_load_operator_status_summarizes_metrics(tmp_path: Path) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(
+        metrics_path,
+        [
+            {
+                "iteration": 1,
+                "issue_number": 101,
+                "worker_status": "completed",
+                "terminal_class": "deliverable_pr_created",
+                "elapsed_seconds": 12.0,
+                "publish_action": "opened_pr",
+                "sanitizer_outcome": None,
+            },
+            {
+                "iteration": 2,
+                "issue_number": 101,
+                "worker_status": "needs_human",
+                "terminal_class": "rescue_publish_deferred",
+                "elapsed_seconds": 18.0,
+                "publish_action": "deferred_due_to_open_boss_prs",
+                "sanitizer_outcome": None,
+            },
+            {
+                "iteration": 3,
+                "issue_number": 202,
+                "worker_status": "needs_human",
+                "terminal_class": "blocked_scope_conflict",
+                "elapsed_seconds": 9.0,
+                "publish_action": None,
+                "sanitizer_outcome": "quarantined",
+            },
+        ],
+    )
+
+    with patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=7):
+        payload = load_operator_status(
+            tmp_path, boss_repo="synaptent/aragora", metrics_path=metrics_path
+        )
+
+    assert payload["summary"]["unique_issues_attempted"] == 2
+    assert payload["summary"]["unique_issues_completed"] == 1
+    assert payload["summary"]["deferred_publish_count"] == 1
+    assert payload["summary"]["sanitizer_rejection_count"] == 1
+    assert payload["summary"]["queue_depth"] == 7
+    assert payload["per_issue_success"][0]["issue_number"] == 101
+    assert payload["per_issue_success"][0]["success_rate"] == 0.5
+
+
+def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable(
+    tmp_path: Path,
+) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(metrics_path, [])
+
+    with patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=None):
+        payload = load_operator_status(tmp_path, metrics_path=metrics_path)
+
+    assert payload["summary"]["queue_depth"] == "unknown"
+
+
+def test_render_operator_status_includes_recent_iterations() -> None:
+    text = render_operator_status(
+        {
+            "summary": {
+                "unique_issues_attempted": 2,
+                "unique_issues_completed": 1,
+                "sanitizer_rejection_rate": 0.25,
+                "deferred_publish_count": 1,
+                "queue_depth": 4,
+            },
+            "last_iterations": [
+                {
+                    "issue_number": 101,
+                    "terminal_class": "deliverable_pr_created",
+                    "elapsed_seconds": 12.0,
+                    "worker_status": "completed",
+                }
+            ],
+            "per_issue_success": [
+                {
+                    "issue_number": 101,
+                    "completed_iterations": 1,
+                    "attempts": 2,
+                    "success_rate": 0.5,
+                }
+            ],
+        }
+    )
+
+    assert "operator attempted=2 completed=1" in text
+    assert "recent iterations:" in text
+    assert "#101 deliverable_pr_created" in text
+    assert "per-issue success:" in text
+
+
+def test_cmd_swarm_status_json_includes_operator_status(tmp_path: Path, capsys) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(
+        metrics_path,
+        [
+            {
+                "iteration": 1,
+                "issue_number": 101,
+                "worker_status": "completed",
+                "terminal_class": "deliverable_pr_created",
+                "elapsed_seconds": 12.0,
+                "publish_action": "opened_pr",
+                "sanitizer_outcome": None,
+            }
+        ],
+    )
+
+    with (
+        patch("aragora.worktree.fleet.resolve_repo_root", return_value=tmp_path),
+        patch("aragora.worktree.fleet.build_fleet_rows", return_value=[]),
+        patch("aragora.worktree.fleet.FleetCoordinationStore") as store_cls,
+        patch(
+            "aragora.swarm.reporter.build_integrator_view",
+            return_value={"summary": {}, "next_actions": []},
+        ),
+        patch("aragora.swarm.SwarmSupervisor") as supervisor_cls,
+        patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=5),
+    ):
+        store_cls.return_value.list_claims.return_value = []
+        store_cls.return_value.list_merge_queue.return_value = []
+        supervisor_cls.return_value.status_summary.return_value = {
+            "runs": [],
+            "counts": {
+                "runs": 0,
+                "queued_work_orders": 0,
+                "leased_work_orders": 0,
+                "completed_work_orders": 0,
+            },
+            "coordination": {"counts": {"active_leases": 0}},
+        }
+        cmd_swarm(_swarm_status_args(json=True, boss_repo="synaptent/aragora"))
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["operator_status"]["summary"]["queue_depth"] == 5
+    assert payload["operator_status"]["summary"]["unique_issues_attempted"] == 1
+
+
+def test_cmd_swarm_status_text_includes_operator_metrics(tmp_path: Path, capsys) -> None:
+    metrics_path = tmp_path / ".aragora" / "overnight" / "boss_metrics.jsonl"
+    _write_metrics(
+        metrics_path,
+        [
+            {
+                "iteration": 1,
+                "issue_number": 101,
+                "worker_status": "completed",
+                "terminal_class": "deliverable_pr_created",
+                "elapsed_seconds": 12.0,
+                "publish_action": "opened_pr",
+                "sanitizer_outcome": None,
+            }
+        ],
+    )
+
+    with (
+        patch("aragora.worktree.fleet.resolve_repo_root", return_value=tmp_path),
+        patch("aragora.worktree.fleet.build_fleet_rows", return_value=[]),
+        patch("aragora.worktree.fleet.FleetCoordinationStore") as store_cls,
+        patch(
+            "aragora.swarm.reporter.build_integrator_view",
+            return_value={
+                "summary": {
+                    "ready_lanes": 0,
+                    "review_lanes": 0,
+                    "blocked_lanes": 0,
+                    "stale_heartbeat_lanes": 0,
+                    "collision_lanes": 0,
+                    "missing_receipt_lanes": 0,
+                    "superseded_lanes": 0,
+                },
+                "next_actions": [],
+            },
+        ),
+        patch("aragora.swarm.SwarmSupervisor") as supervisor_cls,
+        patch(
+            "aragora.swarm.session_coordinator.read_directives",
+            return_value={
+                "summary": {
+                    "directive_count": 0,
+                    "session_count": 0,
+                    "claim_count": 0,
+                    "finding_count": 0,
+                },
+                "directives": [],
+                "claims": [],
+                "findings": [],
+            },
+        ),
+        patch("aragora.cli.commands.swarm_status._boss_ready_queue_depth", return_value=3),
+    ):
+        store_cls.return_value.list_claims.return_value = []
+        store_cls.return_value.list_merge_queue.return_value = []
+        supervisor_cls.return_value.status_summary.return_value = {
+            "runs": [],
+            "counts": {
+                "runs": 1,
+                "queued_work_orders": 0,
+                "leased_work_orders": 0,
+                "completed_work_orders": 1,
+            },
+            "coordination": {"counts": {"active_leases": 0}},
+        }
+        cmd_swarm(_swarm_status_args())
+
+    out = capsys.readouterr().out
+    assert "runs=1 queued=0 leased=0 completed=1" in out
+    assert "operator attempted=1 completed=1" in out
+    assert "queue_depth=3" in out

--- a/tests/cli/test_swarm_status_command.py
+++ b/tests/cli/test_swarm_status_command.py
@@ -6,7 +6,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 from aragora.cli.commands.swarm import cmd_swarm
-from aragora.cli.commands.swarm_status import load_operator_status, render_operator_status
+from aragora.cli.commands.swarm_status import (
+    _optional_float,
+    _optional_int,
+    load_operator_status,
+    render_operator_status,
+)
 
 
 def _write_metrics(metrics_path: Path, rows: list[dict[str, object]]) -> None:
@@ -81,6 +86,16 @@ def test_load_operator_status_summarizes_metrics(tmp_path: Path) -> None:
     assert payload["summary"]["queue_depth"] == 7
     assert payload["per_issue_success"][0]["issue_number"] == 101
     assert payload["per_issue_success"][0]["success_rate"] == 0.5
+
+
+def test_numeric_coercion_helpers_accept_common_object_inputs() -> None:
+    assert _optional_int(7) == 7
+    assert _optional_int("9") == 9
+    assert _optional_int(object()) is None
+
+    assert _optional_float(7) == 7.0
+    assert _optional_float("9.5") == 9.5
+    assert _optional_float(object()) is None
 
 
 def test_load_operator_status_reports_unknown_queue_depth_when_probe_unavailable(

--- a/tests/scripts/test_report_code_quality.py
+++ b/tests/scripts/test_report_code_quality.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 _scripts_dir = str(Path(__file__).resolve().parent.parent.parent / "scripts")
 if _scripts_dir not in sys.path:
@@ -54,3 +57,79 @@ def test_check_ratchet_allows_files_at_file_loc_ceiling() -> None:
     )
 
     assert violations == []
+
+
+def test_build_comparison_reports_delta_from_last_recorded_baseline() -> None:
+    comparison = report_code_quality.build_comparison(
+        {"except_exception": 768, "type_ignore": 625, "noqa": 2568}
+    )
+
+    assert comparison["baseline_date"] == "2026-04-12"
+    assert comparison["global_suppressions"]["except_exception"] == {
+        "baseline": 770,
+        "current": 768,
+        "delta": -2,
+    }
+
+
+def test_build_comparison_reports_positive_delta_when_regressed() -> None:
+    comparison = report_code_quality.build_comparison(
+        {"except_exception": 771, "type_ignore": 625, "noqa": 2568}
+    )
+
+    assert comparison["global_suppressions"]["except_exception"]["delta"] == 1
+
+
+def test_main_json_compare_includes_baseline_comparison(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["report_code_quality.py", "--json", "--compare"],
+    )
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_all_aragora",
+        lambda: {"except_exception": 768, "type_ignore": 0, "noqa": 0, "todo": 0, "fixme": 0},
+    )
+    monkeypatch.setattr(report_code_quality, "scan_boss_metrics", lambda: {"available": False})
+    monkeypatch.setattr(report_code_quality, "scan_subsystem", lambda name, path: {"name": name})
+
+    report_code_quality.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["baseline_comparison"]["baseline_date"] == "2026-04-12"
+    assert payload["baseline_comparison"]["global_suppressions"]["except_exception"]["delta"] == -2
+
+
+def test_main_text_compare_prints_baseline_section(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["report_code_quality.py", "--compare"])
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_all_aragora",
+        lambda: {"except_exception": 771, "type_ignore": 0, "noqa": 0, "todo": 0, "fixme": 0},
+    )
+    monkeypatch.setattr(report_code_quality, "scan_boss_metrics", lambda: {"available": False})
+    monkeypatch.setattr(
+        report_code_quality,
+        "scan_subsystem",
+        lambda name, path: {
+            "name": name,
+            "files": 0,
+            "loc": 0,
+            "test_ratio": 0.0,
+            "suppressions": {"except_exception": 0, "noqa": 0},
+            "top5_largest": [],
+        },
+    )
+
+    report_code_quality.main()
+
+    output = capsys.readouterr().out
+    assert "Baseline Comparison:" in output
+    assert "baseline_date: 2026-04-12" in output
+    assert "except_exception" in output
+    assert "delta=+1" in output

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -25,6 +25,17 @@ def test_session_state_roundtrip_serialization() -> None:
         pr_url="https://github.com/synaptent/aragora/pull/9999",
         resume_hint="resume after review",
         retry_count=2,
+        phase="repair",
+        attempts=[
+            {
+                "at": "2026-04-13T09:45:00+00:00",
+                "exit_code": 1,
+                "changed_files": ["aragora/swarm/session_state.py"],
+                "test_output": "AssertionError: boom",
+                "worker_outcome": "needs_human",
+            }
+        ],
+        repair_journal=[{"at": "2026-04-13T09:50:00+00:00", "note": "tighten retry path"}],
         metadata={"receipt_id": "rcpt-123", "phase": "skeleton"},
         created_at=created_at,
         updated_at=updated_at,
@@ -33,6 +44,14 @@ def test_session_state_roundtrip_serialization() -> None:
     restored = SessionState.from_dict(state.to_dict())
 
     assert restored.to_dict() == state.to_dict()
+
+
+def test_session_state_defaults_to_explore_phase() -> None:
+    state = SessionState(session_id="default-phase")
+
+    assert state.phase == "explore"
+    assert state.attempts == []
+    assert state.repair_journal == []
 
 
 def test_session_state_store_save_and_load(tmp_path: Path) -> None:
@@ -120,3 +139,66 @@ def test_session_state_store_default_path_uses_home(tmp_path: Path, monkeypatch)
     store = SessionStateStore()
 
     assert store.state_dir == tmp_path / ".aragora" / "sessions"
+
+
+def test_record_attempt_updates_retry_count_and_last_attempt() -> None:
+    state = SessionState(session_id="resume", phase="verify")
+
+    recorded = state.record_attempt(
+        1,
+        ["aragora/swarm/session_state.py", "tests/swarm/test_session_state.py"],
+        "AssertionError: expected resume context",
+        "needs_human",
+    )
+
+    assert state.retry_count == 1
+    assert recorded["changed_files"] == [
+        "aragora/swarm/session_state.py",
+        "tests/swarm/test_session_state.py",
+    ]
+    assert state.last_attempt() == recorded
+
+
+def test_should_resume_when_previous_attempt_changed_files() -> None:
+    state = SessionState(session_id="resume-files", phase="repair")
+    state.record_attempt(1, ["aragora/swarm/session_state.py"], "", "needs_human")
+
+    assert state.should_resume() is True
+
+
+def test_should_resume_when_repair_journal_exists_without_attempts() -> None:
+    state = SessionState(
+        session_id="resume-journal",
+        phase="repair",
+        repair_journal=[{"at": "2026-04-13T11:00:00+00:00", "note": "retry with narrowed scope"}],
+    )
+
+    assert state.should_resume() is True
+
+
+def test_should_not_resume_for_clean_exploration_state() -> None:
+    state = SessionState(session_id="fresh-start", phase="explore")
+
+    assert state.should_resume() is False
+    assert state.resume_context() == ""
+
+
+def test_resume_context_summarizes_prior_attempts() -> None:
+    state = SessionState(
+        session_id="resume-context",
+        phase="repair",
+        resume_hint="continue from the failing pytest lane",
+    )
+    state.record_attempt(
+        1,
+        ["aragora/swarm/session_state.py"],
+        "AssertionError: blocker evidence missing",
+        "needs_human",
+    )
+
+    text = state.resume_context()
+
+    assert "Resume from phase: repair" in text
+    assert "continue from the failing pytest lane" in text
+    assert "Attempt 1" in text
+    assert "AssertionError: blocker evidence missing" in text

--- a/tests/swarm/test_session_state.py
+++ b/tests/swarm/test_session_state.py
@@ -4,7 +4,11 @@ import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from aragora.swarm.session_state import SessionState, SessionStateStore
+from aragora.swarm.session_state import (
+    SessionState,
+    SessionStateStore,
+    classify_session_blocker,
+)
 
 
 def _dt(text: str) -> datetime:
@@ -202,3 +206,73 @@ def test_resume_context_summarizes_prior_attempts() -> None:
     assert "continue from the failing pytest lane" in text
     assert "Attempt 1" in text
     assert "AssertionError: blocker evidence missing" in text
+
+
+def test_blocker_evidence_roundtrips_through_serialization() -> None:
+    state = SessionState(
+        session_id="blocker-roundtrip", blocker_evidence="pytest timed out on lane"
+    )
+
+    restored = SessionState.from_dict(state.to_dict())
+
+    assert restored.blocker_evidence == "pytest timed out on lane"
+
+
+def test_set_blocker_and_clear_blocker() -> None:
+    state = SessionState(session_id="set-blocker")
+
+    state.set_blocker("ModuleNotFoundError: missing helper")
+    assert state.blocker_evidence == "ModuleNotFoundError: missing helper"
+
+    state.clear_blocker()
+    assert state.blocker_evidence is None
+
+
+def test_classify_session_blocker_import_error() -> None:
+    state = SessionState(session_id="import-blocker")
+    state.record_attempt(1, [], "ModuleNotFoundError: No module named 'aragora.foo'", "failed")
+
+    result = classify_session_blocker(state)
+
+    assert result["blocker_type"] == "import_error"
+    assert "ModuleNotFoundError" in result["evidence"]
+
+
+def test_classify_session_blocker_dependency_missing() -> None:
+    state = SessionState(session_id="dependency-blocker")
+    state.record_attempt(127, [], "ruff: command not found", "failed")
+
+    result = classify_session_blocker(state)
+
+    assert result["blocker_type"] == "dependency_missing"
+    assert "command not found" in result["evidence"]
+
+
+def test_classify_session_blocker_timeout_from_exit_code() -> None:
+    state = SessionState(session_id="timeout-blocker")
+    state.record_attempt(-1, [], "Timed out after 600s", "failed")
+
+    result = classify_session_blocker(state)
+
+    assert result["blocker_type"] == "timeout"
+    assert "Timed out" in result["evidence"]
+
+
+def test_classify_session_blocker_scope_too_broad() -> None:
+    state = SessionState(session_id="scope-blocker")
+    state.set_blocker("Issue was quarantined by task sanitizer: file scope spans 6 files.")
+
+    result = classify_session_blocker(state)
+
+    assert result["blocker_type"] == "scope_too_broad"
+    assert "file scope spans 6 files" in result["evidence"]
+
+
+def test_classify_session_blocker_defaults_to_test_failure() -> None:
+    state = SessionState(session_id="test-blocker")
+    state.record_attempt(1, [], "AssertionError: expected blocker evidence", "failed")
+
+    result = classify_session_blocker(state)
+
+    assert result["blocker_type"] == "test_failure"
+    assert "AssertionError" in result["evidence"]

--- a/tests/swarm/test_worker_launcher.py
+++ b/tests/swarm/test_worker_launcher.py
@@ -11,6 +11,7 @@ import pytest
 
 from aragora.pipeline.execution_mode import ExecutionMode
 from aragora.swarm.env_utils import git_safe_env
+from aragora.swarm.session_state import SessionState
 from aragora.swarm.worker_launcher import (
     LaunchConfig,
     WorkerLauncher,
@@ -146,6 +147,29 @@ class TestBuildPrompt:
         assert "failing verification" in prompt
         assert "python -m pytest tests/foo.py -q" in prompt
         assert "worker_crash" in prompt
+
+    def test_session_resume_context_included(self):
+        state = SessionState(
+            session_id="resume-prompt",
+            phase="repair",
+            resume_hint="pick up after the failing verify step",
+        )
+        state.record_attempt(
+            1,
+            ["aragora/swarm/session_state.py"],
+            "AssertionError: expected blocker evidence",
+            "needs_human",
+        )
+        prompt = WorkerLauncher._build_prompt(
+            {
+                "title": "Resume retry",
+                "metadata": {"session_state": state.to_dict()},
+            }
+        )
+
+        assert "## Resume context" in prompt
+        assert "pick up after the failing verify step" in prompt
+        assert "AssertionError: expected blocker evidence" in prompt
 
     def test_codex_prompt_includes_lane_closure_guidance(self):
         prompt = WorkerLauncher._build_prompt(


### PR DESCRIPTION
Continuation of the 8-phase roadmap spec from `origin/main`.

Earlier phases were already merged before this branch was cut:
- Phase 1 RS-08: already on `main` via #5261 (`c429afb8a`) — passed
- Phase 2 RS-09: already on `main` via #5261 (`c429afb8a`) — passed
- Phase 3 BC-01: already on `main` via #5262 (`0cba909de`) — passed

This branch carries the remaining phases:
- Phase 4 BC-02: `0dc9b4f96` — passed
- Phase 5 BC-03: `80f807d0a` — passed
- Phase 6 Operator status CLI: `5811fb544` — passed
- Phase 7 Documentation refresh: `0fb1f65af` — passed
- Phase 8 Quality ratchet update: `d389b01a9` — passed

Validation:
- `python3 -m pytest tests/swarm/ -q --timeout=60`
- `python3 -m pytest tests/cli/test_swarm_status_command.py tests/scripts/test_report_code_quality.py -q`
- `bash scripts/automation_pr_preflight.sh origin/main HEAD`

Notes:
- `python3 scripts/report_code_quality.py --compare --json` reports `except_exception=772` versus baseline `770`, so the ratchet threshold was not lowered in this pass.
- No phases were skipped on this continuation branch.
