### PR TITLE
fix(control-plane): log federated shutdown cancellation

### DIFF
--- a/aragora/control_plane/agent_federation.py
+++ b/aragora/control_plane/agent_federation.py
@@ -211,14 +211,14 @@ class FederatedAgentPool:
             try:
                 await self._discovery_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("[FederatedAgentPool] Discovery task cancelled during close")
 
         if self._health_task:
             self._health_task.cancel()
             try:
                 await self._health_task
             except asyncio.CancelledError:
-                pass
+                logger.debug("[FederatedAgentPool] Health task cancelled during close")
 
         self._connected = False
         logger.info("[FederatedAgentPool] Closed")

--- a/tests/control_plane/test_agent_federation.py
+++ b/tests/control_plane/test_agent_federation.py
@@ -164,6 +164,26 @@ class TestFederatedAgentPoolLifecycle:
 
         assert pool._connected is False
 
+    @pytest.mark.asyncio
+    async def test_close_logs_cancelled_background_tasks(self, pool):
+        """Test closing logs cancelled discovery and health tasks."""
+
+        async def wait_forever():
+            await asyncio.Event().wait()
+
+        pool._connected = True
+        pool._discovery_task = asyncio.create_task(wait_forever())
+        pool._health_task = asyncio.create_task(wait_forever())
+
+        with patch("aragora.control_plane.agent_federation.logger") as mock_logger:
+            await pool.close()
+
+        assert pool._connected is False
+        mock_logger.debug.assert_any_call(
+            "[FederatedAgentPool] Discovery task cancelled during close"
+        )
+        mock_logger.debug.assert_any_call("[FederatedAgentPool] Health task cancelled during close")
+
 
 class TestFederatedAgentPoolFindAgents:
     """Tests for finding agents."""


### PR DESCRIPTION
## Summary
- log cancelled discovery and health tasks during federated pool shutdown instead of silently swallowing them
- add a focused regression test covering the cancelled shutdown path

## Validation
- python3 -m pytest tests/control_plane/test_agent_federation.py -q -o cache_dir=/tmp/pytest-agent-federation-post-commit
- ruff check aragora/control_plane/agent_federation.py tests/control_plane/test_agent_federation.py
- bash scripts/automation_pr_preflight.sh origin/main HEAD
